### PR TITLE
fix(oauth): preserve Claude Code credential keys on refresh

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1237,12 +1237,17 @@ def _write_claude_code_credentials(
         }
         if scopes is not None:
             oauth_data["scopes"] = scopes
-        elif "claudeAiOauth" in existing and "scopes" in existing["claudeAiOauth"]:
-            # Preserve previously-stored scopes when the refresh response
-            # does not include a scope field.
-            oauth_data["scopes"] = existing["claudeAiOauth"]["scopes"]
 
-        existing["claudeAiOauth"] = oauth_data
+        # Merge instead of replacing the object wholesale: real Claude Code
+        # credential files carry keys Hermes does not manage
+        # (refreshTokenExpiresAt, subscriptionType, rateLimitTier). Replacing
+        # the whole object dropped them, silently downgrading Claude Code
+        # from subscription to API-key mode (#83338). Update only the fields
+        # Hermes manages and keep everything else intact.
+        existing_oauth = existing.get("claudeAiOauth")
+        merged = dict(existing_oauth) if isinstance(existing_oauth, dict) else {}
+        merged.update(oauth_data)
+        existing["claudeAiOauth"] = merged
 
         cred_path.parent.mkdir(parents=True, exist_ok=True)
         # Per-process random suffix avoids collisions between concurrent

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -453,11 +453,52 @@ class TestWriteClaudeCodeCredentials:
         cred_dir = tmp_path / ".claude"
         cred_dir.mkdir()
         cred_file = cred_dir / ".credentials.json"
+        # Seed a realistic Claude Code credential file: managed keys plus the
+        # unmanaged keys Hermes does not touch (refreshTokenExpiresAt,
+        # subscriptionType, rateLimitTier) and a sibling top-level key.
+        cred_file.write_text(json.dumps({
+            "otherField": "keep-me",
+            "claudeAiOauth": {
+                "accessToken": "old-tok",
+                "refreshToken": "old-ref",
+                "expiresAt": 1,
+                "refreshTokenExpiresAt": 2,
+                "scopes": ["user:inference"],
+                "subscriptionType": "max",
+                "rateLimitTier": "max",
+            },
+        }))
+        _write_claude_code_credentials("new-tok", "new-ref", 99999)
+        data = json.loads(cred_file.read_text())
+        # Sibling top-level keys survive.
+        assert data["otherField"] == "keep-me"
+        # Managed fields are updated...
+        assert data["claudeAiOauth"]["accessToken"] == "new-tok"
+        assert data["claudeAiOauth"]["refreshToken"] == "new-ref"
+        assert data["claudeAiOauth"]["expiresAt"] == 99999
+        # ...and unmanaged keys inside claudeAiOauth survive the refresh.
+        # Regression for #83338: replacing the object wholesale dropped
+        # subscriptionType, downgrading Claude Code to API-key mode.
+        assert data["claudeAiOauth"]["refreshTokenExpiresAt"] == 2
+        assert data["claudeAiOauth"]["subscriptionType"] == "max"
+        assert data["claudeAiOauth"]["rateLimitTier"] == "max"
+        # Pre-existing scopes survive when the refresh omits them.
+        assert data["claudeAiOauth"]["scopes"] == ["user:inference"]
+
+    def test_creates_oauth_object_when_file_has_none(self, tmp_path, monkeypatch):
+        """A file without a claudeAiOauth object behaves as before: the object
+        is created from scratch and sibling keys survive."""
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        cred_dir = tmp_path / ".claude"
+        cred_dir.mkdir()
+        cred_file = cred_dir / ".credentials.json"
         cred_file.write_text(json.dumps({"otherField": "keep-me"}))
         _write_claude_code_credentials("new-tok", "new-ref", 99999)
         data = json.loads(cred_file.read_text())
         assert data["otherField"] == "keep-me"
         assert data["claudeAiOauth"]["accessToken"] == "new-tok"
+        assert data["claudeAiOauth"]["refreshToken"] == "new-ref"
+        assert data["claudeAiOauth"]["expiresAt"] == 99999
 
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
     def test_credentials_file_created_with_0o600(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
When Hermes refreshes an auto-discovered Claude Code OAuth token, it rewrote `~/.claude/.credentials.json` by replacing the whole `claudeAiOauth` object. Real Claude Code credential files carry 7 keys; the write emitted at most 4. The dropped keys included `subscriptionType`, which Claude Code uses to recognize the credential as a subscription — downgrading Claude Code to API-key mode.

## Change
- `agent/anthropic_adapter.py::_write_claude_code_credentials()`: replaced the full-object replace with a **preservative merge** — reads the existing `claudeAiOauth` object (dict-guarded for missing/malformed), updates only the fields Hermes manages (`accessToken`, `refreshToken`, `expiresAt`, `scopes`), and writes the merge. `subscriptionType`, `rateLimitTier`, `refreshTokenExpiresAt`, and unknown future keys survive.
- `tests/agent/test_anthropic_adapter.py`: extended the preserve test to seed a realistic 7-key file and assert the 3 non-managed keys survive the refresh (plus managed fields updated and top-level sibling key preserved); new test for a file without `claudeAiOauth` (created from scratch, sibling preserved).

## Verification
- `tests/agent/test_anthropic_adapter.py`: **95 passed**.

Closes #83338