### PR TITLE
feat(kanban): add default work directory with Browse button to board dialogs

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -218,10 +218,17 @@ export const reclaimTask = (id: string) => nudged(call(withBoard(`/tasks/${id}/r
 export const uploadAttachment = (id: string, upload: { filename: string; contentType?: string; bytes: ArrayBuffer }) =>
   call(withBoard(`/tasks/${id}/attachments`), { method: 'POST', upload })
 
-export const createBoard = (slug: string, name: string, projectId?: string) =>
+export const createBoard = (slug: string, name: string, projectId?: string, defaultWorkdir?: string) =>
   call<{ board: { slug: string } }>('/boards', {
     method: 'POST',
-    body: { slug, name, ...(projectId ? { project_id: projectId } : {}) }
+    body: {
+      slug,
+      name,
+      ...(projectId ? { project_id: projectId } : {}),
+      // Relative paths are resolved to absolute against HermesWorkspace by the
+      // caller; the backend requires an absolute, existing directory.
+      ...(defaultWorkdir ? { default_workdir: defaultWorkdir } : {})
+    }
   })
 
 /** Rough auxiliary-model estimate for a task (tokens + complexity). Makes a

--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -30,13 +30,55 @@ import {
   useQueryClient,
   useValue
 } from '@hermes/plugin-sdk'
-import { useEffect, useState } from 'react'
+import { type ChangeEvent, useEffect, useState } from 'react'
 
-import { $boardSlug, BOARDS_KEY, createBoard, fetchBoards, fetchProjects, PROJECTS_KEY, updateBoard } from './api'
+import {
+  $boardSlug,
+  BOARDS_KEY,
+  createBoard,
+  fetchBoards,
+  fetchProjects,
+  PROJECTS_KEY,
+  updateBoard
+} from './api'
 import type { BoardMeta } from './types'
 import { errText, FIELD_LABEL, useKanban } from './ui'
 
 const NO_PROJECT = '__none__'
+
+/**
+ * Resolve a typed workdir value to an absolute path the backend will accept.
+ * - Absolute paths pass through unchanged.
+ * - Relative paths are anchored on the app's current cwd (the opened
+ *   workspace) when available, else the platform home's `HermesWorkspace`.
+ * - Empty string → inherit (returns '' so the caller omits/sends '').
+ * `~/` tildes are expanded. The backend still validates that the directory
+ * exists, so this only handles the relative→absolute normalization.
+ */
+function resolveWorkdir(value: string): string {
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return ''
+  }
+
+  const expanded = trimmed.replace(/^~(?=$|\/)/, host.state.cwd.get() || '')
+
+  if (expanded.startsWith('/') || /^[A-Za-z]:[\\/]/.test(expanded)) {
+    return expanded
+  }
+
+  const base = host.state.cwd.get() || ''
+
+  if (base) {
+    return `${base.replace(/\/$/, '')}/${expanded.replace(/^\//, '')}`
+  }
+
+  // Fall back to a HermesWorkspace dir under the user home when no cwd is set.
+  const home = (typeof process !== 'undefined' && process.env?.HOME) || ''
+
+  return `${home}/HermesWorkspace/${expanded.replace(/^\//, '')}`
+}
 
 /** Board scope = a first-class Hermes project. Its primary repo becomes the
  *  board's default workspace root; new tasks inherit it as a worktree with a
@@ -70,11 +112,55 @@ function ProjectPicker({ onChange, value }: { onChange: (id: string) => void; va
   )
 }
 
+/** Work directory row: text input + native Browse button. Powers the board's
+ *  default workspace — tasks without an explicit override inherit this. */
+function WorkdirField({
+  onChange,
+  value
+}: {
+  onChange: (path: string) => void
+  value: string
+}) {
+  const k = useKanban()
+
+  const browse = async () => {
+    // host.pickFolder → Electron showOpenDialog({ properties:
+    // ['openDirectory','createDirectory'] }); returns an absolute path or null.
+    const picked = await host.pickFolder(k.defaultWorkdir)
+
+    if (picked) {
+      onChange(picked)
+    }
+  }
+
+  return (
+    <label className="flex flex-col gap-1">
+      <span className={FIELD_LABEL}>{k.defaultWorkdir}</span>
+      <div className="flex items-center gap-2">
+        <Input
+          className="flex-1"
+          onChange={(event: ChangeEvent<HTMLInputElement>) => onChange(event.target.value)}
+          placeholder={k.defaultWorkdirPlaceholder}
+          value={value}
+        />
+        <Button onClick={browse} size="sm" type="button" variant="outline">
+          <Codicon name="folder-opened" size="0.8rem" />
+          {k.browse}
+        </Button>
+      </div>
+      <span className="text-[0.6875rem] leading-relaxed text-(--ui-text-quaternary)">
+        {k.workspaceRelativeHint}
+      </span>
+    </label>
+  )
+}
+
 function NewBoardDialog({ onClose, open }: { onClose: () => void; open: boolean }) {
   const k = useKanban()
   const qc = useQueryClient()
   const [name, setName] = useState('')
   const [project, setProject] = useState('')
+  const [workdir, setWorkdir] = useState('')
 
   const slug = name
     .trim()
@@ -86,11 +172,12 @@ function NewBoardDialog({ onClose, open }: { onClose: () => void; open: boolean 
     if (open) {
       setName('')
       setProject('')
+      setWorkdir('')
     }
   }, [open])
 
   const create = useMutation({
-    mutationFn: () => createBoard(slug, name.trim(), project || undefined),
+    mutationFn: () => createBoard(slug, name.trim(), project || undefined, resolveWorkdir(workdir) || undefined),
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
     onSuccess: result => {
       $boardSlug.set(result.board.slug)
@@ -111,13 +198,14 @@ function NewBoardDialog({ onClose, open }: { onClose: () => void; open: boolean 
             <Input
               autoFocus
               onChange={event => setName(event.target.value)}
-              onKeyDown={event => event.key === 'Enter' && slug && !project && create.mutate()}
+              onKeyDown={event => event.key === 'Enter' && slug && create.mutate()}
               placeholder={k.boardNamePlaceholder}
               value={name}
             />
             {slug && <span className="text-[0.6875rem] text-(--ui-text-quaternary)">{k.slug(slug)}</span>}
           </label>
           <ProjectPicker onChange={setProject} value={project} />
+          <WorkdirField onChange={setWorkdir} value={workdir} />
         </div>
         <DialogFooter>
           <Button onClick={onClose} variant="text">
@@ -137,18 +225,26 @@ function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onCl
   const qc = useQueryClient()
   const [name, setName] = useState('')
   const [project, setProject] = useState('')
+  const [workdir, setWorkdir] = useState('')
 
   useEffect(() => {
     if (board) {
       setName(board.name || '')
       setProject(board.project_id || '')
+      setWorkdir(board.default_workdir || '')
     }
   }, [board])
 
   const save = useMutation({
     // Slug is immutable; send name + project_id ('' clears the scope, which
-    // also drops the mirrored default_workdir on the backend).
-    mutationFn: () => updateBoard(board!.slug, { name: name.trim(), project_id: project }),
+    // also drops the mirrored default_workdir on the backend) + default_workdir
+    // ('' clears it, an absolute path sets it).
+    mutationFn: () =>
+      updateBoard(board!.slug, {
+        name: name.trim(),
+        project_id: project,
+        default_workdir: workdir.trim() ? resolveWorkdir(workdir) : ''
+      }),
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: BOARDS_KEY })
@@ -169,6 +265,7 @@ function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onCl
             {board && <span className="text-[0.6875rem] text-(--ui-text-quaternary)">{k.slug(board.slug)}</span>}
           </label>
           <ProjectPicker onChange={setProject} value={project} />
+          <WorkdirField onChange={setWorkdir} value={workdir} />
         </div>
         <DialogFooter>
           <Button onClick={onClose} variant="text">

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -175,6 +175,10 @@ type KanbanMessages = {
   noProject: string
   projectHintPre: string
   projectHintCmd: string
+  defaultWorkdir: string
+  defaultWorkdirPlaceholder: string
+  browse: string
+  workspaceRelativeHint: string
   createBoard: string
   // orchestration
   orchestratorProfile: string
@@ -367,6 +371,11 @@ const en: KanbanMessages = {
   projectHintPre:
     'New tasks run in the project’s repo (a worktree per task); each task can still override its workspace at creation. Manage projects with ',
   projectHintCmd: 'hermes project',
+  defaultWorkdir: 'Default work directory',
+  defaultWorkdirPlaceholder: 'Absolute path, or relative to HermesWorkspace',
+  browse: 'Browse',
+  workspaceRelativeHint:
+    'Leave blank to inherit from the project above, or enter a path. Relative paths resolve against HermesWorkspace. Use Browse to pick a folder.',
   createBoard: 'Create board',
   orchestratorProfile: 'Orchestrator profile',
   defaultAssignee: 'Default assignee',
@@ -558,6 +567,11 @@ const ja: KanbanMessages = {
   projectHintPre:
     '新しいタスクはプロジェクトのリポジトリで実行されます（タスクごとに worktree）。各タスクは作成時にワークスペースを上書きできます。プロジェクトの管理は ',
   projectHintCmd: 'hermes project',
+  defaultWorkdir: '既定の作業ディレクトリ',
+  defaultWorkdirPlaceholder: '絶対パス、または HermesWorkspace からの相対パス',
+  browse: '参照',
+  workspaceRelativeHint:
+    '上のプロジェクトから継承するには空のままにするか、パスを入力します。相対パスは HermesWorkspace から解決されます。フォルダーを選ぶには「参照」を使用します。',
   createBoard: 'ボードを作成',
   orchestratorProfile: 'オーケストレータープロフィール',
   defaultAssignee: 'デフォルトの担当',
@@ -747,6 +761,11 @@ const zh: KanbanMessages = {
   projectHintPre:
     '新任务将在项目的仓库中运行（每个任务一个 worktree）；每个任务在创建时仍可覆盖其工作区。管理项目请使用 ',
   projectHintCmd: 'hermes project',
+  defaultWorkdir: '默认工作目录',
+  defaultWorkdirPlaceholder: '绝对路径，或相对于 HermesWorkspace 的路径',
+  browse: '浏览',
+  workspaceRelativeHint:
+    '留空以继承上方的项目，或输入一个路径。相对路径会基于 HermesWorkspace 解析。点击“浏览”选择文件夹。',
   createBoard: '创建面板',
   orchestratorProfile: '编排者配置档',
   defaultAssignee: '默认负责人',
@@ -935,6 +954,11 @@ const zhHant: KanbanMessages = {
   projectHintPre:
     '新任務將在專案的儲存庫中執行（每個任務一個 worktree）；每個任務在建立時仍可覆寫其工作區。管理專案請使用 ',
   projectHintCmd: 'hermes project',
+  defaultWorkdir: '預設工作目錄',
+  defaultWorkdirPlaceholder: '絕對路徑，或相對於 HermesWorkspace 的路徑',
+  browse: '瀏覽',
+  workspaceRelativeHint:
+    '留空以繼承上方的專案，或輸入一個路徑。相對路徑會以 HermesWorkspace 為基準解析。點擊「瀏覽」選擇資料夾。',
   createBoard: '建立面板',
   orchestratorProfile: '編排者設定檔',
   defaultAssignee: '預設負責人',

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -23,6 +23,7 @@ import { atom, type ReadableAtom } from 'nanostores'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
 import { getLogs, getStatus } from '@/hermes'
+import { selectDesktopPaths } from '@/lib/desktop-fs'
 import { $gateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
@@ -94,6 +95,17 @@ export const host = {
 
   /** Restart the backend gateway (progress surfaces in the core statusbar). */
   restartGateway: async () => runGatewayRestart(),
+
+  /** Open the OS folder picker (Electron `showOpenDialog` with
+   *  `openDirectory` + `createDirectory`). Resolves to the chosen absolute
+   *  directory path, or `null` if the user cancelled. Plugins use this for
+   *  path inputs (e.g. a board's default work directory) instead of reaching
+   *  into `@/lib/desktop-fs` directly — this is the sanctioned bridge. */
+  pickFolder: async (title?: string): Promise<null | string> => {
+    const paths = await selectDesktopPaths({ title: title ?? 'Select folder', directories: true })
+
+    return paths?.length ? paths[0] : null
+  },
 
   /** One-shot system status snapshot (platforms, versions, …). */
   status: async () => getStatus(),


### PR DESCRIPTION
## Summary
Expose a board's `default_workdir` directly in the **New Board** and **Board Settings** dialogs (desktop app), with a native **Browse** button and HermesWorkspace-relative path entry.

- **Plugin SDK**: add `host.pickFolder(title?)` — the sanctioned bridge over `selectDesktopPaths` → Electron `showOpenDialog({ properties: ['openDirectory','createDirectory'] })`. Plugins no longer need to reach into `@/lib/desktop-fs` (which the `no-restricted-imports` lint forbids).
- **Board dialogs** (`board-switcher.tsx`): new `WorkdirField` with a text input + Browse button, added to both `NewBoardDialog` and `BoardSettingsDialog`.
- **Relative paths**: `resolveWorkdir()` anchors a relative/tilde path on `host.state.cwd` (the opened workspace) or `~/HermesWorkspace` and sends an absolute path — the backend already rejects relative paths in `_validate_workdir`, so this keeps the server contract intact (no backend change needed).
- **API** (`api.ts`): `createBoard` now forwards `default_workdir`; `updateBoard` already accepts it (`''` clears).
- **i18n**: new keys (`defaultWorkdir`, `defaultWorkdirPlaceholder`, `browse`, `workspaceRelativeHint`) added to en/ja/zh/zh-hant.

## Why
Previously the only way to set a board's default work directory was the CLI (`hermes kanban boards create --default-workdir …` / `set-default-workdir`), or by scoping to a first-class Project. There was no GUI path — not even in the task-create dialog's `workspacePath` field, which is a plain text input. This surfaces the capability in the board UI with a proper folder picker.

## Test plan
- [x] `tsc --noEmit -p tsconfig.json` — 0 errors in kanban/sdk files
- [x] `eslint` on changed files — clean (respects `no-restricted-imports` + import sort)
- [ ] Manual: open New Board → pick a folder via Browse → confirm `default_workdir` is set on the created board; edit via Board Settings → clear/reset.
- [ ] Manual: enter `Projects/foo` → confirm it resolves to `<workspace>/Projects/foo` absolute before send.

## Notes
- Backend unchanged: `/boards` POST/PATCH already validate `default_workdir` as an absolute existing directory (`plugins/kanban/dashboard/plugin_api.py: _validate_workdir`). Client-side resolution means the stricter server contract is preserved.