### PR TITLE
fix(cli): report background-dispatch cron runs without false 'failed'

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -472,7 +472,21 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
         print(f"  Next run: {result['job']['next_run_at']}")
     if action == "run":
         job = result.get("job", {})
-        if job.get("executed"):
+        # A manual run can be dispatched to the gateway daemon's background
+        # delegation worker instead of executing inline (e.g. when the CLI
+        # process inherits a gateway/desktop session env and the run
+        # resolves a session key). Such responses carry
+        # execution_mode="background" and/or a delegation_id, and the job
+        # keeps running AFTER this CLI process exits — a terminal
+        # success/failure verdict would be a lie (#83340). Report the
+        # background dispatch instead of claiming the run failed.
+        delegation_id = job.get("delegation_id")
+        if job.get("execution_mode") == "background" or delegation_id:
+            if delegation_id:
+                print(f"  Running in background (delegation {delegation_id}).")
+            else:
+                print("  Running in background.")
+        elif job.get("executed"):
             outcome = "succeeded" if job.get("execution_success") else "failed"
             print(f"  Ran now: {outcome}.")
         elif job.get("execution_skipped"):

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -234,3 +234,126 @@ def test_cron_create_failure_returns_nonzero(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert rc == 1
     assert "Failed to create job: boom" in out
+
+
+class TestCronRunBackgroundDispatch:
+    """`hermes cron run` must not report 'failed' when the run was dispatched
+    to the background delegation worker.
+
+    The CLI process inherits the gateway/desktop session env, so a manual run
+    can be dispatched to the daemon instead of executing inline. Such
+    responses carry execution_mode='background' / delegation_id and the job
+    keeps running after the CLI exits — a terminal success/failure verdict
+    would be a lie (#83340). The CLI must report the background dispatch
+    instead, and leave synchronous runs unchanged.
+    """
+
+    def _run_cmd(self, capsys):
+        rc = cron_command(Namespace(cron_command="run", job_id="job-1"))
+        return rc, capsys.readouterr().out
+
+    def test_background_dispatch_with_delegation_id_does_not_report_failed(
+        self, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {
+                "success": True,
+                "job": {
+                    "id": "job-1",
+                    "name": "Watchdog",
+                    "execution_mode": "background",
+                    "delegation_id": "del-abc123",
+                    # No execution_success — the inline verdict must not apply.
+                    "executed": True,
+                },
+            },
+        )
+
+        rc, out = self._run_cmd(capsys)
+
+        assert rc == 0
+        assert "Running in background (delegation del-abc123)." in out
+        assert "failed" not in out.lower()
+        assert "Ran now" not in out
+
+    def test_background_dispatch_without_delegation_id(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {
+                "success": True,
+                "job": {
+                    "id": "job-1",
+                    "name": "Watchdog",
+                    "execution_mode": "background",
+                },
+            },
+        )
+
+        rc, out = self._run_cmd(capsys)
+
+        assert rc == 0
+        assert "Running in background." in out
+        assert "failed" not in out.lower()
+
+    def test_sync_run_success_unchanged(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {
+                "success": True,
+                "job": {
+                    "id": "job-1",
+                    "name": "Watchdog",
+                    "executed": True,
+                    "execution_success": True,
+                },
+            },
+        )
+
+        rc, out = self._run_cmd(capsys)
+
+        assert rc == 0
+        assert "Ran now: succeeded." in out
+
+    def test_sync_run_failure_still_reported(self, monkeypatch, capsys):
+        # A genuine synchronous failure must keep reporting 'failed' — only
+        # background-dispatched runs are exempt from the terminal verdict.
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {
+                "success": True,
+                "job": {
+                    "id": "job-1",
+                    "name": "Watchdog",
+                    "executed": True,
+                    "execution_success": False,
+                },
+            },
+        )
+
+        rc, out = self._run_cmd(capsys)
+
+        assert rc == 0
+        assert "Ran now: failed." in out
+
+    def test_delegation_id_alone_counts_as_background(self, monkeypatch, capsys):
+        # Some dispatchers may not set execution_mode but always return the
+        # delegation_id — either marker alone must suppress the verdict.
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {
+                "success": True,
+                "job": {"id": "job-1", "name": "Watchdog", "delegation_id": "del-xyz"},
+            },
+        )
+
+        rc, out = self._run_cmd(capsys)
+
+        assert rc == 0
+        assert "Running in background (delegation del-xyz)." in out
+        assert "failed" not in out.lower()


### PR DESCRIPTION
## Summary
`hermes cron run` reported `Ran now: failed.` without executing the job when run from a terminal inside the Hermes desktop app (macOS). The cron engine itself works (the `cronjob` tool `action='run'` completes in ~125ms with `last_status=ok`) — only the CLI path misreported.

## Root Cause
`hermes_cli/cron.py::_job_action("run", ...)` printed `Ran now: failed.` for any response without a truthy `execution_success` — but a run dispatched to the background daemon (delegation) doesn't carry that field, so a legitimately-running background job was reported as failed.

## Change
- `hermes_cli/cron.py`: when the run was dispatched to the background (`execution_mode="background"` / a delegation id is present), the CLI now prints `running in background (delegation <id>)` instead of a false failure verdict.
- `tests/hermes_cli/test_cron.py`: 5 new tests covering background dispatch (no false failed), sync dispatch (unchanged behavior), and the delegation-id rendering.

## Verification
- `tests/hermes_cli/test_cron.py`: **13 passed**.

Closes #83340