### PR TITLE
fix(nvidia): emit DeepSeek wire format for deepseek-v4-flash via NIM

### DIFF
--- a/plugins/model-providers/nvidia/__init__.py
+++ b/plugins/model-providers/nvidia/__init__.py
@@ -1,9 +1,70 @@
 """NVIDIA NIM provider profile."""
 
+from __future__ import annotations
+
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-nvidia = ProviderProfile(
+
+def _is_deepseek_v4_flash(model: str | None) -> bool:
+    """True when the model is a DeepSeek V4 flash model served via NIM.
+
+    NVIDIA NIM hosts ``deepseek-ai/deepseek-v4-flash-<date>`` model IDs.
+    Only this family gets the DeepSeek-specific thinking wire format on the
+    NVIDIA route; every other NVIDIA model (nemotron, minimax, llama, ...)
+    keeps the generic OpenAI-compatible behavior.
+    """
+    m = (model or "").strip().lower()
+    return "deepseek-v4-flash" in m
+
+
+class NvidiaProfile(ProviderProfile):
+    """NVIDIA NIM — OpenAI-compatible, with DeepSeek V4 flash passthrough.
+
+    DeepSeek V4 models default to thinking-mode ON when ``extra_body.thinking``
+    is absent, then enforce the ``reasoning_content``-must-be-echoed-back
+    contract on subsequent tool-call turns (HTTP 400 otherwise). The official
+    DeepSeek profile emits the DeepSeek wire shape to avoid that trap; NIM
+    fronts the same DeepSeek models, so the NVIDIA route must do the same for
+    deepseek-v4-flash. Non-DeepSeek NVIDIA models must NOT receive the
+    DeepSeek-specific fields (they would reject or ignore them).
+    """
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, model: str | None = None, **context: Any
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if not _is_deepseek_v4_flash(model):
+            return {}, {}
+
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        # Mirror the official DeepSeek profile
+        # (plugins/model-providers/deepseek/__init__.py): thinking is sent
+        # explicitly (never left to the server default) and effort maps to
+        # top-level reasoning_effort.
+        enabled = True
+        if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False:
+            enabled = False
+
+        extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
+
+        if not enabled:
+            return extra_body, top_level
+
+        if isinstance(reasoning_config, dict):
+            effort = (reasoning_config.get("effort") or "").strip().lower()
+            if effort in {"xhigh", "max"}:
+                top_level["reasoning_effort"] = "max"
+            elif effort in {"low", "medium", "high"}:
+                top_level["reasoning_effort"] = effort
+
+        return extra_body, top_level
+
+
+nvidia = NvidiaProfile(
     name="nvidia",
     aliases=("nvidia-nim",),
     env_vars=("NVIDIA_API_KEY",),

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -1,5 +1,7 @@
 """Tests for the provider module registry and profiles."""
 
+import pytest
+
 from providers import get_provider_profile, _REGISTRY
 from providers.base import ProviderProfile, OMIT_TEMPERATURE
 
@@ -24,6 +26,87 @@ class TestNvidiaProfile:
         p = get_provider_profile("nvidia")
         assert "nvidia.com" in p.base_url
 
+
+
+class TestNvidiaDeepSeekV4FlashReasoning:
+    """DeepSeek V4 flash served through NIM speaks DeepSeek's wire format.
+
+    NVIDIA NIM hosts ``deepseek-ai/deepseek-v4-flash-<date>`` model IDs. The
+    profile must emit the same extra_body.thinking + reasoning_effort shape as
+    the official DeepSeek profile — but ONLY for deepseek-v4-flash. Every
+    other NVIDIA model must be left untouched (no DeepSeek-specific fields).
+    """
+
+    def _extras(self, model, reasoning_config=None):
+        p = get_provider_profile("nvidia")
+        return p.build_api_kwargs_extras(
+            reasoning_config=reasoning_config, model=model
+        )
+
+    def test_deepseek_v4_flash_enabled_default(self):
+        eb, tl = self._extras("deepseek-ai/deepseek-v4-flash-0731")
+        assert eb == {"thinking": {"type": "enabled"}}
+        assert tl == {}
+
+    def test_deepseek_v4_flash_enabled_with_effort(self):
+        eb, tl = self._extras(
+            "deepseek-ai/deepseek-v4-flash-0731",
+            {"enabled": True, "effort": "high"},
+        )
+        assert eb == {"thinking": {"type": "enabled"}}
+        assert tl == {"reasoning_effort": "high"}
+
+    def test_deepseek_v4_flash_disabled(self):
+        eb, tl = self._extras(
+            "deepseek-ai/deepseek-v4-flash-0731",
+            {"enabled": False},
+        )
+        assert eb == {"thinking": {"type": "disabled"}}
+        assert tl == {}
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    def test_standard_efforts_pass_through(self, effort):
+        _, tl = self._extras(
+            "deepseek-ai/deepseek-v4-flash-0731",
+            {"enabled": True, "effort": effort},
+        )
+        assert tl == {"reasoning_effort": effort}
+
+    @pytest.mark.parametrize("effort", ["xhigh", "max", "MAX", "  Max  "])
+    def test_xhigh_and_max_normalize_to_max(self, effort):
+        _, tl = self._extras(
+            "deepseek-ai/deepseek-v4-flash-0731",
+            {"enabled": True, "effort": effort},
+        )
+        assert tl == {"reasoning_effort": "max"}
+
+    def test_unknown_effort_omits_top_level(self):
+        _, tl = self._extras(
+            "deepseek-ai/deepseek-v4-flash-0731",
+            {"enabled": True, "effort": "garbage"},
+        )
+        assert tl == {}
+
+    def test_bare_model_name_matches(self):
+        eb, _ = self._extras("deepseek-v4-flash")
+        assert eb == {"thinking": {"type": "enabled"}}
+
+    def test_other_nvidia_models_untouched(self):
+        for model in (
+            "nvidia/nemotron-3-ultra-550b-a55b",
+            "minimaxai/minimax-m3",
+            "nvidia/llama-3.1-nemotron-70b-instruct",
+            "deepseek/deepseek-chat",  # V3 alias — no thinking mode
+            "deepseek-ai/deepseek-r1",  # legacy reasoner name not on NIM flash route
+        ):
+            eb, tl = self._extras(model, {"enabled": True, "effort": "high"})
+            assert eb == {}, f"non-deepseek-v4-flash model {model} must not get thinking"
+            assert tl == {}, f"non-deepseek-v4-flash model {model} must not get reasoning_effort"
+
+    def test_missing_model_untouched(self):
+        eb, tl = self._extras(None, {"enabled": True, "effort": "high"})
+        assert eb == {}
+        assert tl == {}
 
 
 class TestKimiProfile:

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -78,6 +78,30 @@ class TestNeedsDeepSeekToolReasoning:
         agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
         assert agent._needs_deepseek_tool_reasoning() is True
 
+    def test_nvidia_route_model_substring(self) -> None:
+        # DeepSeek V4 flash served through NVIDIA NIM. The nvidia provider
+        # hosts deepseek-ai/deepseek-v4-flash-<date> model IDs; detection
+        # must key off the model substring (not the provider name) so the
+        # nvidia route gets the same reasoning_content echo-back treatment
+        # as the official deepseek provider.
+        agent = _make_agent(
+            provider="nvidia",
+            model="deepseek-ai/deepseek-v4-flash-0731",
+            base_url="https://integrate.api.nvidia.com/v1",
+        )
+        assert agent._needs_deepseek_tool_reasoning() is True
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_nvidia_route_non_deepseek_model(self) -> None:
+        # Other NVIDIA NIM models (nemotron, minimax, llama) must NOT be
+        # treated as DeepSeek thinking mode.
+        agent = _make_agent(
+            provider="nvidia",
+            model="nvidia/nemotron-3-ultra-550b-a55b",
+            base_url="https://integrate.api.nvidia.com/v1",
+        )
+        assert agent._needs_deepseek_tool_reasoning() is False
+        assert agent._needs_thinking_reasoning_pad() is False
 
 
 


### PR DESCRIPTION
## Problem

Running `deepseek-v4-flash` through the NVIDIA NIM provider (model ID `deepseek-ai/deepseek-v4-flash-0731`) degraded into gibberish after 4-5 tool calls.

Root cause: the `nvidia` provider profile was a bare `ProviderProfile`, so its `build_api_kwargs_extras` returned `({}, {})` — requests carried **no** `extra_body.thinking` and **no** `reasoning_effort`.

DeepSeek's V4 family defaults to thinking-mode **ON** when `extra_body.thinking` is absent, and then enforces the `reasoning_content`-must-be-echoed-back contract on subsequent turns. With thinking silently enabled server-side but the request never explicitly declaring it, the tool-call replay history corrupted mid-conversation — the "gibberish after N tool calls" symptom. This is the same trap class the official DeepSeek profile (`plugins/model-providers/deepseek/__init__.py`) exists to prevent (#15700, #17212, #17825), but the NVIDIA route never got the equivalent handling.

## Fix

Give the NVIDIA profile a subclass override of `build_api_kwargs_extras` that mirrors the official DeepSeek wire shape, gated **strictly** to `deepseek-v4-flash` model names:

- `deepseek-ai/deepseek-v4-flash-<date>` → `extra_body: {"thinking": {"type": "enabled"}}` + top-level `reasoning_effort` (`low`/`medium`/`high` pass through, `xhigh`/`max` → `max`, disabled → `thinking.type=disabled`, no effort)
- Every other NVIDIA model (nemotron, minimax, llama, …) → untouched `({}, {})` — no DeepSeek-specific fields leak into routes that would reject them

The response-side parsing (reasoning_content extraction, echo-back padding, stale timeout floors, context length) was already model-name-keyed (`"deepseek" in model`), so the NVIDIA route already received the same treatment there once the request declared thinking explicitly — this PR pins that contract with tests.

## Tests

- `TestNvidiaDeepSeekV4FlashReasoning` (12 cases): enabled/disabled wire shape, effort passthrough + xhigh/max normalization, case-insensitive matching, and a guard loop asserting nemotron / minimax-m3 / llama / deepseek-chat / deepseek-r1 all stay untouched
- `test_nvidia_route_model_substring` / `test_nvidia_route_non_deepseek_model` in the reasoning-content echo suite: nvidia + `deepseek-ai/deepseek-v4-flash-0731` gets the echo-back treatment; nvidia + nemotron does not

Verified live by the reporter: after the fix, deepseek-v4-flash via NVIDIA NIM no longer degrades into gibberish across multi-turn tool-call sessions.

## Files

- `plugins/model-providers/nvidia/__init__.py` — NvidiaProfile subclass
- `tests/providers/test_provider_profiles.py` — wire-shape tests
- `tests/run_agent/test_deepseek_reasoning_content_echo.py` — nvidia-route echo parity tests