### PR TITLE
fix(cli): catch KeyboardInterrupt in sessions browse picker to exit g…

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -1099,6 +1099,9 @@ def cmd_sessions(args, sessions_parser=None):
         # the 'd' delete-with-confirmation action.
         try:
             selected_id = _session_browse_picker(sessions, session_db=db)
+        except KeyboardInterrupt:
+            print("\nCancelled.")
+            return
         finally:
             db.close()
         if not selected_id:


### PR DESCRIPTION
## Summary
Fixes #83256.

Wraps the interactive session picker call in `hermes_cli/sessions_cmd.py` with a `try...except KeyboardInterrupt` block.

## Rationale
Prevents an unhandled `KeyboardInterrupt` python traceback from dumping to the terminal when users press `Ctrl+C` while browsing sessions via `hermes sessions browse`.