### PR TITLE
fix: guard MCP dynamic refresh during session teardown

### DIFF
--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -1,6 +1,7 @@
 """Tests for MCP dynamic tool discovery (notifications/tools/list_changed)."""
 
 import asyncio
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -74,6 +75,50 @@ class TestRefreshTools:
             assert "mcp__live_srv__new_tool" in mock_registry.get_all_tool_names()
             assert "mcp__live_srv__new_tool" in resolve_toolset("live_srv")
             assert server._registered_tool_names == ["mcp__live_srv__new_tool"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_skips_when_session_disappears_before_list_tools(self, mock_registry, caplog):
+        """A dynamic refresh must not crash if teardown clears session first."""
+        caplog.set_level(logging.INFO, logger="tools.mcp_tool")
+
+        class OldSession:
+            async def list_tools(self, *args, **kwargs):  # pragma: no cover - should not run
+                raise AssertionError("stale session should not be queried")
+
+        class RaceRpcLock:
+            def __init__(self, server):
+                self.server = server
+
+            async def __aenter__(self):
+                self.server.session = None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def locked(self):
+                return False
+
+        server = MCPServerTask("live_srv")
+        server._refresh_lock = asyncio.Lock()
+        server._rpc_lock = RaceRpcLock(server)
+        server._config = {}
+        server.session = OldSession()
+        server._registered_tool_names = ["mcp__live_srv__old_tool"]
+
+        with patch("tools.registry.registry", mock_registry):
+            await server._refresh_tools()
+
+        assert server._registered_tool_names == ["mcp__live_srv__old_tool"]
+        assert "session is not connected" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_refresh_task_does_not_log_failure_when_session_disappears(self, caplog):
+        server = MCPServerTask("live_srv")
+        server.session = None
+
+        await server._refresh_tools_task()
+
+        assert "dynamic tool refresh failed" not in caplog.text
 
 
 class TestMessageHandler:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2253,10 +2253,24 @@ class MCPServerTask:
             # Capture old tool names for change diff
             old_tool_names = set(self._registered_tool_names)
 
-            # 1. Fetch current tool list from server (follow nextCursor)
+            # 1. Fetch current tool list from server (follow nextCursor).
+            # Dynamic list_changed refreshes are scheduled out-of-band from the
+            # MCP SDK notification handler.  By the time the background task
+            # reaches the RPC lock, the transport may already have recycled or
+            # torn down the session (self.session = None).  A missing session
+            # here is not a user-visible tool-call failure: keep the existing
+            # registered tools and let the normal reconnect/discovery path
+            # refresh the dynamic list on the next live session.
             async with self._rpc_lock:
+                session = self.session
+                if session is None:
+                    logger.info(
+                        "MCP server '%s': skipping dynamic tool refresh; session is not connected",
+                        self.name,
+                    )
+                    return
                 new_mcp_tools = await _paginate_full_list(
-                    self.session.list_tools, "tools", self.name
+                    session.list_tools, "tools", self.name
                 )
 
             # 2. Re-register with fresh tool list. Avoid nuke-and-repave for


### PR DESCRIPTION
## Summary

Guard dynamic MCP tool refresh when a session closes between notification scheduling and refresh execution.

## Fix

- snapshot the current session while holding the RPC lock;
- skip cleanly when no session remains;
- use the stable session snapshot for paginated tool discovery.

## Tests

Regression coverage verifies that a disappearing session is handled without an error and that the refresh task does not report a failure.

Local focused suite: 72 passed. MCP dynamic discovery tests: 8 passed.