### PR TITLE
fix(cli): don't serve stale update-check results after fetch failure

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -340,13 +340,22 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         if is_shallow:
             fetch_args += ["--depth", "1"]
         fetch_args.append("--quiet")
-        subprocess.run(
+        fetch_proc = subprocess.run(
             fetch_args,
             capture_output=True, timeout=10,
             cwd=str(repo_dir),
         )
+        fetch_ok = fetch_proc.returncode == 0
     except Exception:
-        pass  # Offline or timeout — use stale refs, that's fine
+        fetch_ok = False  # Offline or timeout — don't use stale refs
+
+    # When the fetch fails, the local origin/main tracking ref is stale.
+    # Comparing HEAD against it can report "0 behind" (up to date) even when
+    # upstream has moved forward — the exact stale-cache symptom in #82166.
+    # Return None so the caller knows the check was inconclusive and doesn't
+    # cache a false "up to date".
+    if not fetch_ok:
+        return None
 
     if is_shallow:
         # No history to count across the shallow boundary. `origin/main` may not
@@ -444,10 +453,16 @@ def check_for_updates() -> Optional[int]:
             behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
-            encoding="utf-8",
-        )
+        # Don't cache inconclusive results (None). A None means the check
+        # could not run — typically a failed git fetch. Caching None would
+        # suppress retries for the full 6-hour cache window, leaving the
+        # user with a stale "up to date" or no information for hours after
+        # connectivity is restored (#82166).
+        if behind is not None:
+            cache_file.write_text(
+                json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+                encoding="utf-8",
+            )
     except Exception:
         pass
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -349,12 +349,27 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     except Exception:
         fetch_ok = False  # Offline or timeout — don't use stale refs
 
-    # When the fetch fails, the local origin/main tracking ref is stale.
-    # Comparing HEAD against it can report "0 behind" (up to date) even when
-    # upstream has moved forward — the exact stale-cache symptom in #82166.
-    # Return None so the caller knows the check was inconclusive and doesn't
-    # cache a false "up to date".
+    # When the fetch fails, the local origin/main tracking ref is stale. It
+    # cannot prove *currentness* (a 0 behind-count may just mean the stale ref
+    # hasn't caught up), but if it already shows HEAD behind, that is sound
+    # evidence an update exists — the ref was good at some point in the past.
+    # Return the positive stale count; return None (inconclusive) otherwise so
+    # the caller doesn't cache a false "up to date". (#82166, review #92578)
     if not fetch_ok:
+        if not is_shallow:
+            try:
+                result = subprocess.run(
+                    ["git", "rev-list", "--count", "HEAD..origin/main"],
+                    capture_output=True, text=True, encoding="utf-8", errors="replace",
+                    timeout=5,
+                    cwd=str(repo_dir),
+                )
+                if result.returncode == 0:
+                    behind = int(result.stdout.strip())
+                    if behind > 0:
+                        return behind
+            except Exception:
+                pass
         return None
 
     if is_shallow:

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -238,13 +238,22 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         if is_shallow:
             fetch_args += ["--depth", "1"]
         fetch_args.append("--quiet")
-        subprocess.run(
+        fetch_proc = subprocess.run(
             fetch_args,
             capture_output=True, timeout=10,
             cwd=str(repo_dir),
         )
+        fetch_ok = fetch_proc.returncode == 0
     except Exception:
-        pass  # Offline or timeout — use stale refs, that's fine
+        fetch_ok = False  # Offline or timeout — don't use stale refs
+
+    # When the fetch fails, the local origin/main tracking ref is stale.
+    # Comparing HEAD against it can report "0 behind" (up to date) even when
+    # upstream has moved forward — the exact stale-cache symptom in #82166.
+    # Return None so the caller knows the check was inconclusive and doesn't
+    # cache a false "up to date".
+    if not fetch_ok:
+        return None
 
     if is_shallow:
         # No history to count across the shallow boundary. `origin/main` may not
@@ -335,10 +344,16 @@ def check_for_updates() -> Optional[int]:
             behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
-            encoding="utf-8",
-        )
+        # Don't cache inconclusive results (None). A None means the check
+        # could not run — typically a failed git fetch. Caching None would
+        # suppress retries for the full 6-hour cache window, leaving the
+        # user with a stale "up to date" or no information for hours after
+        # connectivity is restored (#82166).
+        if behind is not None:
+            cache_file.write_text(
+                json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+                encoding="utf-8",
+            )
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -59,12 +59,12 @@ def test_prefetch_non_blocking():
 
 
 def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
-    """When git fetch fails, _check_via_local_git must return None instead of
-    comparing against stale origin/main refs (#82166).
+    """When git fetch fails and the stale origin/main ref is not ahead,
+    _check_via_local_git must return None (#82166).
 
-    Without this fix, a fetch failure silently falls through to
-    ``git rev-list --count HEAD..origin/main`` using the stale tracking ref,
-    which can report 0 (up to date) even when upstream has moved forward.
+    A stale tracking ref cannot prove *currentness* (rev-list 0 just means
+    the ref hasn't caught up), so returning None is the honest inconclusive
+    result — and the caller must not cache it as "up to date".
     """
     from hermes_cli import banner
 
@@ -80,17 +80,109 @@ def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
             return "false"
         return None
 
-    # Simulate fetch failure (returncode != 0)
+    # Fetch fails (returncode != 0); stale rev-list reports 0 behind
     failed_proc = MagicMock()
     failed_proc.returncode = 1
     failed_proc.stdout = ""
     failed_proc.stderr = "fatal: could not reach remote"
 
+    stale_zero_proc = MagicMock()
+    stale_zero_proc.returncode = 0
+    stale_zero_proc.stdout = "0"
+
+    def mock_run(args, **kwargs):
+        if args[:2] == ["git", "fetch"]:
+            return failed_proc
+        if args[:2] == ["git", "rev-list"]:
+            return stale_zero_proc
+        raise AssertionError(f"unexpected subprocess.run: {args}")
+
     monkeypatch.setattr(banner, "_git_stdout", mock_git_stdout)
-    monkeypatch.setattr(banner.subprocess, "run", MagicMock(return_value=failed_proc))
+    monkeypatch.setattr(banner.subprocess, "run", mock_run)
 
     result = banner._check_via_local_git(repo_dir)
-    assert result is None, "Fetch failure must return None, not a stale behind-count"
+    assert result is None, (
+        "Fetch failure with stale 0-behind must return None, not 'up to date'"
+    )
+
+
+def test_check_via_local_git_fetch_failure_keeps_positive_stale_count(tmp_path, monkeypatch):
+    """A failed fetch must preserve sound evidence: if the stale origin/main
+    ref already shows HEAD behind, that positive count is still an update
+    signal and must be returned (review #92578)."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def mock_git_stdout(args, *, cwd, timeout=5):
+        if args[:2] == ["remote", "get-url"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "false"
+        return None
+
+    failed_proc = MagicMock()
+    failed_proc.returncode = 1
+    failed_proc.stdout = ""
+    failed_proc.stderr = "fatal: could not reach remote"
+
+    stale_behind_proc = MagicMock()
+    stale_behind_proc.returncode = 0
+    stale_behind_proc.stdout = "5"
+
+    def mock_run(args, **kwargs):
+        if args[:2] == ["git", "fetch"]:
+            return failed_proc
+        if args[:2] == ["git", "rev-list"]:
+            return stale_behind_proc
+        raise AssertionError(f"unexpected subprocess.run: {args}")
+
+    monkeypatch.setattr(banner, "_git_stdout", mock_git_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", mock_run)
+
+    result = banner._check_via_local_git(repo_dir)
+    assert result == 5, "Stale positive behind-count must be preserved on fetch failure"
+
+
+def test_check_via_local_git_fetch_failure_rev_list_error_returns_none(tmp_path, monkeypatch):
+    """If the stale rev-list itself fails, the check stays inconclusive (None)."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def mock_git_stdout(args, *, cwd, timeout=5):
+        if args[:2] == ["remote", "get-url"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "false"
+        return None
+
+    failed_proc = MagicMock()
+    failed_proc.returncode = 1
+    failed_proc.stdout = ""
+    failed_proc.stderr = "fatal: could not reach remote"
+
+    bad_rev_list = MagicMock()
+    bad_rev_list.returncode = 128
+    bad_rev_list.stdout = ""
+    bad_rev_list.stderr = "fatal: ambiguous argument 'HEAD..origin/main'"
+
+    def mock_run(args, **kwargs):
+        if args[:2] == ["git", "fetch"]:
+            return failed_proc
+        if args[:2] == ["git", "rev-list"]:
+            return bad_rev_list
+        raise AssertionError(f"unexpected subprocess.run: {args}")
+
+    monkeypatch.setattr(banner, "_git_stdout", mock_git_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", mock_run)
+
+    result = banner._check_via_local_git(repo_dir)
+    assert result is None
 
 
 def test_check_for_updates_does_not_cache_none(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -58,5 +58,100 @@ def test_prefetch_non_blocking():
         assert banner._update_result == 5
 
 
+def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
+    """When git fetch fails, _check_via_local_git must return None instead of
+    comparing against stale origin/main refs (#82166).
+
+    Without this fix, a fetch failure silently falls through to
+    ``git rev-list --count HEAD..origin/main`` using the stale tracking ref,
+    which can report 0 (up to date) even when upstream has moved forward.
+    """
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    # Simulate a non-shallow, non-SSH-remote checkout
+    def mock_git_stdout(args, *, cwd, timeout=5):
+        if args[:2] == ["remote", "get-url"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "false"
+        return None
+
+    # Simulate fetch failure (returncode != 0)
+    failed_proc = MagicMock()
+    failed_proc.returncode = 1
+    failed_proc.stdout = ""
+    failed_proc.stderr = "fatal: could not reach remote"
+
+    monkeypatch.setattr(banner, "_git_stdout", mock_git_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", MagicMock(return_value=failed_proc))
+
+    result = banner._check_via_local_git(repo_dir)
+    assert result is None, "Fetch failure must return None, not a stale behind-count"
+
+
+def test_check_for_updates_does_not_cache_none(tmp_path, monkeypatch):
+    """check_for_updates must not cache None results so a transient fetch
+    failure doesn't suppress retries for the full 6-hour cache window (#82166).
+
+    Instead of mocking the full Path resolution chain, we verify the cache-write
+    guard directly: call check_for_updates with a mocked _check_via_local_git
+    that returns None, and confirm no cache file is created.
+    """
+    import hermes_cli.banner as banner
+
+    cache_file = tmp_path / ".update_check"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+
+    # Create a fake repo dir so the .git check passes
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    # Mock the internal functions to force the local-git path returning None
+    monkeypatch.setattr(banner, "_check_via_local_git", lambda rd: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.detect_install_method", lambda root: "git"
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_project_root", lambda: repo_dir
+    )
+
+    # Patch __file__ resolution by monkeypatching the module's Path calls.
+    # check_for_updates does: Path(__file__).parent.parent.resolve()
+    # We intercept by making the resolve() return our fake repo_dir.
+    original_init = Path.__init__
+
+    def patched_path_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+
+    # Simpler: just patch the get_hermes_home and the repo_dir resolution
+    # by making check_for_updates find our fake repo via hermes_home fallback.
+    # The code checks Path(__file__).parent.parent/.git first, then falls
+    # back to hermes_home / "hermes-agent". We ensure the fallback hits.
+    # To do this, we make Path(__file__).parent.parent.resolve() return
+    # a path without .git, so it falls through to hermes_home / "hermes-agent".
+    real_resolve = Path.resolve
+
+    def fake_resolve(self, *args, **kwargs):
+        s = str(self)
+        if "banner.py" in s or s.endswith("hermes_cli"):
+            # Return a path that has no .git, forcing the fallback
+            return tmp_path / "no-git-here"
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+    result = banner.check_for_updates()
+    assert result is None
+
+    # The cache file must NOT have been written with a None result
+    assert not cache_file.exists(), "None result must not be cached"
+
+
 
 


### PR DESCRIPTION
## What does this PR do?

When `_check_via_local_git`'s `git fetch origin main` fails (timeout, offline, DNS resolution failure), the code silently fell through to compare `HEAD` against the stale `origin/main` tracking ref. That stale ref hadn't been updated, so `git rev-list --count HEAD..origin/main` could report `0` (up to date) even when upstream had moved forward by several commits.

Combined with the 6-hour cache in `check_for_updates`, a single fetch failure could suppress update notifications for days. This is the exact symptom in #82166: the daily cron job hit the `/api/hermes/update/check` endpoint, which called `check_for_updates()`, which cached the stale `0` for 6 hours. After the cache expired, the next check attempted another fetch — if that also failed (intermittent network issue, slow DNS), another stale `0` was cached. This cycle repeated for 4 days while v0.20.0 was already available on GitHub.

## Related Issue

Fixes #82166

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/banner.py` — `_check_via_local_git()`: detect fetch failure (returncode != 0 or exception) and return `None` instead of falling through to stale refs. The caller treats `None` as "check could not run" rather than "up to date".
- `hermes_cli/banner.py` — `check_for_updates()`: no longer cache `None` results. Previously, a `None` from a failed check was cached for 6 hours, suppressing retries until the cache expired. Now only conclusive results (`0` or `>=1`) are cached, so the next check attempt runs immediately on the next call.

## How to Test

1. `pytest tests/hermes_cli/test_update_check.py -v` — all 4 tests pass
2. `test_check_via_local_git_fetch_failure_returns_none` — verifies that a failed `git fetch` (returncode=1) returns `None` instead of a stale behind-count
3. `test_check_for_updates_does_not_cache_none` — verifies that `None` results are not written to the `.update_check` cache file
4. Manual: simulate a fetch failure by disconnecting network, run `hermes update --check`, confirm it reports "could not determine" instead of "up to date"

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5, Python 3.13.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A