### PR TITLE
fix(terminal): stop remote NOPASSWD sudo from prompting for a password

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -7,7 +7,11 @@ init_session() failure handling, and the CWD marker contract.
 from unittest.mock import MagicMock
 
 import tools.terminal_tool as terminal_tool
-from tools.environments.base import BaseEnvironment, _BoundedOutputCollector
+from tools.environments.base import (
+    BaseEnvironment,
+    _BoundedOutputCollector,
+    _ThreadedProcessHandle,
+)
 
 
 class _TestableEnv(BaseEnvironment):
@@ -63,6 +67,17 @@ def test_nopasswd_probe_fails_closed_on_backend_error(monkeypatch):
     monkeypatch.setattr(env, "_run_bash", MagicMock(side_effect=RuntimeError("offline")))
 
     assert env._sudo_nopasswd_works() is False
+
+
+def test_nopasswd_probe_does_not_short_timeout_sdk_sandbox(monkeypatch):
+    env = _TestableEnv(timeout=10)
+    proc = _ThreadedProcessHandle(lambda: ("", 0), cancel_fn=lambda: None)
+    wait = MagicMock(return_value={"returncode": 0})
+    monkeypatch.setattr(env, "_run_bash", MagicMock(return_value=proc))
+    monkeypatch.setattr(env, "_wait_for_process", wait)
+
+    assert env._sudo_nopasswd_works() is True
+    wait.assert_called_once_with(proc, timeout=10)
 
 
 class TestBoundedOutputCollector:

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -7,15 +7,13 @@ init_session() failure handling, and the CWD marker contract.
 from unittest.mock import MagicMock
 
 import tools.terminal_tool as terminal_tool
-from tools.environments.base import (
-    BaseEnvironment,
-    _BoundedOutputCollector,
-    _ThreadedProcessHandle,
-)
+from tools.environments.base import BaseEnvironment, _BoundedOutputCollector
 
 
 class _TestableEnv(BaseEnvironment):
     """Concrete subclass for testing base class methods."""
+
+    _sudo_nopasswd_probe_supported = True
 
     def __init__(self, cwd="/tmp", timeout=10):
         super().__init__(cwd=cwd, timeout=timeout)
@@ -69,15 +67,14 @@ def test_nopasswd_probe_fails_closed_on_backend_error(monkeypatch):
     assert env._sudo_nopasswd_works() is False
 
 
-def test_nopasswd_probe_does_not_short_timeout_sdk_sandbox(monkeypatch):
-    env = _TestableEnv(timeout=10)
-    proc = _ThreadedProcessHandle(lambda: ("", 0), cancel_fn=lambda: None)
-    wait = MagicMock(return_value={"returncode": 0})
-    monkeypatch.setattr(env, "_run_bash", MagicMock(return_value=proc))
-    monkeypatch.setattr(env, "_wait_for_process", wait)
+def test_nopasswd_probe_skips_backends_without_safe_process_cancel(monkeypatch):
+    env = _TestableEnv()
+    env._sudo_nopasswd_probe_supported = False
+    run = MagicMock(side_effect=AssertionError("probe must not start"))
+    monkeypatch.setattr(env, "_run_bash", run)
 
-    assert env._sudo_nopasswd_works() is True
-    wait.assert_called_once_with(proc, timeout=10)
+    assert env._sudo_nopasswd_works() is False
+    run.assert_not_called()
 
 
 class TestBoundedOutputCollector:

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -6,6 +6,7 @@ init_session() failure handling, and the CWD marker contract.
 
 from unittest.mock import MagicMock
 
+import tools.terminal_tool as terminal_tool
 from tools.environments.base import BaseEnvironment, _BoundedOutputCollector
 
 
@@ -20,6 +21,48 @@ class _TestableEnv(BaseEnvironment):
 
     def cleanup(self):
         pass
+
+
+def test_prepare_command_uses_selected_environment_for_nopasswd(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    env = _TestableEnv()
+    monkeypatch.setattr(env, "_sudo_nopasswd_works", lambda: True)
+
+    def _fail_prompt(*_args, **_kwargs):
+        raise AssertionError("interactive sudo prompt should not run for NOPASSWD")
+
+    monkeypatch.setattr(terminal_tool, "_prompt_for_sudo_password", _fail_prompt)
+
+    transformed, sudo_stdin = env._prepare_command("sudo true")
+
+    assert transformed == "sudo true"
+    assert sudo_stdin is None
+
+
+def test_nopasswd_probe_runs_inside_selected_environment(monkeypatch):
+    env = _TestableEnv()
+    proc = object()
+    run = MagicMock(return_value=proc)
+    wait = MagicMock(return_value={"returncode": 0})
+    monkeypatch.setattr(env, "_run_bash", run)
+    monkeypatch.setattr(env, "_wait_for_process", wait)
+
+    assert env._sudo_nopasswd_works() is True
+    run.assert_called_once_with(
+        "sudo -n true",
+        login=False,
+        timeout=3,
+        stdin_data=None,
+    )
+    wait.assert_called_once_with(proc, timeout=3)
+
+
+def test_nopasswd_probe_fails_closed_on_backend_error(monkeypatch):
+    env = _TestableEnv()
+    monkeypatch.setattr(env, "_run_bash", MagicMock(side_effect=RuntimeError("offline")))
+
+    assert env._sudo_nopasswd_works() is False
 
 
 class TestBoundedOutputCollector:

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -77,6 +77,39 @@ def test_explicit_empty_sudo_password_tries_empty_without_prompt(monkeypatch):
     assert sudo_stdin == "\n"
 
 
+def test_backend_nopasswd_probe_skips_interactive_prompt(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+    def _fail_prompt(*_args, **_kwargs):
+        raise AssertionError("interactive sudo prompt should not run for NOPASSWD")
+
+    monkeypatch.setattr(terminal_tool, "_prompt_for_sudo_password", _fail_prompt)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "sudo true",
+        sudo_nopasswd_check=lambda: True,
+    )
+
+    assert transformed == "sudo true"
+    assert sudo_stdin is None
+
+
+def test_configured_password_does_not_run_backend_nopasswd_probe(monkeypatch):
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+
+    def _fail_probe():
+        raise AssertionError("configured passwords must bypass the NOPASSWD probe")
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "sudo true",
+        sudo_nopasswd_check=_fail_probe,
+    )
+
+    assert transformed == "sudo -S -p '' true"
+    assert sudo_stdin == "testpass\n"
+
+
 def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project; rm -rf /")
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project$(whoami)")

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1450,7 +1450,15 @@ class BaseEnvironment(ABC):
                 timeout=3,
                 stdin_data=None,
             )
-            result = self._wait_for_process(proc, timeout=3)
+            # SDK process handles cancel by stopping/terminating the entire
+            # sandbox.  Do not let this best-effort probe tear down a healthy
+            # backend after three seconds; their own exec call still receives
+            # the short timeout above and the outer wait retains the normal
+            # environment deadline as a safety net.
+            wait_timeout = (
+                self.timeout if isinstance(proc, _ThreadedProcessHandle) else 3
+            )
+            result = self._wait_for_process(proc, timeout=wait_timeout)
             return result.get("returncode") == 0
         except Exception:
             return False

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1433,7 +1433,24 @@ class BaseEnvironment(ABC):
             pass
 
     def _prepare_command(self, command: str) -> tuple[str, str | None]:
-        """Transform sudo commands if SUDO_PASSWORD is available."""
+        """Prepare sudo using this environment's passwordless-sudo probe."""
         from tools.terminal_tool import _transform_sudo_command
 
-        return _transform_sudo_command(command)
+        return _transform_sudo_command(
+            command,
+            sudo_nopasswd_check=self._sudo_nopasswd_works,
+        )
+
+    def _sudo_nopasswd_works(self) -> bool:
+        """Probe passwordless sudo inside this execution environment."""
+        try:
+            proc = self._run_bash(
+                "sudo -n true",
+                login=False,
+                timeout=3,
+                stdin_data=None,
+            )
+            result = self._wait_for_process(proc, timeout=3)
+            return result.get("returncode") == 0
+        except Exception:
+            return False

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -592,6 +592,10 @@ class BaseEnvironment(ABC):
     # Snapshot creation timeout (override for slow cold-starts).
     _snapshot_timeout: int = 30
 
+    # Opt in only when a timed-out probe can kill its command without tearing
+    # down the whole backend. SDK adapters cancel by stopping the sandbox.
+    _sudo_nopasswd_probe_supported: bool = False
+
     # Local and Docker override this because they resolve allowlisted values
     # through the active profile scope. Other backends keep their existing
     # snapshot semantics until they implement the same resolver contract.
@@ -1443,6 +1447,8 @@ class BaseEnvironment(ABC):
 
     def _sudo_nopasswd_works(self) -> bool:
         """Probe passwordless sudo inside this execution environment."""
+        if not self._sudo_nopasswd_probe_supported:
+            return False
         try:
             proc = self._run_bash(
                 "sudo -n true",
@@ -1450,15 +1456,7 @@ class BaseEnvironment(ABC):
                 timeout=3,
                 stdin_data=None,
             )
-            # SDK process handles cancel by stopping/terminating the entire
-            # sandbox.  Do not let this best-effort probe tear down a healthy
-            # backend after three seconds; their own exec call still receives
-            # the short timeout above and the outer wait retains the normal
-            # environment deadline as a safety net.
-            wait_timeout = (
-                self.timeout if isinstance(proc, _ThreadedProcessHandle) else 3
-            )
-            result = self._wait_for_process(proc, timeout=wait_timeout)
+            result = self._wait_for_process(proc, timeout=3)
             return result.get("returncode") == 0
         except Exception:
             return False

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -861,6 +861,7 @@ class DockerEnvironment(BaseEnvironment):
     across container restarts.
     """
 
+    _sudo_nopasswd_probe_supported = True
     _profile_scoped_passthrough = True
 
     def _additional_profile_scoped_passthrough_names(self) -> tuple[str, ...]:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1419,6 +1419,7 @@ class LocalEnvironment(BaseEnvironment):
     CWD persists via file-based read after each command.
     """
 
+    _sudo_nopasswd_probe_supported = True
     _profile_scoped_passthrough = True
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -166,6 +166,8 @@ class SingularityEnvironment(BaseEnvironment):
     CWD persists via in-band stdout markers.
     """
 
+    _sudo_nopasswd_probe_supported = True
+
     def __init__(
         self,
         image: str,

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -46,6 +46,8 @@ class SSHEnvironment(BaseEnvironment):
     Uses SSH ControlMaster for connection reuse.
     """
 
+    _sudo_nopasswd_probe_supported = True
+
     def __init__(self, host: str, user: str, cwd: str = "~",
                  timeout: int = 60, port: int = 22, key_path: str = ""):
         super().__init__(cwd=cwd, timeout=timeout)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -47,7 +47,7 @@ import atexit
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Callable
 
 from utils import env_var_enabled
 
@@ -973,7 +973,10 @@ def _rewrite_compound_background(command: str) -> str:
     return result
 
 
-def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None]:
+def _transform_sudo_command(
+    command: str | None,
+    sudo_nopasswd_check: Callable[[], bool] | None = None,
+) -> tuple[str | None, str | None]:
     """
     Transform sudo commands to use -S flag if SUDO_PASSWORD is available.
 
@@ -1034,14 +1037,18 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
         else _get_cached_sudo_password()
     )
 
-    # Local hosts with sudoers NOPASSWD should not be forced through the
+    # Environments with sudoers NOPASSWD should not be forced through the
     # interactive Hermes password prompt or the sudo -S password-pipe path.
-    # Scoped to the local terminal backend so Docker/SSH/Modal/etc. can't
-    # inherit host sudo state. Re-probes every call (no process-lifetime
-    # cache) so an expired sudo timestamp doesn't make a later command block
-    # silently without Hermes prompting.
-    if not has_configured_password and not sudo_password and _sudo_nopasswd_works():
-        return command, None
+    # BaseEnvironment supplies a probe scoped to the selected backend; direct
+    # callers retain the local-only fallback. Re-probe every call so an expired
+    # sudo timestamp cannot make a later command silently block.
+    if not has_configured_password and not sudo_password:
+        nopasswd_check = sudo_nopasswd_check or _sudo_nopasswd_works
+        try:
+            if nopasswd_check():
+                return command, None
+        except Exception:
+            pass
 
     has_sudo_prompt_callback = _get_sudo_password_callback() is not None
     should_prompt_for_sudo = (


### PR DESCRIPTION
## What does this PR do?

Remote SSH users with `NOPASSWD` sudo no longer receive a Hermes password prompt before their command runs. Hermes now probes passwordless sudo through the selected execution backend, while failed probes preserve the existing password and prompt path and backends without safe per-process cancellation skip the probe.

### Symptom

In an interactive SSH terminal session, running `sudo` as a remote user configured with `NOPASSWD:ALL` still opened a sudo password prompt. Submitting a blank value allowed the command to continue, showing that the prompt was unnecessary.

### Impact

Affected remote users must interrupt their workflow to dismiss a password prompt even though the remote sudo policy requires no password. The behavior was reproduced through an actual `SSHEnvironment` connected to a temporary OpenSSH server with a dedicated `NOPASSWD` account.

### Bug Cause

**Trigger:** `tools/environments/base.py:BaseEnvironment._prepare_command` delegates a real sudo command with no configured or cached password to `_transform_sudo_command`.

**Causal chain:**
1. An interactive remote terminal executes a sudo command for a user whose remote sudoers policy allows `NOPASSWD`.
2. `_transform_sudo_command` can only use its local-host fallback probe, which rejects non-local terminal backends, so it cannot observe the selected backend's sudo policy.
3. Hermes opens its password prompt even though the remote command can run without a password.

**Why it is wrong:** The host-only probe correctly avoids applying host sudo state to another backend, but no backend-scoped probe replaces it. The selected environment is therefore treated as password-protected without testing its own policy.

**Working sibling / contrast:** Local execution already probes `sudo -n true` on the host and skips the prompt when it succeeds. Explicit and cached passwords also bypass the probe and retain the existing `sudo -S` path.

**Ruled out:** This is not an SSH authentication failure. The SSH connection is already established, and the original sudo command succeeds after the unnecessary prompt is dismissed.

### Fix

`_transform_sudo_command` now accepts a lazy passwordless-sudo check supplied by `BaseEnvironment`. Supported backends run `sudo -n true` through their own `_run_bash` transport and fail closed to the existing prompt/password behavior on a nonzero result or probe error. The capability is enabled only for Local, Docker, SSH, and Singularity, where a timed-out probe can be cancelled without tearing down an SDK-managed sandbox.

## Related Issue

Closes #83327

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py` - accept a backend-scoped passwordless-sudo check while preserving local fallback and configured-password behavior.
- `tools/environments/base.py` - probe `sudo -n true` through the selected backend and fail closed.
- `tools/environments/local.py`, `tools/environments/docker.py`, `tools/environments/ssh.py`, `tools/environments/singularity.py` - opt in backends with safe per-process cancellation.
- `tests/tools/test_terminal_tool.py`, `tests/tools/test_base_environment.py` - cover successful backend probes, failed probes, unsupported backends, prompt suppression, and configured-password precedence.

## How to Test

1. Configure the SSH terminal backend for a remote user with `NOPASSWD:ALL` and no `SUDO_PASSWORD`.
2. In an interactive Hermes session, run `sudo true` and verify that no Hermes password prompt appears.
3. Use a user for which `sudo -n true` fails and verify that the existing password prompt/path remains available.
4. Run the focused regression tests:

```bash
scripts/run_tests.sh tests/tools/test_base_environment.py tests/tools/test_terminal_tool.py -k 'nopasswd or configured_password_does_not_run_backend_nopasswd_probe'
scripts/run_tests.sh tests/tools/test_ssh_environment.py
```

Verified results: 6 focused sudo tests passed; the SSH environment suite passed 9 tests with 5 credential-gated skips. Real-environment verification passed against a temporary WSL OpenSSH server for both the remote `NOPASSWD` path and failed-probe password fallback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 with a temporary WSL OpenSSH server

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A; this corrects existing terminal behavior
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the public terminal schema is unchanged
