### PR TITLE
fix(plugins): preserve shell hooks across force=True re-discovery

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1338,6 +1338,27 @@ class PluginManager:
     # Public
     # -----------------------------------------------------------------------
 
+    def _extract_shell_hook_callbacks(
+        self,
+    ) -> Dict[str, List[Callable]]:
+        """Snapshot shell-hook callbacks so a forced reset can restore."""
+        preserved: Dict[str, List[Callable]] = {}
+        for event, callbacks in self._hooks.items():
+            kept = [
+                cb for cb in callbacks
+                if getattr(cb, "__name__", "").startswith("shell_hook[")
+            ]
+            if kept:
+                preserved[event] = kept
+        return preserved
+
+    def _restore_shell_hook_callbacks(
+        self, preserved: Dict[str, List[Callable]],
+    ) -> None:
+        """Re-attach shell-hook callbacks preserved across a forced reset."""
+        for event, callbacks in preserved.items():
+            self._hooks.setdefault(event, []).extend(callbacks)
+
     def discover_and_load(self, force: bool = False) -> None:
         """Scan all plugin sources and load each plugin found.
 
@@ -1352,6 +1373,10 @@ class PluginManager:
             self._discovered = True
             return
         if force:
+            # Shell hooks are wired by register_from_config, not by the
+            # discovery sweep, so a bare _hooks.clear() drops them with no
+            # path to restore them. Preserve them across the reset.
+            preserved_hooks = self._extract_shell_hook_callbacks()
             self._plugins.clear()
             self._hooks.clear()
             self._middleware.clear()
@@ -1364,6 +1389,7 @@ class PluginManager:
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
             self._context_engine = None
+            self._restore_shell_hook_callbacks(preserved_hooks)
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
         # raises so a failed scan is NOT cached as "discovered with an empty

--- a/tests/hermes_cli/test_plugins_shell_hook_rediscovery.py
+++ b/tests/hermes_cli/test_plugins_shell_hook_rediscovery.py
@@ -1,0 +1,47 @@
+"""Regression: shell-hook callbacks survive a force=True re-discovery.
+
+Reproduces the race where a background MCP-discovery sweep
+(discover_and_load(force=True)) cleared _hooks and dropped shell hooks
+wired by register_from_config, so pre_tool_call hooks stopped firing.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.plugins import PluginManager
+
+
+def _make_shell_hook_callback(event: str, command: str):
+    """Mirror agent.shell_hooks._make_callback's shell_hook[...] tag."""
+    def _callback(**kwargs):
+        return None
+    _callback.__name__ = f"shell_hook[{event}:{command}]"
+    _callback.__qualname__ = _callback.__name__
+    return _callback
+
+
+def test_shell_hook_survives_forced_rediscovery():
+    manager = PluginManager()
+    cb = _make_shell_hook_callback(
+        "pre_tool_call", "powershell -File edit-doc-check.ps1"
+    )
+    manager._hooks.setdefault("pre_tool_call", []).append(cb)
+
+    with patch.object(manager, "_discover_and_load_inner", lambda: None):
+        manager.discover_and_load(force=True)
+
+    assert cb in manager._hooks.get("pre_tool_call", [])
+
+
+def test_plugin_hook_dropped_by_forced_rediscovery():
+    """Non-shell (plugin) callbacks are still cleared and re-registered."""
+    manager = PluginManager()
+
+    def plugin_cb(**kwargs):
+        return None
+    plugin_cb.__name__ = "audit_tool_call"
+    manager._hooks.setdefault("pre_tool_call", []).append(plugin_cb)
+
+    with patch.object(manager, "_discover_and_load_inner", lambda: None):
+        manager.discover_and_load(force=True)
+
+    assert plugin_cb not in manager._hooks.get("pre_tool_call", [])


### PR DESCRIPTION
# PR: Preserve shell hooks across `force=True` plugin re-discovery

**Title:**
```
fix(plugins): preserve shell hooks across force=True re-discovery
```

**Base:** `NousResearch/hermes-agent:main`
**Head:** `<your-fork>:fix/shell-hook-force-discovery-race`

---

## Body

Fixes #83334.

### Problem

A configured `pre_tool_call` shell hook registers at TUI startup, then stops firing for the rest of the session. `write_file` / `patch` are never blocked and the hook script is never spawned, while `hermes hooks list` still shows ✓ allowed.

`agent.log`, in order:

```
09:34:36.853  Plugin discovery complete: 55 found, 48 enabled
09:34:36.857  shell hook registered: pre_tool_call -> ...edit-doc-check.ps1 (matcher=write_file|patch)
09:34:39.013  Plugin discovery complete: 55 found, 48 enabled
```

1. `agent/shell_hooks.py:register_from_config()` appends the callback to `PluginManager._hooks["pre_tool_call"]`.
2. `hermes_cli/mcp_startup.py:start_background_mcp_discovery()` spawns a daemon thread → `tools/mcp_tool.py:discover_plugins()` → `PluginManager.discover_and_load(force=True)`.
3. The `force=True` branch runs `self._hooks.clear()`, wiping the shell-hook callback.
4. The sweep re-registers provider plugins without calling `register_from_config()`; the shell hook is not restored.

The `_registered` guard in `agent/shell_hooks.py` is not cleared by `_hooks.clear()`, so a later `register_from_config()` no-ops.

### Fix

`discover_and_load(force=True)` snapshots the shell-hook callbacks (tagged `shell_hook[...]` by `_make_callback`) before `_hooks.clear()` and re-attaches them after. Plugin-registered hooks are still cleared and re-registered by the sweep.

### Tests

`tests/hermes_cli/test_plugins_shell_hook_rediscovery.py`:

- `test_shell_hook_survives_forced_rediscovery` — shell-hook callback is present in `_hooks["pre_tool_call"]` after `discover_and_load(force=True)`.
- `test_plugin_hook_dropped_by_forced_rediscovery` — non-shell plugin callbacks are cleared by the forced sweep.

```
uv run pytest tests/hermes_cli/test_plugins_shell_hook_rediscovery.py -v
```

`tests/hermes_cli/test_plugins.py` passes.
