### PR TITLE
fix(desktop): scope chat-produced preview tabs to their session

### DIFF
--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -16,14 +16,17 @@ import { FileTypeIcon } from '@/components/ui/file-type-icon'
 import { ToolIcon } from '@/components/ui/tool-icon'
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from '@/store/layout'
 import { $previewTabs, closeRightRailTab, type PreviewTarget } from '@/store/preview'
+import { $visiblePreviewTabs } from '@/store/preview'
 
 import { paneMirror } from './pane-mirror'
 import { PreviewTilePane } from './right-rail/preview'
 import { forgetPreviewStripTools, previewStripTools } from './right-rail/preview-strip-tools'
 
-/** The target behind a tile id, or null once its tab is gone. */
+/** The target behind a tile id, or null once its tab is gone. Resolves against
+ *  the tabs VISIBLE in the current chat, so a session-scoped tab hidden by a
+ *  chat switch can't be revealed or fronted from another chat. */
 function targetFor(tabId: string): PreviewTarget | null {
-  return $previewTabs.get().find(tab => tab.id === tabId)?.target ?? null
+  return $visiblePreviewTabs.get().find(tab => tab.id === tabId)?.target ?? null
 }
 
 /** Tab title. A URL is a BROWSER — the tab names the surface, not the page, so
@@ -121,7 +124,7 @@ export function watchPreviewTiles(): void {
 }
 
 const watchPreviewTileMirror = paneMirror<{ id: string }>({
-  source: $previewTabs,
+  source: $visiblePreviewTabs,
   key: tab => tab.id,
   prefix: PREVIEW_TILE_PREFIX,
   // Identical to route (page) tiles: its own zone docked beside main, sized by

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -84,7 +84,11 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
           void normalizeOrLocalPreviewTarget(target, $currentCwd.get() || currentCwd || undefined).then(resolved => {
             if (resolved) {
               const trimmedLabel = typeof label === 'string' ? label.trim() : ''
-              openPreview(trimmedLabel ? { ...resolved, label: trimmedLabel } : resolved, 'tool-result')
+              openPreview(
+                trimmedLabel ? { ...resolved, label: trimmedLabel } : resolved,
+                'tool-result',
+                event.session_id || undefined
+              )
             }
           })
         }

--- a/apps/desktop/src/components/chat/preview-attachment.tsx
+++ b/apps/desktop/src/components/chat/preview-attachment.tsx
@@ -12,8 +12,11 @@ import { $previewTabSources, closePreviewForSource, openPreview, type PreviewRec
 export function PreviewAttachment({ source = 'manual', target }: { source?: PreviewRecordSource; target: string }) {
   const { t } = useI18n()
   // This link lives in one session's transcript; resolve it against THAT
-  // session's cwd, not the primary chat's.
-  const cwd = useStore(useSessionView().$cwd)
+  // session's cwd, not the primary chat's, and scope the preview tab it opens
+  // to that session so it doesn't follow the user into other chats.
+  const sessionView = useSessionView()
+  const cwd = useStore(sessionView.$cwd)
+  const sessionId = useStore(sessionView.$runtimeId)
   const openSources = useStore($previewTabSources)
   const [opening, setOpening] = useState(false)
   const cwdRef = useRef(cwd)
@@ -75,7 +78,7 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
         throw new Error(`Could not open preview target: ${requestTarget}`)
       }
 
-      openPreview(preview, source)
+      openPreview(preview, source, sessionId ?? undefined)
     } catch (error) {
       if (
         !mountedRef.current ||

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { $rightRailActiveTabId } from './layout'
+import { $activeSessionId } from './session'
 import {
   $previewServerRestart,
   $previewServerRestartStatus,
   $previewTabs,
   $previewTarget,
+  $visiblePreviewTabs,
   beginPreviewServerRestart,
   closePreviewForSource,
   closeRightRail,
@@ -32,13 +34,55 @@ describe('preview store', () => {
   beforeEach(() => {
     $previewServerRestart.set(null)
     closeRightRail()
+    $activeSessionId.set(null)
     window.localStorage.clear()
   })
 
   afterEach(() => {
     $previewServerRestart.set(null)
     closeRightRail()
+    $activeSessionId.set(null)
     window.localStorage.clear()
+  })
+
+  it('scopes tool-result tabs to the session that handed them over', () => {
+    $activeSessionId.set('session-a')
+    openPreview(fileTarget('/work/demo.html'), 'tool-result')
+
+    // Visible (and only visible) while its owning session is active.
+    expect($visiblePreviewTabs.get()).toHaveLength(1)
+    $activeSessionId.set('session-b')
+    expect($visiblePreviewTabs.get()).toHaveLength(0)
+    // The tab itself is not destroyed by a chat switch, just hidden.
+    expect($previewTabs.get()).toHaveLength(1)
+    $activeSessionId.set('session-a')
+    expect($visiblePreviewTabs.get()).toHaveLength(1)
+  })
+
+  it('keeps file-browser and manual tabs global across sessions', () => {
+    $activeSessionId.set('session-a')
+    openPreview(fileTarget('/work/browsed.html'), 'file-browser')
+    openPreview(fileTarget('/work/pasted.png'), 'manual')
+
+    $activeSessionId.set('session-b')
+    expect($visiblePreviewTabs.get()).toHaveLength(2)
+  })
+
+  it('prefers an explicit sessionId over the active session', () => {
+    $activeSessionId.set('session-a')
+    openPreview(urlTarget('https://example.com'), 'tool-result', 'session-c')
+
+    $activeSessionId.set('session-c')
+    expect($visiblePreviewTabs.get()).toHaveLength(1)
+    $activeSessionId.set('session-a')
+    expect($visiblePreviewTabs.get()).toHaveLength(0)
+  })
+
+  it('shows all tabs when no session is active (boot / non-chat views)', () => {
+    openPreview(fileTarget('/work/demo.html'), 'tool-result')
+    $activeSessionId.set(null)
+
+    expect($visiblePreviewTabs.get()).toHaveLength(1)
   })
 
   it('does not notify status subscribers for restart progress text', () => {

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -4,6 +4,7 @@ import { persistentAtom } from '@/lib/persisted'
 import { normalize } from '@/lib/text'
 
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from './layout'
+import { $activeSessionId } from './session'
 
 /**
  * PREVIEW RAIL — one list of tabs, one way in.
@@ -58,6 +59,10 @@ export type PreviewRecordSource = 'explicit-link' | 'file-browser' | 'manual' | 
 export interface PreviewTab {
   id: RightRailTabId
   target: PreviewTarget
+  /** Chat session that handed this tab over. When set, the tab only shows
+   *  while that session is the active chat; tabs without one stay global,
+   *  exactly as before. */
+  sessionId?: string
 }
 
 const TABS_STORAGE_KEY = 'hermes.desktop.previewTabs.v2'
@@ -158,6 +163,14 @@ if (typeof window !== 'undefined') {
   }
 }
 
+/** Tabs visible in the CURRENT chat. Session-tagged tabs only surface while
+ *  their owning session is the active one; untagged (global) tabs always
+ *  show. With no session active (boot, non-chat views) everything shows, so
+ *  restored tabs never silently vanish. */
+export const $visiblePreviewTabs = computed([$previewTabs, $activeSessionId], (tabs, activeSessionId) =>
+  activeSessionId ? tabs.filter(tab => !tab.sessionId || tab.sessionId === activeSessionId) : tabs
+)
+
 /** The tab the rail actually shows. A stale or missing selection falls back to
  *  the first tab, so the strip, `⌘W`, and the pane never disagree about which
  *  tab is on screen. */
@@ -166,7 +179,7 @@ function resolveActiveTab(tabs: PreviewTab[], activeTabId: RightRailTabId | null
 }
 
 function activePreviewTab(): PreviewTab | null {
-  return resolveActiveTab($previewTabs.get(), $rightRailActiveTabId.get())
+  return resolveActiveTab($visiblePreviewTabs.get(), $rightRailActiveTabId.get())
 }
 
 // A restored active id whose tab didn't survive validation would leave the rail
@@ -175,13 +188,14 @@ selectRightRailTab(activePreviewTab()?.id ?? null)
 
 /** The target the rail is currently showing, or null when it has no tabs. */
 export const $previewTarget = computed(
-  [$previewTabs, $rightRailActiveTabId],
+  [$visiblePreviewTabs, $rightRailActiveTabId],
   (tabs, activeTabId) => resolveActiveTab(tabs, activeTabId)?.target ?? null
 )
 
-/** Raw `source` strings of every open tab, for the composer rows that toggle a
- *  preview open and closed by the target they were handed. */
-export const $previewTabSources = computed($previewTabs, tabs => tabs.map(tab => tab.target.source))
+/** Raw `source` strings of every tab VISIBLE in the current chat, for the
+ *  composer rows that toggle a preview open and closed by the target they
+ *  were handed. */
+export const $previewTabSources = computed($visiblePreviewTabs, tabs => tabs.map(tab => tab.target.source))
 
 export const $previewReloadRequest = atom(0)
 export const $previewServerRestart = atom<PreviewServerRestart | null>(null)
@@ -214,13 +228,20 @@ function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSour
 
 /** Open (or re-front) the tab for `target`. Re-opening an existing tab refreshes
  *  its target so a stale label/path can't outlive the thing it points at. The
- *  only way anything reaches a preview. */
-export function openPreview(target: PreviewTarget, source: PreviewRecordSource = 'manual') {
+ *  only way anything reaches a preview.
+ *
+ *  `sessionId` scopes the tab to one chat. When omitted, chat-produced opens
+ *  (tool results, links inside a transcript) are stamped with the active
+ *  session so they follow the chat that handed them over; browser and manual
+ *  opens stay global. */
+export function openPreview(target: PreviewTarget, source: PreviewRecordSource = 'manual', sessionId?: string) {
   const resolved = previewTargetForSource(target, source)
   const id = previewTabId(resolved)
   const current = $previewTabs.get()
   const index = current.findIndex(tab => tab.id === id)
-  const tab: PreviewTab = { id, target: resolved }
+  const owner =
+    sessionId ?? (source === 'file-browser' || source === 'manual' ? undefined : $activeSessionId.get() ?? undefined)
+  const tab: PreviewTab = { id, target: resolved, sessionId: owner }
 
   $previewTabs.set(index === -1 ? [...current, tab] : current.map((item, i) => (i === index ? tab : item)))
   selectRightRailTab(id)


### PR DESCRIPTION
Preview tabs are global: a preview opened from one chat (a tool result, a file link inside a transcript) stays open and follows the user into every other chat, where it hovers over the composer. This scopes chat-produced tabs to the session that handed them over.

Changes:
- `PreviewTab` gains an optional `sessionId`; `openPreview` stamps it for tool-result and transcript-link opens (explicit owner or active session), while file-browser and manual opens stay global as before.
- New `$visiblePreviewTabs` computed filters tabs by the active session. The pane mirror, active-tab resolution, `$previewTarget` and tab-source rows read it, so a chat switch hides the other chat's tabs and re-shows them on return, without destroying them.
- `preview.open` gateway events pass their `session_id`; `PreviewAttachment` passes its transcript session's runtime id (so links clicked in an older chat scope to that chat, not the current one).
- Migration-safe: tabs persisted before this change carry no `sessionId` and stay visible everywhere; with no session active everything shows, so boot and non-chat views are unchanged.

Tests: 4 new store tests covering session scoping, global opens, explicit owner precedence, and the no-session fallback. Typecheck clean (`npx tsc -p tsconfig.json --noEmit`).
