### PR TITLE
fix(kanban): resolve project-linked board from cwd fallback

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -459,6 +459,67 @@ def current_board_path() -> Path:
     return kanban_home() / "kanban" / "current"
 
 
+def _read_project_slug(marker: Path) -> str:
+    """Extract the top-level ``slug:`` value from a ``.project.yaml`` file."""
+    try:
+        for line in marker.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line[:1].isspace():
+                continue  # nested block — not a top-level key
+            if line.startswith("slug:"):
+                return line[len("slug:"):].strip().strip("'\"")
+    except OSError:
+        pass
+    return ""
+
+
+def _project_board_from_cwd() -> str:
+    """Map the current working directory's project to a linked board slug.
+
+    The kanban tools resolve the active board from env pins and the
+    ``kanban/current`` file only — never from the project folder. This
+    fallback closes that gap for ad-hoc sessions: when no board has been
+    pinned, a session started inside a project folder resolves to the
+    project-linked board (if one exists) instead of silently falling back
+    to ``default``. That silent fallback is what produced the recurring
+    ``task <id> not found`` error when a board task id was referenced from
+    a session running inside the project.
+
+    Resolution:
+      1. Walk up from ``cwd`` to the nearest ``.project.yaml``.
+      2. If a board whose slug equals the project slug exists, use it.
+      3. Else scan boards for one whose ``default_workdir`` points at the
+         project root (covers slug-mismatch project links).
+
+    Returns ``""`` when no project marker or no linked board is found.
+    """
+    try:
+        start = Path(os.getcwd()).resolve()
+    except OSError:
+        return ""
+    for d in (start, *start.parents):
+        marker = d / ".project.yaml"
+        if not marker.is_file():
+            continue
+        slug = _read_project_slug(marker)
+        if slug:
+            try:
+                normed = _normalize_board_slug(slug)
+            except ValueError:
+                normed = None
+            if normed and board_exists(normed):
+                return normed
+            # No board of the same name — match on default_workdir so
+            # slug-mismatched project links still resolve.
+            proj_root = str(d)
+            for meta in list_boards():
+                wd = (meta.get("default_workdir") or "").strip()
+                if wd and str(Path(wd).expanduser().resolve()) == proj_root:
+                    return meta.get("slug") or ""
+        # The nearest project marker wins even if it has no linked board.
+        break
+    return ""
+
+
 def get_current_board() -> str:
     """Return the active board slug, honouring the resolution chain.
 
@@ -468,7 +529,11 @@ def get_current_board() -> str:
        spawn, or manually for ad-hoc overrides).
     2. ``<root>/kanban/current`` on disk (set by ``hermes kanban boards
        switch``), but only when that board still exists.
-    3. ``DEFAULT_BOARD`` (``"default"``).
+    3. Project-context fallback (:func:`_project_board_from_cwd`) — when
+       the process runs inside a project folder with a linked board, that
+       board is used so ad-hoc sessions see the project's tasks instead of
+       silently hitting the ``default`` board.
+    4. ``DEFAULT_BOARD`` (``"default"``).
 
     A malformed or stale slug at any step falls through to the next layer
     with a best-effort warning — the dispatcher must never crash because a
@@ -504,6 +569,9 @@ def get_current_board() -> str:
                     pass
     except OSError:
         pass
+    project = _project_board_from_cwd()
+    if project:
+        return project
     return DEFAULT_BOARD
 
 


### PR DESCRIPTION
## Problem

`get_current_board()` resolves the active board only from `HERMES_KANBAN_BOARD` and the on-disk `kanban/current` file. Sessions started inside a project folder (Desktop chat, manual tool calls, non-dispatcher paths) silently fall back to the `default` board, so project board task ids fail with `task <id> not found`. The `project=` parameter on `kanban_create` only sets `project_id`, not the board.

## Change

Add `_project_board_from_cwd()` which walks up from `cwd` to the nearest `.project.yaml`, maps the project slug to a linked board (by slug, then by `default_workdir` match), and add a project-context step to `get_current_board()` between the on-disk `current` file and `DEFAULT_BOARD`. If no project marker or no linked board is found, resolution falls through unchanged.

## Why this is safe

The fallback only fires when no board was pinned via env or the `current` file; dispatcher-spawned workers are unaffected (they are env-pinned). The walk breaks at the nearest `.project.yaml`; a project without a linked board still falls through to `DEFAULT_BOARD`.

## Tests

`tests/hermes_cli/test_kanban_board_project.py` + `tests/hermes_cli/test_pin_kanban_board_env.py` (6 passed). Full suite requires `pytest_asyncio` (currently missing in dev env).
