### PR TITLE
Pause turns when clarification is unanswered

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -785,6 +785,7 @@ def init_agent(
     agent._executing_tools = False
     agent._tool_guardrails = ToolCallGuardrailController()
     agent._tool_guardrail_halt_decision: ToolGuardrailDecision | None = None
+    agent._clarify_pause_status: str | None = None
 
     # Interrupt mechanism for breaking out of tool loops
     agent._interrupt_requested = False

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1561,6 +1561,7 @@ def run_conversation(
     # A configured SessionDB append failure halts only the affected turn. A
     # cached gateway agent must recover on the next message if storage did.
     agent._incremental_persistence_failed = False
+    agent._clarify_pause_status = None
     # Cause of the most recent persistence failure this turn ('locked',
     # 'disk', or 'unknown' — see hermes_state.classify_persistence_error).
     # Reset alongside the failure flag so a lock-contention diagnosis from a
@@ -6772,6 +6773,19 @@ def run_conversation(
                     _turn_exit_reason = "session_persistence_failed"
                     final_response = ""
                     failed = True
+                    break
+
+                if getattr(agent, "_clarify_pause_status", None):
+                    pause_status = agent._clarify_pause_status
+                    _turn_exit_reason = f"clarify_{pause_status}"
+                    final_response = (
+                        "Input request expired; no action was taken. "
+                        "Send a new message to continue."
+                        if pause_status == "expired"
+                        else "Input request was cancelled; no action was taken. Send a new message to continue."
+                        if pause_status == "cancelled"
+                        else "Input request could not be delivered; no action was taken. Send a new message to continue."
+                    )
                     break
 
                 if agent._tool_guardrail_halt_decision is not None:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -755,6 +755,36 @@ def _begin_tool_execution(
             pass
 
 
+def _append_clarify_cancelled_tool_results(agent, tool_calls, messages, effective_task_id: str) -> bool:
+    """Persist one cancellation result for every tool suppressed by clarify."""
+    status = getattr(agent, "_clarify_pause_status", "cancelled")
+    for tool_call in tool_calls:
+        name = tool_call.function.name
+        result = (
+            f"[Tool execution cancelled — {name} was not started because "
+            f"clarify ended with {status}]"
+        )
+        messages.append(make_tool_result_message(
+            name, result, tool_call.id, effect_disposition="none",
+        ))
+        _emit_terminal_post_tool_call(
+            agent,
+            function_name=name,
+            function_args={},
+            result=result,
+            effective_task_id=effective_task_id,
+            tool_call_id=getattr(tool_call, "id", "") or "",
+            status="cancelled",
+            error_type=f"clarify_{status}",
+            error_message="Tool execution skipped because the turn is paused",
+        )
+        if not _flush_session_db_after_tool_progress(
+            agent, messages, stage=f"clarify-cancelled tool result {name}",
+        ):
+            return False
+    return True
+
+
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
@@ -771,6 +801,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # Resolve the context-scaled tool-output budget once per turn (cheap, but
     # avoids rebuilding it per result inside the loop below).
     _tool_budget = _budget_for_agent(agent)
+
+    if getattr(agent, "_clarify_pause_status", None):
+        _append_clarify_cancelled_tool_results(
+            agent, tool_calls, messages, effective_task_id,
+        )
+        return
 
     # ── Pre-flight: interrupt check ──────────────────────────────────
     if agent._interrupt_requested:
@@ -1612,6 +1648,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
+        if getattr(agent, "_clarify_pause_status", None):
+            _append_clarify_cancelled_tool_results(
+                agent, assistant_message.tool_calls[i - 1:], messages, effective_task_id,
+            )
+            break
         # SAFETY: check interrupt BEFORE starting each tool.
         # If the user sent "stop" during a previous tool's execution,
         # do NOT start any more tools -- skip them all immediately.
@@ -2273,6 +2314,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         ):
             return
 
+        if function_name == "clarify":
+            from tools.clarify_tool import clarify_pause_status
+            pause_status = clarify_pause_status(display_function_result)
+            if pause_status:
+                agent._clarify_pause_status = pause_status
+
         # UI completion/progress events are projections of the canonical tool
         # row, never a competing in-memory authority.
         if not _execution_blocked and agent.tool_progress_callback:
@@ -2392,9 +2439,18 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
-    for kind, calls in segments:
+    for segment_index, (kind, calls) in enumerate(segments):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
+        if getattr(agent, "_clarify_pause_status", None):
+            remaining_calls = [
+                call for _, segment_calls in segments[segment_index:]
+                for call in segment_calls
+            ]
+            _append_clarify_cancelled_tool_results(
+                agent, remaining_calls, messages, effective_task_id,
+            )
+            break
         segment_message = SimpleNamespace(tool_calls=list(calls))
         if kind == "parallel":
             execute_tool_calls_concurrent(

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -193,9 +193,13 @@ def finalize_turn(
 
     # Determine if conversation completed successfully
     normal_text_response = str(_turn_exit_reason).startswith("text_response(")
+    paused = str(_turn_exit_reason) in {
+        "clarify_expired", "clarify_cancelled", "clarify_delivery_failed",
+    }
     completed = (
         final_response is not None
         and not failed
+        and not paused
         and (
             api_call_count < agent.max_iterations
             or normal_text_response
@@ -375,6 +379,7 @@ def finalize_turn(
                     and getattr(_compressor, '_micro_compact_enabled', False) is True
                     and callable(getattr(_compressor, '_micro_compact', None))
                     and final_response
+                    and not paused
                     # Persistence-isolated agents (background review fork)
                     # must not micro-compact: the pass burns a real aux-LLM
                     # call on a throwaway replay transcript, and if the
@@ -659,6 +664,7 @@ def finalize_turn(
         "messages": messages,
         "api_calls": api_call_count,
         "completed": completed,
+        "paused": paused,
         "turn_exit_reason": _turn_exit_reason,
         "failed": failed,
         "partial": False,  # True only when stopped due to invalid tool calls

--- a/cli.py
+++ b/cli.py
@@ -13347,8 +13347,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         Sets up the interactive selection UI (or freetext prompt for open-ended
         questions), then blocks until the user responds via the prompt_toolkit
-        key bindings.  If no response arrives within the configured timeout the
-        question is dismissed and the agent is told to decide on its own.
+        key bindings. If no response arrives within the configured timeout the
+        question is dismissed and the current agent turn is paused.
 
         When ``multi_select`` is True, shows checkboxes and the user can
         select multiple options with Space, confirming with Enter.
@@ -13394,7 +13394,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 result = response_queue.get(timeout=1)
                 self._clarify_deadline = None
                 self._persist_prompt_summary("?", "Clarify", question, str(result))
-                return result
+                return {"status": "answered", "response": result}
             except queue.Empty:
                 # None deadline = unlimited: never auto-skip, just keep polling.
                 if self._clarify_deadline is not None:
@@ -13406,17 +13406,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     _last_countdown_refresh = now
                     self._paint_now()
 
-        # Timed out — tear down the UI and let the agent decide
+        # Timed out — tear down the UI and pause the current turn.
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = None
         self._clarify_multi_base = None
         self._paint_now()
-        _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
-        return (
-            "The user did not provide a response within the time limit. "
-            "Use your best judgement to make the choice and proceed."
-        )
+        _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — turn paused){_RST}")
+        return {"status": "expired"}
 
     def _sudo_password_callback(self) -> str:
         """

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5143,12 +5143,12 @@ class TurnRunner:
         # explaining that no response arrived (so the agent can adapt
         # rather than hang forever).
         # ------------------------------------------------------------------
-        def _clarify_callback_sync(question: str, choices, multi_select: bool = False) -> str:
+        def _clarify_callback_sync(question: str, choices, multi_select: bool = False) -> dict:
             from tools import clarify_gateway as _clarify_mod
             import uuid as _uuid
 
             if not ctx._status_adapter:
-                return ""
+                return {"status": "delivery_failed"}
 
             clarify_id = _uuid.uuid4().hex[:10]
             _clarify_mod.register(
@@ -5216,14 +5216,13 @@ class TurnRunner:
                 # sentinel so the agent can fall back to a sensible
                 # default rather than hanging.
                 _clarify_mod.clear_session(ctx.session_key or "")
-                return "[clarify prompt could not be delivered]"
+                return {"status": "delivery_failed"}
 
             timeout = _clarify_mod.get_clarify_timeout()
             response = _clarify_mod.wait_for_response(clarify_id, timeout=float(timeout))
             if response is None or response == "":
-                # Timeout or session-boundary cancellation
-                return f"[user did not respond within {int(timeout / 60)}m]"
-            return response
+                return {"status": "expired" if response is None else "cancelled"}
+            return {"status": "answered", "response": response}
 
         agent.clarify_callback = _clarify_callback_sync
 

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -52,7 +52,7 @@ def clarify_callback(cli, question, choices, multi_select=False):
         try:
             result = response_queue.get(timeout=1)
             cli._clarify_deadline = None
-            return result
+            return {"status": "answered", "response": result}
         except queue.Empty:
             # None deadline = unlimited: never auto-skip, just keep polling.
             if cli._clarify_deadline is not None:
@@ -67,11 +67,8 @@ def clarify_callback(cli, question, choices, multi_select=False):
     cli._clarify_deadline = None
     if hasattr(cli, "_app") and cli._app:
         cli._app.invalidate()
-    cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
-    return (
-        "The user did not provide a response within the time limit. "
-        "Use your best judgement to make the choice and proceed."
-    )
+    cprint(f"\n{_DIM}(clarify timed out after {timeout}s — turn paused){_RST}")
+    return {"status": "expired"}
 
 
 def prompt_for_secret(cli, var_name: str, prompt: str, metadata=None) -> dict:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -492,20 +492,6 @@ def _run_agent(
                 logging.debug("oneshot session store cleanup failed", exc_info=True)
 
 
-def _oneshot_clarify_callback(question: str, choices=None, multi_select=False) -> str:
-    """Clarify is disabled in oneshot mode — tell the agent to pick a
-    default and proceed instead of stalling or erroring."""
-    if choices:
-        if multi_select:
-            return (
-                f"[oneshot mode: no user available. Pick the best subset from "
-                f"{choices} using your own judgment and continue.]"
-            )
-        return (
-            f"[oneshot mode: no user available. Pick the best option from "
-            f"{choices} using your own judgment and continue.]"
-        )
-    return (
-        "[oneshot mode: no user available. Make the most reasonable "
-        "assumption you can and continue.]"
-    )
+def _oneshot_clarify_callback(question: str, choices=None, multi_select=False) -> dict:
+    """Clarify cannot be answered in oneshot mode, so pause the turn."""
+    return {"status": "cancelled"}

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -128,6 +128,38 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
     assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}
 
 
+def test_clarify_expiry_is_paused_not_completed_and_closes_tool_tail(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    messages = [
+        {"role": "user", "content": "pick a node"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "clarify-1", "function": {"name": "clarify", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "clarify-1", "name": "clarify", "content": '{"status":"expired"}'},
+    ]
+    notice = "Input request expired; no action was taken. Send a new message to continue."
+    result = finalize_turn(
+        agent,
+        final_response=notice,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="pick a node",
+        original_user_message="pick a node",
+        _should_review_memory=False,
+        _turn_exit_reason="clarify_expired",
+    )
+    assert result["completed"] is False
+    assert result["paused"] is True
+    assert result["turn_exit_reason"] == "clarify_expired"
+    assert agent.persisted_messages[-1] == {"role": "assistant", "content": notice}
+
+
 def test_final_response_fills_pure_tool_call_tail(monkeypatch):
     """A tail assistant row that is a *pure tool-call turn* carries no answer.
 

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -471,7 +471,7 @@ class TestPersistPromptSummary:
             cli._clarify_state["response_queue"].put("B")
             t.join(timeout=2)
 
-        assert result["value"] == "B"
+        assert result["value"] == {"status": "answered", "response": "B"}
         summary = "\n".join(printed)
         assert "Clarify" in summary
         assert "Pick a path?" in summary
@@ -561,4 +561,3 @@ class TestClearOverlaysForInterrupt:
 
         assert not t.is_alive(), "worker thread never unblocked"
         assert result["value"] == "deny"
-

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -370,7 +370,7 @@ def agent():
     with (
         patch(
             "run_agent.get_tool_definitions",
-            return_value=_make_tool_defs("web_search", "terminal"),
+            return_value=_make_tool_defs("web_search", "terminal", "clarify"),
         ),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
@@ -387,6 +387,31 @@ def agent():
 
 
 class TestSegmentedDispatchIntegration:
+    def test_expired_clarify_persists_result_and_cancels_remaining_batch(self, agent):
+        calls = [
+            _tc("clarify", '{"question":"Which node?","choices":["office","xiael"]}', call_id="c1"),
+            _tc("terminal", '{"command":"echo must-not-run"}', call_id="t1"),
+            _tc("web_search", '{"query":"must-not-run"}', call_id="s1"),
+            _tc("web_search", '{"query":"also-must-not-run"}', call_id="s2"),
+        ]
+        msg = SimpleNamespace(content="", tool_calls=calls)
+        messages = []
+        executed = []
+        agent.clarify_callback = lambda *_args, **_kwargs: {"status": "expired"}
+
+        def fake_handle(name, args, task_id, **kwargs):
+            executed.append(kwargs["tool_call_id"])
+            return json.dumps({"ok": True})
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls(msg, messages, "task-1")
+
+        assert [m["tool_call_id"] for m in messages] == ["c1", "t1", "s1", "s2"]
+        assert json.loads(messages[0]["content"])["status"] == "expired"
+        assert executed == []
+        assert all("cancelled" in m["content"] for m in messages[1:])
+        assert agent._clarify_pause_status == "expired"
+
     def test_mixed_batch_runs_safe_prefix_concurrently_and_barrier_after(self, agent):
         """Two web_search calls must overlap in time; terminal must start only
         after both finish; results land in the model's emission order."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9868,6 +9868,8 @@ def test_interrupt_only_clears_own_session_pending():
         server._pending.pop("rid-b", None)
         server._answers.pop("rid-a", None)
         server._answers.pop("rid-b", None)
+        server._cancelled_prompt_ids.discard("rid-a")
+        server._cancelled_prompt_ids.discard("rid-b")
 
 
 def test_interrupt_clears_multiple_own_pending():
@@ -9895,6 +9897,7 @@ def test_interrupt_clears_multiple_own_pending():
         for key in ("r1", "r2"):
             server._pending.pop(key, None)
             server._answers.pop(key, None)
+            server._cancelled_prompt_ids.discard(key)
 
 
 def test_run_prompt_submit_registers_turn_thread_for_interrupt(monkeypatch):
@@ -10532,6 +10535,56 @@ def test_clear_pending_without_sid_clears_all():
         for key in ("a", "b", "c"):
             server._pending.pop(key, None)
             server._answers.pop(key, None)
+            server._cancelled_prompt_ids.discard(key)
+
+
+def test_typed_block_distinguishes_timeout_and_session_cancellation(monkeypatch):
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    assert server._block("clarify.request", "timeout-sid", {}, timeout=0, typed=True) == {
+        "status": "expired"
+    }
+
+    result = {}
+    thread = threading.Thread(
+        target=lambda: result.setdefault(
+            "value",
+            server._block("clarify.request", "cancel-sid", {}, timeout=2, typed=True),
+        ),
+        daemon=True,
+    )
+    thread.start()
+    deadline = time.time() + 1
+    while not any(owner == "cancel-sid" for owner, _event in server._pending.values()):
+        assert time.time() < deadline
+        time.sleep(0.01)
+    server._clear_pending("cancel-sid")
+    thread.join(timeout=1)
+
+    assert result["value"] == {"status": "cancelled"}
+
+
+def test_typed_block_rejects_late_clarify_reply(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload: emitted.append((event, sid, dict(payload))),
+    )
+
+    assert server._block("clarify.request", "late-sid", {}, timeout=0, typed=True) == {
+        "status": "expired"
+    }
+    request_id = emitted[0][2]["request_id"]
+    response = server.handle_request(
+        {
+            "id": "late",
+            "method": "clarify.respond",
+            "params": {"request_id": request_id, "answer": "too late"},
+        }
+    )
+
+    assert response["result"] == {"status": "expired"}
 
 
 def test_respond_unpacks_sid_tuple_correctly():
@@ -16276,17 +16329,18 @@ def test_clarify_callback_uses_configured_timeout(monkeypatch):
 
     monkeypatch.setattr(server, "_clarify_timeout_seconds", lambda: 42)
 
-    def fake_block(event, sid, payload, timeout=300):
-        captured.update(event=event, sid=sid, payload=payload, timeout=timeout)
-        return "answer"
+    def fake_block(event, sid, payload, timeout=300, **kwargs):
+        captured.update(event=event, sid=sid, payload=payload, timeout=timeout, **kwargs)
+        return {"status": "answered", "response": "answer"}
 
     monkeypatch.setattr(server, "_block", fake_block)
 
     result = server._agent_cbs("sid-1")["clarify_callback"]("Pick one", ["a", "b"])
 
-    assert result == "answer"
+    assert result == {"status": "answered", "response": "answer"}
     assert captured["event"] == "clarify.request"
     assert captured["timeout"] == 42
+    assert captured["typed"] is True
     assert captured["payload"] == {"question": "Pick one", "choices": ["a", "b"]}
 
 
@@ -16296,7 +16350,7 @@ def test_clarify_callback_multi_select_hint(monkeypatch):
     (older renderers must never see the extra field)."""
     captured = {}
 
-    def fake_block(event, sid, payload, timeout=300):
+    def fake_block(event, sid, payload, timeout=300, **_kwargs):
         captured.update(payload=payload)
         return "answer"
 

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -24,16 +24,16 @@ class TestClarifyToolBasics:
             return "blue"
 
         result = json.loads(clarify_tool("What color?", callback=mock_callback))
+        assert result["status"] == "answered"
         assert result["question"] == "What color?"
         assert result["choices_offered"] is None
         assert result["user_response"] == "blue"
 
 
-    def test_no_callback_returns_error(self):
-        """Should return error when no callback is provided."""
+    def test_no_callback_is_typed_delivery_failure(self):
         result = json.loads(clarify_tool("What do you want?"))
-        assert "error" in result
-        assert "not available" in result["error"].lower()
+        assert result["status"] == "delivery_failed"
+        assert "user_response" not in result
 
 
 class TestClarifyToolChoicesValidation:
@@ -68,15 +68,21 @@ class TestClarifyToolChoicesValidation:
 class TestClarifyToolCallbackHandling:
     """Tests for callback error handling."""
 
-    def test_callback_exception_returns_error(self):
-        """Should return error if callback raises exception."""
+    def test_callback_exception_is_typed_delivery_failure(self):
         def failing_callback(question: str, choices: Optional[List[str]]) -> str:
             raise RuntimeError("User cancelled")
 
         result = json.loads(clarify_tool("Question?", callback=failing_callback))
-        assert "error" in result
-        assert "Failed to get user input" in result["error"]
-        assert "User cancelled" in result["error"]
+        assert result["status"] == "delivery_failed"
+        assert "user_response" not in result
+
+    def test_non_answered_outcomes_never_become_user_responses(self):
+        for status in ("expired", "cancelled", "delivery_failed"):
+            result = json.loads(clarify_tool(
+                "Q?", callback=lambda *_args, value=status: {"status": value}
+            ))
+            assert result["status"] == status
+            assert "user_response" not in result
 
 
     def test_user_response_stripped(self):

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -15,12 +15,42 @@ a thin dispatcher that delegates to a platform-provided callback.
 """
 
 import json
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Literal, TypedDict
 
 
 # Maximum number of predefined choices the agent can offer.
 # A 5th "Other (type your answer)" option is always appended by the UI.
 MAX_CHOICES = 4
+
+
+class ClarifyCallbackResult(TypedDict, total=False):
+    status: Literal["answered", "expired", "cancelled", "delivery_failed"]
+    response: object
+
+
+CLARIFY_PAUSE_STATUSES = {"expired", "cancelled", "delivery_failed"}
+
+
+def _normalize_callback_result(value) -> ClarifyCallbackResult:
+    if isinstance(value, dict):
+        status = value.get("status")
+        if status not in {"answered", *CLARIFY_PAUSE_STATUSES}:
+            return {"status": "delivery_failed"}
+        if status == "answered" and "response" not in value:
+            return {"status": "delivery_failed"}
+        return {"status": status, **({"response": value.get("response")} if status == "answered" else {})}
+    # Compatibility for third-party callbacks: a returned value is an answer.
+    return {"status": "answered", "response": value}
+
+
+def clarify_pause_status(tool_result) -> Optional[str]:
+    try:
+        parsed = json.loads(tool_result) if isinstance(tool_result, str) else tool_result
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if isinstance(parsed, dict) and parsed.get("status") in CLARIFY_PAUSE_STATUSES:
+        return str(parsed["status"])
+    return None
 
 
 def _flatten_choice(c) -> str:
@@ -157,12 +187,23 @@ def clarify_tool(
             choices = None  # empty list → open-ended
 
     if callback is None:
-        return tool_error("Clarify tool is not available in this execution context.")
+        callback_result: ClarifyCallbackResult = {"status": "delivery_failed"}
+    else:
+        try:
+            callback_result = _normalize_callback_result(
+                _invoke_callback(callback, question, choices, multi_select)
+            )
+        except Exception:
+            callback_result = {"status": "delivery_failed"}
 
-    try:
-        raw_response = _invoke_callback(callback, question, choices, multi_select)
-    except Exception as exc:
-        return tool_error(f"Failed to get user input: {exc}")
+    status = callback_result["status"]
+    if status != "answered":
+        return json.dumps({
+            "question": question,
+            "choices_offered": choices,
+            "status": status,
+        }, ensure_ascii=False)
+    raw_response = callback_result.get("response", "")
 
     if multi_select and choices is not None:
         user_response = _parse_multi_select_response(raw_response)
@@ -172,6 +213,7 @@ def clarify_tool(
     return json.dumps({
         "question": question,
         "choices_offered": choices,
+        "status": "answered",
         "user_response": user_response,
     }, ensure_ascii=False)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -145,6 +145,7 @@ _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
 _answers: dict[str, str] = {}
+_cancelled_prompt_ids: set[str] = set()
 _db = None
 _db_error: str | None = None
 _stdout_lock = threading.Lock()
@@ -3249,7 +3250,14 @@ def _enable_gateway_prompts() -> None:
 # ── Blocking prompt factory ──────────────────────────────────────────
 
 
-def _block(event: str, sid: str, payload: dict, timeout: float | None = 300) -> str:
+def _block(
+    event: str,
+    sid: str,
+    payload: dict,
+    timeout: float | None = 300,
+    *,
+    typed: bool = False,
+):
     rid = uuid.uuid4().hex[:8]
     ev = threading.Event()
     with _prompt_lock:
@@ -3259,6 +3267,7 @@ def _block(event: str, sid: str, payload: dict, timeout: float | None = 300) -> 
     answered = False
     answer = ""
     answer_present = False
+    cancelled = False
     try:
         _emit(event, sid, payload)
         # Natural Event semantics: None → wait forever (clarify configured with
@@ -3271,6 +3280,8 @@ def _block(event: str, sid: str, payload: dict, timeout: float | None = 300) -> 
             _pending_prompt_payloads.pop(rid, None)
             answer_present = rid in _answers
             answer = _answers.pop(rid, "")
+            cancelled = rid in _cancelled_prompt_ids
+            _cancelled_prompt_ids.discard(rid)
 
     # Emit an `.expire` notification on timeout for every blocking request type
     # whose `*.respond` handler tolerates a late reply (allow_expired=True).
@@ -3292,6 +3303,12 @@ def _block(event: str, sid: str, payload: dict, timeout: float | None = 300) -> 
             sid,
             {"request_id": rid},
         )
+    if typed:
+        if cancelled:
+            return {"status": "cancelled"}
+        if answer_present:
+            return {"status": "answered", "response": answer}
+        return {"status": "cancelled" if answered else "expired"}
     return answer
 
 
@@ -3321,6 +3338,7 @@ def _clear_pending(sid: str | None = None) -> None:
         for rid, (owner_sid, ev) in list(_pending.items()):
             if sid is None or owner_sid == sid:
                 _answers[rid] = ""
+                _cancelled_prompt_ids.add(rid)
                 ev.set()
 
 
@@ -5848,6 +5866,7 @@ def _agent_cbs(sid: str) -> dict:
                 else {"question": q, "choices": c}
             ),
             timeout=_clarify_timeout_seconds(),
+            typed=True,
         ),
         # read_terminal tool (desktop GUI): same blocking bridge as clarify — the
         # renderer answers terminal.read.respond with the serialized buffer.
@@ -10833,6 +10852,7 @@ def _respond(rid, params, key, *, allow_expired=False):
                 return _ok(rid, {"status": "expired"})
             return _err(rid, 4009, f"no pending {key} request")
         _, ev = entry
+        _cancelled_prompt_ids.discard(r)
         _answers[r] = params.get(key, "")
         ev.set()
     return _ok(rid, {"status": "ok"})


### PR DESCRIPTION
## Summary
- type clarification callbacks as answered, expired, cancelled, or delivery_failed
- persist unanswered clarification results and cancel remaining batch tools
- finish the current turn as paused instead of allowing guessed continuation

## Verification
- targeted pytest suites: 630 passed, 1 skipped
- Ruff checks passed
- Python compile checks passed