### PR TITLE
fix(desktop): pin venv interpreter in the generated launcher entry

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -63,15 +63,45 @@ def resolve_exec_command() -> str:
     Prefer the real ``hermes`` executable (argv[0] or PATH). When Hermes
     runs as a module with no launcher installed, use the current
     interpreter, also absolute.
+
+    Desktop launchers start applications with a minimal environment: no
+    shell profile, no venv on PATH, no PYTHONPATH. A checkout's
+    ``./hermes`` script is a ``#!/usr/bin/env python3`` launcher whose
+    interpreter is resolved by ``env`` at exec time — under KDE/GNOME
+    that picks the system python, which lacks the venv packages, and the
+    entry silently dies. Pin the current (venv) interpreter in front of
+    any python-shebang script so the entry works from any launcher.
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
     bin_path = resolve_hermes_bin()
     if bin_path:
-        argv = [str(Path(bin_path).resolve()), "desktop"]
+        resolved = Path(bin_path).resolve()
+        argv = [str(resolved), "desktop"]
+        if _is_python_script(resolved):
+            # Keep sys.executable as-is: resolving the venv's python
+            # symlink to the base interpreter would skip pyvenv.cfg and
+            # the site-packages .pth files the editable install needs.
+            argv = [str(sys.executable), str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(sys.executable), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _is_python_script(path: Path) -> bool:
+    """True when ``path`` is a text script with a python shebang.
+
+    Such scripts resolve their interpreter through ``env`` at exec time,
+    so a desktop entry must not point at them bare.
+    """
+    try:
+        head = path.read_bytes()[:128]
+    except OSError:
+        return False
+    if not head.startswith(b"#!"):
+        return False
+    shebang = head.splitlines()[0].decode("utf-8", "replace")
+    return "python" in shebang.lower()
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -189,6 +190,38 @@ def test_refresh_reports_only_tools_that_succeeded(monkeypatch, tmp_path):
 
 def test_run_quiet_swallows_missing_binary(tmp_path):
     assert lde._run_quiet([str(tmp_path / "definitely-not-a-binary")]) is False
+
+
+def test_exec_pins_interpreter_for_python_shebang_script(tmp_path, xdg_home, monkeypatch):
+    """A ``#!/usr/bin/env python3`` script must not be Exec'd bare.
+
+    Desktop launchers resolve ``env python3`` to the system interpreter,
+    which lacks the venv packages. Pin the current interpreter instead.
+    """
+    root = _make_project(tmp_path)
+    script = tmp_path / "hermes"
+    script.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(script))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{sys.executable} {script} desktop"
+
+
+def test_exec_leaves_non_python_script_bare(tmp_path, xdg_home, monkeypatch):
+    """Shell wrappers (``#!/usr/bin/env bash``) resolve fine anywhere."""
+    root = _make_project(tmp_path)
+    script = tmp_path / "hermes"
+    script.write_text("#!/usr/bin/env bash\nexec hermes \"$@\"\n", encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(script))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{script} desktop"
 
 
 def test_exec_arg_quoting_handles_spaces(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Problem

`hermes desktop` installs its own Linux launcher entry on every
launch. The entry pointed at the checkout script `hermes`. This
script starts with `#!/usr/bin/env python3`.

A desktop launcher starts applications with a minimal environment.
The venv is not on PATH. `env python3` resolves to the system
python. The system python has no venv packages, so the app does
not start. The launcher entry shows the icon, but nothing opens.

## Fix

`resolve_exec_command` pins the current interpreter in front of
any python script. It keeps the interpreter path as-is. Resolving
the venv python symlink would skip `pyvenv.cfg` and the
site-packages `.pth` files, so the editable install would not
import.

## Test

- 14 tests pass in `tests/hermes_cli/test_linux_desktop_entry.py`
- The exact generated `Exec=` line starts the desktop app from a
  minimal environment
