### PR TITLE
fix(agent): recover silent streams and scoped cleanup

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 import time
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
@@ -25,6 +26,18 @@ from typing import Any, Callable, Dict, List
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 
 logger = logging.getLogger(__name__)
+
+# Responses iteration is synchronous and can block inside ``next()`` while the
+# server is legitimately reasoning without emitting SSE frames. Keep the
+# gateway activity clock alive independently of event arrival.
+_CODEX_STREAM_HEARTBEAT_SECONDS = 30.0
+# One retry is allowed below. Two fully silent attempts (2 * 420s), plus retry
+# overhead, still fail before the gateway's default 900s inactivity warning.
+# ``interruptible_api_call`` independently enforces TTFB, SSE-idle, and absolute
+# hard watchdogs from outside this worker; the heartbeat below intentionally
+# does not update ``_codex_stream_last_event_ts`` used by those watchdogs.
+_CODEX_STREAM_READ_TIMEOUT_SECONDS = 420.0
+_CODEX_STREAM_CONNECT_TIMEOUT_SECONDS = 30.0
 
 
 def _coerce_usage_int(value: Any) -> int:
@@ -1286,6 +1299,15 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         def _open_codex_stream(next_api_kwargs: dict[str, Any]):
             stream_kwargs = dict(next_api_kwargs)
             stream_kwargs["stream"] = True
+            # ``build_api_kwargs`` carries the general API timeout (typically
+            # 1800s). Override it for the physical SSE attempt so the read can
+            # never outlive the gateway's recovery window.
+            stream_kwargs["timeout"] = _httpx.Timeout(
+                connect=_CODEX_STREAM_CONNECT_TIMEOUT_SECONDS,
+                read=_CODEX_STREAM_READ_TIMEOUT_SECONDS,
+                write=_CODEX_STREAM_READ_TIMEOUT_SECONDS,
+                pool=_CODEX_STREAM_CONNECT_TIMEOUT_SECONDS,
+            )
             return active_client.responses.create(**stream_kwargs)
 
         def _codex_stream_created(_raw_stream: Any) -> None:
@@ -1361,6 +1383,24 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         def _interrupt_or_superseded() -> bool:
             return bool(agent._interrupt_requested)
 
+        heartbeat_stop = threading.Event()
+
+        def _heartbeat_while_stream_is_quiet() -> None:
+            while not heartbeat_stop.wait(_CODEX_STREAM_HEARTBEAT_SECONDS):
+                if agent._interrupt_requested:
+                    return
+                try:
+                    agent._touch_activity("waiting for Codex Responses stream")
+                except Exception:
+                    logger.debug("Codex Responses heartbeat failed", exc_info=True)
+
+        heartbeat_thread = threading.Thread(
+            target=_heartbeat_while_stream_is_quiet,
+            name="codex-responses-heartbeat",
+            daemon=True,
+        )
+        heartbeat_thread.start()
+
         try:
             try:
                 final = _consume_codex_event_stream(
@@ -1425,6 +1465,8 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
             return final
         finally:
+            heartbeat_stop.set()
+            heartbeat_thread.join(timeout=1.0)
             close_fn = getattr(event_stream, "close", None)
             if callable(close_fn):
                 try:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,4 +1,6 @@
 import sys
+import threading
+import time
 import types
 from types import SimpleNamespace
 
@@ -236,6 +238,24 @@ class _FakeCreateStream:
         self.closed = True
 
 
+class _SilentThenCompletedStream:
+    """Keep the iterator silent long enough to require an out-of-band heartbeat."""
+
+    def __init__(self, response, quiet_seconds=0.08):
+        self.response = response
+        self.quiet_seconds = quiet_seconds
+        self.first_yield_at = None
+        self.closed = False
+
+    def __iter__(self):
+        threading.Event().wait(self.quiet_seconds)
+        self.first_yield_at = time.monotonic()
+        yield SimpleNamespace(type="response.completed", response=self.response)
+
+    def close(self):
+        self.closed = True
+
+
 def _codex_request_kwargs():
     return {
         "model": "gpt-5-codex",
@@ -244,6 +264,63 @@ def _codex_request_kwargs():
         "tools": None,
         "store": False,
     }
+
+
+def test_codex_stream_heartbeats_while_sse_iterator_is_silent(monkeypatch):
+    from agent import codex_runtime
+
+    agent = _build_agent(monkeypatch)
+    stream = _SilentThenCompletedStream(_codex_message_response("done"))
+    touches = []
+    agent._touch_activity = lambda description: touches.append(
+        (description, time.monotonic())
+    )
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: stream),
+    )
+    monkeypatch.setattr(
+        codex_runtime, "_CODEX_STREAM_HEARTBEAT_SECONDS", 0.01, raising=False
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.status == "completed"
+    assert stream.first_yield_at is not None
+    assert any(
+        description == "waiting for Codex Responses stream"
+        and touched_at < stream.first_yield_at
+        for description, touched_at in touches
+    )
+
+
+def test_codex_stream_sets_a_bounded_read_timeout(monkeypatch):
+    from agent import codex_runtime
+
+    agent = _build_agent(monkeypatch)
+    seen_kwargs = []
+
+    def create(**kwargs):
+        seen_kwargs.append(kwargs)
+        return _FakeCreateStream(
+            [
+                SimpleNamespace(
+                    type="response.completed",
+                    response=_codex_message_response("done"),
+                )
+            ]
+        )
+
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=create))
+
+    request_kwargs = _codex_request_kwargs()
+    request_kwargs["timeout"] = 1800
+    response = agent._run_codex_stream(request_kwargs)
+
+    assert response.status == "completed"
+    timeout = seen_kwargs[0]["timeout"]
+    assert timeout.read == codex_runtime._CODEX_STREAM_READ_TIMEOUT_SECONDS
+    assert timeout.connect == codex_runtime._CODEX_STREAM_CONNECT_TIMEOUT_SECONDS
+    assert timeout.read * 2 < 900
 
 
 def test_api_mode_uses_explicit_provider_when_codex(monkeypatch):

--- a/tests/tools/test_browser_cleanup_secret_scope.py
+++ b/tests/tools/test_browser_cleanup_secret_scope.py
@@ -1,0 +1,121 @@
+"""Regression coverage for browser cleanup in multiplexed gateways."""
+
+import time
+
+from agent.secret_scope import (
+    get_secret,
+    reset_secret_scope,
+    set_multiplex_active,
+    set_secret_scope,
+)
+from tools import browser_tool
+
+
+def test_inactive_cleanup_reinstalls_session_secret_scope(monkeypatch):
+    task_id = "profile-session"
+    seen = []
+
+    monkeypatch.setattr(browser_tool, "_session_last_activity", {})
+    monkeypatch.setattr(browser_tool, "_session_secret_scopes", {}, raising=False)
+    monkeypatch.setattr(browser_tool, "BROWSER_SESSION_INACTIVITY_TIMEOUT", 30)
+
+    def scoped_cleanup(cleanup_task_id):
+        seen.append((cleanup_task_id, get_secret("CAMOFOX_URL")))
+
+    monkeypatch.setattr(browser_tool, "_cleanup_single_browser_session", scoped_cleanup)
+    set_multiplex_active(True)
+    token = set_secret_scope({"CAMOFOX_URL": "http://profile-camofox"})
+    try:
+        browser_tool._update_session_activity(task_id)
+    finally:
+        reset_secret_scope(token)
+
+    browser_tool._session_last_activity[task_id] = time.time() - 31
+    try:
+        browser_tool._cleanup_inactive_browser_sessions()
+    finally:
+        set_multiplex_active(False)
+
+    assert seen == [(task_id, "http://profile-camofox")]
+    assert task_id not in browser_tool._session_last_activity
+    assert task_id not in browser_tool._session_secret_scopes
+
+
+def test_shutdown_cleanup_reinstalls_each_session_secret_scope(monkeypatch):
+    seen = []
+    monkeypatch.setattr(browser_tool, "_active_sessions", {"a": {}, "b": {}})
+    monkeypatch.setattr(
+        browser_tool,
+        "_session_secret_scopes",
+        {
+            "a": {"CAMOFOX_URL": "http://profile-a"},
+            "b": {"CAMOFOX_URL": "http://profile-b"},
+        },
+    )
+    monkeypatch.setattr(
+        browser_tool,
+        "_cleanup_single_browser_session",
+        lambda task_id: seen.append((task_id, get_secret("CAMOFOX_URL"))),
+    )
+
+    set_multiplex_active(True)
+    try:
+        browser_tool.cleanup_all_browsers()
+    finally:
+        set_multiplex_active(False)
+
+    assert seen == [
+        ("a", "http://profile-a"),
+        ("b", "http://profile-b"),
+    ]
+
+
+def test_direct_cleanup_reinstalls_each_exact_session_scope(monkeypatch):
+    task_id = "agent-close-session"
+    sidecar_id = f"{task_id}{browser_tool._LOCAL_SUFFIX}"
+    seen = []
+    monkeypatch.setattr(
+        browser_tool,
+        "_active_sessions",
+        {task_id: {}, sidecar_id: {}},
+    )
+    monkeypatch.setattr(
+        browser_tool,
+        "_session_secret_scopes",
+        {
+            task_id: {"CAMOFOX_URL": "http://profile-close"},
+            sidecar_id: {"CAMOFOX_URL": "http://profile-sidecar"},
+        },
+    )
+    monkeypatch.setattr(
+        browser_tool,
+        "_cleanup_single_browser_session",
+        lambda cleanup_task_id: seen.append(
+            (cleanup_task_id, get_secret("CAMOFOX_URL"))
+        ),
+    )
+
+    set_multiplex_active(True)
+    try:
+        browser_tool.cleanup_browser(task_id)
+    finally:
+        set_multiplex_active(False)
+
+    assert seen == [
+        (task_id, "http://profile-close"),
+        (sidecar_id, "http://profile-sidecar"),
+    ]
+
+
+def test_unscoped_activity_never_reuses_a_stale_profile_scope(monkeypatch):
+    task_id = "reused-session"
+    monkeypatch.setattr(browser_tool, "_session_last_activity", {})
+    monkeypatch.setattr(
+        browser_tool,
+        "_session_secret_scopes",
+        {task_id: {"CAMOFOX_URL": "http://stale-profile"}},
+    )
+
+    browser_tool._update_session_activity(task_id)
+
+    assert browser_tool._session_secret_scopes[task_id] is None

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1560,6 +1560,11 @@ BROWSER_SESSION_INACTIVITY_TIMEOUT = _get_session_inactivity_timeout()
 
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}
+# Background cleanup runs outside the per-turn ContextVar context.  Preserve
+# the credential scope that owned each browser session so cleanup can reinstall
+# that exact scope instead of performing an unscoped (and therefore unsafe)
+# secret read in a multiplexed gateway.
+_session_secret_scopes: Dict[str, Optional[Dict[str, str]]] = {}
 
 # Background cleanup thread state
 _cleanup_thread = None
@@ -1632,6 +1637,7 @@ def _emergency_cleanup_all_sessions():
             with _cleanup_lock:
                 _active_sessions.clear()
                 _session_last_activity.clear()
+                _session_secret_scopes.clear()
                 _recording_sessions.clear()
 
     # Sweep orphans from other crashed hermes processes.  Safe even if we
@@ -1678,8 +1684,8 @@ def _cleanup_inactive_browser_sessions():
             logger.info("Cleaning up inactive session for task: %s (inactive for %ss)", task_id, elapsed)
             cleanup_browser(task_id)
             with _cleanup_lock:
-                if task_id in _session_last_activity:
-                    del _session_last_activity[task_id]
+                _session_last_activity.pop(task_id, None)
+                _session_secret_scopes.pop(task_id, None)
         except Exception as e:
             logger.warning("Error cleaning up inactive session %s: %s", task_id, e)
 
@@ -1966,8 +1972,14 @@ def _stop_browser_cleanup_thread():
 
 def _update_session_activity(task_id: str):
     """Update the last activity timestamp for a session."""
+    from agent.secret_scope import current_secret_scope
+
+    current_scope = current_secret_scope()
     with _cleanup_lock:
         _session_last_activity[task_id] = time.time()
+        _session_secret_scopes[task_id] = (
+            dict(current_scope) if current_scope is not None else None
+        )
 
 
 # Register cleanup thread stop on exit
@@ -4518,6 +4530,19 @@ def _cleanup_old_recordings(max_age_hours=72):
 # Cleanup and Management Functions
 # ============================================================================
 
+def _cleanup_browser_session_in_scope(session_key: str) -> None:
+    """Reap one session under the profile secret scope that created it."""
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    with _cleanup_lock:
+        session_scope = _session_secret_scopes.get(session_key)
+    scope_token = set_secret_scope(session_scope)
+    try:
+        _cleanup_single_browser_session(session_key)
+    finally:
+        reset_secret_scope(scope_token)
+
+
 def cleanup_browser(task_id: Optional[str] = None) -> None:
     """
     Clean up browser session(s) for a task.
@@ -4551,7 +4576,7 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
         bare_task_id = task_id
 
     for session_key in session_keys:
-        _cleanup_single_browser_session(session_key)
+        _cleanup_browser_session_in_scope(session_key)
 
     # Drop stale last-active ownership. Cleaning a bare task drops its binding;
     # cleaning a sidecar drops the binding only if that sidecar was still the
@@ -4619,6 +4644,7 @@ def _cleanup_single_browser_session(task_id: str) -> None:
         with _cleanup_lock:
             _active_sessions.pop(task_id, None)
             _session_last_activity.pop(task_id, None)
+            _session_secret_scopes.pop(task_id, None)
 
         # Cloud mode: close the cloud browser session via provider API.
         # Local sidecars have bb_session_id=None so this no-ops for them.


### PR DESCRIPTION
## Summary
- bound each Codex Responses SSE attempt with explicit HTTPX read/write and connect/pool timeouts
- emit gateway activity heartbeats without mutating the event timestamp used by the existing physical-stream watchdogs
- restore the exact owning profile secret scope for every browser cleanup path, including direct agent shutdown and hybrid sidecars
- fail closed instead of retaining a stale profile scope when activity occurs unscoped

## Regression coverage
- silent SSE heartbeat and inherited-timeout override
- direct, inactive, global, and sidecar browser cleanup under multiplexing
- stale-scope reuse prevention

## Related existing reports
- #70943 tracks Codex Responses streams that can remain open without reaching failure delivery.
- #11772 is the prior sparse-stream heartbeat proposal.
- #76882 and #57624 track related per-profile secret-scope/browser isolation gaps.
- #72500 tracks the separate terminal/approval/environment hang class observed during the same operational investigation; this PR does not claim to close that executor work.

## Validation
- `scripts/run_tests.sh` targeted state/FTS: 20 passed
- targeted agent/state/browser suite: 211 passed
- full `tests/tools/test_browser*.py`: 333 passed
- Codex/watchdog suite: 54 passed
- independent fail-closed security/correctness review: passed
- Ruff, py_compile, and `git diff --check`: passed