### PR TITLE
fix(compression): stop Kimi long sessions from barely compressing

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1008,7 +1008,11 @@ def _reasoning_details_text_chars(value: Any) -> int:
     return total
 
 
-def _estimate_msg_budget_tokens(msg: dict, charge_stale_thinking: bool = True) -> int:
+def _estimate_msg_budget_tokens(
+    msg: dict,
+    charge_stale_thinking: bool = True,
+    charge_thinking_envelope: bool = False,
+) -> int:
     """Token estimate for one message in the tail-protection budget walks.
 
     Counts the message content plus the **full** ``tool_call`` envelope —
@@ -1039,6 +1043,12 @@ def _estimate_msg_budget_tokens(msg: dict, charge_stale_thinking: bool = True) -
     cut land early and discard more real transcript than configured).
     Default ``True`` preserves the conservative full charge for callers
     without turn-position context.
+
+    ``charge_thinking_envelope`` additionally charges the serialized
+    ``reasoning_details`` carrier. It is reserved for transports whose
+    preserved-thinking contract replays historical signed/opaque blocks; on
+    those routes the envelope itself rides the request wire and cannot use the
+    ordinary text-only estimate.
     """
     content = msg.get("content") or ""
     if isinstance(content, str):
@@ -1053,15 +1063,28 @@ def _estimate_msg_budget_tokens(msg: dict, charge_stale_thinking: bool = True) -
         tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     if not charge_stale_thinking:
         return tokens
+    generic_thinking_tokens = 0
     for key in _NEWEST_TURN_ONLY_BUDGET_KEYS:
-        tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
+        generic_thinking_tokens += (
+            _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
+        )
+    tokens += generic_thinking_tokens
     # reasoning_details: charge only the thinking TEXT, never the signed /
     # base64 envelope (#73298 second site; mirrors the preflight estimator's
     # exclusion in model_metadata).  When the same thinking text already rides
     # in ``reasoning``/``reasoning_content`` (measured byte-identical on
     # Anthropic-wire sessions), skip it here entirely so the prose is not
     # charged twice on top of the envelope exclusion.
-    if not (msg.get("reasoning") or msg.get("reasoning_content")):
+    if charge_thinking_envelope:
+        envelope_tokens = (
+            _serialized_length_for_budget(msg.get("reasoning_details"))
+            // _CHARS_PER_TOKEN
+        )
+        # ``reasoning`` and ``reasoning_details`` commonly carry the same
+        # thinking text. Charge whichever replay carrier is larger rather than
+        # counting that text twice.
+        tokens += max(0, envelope_tokens - generic_thinking_tokens)
+    elif not (msg.get("reasoning") or msg.get("reasoning_content")):
         tokens += (
             _reasoning_details_text_chars(msg.get("reasoning_details"))
             // _CHARS_PER_TOKEN
@@ -2389,6 +2412,19 @@ class ContextCompressor(ContextEngine):
         self._proactive_prune_rearm_tokens = 0
         self._clear_durable_proactive_prune_rearm()
 
+    def _transport_stale_thinking_budget(self) -> tuple[bool, bool]:
+        """Resolve historical thinking-text/envelope replay capabilities."""
+        from agent.transports import get_transport
+
+        transport = get_transport(self.api_mode)
+        if transport is None:
+            return False, False
+        kwargs = {"base_url": self.base_url, "model": self.model}
+        return (
+            transport.replays_stale_thinking(**kwargs),
+            transport.replays_stale_thinking_envelope(**kwargs),
+        )
+
     # When the MINIMUM_CONTEXT_LENGTH floor meets/exceeds a small context
     # window, compacting at the percentage (50% → 32K of a 64K window) wastes
     # half the usable context. Trigger near the top of the window instead so a
@@ -3162,14 +3198,22 @@ class ContextCompressor(ContextEngine):
                 len(result),
                 _MAX_TAIL_MESSAGE_FLOOR,
             )
-            # Same newest-turn-only thinking charge as the tail-cut walk
-            # (#73624) — this boundary decides which tool results stay
-            # prunable, and overcharging stale thinking shrinks that window.
+            # Match the active request transport: most wires only replay the
+            # newest assistant's thinking, while preserved-thinking routes
+            # replay every historical envelope.
             _newest_asst_idx = _last_assistant_index(result)
+            (
+                _replays_stale_thinking,
+                _replays_stale_thinking_envelope,
+            ) = self._transport_stale_thinking_budget()
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
                 msg_tokens = _estimate_msg_budget_tokens(
-                    msg, charge_stale_thinking=(i == _newest_asst_idx)
+                    msg,
+                    charge_stale_thinking=(
+                        _replays_stale_thinking or i == _newest_asst_idx
+                    ),
+                    charge_thinking_envelope=_replays_stale_thinking_envelope,
                 )
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
@@ -5543,16 +5587,23 @@ This compaction should PRIORITISE preserving all information related to the focu
         accumulated = 0
         cut_idx = n  # start from beyond the end
 
-        # Newest assistant turn: the only message whose generic thinking
-        # fields any transport still replays (#73624) — every older turn's
-        # reasoning/reasoning_content is stripped or padded at send time,
-        # so charging it here spends tail budget on bytes that never ship.
+        # Match the active request transport. Most wires only replay the
+        # newest assistant's generic thinking (#73624); preserved-thinking
+        # routes replay every historical signed/opaque envelope.
         _newest_asst_idx = _last_assistant_index(messages)
+        (
+            _replays_stale_thinking,
+            _replays_stale_thinking_envelope,
+        ) = self._transport_stale_thinking_budget()
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
             msg_tokens = _estimate_msg_budget_tokens(
-                msg, charge_stale_thinking=(i == _newest_asst_idx)
+                msg,
+                charge_stale_thinking=(
+                    _replays_stale_thinking or i == _newest_asst_idx
+                ),
+                charge_thinking_envelope=_replays_stale_thinking_envelope,
             )
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
@@ -5580,7 +5631,11 @@ This compaction should PRIORITISE preserving all information related to the focu
             for j in range(n - 1, head_end - 1, -1):
                 raw_msg = messages[j]
                 raw_tok = _estimate_msg_budget_tokens(
-                    raw_msg, charge_stale_thinking=(j == _newest_asst_idx)
+                    raw_msg,
+                    charge_stale_thinking=(
+                        _replays_stale_thinking or j == _newest_asst_idx
+                    ),
+                    charge_thinking_envelope=_replays_stale_thinking_envelope,
                 )
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2416,7 +2416,7 @@ class ContextCompressor(ContextEngine):
         """Resolve historical thinking-text/envelope replay capabilities."""
         from agent.transports import get_transport
 
-        transport = get_transport(self.api_mode)
+        transport = get_transport(getattr(self, "api_mode", None))
         if transport is None:
             return False, False
         kwargs = {"base_url": self.base_url, "model": self.model}

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -244,6 +244,27 @@ class AnthropicTransport(ProviderTransport):
         """Map Anthropic stop_reason to OpenAI finish_reason."""
         return self._STOP_REASON_MAP.get(raw_reason, "stop")
 
+    def replays_stale_thinking(
+        self, *, base_url: str = "", model: str = ""
+    ) -> bool:
+        """Report routes whose preserved-thinking contract replays history."""
+        from agent.anthropic_adapter import (
+            _is_deepseek_anthropic_endpoint,
+            _is_kimi_family_endpoint,
+        )
+
+        return _is_kimi_family_endpoint(base_url, model) or (
+            _is_deepseek_anthropic_endpoint(base_url)
+        )
+
+    def replays_stale_thinking_envelope(
+        self, *, base_url: str = "", model: str = ""
+    ) -> bool:
+        """Kimi replays signed envelopes; DeepSeek strips their signatures."""
+        from agent.anthropic_adapter import _is_kimi_family_endpoint
+
+        return _is_kimi_family_endpoint(base_url, model)
+
 
 # Auto-register on import
 from agent.transports import register_transport  # noqa: E402

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -87,3 +87,20 @@ class ProviderTransport(ABC):
         with different stop reason vocabularies.
         """
         return raw_reason
+
+    def replays_stale_thinking(
+        self, *, base_url: str = "", model: str = ""
+    ) -> bool:
+        """Whether historical assistant thinking is replayed on this route.
+
+        Most transports strip thinking from all but the newest assistant turn.
+        Transports with route-specific preserved-thinking contracts override
+        this capability so context accounting matches the request wire.
+        """
+        return False
+
+    def replays_stale_thinking_envelope(
+        self, *, base_url: str = "", model: str = ""
+    ) -> bool:
+        """Whether opaque historical thinking envelopes ride the request wire."""
+        return False

--- a/tests/agent/test_replay_budget_accounting.py
+++ b/tests/agent/test_replay_budget_accounting.py
@@ -111,15 +111,43 @@ class TestTailCutBehavior:
     """The tail cut must protect MORE real transcript when stale turns carry
     heavy thinking — the #73624 symptom was the cut landing early."""
 
-    def _compressor(self):
+    def _compressor(
+        self,
+        *,
+        model="claude-opus-5",
+        base_url="",
+        api_mode="anthropic_messages",
+    ):
         from agent.context_compressor import ContextCompressor
 
         cc = ContextCompressor(
-            model="claude-opus-5",
+            model=model,
+            base_url=base_url,
+            api_mode=api_mode,
             quiet_mode=True,
             config_context_length=200_000,
         )
         return cc
+
+    @staticmethod
+    def _reasoning_details_transcript():
+        msgs = [{"role": "system", "content": "sys"}]
+        for i in range(30):
+            msgs.append({"role": "user", "content": f"question {i}"})
+            msgs.append(
+                {
+                    "role": "assistant",
+                    "content": f"answer {i}",
+                    "reasoning_details": [
+                        {
+                            "type": "thinking",
+                            "thinking": "plan",
+                            "signature": "s" * 4_000,
+                        }
+                    ],
+                }
+            )
+        return msgs
 
     def test_stale_thinking_does_not_shrink_tail(self):
         cc = self._compressor()
@@ -156,3 +184,36 @@ class TestTailCutBehavior:
         # index = more messages in the tail), and strictly more here because
         # the stale thinking dominates each message's old-cost.
         assert cut < old_cut
+
+    def test_kimi_replayed_thinking_envelopes_shrink_protected_tail(self):
+        """Kimi replays every signed reasoning_details block, so its protected
+        tail must be priced from the replayed envelopes rather than the direct
+        Anthropic newest-turn-only exemption."""
+        msgs = self._reasoning_details_transcript()
+        budget = 500
+
+        direct_cut = self._compressor()._find_tail_cut_by_tokens(
+            msgs, 1, token_budget=budget
+        )
+        kimi_cut = self._compressor(
+            model="k3",
+            base_url="https://api.kimi.com/coding",
+        )._find_tail_cut_by_tokens(msgs, 1, token_budget=budget)
+
+        assert kimi_cut > direct_cut
+
+    def test_kimi_model_on_foreign_gateway_charges_replayed_thinking(self):
+        """The request builder identifies proxied Kimi from the model slug;
+        compression accounting must use the same capability knowledge."""
+        msgs = self._reasoning_details_transcript()
+        budget = 500
+
+        direct_cut = self._compressor()._find_tail_cut_by_tokens(
+            msgs, 1, token_budget=budget
+        )
+        proxied_kimi_cut = self._compressor(
+            model="moonshotai/kimi-k2.5",
+            base_url="https://gateway.example/v1/messages",
+        )._find_tail_cut_by_tokens(msgs, 1, token_budget=budget)
+
+        assert proxied_kimi_cut > direct_cut


### PR DESCRIPTION
## What does this PR do?

Kimi preserved-thinking sessions can replay signed reasoning blocks from every historical assistant turn, but compression priced those blocks only on the newest turn. On long sessions this makes nearly the entire transcript appear to fit in the protected tail, so a reported 637-message window compressed by only four messages while invalidating its prompt cache. This change makes tail accounting follow the active transport's replay capabilities while preserving newest-turn-only accounting for transports that strip stale thinking.

### Symptom

On a long Kimi K3 session, manual compression can summarize only a handful of messages because historical signed `reasoning_details` blocks are treated as free during the tail-cut walk. The reported incident reduced 637 messages to 633 even though the provider prompt still contained about 298K tokens after compression.

### Impact

Kimi and Moonshot users with long preserved-thinking histories can receive ineffective compression, retain an oversized provider prompt, and lose prompt-cache reuse for little context reduction. Direct Anthropic and transports that strip historical thinking are not affected by this fix.

### Bug Cause

**Trigger:** `agent/context_compressor.py` / `_find_tail_cut_by_tokens()` when the Anthropic Messages route preserves historical thinking.

**Causal chain:**
1. Kimi-family routes replay each historical assistant turn's signed `reasoning_details` envelope.
2. Compression applies the newest-assistant-only stale-thinking exemption globally, so historical replayed envelopes contribute no tail-budget cost.
3. The backward walk protects nearly the full transcript and leaves only a tiny summarization region.

**Why it is wrong:** The budget walk assumed every transport strips stale thinking, but preserved-thinking behavior depends on the transport endpoint and model route.

**Working sibling / contrast:** Direct Anthropic strips or pads historical thinking and should retain newest-turn-only accounting. DeepSeek replays historical thinking text but strips signed envelopes.

**Ruled out:** Tool-result pruning can compound the small estimate, but it does not explain the missing cost of irreducible signed Kimi envelopes and remains outside this fix.

### Fix

Add transport capabilities for historical thinking text and opaque-envelope replay. Anthropic transport resolves them through the same Kimi and DeepSeek route predicates used by request conversion, and all three compression tail/prune budget walks now apply those capabilities consistently. Kimi and Moonshot routes charge replayed signed envelopes, DeepSeek charges replayed text without signatures, and ordinary transports keep the existing newest-turn-only behavior.

## Related Issue

Fixes #83247

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/base.py` - define default historical thinking replay capabilities.
- `agent/transports/anthropic.py` - identify Kimi, Moonshot, proxied Kimi, and DeepSeek replay behavior with canonical route predicates.
- `agent/context_compressor.py` - apply transport-aware text and envelope charging in each tail/prune budget walk.
- `tests/agent/test_replay_budget_accounting.py` - cover official and proxied Kimi preserved-thinking accounting while retaining direct Anthropic behavior.

## How to Test

1. Run the focused Kimi preserved-thinking regressions.
2. Run the related replay, compression, pruning, and context-engine suite.

```bash
scripts/run_tests.sh tests/agent/test_replay_budget_accounting.py -k 'kimi_replayed_thinking_envelopes_shrink_protected_tail or kimi_model_on_foreign_gateway_charges_replayed_thinking'
scripts/run_tests.sh tests/agent/test_replay_budget_accounting.py tests/agent/test_anthropic_kimi_signed_thinking_replay.py tests/agent/test_context_compressor.py tests/agent/test_proactive_tool_result_pruning.py tests/agent/test_context_engine.py
```

Results: 2 focused tests passed; 171 related tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration or workflow changes
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow policy changed
- [x] Cross-platform impact considered: the change is transport accounting logic with platform-independent tests
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed
