### PR TITLE
feat(desktop): show an always-visible timestamp on each chat message

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/assistant-ui/thread/content'
 import { MESSAGE_PARTS_COMPONENTS } from '@/components/assistant-ui/thread/message-parts'
 import { ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
+import { MessageTimestamp } from '@/components/assistant-ui/thread/message-timestamp'
 import { ResponseLoadingIndicator, StreamStallIndicator } from '@/components/assistant-ui/thread/status'
 import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
 import { useMessageReactions, useTapbackDoubleClick } from '@/components/assistant-ui/thread/use-message-reactions'
@@ -157,6 +158,9 @@ export const AssistantMessage: FC<{
             )}
           </ErrorPrimitive.Root>
         </MessagePrimitive.Error>
+        {/* When this reply was written, visible at a glance — the hover-only
+            relative age in the action bar never showed the actual time. */}
+        <MessageTimestamp className="mt-1 block pr-(--message-text-indent) pl-(--message-text-indent) text-right" />
       </div>
       {hasVisibleText && !isInterim && (
         <AssistantFooter getMessageText={getMessageText} messageId={messageId} onBranchInNewChat={onBranchInNewChat} />

--- a/apps/desktop/src/components/assistant-ui/thread/message-timestamp.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-timestamp.test.tsx
@@ -1,0 +1,148 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Thread } from '.'
+
+// Message timestamps should be visible at a glance on every message — the
+// hover-only relative age in the assistant action bar never showed the actual
+// time. These tests pin the always-visible label (and its absence when no
+// timestamp exists, e.g. pending/streaming rows).
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+// The running-state enter animation calls `el.animate`, which jsdom lacks.
+Element.prototype.animate = function animate(): Animation {
+  return {
+    cancel: () => {},
+    currentTime: null,
+    effect: null,
+    finished: Promise.resolve(),
+    id: '',
+    oncancel: null,
+    onfinish: null,
+    onremove: null,
+    pause: () => {},
+    pending: false,
+    play: () => {},
+    playState: 'finished',
+    playbackRate: 1,
+    ready: Promise.resolve(),
+    remove: () => {},
+    replaceState: 'active',
+    startTime: null,
+    timeline: null,
+    updatePlaybackRate: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+    commitStyles: () => {},
+    persist: () => {},
+    reverse: () => {},
+    finish: () => {}
+  } as unknown as Animation
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+function userMessage(over: Partial<ThreadMessage> = {}): ThreadMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'question one' }],
+    attachments: [],
+    createdAt: new Date(),
+    metadata: { custom: {} },
+    ...over
+  } as ThreadMessage
+}
+
+function assistantMessage(over: Partial<ThreadMessage> = {}): ThreadMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'done' }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt: new Date(),
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    },
+    ...over
+  } as ThreadMessage
+}
+
+function timestampIn(root: string): string | null {
+  const rootEl = document.querySelector(root)
+
+  return rootEl?.querySelector('[data-slot="aui_msg-timestamp"]')?.textContent ?? null
+}
+
+function Harness({ messages }: { messages: ThreadMessage[] }) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages,
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('MessageTimestamp', () => {
+  it('shows an always-visible time label on the user message', async () => {
+    const createdAt = new Date(Date.now() - 2 * 60 * 60 * 1000)
+    render(<Harness messages={[userMessage({ createdAt }), assistantMessage()]} />)
+
+    await screen.findByText('done')
+
+    // "Today, 3:42 PM" / "Yesterday, 3:42 PM" — a visible label on the message
+    // itself, not a hover tooltip.
+    expect(timestampIn('[data-role="user"]')).toMatch(/^(Today|Yesterday), /)
+  })
+
+  it('shows an always-visible time label on the assistant message', async () => {
+    const createdAt = new Date(Date.now() - 2 * 60 * 60 * 1000)
+    render(<Harness messages={[userMessage(), assistantMessage({ createdAt })]} />)
+
+    await screen.findByText('done')
+
+    expect(timestampIn('[data-role="assistant"]')).toMatch(/^(Today|Yesterday), /)
+  })
+
+  it('renders no timestamp when the message has none (pending / streaming rows)', async () => {
+    render(
+      <Harness
+        messages={[
+          userMessage({ createdAt: undefined }),
+          assistantMessage({ createdAt: undefined, status: { type: 'running' } })
+        ]}
+      />
+    )
+
+    await screen.findByText('done')
+
+    expect(timestampIn('[data-role="user"]')).toBeNull()
+    expect(timestampIn('[data-role="assistant"]')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/message-timestamp.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-timestamp.tsx
@@ -1,0 +1,38 @@
+import { useAuiState } from '@assistant-ui/react'
+import { type FC } from 'react'
+
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+import { formatMessageTimestamp } from './timestamp'
+
+/**
+ * Always-visible message time — "Today, 3:42 PM", "Yesterday, 3:42 PM", or an
+ * absolute date+time for older messages (see {@link formatMessageTimestamp}).
+ *
+ * Distinct from the hover-only relative age in the assistant action bar
+ * (`MessageAge`): that one is compact and sits behind an opacity-0 hover
+ * reveal, so there was no way to see *when* a message was written at a glance.
+ * This is the durable "when did this happen" answer on every message.
+ *
+ * Renders nothing while the timestamp is missing (pending / streaming rows)
+ * or unparseable.
+ */
+export const MessageTimestamp: FC<{ className?: string }> = ({ className }) => {
+  const { t } = useI18n()
+  const createdAt = useAuiState(s => s.message.createdAt)
+  const label = formatMessageTimestamp(createdAt, t.assistant.thread)
+
+  if (!label) {
+    return null
+  }
+
+  return (
+    <span
+      className={cn('text-[0.6875rem] tabular-nums text-muted-foreground/70', className)}
+      data-slot="aui_msg-timestamp"
+    >
+      {label}
+    </span>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -4,6 +4,7 @@ import { type FC, type ReactNode, useCallback, useRef, useState } from 'react'
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
+import { MessageTimestamp } from '@/components/assistant-ui/thread/message-timestamp'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { useMessageReactions } from '@/components/assistant-ui/thread/use-message-reactions'
 import { UserMessageText } from '@/components/assistant-ui/thread/user-message-text'
@@ -260,6 +261,15 @@ export const UserMessage: FC<{
     </div>
   )
 
+  // When this prompt was written, always visible under the text. Kept out of
+  // the clamped text block so the 2-line clamp measurement stays text-only.
+  const bubbleBody = hasBody && (
+    <>
+      {bubbleContent}
+      <MessageTimestamp className="self-end" />
+    </>
+  )
+
   return (
     <MessagePrimitive.Root asChild>
       <StickyHumanMessageContainer
@@ -320,7 +330,7 @@ export const UserMessage: FC<{
                     title={bodyClamped ? (expanded ? t.common.collapse : copy.expandMessage) : undefined}
                     type="button"
                   >
-                    {bubbleContent}
+                    {bubbleBody}
                   </button>
                 ) : (
                   // Always editable — clicking opens the edit composer even while a
@@ -351,7 +361,7 @@ export const UserMessage: FC<{
                       title={copy.editMessage}
                       type="button"
                     >
-                      {bubbleContent}
+                      {bubbleBody}
                     </button>
                   </ActionBarPrimitive.Edit>
                 )}


### PR DESCRIPTION
## Summary

Show an **always-visible timestamp on every chat message** so it's obvious *when* each message was written — and by extension how long a conversation has been going. Today the only time display is a compact relative age (`"2h ago"`) inside the assistant action bar, which is `opacity-0` until hover; the actual date/time is only a tooltip. User messages had no time at all.

## Changes

- **New `MessageTimestamp` component** (`apps/desktop/src/components/assistant-ui/thread/message-timestamp.tsx`) — reads the message's `createdAt` and renders the label via the existing `formatMessageTimestamp`: `"Today, 3:42 PM"`, `"Yesterday, 3:42 PM"`, or an absolute date+time for older messages (existing i18n labels, no new strings). Renders nothing for pending/streaming rows that have no timestamp yet.
- **Assistant messages** — the label sits under the content, aligned with the action-bar indent.
- **User messages** — the label sits inside the bubble below the text, outside the clamped text block so the 2-line clamp measurement stays text-only.

## Why this shape

- Reuses `formatMessageTimestamp` + `t.assistant.thread.today/yesterday` — zero new locale strings, consistent formatting everywhere.
- Per-message labels rather than day dividers: minimal surface in the heavily-optimized thread list (render-budgeted/virtualized groups), and it answers "when was this written" for any message at a glance.

## Testing

- 3 new tests (`message-timestamp.test.tsx`): visible label on the user message, visible label on the assistant message, and no label when the message has no `createdAt` (pending/streaming).
- Full thread component suite: **21 files / 120 tests passed**.
- `tsc -p . && tsc -p tsconfig.electron.json && tsc -p tsconfig.e2e.json` clean.
