### PR TITLE
feat(gateway): config flag to omit model/provider from reset notices

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -940,6 +940,14 @@ class GatewayConfig:
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
 
+    # Reset notices (manual /new-//reset replies and auto-reset
+    # notifications) append a session-info block: model, provider, context
+    # window. Set False to omit that block — e.g. multi-user group chats
+    # where the operator prefers not to advertise the runtime identity.
+    # The block is emitted by the gateway itself, so no system-prompt
+    # instruction can suppress it; only this switch can.
+    reset_notice_session_info: bool = True
+
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
@@ -1073,6 +1081,7 @@ class GatewayConfig:
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "loop_watchdog": self.loop_watchdog,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
+            "reset_notice_session_info": self.reset_notice_session_info,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
             "profile_routes": [
@@ -1211,6 +1220,9 @@ class GatewayConfig:
             loop_watchdog=loop_watchdog,
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
+            reset_notice_session_info=_coerce_bool(
+                data.get("reset_notice_session_info"), True
+            ),
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
             profile_routes=profile_routes,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18809,7 +18809,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         HTTP probes) that must not run on the event loop. The scope is entered
         inside this method, so contextvars behave correctly in the worker
         thread.
+
+        Returns ``""`` when ``reset_notice_session_info`` is disabled — the
+        single choke point for both the manual /new-//reset reply and the
+        auto-reset notice, so operators of multi-user group chats can keep
+        model/provider details out of platform-emitted messages.
         """
+        if not getattr(
+            getattr(self, "config", None), "reset_notice_session_info", True
+        ):
+            return ""
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
                 return self._format_session_info()

--- a/tests/gateway/test_reset_notice_session_info.py
+++ b/tests/gateway/test_reset_notice_session_info.py
@@ -1,0 +1,56 @@
+"""reset_notice_session_info: keep model/provider out of reset notices.
+
+The manual /new-//reset reply and the auto-reset notification both append a
+session-info block (model, provider, context window) resolved by
+``GatewayRunner._reset_notice_session_info``. That block is emitted by the
+gateway itself, so no system-prompt instruction can suppress it — operators
+of multi-user group chats need a config switch to keep the runtime identity
+private. These tests cover the config plumbing and the single choke point.
+"""
+
+from types import SimpleNamespace
+
+from gateway.config import GatewayConfig
+from gateway.run import GatewayRunner
+
+
+def test_config_defaults_to_showing_session_info():
+    cfg = GatewayConfig.from_dict({})
+    assert cfg.reset_notice_session_info is True
+
+
+def test_config_parses_disabled_value():
+    cfg = GatewayConfig.from_dict({"reset_notice_session_info": False})
+    assert cfg.reset_notice_session_info is False
+    # String forms coming from hand-edited YAML must coerce too.
+    cfg = GatewayConfig.from_dict({"reset_notice_session_info": "false"})
+    assert cfg.reset_notice_session_info is False
+
+
+def test_config_round_trips_through_to_dict():
+    cfg = GatewayConfig.from_dict({"reset_notice_session_info": False})
+    assert cfg.to_dict()["reset_notice_session_info"] is False
+
+
+def _stub_runner(reset_notice_session_info: bool) -> SimpleNamespace:
+    """Minimal stand-in exercising the real unbound method."""
+    stub = SimpleNamespace(
+        config=SimpleNamespace(
+            reset_notice_session_info=reset_notice_session_info,
+            multiplex_profiles=False,
+        ),
+        _format_session_info=lambda: "◆ Model: `some-model`",
+    )
+    return stub
+
+
+def test_session_info_returned_when_enabled():
+    stub = _stub_runner(reset_notice_session_info=True)
+    result = GatewayRunner._reset_notice_session_info(stub, source=None)
+    assert "some-model" in result
+
+
+def test_session_info_suppressed_when_disabled():
+    stub = _stub_runner(reset_notice_session_info=False)
+    result = GatewayRunner._reset_notice_session_info(stub, source=None)
+    assert result == ""

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -727,6 +727,19 @@ Before a session is auto-reset, the agent is given a turn to save any important 
 
 Sessions with **active background processes** are never auto-reset, regardless of policy.
 
+Reset notices — the `/new`-`/reset` confirmation and the auto-reset
+notification — append a session-info block showing the model, provider, and
+context window. In multi-user group chats you may prefer not to advertise the
+runtime identity; disable the block with:
+
+```yaml
+gateway:
+  reset_notice_session_info: false
+```
+
+The block is emitted by the gateway itself (not the model), so a system-prompt
+instruction cannot suppress it — only this setting can.
+
 ### Continuity After Crashes and Restarts
 
 A gateway chat is designed to be **one continuous session** — compacted


### PR DESCRIPTION
The \`/new\`-\`/reset\` confirmation reply and the auto-reset notification both append a session-info block — model, provider, context window — resolved by \`GatewayRunner._reset_notice_session_info\`.

That block is emitted by the **gateway itself**, so no system-prompt / SOUL instruction can suppress it. In a multi-user group chat an operator may legitimately not want to advertise the runtime identity to every participant, and today there is no way to turn it off.

## Change

- New \`gateway.reset_notice_session_info\` config flag, **default \`True\`** (fully behavior-preserving).
- Gated at the single choke point both the manual reply and the auto-reset notice already share (\`_reset_notice_session_info\`): returns \`""\` when disabled, so the notices carry only the reset message.
- \`to_dict\`/\`from_dict\` plumbing with \`_coerce_bool\`, matching the surrounding fields (e.g. \`unauthorized_dm_behavior\`).
- Docs under *Session Reset Policies*.

## Tests

\`tests/gateway/test_reset_notice_session_info.py\` — config default/parse/round-trip, and the choke point (enabled → block present, disabled → empty string). 5 passing.

## Notes

The pre-existing failures in \`tests/gateway/test_unauthorized_dm_behavior.py\` reproduce on a clean checkout in my environment (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)