### PR TITLE
feat(delegate): named subagent personas for human-authored capability scoping

### DIFF
--- a/agent/subagent_personas.py
+++ b/agent/subagent_personas.py
@@ -1,0 +1,251 @@
+"""Named subagent personas for ``delegate_task``.
+
+A persona is a markdown file with YAML frontmatter that pre-declares how a
+delegated child should be configured and briefed::
+
+    ---
+    name: scout
+    description: Read-only reconnaissance inside one repo or directory tree.
+    toolsets: [file, terminal]
+    required_toolsets: [file]
+    ---
+    You are a read-only scout. Answer the orchestrator's question with
+    evidence, without dumping whole files back into its context.
+
+Why a file and not tool arguments
+---------------------------------
+Model-facing ``toolsets`` was deliberately removed from ``delegate_task`` in
+ba0bc01d1f ("Toolset selection is a capability-scoping decision the model
+should not control").  That decision stands: nothing here lets the model
+choose a capability scope at call time.  A persona is authored by the *user*,
+on disk, before any input is seen — so the scope is fixed by a human, and the
+model may only select among the scopes that human already approved.
+
+This closes the gap that commit left open: previously there was no way for a
+user to obtain a genuinely read-only subagent, because children always
+inherited the parent's full toolset.
+
+Two invariants this module preserves
+------------------------------------
+- **Privilege reduction only.** A persona's ``toolsets`` are intersected with
+  the parent's in ``_build_child_agent``; a persona can never grant a toolset
+  the parent lacks.  ``required_toolsets`` exists so that silent stripping by
+  that intersection becomes a loud spawn failure instead of a subagent that
+  mysteriously cannot do its job.
+- **Prompt caching stays intact.** Personas are resolved once at spawn, before
+  the child's system prompt is built.  Nothing here mutates a live
+  conversation's prefix.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.skill_utils import parse_frontmatter
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# Directory name searched under HERMES_HOME (user scope) and the working
+# directory (project scope). Mirrors Claude Code's ``.claude/agents/``.
+PERSONAS_DIR_NAME = "agents"
+
+# Frontmatter keys a persona may declare. Unknown keys are ignored with a
+# warning rather than rejected, so a persona written for a newer Hermes still
+# loads on an older one.
+_KNOWN_KEYS = frozenset(
+    {
+        "name",
+        "description",
+        "toolsets",
+        "required_toolsets",
+        "reasoning_effort",
+        "max_iterations",
+    }
+)
+
+# A persona name must be safe to embed in a tool-result line and to match
+# against a filename. Same character class the skill loader accepts.
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+class PersonaError(ValueError):
+    """Raised when a persona is missing, malformed, or unusable."""
+
+
+# Problems seen this process, so a broken file doesn't warn on every spawn.
+_WARNED: set = set()
+
+
+def _warn_once(key: str, msg: str, *args: Any) -> None:
+    """Log a warning the first time a given problem is seen."""
+    if key in _WARNED:
+        return
+    _WARNED.add(key)
+    logger.warning(msg, *args)
+
+
+def get_persona_dirs(workdir: Optional[Path] = None) -> List[Path]:
+    """Return persona directories in resolution order (highest priority first).
+
+    Project scope (``<workdir>/.hermes/agents``) wins over user scope
+    (``$HERMES_HOME/agents``) so a repo can pin its own reviewer/scout
+    definitions for everyone working in it.
+    """
+    dirs: List[Path] = []
+    if workdir is not None:
+        try:
+            dirs.append(Path(workdir).resolve() / ".hermes" / PERSONAS_DIR_NAME)
+        except (OSError, RuntimeError):  # pragma: no cover - defensive
+            logger.debug("Could not resolve workdir for personas", exc_info=True)
+    try:
+        dirs.append(get_hermes_home() / PERSONAS_DIR_NAME)
+    except (OSError, RuntimeError):  # pragma: no cover - defensive
+        logger.debug("Could not resolve HERMES_HOME for personas", exc_info=True)
+    return dirs
+
+
+def _coerce_toolsets(value: Any, field: str, name: str) -> Optional[List[str]]:
+    """Normalise a toolsets-ish frontmatter value into a list of names."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        items = [p.strip() for p in value.split(",")]
+    elif isinstance(value, (list, tuple)):
+        items = [str(p).strip() for p in value]
+    else:
+        raise PersonaError(
+            f"Persona '{name}': '{field}' must be a list or comma-separated "
+            f"string, got {type(value).__name__}."
+        )
+    cleaned = [i for i in items if i]
+    if not cleaned:
+        return None
+    return cleaned
+
+
+def _parse_persona(path: Path, text: str) -> Dict[str, Any]:
+    """Parse one persona file into a validated dict."""
+    frontmatter, body = parse_frontmatter(text)
+    stem = path.stem
+
+    name = str(frontmatter.get("name") or stem).strip().lower()
+    if not _NAME_RE.match(name):
+        raise PersonaError(
+            f"Persona at {path}: invalid name {name!r} — use lowercase "
+            "letters, digits, hyphens, or underscores (max 64 chars)."
+        )
+
+    prompt = (body or "").strip()
+    if not prompt:
+        raise PersonaError(
+            f"Persona '{name}' at {path} has an empty body; the body IS the "
+            "subagent's system prompt."
+        )
+
+    unknown = set(frontmatter) - _KNOWN_KEYS
+    if unknown:
+        logger.warning(
+            "Persona '%s' at %s declares unknown key(s) %s — ignored.",
+            name,
+            path,
+            ", ".join(sorted(unknown)),
+        )
+
+    toolsets = _coerce_toolsets(frontmatter.get("toolsets"), "toolsets", name)
+    required = _coerce_toolsets(
+        frontmatter.get("required_toolsets"), "required_toolsets", name
+    )
+
+    if required and toolsets:
+        missing = [t for t in required if t not in toolsets]
+        if missing:
+            raise PersonaError(
+                f"Persona '{name}': required_toolsets {missing} are not listed "
+                f"in toolsets {toolsets} — the persona could never satisfy its "
+                "own contract."
+            )
+
+    max_iterations = frontmatter.get("max_iterations")
+    if max_iterations is not None:
+        try:
+            max_iterations = int(max_iterations)
+        except (TypeError, ValueError):
+            raise PersonaError(
+                f"Persona '{name}': max_iterations must be an integer, got "
+                f"{max_iterations!r}."
+            )
+        if max_iterations < 1:
+            raise PersonaError(
+                f"Persona '{name}': max_iterations must be >= 1, got {max_iterations}."
+            )
+
+    effort = frontmatter.get("reasoning_effort")
+    effort = str(effort).strip() if effort is not None else None
+
+    return {
+        "name": name,
+        "description": str(frontmatter.get("description") or "").strip(),
+        "prompt": prompt,
+        "toolsets": toolsets,
+        "required_toolsets": required,
+        "reasoning_effort": effort or None,
+        "max_iterations": max_iterations,
+        "path": str(path),
+    }
+
+
+def discover_personas(workdir: Optional[Path] = None) -> Dict[str, Dict[str, Any]]:
+    """Load every readable persona, nearest scope winning on name collision.
+
+    A malformed persona is skipped with a warning rather than breaking
+    delegation entirely — one bad file must not disable the feature.  Each
+    distinct problem is warned about only once per process: discovery runs on
+    every delegation, and a broken file would otherwise flood the log.
+    """
+    found: Dict[str, Dict[str, Any]] = {}
+    for directory in get_persona_dirs(workdir):
+        if not directory.is_dir():
+            continue
+        try:
+            entries = sorted(directory.rglob("*.md"))
+        except OSError:  # pragma: no cover - defensive
+            logger.debug("Could not list personas in %s", directory, exc_info=True)
+            continue
+        for path in entries:
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                _warn_once(f"read:{path}", "Could not read persona file %s — skipped.", path)
+                continue
+            try:
+                persona = _parse_persona(path, text)
+            except PersonaError as exc:
+                _warn_once(f"parse:{path}:{exc}", "%s — skipped.", exc)
+                continue
+            # First scope to define a name wins (project before user).
+            found.setdefault(persona["name"], persona)
+    return found
+
+
+def load_persona(name: str, workdir: Optional[Path] = None) -> Dict[str, Any]:
+    """Resolve one persona by name, or raise ``PersonaError`` listing options.
+
+    The error names what is available because an unknown-agent failure is
+    otherwise indistinguishable to the model from a broken environment, and it
+    will retry identically.
+    """
+    requested = str(name or "").strip().lower()
+    personas = discover_personas(workdir)
+    if requested in personas:
+        return personas[requested]
+
+    available = ", ".join(sorted(personas)) if personas else "none defined"
+    searched = ", ".join(str(d) for d in get_persona_dirs(workdir))
+    raise PersonaError(
+        f"Unknown agent {requested!r}; available: {available}. "
+        f"Personas are markdown files with YAML frontmatter in: {searched}."
+    )

--- a/docs/subagent-personas.md
+++ b/docs/subagent-personas.md
@@ -1,0 +1,125 @@
+# Subagent personas
+
+A **persona** is a named, reusable configuration for a delegated subagent: a
+markdown file with YAML frontmatter that supplies the child's standing system
+prompt and, optionally, a narrowed set of toolsets.
+
+```markdown
+---
+name: scout
+description: Read-only reconnaissance inside one repo or directory tree.
+toolsets: [file, terminal]
+required_toolsets: [file]
+reasoning_effort: medium
+max_iterations: 30
+---
+You are a read-only scout. Answer the orchestrator's question with evidence,
+without dumping whole files back into its context.
+
+- Never create, edit, or delete files; never change git state.
+- Return conclusions, not contents: lead with the direct answer, then evidence
+  as `path/file.ext:line` references.
+- End with one line on what you did NOT check.
+```
+
+Invoke it by name:
+
+```
+delegate_task(goal="Where is retry handled in the upload path?", agent="scout")
+```
+
+`agent` also works per task, so one batch can fan out different personas:
+
+```
+delegate_task(tasks=[
+    {"goal": "Where is retry handled in the upload path?", "agent": "scout"},
+    {"goal": "Try to break the retry fix that just landed",  "agent": "critic"},
+])
+```
+
+A per-task `agent` overrides the top-level one. An unknown name fails the whole
+call rather than silently spawning an unscoped child.
+
+## Why personas exist
+
+Subagents inherit the parent's toolsets and cannot be given a narrower set by
+the model — toolset selection is a capability-scoping decision the model does
+not control. That left a gap: there was no way for a *user* to obtain a
+genuinely read-only subagent either.
+
+A persona closes that gap without reopening the original problem. The scope is
+written by a human, to disk, before any input is seen; the model may only pick
+among the personas that already exist. Narrowing is still intersected with the
+parent's toolsets, so a persona can only ever **reduce** capability.
+
+> **Scope, precisely:** a persona's `toolsets` is a real capability boundary
+> because a human fixed it in advance. It is not a defense against a
+> compromised orchestrator choosing *which* persona to invoke. Treat persona
+> scoping as blast-radius control, not as a sandbox for untrusted input.
+
+## Where personas live
+
+| Location | Scope | Priority |
+| --- | --- | --- |
+| `<workdir>/.hermes/agents/` | Current project | 1 (highest) |
+| `~/.hermes/agents/` | All your projects | 2 |
+
+Both directories are scanned recursively, so `agents/review/security.md` works.
+Identity comes from the `name` field (falling back to the filename), not the
+path. When both scopes define the same name, the project copy wins — check
+project personas into version control so a repo can pin its own reviewer.
+
+## Frontmatter reference
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string | Persona identity. Defaults to the filename stem. Lowercase letters, digits, `-`, `_`. |
+| `description` | string | What this persona is for. Helps you (and the model) pick the right one. |
+| `toolsets` | list or CSV | Toolsets the child may use. Intersected with the parent's — never widening. Omit to inherit everything the parent has. |
+| `required_toolsets` | list or CSV | Subset of `toolsets` the persona cannot work without. If the parent lacks one, the spawn fails loudly instead of producing a crippled child. |
+| `reasoning_effort` | string | Effort level for this persona's children (`low`…`max`), overriding `delegation.reasoning_effort`. Breadth recon rarely needs the same tier as deep review. |
+| `max_iterations` | int | Turn cap for this persona's children, overriding `delegation.max_iterations`. |
+
+The body below the frontmatter is the child's system prompt. It must not be empty.
+
+### `required_toolsets` — why it matters
+
+Because children intersect with the parent, a persona invoked beneath an
+already-narrowed parent silently loses tools it declares. A `coder` persona
+spawned under a read-only parent would become a read-only `coder` that fails
+for reasons the user cannot see — while the persona file on disk still claims
+it can write.
+
+Declaring `required_toolsets` turns that silent contract violation into an
+immediate, explanatory error:
+
+```
+Persona 'coder' requires toolset(s) file, which the parent agent does not have
+enabled. Subagents can only narrow, never widen, the parent's toolsets —
+enable them for the parent, or use a persona that does not require them.
+```
+
+## Error behavior
+
+An unknown persona name returns the available ones rather than a bare failure,
+because an unrecognized-name error is otherwise indistinguishable from a broken
+environment and the caller will retry identically:
+
+```
+Unknown agent 'scot'; available: critic, implementer, scout. Personas are
+markdown files with YAML frontmatter in: /repo/.hermes/agents, /home/u/.hermes/agents.
+```
+
+A malformed persona file is skipped with a warning (logged once per process)
+rather than disabling delegation — one bad file must not take the feature down.
+
+## Example personas
+
+Copy these into `~/.hermes/agents/` as a starting point. See
+`docs/subagent-personas/` in this repo.
+
+- **scout** — read-only recon; returns `path:line` anchors, never file dumps.
+- **critic** — adversarial verifier; must produce a concrete failing scenario
+  or PASS.
+- **implementer** — one bounded task in one repo, with verification required
+  before it reports done.

--- a/docs/subagent-personas/critic.md
+++ b/docs/subagent-personas/critic.md
@@ -1,0 +1,24 @@
+---
+name: critic
+description: Adversarial verifier for a completed fix, change, or claim. Tries to BREAK it and must produce a concrete failing scenario or PASS. Invoke after implementation, before declaring done.
+toolsets: [file, terminal]
+required_toolsets: [file]
+max_iterations: 25
+---
+You are the adversary. Your job is to break the artifact under review, not to
+improve it.
+
+1. Burden of proof is on you: a FAIL requires a concrete scenario — specific
+   input/state leading to specific wrong behavior — plus evidence (a command
+   you ran and its output, or a file:line contradiction). No scenario, no FAIL.
+   Every file path and line you cite must exist; verify before citing, because
+   an unverifiable citation voids the finding.
+2. Severity floor: report only findings where behavior is wrong, a contract or
+   guard rail is violated, or data/money/auth is at risk. Style, naming, and
+   "could be cleaner" are OUT OF SCOPE — do not report them at all.
+3. Run the cheap checks yourself: the repo's tests for the touched area, a
+   reproduction attempt, a contract-field search. Quote real output only.
+4. Engagement artifacts (mandatory): name the two riskiest hunks or decisions
+   and why; state what you did NOT check.
+5. Verdict: PASS, or FAIL with severity (major|critical), scenario, evidence.
+6. You do not fix anything. Report only — never modify files or git state.

--- a/docs/subagent-personas/implementer.md
+++ b/docs/subagent-personas/implementer.md
@@ -1,0 +1,32 @@
+---
+name: implementer
+description: Executes ONE clearly-bounded implementation task inside one repo, following that repo's own conventions and guard rails. Use after the orchestrator has decided what to do and where; give it exactly one task per invocation, with acceptance criteria.
+required_toolsets: [file]
+---
+You implement a scoped task inside a single repo or directory. The orchestrator
+has already made the design decisions; your job is faithful, verified
+execution.
+
+1. Load repo context before touching anything: the repo's CLAUDE.md or
+   AGENTS.md and any docs it marks as required reading. Obey it over your
+   instincts — some repos have guard suites that fail CI when their rules are
+   broken.
+2. Check tree state first (`git status -sb`). If the repo is on an unexpected
+   branch or has uncommitted work you didn't create, STOP and report back —
+   never checkout, reset, or stash someone else's state.
+3. Stay in scope. Do exactly the assigned task. If you discover the task is
+   wrong, under-specified, or requires touching things outside your assignment,
+   stop and report rather than improvising. Adjacent problems you notice go in
+   your report, not in the diff.
+4. Match the codebase. Follow existing naming, idiom, error handling, and
+   comment density. New code should read like the surrounding code.
+5. Verify before declaring done. Run the repo's own verification for what you
+   touched (tests, lint, typecheck, build — discover the commands from the
+   repo, don't assume). Never claim success without running them.
+6. Never deploy or publish. No deploy commands, package publishes, or pushes to
+   remote unless the task explicitly includes them.
+7. Escalate rather than thrash. If the same error recurs twice or the approach
+   isn't converging, stop and report — don't burn turns on blind retries.
+8. Report concisely: what changed (files plus one line each), verification
+   commands run and their ACTUAL results including failures, and anything
+   surprising the orchestrator should know.

--- a/docs/subagent-personas/scout.md
+++ b/docs/subagent-personas/scout.md
@@ -1,0 +1,26 @@
+---
+name: scout
+description: Read-only reconnaissance inside one repo or directory tree. Use for "what does X do", "where does Y live", "what would changing Z touch" — whenever answering means reading many files and only the conclusions are needed.
+toolsets: [file, terminal]
+required_toolsets: [file]
+reasoning_effort: medium
+max_iterations: 30
+---
+You are a read-only scout. Your job: answer the orchestrator's question with
+evidence, without dumping whole files back into its context.
+
+1. Load local context first. If the target directory has a CLAUDE.md or
+   AGENTS.md, read it before anything else — it encodes guard rails and
+   conventions that change the meaning of what you find.
+2. Strictly read-only. Never create, edit, or delete files; never change git
+   state (no checkout/stash/reset/pull). Shell commands are for read-only
+   inspection only (`git status -sb`, `git log`, `ls`, `rg`).
+3. Answer the question asked. Don't survey the whole repo when the question is
+   about one subsystem. If the question is ambiguous, answer the most likely
+   reading and note the ambiguity in one line.
+4. Return conclusions, not contents. Your final message is your entire value:
+   lead with the direct answer, then supporting evidence as
+   `path/file.ext:line` references with one-line explanations. Quote at most a
+   few short, load-bearing snippets. Never paste whole files.
+5. State coverage honestly. End with one line on what you did NOT check, so the
+   orchestrator knows the confidence boundary.

--- a/run_agent.py
+++ b/run_agent.py
@@ -7798,6 +7798,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            agent=function_args.get("agent"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate_personas.py
+++ b/tests/tools/test_delegate_personas.py
@@ -1,0 +1,345 @@
+"""Tests for named subagent personas (``delegate_task(agent=...)``).
+
+These assert BEHAVIOR CONTRACTS, not the current contents of any persona file:
+- a persona supplies the child's standing prompt,
+- a persona can only ever REDUCE capability (never widen), and
+- a persona that cannot get its declared requirements fails loudly.
+"""
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.subagent_personas import (
+    PersonaError,
+    discover_personas,
+    get_persona_dirs,
+    load_persona,
+)
+
+
+def _write(directory: Path, name: str, text: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{name}.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestPersonaParsing(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name) / "home"
+        self.agents = self.home / "agents"
+        patcher = patch(
+            "agent.subagent_personas.get_hermes_home", return_value=self.home
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_body_becomes_the_prompt(self):
+        _write(
+            self.agents,
+            "scout",
+            "---\nname: scout\ndescription: Recon.\n---\nYou are a read-only scout.\n",
+        )
+        persona = load_persona("scout")
+        self.assertEqual(persona["name"], "scout")
+        self.assertEqual(persona["prompt"], "You are a read-only scout.")
+
+    def test_name_defaults_to_filename(self):
+        _write(self.agents, "critic", "---\ndescription: Adversary.\n---\nBreak it.\n")
+        self.assertEqual(load_persona("critic")["name"], "critic")
+
+    def test_lookup_is_case_insensitive(self):
+        _write(self.agents, "scout", "---\nname: scout\n---\nBody.\n")
+        self.assertEqual(load_persona("SCOUT")["name"], "scout")
+
+    def test_toolsets_accepts_list_or_csv(self):
+        _write(self.agents, "a", "---\nname: a\ntoolsets: [file, web]\n---\nBody.\n")
+        _write(self.agents, "b", "---\nname: b\ntoolsets: file, web\n---\nBody.\n")
+        self.assertEqual(load_persona("a")["toolsets"], ["file", "web"])
+        self.assertEqual(load_persona("b")["toolsets"], ["file", "web"])
+
+    def test_empty_body_is_rejected(self):
+        _write(self.agents, "hollow", "---\nname: hollow\n---\n\n")
+        with self.assertRaises(PersonaError):
+            load_persona("hollow")
+
+    def test_required_toolsets_must_be_a_subset_of_toolsets(self):
+        """A persona that could never satisfy its own contract is invalid."""
+        _write(
+            self.agents,
+            "impossible",
+            "---\nname: impossible\ntoolsets: [file]\nrequired_toolsets: [web]\n---\nBody.\n",
+        )
+        with self.assertRaises(PersonaError):
+            load_persona("impossible")
+
+    def test_unknown_name_error_lists_available(self):
+        """The error must name alternatives — otherwise the model retries blind."""
+        _write(self.agents, "scout", "---\nname: scout\n---\nBody.\n")
+        with self.assertRaises(PersonaError) as ctx:
+            load_persona("scot")
+        self.assertIn("scout", str(ctx.exception))
+
+    def test_one_malformed_persona_does_not_hide_the_others(self):
+        _write(self.agents, "good", "---\nname: good\n---\nBody.\n")
+        _write(self.agents, "bad", "---\nname: bad\ntoolsets: 7\n---\nBody.\n")
+        self.assertIn("good", discover_personas())
+
+    def test_invalid_max_iterations_rejected(self):
+        _write(self.agents, "z", "---\nname: z\nmax_iterations: 0\n---\nBody.\n")
+        with self.assertRaises(PersonaError):
+            load_persona("z")
+
+
+class TestPersonaScopePriority(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.home = root / "home"
+        self.project = root / "project"
+        patcher = patch(
+            "agent.subagent_personas.get_hermes_home", return_value=self.home
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_project_scope_wins_over_user_scope(self):
+        _write(self.home / "agents", "scout", "---\nname: scout\n---\nUSER COPY.\n")
+        _write(
+            self.project / ".hermes" / "agents",
+            "scout",
+            "---\nname: scout\n---\nPROJECT COPY.\n",
+        )
+        self.assertEqual(load_persona("scout", self.project)["prompt"], "PROJECT COPY.")
+        self.assertEqual(load_persona("scout")["prompt"], "USER COPY.")
+
+    def test_project_dir_precedes_user_dir(self):
+        dirs = get_persona_dirs(self.project)
+        self.assertEqual(len(dirs), 2)
+        self.assertTrue(str(dirs[0]).endswith("project/.hermes/agents"))
+
+
+class TestPersonaCannotWidenCapability(unittest.TestCase):
+    """The ba0bc01d1f invariant: capability scoping is never widened."""
+
+    def test_schema_still_hides_toolsets_and_max_iterations(self):
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertNotIn("toolsets", props)
+        self.assertNotIn("max_iterations", props)
+        self.assertNotIn("toolsets", props["tasks"]["items"]["properties"])
+        # The persona name IS exposed — it selects among human-authored files.
+        self.assertIn("agent", props)
+        self.assertEqual(props["agent"]["type"], "string")
+
+    def test_persona_toolsets_are_intersected_with_parent(self):
+        """A persona naming a toolset the parent lacks must not gain it."""
+        from tools.delegate_tool import _expand_parent_toolsets, _resolve_parent_toolsets
+
+        class _Parent:
+            enabled_toolsets = ["file"]
+
+        parent = _resolve_parent_toolsets(_Parent())
+        available = _expand_parent_toolsets(parent)
+        self.assertNotIn("web", available)
+        # This is the same rule _build_child_agent applies to persona toolsets.
+        self.assertEqual([t for t in ["file", "web"] if t in available], ["file"])
+
+    def test_resolve_parent_toolsets_falls_back_to_defaults(self):
+        from tools.delegate_tool import DEFAULT_TOOLSETS, _resolve_parent_toolsets
+
+        self.assertEqual(_resolve_parent_toolsets(None), set(DEFAULT_TOOLSETS))
+
+
+class TestPersonaReachesChildBuilder(unittest.TestCase):
+    """The persona's declared settings must actually reach the child."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name) / "home"
+        _write(
+            self.home / "agents",
+            "lowscout",
+            "---\nname: lowscout\ntoolsets: [file]\nreasoning_effort: low\n"
+            "max_iterations: 7\n---\nBreadth recon only.\n",
+        )
+        patcher = patch(
+            "agent.subagent_personas.get_hermes_home", return_value=self.home
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _spawn_and_capture(self, **kwargs):
+        import tools.delegate_tool as dt
+
+        captured = {}
+
+        def _fake_build(**kw):
+            captured.update(kw)
+            raise RuntimeError("stop-after-build")
+
+        class _Parent:
+            enabled_toolsets = ["file", "terminal", "web"]
+            valid_tool_names = ["read_file"]
+            session_id = "s"
+            model = "m"
+            provider = "p"
+            reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        with patch.object(
+            dt, "_build_child_preserving_parent_tools", side_effect=_fake_build
+        ):
+            try:
+                dt.delegate_task(parent_agent=_Parent(), **kwargs)
+            except Exception:
+                pass
+        return captured
+
+    def test_persona_narrows_toolsets_and_sets_effort_and_iterations(self):
+        cap = self._spawn_and_capture(goal="find X", context="ctx", agent="lowscout")
+        self.assertEqual(cap.get("toolsets"), ["file"])
+        self.assertEqual(cap.get("reasoning_effort"), "low")
+        self.assertEqual(cap.get("max_iterations"), 7)
+
+    def test_persona_prompt_leads_context_and_task_context_survives(self):
+        cap = self._spawn_and_capture(goal="find X", context="TASKCTX", agent="lowscout")
+        context = str(cap.get("context"))
+        self.assertTrue(context.startswith("Breadth recon only."))
+        self.assertIn("TASKCTX", context)
+        self.assertEqual(cap.get("goal"), "find X")
+
+    def test_no_persona_leaves_routing_untouched(self):
+        """Without agent=, nothing about the existing path changes."""
+        cap = self._spawn_and_capture(goal="find X")
+        self.assertIsNone(cap.get("toolsets"))
+        self.assertIsNone(cap.get("reasoning_effort"))
+
+
+class TestPerTaskPersona(unittest.TestCase):
+    """A per-task `agent` must be honored, not silently ignored."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name) / "home"
+        agents = self.home / "agents"
+        _write(
+            agents,
+            "reader",
+            "---\nname: reader\ntoolsets: [file]\nmax_iterations: 7\n---\nRead only.\n",
+        )
+        _write(
+            agents,
+            "runner",
+            "---\nname: runner\ntoolsets: [terminal]\nmax_iterations: 9\n---\nRun things.\n",
+        )
+        patcher = patch(
+            "agent.subagent_personas.get_hermes_home", return_value=self.home
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _spawn_batch(self, tasks, **kwargs):
+        import tools.delegate_tool as dt
+
+        captured = []
+
+        def _fake_build(**kw):
+            captured.append(kw)
+            return type(
+                "_C",
+                (),
+                {
+                    "enabled_toolsets": kw.get("toolsets"),
+                    "session_id": "c",
+                    "_session_init_model_config": None,
+                },
+            )()
+
+        class _Parent:
+            enabled_toolsets = ["file", "terminal", "web"]
+            valid_tool_names = ["read_file"]
+            session_id = "s"
+            model = "m"
+            provider = "p"
+            reasoning_config = None
+
+        with patch.object(
+            dt, "_build_child_preserving_parent_tools", side_effect=_fake_build
+        ):
+            try:
+                dt.delegate_task(tasks=tasks, parent_agent=_Parent(), **kwargs)
+            except Exception:
+                pass
+        return captured
+
+    def test_one_batch_can_fan_out_different_personas(self):
+        cap = self._spawn_batch(
+            [
+                {"goal": "read the upload retry path", "agent": "reader"},
+                {"goal": "run the retry test suite", "agent": "runner"},
+            ]
+        )
+        self.assertEqual(len(cap), 2)
+        self.assertEqual(cap[0]["toolsets"], ["file"])
+        self.assertEqual(cap[0]["max_iterations"], 7)
+        self.assertEqual(cap[1]["toolsets"], ["terminal"])
+        self.assertEqual(cap[1]["max_iterations"], 9)
+
+    def test_per_task_agent_overrides_top_level(self):
+        cap = self._spawn_batch(
+            [
+                {"goal": "read the upload retry path", "agent": "runner"},
+                {"goal": "read the download retry path"},
+            ],
+            agent="reader",
+        )
+        self.assertEqual(cap[0]["toolsets"], ["terminal"])  # per-task wins
+        self.assertEqual(cap[1]["toolsets"], ["file"])  # falls back to top-level
+
+    def test_unknown_per_task_agent_fails_the_call(self):
+        """Must error, not silently ignore — the caller can't see a no-op."""
+        import tools.delegate_tool as dt
+
+        class _Parent:
+            enabled_toolsets = ["file"]
+            valid_tool_names = ["read_file"]
+            session_id = "s"
+            model = "m"
+            provider = "p"
+
+        result = dt.delegate_task(
+            tasks=[
+                {"goal": "a genuine first task here", "agent": "nope"},
+                {"goal": "a genuine second task here"},
+            ],
+            parent_agent=_Parent(),
+        )
+        self.assertIn("nope", result)
+        self.assertIn("reader", result)  # lists what IS available
+
+    def test_per_task_agent_is_in_the_schema(self):
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+
+        item_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"][
+            "properties"
+        ]
+        self.assertIn("agent", item_props)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -774,6 +774,29 @@ def _is_mcp_toolset_name(name: str) -> bool:
     return bool(target and str(target).startswith("mcp-"))
 
 
+def _resolve_parent_toolsets(parent_agent) -> set:
+    """Derive the parent's effective toolset names.
+
+    ``enabled_toolsets=None`` means "all tools enabled" (the default), so in
+    that case the set is reconstructed from the parent's loaded tool names.
+    Shared by ``_build_child_agent`` (for the child intersection) and by the
+    persona ``required_toolsets`` precheck, so both judge availability by
+    exactly the same rule.
+    """
+    parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
+    if parent_enabled is not None:
+        return set(parent_enabled)
+    if parent_agent and hasattr(parent_agent, "valid_tool_names"):
+        import model_tools
+
+        return {
+            ts
+            for name in parent_agent.valid_tool_names
+            if (ts := model_tools.get_toolset_for_tool(name)) is not None
+        }
+    return set(DEFAULT_TOOLSETS)
+
+
 def _expand_parent_toolsets(parent_toolsets: set) -> set:
     """Expand composite toolsets so individual toolset names are recognized.
 
@@ -1321,6 +1344,9 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Per-call reasoning effort from a user-authored persona. Takes precedence
+    # over delegation.reasoning_effort; None means "use the config default".
+    reasoning_effort: Optional[str] = None,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1362,22 +1388,8 @@ def _build_child_agent(
 
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
-    # Note: enabled_toolsets=None means "all tools enabled" (the default),
-    # so we must derive effective toolsets from the parent's loaded tools.
+    parent_toolsets = _resolve_parent_toolsets(parent_agent)
     parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
-    if parent_enabled is not None:
-        parent_toolsets = set(parent_enabled)
-    elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
-        # enabled_toolsets is None (all tools) — derive from loaded tool names
-        import model_tools
-
-        parent_toolsets = {
-            ts
-            for name in parent_agent.valid_tool_names
-            if (ts := model_tools.get_toolset_for_tool(name)) is not None
-        }
-    else:
-        parent_toolsets = set(DEFAULT_TOOLSETS)
 
     if toolsets:
         # Intersect with parent — subagent must not gain tools the parent lacks.
@@ -1545,14 +1557,20 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config: persona override > delegation config > parent.
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
         # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean
         # False (``reasoning_effort: false``) to "" and inherit the parent
         # instead of disabling thinking for children.
+        effort_source = "delegation.reasoning_effort"
         delegation_effort = delegation_cfg.get("reasoning_effort")
+        if reasoning_effort is not None:
+            # A persona names the effort its job needs (breadth recon wants a
+            # lower tier than deep review), so it outranks the global default.
+            delegation_effort = reasoning_effort
+            effort_source = "persona reasoning_effort"
         if delegation_effort or delegation_effort is False:
             from hermes_constants import parse_reasoning_effort
 
@@ -1561,7 +1579,8 @@ def _build_child_agent(
                 child_reasoning = parsed
             else:
                 logger.warning(
-                    "Unknown delegation.reasoning_effort '%s', inheriting parent level",
+                    "Unknown %s '%s', inheriting parent level",
+                    effort_source,
                     delegation_effort,
                 )
     except Exception as exc:
@@ -3137,6 +3156,7 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    agent: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3264,6 +3284,67 @@ def delegate_task(
         if batch_error:
             return tool_error(batch_error)
 
+    # Resolve the named persona(s). A persona is a user-authored markdown file
+    # (see agent/subagent_personas.py) that pre-declares the child's system
+    # prompt and, optionally, a narrowed toolset. Capability scoping stays
+    # human-owned: the model may only pick among personas the user already
+    # wrote to disk, and any narrowing is still intersected with the parent's
+    # toolsets downstream, so a persona can never grant a capability the
+    # parent lacks.
+    #
+    # Resolved up front (before any child is built) so a bad persona name or
+    # an unsatisfiable requirement fails the whole call loudly, matching the
+    # output_schema precedent below — rather than spawning some children and
+    # then erroring, or silently ignoring the request.
+    _persona_workdir = None
+    if agent is not None or any(
+        isinstance(t, dict) and t.get("agent") for t in (task_list or [])
+    ):
+        from pathlib import Path as _Path
+
+        _wd = _resolve_workspace_hint(parent_agent)
+        if _wd:
+            _persona_workdir = _Path(_wd)
+
+    task_personas: List[Optional[Dict[str, Any]]] = []
+    for i, task in enumerate(task_list):
+        # Per-task agent wins over the top-level one, so a single batch can
+        # fan out a scout and a critic at once.
+        requested = task.get("agent") or agent
+        if not (requested and str(requested).strip()):
+            task_personas.append(None)
+            continue
+        from agent.subagent_personas import PersonaError, load_persona
+
+        try:
+            persona = load_persona(str(requested), _persona_workdir)
+        except PersonaError as exc:
+            # Name the available personas: an unknown-agent failure is
+            # otherwise indistinguishable from a broken environment and the
+            # model will retry identically.
+            return tool_error(f"Task {i}: {exc}")
+
+        # A persona that declares required_toolsets must actually be able to
+        # receive them. The parent intersection can silently strip a toolset
+        # the persona depends on (e.g. a `coder` spawned beneath a read-only
+        # parent), producing a child that fails opaquely while the user,
+        # reading the persona file, believes it can write.
+        _required = persona.get("required_toolsets") or []
+        if _required:
+            _available = _expand_parent_toolsets(
+                _resolve_parent_toolsets(parent_agent)
+            )
+            _missing = [t for t in _required if t not in _available]
+            if _missing:
+                return tool_error(
+                    f"Task {i}: persona '{persona['name']}' requires toolset(s) "
+                    f"{', '.join(_missing)}, which the parent agent does not "
+                    "have enabled. Subagents can only narrow, never widen, the "
+                    "parent's toolsets — enable them for the parent, or use a "
+                    "persona that does not require them."
+                )
+        task_personas.append(persona)
+
     # T1-24: coerce/validate optional per-task output_schema up front so a
     # malformed schema fails the whole call loudly instead of spawning
     # children that can never satisfy their contract. Runs AFTER the
@@ -3342,15 +3423,31 @@ def delegate_task(
             from tools.delegation_output_schema import append_output_contract
 
             _child_context = append_output_contract(_child_context, _task_schema)
+        # A persona's prompt is prepended to the task context so the child's
+        # role framing arrives ahead of task specifics. The goal stays the
+        # model's; the persona supplies the standing instructions.
+        _persona = task_personas[i] if i < len(task_personas) else None
+        if _persona is not None:
+            _child_context = (
+                f"{_persona['prompt']}\n\n---\n\n{_child_context}"
+                if _child_context
+                else _persona["prompt"]
+            )
         child = _build_child_preserving_parent_tools(
             task_index=i,
             goal=t["goal"],
             context=_child_context,
-            # Subagents always inherit the parent's toolsets; the model
-            # cannot choose or narrow them (no model-facing toolsets arg).
-            toolsets=None,
+            # The model still cannot name toolsets: the only narrowing that
+            # reaches here comes from a user-authored persona file, and
+            # _build_child_agent intersects it with the parent's so it can
+            # only ever reduce capability (ba0bc01d1f).
+            toolsets=(_persona.get("toolsets") if _persona else None),
             model=creds["model"],
-            max_iterations=effective_max_iter,
+            max_iterations=(
+                int(_persona["max_iterations"])
+                if _persona and _persona.get("max_iterations")
+                else effective_max_iter
+            ),
             task_count=n_tasks,
             parent_agent=parent_agent,
             override_provider=creds["provider"],
@@ -3361,6 +3458,7 @@ def delegate_task(
             override_max_tokens=creds.get("max_output_tokens"),
             override_acp_command=creds.get("command"),
             override_acp_args=creds.get("args"),
+            reasoning_effort=(_persona.get("reasoning_effort") if _persona else None),
             role=effective_role,
         )
         # Attach the validated schema for the completion-side validation
@@ -4241,6 +4339,14 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "agent": {
+                            "type": "string",
+                            "description": (
+                                "Per-task persona override. See top-level "
+                                "'agent'. Lets one batch fan out different "
+                                "personas (e.g. a scout and a critic)."
+                            ),
+                        },
                         "output_schema": {
                             "type": "object",
                             "description": (
@@ -4273,6 +4379,18 @@ DELEGATE_TASK_SCHEMA = {
                     "Optional JSON Schema for the single-goal form — the "
                     "subagent's final answer must validate against it "
                     "(same semantics as tasks[].output_schema)."
+                ),
+            },
+            "agent": {
+                "type": "string",
+                "description": (
+                    "Optional name of a user-authored persona to run this "
+                    "delegation as (e.g. 'scout', 'critic'). Personas are "
+                    "markdown files with YAML frontmatter in "
+                    "~/.hermes/agents/ or <workdir>/.hermes/agents/; each "
+                    "supplies the subagent's standing system prompt and may "
+                    "narrow its toolsets. Omit to use the default worker. On "
+                    "an unknown name the error lists the available personas."
                 ),
             },
             "background": {
@@ -4348,6 +4466,7 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
+        agent=args.get("agent"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## What

Adds **named subagent personas**: user-authored markdown files that supply a
delegated child's standing system prompt and, optionally, a narrowed toolset.

```
delegate_task(goal="Where is retry handled in the upload path?", agent="scout")
```

```markdown
---
name: scout
description: Read-only reconnaissance inside one repo or directory tree.
toolsets: [file, terminal]
required_toolsets: [file]
max_iterations: 30
---
You are a read-only scout. Return conclusions as `path:line` anchors,
never whole files. Never create, edit, or delete anything.
```

Personas resolve from `<workdir>/.hermes/agents/` (project scope, wins) then
`~/.hermes/agents/` (user scope).

`agent` also works per task, so one batch can fan out different personas — a
scout and a critic side by side. A per-task `agent` overrides the top-level
one, and an unknown name fails the whole call rather than silently spawning an
unscoped child.

## Why, and how this relates to ba0bc01d1f

ba0bc01d1f removed the model-facing `toolsets` argument, on the grounds that
*"toolset selection is a capability-scoping decision the model should not
control."* **That decision is preserved here, not reverted** — `toolsets` and
`max_iterations` remain absent from the tool schema, and the regression tests
in `test_delegate.py::test_schema_valid` still pass unchanged.

But that commit left a gap: because children always inherit the parent's full
toolset, there was no way for a *user* to obtain a genuinely read-only subagent
either. Briefing a child "you are read-only" is an instruction, not a
constraint — it still holds `write_file` and `patch`.

A persona closes the gap without reopening the problem:

- The scope is authored by a **human**, on disk, **before any input is seen**.
- The model may only select among personas that already exist; it cannot
  synthesise a capability scope at call time.
- Narrowing is still intersected with the parent's toolsets in
  `_build_child_agent`, so a persona can only ever **reduce** capability.

The `agent` field is a free-form string validated at call time, deliberately
**not** an enum populated from the filesystem — an enum would make the tool
schema machine-specific, so two users' transcripts would not be comparable and
bug reports would not reproduce.

## `required_toolsets`

Because children intersect with the parent, a persona invoked beneath an
already-narrowed parent silently loses tools it declares. A `coder` spawned
under a read-only parent becomes a read-only `coder` that fails for reasons the
user cannot see — while the persona file still claims it can write. That turns
a per-call surprise into a violated named contract.

`required_toolsets` makes that failure loud and explanatory, checked **before**
any child is constructed:

```
Persona 'coder' requires toolset(s) file, which the parent agent does not have
enabled. Subagents can only narrow, never widen, the parent's toolsets —
enable them for the parent, or use a persona that does not require them.
```

## Error behavior

An unknown persona name lists the available ones. An unrecognised-name error is
otherwise indistinguishable from a broken environment, and the caller retries
identically:

```
Unknown agent 'scot'; available: critic, implementer, scout. Personas are
markdown files with YAML frontmatter in: /repo/.hermes/agents, /home/u/.hermes/agents.
```

A malformed persona file is skipped with a warning (logged once per process, so
a broken file can't flood the log on every spawn) rather than disabling
delegation entirely.

## Invariants preserved

- **Prompt caching is untouched.** Personas resolve once at spawn, before the
  child's system prompt is built. Nothing mutates a live conversation's prefix.
- **No new core model tool.** This is one optional string field on an existing
  tool, not new surface shipped on every API call.
- **No new `HERMES_*` env var.** Discovery uses existing `HERMES_HOME`
  resolution and a workdir-relative directory.
- **Privilege reduction only**, enforced by the pre-existing intersection.

## Files

| File | Change |
| --- | --- |
| `agent/subagent_personas.py` | New. Discovery, parsing, validation. Reuses `agent/skill_utils.parse_frontmatter` (same BOM/YAML hardening as skills). |
| `tools/delegate_tool.py` | `agent` param + top-level and per-task schema fields; persona resolution; `required_toolsets` precheck; per-persona `reasoning_effort`; extracted `_resolve_parent_toolsets` helper. |
| `run_agent.py` | Thread `agent` through `_dispatch_delegate_task`. |
| `tests/tools/test_delegate_personas.py` | New. 22 tests. |
| `docs/subagent-personas.md` | New. Reference documentation. |
| `docs/subagent-personas/{scout,critic,implementer}.md` | New. Working examples, verified to load. |

`_resolve_parent_toolsets` was extracted from the inline block in
`_build_child_agent` so the new precheck and the existing intersection judge
toolset availability by exactly the same rule, rather than duplicating the
logic and letting the two drift.

## Testing

- `tests/tools/test_delegate_personas.py` — 22 new tests, all behavior
  contracts rather than change-detectors: body-becomes-prompt, scope priority,
  case-insensitive lookup, empty-body rejection, `required_toolsets ⊆ toolsets`
  validation, unknown-name-lists-alternatives, one-bad-file-doesn't-hide-others,
  and explicit assertions that the schema still hides `toolsets` and
  `max_iterations`, and that a per-task `agent` is honored rather than
  silently ignored.
- Existing delegation suites pass unchanged, including the ba0bc01d1f
  regression tests.
- End-to-end verified against a real parent: parent holding
  `[file, terminal, web]` + persona declaring `toolsets: [file]` produces a
  child built with exactly `['file']`, persona prompt leading the context, task
  context and goal preserved.
