### PR TITLE
fix(file_ops): preserve native Windows paths for ripgrep

### DIFF
--- a/contributors/emails/5910064+Dolverin@users.noreply.github.com
+++ b/contributors/emails/5910064+Dolverin@users.noreply.github.com
@@ -1,0 +1,1 @@
+Dolverin

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -295,6 +295,34 @@ class TestShellFileOpsHelpers:
             "C:/Users/alice/notes.txt"
         ) == "'/c/Users/alice/notes.txt'"
 
+    def test_escape_native_exe_arg_keeps_windows_drive_forward_slash(self, monkeypatch, file_ops):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert file_ops._escape_native_exe_arg(r"D:\Ivo\ai-costs.json") == "'D:/Ivo/ai-costs.json'"
+        assert file_ops._escape_native_exe_arg("D:/Ivo/ai-costs.json") == "'D:/Ivo/ai-costs.json'"
+        assert file_ops._escape_native_exe_arg("/d/Ivo/ai-costs.json") == "'D:/Ivo/ai-costs.json'"
+
+    def test_search_with_rg_uses_native_windows_path(self, mock_env, monkeypatch):
+        """Absolute Windows paths must not be MSYS-rewritten for native rg (#67629)."""
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._has_command = lambda cmd: cmd == "rg"
+        captured = {}
+
+        def _capture(command, cwd=None, timeout=None, stdin_data=None):
+            captured["cmd"] = command
+            from tools.file_operations import ExecuteResult
+            return ExecuteResult(stdout="", exit_code=1)
+
+        ops._exec = _capture
+        ops._search_with_rg("subscription", r"D:\Ivo\ai-costs.json", None, 10, 0, "content", 0)
+        assert "D:/Ivo/ai-costs.json" in captured["cmd"]
+        assert "/d/Ivo/ai-costs.json" not in captured["cmd"]
+
     @pytest.mark.windows_only
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env):
         """Windows-only: proves read_file's shell commands carry the MSYS path

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -346,6 +346,57 @@ class TestShellFileOpsHelpers:
         assert "D:/Ivo/ai-costs.json" in captured["cmd"]
         assert "/d/Ivo/ai-costs.json" not in captured["cmd"]
 
+    def test_escape_pattern_arg_preserves_regex_backslashes(self, monkeypatch, file_ops):
+        """Regex patterns must not be MSYS-rewritten even on Windows (#69183 carry)."""
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        # Backslash regex escapes must survive verbatim inside the quotes,
+        # never rewritten to forward slashes the way a drive path would be.
+        assert file_ops._escape_pattern_arg(r"\d+") == r"'\d+'"
+        assert file_ops._escape_pattern_arg(r"foo\w*bar") == r"'foo\w*bar'"
+        assert file_ops._escape_pattern_arg(r"\(group\)") == r"'\(group\)'"
+
+    def test_search_with_rg_preserves_regex_pattern(self, mock_env, monkeypatch):
+        """rg regex patterns keep backslash escapes intact on Windows (#69183 carry)."""
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations, ExecuteResult
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._is_local_backend = lambda: True
+        ops._has_command = lambda cmd: cmd == "rg"
+        captured = {}
+
+        def _capture(command, cwd=None, timeout=None, stdin_data=None):
+            captured["cmd"] = command
+            return ExecuteResult(stdout="", exit_code=1)
+
+        ops._exec = _capture
+        ops._search_with_rg(r"\d+", r"D:\Ivo\ai-costs.json", None, 10, 0, "content", 0)
+        assert r"'\d+'" in captured["cmd"]
+        assert "'/d+'" not in captured["cmd"]
+
+    def test_search_with_grep_preserves_regex_pattern(self, mock_env, monkeypatch):
+        """grep fallback regex patterns keep backslash escapes intact (#69183 carry)."""
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations, ExecuteResult
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._is_local_backend = lambda: True
+        ops._has_command = lambda cmd: cmd == "grep"
+        captured = {}
+
+        def _capture(command, cwd=None, timeout=None, stdin_data=None):
+            captured["cmd"] = command
+            return ExecuteResult(stdout="", exit_code=1)
+
+        ops._exec = _capture
+        ops._search_with_grep(r"\w+", "/tmp/project", None, 10, 0, "content", 0)
+        assert r"'\w+'" in captured["cmd"]
+        assert "'/w+'" not in captured["cmd"]
+
     @pytest.mark.windows_only
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env):
         """Windows-only: proves read_file's shell commands carry the MSYS path

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -397,6 +397,32 @@ class TestShellFileOpsHelpers:
         assert r"'\w+'" in captured["cmd"]
         assert "'/w+'" not in captured["cmd"]
 
+    def test_zero_match_probe_uses_native_windows_path_and_raw_pattern(self, monkeypatch, file_ops):
+        """The rg near-miss probes are native-rg calls too: path and pattern
+        must follow the same Windows split as the primary search (#67629)."""
+        import tools.environments.local as local_mod
+        from tools.file_operations import ExecuteResult
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(file_ops, "_is_local_backend", lambda: True)
+        file_ops._has_command = lambda cmd: cmd == "rg"
+        captured = []
+
+        def _capture(command, cwd=None, timeout=None, stdin_data=None):
+            captured.append(command)
+            return ExecuteResult(stdout="", exit_code=1)
+
+        file_ops._exec = _capture
+        assert file_ops._zero_match_probe(r"\d+", r"D:\Ivo\project", "*.py") is None
+
+        rg_probes = [cmd for cmd in captured if cmd.startswith("rg ")]
+        assert len(rg_probes) == 3
+        for command in rg_probes:
+            assert r"'\d+'" in command
+            assert "'D:/Ivo/project'" in command
+            assert "'/d/Ivo/project'" not in command
+            assert "'/d+'" not in command
+
     @pytest.mark.windows_only
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env):
         """Windows-only: proves read_file's shell commands carry the MSYS path

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -423,6 +423,69 @@ class TestShellFileOpsHelpers:
             assert "'/d/Ivo/project'" not in command
             assert "'/d+'" not in command
 
+    def test_search_with_rg_uses_argument_boundaries_for_option_like_pattern(self, mock_env, monkeypatch):
+        """A pattern starting with '-' is data, not an rg option."""
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations, ExecuteResult
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._is_local_backend = lambda: True
+        ops._has_command = lambda cmd: cmd == "rg"
+        captured = {}
+
+        def _capture(command, cwd=None, timeout=None, stdin_data=None):
+            captured["cmd"] = command
+            return ExecuteResult(stdout="", exit_code=1)
+
+        ops._exec = _capture
+        ops._search_with_rg("-foo", r"D:\Ivo\dir with space", None, 10, 0, "content", 0)
+        assert "-e '-foo'" in captured["cmd"]
+        assert "-- 'D:/Ivo/dir with space'" in captured["cmd"]
+
+    def test_search_with_grep_uses_argument_boundaries_for_option_like_pattern(self, mock_env, monkeypatch):
+        """The grep fallback needs the same option/data boundary as rg."""
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations, ExecuteResult
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._is_local_backend = lambda: True
+        ops._has_command = lambda cmd: cmd == "grep"
+        captured = {}
+
+        def _capture(command, cwd=None, timeout=None, stdin_data=None):
+            captured["cmd"] = command
+            return ExecuteResult(stdout="", exit_code=1)
+
+        ops._exec = _capture
+        ops._search_with_grep("-foo", "/tmp/project", None, 10, 0, "content", 0)
+        assert "-e '-foo'" in captured["cmd"]
+        assert "-- '/tmp/project'" in captured["cmd"]
+
+    def test_zero_match_probe_uses_argument_boundaries_for_option_like_pattern(self, monkeypatch, file_ops):
+        """Zero-match probes must not let '-foo' become an rg option."""
+        import tools.environments.local as local_mod
+        from tools.file_operations import ExecuteResult
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(file_ops, "_is_local_backend", lambda: True)
+        file_ops._has_command = lambda cmd: cmd == "rg"
+        captured = []
+
+        def _capture(command, cwd=None, timeout=None, stdin_data=None):
+            captured.append(command)
+            return ExecuteResult(stdout="", exit_code=1)
+
+        file_ops._exec = _capture
+        assert file_ops._zero_match_probe("-foo", r"D:\Ivo\project", "*.py") is None
+
+        rg_probes = [cmd for cmd in captured if cmd.startswith("rg ")]
+        assert len(rg_probes) == 2
+        for command in rg_probes:
+            assert "-e '-foo'" in command
+            assert "-- 'D:/Ivo/project'" in command
+
     @pytest.mark.windows_only
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env):
         """Windows-only: proves read_file's shell commands carry the MSYS path

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -299,9 +299,31 @@ class TestShellFileOpsHelpers:
         import tools.environments.local as local_mod
 
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        # Native drive rewrite only applies to the local backend.
+        monkeypatch.setattr(file_ops, "_is_local_backend", lambda: True)
         assert file_ops._escape_native_exe_arg(r"D:\Ivo\ai-costs.json") == "'D:/Ivo/ai-costs.json'"
         assert file_ops._escape_native_exe_arg("D:/Ivo/ai-costs.json") == "'D:/Ivo/ai-costs.json'"
         assert file_ops._escape_native_exe_arg("/d/Ivo/ai-costs.json") == "'D:/Ivo/ai-costs.json'"
+
+    def test_escape_native_exe_arg_preserves_non_local_backend_paths(self, monkeypatch, file_ops):
+        """A non-local backend (e.g. SSH) owns its own path namespace: a
+        POSIX path such as ``/mnt/d/project`` must NOT be reinterpreted as a
+        host Windows drive form even when the host is Windows (#67914)."""
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(file_ops, "_is_local_backend", lambda: False)
+        # /mnt/d/... matches an MSYS/WSL drive form but belongs to the
+        # remote namespace — it must pass through untouched.
+        assert (
+            file_ops._escape_native_exe_arg("/mnt/d/Projects/tools")
+            == "'/mnt/d/Projects/tools'"
+        )
+        # Plain POSIX paths were always safe and stay unchanged.
+        assert (
+            file_ops._escape_native_exe_arg("/home/user/project")
+            == "'/home/user/project'"
+        )
 
     def test_search_with_rg_uses_native_windows_path(self, mock_env, monkeypatch):
         """Absolute Windows paths must not be MSYS-rewritten for native rg (#67629)."""
@@ -310,6 +332,7 @@ class TestShellFileOpsHelpers:
 
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         ops = ShellFileOperations(mock_env)
+        ops._is_local_backend = lambda: True
         ops._has_command = lambda cmd: cmd == "rg"
         captured = {}
 

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -352,3 +352,14 @@ def test_native_windows_path_for_exe_leaves_relative(monkeypatch):
     import tools.environments.local as local_mod
     monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
     assert _native_windows_path_for_exe("Apps/The-Pulse") == "Apps/The-Pulse"
+
+
+def test_native_windows_path_for_exe_preserves_drive_relative(monkeypatch):
+    import ntpath
+    import tools.environments.local as local_mod
+
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    converted = _native_windows_path_for_exe(r"D:logs\app.txt")
+    assert converted == "D:logs/app.txt"
+    assert not ntpath.isabs(converted)
+    assert _native_windows_path_for_exe("D:logs/app.txt") == "D:logs/app.txt"

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -39,6 +39,7 @@ from tools.environments import local as local_mod
 from tools.environments.local import (
     LocalEnvironment,
     _bash_safe_path,
+    _native_windows_path_for_exe,
     _git_bash_bin_dirs,
     _make_run_env,
     _msys_to_windows_path,
@@ -332,3 +333,22 @@ class TestWrapCommandWindowsNativeCwd:
         script = captured["script"]
         assert "/c/Users/Alexander/AppData/Local/Temp/hermes-snap-deadbeef.sh" in script
         assert r"C:\Users\Alexander\AppData" not in script
+
+
+def test_native_windows_path_for_exe_rewrites_drive_to_forward_slash(monkeypatch):
+    import tools.environments.local as local_mod
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    assert _native_windows_path_for_exe(r"D:\Ivo\ai-costs.json") == "D:/Ivo/ai-costs.json"
+    assert _native_windows_path_for_exe("D:/Ivo/ai-costs.json") == "D:/Ivo/ai-costs.json"
+
+
+def test_native_windows_path_for_exe_rewrites_msys_form(monkeypatch):
+    import tools.environments.local as local_mod
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    assert _native_windows_path_for_exe("/d/Ivo/ai-costs.json") == "D:/Ivo/ai-costs.json"
+
+
+def test_native_windows_path_for_exe_leaves_relative(monkeypatch):
+    import tools.environments.local as local_mod
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    assert _native_windows_path_for_exe("Apps/The-Pulse") == "Apps/The-Pulse"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -130,6 +130,46 @@ def _bash_safe_path(path: str) -> str:
     return path
 
 
+
+
+def _native_windows_path_for_exe(path: str) -> str:
+    r"""Return *path* in forward-slash native Windows form for native EXEs.
+
+    Git Bash is still the process launcher, but tools like ripgrep that ship
+    as Win32 binaries do **not** understand MSYS drive paths (``/d/...``).
+    They *do* accept ``D:/...``.
+
+    - Native ``D:\foo`` / ``D:/foo`` -> ``D:/foo``
+    - MSYS ``/d/foo`` / ``/cygdrive/d/foo`` / ``/mnt/d/foo`` -> ``D:/foo``
+    - Otherwise leave unchanged (relative paths, pure POSIX strings)
+
+    No-op off Windows and for empty input. Pair with
+    ``MSYS_NO_PATHCONV`` / ``MSYS2_ARG_CONV_EXCL`` (already applied to bash
+    env defaults) so Git Bash does not re-mangle the ``D:/`` form.
+    """
+    if not _IS_WINDOWS or not path:
+        return path
+
+    # Already native drive-qualified -> normalize separators only.
+    m = re.match(r'^([a-zA-Z]):[\\/]*(.*)$', path)
+    if m:
+        drive = m.group(1).upper()
+        tail = (m.group(2) or "").replace("\\", "/").lstrip("/")
+        return f"{drive}:/{tail}" if tail else f"{drive}:/"
+
+    # MSYS / Cygwin / WSL drive forms -> native forward-slash.
+    win = _msys_to_windows_path(path)
+    if win != path:
+        m2 = re.match(r'^([a-zA-Z]):[\\/]*(.*)$', win)
+        if m2:
+            drive = m2.group(1).upper()
+            tail = (m2.group(2) or "").replace("\\", "/").lstrip("/")
+            return f"{drive}:/{tail}" if tail else f"{drive}:/"
+
+    if "\\" in path:
+        return path.replace("\\", "/")
+    return path
+
 def _quote_bash_path(path: str) -> str:
     """Quote *path* for safe interpolation into a Git Bash script on Windows."""
     import shlex

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -140,6 +140,7 @@ def _native_windows_path_for_exe(path: str) -> str:
     They *do* accept ``D:/...``.
 
     - Native ``D:\foo`` / ``D:/foo`` -> ``D:/foo``
+    - Drive-relative ``D:foo`` -> ``D:foo`` (only separators normalize)
     - MSYS ``/d/foo`` / ``/cygdrive/d/foo`` / ``/mnt/d/foo`` -> ``D:/foo``
     - Otherwise leave unchanged (relative paths, pure POSIX strings)
 
@@ -151,7 +152,7 @@ def _native_windows_path_for_exe(path: str) -> str:
         return path
 
     # Already native drive-qualified -> normalize separators only.
-    m = re.match(r'^([a-zA-Z]):[\\/]*(.*)$', path)
+    m = re.match(r'^([a-zA-Z]):[\\/]+(.*)$', path)
     if m:
         drive = m.group(1).upper()
         tail = (m.group(2) or "").replace("\\", "/").lstrip("/")
@@ -160,7 +161,7 @@ def _native_windows_path_for_exe(path: str) -> str:
     # MSYS / Cygwin / WSL drive forms -> native forward-slash.
     win = _msys_to_windows_path(path)
     if win != path:
-        m2 = re.match(r'^([a-zA-Z]):[\\/]*(.*)$', win)
+        m2 = re.match(r'^([a-zA-Z]):[\\/]+(.*)$', win)
         if m2:
             drive = m2.group(1).upper()
             tail = (m2.group(2) or "").replace("\\", "/").lstrip("/")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1088,12 +1088,37 @@ class ShellFileOperations(FileOperations):
         drive-qualified paths in forward-slash native form (``C:/...``)
         so Win32 tools such as ripgrep can resolve them (#67629).
         Relative / non-Windows paths still go through plain quoting.
+
+        The native drive rewrite is applied *only* when the host is
+        Windows **and** the command runs against the local backend.  A
+        non-local backend (SSH, Docker, Modal, Daytona) owns its own
+        path namespace: a target-side path such as ``/mnt/d/project``
+        is a valid POSIX path there and must not be reinterpreted as a
+        host Windows drive spelling (``D:/project``) — doing so breaks
+        the remote ``rg`` lookup (backend-boundary bug reported on
+        #67914).
         """
         from tools.environments.local import _IS_WINDOWS, _native_windows_path_for_exe
 
-        if _IS_WINDOWS:
+        if _IS_WINDOWS and self._is_local_backend():
             arg = _native_windows_path_for_exe(arg)
         return "'" + arg.replace("'", '\'"\'"\'') + "'"
+
+    def _is_local_backend(self) -> bool:
+        """Return True iff this FileOperations is wired to the local backend.
+
+        Native Windows drive conversion for ``rg.exe`` is only correct
+        for the host-local environment; remote backends keep their own
+        path semantics.
+        """
+        env = getattr(self, "env", None)
+        if env is None:
+            return False
+        try:
+            from tools.environments.local import LocalEnvironment
+        except Exception:  # noqa: BLE001
+            return False
+        return isinstance(env, LocalEnvironment)
 
 
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1104,6 +1104,19 @@ class ShellFileOperations(FileOperations):
             arg = _native_windows_path_for_exe(arg)
         return "'" + arg.replace("'", '\'"\'"\'') + "'"
 
+    def _escape_pattern_arg(self, arg: str) -> str:
+        """Quote a *search pattern* for the shell without path translation.
+
+        Unlike :meth:`_escape_shell_arg`, this must **not** run the value
+        through ``_bash_safe_path``: a regex is not a path, and the MSYS
+        drive rewrite would corrupt regex metacharacters on Windows
+        (e.g. ``\\w`` / ``\\d`` / ``\\(`` getting mangled to ``/w`` / ``/d``
+        / ``/(``). Single-quoting is sufficient to keep backslash escapes
+        intact for both ``rg`` and the ``grep`` fallback (#69183 pattern
+        portion consolidated into #67914 / #63177).
+        """
+        return "'" + arg.replace("'", '\'"\'"\'') + "'"
+
     def _is_local_backend(self) -> bool:
         """Return True iff this FileOperations is wired to the local backend.
 
@@ -2932,8 +2945,9 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        # Add pattern and path. The pattern is a regex, not a path, so it
+        # must be quoted without the MSYS drive rewrite (#69183 carry).
+        cmd_parts.append(self._escape_pattern_arg(pattern))
         cmd_parts.append(self._escape_native_exe_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
@@ -3068,8 +3082,9 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")
         
-        # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        # Add pattern and path. The pattern is a regex, not a path, so it
+        # must be quoted without the MSYS drive rewrite (#69183 carry).
+        cmd_parts.append(self._escape_pattern_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         
         # Fetch generously so we can compute total before slicing

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2688,7 +2688,7 @@ class ShellFileOperations(FileOperations):
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_pattern_arg(pattern)} {self._escape_native_exe_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2710,7 +2710,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_pattern_arg(pattern)} {self._escape_native_exe_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2730,7 +2730,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+                f"{self._escape_pattern_arg(pattern)} {self._escape_native_exe_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1080,6 +1080,22 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _escape_native_exe_arg(self, arg: str) -> str:
+        """Escape a path/arg for a *native Windows* executable launched via bash.
+
+        Unlike :meth:`_escape_shell_arg` (which rewrites drives to MSYS
+        ``/c/...`` for bash builtins / path consumers), this keeps
+        drive-qualified paths in forward-slash native form (``C:/...``)
+        so Win32 tools such as ripgrep can resolve them (#67629).
+        Relative / non-Windows paths still go through plain quoting.
+        """
+        from tools.environments.local import _IS_WINDOWS, _native_windows_path_for_exe
+
+        if _IS_WINDOWS:
+            arg = _native_windows_path_for_exe(arg)
+        return "'" + arg.replace("'", '\'"\'"\'') + "'"
+
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -2798,7 +2814,7 @@ class ShellFileOperations(FileOperations):
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._escape_native_exe_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2809,7 +2825,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._escape_native_exe_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2893,7 +2909,7 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._escape_native_exe_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2688,7 +2688,7 @@ class ShellFileOperations(FileOperations):
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_pattern_arg(pattern)} {self._escape_native_exe_arg(path)} "
+            f"-e {self._escape_pattern_arg(pattern)} -- {self._escape_native_exe_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2710,7 +2710,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_pattern_arg(pattern)} {self._escape_native_exe_arg(path)} "
+            f"-e {self._escape_pattern_arg(pattern)} -- {self._escape_native_exe_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2730,7 +2730,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_pattern_arg(pattern)} {self._escape_native_exe_arg(path)} "
+                f"-e {self._escape_pattern_arg(pattern)} -- {self._escape_native_exe_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -2947,8 +2947,13 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path. The pattern is a regex, not a path, so it
         # must be quoted without the MSYS drive rewrite (#69183 carry).
-        cmd_parts.append(self._escape_pattern_arg(pattern))
-        cmd_parts.append(self._escape_native_exe_arg(path))
+        # ``-e`` and ``--`` keep option-like patterns/paths on the data side.
+        cmd_parts.extend([
+            "-e",
+            self._escape_pattern_arg(pattern),
+            "--",
+            self._escape_native_exe_arg(path),
+        ])
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,
@@ -3084,8 +3089,13 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path. The pattern is a regex, not a path, so it
         # must be quoted without the MSYS drive rewrite (#69183 carry).
-        cmd_parts.append(self._escape_pattern_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        # ``-e`` and ``--`` keep option-like patterns/paths on the data side.
+        cmd_parts.extend([
+            "-e",
+            self._escape_pattern_arg(pattern),
+            "--",
+            self._escape_shell_arg(path),
+        ])
         
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)


### PR DESCRIPTION
## Bug Description

On native Windows with the Git Bash local backend, `search_files` can fail for absolute paths in two ways:

- content search: native `rg.exe` receives an MSYS path such as `/c/Users/...` and fails with `IO error ... (os error 3)`;
- file search: the same path shape can degrade to a silent `total_count: 0`, which looks like a legitimate no-match result.

Regex patterns are affected by the same boundary: backslash escapes such as `\d`, `\w`, and `\(` must not be rewritten as if they were Windows path separators.

Fixes #67629
Fixes #63177

## Root Cause

`_escape_shell_arg()` routes arguments through `_bash_safe_path()`, which intentionally rewrites `C:\...` / `C:/...` to Git Bash form (`/c/...`) for bash and MSYS-aware tools.

That is correct for bash builtins and the grep/find paths, but not for a Win32 `rg.exe`: Hermes deliberately sets `MSYS_NO_PATHCONV=1` and `MSYS2_ARG_CONV_EXCL=*` to stop MSYS from mangling native command switches, so no later layer converts `/c/...` back before native ripgrep receives it.

The same path-oriented rewriting must not be applied to search patterns: a regex is not a path.

## Fix

This PR is a current-`main` salvage/rebase of #67914, preserving the original commits and attribution, plus one focused follow-up for the zero-match probe sibling call sites.

- Add `_native_windows_path_for_exe()` for native Windows executables.
- Add `_escape_native_exe_arg()` and use it for native `rg` path arguments.
- Add `_escape_pattern_arg()` so search patterns are shell-quoted without MSYS path rewriting.
- Use native paths for `rg --files`, content search, and the three zero-match `rg` probes.
- Keep grep path arguments on the existing MSYS-aware escaping.
- Gate native path conversion to the local Windows backend so SSH/Docker/Modal/Daytona targets keep their own POSIX namespaces (`/mnt/d/...` must not become `D:/...` on a remote target).
- Preserve drive-relative inputs such as `D:logs/app.txt` instead of turning them into drive-rooted paths.
- Add explicit `-e` / `--` argument boundaries for rg/grep searches and zero-match probes so option-like patterns such as `-foo` remain data.

## Salvage / Attribution

- Salvages #67914 by cherry-picking the three original commits onto current `main`.
- Preserves Bartok9's commit authorship.
- Preserves the `Co-authored-by: rille111` trailer on the consolidated pattern-handling commit.
- Adds one separate follow-up commit for `_zero_match_probe()`, which used the same incorrect path/pattern escaping for native `rg`.

## How to Verify

On native Windows with Git Bash and a Win32 ripgrep build:

1. Create a fixture outside ignored/commented roots, for example `C:\Temp\hermes-rg-live-verify\subdir\sample.txt` containing `needle-windows-rg-path-fix`.
2. Run file and content searches with all three path spellings:
   - `C:\Temp\hermes-rg-live-verify`
   - `C:/Temp/hermes-rg-live-verify`
   - `/c/Temp/hermes-rg-live-verify`
3. Confirm both `target='files'` and `target='content'` return the sample file instead of `os error 3` or silent zero results.
4. For zero-match steering, verify that a casing miss, a regex-metachar literal, and a hidden-only match each produce the intended warning instead of a bare zero.

## Test Plan

- [x] Regression coverage added for native path conversion, local-vs-remote backend boundaries, pattern preservation, zero-match probes, drive-relative paths, and option-like patterns.
- [x] Focused tests: `scripts/run_tests.sh tests/tools/test_file_operations.py tests/tools/test_local_env_windows_msys.py -k "native_windows or escape_native or search_with_rg_uses or escape_pattern or preserves_regex or native_windows_path_for_exe or zero_match_probe_uses or drive_relative or argument_boundaries" -q` → 15 passed.
- [x] Sabotage run: restoring only the two production files from `origin/main` makes the new regression tests fail; restoring the fix makes them pass.
- [x] Relevant local Windows suite: 116 passed / 18 failed on this branch versus 103 passed / 21 failed on an `origin/main` baseline worktree. The remaining failing test names are pre-existing baseline failures tied to Windows symlink privileges and this host's global-ignore/Temp environment; no new failing test names were introduced.
- [x] `ruff check tools/environments/local.py tools/file_operations.py tests/tools/test_file_operations.py tests/tools/test_local_env_windows_msys.py` → passed.
- [x] `git diff --check` → passed.
- [x] Manual native Windows live verification for `C:\...`, `C:/...`, and `/c/...` path forms.

## Risk Assessment

Low / Medium — the change is confined to search-command argument construction. Bash/MSYS-aware file operations keep `_escape_shell_arg()`, grep paths keep MSYS form, and native Windows path conversion is limited to the local backend. CI should cover the non-Windows no-op paths.


