### PR TITLE
fix(gateway): route multiplex clarify replies by profile

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6045,9 +6045,25 @@ class BasePlatformAdapter(ABC):
             if not cmd:
                 try:
                     from tools import clarify_gateway as _clarify_mod
+                    # Adapter busy guards are isolated per adapter, so their
+                    # active-session keys retain the legacy ``agent:main``
+                    # namespace. Clarify entries, however, are registered by
+                    # the multiplexing runner under the routed profile's
+                    # namespace. Resolve that canonical key for the lookup so
+                    # secondary-profile replies bypass busy handling too.
+                    _clarify_session_key = build_session_key(
+                        event.source,
+                        group_sessions_per_user=self.config.extra.get(
+                            "group_sessions_per_user", True,
+                        ),
+                        thread_sessions_per_user=self.config.extra.get(
+                            "thread_sessions_per_user", False,
+                        ),
+                        profile=event.source.profile,
+                    )
                     _has_text_clarify = (
                         _clarify_mod.get_pending_for_session(
-                            session_key,
+                            _clarify_session_key,
                             include_choice_prompts=True,
                         ) is not None
                     )
@@ -6057,7 +6073,7 @@ class BasePlatformAdapter(ABC):
                 if _has_text_clarify:
                     logger.debug(
                         "[%s] Routing message to clarify text-intercept for %s",
-                        self.name, session_key,
+                        self.name, _clarify_session_key,
                     )
                     try:
                         _thread_meta = _thread_metadata_for_source(

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -87,3 +87,44 @@ async def test_active_session_routes_typed_choice_clarify_reply_to_runner_not_bu
     assert adapter._pending_messages == {}
 
 
+@pytest.mark.asyncio
+async def test_active_session_routes_secondary_profile_clarify_reply_to_runner():
+    """Multiplexed clarify lookup must use the routed profile namespace."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter()
+    adapter._message_handler = AsyncMock(return_value="")
+    adapter._busy_session_handler = AsyncMock(return_value=True)
+    event = _event("1")
+    event.source.profile = "research"
+
+    adapter_session_key = build_session_key(
+        event.source,
+        group_sessions_per_user=adapter.config.extra.get(
+            "group_sessions_per_user", True,
+        ),
+        thread_sessions_per_user=adapter.config.extra.get(
+            "thread_sessions_per_user", False,
+        ),
+    )
+    clarify_session_key = build_session_key(
+        event.source,
+        group_sessions_per_user=adapter.config.extra.get(
+            "group_sessions_per_user", True,
+        ),
+        thread_sessions_per_user=adapter.config.extra.get(
+            "thread_sessions_per_user", False,
+        ),
+        profile=event.source.profile,
+    )
+    assert adapter_session_key != clarify_session_key
+
+    adapter._active_sessions[adapter_session_key] = asyncio.Event()
+    cm.register("clarify-secondary", clarify_session_key, "Pick one", ["A", "B"])
+
+    await adapter.handle_message(event)
+
+    adapter._message_handler.assert_awaited_once_with(event)
+    adapter._busy_session_handler.assert_not_awaited()
+    assert adapter._pending_messages == {}


### PR DESCRIPTION
## What does this PR do?

Routes active-session clarify replies through a profile-aware session key.

Under gateway multiplexing, the adapter busy guard remains adapter-local and uses the legacy `agent:main` key, while a pending clarify request for a named profile is stored under `agent:<profile>`. The previous clarify bypass reused the adapter-local key, so replies for secondary profiles missed the pending clarify and fell through to the busy interrupt path.

The fix builds a canonical clarify lookup key from the inbound event, including `event.source.profile`, while leaving adapter-local active-session bookkeeping unchanged. This preserves default-profile behavior and routes secondary-profile replies to the existing clarify resolver.

## Related Issue

Fixes #83345

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: build the pending-clarify lookup key with the routed source profile.
- `tests/gateway/test_clarify_active_session_bypass.py`: add a behavioral regression test covering an adapter busy key under `agent:main` and pending clarify under `agent:research`.

## How to Test

1. Configure one gateway process with `gateway.multiplex_profiles: true`, a default profile, and a named secondary profile.
2. Start a task through the secondary profile that invokes `clarify`, then reply with a choice such as `1`.
3. Verify that the reply reaches the clarify resolver, the same agent turn continues, and the busy interrupt handler is not invoked.

Focused automated verification:

```text
scripts/run_tests.sh tests/gateway/test_clarify_active_session_bypass.py tests/gateway/test_clarify_thread_followup_not_swallowed.py tests/gateway/test_multiplex_adapter_registry.py -q
3 files, 18 tests passed, 0 failed
```

```text
ruff check gateway/platforms/base.py tests/gateway/test_clarify_active_session_bypass.py
All checks passed
```

The original behavior was reproduced on a Linux gateway. The focused regression suite was run on Linux with Python 3.11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run the complete test suite locally; focused affected tests pass and the full repository suite is pending CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux, Python 3.11

### Documentation & Housekeeping

- [x] Documentation update: N/A — no public interface or configuration changes
- [x] `cli-config.yaml.example` update: N/A — no configuration keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A — no architecture or workflow changes
- [x] Cross-platform impact considered: the change only affects profile-aware session-key construction and introduces no OS-specific behavior
- [x] Tool descriptions/schemas update: N/A — no tool contract changed

## Screenshots / Logs

No deployment screenshots or private gateway logs are attached because they may contain messaging identifiers. The minimal reproduction, focused test output, and regression test contain no account or peer data.