### PR TITLE
fix(ci): review comment poller deadlocked on its own run

### DIFF
--- a/.github/workflows/ci-review-comment.yml
+++ b/.github/workflows/ci-review-comment.yml
@@ -58,9 +58,12 @@ jobs:
       - name: Run live comment poller
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          # The CI run to report on — not this run.
-          GITHUB_RUN_ID: ${{ github.event.workflow_run.id }}
+          # The CI run to report on — not this run. The name must not be
+          # GITHUB_RUN_ID: the runner sets the GITHUB_* defaults itself and
+          # ignores an env: override, so that name silently resolves to THIS
+          # run. The poller then watches itself, which stays in_progress for
+          # as long as the poller runs, and it waits out its whole timeout.
+          CI_RUN_ID: ${{ github.event.workflow_run.id }}
           # Sibling runs for the same commit that the comment also covers,
           # one workflow name per line (a name can contain a comma).
           # The poller resolves each name to its runs through the API.

--- a/scripts/ci/live_comment.py
+++ b/scripts/ci/live_comment.py
@@ -12,8 +12,13 @@ The comment is identified by the ``<!-- hermes-ci-review-bot -->`` marker
 previous comment from an earlier run.
 
 This runs from ``.github/workflows/ci-review-comment.yml``, a separate
-``workflow_run`` workflow. Thus ``GITHUB_RUN_ID`` names the CI run to report
-on, not the run that contains this script. The poller reports on runs that
+``workflow_run`` workflow. Thus ``CI_RUN_ID`` names the CI run to report
+on, not the run that contains this script. (The variable cannot be
+called ``GITHUB_RUN_ID``: the Actions runner sets the ``GITHUB_*``
+defaults itself and ignores an ``env:`` override, so that name would
+silently resolve to the poller's own run — which stays ``in_progress``
+for as long as the poller runs, deadlocking it against itself.)
+The poller reports on runs that
 it does not belong to. This is also how it covers a workflow that CI does
 not contain: ``WATCH_WORKFLOWS`` names sibling workflows that the same
 commit triggered (the Docker image build). Their jobs join the comment.
@@ -721,7 +726,7 @@ def main() -> int:
 
     token = os.environ.get("GITHUB_TOKEN", "")
     repo = os.environ.get("GITHUB_REPOSITORY", "")
-    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    run_id = os.environ.get("CI_RUN_ID", "")
     pr_number = os.environ.get("PR_NUMBER", "")
     run_url = os.environ.get("RUN_URL", "")
 
@@ -737,7 +742,7 @@ def main() -> int:
             print("GITHUB_REPOSITORY is required", file=sys.stderr)
             return 1
         if not run_id:
-            print("GITHUB_RUN_ID is required", file=sys.stderr)
+            print("CI_RUN_ID is required", file=sys.stderr)
             return 1
 
     # Build commit info line from env vars (set by ci-review-comment.yml).


### PR DESCRIPTION
## What does this PR do?

Since #83139-era commit `7aecab56d` moved the review comment into its own `workflow_run` workflow, the live poller has deadlocked on every PR: the comment freezes at "waiting for jobs to start…" and the job burns its full 3000s timeout, even when all checks passed long ago (see PR #83262 — all green at 15:28, poller still waiting at 16:06).

Root cause: the workflow passed the CI run id as `GITHUB_RUN_ID` in `env:`. The Actions runner sets the `GITHUB_*` default variables itself and **ignores `env:` overrides** ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables): "You can't overwrite the value of the default environment variables named `GITHUB_*` and `RUNNER_*`"). So the poller read its **own** run id and watched itself. Its own run stays `in_progress` for exactly as long as the poller runs, so `runs_all_completed()` (from `8359e760b`) could never become true. The "6 review jobs" in the stuck logs were the watched Docker sibling run — the only run it resolved correctly, via `head_sha`.

This went unnoticed before `8359e760b` because the old exit condition (`not pending`) didn't consult run status — the self-watch bug was latent; that fix armed it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ci-review-comment.yml`: rename the variable to `CI_RUN_ID`, with a comment on why the `GITHUB_` name silently fails. Also drop the `GITHUB_REPOSITORY` override — a no-op for the same reason, and the runner default already holds the right value.
- `live_comment.py`: read `CI_RUN_ID`, update the docstring and the missing-var error.

## Verification

- Ran the patched poller locally (dry-run) with `CI_RUN_ID=31401588943` (the exact run the stuck poller watched for #83262): it fetched all 44 jobs of the CI run, used the 10s grace pass, and exited "All jobs completed — done."
- Reproduced the failure mode with the old env name: the poller sees only the 7 Docker sibling jobs and loops on "a run is still queued or in progress".
- `scripts/run_tests.sh tests/ci/` — 101 tests passed, 0 failed.
- Swept `.github/workflows/` for other `env:` overrides of `GITHUB_*` defaults: this was the only site.
