### PR TITLE
feat: add Discord background work sessions

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1801,6 +1801,25 @@ def get_job(job_id: str) -> Optional[Dict[str, Any]]:
     return None
 
 
+def find_operations_binding(thread_id: str) -> Optional[Dict[str, Any]]:
+    """Return the retained Discord work binding for a thread, if authenticated."""
+    needle = str(thread_id or "")
+    if not needle:
+        return None
+    for job in load_jobs():
+        binding = job.get("operations_binding")
+        if not isinstance(binding, dict) or binding.get("platform") != "discord":
+            continue
+        if str(binding.get("thread_id") or "") != needle:
+            continue
+        if binding.get("state") not in {"running", "retained", "needs_intervention"}:
+            continue
+        result = dict(binding)
+        result.setdefault("job_id", str(job.get("id") or ""))
+        return result
+    return None
+
+
 class AmbiguousJobReference(LookupError):
     """Raised when a job name matches more than one job."""
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1477,18 +1477,20 @@ def _send_media_via_adapter(
     loop,
     job: dict,
     platform=None,
-) -> None:
-    """Send extracted MEDIA files as native platform attachments via a live adapter.
+) -> bool:
+    """Send extracted MEDIA files and return aggregate delivery success.
 
     Routes each file to the appropriate adapter method (send_voice, send_image_file,
-    send_video, send_document) based on file extension — mirroring the routing logic
-    in ``BasePlatformAdapter._process_message_background``.
+    send_video, send_document) based on file extension.  A missing loop, raised
+    exception, or explicit adapter failure makes the aggregate false so callers
+    never archive a thread after only its text was delivered.
     """
     from pathlib import Path
 
     from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    all_delivered = True
 
     for media_path, _is_voice in media_files:
         try:
@@ -1510,20 +1512,24 @@ def _send_media_via_adapter(
                     "Job '%s': cannot send media %s, gateway loop unavailable",
                     job.get("id", "?"), media_path,
                 )
-                return
+                all_delivered = False
+                continue
             try:
                 result = future.result(timeout=30)
             except TimeoutError:
                 future.cancel()
                 raise
-            if result and not getattr(result, "success", True):
+            if not _confirm_adapter_delivery(result):
+                all_delivered = False
                 logger.warning(
                     "Job '%s': media send failed for %s: %s",
                     job.get("id", "?"), media_path, getattr(result, "error", "unknown"),
                 )
         except Exception as e:
+            all_delivered = False
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
+    return all_delivered
 
 def _confirm_adapter_delivery(send_result) -> bool:
     """Return True only if ``send_result`` unambiguously confirms delivery.
@@ -3163,7 +3169,7 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
 
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None,
-    extra_prompt: Optional[str] = None,
+    extra_prompt: Optional[str] = None, session_id: Optional[str] = None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -3474,7 +3480,7 @@ def run_job(
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None
-    _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    _cron_session_id = session_id or f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -4516,6 +4522,119 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
+def _operations_binding_for_job(job: dict, *, run_id: str, session_id: str, handle) -> dict:
+    """Build the durable, authenticated reply binding for one cron run."""
+    return {
+        "platform": "discord",
+        "guild_id": getattr(handle, "guild_id", None),
+        "channel_id": str(handle.parent_channel_id),
+        "thread_id": str(handle.thread_id),
+        "job_id": str(job["id"]),
+        "run_id": str(run_id),
+        "session_id": str(session_id),
+        "state": "running",
+    }
+
+
+def _cron_operations_setup(job: dict, run_id: str, session_id: str, adapters, loop):
+    """Create and durably bind a fresh Discord operations thread, if enabled."""
+    try:
+        from gateway.config import Platform, resolve_noninteractive_work_policy
+        from gateway.run import _load_gateway_config
+        policy = resolve_noninteractive_work_policy(_load_gateway_config())
+        if policy.route_for("cron") != "operations" or not adapters or loop is None:
+            return None, None, None
+        adapter = adapters.get(Platform.DISCORD)
+        if adapter is None or not getattr(loop, "is_running", lambda: False)():
+            return None, policy, None
+        from agent.async_utils import safe_schedule_threadsafe
+        title = (job.get("name") or job.get("id") or "cron").strip()[:70]
+        future = safe_schedule_threadsafe(
+            adapter.create_noninteractive_work_thread(
+                policy.channel_id, f"cron {job['id']}: {title}",
+                auto_archive_duration=policy.auto_archive_duration,
+            ), loop,
+        )
+        handle = future.result(timeout=30) if future is not None else None
+        if handle is None:
+            return None, policy, None
+        binding = _operations_binding_for_job(job, run_id=run_id, session_id=session_id, handle=handle)
+        from cron.jobs import update_job
+        try:
+            update_job(job["id"], {"operations_binding": binding})
+        except Exception as exc:
+            # A remote thread without a durable binding is an untracked live
+            # resource. Best-effort cleanup before reporting setup failure.
+            try:
+                cleanup = "delete" if not policy.retain_failures and policy.cleanup == "delete" else "archive"
+                cleanup_result = getattr(adapter, f"{cleanup}_noninteractive_work_thread")(handle)
+                cleanup_future = safe_schedule_threadsafe(cleanup_result, loop)
+                if cleanup_future is not None:
+                    cleanup_future.result(timeout=30)
+            except Exception:
+                logger.error("Cron '%s': failed to clean untracked operations thread", job.get("id"), exc_info=True)
+            raise RuntimeError("operations thread was created but its durable binding could not be saved") from exc
+        return adapter, policy, handle
+    except Exception as exc:
+        logger.warning("Cron '%s' operations thread setup failed: %s", job.get("id"), exc)
+        return None, None, None
+
+
+def _cron_operations_send(adapter, handle, content: str, *, event: str, policy, loop) -> bool:
+    """Send one bounded lifecycle message through the live adapter."""
+    try:
+        from agent.async_utils import safe_schedule_threadsafe
+        from gateway.run import _delivery_succeeded
+        from gateway.platforms.base import BasePlatformAdapter
+        media_files, clean_content = BasePlatformAdapter.extract_media(content)
+    except Exception:
+        return False
+    result = adapter.send_noninteractive_work_notification(
+        handle, clean_content[:3500], event=event,
+        chief_user_id=(policy.chief_user_id if event in policy.mention_on or event == "intervention" else None),
+    )
+    future = safe_schedule_threadsafe(result, loop)
+    delivered = bool(future and _delivery_succeeded(future.result(timeout=30)))
+    if delivered and media_files:
+        delivered = _send_media_via_adapter(
+            adapter, handle.thread_id, media_files,
+            {"thread_id": handle.thread_id}, loop,
+            {"id": handle.thread_id}, platform="discord",
+        ) and delivered
+    return delivered
+
+
+def _cron_operations_finalize(job_id: str, adapter, handle, policy, loop, *,
+                              successful: bool, needs_intervention: bool) -> None:
+    """Apply cleanup only after the adapter confirms it succeeded."""
+    from cron.jobs import get_job, update_job
+    binding = dict((get_job(job_id) or {}).get("operations_binding") or {})
+    failure = (not successful) or needs_intervention
+    retain = policy.cleanup == "retain" or (failure and policy.retain_failures)
+    cleanup_ok = True
+    if not retain and policy.cleanup in {"archive", "delete"}:
+        try:
+            from agent.async_utils import safe_schedule_threadsafe
+            method = getattr(adapter, f"{policy.cleanup}_noninteractive_work_thread")
+            future = safe_schedule_threadsafe(method(handle), loop)
+            cleanup_ok = bool(future and future.result(timeout=30) is True)
+        except Exception:
+            cleanup_ok = False
+    if retain:
+        state = "needs_intervention" if failure else "retained"
+    elif cleanup_ok:
+        state = "archived"
+    else:
+        state = "needs_intervention"
+    binding["state"] = state
+    if not cleanup_ok:
+        binding["cleanup_error"] = f"{policy.cleanup} operation failed"
+    try:
+        update_job(job_id, {"operations_binding": binding})
+    except Exception:
+        logger.warning("Cron '%s': operations binding finalization persistence failed", job_id, exc_info=True)
+
+
 def run_one_job(
     job: dict, *, adapters=None, loop=None, verbose: bool = False,
     extra_prompt: Optional[str] = None,
@@ -4535,6 +4654,11 @@ def run_one_job(
     failure is recorded via ``mark_job_run``), False only if processing raised.
     """
     execution_id = job.get("execution_id")
+    operations_adapter = None
+    operations_policy = None
+    operations_handle = None
+    operations = False
+    operations_needs_intervention = False
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]
     try:
@@ -4560,6 +4684,36 @@ def run_one_job(
         # The attempt is claimed durably before executor/provider dispatch and
         # becomes running only immediately before the actual run.
         mark_execution_running(execution_id)
+        cron_session_id = f"cron_{job['id']}_{execution_id}"
+        operations_adapter, operations_policy, operations_handle = _cron_operations_setup(
+            job, execution_id, cron_session_id, adapters, loop
+        )
+        operations = operations_handle is not None
+        operations_needs_intervention = False
+        if operations:
+            started = _cron_operations_send(
+                operations_adapter, operations_handle,
+                f"▶️ Cron job {job.get('name') or job['id']} started (run {execution_id}).",
+                event="start", policy=operations_policy, loop=loop,
+            )
+            if not started:
+                operations_needs_intervention = True
+                try:
+                    from cron.jobs import get_job, update_job
+                    binding = dict((get_job(job["id"]) or {}).get("operations_binding") or {})
+                    binding["state"] = "needs_intervention"
+                    update_job(job["id"], {"operations_binding": binding})
+                except Exception:
+                    logger.warning("Cron '%s': failed to persist start failure state", job["id"], exc_info=True)
+                try:
+                    _cron_operations_send(
+                        operations_adapter, operations_handle,
+                        f"⚠️ Cron job {job.get('name') or job['id']} needs intervention: "
+                        "the start notification was not delivered; this thread is retained.",
+                        event="intervention", policy=operations_policy, loop=loop,
+                    )
+                except Exception:
+                    logger.warning("Cron '%s': intervention notification failed", job["id"], exc_info=True)
 
         # Run the job under the profile's secret scope. get_secret() fails
         # closed outside a scope once profile isolation is in play (multiple
@@ -4588,7 +4742,7 @@ def run_one_job(
         try:
             success, output, final_response, error = run_job(
                 job, defer_agent_teardown=_deferred_agents,
-                extra_prompt=extra_prompt,
+                extra_prompt=extra_prompt, session_id=cron_session_id,
             )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
@@ -4678,7 +4832,13 @@ def run_one_job(
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
 
-            if should_deliver:
+            if should_deliver and operations:
+                delivery_error = None if _cron_operations_send(
+                    operations_adapter, operations_handle, deliver_content,
+                    event="success" if success else "failure",
+                    policy=operations_policy, loop=loop,
+                ) else "operations thread delivery failed"
+            elif should_deliver:
                 unresolved_origin = (
                     _normalize_deliver_value(job.get("deliver", "local")) == "origin"
                     and not _resolve_delivery_targets(job)
@@ -4709,7 +4869,18 @@ def run_one_job(
                     status="blocked_config",
                 )
             else:
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+                if operations and not success:
+                    mark_job_run(job["id"], success, error, delivery_error=delivery_error,
+                                 status="needs_intervention")
+                else:
+                    mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+        if operations:
+            _cron_operations_finalize(
+                job["id"], operations_adapter, operations_handle,
+                operations_policy, loop,
+                successful=success and not delivery_error,
+                needs_intervention=operations_needs_intervention,
+            )
         normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
         if delivery_error:
             delivery_outcome = "failed"
@@ -4739,6 +4910,29 @@ def run_one_job(
         # anything that isn't a plain Exception.
         _err_text = str(e) or type(e).__name__
         logger.error("Error processing job %s: %s", job['id'], _err_text)
+        if operations and operations_adapter is not None and operations_handle is not None:
+            # Any cancellation/unexpected exception after thread setup must not
+            # leave a running binding. Keep it retained and publish only a
+            # bounded, non-sensitive intervention alert.
+            operations_needs_intervention = True
+            try:
+                _cron_operations_send(
+                    operations_adapter, operations_handle,
+                    f"⚠️ Cron job {job.get('name') or job['id']} needs intervention: "
+                    f"run {execution_id} terminated unexpectedly ({type(e).__name__}); "
+                    "the operations thread was retained for investigation.",
+                    event="intervention", policy=operations_policy, loop=loop,
+                )
+            except BaseException:
+                logger.warning("Cron '%s': failed to publish exception alert", job["id"], exc_info=True)
+            try:
+                _cron_operations_finalize(
+                    job["id"], operations_adapter, operations_handle,
+                    operations_policy, loop,
+                    successful=False, needs_intervention=True,
+                )
+            except BaseException:
+                logger.warning("Cron '%s': failed to finalize exception binding", job["id"], exc_info=True)
         try:
             if not _consume_interrupted_flag(job["id"]):
                 mark_job_run(job["id"], False, _err_text)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -23,6 +23,18 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 
+def resolve_noninteractive_work_policy(config: Any):
+    """Normalize Discord non-interactive delivery settings without mutation.
+
+    The implementation lives with the gateway delivery contracts; this
+    configuration-facing entry point keeps callers from depending on the
+    delivery module's broader transport helpers.
+    """
+    from gateway.delivery import resolve_noninteractive_work_policy as _resolve
+
+    return _resolve(config)
+
+
 def _coerce_bool(value: Any, default: bool = True) -> bool:
     """Coerce bool-ish config values, preserving a caller-provided default."""
     if value is None:

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -14,7 +14,8 @@ import re
 from pathlib import Path
 from datetime import datetime
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Any
+from types import MappingProxyType
+from typing import Dict, List, Optional, Any, Mapping
 
 from hermes_cli.config import get_hermes_home
 
@@ -54,7 +55,7 @@ def _is_silence_narration(content: Optional[str]) -> bool:
         return False
     return bool(_SILENCE_NARRATION.match(stripped))
 
-from .config import Platform, GatewayConfig, PlatformConfig
+from .config import Platform, GatewayConfig, PlatformConfig, _coerce_bool
 from .session import SessionSource
 from .dead_targets import DeadTargetRegistry
 
@@ -642,5 +643,189 @@ class DeliveryRouter:
         return result
 
 
+_NONINTERACTIVE_ARCHIVE_DURATIONS = frozenset({60, 1440, 4320, 10080})
+_NONINTERACTIVE_CLEANUP_MODES = frozenset({"archive", "delete", "retain"})
+_NONINTERACTIVE_ROUTES = frozenset({"operations", "origin", "local"})
+_NONINTERACTIVE_MENTION_EVENTS = frozenset({"failure", "intervention"})
+_NONINTERACTIVE_DEFAULT_MENTION_EVENTS = ("failure", "intervention")
 
 
+def _freeze_noninteractive_value(value: Any) -> Any:
+    """Return a recursively copied immutable snapshot of a contract value."""
+    if isinstance(value, Mapping):
+        return MappingProxyType({
+            key: _freeze_noninteractive_value(item)
+            for key, item in value.items()
+        })
+    if isinstance(value, list):
+        return tuple(_freeze_noninteractive_value(item) for item in value)
+    if isinstance(value, tuple):
+        return tuple(_freeze_noninteractive_value(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze_noninteractive_value(item) for item in value)
+    return value
+
+
+def _normalize_noninteractive_user_id(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if re.fullmatch(r"[0-9]{17,20}", value) else None
+
+
+def _normalize_noninteractive_mention_on(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple, set, frozenset)) or not value:
+        return _NONINTERACTIVE_DEFAULT_MENTION_EVENTS
+    normalized = []
+    for item in value:
+        if not isinstance(item, str):
+            return _NONINTERACTIVE_DEFAULT_MENTION_EVENTS
+        event = item.strip().lower()
+        if event not in _NONINTERACTIVE_MENTION_EVENTS:
+            return _NONINTERACTIVE_DEFAULT_MENTION_EVENTS
+        normalized.append(event)
+    return tuple(event for event in _NONINTERACTIVE_DEFAULT_MENTION_EVENTS if event in normalized)
+
+
+@dataclass(frozen=True)
+class NonInteractiveWorkDescriptor:
+    """Producer-neutral identity and lifecycle state for autonomous work."""
+
+    producer: str
+    work_id: str
+    title: str
+    origin: Mapping[str, Any]
+    interaction_mode: str = "terminal"
+    terminal_status: str = "running"
+    reply_binding: Optional[Mapping[str, Any]] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "origin", _freeze_noninteractive_value(self.origin or {}))
+        if self.reply_binding is not None:
+            object.__setattr__(self, "reply_binding", _freeze_noninteractive_value(self.reply_binding))
+
+
+@dataclass(frozen=True)
+class NonInteractiveWorkPolicy:
+    """Validated Discord operations-channel policy for non-interactive work."""
+
+    enabled: bool = False
+    channel_id: Optional[str] = None
+    chief_user_id: Optional[str] = None
+    mention_on: tuple[str, ...] = _NONINTERACTIVE_DEFAULT_MENTION_EVENTS
+    channel_name: Optional[str] = None
+    auto_archive_duration: int = 1440
+    cleanup: str = "archive"
+    retain_failures: bool = True
+    fallback_to_origin: bool = True
+    include_start_message: bool = True
+    include_cron: bool = True
+    include_background: bool = True
+    include_delegated: bool = True
+    routing: Optional[Mapping[str, str]] = None
+
+    def __post_init__(self) -> None:
+        channel_id = _normalize_noninteractive_user_id(self.channel_id)
+        object.__setattr__(self, "channel_id", channel_id)
+        if self.enabled and channel_id is None:
+            object.__setattr__(self, "enabled", False)
+        object.__setattr__(self, "chief_user_id", _normalize_noninteractive_user_id(self.chief_user_id))
+        object.__setattr__(self, "mention_on", _normalize_noninteractive_mention_on(self.mention_on))
+        object.__setattr__(self, "routing", _freeze_noninteractive_value(self.routing or {}))
+
+    def route_for(self, producer: str) -> str:
+        """Resolve a producer route, retaining origin behavior when disabled."""
+        producer = str(producer).strip().lower()
+        route = (self.routing or {}).get(producer)
+        included = {
+            "cron": self.include_cron,
+            "background": self.include_background,
+            "delegated": self.include_delegated,
+        }.get(producer, True)
+        if not included:
+            return route if route in {"origin", "local"} else "origin"
+        if route in {"origin", "local"}:
+            return route
+        if self.enabled:
+            return "operations"
+        return "origin"
+
+
+def _noninteractive_block(value: Any) -> dict:
+    """Extract the block from a raw config, PlatformConfig-like object, or block."""
+    def from_platform(platform: Any) -> dict:
+        extra = platform.get("extra") if isinstance(platform, Mapping) else getattr(platform, "extra", None)
+        if isinstance(extra, Mapping):
+            return dict(extra.get("noninteractive_work") or {})
+        return {}
+
+    if isinstance(value, Mapping):
+        platforms = value.get("platforms")
+        if isinstance(platforms, Mapping):
+            discord = platforms.get(Platform.DISCORD) or platforms.get("discord") or platforms.get("DISCORD")
+            if discord is not None:
+                return from_platform(discord)
+        if "noninteractive_work" in value:
+            return dict(value.get("noninteractive_work") or {})
+        # A mapping containing policy keys is itself the policy block.
+        return dict(value)
+    platforms = getattr(value, "platforms", None)
+    if isinstance(platforms, Mapping):
+        discord = platforms.get(Platform.DISCORD) or platforms.get("discord") or platforms.get("DISCORD")
+        if discord is not None:
+            return from_platform(discord)
+    extra = getattr(value, "extra", None)
+    return dict(extra.get("noninteractive_work") or {}) if isinstance(extra, Mapping) else {}
+
+
+def _noninteractive_bool(value: Any, default: bool) -> bool:
+    return _coerce_bool(value, default=default)
+
+
+def resolve_noninteractive_work_policy(config: Any) -> NonInteractiveWorkPolicy:
+    """Return a normalized, non-mutating policy for Discord autonomous work."""
+    raw = _noninteractive_block(config)
+    channel_id = _normalize_noninteractive_user_id(raw.get("channel_id"))
+
+    try:
+        archive_duration = int(raw.get("auto_archive_duration", 1440))
+    except (TypeError, ValueError):
+        archive_duration = 1440
+    if archive_duration not in _NONINTERACTIVE_ARCHIVE_DURATIONS:
+        archive_duration = 1440
+
+    cleanup = str(raw.get("cleanup", "archive") or "archive").strip().lower()
+    if cleanup not in _NONINTERACTIVE_CLEANUP_MODES:
+        cleanup = "archive"
+
+    routing_raw = raw.get("routing")
+    routing = {}
+    if isinstance(routing_raw, Mapping):
+        for producer, route in routing_raw.items():
+            producer = str(producer).strip().lower()
+            route = str(route).strip().lower()
+            if producer and route in _NONINTERACTIVE_ROUTES:
+                routing[producer] = route
+
+    enabled = _noninteractive_bool(raw.get("enabled"), False) and channel_id is not None
+    return NonInteractiveWorkPolicy(
+        enabled=enabled,
+        channel_id=channel_id,
+        chief_user_id=_normalize_noninteractive_user_id(raw.get("chief_user_id")),
+        mention_on=_normalize_noninteractive_mention_on(raw.get("mention_on")),
+        channel_name=str(raw["channel_name"]) if raw.get("channel_name") is not None else None,
+        auto_archive_duration=archive_duration,
+        cleanup=cleanup,
+        retain_failures=_noninteractive_bool(raw.get("retain_failures"), True),
+        fallback_to_origin=_noninteractive_bool(raw.get("fallback_to_origin"), True),
+        include_start_message=_noninteractive_bool(raw.get("include_start_message"), True),
+        include_cron=_noninteractive_bool(raw.get("include_cron"), True),
+        include_background=_noninteractive_bool(raw.get("include_background"), True),
+        include_delegated=_noninteractive_bool(raw.get("include_delegated"), True),
+        routing=routing,
+    )
+
+
+# Short aliases for callers that prefer the contract terminology.
+WorkDescriptor = NonInteractiveWorkDescriptor
+NonInteractivePolicy = NonInteractiveWorkPolicy

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2450,6 +2450,16 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
         return
 
 
+@dataclass(frozen=True)
+class NonInteractiveWorkThreadHandle:
+    """Platform-neutral identity for a non-interactive work thread."""
+
+    parent_channel_id: str
+    thread_id: str
+    thread_name: str
+    guild_id: Optional[str] = None
+
+
 @dataclass
 class SendResult:
     """Result of sending a message."""
@@ -3921,6 +3931,40 @@ class BasePlatformAdapter(ABC):
           - Slack:    seed-message thread anchoring
         """
         return None
+
+
+    async def create_noninteractive_work_thread(
+        self,
+        parent_channel_id: str,
+        name: str,
+        *,
+        auto_archive_duration: int = 1440,
+    ) -> Optional[NonInteractiveWorkThreadHandle]:
+        """Create a platform thread for autonomous/non-interactive work."""
+        return None
+
+    async def archive_noninteractive_work_thread(
+        self, handle: Optional[NonInteractiveWorkThreadHandle]
+    ) -> bool:
+        """Archive a non-interactive work thread, if supported."""
+        return False
+
+    async def delete_noninteractive_work_thread(
+        self, handle: Optional[NonInteractiveWorkThreadHandle]
+    ) -> bool:
+        """Delete a non-interactive work thread, if supported."""
+        return False
+
+    async def send_noninteractive_work_notification(
+        self,
+        handle: Optional[NonInteractiveWorkThreadHandle],
+        content: str,
+        *,
+        event: str,
+        chief_user_id: Optional[str] = None,
+    ) -> SendResult:
+        """Send an actionable/routine work notification, if supported."""
+        return SendResult(success=False, error="Not supported")
 
 
     async def edit_message(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -65,6 +65,32 @@ from agent.turn_context import (
 )
 from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.platforms.base import SendResult
+
+
+def _delivery_succeeded(result: Any) -> bool:
+    """Interpret adapter delivery results without breaking legacy adapters.
+
+    Current adapters return :class:`SendResult`, whose explicit failure must
+    prevent archival. Older adapters returned ``None`` (or other opaque
+    values), and those remain successful unless they expose an explicit,
+    concrete failure or error value.
+    """
+    if isinstance(result, SendResult):
+        return result.success is True
+    if isinstance(result, dict):
+        if result.get("success") is False or result.get("error"):
+            return False
+        return True
+
+    success = getattr(result, "success", None)
+    if isinstance(success, bool) and not success:
+        return False
+    error = getattr(result, "error", None)
+    if isinstance(error, str) and error:
+        return False
+    return True
+
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -5843,6 +5869,18 @@ class TurnRunner:
             "agent_persisted": (ctx.result_holder[0].get("agent_persisted", True) if ctx.result_holder[0] else True),
         }
 
+
+
+def _find_retained_cron_reply_binding(event: MessageEvent):
+    """Resolve a retained Discord cron thread without trusting thread names."""
+    source = getattr(event, "source", None)
+    if not source or getattr(source, "platform", None) != Platform.DISCORD:
+        return None
+    thread_id = getattr(source, "thread_id", None)
+    if not thread_id:
+        return None
+    from cron.jobs import find_operations_binding
+    return find_operations_binding(str(thread_id))
 
 
 class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
@@ -14650,6 +14688,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         source = event.source
 
+        # Retained cron work threads are authenticated bindings for a new,
+        # bounded follow-up; they never imply resuming the completed process.
+        if not getattr(event, "internal", False):
+            try:
+                binding = _find_retained_cron_reply_binding(event)
+                if binding:
+                    # Keep the authenticated binding on the event so the inner
+                    # dispatch can switch the durable SessionStore mapping. The
+                    # visible prefix is only context; it is not the binding.
+                    event._cron_reply_binding = dict(binding)
+                    event.text = (
+                        f"[Cron follow-up for job {binding['job_id']}, run "
+                        f"{binding['run_id']}; bounded follow-up]\n"
+                        f"{(event.text or '')[:3500]}"
+                    )
+            except Exception:
+                logger.debug("Retained cron reply binding lookup failed", exc_info=True)
+
         # 🔴 Cross-session leak guard. This handler runs inside a per-message
         # asyncio task created via create_task(), which snapshots the spawning
         # context with copy_context(). If a *concurrent* message had already
@@ -16776,6 +16832,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
 
         session_entry = await self.async_session_store.get_or_create_session(source)
+        cron_reply_binding = getattr(event, "_cron_reply_binding", None)
+        bound_cron_session_id = str((cron_reply_binding or {}).get("session_id") or "").strip()
+        if bound_cron_session_id:
+            switched = await self.async_session_store.switch_session(
+                session_entry.session_key, bound_cron_session_id
+            )
+            if switched is None:
+                logger.warning(
+                    "Cron reply binding target %s is unavailable; keeping a new session",
+                    bound_cron_session_id,
+                )
+            else:
+                session_entry = switched
         session_key = session_entry.session_key
         pinned_session_id = str(
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
@@ -20014,6 +20083,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         event_message_id: Optional[str] = None,
         media_urls: Optional[List[str]] = None,
         media_types: Optional[List[str]] = None,
+        lifecycle_handle=None,
+        lifecycle_policy=None,
+        lifecycle_start_failed: bool = False,
+        lifecycle_adapter=None,
     ) -> None:
         """Profile-scoping wrapper around the background agent task.
 
@@ -20025,12 +20098,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
             return await self._run_background_task_inner(
                 prompt, source, task_id, event_message_id, media_urls, media_types,
+                lifecycle_handle, lifecycle_policy,
+                lifecycle_start_failed, lifecycle_adapter,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
         with _profile_runtime_scope(profile_home):
             return await self._run_background_task_inner(
                 prompt, source, task_id, event_message_id, media_urls, media_types,
+                lifecycle_handle, lifecycle_policy,
+                lifecycle_start_failed, lifecycle_adapter,
             )
 
     async def _run_background_task_inner(
@@ -20041,6 +20118,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         event_message_id: Optional[str] = None,
         media_urls: Optional[List[str]] = None,
         media_types: Optional[List[str]] = None,
+        lifecycle_handle=None,
+        lifecycle_policy=None,
+        lifecycle_start_failed: bool = False,
+        lifecycle_adapter=None,
     ) -> None:
         """Execute a background agent task and deliver the result to the chat."""
         from run_agent import AIAgent
@@ -20051,9 +20132,124 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter = self._adapter_for_source(source)
         if not adapter:
             logger.warning("No adapter for platform %s in background task %s", source.platform, task_id)
+            if lifecycle_handle is not None and lifecycle_policy is not None and lifecycle_adapter is not None:
+                try:
+                    if lifecycle_policy.retain_failures:
+                        return
+                    if lifecycle_policy.cleanup == "delete":
+                        await lifecycle_adapter.delete_noninteractive_work_thread(lifecycle_handle)
+                    elif lifecycle_policy.cleanup != "retain":
+                        await lifecycle_adapter.archive_noninteractive_work_thread(lifecycle_handle)
+                except Exception:
+                    logger.debug("Background orphan cleanup failed", exc_info=True)
             return
 
         _thread_metadata = self._thread_metadata_for_source(source, event_message_id)
+        operations = lifecycle_handle is not None and lifecycle_policy is not None
+        delivery_disabled = (
+            lifecycle_handle is None
+            and lifecycle_policy is not None
+            and not lifecycle_policy.fallback_to_origin
+        )
+        # A failed start notification is independent from final-result/media
+        # delivery.  It should not turn a successfully delivered result into a
+        # delivery failure (or suppress success cleanup).
+        delivery_ok = True
+        failure_escalated = False
+        failure_escalation_delivered = False
+        notification_exception = False
+        if lifecycle_start_failed:
+            logger.warning("Background task %s start notification was not delivered", task_id)
+        _delivery_chat_id = lifecycle_handle.thread_id if operations else source.chat_id
+        _delivery_metadata = {"thread_id": lifecycle_handle.thread_id} if operations else _thread_metadata
+        safe_prompt = _sanitize_gateway_final_response(source.platform, prompt)
+
+        async def _notify(content: str, event: str) -> bool:
+            nonlocal delivery_ok, notification_exception
+            content = _sanitize_gateway_final_response(source.platform, content)
+            if delivery_disabled:
+                logger.error("Background task %s result undelivered: operations thread unavailable and origin fallback disabled", task_id)
+                delivery_ok = False
+                return False
+            try:
+                if operations:
+                    result = await adapter.send_noninteractive_work_notification(
+                        lifecycle_handle,
+                        content,
+                        event=event,
+                        chief_user_id=(lifecycle_policy.chief_user_id if event in lifecycle_policy.mention_on else None),
+                    )
+                else:
+                    origin_metadata = dict(_thread_metadata or {})
+                    origin_metadata["_hermes_origin_background"] = True
+                    result = await adapter.send(source.chat_id, content, metadata=origin_metadata)
+            except Exception:
+                notification_exception = True
+                delivery_ok = False
+                logger.debug("Background notification failed", exc_info=True)
+                return False
+            delivery_succeeded = _delivery_succeeded(result)
+            if not delivery_succeeded:
+                delivery_ok = False
+            return delivery_succeeded
+
+        async def _origin_failure(content: str) -> bool:
+            nonlocal delivery_ok
+            if (
+                not operations
+                or not lifecycle_policy.fallback_to_origin
+            ):
+                return True
+            content = _sanitize_gateway_final_response(source.platform, content)
+            guild_id = getattr(lifecycle_handle, "guild_id", None)
+            location = (
+                f"see https://discord.com/channels/{guild_id}/{lifecycle_handle.parent_channel_id}/{lifecycle_handle.thread_id}"
+                if guild_id
+                else f"see thread {lifecycle_handle.thread_id} in channel {lifecycle_handle.parent_channel_id}"
+            )
+            chief_user_id = lifecycle_policy.chief_user_id
+            valid_chief_user_id = (
+                isinstance(chief_user_id, str)
+                and chief_user_id.isdigit()
+                and 17 <= len(chief_user_id) <= 20
+            )
+            mention = f"<@{chief_user_id}> " if valid_chief_user_id else ""
+            origin_metadata = dict(_thread_metadata or {})
+            origin_metadata["_hermes_origin_failure"] = True
+            origin_metadata["_hermes_chief_user_id"] = chief_user_id if valid_chief_user_id else None
+            try:
+                result = await adapter.send(
+                    source.chat_id,
+                    f"{mention}Background task {task_id} failed: {content}; {location}",
+                    metadata=origin_metadata,
+                )
+                succeeded = _delivery_succeeded(result)
+                if not succeeded:
+                    delivery_ok = False
+                return succeeded
+            except Exception:
+                delivery_ok = False
+                logger.debug("Background origin failure notification failed", exc_info=True)
+                return False
+
+        async def _cleanup_failure() -> None:
+            if (
+                not operations
+                or lifecycle_policy.retain_failures
+                or lifecycle_policy.cleanup == "retain"
+                or (
+                    not delivery_ok
+                    and (not failure_escalation_delivered or notification_exception)
+                )
+            ):
+                return
+            try:
+                if lifecycle_policy.cleanup == "delete":
+                    await adapter.delete_noninteractive_work_thread(lifecycle_handle)
+                else:
+                    await adapter.archive_noninteractive_work_thread(lifecycle_handle)
+            except Exception:
+                logger.debug("Background failure cleanup failed", exc_info=True)
 
         try:
             user_config = _load_gateway_config()
@@ -20062,11 +20258,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_config=user_config,
             )
             if not runtime_kwargs.get("api_key"):
-                await adapter.send(
-                    source.chat_id,
+                final_delivered = await _notify(
                     f"❌ Background task {task_id} failed: no provider credentials configured.",
-                    metadata=_thread_metadata,
+                    "failure",
                 )
+                if not final_delivered:
+                    failure_escalation_delivered = await _notify(
+                        f"❌ Background task {task_id} failure notification could not be delivered.", "failure"
+                    )
+                    failure_escalated = True
+                await _origin_failure("no provider credentials configured")
+                await _cleanup_failure()
                 return
 
             platform_key = _platform_config_key(source.platform)
@@ -20144,9 +20346,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             result = await self._run_in_executor_with_context(run_sync)
 
+            result_error = result.get("error") if isinstance(result, dict) else getattr(result, "error", None)
+            if result_error:
+                safe_error = _redact_gateway_user_facing_secrets(str(result_error))
+                safe_error = re.sub(r"(?i)(secret|token|password|api[_-]?key)\s*[=:]\s*\S+", r"\1=[REDACTED]", safe_error)
+                await _notify(f"❌ Background task {task_id} failed: {safe_error}", "failure")
+                await _origin_failure(safe_error)
+                await _cleanup_failure()
+                return
+
             response = result.get("final_response", "") if result else ""
-            if not response and result and result.get("error"):
-                response = f"Error: {result['error']}"
 
             # Extract media files from the response
             if response:
@@ -20155,33 +20364,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
                 images, text_content = adapter.extract_images(response)
 
-                preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+                preview = safe_prompt[:60] + ("..." if len(safe_prompt) > 60 else "")
                 header = f'✅ Background task complete\nPrompt: "{preview}"\n\n'
 
                 if text_content:
-                    await adapter.send(
-                        chat_id=source.chat_id,
-                        content=header + text_content,
-                        metadata=_thread_metadata,
+                    final_delivered = await _notify(
+                        header + text_content,
+                        "success",
                     )
                 elif not images and not media_files:
-                    await adapter.send(
-                        chat_id=source.chat_id,
-                        content=header + "(No response generated)",
-                        metadata=_thread_metadata,
+                    final_delivered = await _notify(
+                        header + "(No response generated)",
+                        "success",
                     )
 
-                # Send extracted images
+                # Send extracted images and result media into the lifecycle thread.
+                _media_metadata = _delivery_metadata
                 for image_url, alt_text in (images or []):
                     try:
-                        await adapter.send_image(
-                            chat_id=source.chat_id,
+                        send_result = await adapter.send_image(
+                            chat_id=_delivery_chat_id,
                             image_url=image_url,
                             caption=alt_text,
-                            metadata=_thread_metadata,
+                            metadata=_media_metadata,
                         )
+                        if not _delivery_succeeded(send_result):
+                            delivery_ok = False
                     except Exception:
-                        pass
+                        delivery_ok = False
 
                 # Send media files, routing each by type so a TTS clip
                 # arrives as a voice bubble / a clip as a video rather than
@@ -20195,47 +20405,74 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _ext = os.path.splitext(media_path)[1].lower()
                     try:
                         if _should_send_media_as_audio(source.platform, _ext, _is_voice):
-                            await adapter.send_voice(
-                                chat_id=source.chat_id,
+                            send_result = await adapter.send_voice(
+                                chat_id=_delivery_chat_id,
                                 audio_path=media_path,
-                                metadata=_thread_metadata,
+                                metadata=_media_metadata,
                             )
                         elif _ext in _VIDEO_EXTS:
-                            await adapter.send_video(
-                                chat_id=source.chat_id,
+                            send_result = await adapter.send_video(
+                                chat_id=_delivery_chat_id,
                                 video_path=media_path,
-                                metadata=_thread_metadata,
+                                metadata=_media_metadata,
                             )
                         elif _ext in _IMAGE_EXTS:
-                            await adapter.send_image_file(
-                                chat_id=source.chat_id,
+                            send_result = await adapter.send_image_file(
+                                chat_id=_delivery_chat_id,
                                 image_path=media_path,
-                                metadata=_thread_metadata,
+                                metadata=_media_metadata,
                             )
                         else:
-                            await adapter.send_document(
-                                chat_id=source.chat_id,
+                            send_result = await adapter.send_document(
+                                chat_id=_delivery_chat_id,
                                 file_path=media_path,
-                                metadata=_thread_metadata,
+                                metadata=_media_metadata,
                             )
                     except Exception:
-                        pass
+                        delivery_ok = False
+                        continue
+                    if not _delivery_succeeded(send_result):
+                        delivery_ok = False
+                if not delivery_ok and not failure_escalated:
+                    failure_escalation_delivered = await _notify(
+                        f"❌ Background task {task_id} completed, but result delivery failed.", "failure"
+                    )
+                    failure_escalated = True
+                    await _origin_failure("result delivery failed")
+                    await _cleanup_failure()
             else:
-                preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-                await adapter.send(
-                    chat_id=source.chat_id,
-                    content=f'✅ Background task complete\nPrompt: "{preview}"\n\n(No response generated)',
-                    metadata=_thread_metadata,
+                preview = safe_prompt[:60] + ("..." if len(safe_prompt) > 60 else "")
+                final_delivered = await _notify(
+                    f'✅ Background task complete\nPrompt: "{preview}"\n\n(No response generated)',
+                    "success",
                 )
+                if not delivery_ok and not failure_escalated:
+                    failure_escalation_delivered = await _notify(
+                        f"❌ Background task {task_id} result delivery failed.", "failure"
+                    )
+                    failure_escalated = True
+                    await _origin_failure("result delivery failed")
+                    await _cleanup_failure()
+            if operations and delivery_ok and lifecycle_policy.cleanup != "retain":
+                try:
+                    if lifecycle_policy.cleanup == "delete":
+                        await adapter.delete_noninteractive_work_thread(lifecycle_handle)
+                    else:
+                        await adapter.archive_noninteractive_work_thread(lifecycle_handle)
+                except Exception:
+                    logger.debug("Background operations archive failed", exc_info=True)
 
         except Exception as e:
             logger.exception("Background task %s failed", task_id)
             try:
-                await adapter.send(
-                    chat_id=source.chat_id,
-                    content=f"❌ Background task {task_id} failed: {e}",
-                    metadata=_thread_metadata,
+                safe_error = _redact_gateway_user_facing_secrets(str(e))
+                safe_error = re.sub(r"(?i)(secret|token|password|api[_-]?key)\s*[=:]\s*\S+", r"\1=[REDACTED]", safe_error)
+                await _notify(
+                    f"❌ Background task {task_id} failed: {safe_error}",
+                    "failure",
                 )
+                await _origin_failure(safe_error)
+                await _cleanup_failure()
             except Exception:
                 pass
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -32,8 +32,15 @@ from typing import Any, Optional, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
 from agent.turn_context import extract_api_content_sidecar
-from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
+from gateway.config import (
+    HomeChannel,
+    Platform,
+    PlatformConfig,
+    persist_home_channel,
+    resolve_noninteractive_work_policy,
+)
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
+from gateway.delivery import NonInteractiveWorkDescriptor
 from gateway.session import (
     AsyncSessionStore,
     SessionSource,
@@ -3331,6 +3338,45 @@ class GatewaySlashCommandsMixin:
         media_urls = list(event.media_urls) if event.media_urls else []
         media_types = list(event.media_types) if event.media_types else []
 
+        from gateway.run import _sanitize_gateway_final_response
+        safe_prompt = _sanitize_gateway_final_response(source.platform, prompt)
+
+        # Create the Discord operations surface before scheduling so failures
+        # have a retained destination and the handle is immutable per run.
+        lifecycle_handle = None
+        lifecycle_policy = None
+        operations_requested = False
+        lifecycle_start_failed = False
+        if source.platform == Platform.DISCORD:
+            try:
+                from gateway.run import _load_gateway_config
+                lifecycle_policy = resolve_noninteractive_work_policy(_load_gateway_config())
+                if lifecycle_policy.route_for("background") == "operations":
+                    operations_requested = True
+                    adapter = (
+                        self._adapter_for_source(source)
+                        if hasattr(self, "_adapter_for_source")
+                        else None
+                    ) or self.adapters.get(source.platform)
+                    safe_prompt = _sanitize_gateway_final_response(source.platform, prompt)
+                    lifecycle_handle = await adapter.create_noninteractive_work_thread(
+                        lifecycle_policy.channel_id,
+                        f"background {task_id}: {safe_prompt[:70]}",
+                        auto_archive_duration=lifecycle_policy.auto_archive_duration,
+                    )
+                    if lifecycle_handle and lifecycle_policy.include_start_message:
+                        from gateway.run import _delivery_succeeded
+                        start_result = await adapter.send_noninteractive_work_notification(
+                            lifecycle_handle,
+                            f"▶️ Background task {task_id} started. Prompt: {_sanitize_gateway_final_response(source.platform, prompt)[:240]}",
+                            event="start",
+                        )
+                        if not _delivery_succeeded(start_result):
+                            lifecycle_start_failed = True
+            except Exception as exc:
+                logger.warning("Background operations thread setup failed for %s: %s", task_id, exc)
+                lifecycle_start_failed = lifecycle_handle is not None
+
         # Fire-and-forget the background task
         _task = asyncio.create_task(
             self._run_background_task(
@@ -3340,13 +3386,18 @@ class GatewaySlashCommandsMixin:
                 event_message_id=event_message_id,
                 media_urls=media_urls,
                 media_types=media_types,
+                lifecycle_handle=lifecycle_handle,
+                lifecycle_policy=lifecycle_policy,
+                lifecycle_start_failed=lifecycle_start_failed,
+                lifecycle_adapter=adapter if lifecycle_handle is not None else None,
             )
         )
         self._background_tasks.add(_task)
         _task.add_done_callback(self._background_tasks.discard)
 
-        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-        return t("gateway.background.started", preview=preview, task_id=task_id)
+        preview = safe_prompt[:60] + ("..." if len(safe_prompt) > 60 else "")
+        fallback_note = " Operations thread unavailable; results will be sent here." if operations_requested and lifecycle_handle is None else ""
+        return t("gateway.background.started", preview=preview, task_id=task_id) + fallback_note
 
     def _save_gateway_config_key(self, key_path: str, value) -> bool:
         """Save a dot-separated key to config.yaml (shared by /reasoning, /fast

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -70,6 +70,7 @@ class _Snowflake:
         self.id = id
 
 VALID_THREAD_AUTO_ARCHIVE_MINUTES = {60, 1440, 4320, 10080}
+_DISCORD_NONINTERACTIVE_MISSING = object()
 _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
 _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
@@ -154,6 +155,7 @@ from gateway.platforms.base import (
     MessageType,
     ProcessingOutcome,
     SendResult,
+    NonInteractiveWorkThreadHandle,
     cache_image_from_url,
     cache_image_from_bytes,
     cache_audio_from_url,
@@ -3083,6 +3085,27 @@ class DiscordAdapter(BasePlatformAdapter):
                 thread_id = metadata["thread_id"]
             nonconversational = _metadata_marks_nonconversational(metadata)
             final_delivery = bool(metadata and metadata.get("notify"))
+            origin_failure = bool(metadata and metadata.get("_hermes_origin_failure"))
+            origin_background = bool(metadata and metadata.get("_hermes_origin_background"))
+            allowed_mentions = None
+            if origin_failure:
+                chief_user_id = metadata.get("_hermes_chief_user_id") if metadata else None
+                valid_chief_user_id = (
+                    isinstance(chief_user_id, str)
+                    and chief_user_id.isdigit()
+                    and 17 <= len(chief_user_id) <= 20
+                )
+                if valid_chief_user_id:
+                    allowed_mentions = discord.AllowedMentions(
+                        everyone=False,
+                        roles=False,
+                        replied_user=False,
+                        users=[discord.Object(id=int(chief_user_id))],
+                    )
+                else:
+                    allowed_mentions = discord.AllowedMentions.none()
+            elif origin_background:
+                allowed_mentions = discord.AllowedMentions.none()
 
             if thread_id:
                 # Fetch the thread directly — threads are addressed by their own ID.
@@ -3101,7 +3124,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
-                result = await self._send_to_forum(channel, content)
+                result = await self._send_to_forum(channel, content, allowed_mentions=allowed_mentions)
                 await asyncio.to_thread(
                     self._record_discord_response,
                     reply_to=reply_to,
@@ -3128,6 +3151,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     msg = await channel.send(
                         content=chunk,
                         reference=chunk_reference,
+                        **({"allowed_mentions": allowed_mentions} if allowed_mentions is not None else {}),
                     )
                 except Exception as e:
                     err_text = str(e)
@@ -3150,6 +3174,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         msg = await channel.send(
                             content=chunk,
                             reference=None,
+                            **({"allowed_mentions": allowed_mentions} if allowed_mentions is not None else {}),
                         )
                     else:
                         raise
@@ -3190,7 +3215,13 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return result
 
-    async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
+    async def _send_to_forum(
+        self,
+        forum_channel: Any,
+        content: str,
+        *,
+        allowed_mentions: Any = None,
+    ) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
         Forum channels (type 15) don't support direct messages.  Instead we
@@ -3213,6 +3244,7 @@ class DiscordAdapter(BasePlatformAdapter):
             thread = await forum_channel.create_thread(
                 name=thread_name,
                 content=starter_content,
+                **({"allowed_mentions": allowed_mentions} if allowed_mentions is not None else {}),
             )
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
@@ -3229,7 +3261,10 @@ class DiscordAdapter(BasePlatformAdapter):
         warnings: list[str] = []
         for chunk in chunks[1:]:
             try:
-                msg = await thread_channel.send(content=chunk)
+                msg = await thread_channel.send(
+                    content=chunk,
+                    **({"allowed_mentions": allowed_mentions} if allowed_mentions is not None else {}),
+                )
                 message_ids.append(str(msg.id))
             except Exception as e:
                 warning = f"Failed to send follow-up chunk to forum thread {thread_id}: {e}"
@@ -6934,6 +6969,175 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception:
             logger.debug("[%s] Failed to rename Discord thread %s", self.name, thread_id, exc_info=True)
             return False
+
+    async def create_noninteractive_work_thread(
+        self,
+        parent_channel_id: str,
+        name: str,
+        *,
+        auto_archive_duration: int = 1440,
+    ) -> Optional[NonInteractiveWorkThreadHandle]:
+        """Create an operations thread, preferring Discord's direct API path."""
+        if auto_archive_duration not in VALID_THREAD_AUTO_ARCHIVE_MINUTES:
+            return None
+        if not self._client or not DISCORD_AVAILABLE:
+            return None
+        try:
+            parent_id = str(int(parent_channel_id))
+            parent = self._client.get_channel(int(parent_id))
+            if parent is None:
+                parent = await self._client.fetch_channel(int(parent_id))
+            if parent is None:
+                return None
+            thread_name = (name or "non-interactive work").strip()[:100] or "non-interactive work"
+            create = getattr(parent, "create_thread", None)
+            if callable(create):
+                try:
+                    thread = await create(
+                        name=thread_name,
+                        auto_archive_duration=auto_archive_duration,
+                        reason="Hermes non-interactive work",
+                    )
+                except Exception:
+                    thread = None
+                if thread is not None:
+                    return NonInteractiveWorkThreadHandle(
+                        parent_channel_id=parent_id,
+                        thread_id=str(thread.id),
+                        thread_name=getattr(thread, "name", None) or thread_name,
+                        guild_id=(str(getattr(getattr(parent, "guild", None), "id", "")) or None),
+                    )
+
+            send = getattr(parent, "send", None)
+            if not callable(send):
+                return None
+            seed = await send(
+                f"🧵 Hermes non-interactive work: **{thread_name}**",
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+            try:
+                thread = await seed.create_thread(
+                    name=thread_name,
+                    auto_archive_duration=auto_archive_duration,
+                    reason="Hermes non-interactive work",
+                )
+            except Exception:
+                # The seed is only an implementation detail of the fallback
+                # path.  Do not leave it in the parent when thread creation
+                # fails, but preserve the original failure result.
+                try:
+                    await seed.delete(reason="Hermes non-interactive work cleanup")
+                except Exception:
+                    logger.debug("[%s] Failed to delete orphaned non-interactive seed", self.name, exc_info=True)
+                raise
+            return NonInteractiveWorkThreadHandle(
+                parent_channel_id=parent_id,
+                thread_id=str(thread.id),
+                thread_name=getattr(thread, "name", None) or thread_name,
+                guild_id=(str(getattr(getattr(parent, "guild", None), "id", "")) or None),
+            )
+        except Exception:
+            logger.warning("[%s] Failed to create non-interactive work thread", self.name, exc_info=True)
+            return None
+
+    async def _noninteractive_thread(self, handle: NonInteractiveWorkThreadHandle) -> Optional[Any]:
+        if not self._client or not handle:
+            return None
+        try:
+            thread_id = int(handle.thread_id)
+        except (TypeError, ValueError):
+            return None
+        thread = self._client.get_channel(thread_id)
+        if thread is None:
+            try:
+                thread = await self._client.fetch_channel(thread_id)
+                if thread is None:
+                    return _DISCORD_NONINTERACTIVE_MISSING
+            except Exception as exc:
+                if "unknown channel" in str(exc).lower() or "unknown thread" in str(exc).lower():
+                    return _DISCORD_NONINTERACTIVE_MISSING
+                logger.warning("[%s] Failed to look up non-interactive thread %s", self.name, handle.thread_id, exc_info=True)
+                return None
+        return thread
+
+    async def archive_noninteractive_work_thread(
+        self, handle: Optional[NonInteractiveWorkThreadHandle]
+    ) -> bool:
+        thread = await self._noninteractive_thread(handle)
+        if thread is None:
+            return False
+        if thread is _DISCORD_NONINTERACTIVE_MISSING:
+            return True
+        if getattr(thread, "archived", False):
+            return True
+        try:
+            await thread.edit(archived=True, reason="Hermes non-interactive work cleanup")
+            return True
+        except Exception as exc:
+            if "unknown channel" in str(exc).lower() or "unknown thread" in str(exc).lower():
+                return True
+            logger.warning("[%s] Failed to archive non-interactive thread %s", self.name, handle.thread_id, exc_info=True)
+            return False
+
+    async def delete_noninteractive_work_thread(
+        self, handle: Optional[NonInteractiveWorkThreadHandle]
+    ) -> bool:
+        thread = await self._noninteractive_thread(handle)
+        if thread is None:
+            return False
+        if thread is _DISCORD_NONINTERACTIVE_MISSING:
+            return True
+        try:
+            await thread.delete(reason="Hermes non-interactive work cleanup")
+            return True
+        except Exception as exc:
+            if "unknown channel" in str(exc).lower() or "unknown thread" in str(exc).lower():
+                return True
+            logger.warning("[%s] Failed to delete non-interactive thread %s", self.name, handle.thread_id, exc_info=True)
+            return False
+
+    async def send_noninteractive_work_notification(
+        self,
+        handle: Optional[NonInteractiveWorkThreadHandle],
+        content: str,
+        *,
+        event: str,
+        chief_user_id: Optional[str] = None,
+    ) -> SendResult:
+        """Send a work update with explicit mention gating and allowed mentions."""
+        thread = await self._noninteractive_thread(handle)
+        if thread is None:
+            return SendResult(success=False, error="Thread not found")
+        valid_chief_user_id = (
+            isinstance(chief_user_id, str)
+            and chief_user_id.isdigit()
+            and 17 <= len(chief_user_id) <= 20
+        )
+        actionable = event in {"failure", "intervention"} and valid_chief_user_id
+        message = f"<@{chief_user_id}> {content}" if actionable else content
+        try:
+            if actionable:
+                allowed_mentions = discord.AllowedMentions(
+                    everyone=False,
+                    roles=False,
+                    replied_user=False,
+                    users=[discord.Object(id=int(chief_user_id))],
+                )
+            else:
+                allowed_mentions = discord.AllowedMentions.none()
+            chunks = self.truncate_message(message, self.MAX_MESSAGE_LENGTH)
+            last_message_id = None
+            for index, chunk in enumerate(chunks):
+                # Only the first chunk is permitted to notify the Chief.  The
+                # remainder must be mention-free even if its text contains
+                # mention-looking content.
+                chunk_mentions = allowed_mentions if index == 0 else discord.AllowedMentions.none()
+                sent = await thread.send(content=chunk, allowed_mentions=chunk_mentions)
+                last_message_id = str(getattr(sent, "id", "")) or last_message_id
+            return SendResult(success=True, message_id=last_message_id)
+        except Exception as exc:
+            logger.warning("[%s] Failed to send non-interactive notification", self.name, exc_info=True)
+            return SendResult(success=False, error=str(exc))
 
     async def create_handoff_thread(
         self,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,9 +9,75 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets, _operations_binding_for_job
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
+
+
+def test_retained_operations_binding_is_resolved_by_thread(tmp_path, monkeypatch):
+    from cron import jobs
+    monkeypatch.setattr(jobs, "CRON_DIR", tmp_path)
+    monkeypatch.setattr(jobs, "JOBS_FILE", tmp_path / "jobs.json")
+    jobs.save_jobs([{
+        "id": "job-1", "name": "Nightly", "enabled": True,
+        "operations_binding": {"platform": "discord", "thread_id": "thread-1", "state": "retained"},
+    }])
+    assert jobs.find_operations_binding("thread-1")["job_id"] == "job-1"
+    assert jobs.find_operations_binding("thread-2") is None
+
+
+def test_operations_binding_contains_authoritative_run_identity():
+    binding = _operations_binding_for_job(
+        {"id": "job-1", "name": "Nightly"},
+        run_id="run-1",
+        session_id="cron-session-1",
+        handle=type("Handle", (), {
+            "parent_channel_id": "123456789012345678",
+            "thread_id": "234567890123456789",
+            "guild_id": "345678901234567890",
+        })(),
+    )
+
+    assert binding == {
+        "platform": "discord",
+        "guild_id": "345678901234567890",
+        "channel_id": "123456789012345678",
+        "thread_id": "234567890123456789",
+        "job_id": "job-1",
+        "run_id": "run-1",
+        "session_id": "cron-session-1",
+        "state": "running",
+    }
+
+
+def test_send_media_via_adapter_reports_explicit_attachment_failure(tmp_path, monkeypatch):
+    media_path = tmp_path / "report.pdf"
+    media_path.write_bytes(b"pdf")
+    monkeypatch.setattr("gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS", (tmp_path,))
+    adapter = MagicMock()
+    adapter.send_document.return_value = AsyncMock()
+    loop = MagicMock()
+    failed = MagicMock(success=False, error="discord unavailable")
+    future = MagicMock()
+    future.result.return_value = failed
+    with patch("agent.async_utils.safe_schedule_threadsafe", return_value=future):
+        assert _send_media_via_adapter(
+            adapter, "thread-1", [(str(media_path), False)], {}, loop,
+            {"id": "job-1"}, platform="discord",
+        ) is False
+
+
+def test_retained_cron_reply_binding_preserves_authoritative_session_id(monkeypatch):
+    from gateway.config import Platform
+    from gateway.run import _find_retained_cron_reply_binding
+    event = MagicMock()
+    event.source.platform = Platform.DISCORD
+    event.source.thread_id = "thread-1"
+    monkeypatch.setattr(
+        "cron.jobs.find_operations_binding",
+        lambda _thread_id: {"job_id": "job-1", "run_id": "run-1", "session_id": "cron-session-1"},
+    )
+    assert _find_retained_cron_reply_binding(event)["session_id"] == "cron-session-1"
 
 
 class TestPerJobToolsetMcpMerge:

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -10,7 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, NonInteractiveWorkThreadHandle, SendResult
+from gateway.run import _delivery_succeeded
 from gateway.session import SessionSource
 
 
@@ -81,6 +82,61 @@ class TestHandleBackgroundCommand:
         result = await runner._handle_background_command(event)
         assert "Usage:" in result
 
+    @pytest.mark.asyncio
+    async def test_discord_operations_route_creates_thread_and_passes_handle(self):
+        runner = _make_runner()
+        adapter = MagicMock()
+        adapter.create_noninteractive_work_thread = AsyncMock(
+            return_value=NonInteractiveWorkThreadHandle("999", "888", "background bg_test")
+        )
+        adapter.send_noninteractive_work_notification = AsyncMock()
+        runner.adapters[Platform.DISCORD] = adapter
+        event = _make_event(text="/background do the work", platform=Platform.DISCORD)
+
+        with patch(
+            "gateway.slash_commands.resolve_noninteractive_work_policy",
+            return_value=MagicMock(
+                enabled=True, channel_id="999", include_start_message=True,
+                auto_archive_duration=1440, cleanup="archive",
+                retain_failures=True, fallback_to_origin=True,
+                route_for=lambda producer: "operations",
+            ),
+        ), patch.object(runner, "_run_background_task", new_callable=AsyncMock) as run_task:
+            await runner._handle_background_command(event)
+            await asyncio.sleep(0)
+
+        adapter.create_noninteractive_work_thread.assert_awaited_once()
+        assert run_task.await_args.kwargs["lifecycle_handle"].thread_id == "888"
+
+    @pytest.mark.asyncio
+    async def test_discord_operations_prompt_is_sanitized_before_thread_and_start_delivery(self):
+        runner = _make_runner()
+        adapter = MagicMock()
+        adapter.create_noninteractive_work_thread = AsyncMock(
+            return_value=NonInteractiveWorkThreadHandle("999", "888", "background bg_test")
+        )
+        adapter.send_noninteractive_work_notification = AsyncMock()
+        runner.adapters[Platform.DISCORD] = adapter
+        secret = "api_key=TOPSECRET"
+        event = _make_event(text=f"/background do {secret}", platform=Platform.DISCORD)
+
+        with patch(
+            "gateway.slash_commands.resolve_noninteractive_work_policy",
+            return_value=MagicMock(
+                enabled=True, channel_id="999", include_start_message=True,
+                auto_archive_duration=1440, cleanup="archive",
+                retain_failures=True, fallback_to_origin=True,
+                route_for=lambda producer: "operations",
+            ),
+        ), patch.object(runner, "_run_background_task", new_callable=AsyncMock):
+            acknowledgement = await runner._handle_background_command(event)
+
+        thread_name = adapter.create_noninteractive_work_thread.await_args.args[1]
+        start_message = adapter.send_noninteractive_work_notification.await_args.args[1]
+        assert "TOPSECRET" not in thread_name
+        assert "TOPSECRET" not in start_message
+        assert "TOPSECRET" not in acknowledgement
+
 
 # ---------------------------------------------------------------------------
 # _run_background_task
@@ -113,6 +169,41 @@ class TestRunBackgroundTask:
         mock_adapter.send.assert_called_once()
         call_args = mock_adapter.send.call_args
         assert "failed" in call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "").lower()
+
+    @pytest.mark.asyncio
+    async def test_successful_origin_prompt_marks_discord_send_as_mentionless(self):
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter.extract_media = MagicMock(return_value=([], "done"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.DISCORD] = mock_adapter
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+        hostile_prompt = "<@12345678901234567> <@&88888888888888888> @everyone @here"
+        mock_result = {"final_response": "done", "messages": []}
+
+        with (
+            patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
+            patch("gateway.run._load_gateway_config", return_value={}),
+            patch("run_agent.AIAgent") as MockAgent,
+        ):
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task(hostile_prompt, source, "bg_test")
+
+        mock_adapter.send.assert_called_once()
+        metadata = mock_adapter.send.call_args.kwargs["metadata"]
+        assert metadata["_hermes_origin_background"] is True
+        assert hostile_prompt in mock_adapter.send.call_args.args[1]
 
     @pytest.mark.asyncio
     async def test_successful_task_sends_result(self):
@@ -166,6 +257,34 @@ class TestRunBackgroundTask:
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_operations_result_is_sent_to_thread_and_success_is_archived(self):
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Hello from background!"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Hello from background!"))
+        mock_adapter.send_noninteractive_work_notification = AsyncMock()
+        mock_adapter.archive_noninteractive_work_thread = AsyncMock(return_value=True)
+        runner.adapters[Platform.DISCORD] = mock_adapter
+        source = SessionSource(platform=Platform.DISCORD, user_id="12345", chat_id="67890")
+        handle = NonInteractiveWorkThreadHandle("999", "888", "background bg_test")
+        config = {"agent": {}, "platforms": {"discord": {}}}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("gateway.run._load_gateway_config", return_value=config), \
+             patch("run_agent.AIAgent") as MockAgent:
+            instance = MagicMock()
+            instance.run_conversation.return_value = {"final_response": "Hello from background!", "messages": []}
+            MockAgent.return_value = instance
+            await runner._run_background_task(
+                "say hello", source, "bg_test", lifecycle_handle=handle,
+                lifecycle_policy=MagicMock(cleanup="archive", retain_failures=True,
+                                           chief_user_id=None, mention_on=("failure", "intervention")),
+            )
+
+        assert any(call.kwargs.get("event") == "success" for call in mock_adapter.send_noninteractive_work_notification.await_args_list)
+        mock_adapter.archive_noninteractive_work_thread.assert_awaited_once_with(handle)
+
 
 # ---------------------------------------------------------------------------
 # /background in help and known_commands
@@ -209,3 +328,443 @@ class TestBackgroundInCLICommands:
         completions = list(completer.get_completions(doc, None))
         cmd_displays = [str(c.display) for c in completions]
         assert any("/background" in d for d in cmd_displays)
+
+
+class _Policy:
+    cleanup = "archive"
+    retain_failures = True
+    fallback_to_origin = True
+    chief_user_id = "12345678901234567"
+    mention_on = ("failure", "intervention")
+
+
+@pytest.mark.asyncio
+async def test_result_error_is_failure_and_retains_thread():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.extract_media = MagicMock(return_value=([], ""))
+    adapter.extract_images = MagicMock(return_value=([], ""))
+    adapter.send_noninteractive_work_notification = AsyncMock(return_value=SendResult(True))
+    adapter.archive_noninteractive_work_thread = AsyncMock()
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="c")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background")
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "key"}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}), \
+         patch("run_agent.AIAgent") as mock_agent:
+        instance = MagicMock()
+        instance.run_conversation.return_value = {"final_response": "", "error": "provider secret=TOPSECRET"}
+        mock_agent.return_value = instance
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=_Policy())
+    events = [call.kwargs["event"] for call in adapter.send_noninteractive_work_notification.await_args_list]
+    assert "failure" in events
+    adapter.archive_noninteractive_work_thread.assert_not_awaited()
+    assert all("TOPSECRET" not in call.args[1] for call in adapter.send_noninteractive_work_notification.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_start_notification_failure_does_not_mislabel_successful_final_result():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.extract_media = MagicMock(return_value=([], "successful result"))
+    adapter.extract_images = MagicMock(return_value=([], "successful result"))
+    adapter.send_noninteractive_work_notification = AsyncMock(
+        return_value=SendResult(True)
+    )
+    adapter.archive_noninteractive_work_thread = AsyncMock()
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="c")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background")
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "key"}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}), \
+         patch("run_agent.AIAgent") as mock_agent:
+        instance = MagicMock()
+        instance.run_conversation.return_value = {"final_response": "successful result", "messages": []}
+        mock_agent.return_value = instance
+        await runner._run_background_task(
+            "prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=_Policy(),
+            lifecycle_start_failed=True,
+        )
+
+    events = [call.kwargs["event"] for call in adapter.send_noninteractive_work_notification.await_args_list]
+    assert "success" in events
+    assert "result delivery failed" not in " ".join(call.args[1] for call in adapter.send_noninteractive_work_notification.await_args_list)
+    adapter.archive_noninteractive_work_thread.assert_awaited_once_with(handle)
+
+
+@pytest.mark.asyncio
+async def test_media_send_result_failure_prevents_archive():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.extract_media = MagicMock(return_value=([(__file__, False)], "text"))
+    adapter.extract_images = MagicMock(return_value=([], "text"))
+    adapter.send_noninteractive_work_notification = AsyncMock(return_value=SendResult(True))
+    adapter.send_document = AsyncMock(return_value=SendResult(False, error="upload failed"))
+    adapter.archive_noninteractive_work_thread = AsyncMock()
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="c")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background")
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "key"}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}), \
+         patch("run_agent.AIAgent") as mock_agent:
+        instance = MagicMock()
+        instance.run_conversation.return_value = {"final_response": "text", "messages": []}
+        mock_agent.return_value = instance
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=_Policy())
+
+
+@pytest.mark.asyncio
+async def test_text_delivery_failure_escalates_and_does_not_archive():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.extract_media = MagicMock(return_value=([], ""))
+    adapter.extract_images = MagicMock(return_value=([], "text"))
+    adapter.send_noninteractive_work_notification = AsyncMock(
+        side_effect=[SendResult(False, error="thread send failed"), SendResult(False, error="escalation failed")]
+    )
+    adapter.send = AsyncMock(return_value=SendResult(False, error="origin send failed"))
+    adapter.archive_noninteractive_work_thread = AsyncMock()
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background", guild_id="777")
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "key"}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}), \
+         patch("run_agent.AIAgent") as mock_agent:
+        instance = MagicMock()
+        instance.run_conversation.return_value = {"final_response": "text", "messages": []}
+        mock_agent.return_value = instance
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=_Policy())
+    assert adapter.send_noninteractive_work_notification.await_count == 2
+    adapter.archive_noninteractive_work_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_response_delivery_failure_escalates_and_does_not_archive():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.extract_media = MagicMock(return_value=([], ""))
+    adapter.extract_images = MagicMock(return_value=([], ""))
+    adapter.send_noninteractive_work_notification = AsyncMock(
+        side_effect=[SendResult(False, error="thread send failed"), SendResult(True)]
+    )
+    adapter.send = AsyncMock(return_value=SendResult(True))
+    adapter.archive_noninteractive_work_thread = AsyncMock()
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background", guild_id="777")
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "key"}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}), \
+         patch("run_agent.AIAgent") as mock_agent:
+        instance = MagicMock()
+        instance.run_conversation.return_value = {"final_response": "", "messages": []}
+        mock_agent.return_value = instance
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=_Policy())
+    assert adapter.send_noninteractive_work_notification.await_count == 2
+    adapter.archive_noninteractive_work_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_text_delivery_failure_archives_when_failure_escalation_succeeds_and_retain_false():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.extract_media = MagicMock(return_value=([], ""))
+    adapter.extract_images = MagicMock(return_value=([], "text"))
+    adapter.send_noninteractive_work_notification = AsyncMock(
+        side_effect=[SendResult(False, error="thread send failed"), SendResult(True)]
+    )
+    adapter.send = AsyncMock(return_value=SendResult(True))
+    adapter.archive_noninteractive_work_thread = AsyncMock(return_value=True)
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background", guild_id="777")
+    policy = _Policy()
+    policy.retain_failures = False
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "key"}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}), \
+         patch("run_agent.AIAgent") as mock_agent:
+        instance = MagicMock()
+        instance.run_conversation.return_value = {"final_response": "text", "messages": []}
+        mock_agent.return_value = instance
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=policy)
+    adapter.archive_noninteractive_work_thread.assert_awaited_once_with(handle)
+
+
+@pytest.mark.asyncio
+async def test_text_delivery_failure_retains_when_failure_escalation_fails_and_retain_false():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.extract_media = MagicMock(return_value=([], ""))
+    adapter.extract_images = MagicMock(return_value=([], "text"))
+    adapter.send_noninteractive_work_notification = AsyncMock(
+        side_effect=[
+            SendResult(False, error="thread send failed"),
+            SendResult(False, error="escalation failed"),
+        ]
+    )
+    adapter.send = AsyncMock(return_value=SendResult(True))
+    adapter.archive_noninteractive_work_thread = AsyncMock()
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background", guild_id="777")
+    policy = _Policy()
+    policy.retain_failures = False
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "key"}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}), \
+         patch("run_agent.AIAgent") as mock_agent:
+        instance = MagicMock()
+        instance.run_conversation.return_value = {"final_response": "text", "messages": []}
+        mock_agent.return_value = instance
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=policy)
+    adapter.archive_noninteractive_work_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_text_delivery_failure_attempts_media_before_escalation_and_cleanup():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.extract_media = MagicMock(return_value=([(__file__, False)], ""))
+    adapter.extract_images = MagicMock(return_value=([("https://example.test/result.png", "result")], "text"))
+    adapter.send_noninteractive_work_notification = AsyncMock(
+        side_effect=[
+            SendResult(False, error="thread send failed"),
+            SendResult(True),
+        ]
+    )
+    adapter.send_image = AsyncMock(return_value=SendResult(True))
+    adapter.send_document = AsyncMock(return_value=SendResult(True))
+    adapter.archive_noninteractive_work_thread = AsyncMock(return_value=True)
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background", guild_id="777")
+    policy = _Policy()
+    policy.retain_failures = False
+    order = []
+    adapter.send_document.side_effect = lambda **kwargs: order.append("media") or SendResult(True)
+    adapter.send_image.side_effect = lambda **kwargs: order.append("image") or SendResult(True)
+    adapter.send_noninteractive_work_notification.side_effect = (
+        lambda *args, **kwargs: order.append("notify") or SendResult(False if len(order) == 1 else True)
+    )
+    adapter.archive_noninteractive_work_thread.side_effect = (
+        lambda handle: order.append("cleanup") or True
+    )
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "key"}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}), \
+         patch("run_agent.AIAgent") as mock_agent:
+        instance = MagicMock()
+        instance.run_conversation.return_value = {"final_response": "text", "messages": []}
+        mock_agent.return_value = instance
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=policy)
+    assert order == ["notify", "image", "media", "notify", "cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_origin_failure_without_guild_does_not_fabricate_dm_link():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.send_noninteractive_work_notification = AsyncMock(return_value=SendResult(True))
+    adapter.send = AsyncMock(return_value=SendResult(True))
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background")
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": None}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}):
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=_Policy())
+    origin_content = adapter.send.await_args.args[1]
+    assert "channels/@me/" not in origin_content
+    assert "thread 888" in origin_content
+
+
+@pytest.mark.asyncio
+async def test_origin_failure_falls_back_without_chief_mention_target():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.send_noninteractive_work_notification = AsyncMock(return_value=SendResult(True))
+    adapter.send = AsyncMock(return_value=SendResult(True))
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background", guild_id="777")
+    policy = _Policy()
+    policy.chief_user_id = None
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": None}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}):
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=policy)
+    origin_content = adapter.send.await_args.args[1]
+    assert "failed" in origin_content.lower()
+    assert "<@" not in origin_content
+
+
+@pytest.mark.asyncio
+async def test_failure_cleanup_retains_thread_when_failure_notification_raises():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.send_noninteractive_work_notification = AsyncMock(side_effect=RuntimeError("send failed"))
+    adapter.archive_noninteractive_work_thread = AsyncMock(return_value=True)
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background")
+    policy = _Policy()
+    policy.retain_failures = False
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": None}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}):
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=policy)
+    adapter.archive_noninteractive_work_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fallback_false_does_not_publish_to_origin_without_thread():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    policy = _Policy()
+    policy.fallback_to_origin = False
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": None}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}):
+        await runner._run_background_task("prompt", source, "bg", lifecycle_policy=policy)
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fallback_false_does_not_publish_origin_failure_with_operations_thread():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.send_noninteractive_work_notification = AsyncMock(return_value=SendResult(True))
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    policy = _Policy()
+    policy.fallback_to_origin = False
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background")
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": None}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}):
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=policy)
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_task_cleans_up_only_after_failure_delivery_when_retain_false():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.send_noninteractive_work_notification = AsyncMock(return_value=SendResult(True))
+    adapter.archive_noninteractive_work_thread = AsyncMock(return_value=True)
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    policy = _Policy()
+    policy.retain_failures = False
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background")
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": None}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}):
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=policy)
+    adapter.archive_noninteractive_work_thread.assert_awaited_once_with(handle)
+
+
+@pytest.mark.asyncio
+async def test_failed_task_keeps_thread_when_failure_delivery_fails_even_if_retain_false():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.send_noninteractive_work_notification = AsyncMock(return_value=SendResult(False, error="send failed"))
+    adapter.archive_noninteractive_work_thread = AsyncMock()
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    policy = _Policy()
+    policy.retain_failures = False
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background")
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": None}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}):
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=policy)
+    adapter.archive_noninteractive_work_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_notification_dict_failure_is_not_treated_as_success():
+    runner = _make_runner()
+    adapter = MagicMock()
+    adapter.create_noninteractive_work_thread = AsyncMock(
+        return_value=NonInteractiveWorkThreadHandle("999", "888", "background bg_test")
+    )
+    adapter.send_noninteractive_work_notification = AsyncMock(return_value={"success": False, "error": "send failed"})
+    runner.adapters[Platform.DISCORD] = adapter
+    event = _make_event(text="/background do the work", platform=Platform.DISCORD)
+    with patch(
+        "gateway.slash_commands.resolve_noninteractive_work_policy",
+        return_value=MagicMock(
+            channel_id="999", include_start_message=True, auto_archive_duration=1440,
+            route_for=lambda producer: "operations",
+        ),
+    ), patch.object(runner, "_run_background_task", new_callable=AsyncMock) as run_task:
+        await runner._handle_background_command(event)
+        await asyncio.sleep(0)
+    assert run_task.await_args.kwargs["lifecycle_start_failed"] is True
+
+
+@pytest.mark.asyncio
+async def test_exception_origin_failure_uses_sanitized_error():
+    runner = _make_runner()
+    adapter = AsyncMock()
+    adapter.send_noninteractive_work_notification = AsyncMock(return_value=SendResult(True))
+    adapter.send = AsyncMock(return_value=SendResult(True))
+    runner.adapters[Platform.DISCORD] = adapter
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background", guild_id="777")
+    with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "key"}), \
+         patch("gateway.run._load_gateway_config", return_value={"agent": {}}), \
+         patch.object(runner, "_run_in_executor_with_context", new_callable=AsyncMock,
+                      side_effect=RuntimeError("api_key=TOPSECRET")):
+        await runner._run_background_task("prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=_Policy())
+    origin_content = adapter.send.await_args.args[1]
+    assert "TOPSECRET" not in origin_content
+    assert "***" in origin_content
+
+
+
+def test_thread_handle_carries_guild_for_valid_discord_link():
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background", guild_id="777")
+    assert handle.guild_id == "777"
+
+
+@pytest.mark.asyncio
+async def test_missing_runtime_adapter_cleans_created_lifecycle_thread():
+    runner = _make_runner()
+    runner.adapters.pop(Platform.DISCORD, None)
+    lifecycle_adapter = AsyncMock()
+    lifecycle_adapter.delete_noninteractive_work_thread = AsyncMock(return_value=True)
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background")
+    policy = _Policy()
+    policy.cleanup = "delete"
+    policy.retain_failures = False
+    await runner._run_background_task(
+        "prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=policy,
+        lifecycle_adapter=lifecycle_adapter,
+    )
+    lifecycle_adapter.delete_noninteractive_work_thread.assert_awaited_once_with(handle)
+
+
+@pytest.mark.asyncio
+async def test_missing_runtime_adapter_retains_created_thread_when_failures_are_retained():
+    runner = _make_runner()
+    runner.adapters.pop(Platform.DISCORD, None)
+    lifecycle_adapter = AsyncMock()
+    source = SessionSource(platform=Platform.DISCORD, user_id="u", chat_id="origin")
+    handle = NonInteractiveWorkThreadHandle("999", "888", "background")
+    policy = _Policy()
+    policy.cleanup = "delete"
+    policy.retain_failures = True
+    await runner._run_background_task(
+        "prompt", source, "bg", lifecycle_handle=handle, lifecycle_policy=policy,
+        lifecycle_adapter=lifecycle_adapter,
+    )
+    lifecycle_adapter.delete_noninteractive_work_thread.assert_not_awaited()
+    lifecycle_adapter.archive_noninteractive_work_thread.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (SendResult(success=True), True),
+        (SendResult(success=False, error="delivery failed"), False),
+        (None, True),
+        (MagicMock(), True),
+    ],
+)
+def test_delivery_succeeded_preserves_legacy_returns_but_honors_send_result(result, expected):
+    assert _delivery_succeeded(result) is expected

--- a/tests/gateway/test_discord_background_delivery.py
+++ b/tests/gateway/test_discord_background_delivery.py
@@ -1,0 +1,432 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from plugins.platforms.discord import adapter as discord_adapter
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+class DummyAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect=False):
+        return False
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=False, error="unused")
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+class FakeAllowedMentions:
+    def __init__(self, users=None, everyone=None, roles=None, replied_user=None):
+        self.users = users or []
+        self.everyone = everyone
+        self.roles = roles
+        self.replied_user = replied_user
+
+    @classmethod
+    def none(cls):
+        return cls([], everyone=False, roles=False, replied_user=False)
+
+
+class FakeObject:
+    def __init__(self, id):
+        self.id = id
+
+
+class FakeThread:
+    def __init__(self, thread_id="123456789012345679", name="actual name"):
+        self.id = thread_id
+        self.name = name
+        self.archived = False
+        self.send = AsyncMock()
+        self.edit = AsyncMock()
+        self.delete = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_base_noninteractive_lifecycle_is_unsupported_by_default():
+    adapter = object.__new__(DummyAdapter)
+
+    assert await adapter.create_noninteractive_work_thread("parent", "work") is None
+    assert await adapter.archive_noninteractive_work_thread(None) is False
+    assert await adapter.delete_noninteractive_work_thread(None) is False
+    result = await adapter.send_noninteractive_work_notification(
+        None, "routine", event="success", chief_user_id="12345678901234567"
+    )
+    assert result.success is False
+    assert result.error == "Not supported"
+
+
+@pytest.mark.asyncio
+async def test_discord_creates_noninteractive_thread_directly_and_returns_handle(monkeypatch):
+    parent = SimpleNamespace(create_thread=AsyncMock())
+    thread = FakeThread(name="actual Discord name")
+    parent.create_thread.return_value = thread
+    client = SimpleNamespace(get_channel=lambda channel_id: parent, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+
+    handle = await adapter.create_noninteractive_work_thread(
+        "123456789012345678", "work title", auto_archive_duration=60
+    )
+
+    assert handle.parent_channel_id == "123456789012345678"
+    assert handle.thread_id == "123456789012345679"
+    assert handle.thread_name == "actual Discord name"
+    parent.create_thread.assert_awaited_once_with(
+        name="work title", auto_archive_duration=60, reason="Hermes non-interactive work"
+    )
+
+
+@pytest.mark.asyncio
+async def test_discord_uses_seed_message_fallback_with_mentions_suppressed(monkeypatch):
+    thread = FakeThread()
+    seed = SimpleNamespace(create_thread=AsyncMock(return_value=thread))
+    parent = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=PermissionError("no direct permission")),
+        send=AsyncMock(return_value=seed),
+        guild=SimpleNamespace(id="777777777777777777"),
+    )
+    client = SimpleNamespace(get_channel=lambda channel_id: parent, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+
+    handle = await adapter.create_noninteractive_work_thread(
+        "123456789012345678", "work @everyone @here <@&88888888888888888>"
+    )
+
+    assert handle.thread_id == "123456789012345679"
+    assert handle.guild_id == "777777777777777777"
+    assert parent.send.await_args.args == (
+        "🧵 Hermes non-interactive work: **work @everyone @here <@&88888888888888888>**",
+    )
+    allowed = parent.send.await_args.kwargs["allowed_mentions"]
+    assert allowed.everyone is False
+    assert allowed.roles is False
+    assert allowed.replied_user is False
+    assert allowed.users == []
+
+
+@pytest.mark.asyncio
+async def test_discord_seed_fallback_deletes_orphan_when_thread_creation_fails(monkeypatch):
+    seed = SimpleNamespace(create_thread=AsyncMock(side_effect=PermissionError("no thread permission")), delete=AsyncMock())
+    parent = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=PermissionError("no direct permission")),
+        send=AsyncMock(return_value=seed),
+    )
+    client = SimpleNamespace(get_channel=lambda channel_id: parent, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+
+    assert await adapter.create_noninteractive_work_thread("123456789012345678", "work") is None
+
+    seed.delete.assert_awaited_once_with(reason="Hermes non-interactive work cleanup")
+
+
+@pytest.mark.asyncio
+async def test_discord_long_notification_chunks_and_only_first_chunk_mentions(monkeypatch):
+    thread = FakeThread()
+    client = SimpleNamespace(get_channel=lambda channel_id: thread, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+    monkeypatch.setattr(discord_adapter.discord, "Object", FakeObject)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    result = await adapter.send_noninteractive_work_notification(
+        handle, "x" * 4500, event="failure", chief_user_id="12345678901234567"
+    )
+
+    assert result.success is True
+    calls = thread.send.await_args_list
+    assert len(calls) >= 3
+    assert all(len(call.kwargs["content"]) <= 2000 for call in calls)
+    assert calls[0].kwargs["allowed_mentions"].users[0].id == 12345678901234567
+    assert all(call.kwargs["allowed_mentions"].users == [] for call in calls[1:])
+
+
+@pytest.mark.asyncio
+async def test_discord_origin_background_suppresses_all_mentions(monkeypatch):
+    channel = FakeThread()
+    client = SimpleNamespace(get_channel=lambda channel_id: channel, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    adapter._reply_to_mode = "off"
+    adapter._last_self_message_id = {}
+    adapter.config = SimpleNamespace(extra={})
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+
+    result = await adapter.send(
+        "123456789012345678",
+        "<@99999999999999999> <@&88888888888888888> @everyone @here success",
+        metadata={"_hermes_origin_background": True},
+    )
+
+    assert result.success is True
+    allowed = channel.send.await_args.kwargs["allowed_mentions"]
+    assert allowed.everyone is False
+    assert allowed.roles is False
+    assert allowed.replied_user is False
+    assert allowed.users == []
+
+
+@pytest.mark.asyncio
+async def test_discord_origin_failure_explicitly_allows_only_valid_chief_mention(monkeypatch):
+    channel = FakeThread()
+    client = SimpleNamespace(get_channel=lambda channel_id: channel, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    adapter._reply_to_mode = "off"
+    adapter._last_self_message_id = {}
+    adapter.config = SimpleNamespace(extra={})
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+    monkeypatch.setattr(discord_adapter.discord, "Object", FakeObject)
+
+    result = await adapter.send(
+        "123456789012345678",
+        "<@99999999999999999> <@&88888888888888888> @everyone @here failure",
+        metadata={
+            "_hermes_origin_failure": True,
+            "_hermes_chief_user_id": "12345678901234567",
+        },
+    )
+
+    assert result.success is True
+    allowed = channel.send.await_args.kwargs["allowed_mentions"]
+    assert allowed.everyone is False
+    assert allowed.roles is False
+    assert allowed.replied_user is False
+    assert [user.id for user in allowed.users] == [12345678901234567]
+
+
+@pytest.mark.asyncio
+async def test_discord_long_notification_reports_later_chunk_failure(monkeypatch):
+    thread = FakeThread()
+    thread.send.side_effect = [SimpleNamespace(id="first"), RuntimeError("second failed")]
+    client = SimpleNamespace(get_channel=lambda channel_id: thread, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+    monkeypatch.setattr(discord_adapter.discord, "Object", FakeObject)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    result = await adapter.send_noninteractive_work_notification(
+        handle, "x" * 4500, event="success", chief_user_id="12345678901234567"
+    )
+
+    assert result.success is False
+    assert "second failed" in result.error
+
+
+@pytest.mark.asyncio
+async def test_discord_rejects_invalid_archive_duration_before_creation(monkeypatch):
+    parent = SimpleNamespace(create_thread=AsyncMock(), send=AsyncMock())
+    client = SimpleNamespace(get_channel=lambda channel_id: parent, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+
+    assert await adapter.create_noninteractive_work_thread(
+        "123456789012345678", "work", auto_archive_duration=30
+    ) is None
+    parent.create_thread.assert_not_awaited()
+    parent.send.assert_not_awaited()
+    client.fetch_channel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_archive_and_delete_are_idempotent(monkeypatch):
+    thread = FakeThread()
+    client = SimpleNamespace(get_channel=lambda channel_id: thread, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+    monkeypatch.setattr(discord_adapter.discord, "Object", FakeObject)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    assert await adapter.archive_noninteractive_work_thread(handle) is True
+    thread.edit.assert_awaited_once_with(archived=True, reason="Hermes non-interactive work cleanup")
+
+    thread.delete.side_effect = RuntimeError("Unknown Channel")
+    assert await adapter.delete_noninteractive_work_thread(handle) is True
+
+
+@pytest.mark.asyncio
+async def test_discord_archive_treats_thread_deleted_during_edit_as_idempotent(monkeypatch):
+    thread = FakeThread()
+    thread.edit.side_effect = RuntimeError("Unknown Thread")
+    client = SimpleNamespace(get_channel=lambda channel_id: thread, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    assert await adapter.archive_noninteractive_work_thread(handle) is True
+
+
+@pytest.mark.asyncio
+async def test_discord_archive_and_delete_report_lookup_failures(monkeypatch):
+    client = SimpleNamespace(
+        get_channel=lambda channel_id: None,
+        fetch_channel=AsyncMock(side_effect=PermissionError("forbidden")),
+    )
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    assert await adapter.archive_noninteractive_work_thread(handle) is False
+    assert await adapter.delete_noninteractive_work_thread(handle) is False
+
+
+@pytest.mark.asyncio
+async def test_discord_archive_and_delete_treat_missing_lookup_as_idempotent(monkeypatch):
+    client = SimpleNamespace(
+        get_channel=lambda channel_id: None,
+        fetch_channel=AsyncMock(return_value=None),
+    )
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    assert await adapter.archive_noninteractive_work_thread(handle) is True
+    assert await adapter.delete_noninteractive_work_thread(handle) is True
+
+
+@pytest.mark.asyncio
+async def test_discord_archive_and_delete_report_api_failures(monkeypatch):
+    thread = FakeThread()
+    thread.edit.side_effect = RuntimeError("rate limited")
+    thread.delete.side_effect = RuntimeError("rate limited")
+    client = SimpleNamespace(get_channel=lambda channel_id: thread, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    assert await adapter.archive_noninteractive_work_thread(handle) is False
+    assert await adapter.delete_noninteractive_work_thread(handle) is False
+
+
+@pytest.mark.asyncio
+async def test_discord_actionable_notification_mentions_only_chief(monkeypatch):
+    thread = FakeThread()
+    client = SimpleNamespace(get_channel=lambda channel_id: thread, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+    monkeypatch.setattr(discord_adapter.discord, "Object", FakeObject)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    result = await adapter.send_noninteractive_work_notification(
+        handle,
+        "Task failed",
+        event="failure",
+        chief_user_id="12345678901234567",
+    )
+
+    assert result.success is True
+    kwargs = thread.send.call_args.kwargs
+    assert kwargs["content"] == "<@12345678901234567> Task failed"
+    assert kwargs["allowed_mentions"].users[0].id == 12345678901234567
+    assert kwargs["allowed_mentions"].everyone is False
+    assert kwargs["allowed_mentions"].roles is False
+    assert kwargs["allowed_mentions"].replied_user is False
+
+
+@pytest.mark.asyncio
+async def test_discord_routine_notification_disables_mentions(monkeypatch):
+    thread = FakeThread()
+    client = SimpleNamespace(get_channel=lambda channel_id: thread, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+    monkeypatch.setattr(discord_adapter.discord, "Object", FakeObject)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    result = await adapter.send_noninteractive_work_notification(
+        handle,
+        "Task succeeded",
+        event="success",
+        chief_user_id="12345678901234567",
+    )
+
+    assert result.success is True
+    kwargs = thread.send.call_args.kwargs
+    assert kwargs["content"] == "Task succeeded"
+    assert kwargs["allowed_mentions"].users == []
+
+
+@pytest.mark.asyncio
+async def test_discord_notification_send_failure_returns_unsuccessful_result(monkeypatch):
+    thread = FakeThread()
+    thread.send.side_effect = RuntimeError("send failed")
+    client = SimpleNamespace(get_channel=lambda channel_id: thread, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    result = await adapter.send_noninteractive_work_notification(
+        handle, "Task failed", event="failure", chief_user_id="not-an-id"
+    )
+
+    assert result.success is False
+    assert "send failed" in result.error
+
+
+@pytest.mark.asyncio
+async def test_discord_notification_ignores_malformed_chief_id_without_mentioning(monkeypatch):
+    thread = FakeThread()
+    thread.send.return_value = SimpleNamespace(id="message-id")
+    client = SimpleNamespace(get_channel=lambda channel_id: thread, fetch_channel=AsyncMock())
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = client
+    adapter.platform = discord_adapter.Platform.DISCORD
+    monkeypatch.setattr(discord_adapter, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+    handle = discord_adapter.NonInteractiveWorkThreadHandle("parent", "123456789012345679", "work")
+
+    result = await adapter.send_noninteractive_work_notification(
+        handle, "Task failed", event="failure", chief_user_id="<@bad>"
+    )
+
+    assert result.success is True
+    kwargs = thread.send.call_args.kwargs
+    assert kwargs["content"] == "Task failed"
+    assert kwargs["allowed_mentions"].users == []

--- a/tests/gateway/test_noninteractive_work_delivery.py
+++ b/tests/gateway/test_noninteractive_work_delivery.py
@@ -1,0 +1,303 @@
+"""Focused tests for the producer-neutral non-interactive delivery contract."""
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.delivery import (
+    NonInteractiveWorkDescriptor,
+    NonInteractiveWorkPolicy,
+    resolve_noninteractive_work_policy,
+)
+
+
+def test_missing_configuration_preserves_origin_delivery():
+    policy = resolve_noninteractive_work_policy({})
+
+    assert policy.enabled is False
+    assert policy.route_for("background") == "origin"
+    assert policy.route_for("cron") == "origin"
+
+
+def test_enabled_operations_policy_normalizes_values_without_mutating_input():
+    raw = {
+        "enabled": True,
+        "channel_id": "123456789012345678",
+        "chief_user_id": " 987654321098765432 ",
+        "mention_on": ["intervention", "failure"],
+        "channel_name": "background-sessions",
+        "auto_archive_duration": "4320",
+        "cleanup": "RETAIN",
+        "routing": {"background": "local"},
+    }
+    original = dict(raw)
+
+    policy = resolve_noninteractive_work_policy(raw)
+
+    assert policy.enabled is True
+    assert policy.channel_id == "123456789012345678"
+    assert policy.chief_user_id == "987654321098765432"
+    assert policy.mention_on == ("failure", "intervention")
+    assert policy.channel_name == "background-sessions"
+    assert policy.auto_archive_duration == 4320
+    assert policy.cleanup == "retain"
+    assert policy.route_for("background") == "local"
+    assert policy.route_for("cron") == "operations"
+    assert raw == original
+
+
+def test_invalid_values_fall_back_safely():
+    policy = resolve_noninteractive_work_policy(
+        {
+            "enabled": True,
+            "channel_id": "background-sessions",
+            "auto_archive_duration": 999,
+            "cleanup": "purge",
+            "routing": {"background": "operations"},
+        }
+    )
+
+    assert policy.enabled is False
+    assert policy.channel_id is None
+    assert policy.auto_archive_duration == 1440
+    assert policy.cleanup == "archive"
+    assert policy.route_for("background") == "origin"
+    assert policy.route_for("cron") == "origin"
+
+
+def test_public_config_entry_point_resolves_nested_raw_config():
+    from gateway.config import resolve_noninteractive_work_policy
+
+    policy = resolve_noninteractive_work_policy(
+        {
+            "platforms": {
+                "discord": {
+                    "extra": {
+                        "noninteractive_work": {
+                            "enabled": True,
+                            "channel_id": "123456789012345678",
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+    assert policy.enabled is True
+    assert policy.channel_id == "123456789012345678"
+
+
+def test_gateway_config_platform_shape_resolves_discord_extra():
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                extra={
+                    "noninteractive_work": {
+                        "enabled": True,
+                        "channel_id": "123456789012345678",
+                    }
+                }
+            )
+        }
+    )
+
+    policy = resolve_noninteractive_work_policy(config)
+
+    assert policy.enabled is True
+    assert policy.channel_id == "123456789012345678"
+
+
+def test_unknown_boolean_tokens_use_each_field_default():
+    policy = resolve_noninteractive_work_policy(
+        {
+            "enabled": "maybe",
+            "channel_id": "123456789012345678",
+            "retain_failures": "maybe",
+            "fallback_to_origin": "maybe",
+            "include_start_message": "maybe",
+            "include_cron": "maybe",
+            "include_background": "maybe",
+            "include_delegated": "maybe",
+        }
+    )
+
+    assert policy.enabled is False
+    assert policy.retain_failures is True
+    assert policy.fallback_to_origin is True
+    assert policy.include_start_message is True
+    assert policy.include_cron is True
+    assert policy.include_background is True
+    assert policy.include_delegated is True
+
+
+def test_channel_id_whitespace_is_stripped_before_validation():
+    policy = resolve_noninteractive_work_policy(
+        {"enabled": True, "channel_id": " 123456789012345678 "}
+    )
+
+    assert policy.enabled is True
+    assert policy.channel_id == "123456789012345678"
+
+
+@pytest.mark.parametrize("value", [None, "", "  ", "123", "12345678901234567890a"])
+def test_chief_user_id_requires_a_trimmed_17_to_20_digit_string(value):
+    policy = resolve_noninteractive_work_policy({"chief_user_id": value})
+
+    assert policy.chief_user_id is None
+
+
+def test_mention_on_defaults_to_failure_and_intervention():
+    policy = resolve_noninteractive_work_policy({})
+
+    assert policy.mention_on == ("failure", "intervention")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ["success"],
+        ["failure", "start"],
+        "failure,intervention",
+        [],
+    ],
+)
+def test_malformed_mention_on_uses_safe_default_without_routine_events(value):
+    policy = resolve_noninteractive_work_policy({"mention_on": value})
+
+    assert policy.mention_on == ("failure", "intervention")
+    assert not set(policy.mention_on) & {"start", "progress", "success"}
+
+
+def test_frozen_policy_mappings_are_immutable():
+    policy = NonInteractiveWorkPolicy(
+        routing={"cron": "local"},
+    )
+    work = NonInteractiveWorkDescriptor(
+        producer="cron",
+        work_id="run-1",
+        title="Job",
+        origin={"chat_id": "99"},
+        reply_binding={"session_id": "session-1"},
+    )
+
+    with pytest.raises(TypeError):
+        policy.routing["cron"] = "origin"
+    with pytest.raises(TypeError):
+        work.origin["chat_id"] = "100"
+    with pytest.raises(TypeError):
+        work.reply_binding["session_id"] = "session-2"
+
+
+def test_descriptor_takes_a_deeply_immutable_snapshot_of_nested_values():
+    origin = {"metadata": {"labels": ["initial"], "scopes": {"read"}}}
+    binding = {"parameters": [{"name": "region"}]}
+
+    work = NonInteractiveWorkDescriptor(
+        producer="cron",
+        work_id="run-1",
+        title="Job",
+        origin=origin,
+        reply_binding=binding,
+    )
+
+    origin["metadata"]["labels"].append("changed")
+    binding["parameters"][0]["name"] = "changed"
+
+    assert list(work.origin["metadata"]["labels"]) == ["initial"]
+    assert work.origin["metadata"]["scopes"] == frozenset({"read"})
+    assert work.reply_binding["parameters"][0]["name"] == "region"
+    with pytest.raises(TypeError):
+        work.origin["metadata"]["labels"][0] = "blocked"
+    with pytest.raises(TypeError):
+        work.reply_binding["parameters"][0]["name"] = "blocked"
+
+
+def test_policy_takes_a_deeply_immutable_snapshot_of_routing_values():
+    routing = {"cron": {"destinations": ["operations"]}}
+
+    policy = NonInteractiveWorkPolicy(routing=routing)
+
+    routing["cron"]["destinations"].append("local")
+
+    assert list(policy.routing["cron"]["destinations"]) == ["operations"]
+    with pytest.raises(TypeError):
+        policy.routing["cron"]["destinations"][0] = "blocked"
+
+
+@pytest.mark.parametrize("channel_id", [None, "background-sessions"])
+def test_direct_enabled_policy_with_invalid_channel_never_routes_to_operations(channel_id):
+    policy = NonInteractiveWorkPolicy(enabled=True, channel_id=channel_id)
+
+    assert policy.route_for("background") == "origin"
+    assert policy.route_for("cron") == "origin"
+
+
+def test_direct_enabled_policy_with_valid_channel_routes_to_operations():
+    policy = NonInteractiveWorkPolicy(
+        enabled=True,
+        channel_id="123456789012345678",
+    )
+
+    assert policy.route_for("background") == "operations"
+    assert policy.route_for("cron") == "operations"
+
+
+def test_disabled_policy_keeps_safe_local_and_origin_overrides_but_not_operations():
+    policy = resolve_noninteractive_work_policy(
+        {
+            "routing": {"cron": "local", "background": "operations"},
+        }
+    )
+
+    assert policy.enabled is False
+    assert policy.route_for("cron") == "local"
+    assert policy.route_for("background") == "origin"
+    assert policy.route_for("delegated") == "origin"
+
+
+@pytest.mark.parametrize(
+    ("producer", "field"),
+    [
+        ("cron", "include_cron"),
+        ("background", "include_background"),
+        ("delegated", "include_delegated"),
+    ],
+)
+def test_disabled_producer_routes_to_origin_even_with_operations_override(producer, field):
+    policy = NonInteractiveWorkPolicy(
+        enabled=True,
+        channel_id="123456789012345678",
+        **{field: False},
+        routing={producer: "operations"},
+    )
+
+    assert policy.route_for(producer) == "origin"
+
+
+def test_disabled_producer_preserves_safe_local_override():
+    policy = NonInteractiveWorkPolicy(
+        enabled=True,
+        channel_id="123456789012345678",
+        include_background=False,
+        routing={"background": "local"},
+    )
+
+    assert policy.route_for("background") == "local"
+
+
+def test_work_descriptor_carries_producer_neutral_lifecycle_and_binding():
+    work = NonInteractiveWorkDescriptor(
+        producer="delegated",
+        work_id="run-42",
+        title="Deploy service",
+        origin={"platform": "discord", "chat_id": "99"},
+        interaction_mode="intervention-capable",
+        terminal_status="needs_intervention",
+        reply_binding={"session_id": "session-42"},
+    )
+
+    assert work.producer == "delegated"
+    assert work.work_id == "run-42"
+    assert work.origin["chat_id"] == "99"
+    assert work.interaction_mode == "intervention-capable"
+    assert work.terminal_status == "needs_intervention"
+    assert work.reply_binding == {"session_id": "session-42"}

--- a/website/docs/user-guide/messaging/discord-background-work.md
+++ b/website/docs/user-guide/messaging/discord-background-work.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 3.1
+title: "Discord Background Work"
+description: "Route non-interactive work and cron runs into durable Discord operations threads"
+---
+
+# Discord Background Work
+
+Hermes can publish non-interactive work to a dedicated Discord operations channel. This keeps `/background` tasks and cron runs out of ordinary conversations while retaining a replyable surface when an operator must intervene.
+
+The feature is opt-in. With no `platforms.discord.extra.noninteractive_work` block, Hermes keeps its existing delivery behavior: interactive messages stay in their origin, and background results use the existing origin delivery path.
+
+## Configure the operations channel
+
+Set a numeric Discord channel ID. The configured name is informational only; Hermes routes by ID so renaming the channel does not change the destination.
+
+```yaml
+platforms:
+  discord:
+    extra:
+      noninteractive_work:
+        enabled: true
+        channel_id: "123456789012345678"
+        channel_name: background-sessions
+        auto_archive_duration: 1440
+        cleanup: archive
+        retain_failures: true
+        fallback_to_origin: true
+        include_start_message: true
+        include_cron: true
+        include_background: true
+        include_delegated: true
+        chief_user_id: "234567890123456789"
+        mention_on: [failure, intervention]
+```
+
+`channel_id` and `chief_user_id` must be Discord snowflakes (numeric strings). `auto_archive_duration` uses Discord's supported thread durations. `cleanup` can be `archive`, `delete`, or `retain`; successful work uses this policy. When `retain_failures` is enabled, failed or intervention-required work is retained even if `cleanup: delete` is configured. `fallback_to_origin` controls whether Hermes reports through the originating conversation when operations-channel or thread delivery cannot be created.
+
+The `include_*` flags select producers: cron runs, `/background` work, and delegated work. `include_start_message` controls the initial lifecycle message. `channel_name` is for operator documentation and does not select a channel.
+
+`mention_on` controls actionable event types. By default, only `failure` and `intervention` mention the configured `chief_user_id`; start, progress, and success messages do not. Ordinary interactive Discord messages do not notify Chief through this feature.
+
+## Thread and delivery behavior
+
+- Every cron run gets a fresh operations thread when the feature is enabled, including recurring and otherwise continuable jobs. A recurring schedule therefore creates one thread per run.
+- `/background` work uses a dedicated thread when the originating interaction is eligible for operations delivery. The origin receives its acknowledgement as usual.
+- A successful run publishes its result and is then cleaned up according to `cleanup` (archived by default).
+- Cron failures and intervention-required cron runs are retained by default. They remain visible and replyable so an operator can provide input. Background result failures follow the configured retention policy; a failed background start notification is logged but does not by itself create a durable intervention binding.
+- A reply to a retained **cron** work thread is bound to the recorded job/run/session context and creates a bounded follow-up or input event. It does **not** resurrect a process that has already exited. Retained `/background` threads do not currently provide the same durable cron reply binding.
+- If the operations channel or thread cannot be used, Hermes follows `fallback_to_origin` rather than silently dropping the result. If fallback is disabled, the delivery failure is recorded in the gateway logs and the operations result is not moved into an unrelated channel.
+
+Interactive conversations that did not originate as non-interactive work continue to use their existing Discord channel or thread. Ordinary messages do not notify Chief through this feature, and they are not automatically copied into the operations channel.
+
+## Discord permissions
+
+Grant the bot these permissions on the configured channel (or its parent category):
+
+- **View Channel**
+- **Send Messages**
+- **Create Public Threads**
+- **Send Messages in Threads**
+- **Manage Threads** — required for archive/delete cleanup
+
+The bot also needs the normal Discord gateway intents and message permissions described in [Discord setup](./discord). Restrict access to the operations channel to the operators who should see autonomous prompts and results.
+
+## Data-sharing and security boundary
+
+Operations delivery copies bounded task status, prompts, results, and any delivered media into the configured Discord channel. Anyone who can read that channel may see that data, so choosing the channel is an explicit data-sharing decision. Do not use a broadly visible channel for secrets, credentials, private environment data, or other content that should not leave the Hermes host. `channel_name` does not provide an access-control boundary; Discord permissions and channel membership do.
+
+Actionable alerts mention only the configured numeric `chief_user_id`. Hermes does not resolve a display name to choose a mention target, and routine lifecycle or success messages do not mention Chief.
+
+## Troubleshooting
+
+### No operations thread is created
+
+Check that `enabled: true` is present and `channel_id` is a valid numeric Discord channel ID, not `#channel-name` or a display name. `channel_name` is not used for lookup. Restart or reload the gateway after changing configuration.
+
+If the ID is valid but the bot cannot access it, verify **View Channel**, **Send Messages**, and **Create Public Threads** for that channel. Check the gateway logs for the Discord API error. With `fallback_to_origin: true`, the originating conversation remains the fallback delivery path.
+
+### Threads are created but messages fail
+
+Verify **Send Messages in Threads** and that the thread has not been manually archived or deleted. A missing **Manage Threads** permission prevents archive/delete cleanup; it should not turn a completed task into a failed task. Cleanup errors leave the thread in place and are logged.
+
+### Failures disappear
+
+Use `retain_failures: true` (the default) and avoid deleting the thread manually. This setting overrides `cleanup: delete` for failure and intervention states. A retained cron thread requires its durable job/run binding; replies are bounded follow-ups or input, not process resurrection. Retained `/background` threads follow the background lifecycle policy and do not currently have the cron reply-binding behavior.
+
+### Chief is not mentioned
+
+Set `chief_user_id` to the user's numeric Discord ID and keep `mention_on` set to include `failure` or `intervention`. Display names and usernames are not accepted as mention targets. No mention is expected for ordinary messages, starts, progress, or success.
+
+This documentation describes the configured and unit-tested behavior; it does not constitute a live Discord smoke-test result.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -634,6 +634,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'user-guide/messaging/telegram',
             'user-guide/messaging/discord',
+            'user-guide/messaging/discord-background-work',
             'user-guide/messaging/slack',
             'user-guide/messaging/whatsapp',
             'user-guide/messaging/whatsapp-cloud',


### PR DESCRIPTION
## Summary
- Add opt-in Discord operations-thread delivery for non-interactive work.
- Route every configured cron run through a fresh thread with durable job/run/session binding.
- Retain actionable failures, enforce Discord mention safety, and support bounded retained-cron follow-ups.
- Add operator documentation and configuration guidance.

## Verification
- 253 tests passed, 1 skipped.
- Python compileall passed.
- git diff --check passed.
- website npm run build:fast passed.

## Known limitations
- No live Discord smoke test was run; real channel permissions, thread creation, archive behavior, and end-to-end reply delivery remain deployment validation items.
- The docs build reports two pre-existing broken links from /docs/ to /docs/llms.txt and /docs/llms-full.txt.
- The test suite retains one existing unawaited mocked-coroutine warning.

Co-Authored-By: Jay