### PR TITLE
fix(desktop): fail-soft image pre-analysis with timeout and visible error

### DIFF
--- a/tests/tui_gateway/test_image_preanalysis_fail_soft.py
+++ b/tests/tui_gateway/test_image_preanalysis_fail_soft.py
@@ -1,0 +1,119 @@
+"""Fail-soft regression tests for desktop image pre-analysis (issue #83291).
+
+Dragging images into the desktop chat ran a serial vision pre-analysis
+(``_enrich_with_attached_images``) that could hang for minutes per image,
+swallow failures silently, and — on interrupt — kill the whole turn with
+api_calls=0 and an empty response. The contract now: per-image timeout
+(``_IMAGE_PREANALYSIS_TIMEOUT_S``), the real error printed to stderr, degrade
+to a ``vision_analyze`` retry hint, user text always preserved, and the
+function NEVER raises.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from tui_gateway.server import _enrich_with_attached_images
+
+_SUCCESS = json.dumps({"success": True, "analysis": "A red ball on a table."})
+
+
+@pytest.fixture
+def fake_image(tmp_path):
+    img = tmp_path / "shot.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n fake png bytes")
+    return img
+
+
+def test_failure_degrades_to_retry_hint_and_preserves_text(fake_image, monkeypatch):
+    async def boom(image_url, user_prompt):
+        raise RuntimeError("vision backend exploded")
+
+    monkeypatch.setattr("tools.vision_tools.vision_analyze_tool", boom)
+
+    result = _enrich_with_attached_images("what is this?", [str(fake_image)])
+
+    assert "analysis failed" in result
+    assert "vision_analyze using image_url" in result
+    assert str(fake_image) in result
+    assert "what is this?" in result  # user text preserved
+
+
+def test_timeout_degrades_and_does_not_hang(fake_image, monkeypatch):
+    async def slow(image_url, user_prompt):
+        await asyncio.sleep(60)  # would stall the turn without the timeout
+        return _SUCCESS
+
+    monkeypatch.setattr("tools.vision_tools.vision_analyze_tool", slow)
+    monkeypatch.setattr("tui_gateway.server._IMAGE_PREANALYSIS_TIMEOUT_S", 0.05)
+
+    result = _enrich_with_attached_images("what is this?", [str(fake_image)])
+
+    assert "analysis failed" in result
+    assert "vision_analyze using image_url" in result
+    assert "what is this?" in result
+
+
+@pytest.mark.parametrize(
+    "interrupt",
+    [asyncio.CancelledError("user hit stop"), KeyboardInterrupt("ctrl-c")],
+)
+def test_interrupt_does_not_kill_turn(fake_image, monkeypatch, interrupt):
+    async def interrupted(image_url, user_prompt):
+        raise interrupt
+
+    monkeypatch.setattr("tools.vision_tools.vision_analyze_tool", interrupted)
+
+    result = _enrich_with_attached_images("what is this?", [str(fake_image)])
+
+    assert "analysis failed" in result
+    assert "vision_analyze using image_url" in result
+    assert "what is this?" in result
+
+
+def test_success_keeps_description_and_hint(fake_image, monkeypatch):
+    async def ok(image_url, user_prompt):
+        return _SUCCESS
+
+    monkeypatch.setattr("tools.vision_tools.vision_analyze_tool", ok)
+
+    result = _enrich_with_attached_images("what is this?", [str(fake_image)])
+
+    assert "A red ball on a table." in result
+    assert "vision_analyze using image_url" in result
+    assert "what is this?" in result
+
+
+def test_failure_logs_real_error_to_stderr(fake_image, monkeypatch, capsys):
+    async def boom(image_url, user_prompt):
+        raise TimeoutError("vision call timed out")
+
+    monkeypatch.setattr("tools.vision_tools.vision_analyze_tool", boom)
+
+    _enrich_with_attached_images("what is this?", [str(fake_image)])
+
+    captured = capsys.readouterr()
+    assert "[tui_gateway] vision pre-analysis failed" in captured.err
+    assert str(fake_image) in captured.err
+    assert "timed out" in captured.err  # the real error, never swallowed
+
+
+def test_mixed_good_and_failing_images_both_handled(tmp_path, monkeypatch):
+    good = tmp_path / "good.png"
+    good.write_bytes(b"\x89PNG\r\n\x1a\n good")
+    bad = tmp_path / "bad.png"
+    bad.write_bytes(b"\x89PNG\r\n\x1a\n bad")
+
+    async def flaky(image_url, user_prompt):
+        if "bad" in image_url:
+            raise RuntimeError("oops")
+        return _SUCCESS
+
+    monkeypatch.setattr("tools.vision_tools.vision_analyze_tool", flaky)
+
+    result = _enrich_with_attached_images("keep me", [str(bad), str(good)])
+
+    assert "keep me" in result
+    assert "A red ball on a table." in result
+    assert "analysis failed" in result

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6823,8 +6823,24 @@ def _active_image_routing_identity(agent: Any) -> tuple[str, str]:
     )
 
 
+# Per-image cap on desktop image pre-analysis (issue #83291): a single hung
+# vision call must not hold the turn hostage for minutes. On timeout the image
+# degrades to a vision_analyze retry hint instead of stalling the submission.
+_IMAGE_PREANALYSIS_TIMEOUT_S = 120.0
+
+
 def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
-    """Pre-analyze attached images via vision and prepend descriptions to user text."""
+    """Pre-analyze attached images via vision and prepend descriptions to user text.
+
+    Fail-soft by contract: per-image pre-analysis runs under
+    ``_IMAGE_PREANALYSIS_TIMEOUT_S``, and any failure/timeout/interrupt logs the
+    real error to stderr and degrades that image to a ``vision_analyze`` retry
+    hint so the main loop can still analyze it with its own retry. The user's
+    text is always preserved and this function NEVER raises — a broken vision
+    call can never kill the turn (issue #83291: swallowed pre-analysis failures
+    and interrupts during the 60-90s/image window left desktop drag-and-drop
+    attachments with no response or a minutes-long stall).
+    """
     import asyncio, json as _json
     from tools.vision_tools import vision_analyze_tool
 
@@ -6842,7 +6858,12 @@ def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
         hint = f"[You can examine it with vision_analyze using image_url: {p}]"
         try:
             r = _json.loads(
-                asyncio.run(vision_analyze_tool(image_url=str(p), user_prompt=prompt))
+                asyncio.run(
+                    asyncio.wait_for(
+                        vision_analyze_tool(image_url=str(p), user_prompt=prompt),
+                        timeout=_IMAGE_PREANALYSIS_TIMEOUT_S,
+                    )
+                )
             )
             desc = r.get("analysis", "") if r.get("success") else None
             parts.append(
@@ -6850,7 +6871,13 @@ def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
                 if desc
                 else f"[The user attached an image but analysis failed.]\n{hint}"
             )
-        except Exception:
+        except BaseException as _pa_exc:  # noqa: BLE001 — fail-soft, never kill the turn
+            # Visible error (mirrors the CLI warning); the image still degrades
+            # to a retry hint so the main loop can analyze it with its own retry.
+            print(
+                f"[tui_gateway] vision pre-analysis failed for {p}: {_pa_exc!r}",
+                file=sys.stderr,
+            )
             parts.append(f"[The user attached an image but analysis failed.]\n{hint}")
 
     text = user_text or ""


### PR DESCRIPTION
## Summary
On the desktop app, dragging image files directly into chat (as image attachments) could produce **no response at all**, or a response delayed by minutes. Dragging a folder containing the same images works normally. Root cause is in the desktop gateway's send path: direct image attachments are pre-analyzed by the auxiliary vision model before the turn is dispatched; a failure was silently swallowed (`except Exception`), and an interrupt during the 60-90s/image window killed the turn with `api_calls=0` and an empty response.

## Change
- `tui_gateway/server.py::_enrich_with_attached_images`:
  - **Per-image timeout** — `_IMAGE_PREANALYSIS_TIMEOUT_S = 120.0` via `asyncio.wait_for`; a stuck call no longer holds the turn for minutes.
  - **Visible error** — failure/timeout/interrupt now logs the real error to stderr (`[tui_gateway] vision pre-analysis failed for <path>: <exc>`), mirroring the CLI warning; never silent.
  - **Real fail-soft** — a failed image degrades to a retry hint with the path (`vision_analyze using image_url: ...`) so the main loop can analyze it with its own retry; user text is always preserved; `except BaseException` guarantees the function never raises (CancelledError/KeyboardInterrupt included — the turn never dies because of pre-analysis).
- `tests/tui_gateway/test_image_preanalysis_fail_soft.py` (new, 7 cases): failure → degrade + text preserved; timeout → degrade without hanging (mock sleeps 60s, patched timeout 0.05s); interrupt → turn survives (CancelledError + KeyboardInterrupt); success → normal description + hint; real error visible on stderr.

## Verification
- `tests/tui_gateway/test_image_preanalysis_fail_soft.py`: **7 passed**.
- Neighboring affected suites (image_routing_stale_model, failed_turn_retention, auto_continue): **25 passed**.

Closes #83291