### PR TITLE
fix(lazy-deps): target uv installs at Hermes interpreter (#83264)

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -756,7 +756,16 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         if uv_bin:
             try:
                 r = subprocess.run(
-                    [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
+                    [
+                        uv_bin,
+                        "pip",
+                        "install",
+                        *target_args,
+                        *constraint_args,
+                        "--python",
+                        sys.executable,
+                        *specs,
+                    ],
                     capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
                     creationflags=windows_hide_flags(),


### PR DESCRIPTION
## Summary

- Fixes #83264.
- Passes the running Hermes interpreter explicitly to `uv pip install`, so updates do not depend on an inferred or stale `VIRTUAL_ENV` path.

## Tests

- `python3 -m pytest -q tests/tools/test_lazy_deps.py tests/test_windows_subprocess_no_window_flags.py` (64 passed, 4 skipped)
