### PR TITLE
fix(desktop,cli): stop rendering the unknown update count as "1 change included"

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2596,13 +2596,17 @@ async function checkUpdates() {
     hasMergeBase
   })
 
-  const commits = behind > 0 ? await readCommitLog(updateRoot, branch) : []
+  // behind === null means "update available, exact count unknown" (shallow
+  // clone without a merge-base): still list what origin offers (the log read
+  // is capped at 40 entries), so "See what's new" stays useful and honest.
+  const commits = behind !== 0 ? await readCommitLog(updateRoot, branch) : []
 
   return {
     supported: true,
     branch,
     currentBranch,
     behind,
+    updateAvailable: behind === null || behind > 0,
     currentSha,
     targetSha,
     commits,

--- a/apps/desktop/electron/update-count.test.ts
+++ b/apps/desktop/electron/update-count.test.ts
@@ -4,10 +4,11 @@ import { test } from 'vitest'
 
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 
-// FAIL-BEFORE: pre-fix the function did `Number.parseInt(countStr) || 0`
-// unconditionally, so a shallow checkout with no merge-base surfaced the bogus
-// rev-list count (e.g. 12104). This asserts the new shallow/no-merge-base branch.
-test('shallow checkout with no merge-base does NOT trust the bogus rev-list count', () => {
+// FAIL-BEFORE: the shallow/no-merge-base branch returned the sentinel `1`,
+// which the UI rendered as a literal "1 change included" even when the true
+// count was far higher (e.g. 90). An update IS available here, but its exact
+// size is unknown — the only honest value is `null`.
+test('shallow checkout with no merge-base reports null (unknown count), not a fake 1', () => {
   assert.equal(
     resolveBehindCount({
       countStr: '12104',
@@ -16,7 +17,7 @@ test('shallow checkout with no merge-base does NOT trust the bogus rev-list coun
       isShallow: true,
       hasMergeBase: false
     }),
-    1
+    null
   )
 })
 
@@ -113,7 +114,7 @@ test('skipped-count path resolves via SHA compare, never via empty countStr', ()
       isShallow: true,
       hasMergeBase: false
     }),
-    1
+    null
   )
   assert.equal(
     resolveBehindCount({

--- a/apps/desktop/electron/update-count.ts
+++ b/apps/desktop/electron/update-count.ts
@@ -21,7 +21,11 @@ function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, hasMer
       return 0
     }
 
-    return 1 // behind by an unknown amount — show a generic "update available"
+    // An update IS available, but its size is unknowable without a merge-base.
+    // Return null — never a numeric sentinel: the UI used to render the old
+    // `1` as a literal "1 change included" even when the true distance was
+    // far larger. null lets every surface say "update available" honestly.
+    return null
   }
 
   return Number.parseInt(countStr, 10) || 0

--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -63,6 +63,9 @@ export function AboutSettings() {
   }, [])
 
   const behind = status?.behind ?? 0
+  // behind is null when the exact count is unknowable (shallow clone): the
+  // backend flags that case via updateAvailable instead of a number.
+  const updateAvailable = behind > 0 || Boolean(status?.updateAvailable)
   const supported = status?.supported !== false
   const applying = apply.applying || apply.stage === 'restart'
 
@@ -84,8 +87,8 @@ export function AboutSettings() {
   } else if (applying) {
     statusLine = a.installing
     statusTone = 'available'
-  } else if (behind > 0) {
-    statusLine = a.updateReady(behind)
+  } else if (updateAvailable) {
+    statusLine = behind > 0 ? a.updateReady(behind) : a.updateReadyUnknown
     statusTone = 'available'
   } else if (status) {
     statusLine = a.onLatest
@@ -142,7 +145,7 @@ export function AboutSettings() {
               {checking ? a.checking : a.checkNow}
             </Button>
 
-            {behind > 0 && supported && !applying && (
+            {updateAvailable && supported && !applying && (
               <>
                 <Button onClick={() => startActiveUpdate()} size="sm">
                   {a.updateNow}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -423,7 +423,10 @@ export interface DesktopUpdateStatus {
   reason?: string
   message?: string
   error?: string
-  behind?: number
+  /** Exact commits behind. null = update available, but the count is
+   *  unknowable (shallow clone without a merge-base) — never render it as a
+   *  literal number. */
+  behind?: number | null
   currentSha?: string
   /** Backend only: the version string the backend reports for itself. */
   currentVersion?: string

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -113,6 +113,7 @@ export const ar = defineLocale({
     updateHermes: 'تحديث Hermes',
     updateReadyTitle: 'التحديث جاهز',
     updateReadyMessage: count => `${count} تغيير جديد متاح.`,
+    updateReadyMessageUnknown: 'يتوفر تحديث جديد.',
     seeWhatsNew: 'عرض الجديد',
     errors: {
       elevenLabsNeedsKey: 'يتطلب ElevenLabs STT المفتاح ELEVENLABS_API_KEY.',
@@ -602,6 +603,7 @@ export const ar = defineLocale({
       cantReach: 'تعذر الوصول لخدمة التحديث',
       tapCheck: 'اضغط للتحقق من التحديثات.',
       updateReady: count => `${count} تحديث متاح`,
+      updateReadyUnknown: 'تحديث جديد جاهز.',
       lastChecked: age => `آخر تحقق ${age}`,
       justNowSuffix: 'الآن',
       automaticUpdates: 'التحديثات التلقائية',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -128,6 +128,7 @@ export const en: Translations = {
     updateHermes: 'Update Hermes',
     updateReadyTitle: 'Update ready',
     updateReadyMessage: count => `${count} new change${count === 1 ? '' : 's'} available.`,
+    updateReadyMessageUnknown: 'A new update is available.',
     seeWhatsNew: "See what's new",
     errors: {
       elevenLabsNeedsKey: 'ElevenLabs STT needs ELEVENLABS_API_KEY.',
@@ -553,6 +554,7 @@ export const en: Translations = {
       cantReach: "We couldn't reach the update server.",
       tapCheck: 'Tap "Check now" to look for updates.',
       updateReady: count => `A new update is ready (${count} change${count === 1 ? '' : 's'} included).`,
+      updateReadyUnknown: 'A new update is ready.',
       lastChecked: age => `Last checked ${age}`,
       justNowSuffix: ' · just now',
       automaticUpdates: 'Automatic updates',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -129,6 +129,7 @@ export const ja = defineLocale({
     updateHermes: 'Hermes を更新',
     updateReadyTitle: '更新の準備ができました',
     updateReadyMessage: count => `${count} 件の新しい変更が利用可能です。`,
+    updateReadyMessageUnknown: '新しい更新が利用可能です。',
     seeWhatsNew: '新機能を見る',
     errors: {
       elevenLabsNeedsKey: 'ElevenLabs STT には ELEVENLABS_API_KEY が必要です。',
@@ -637,6 +638,7 @@ export const ja = defineLocale({
       cantReach: '更新サーバーに接続できませんでした。',
       tapCheck: '更新を探すには「今すぐ確認」を押してください。',
       updateReady: count => `新しい更新の準備ができました (${count} 件の変更を含みます)。`,
+      updateReadyUnknown: '新しい更新の準備ができました。',
       lastChecked: age => `前回確認: ${age}`,
       justNowSuffix: ' · たった今',
       automaticUpdates: '自動更新',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -170,6 +170,7 @@ export interface Translations {
     updateHermes: string
     updateReadyTitle: string
     updateReadyMessage: (count: number) => string
+    updateReadyMessageUnknown: string
     seeWhatsNew: string
     errors: {
       elevenLabsNeedsKey: string
@@ -450,6 +451,7 @@ export interface Translations {
       cantReach: string
       tapCheck: string
       updateReady: (count: number) => string
+      updateReadyUnknown: string
       lastChecked: (age: string) => string
       justNowSuffix: string
       automaticUpdates: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -125,6 +125,7 @@ export const zhHant = defineLocale({
     updateHermes: '更新 Hermes',
     updateReadyTitle: '有可用更新',
     updateReadyMessage: count => `有 ${count} 項新變更可用。`,
+    updateReadyMessageUnknown: '有新更新可用。',
     seeWhatsNew: '查看新增內容',
     errors: {
       elevenLabsNeedsKey: 'ElevenLabs STT 需要 ELEVENLABS_API_KEY。',
@@ -624,6 +625,7 @@ export const zhHant = defineLocale({
       cantReach: '無法連線到更新伺服器。',
       tapCheck: '點選「立即檢查」以尋找更新。',
       updateReady: count => `新更新已就緒（包含 ${count} 項變更）。`,
+      updateReadyUnknown: '新更新已就緒。',
       lastChecked: age => `上次檢查：${age}`,
       justNowSuffix: ' · 剛剛',
       automaticUpdates: '自動更新',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -125,6 +125,7 @@ export const zh: Translations = {
     updateHermes: '更新 Hermes',
     updateReadyTitle: '有可用更新',
     updateReadyMessage: count => `有 ${count} 项新更改可用。`,
+    updateReadyMessageUnknown: '有新更新可用。',
     seeWhatsNew: '查看更新内容',
     errors: {
       elevenLabsNeedsKey: 'ElevenLabs STT 需要 ELEVENLABS_API_KEY。',
@@ -762,6 +763,7 @@ export const zh: Translations = {
       cantReach: '无法连接更新服务器。',
       tapCheck: '点击"立即检查"以查找更新。',
       updateReady: count => `已准备好新更新 (包含 ${count} 项更改)。`,
+      updateReadyUnknown: '新更新已就绪。',
       lastChecked: age => `上次检查:${age}`,
       justNowSuffix: ' · 刚刚',
       automaticUpdates: '自动更新',

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -123,6 +123,15 @@ describe('maybeNotifyUpdateAvailable', () => {
     maybeNotifyUpdateAvailable(status({ behind: 0 }))
     expect(notifySpy).not.toHaveBeenCalled()
   })
+
+  // FAIL-BEFORE: a shallow installer clone reports behind:null + updateAvailable
+  // (exact count unknowable without a merge-base). The guard treated null as 0
+  // and silently swallowed the notification entirely.
+  it('still notifies with generic copy when the exact behind count is unknown', () => {
+    maybeNotifyUpdateAvailable(status({ behind: null, updateAvailable: true }))
+    expect(notifySpy).toHaveBeenCalledTimes(1)
+    expect(notifySpy.mock.calls[0]?.[0]).toMatchObject({ message: 'A new update is available.' })
+  })
 })
 
 describe('reportBackendContract', () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -206,7 +206,11 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
     return
   }
 
-  if ((status.behind ?? 0) <= 0) {
+  const behind = typeof status.behind === 'number' ? status.behind : null
+
+  // behind === null means "update available, exact count unknown" (shallow
+  // clone). That still deserves the toast — just with count-free copy.
+  if ((behind ?? 0) <= 0 && !status.updateAvailable) {
     return
   }
 
@@ -217,8 +221,6 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
   if ($updateApply.get().applying) {
     return
   }
-
-  const behind = status.behind ?? 0
 
   notify({
     action: {
@@ -232,7 +234,10 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
     icon: 'gift',
     id: UPDATE_TOAST_ID,
     kind: 'info',
-    message: translateNow('notifications.updateReadyMessage', behind),
+    message:
+      behind !== null && behind > 0
+        ? translateNow('notifications.updateReadyMessage', behind)
+        : translateNow('notifications.updateReadyMessageUnknown'),
     onDismiss: () => snoozeUpdateToast(),
     title: translateNow('notifications.updateReadyTitle')
   })

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -220,10 +220,12 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        checked = _check_via_rev(head_rev) if head_rev else None
-        if checked == UPDATE_AVAILABLE_NO_COUNT:
-            return 1
-        return checked
+        # Pass the sentinel through untouched: UPDATE_AVAILABLE_NO_COUNT (-1)
+        # means "update available, count unknown" and every consumer renders
+        # that honestly. Collapsing it to a literal 1 here made the banner and
+        # `hermes version` claim "1 commit behind" — the same fake precision
+        # the desktop UI showed as "1 change included".
+        return _check_via_rev(head_rev) if head_rev else None
 
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5009,7 +5009,7 @@ def _print_version_info(*, check_updates: bool = True) -> None:
 
     # Show update status (synchronous — acceptable since user asked for version info)
     try:
-        from hermes_cli.banner import check_for_updates
+        from hermes_cli.banner import UPDATE_AVAILABLE_NO_COUNT, check_for_updates
         from hermes_cli.config import recommended_update_command
 
         behind = check_for_updates()
@@ -5019,6 +5019,10 @@ def _print_version_info(*, check_updates: bool = True) -> None:
                 f"Update available: {behind} {commits_word} behind — "
                 f"run '{recommended_update_command()}'"
             )
+        elif behind == UPDATE_AVAILABLE_NO_COUNT:
+            # Known update, unknowable distance (shallow/SSH presence-only
+            # check): say so instead of inventing a count.
+            print(f"Update available — run '{recommended_update_command()}'")
         elif behind == 0:
             print("Up to date")
     except Exception:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -60,3 +60,63 @@ def test_prefetch_non_blocking():
 
 
 
+def _fake_official_ssh_git(args, *, cwd, timeout=5):
+    if args == ["remote", "get-url", "origin"]:
+        return "git@github.com:NousResearch/hermes-agent.git"
+    if args == ["rev-parse", "HEAD"]:
+        return "aaa111"
+    raise AssertionError(f"unexpected git call: {args}")
+
+
+def test_check_via_local_git_official_ssh_remote_returns_no_count_sentinel(tmp_path):
+    """Official SSH origin + uncountable update ⇒ NO_COUNT sentinel, never a fake 1.
+
+    FAIL-BEFORE: this branch mapped UPDATE_AVAILABLE_NO_COUNT to a literal `1`,
+    which the banner and `hermes version` rendered as "1 commit behind" — the
+    same lie the desktop UI told ("1 change included")."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+
+    with patch.object(banner, "_git_stdout", side_effect=_fake_official_ssh_git), patch.object(
+        banner, "_check_via_rev", return_value=banner.UPDATE_AVAILABLE_NO_COUNT
+    ):
+        assert banner._check_via_local_git(repo_dir) == banner.UPDATE_AVAILABLE_NO_COUNT
+
+
+def test_check_via_local_git_official_ssh_remote_up_to_date_returns_zero(tmp_path):
+    """Same SSH path with identical SHAs must keep reporting 0."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+
+    with patch.object(banner, "_git_stdout", side_effect=_fake_official_ssh_git), patch.object(
+        banner, "_check_via_rev", return_value=0
+    ):
+        assert banner._check_via_local_git(repo_dir) == 0
+
+
+def test_print_version_info_unknown_count_shows_generic_update_line(capsys):
+    """`hermes version` must say "Update available" — not "1 commit behind"."""
+    from types import SimpleNamespace
+
+    import hermes_cli.banner as banner
+    import hermes_cli.main as main
+
+    with patch(
+        "hermes_cli.slash_exec.execute_command",
+        return_value=SimpleNamespace(text="Hermes Agent v0.0.0"),
+    ), patch("hermes_cli.config.detect_install_method", return_value="git"), patch.object(
+        banner, "check_for_updates", return_value=banner.UPDATE_AVAILABLE_NO_COUNT
+    ):
+        main._print_version_info(check_updates=True)
+
+    out = capsys.readouterr().out
+    assert "Update available" in out
+    assert "1 commit behind" not in out
+
+
+
+


### PR DESCRIPTION
## Problem

Windows installer checkouts are shallow (`clone --depth 1`), and passive update checks against the official SSH origin deliberately use presence-only HTTPS `ls-remote` so a FIDO2/passkey key is never touched (#51922 documented the fallout of trusting `rev-list` there). In that state the exact behind-count is **unknowable** — but the sentinel value for "unknown" was a literal `1`, and every surface rendered it as a real number:

- Desktop About page: **"A new update is ready (1 change included)."** — observed while 90+ commits were actually pending
- CLI banner / `hermes version`: **"1 commit behind"**

The code comments already stated the intent ("show a generic update available"), but nothing downstream distinguished the sentinel from a real count.

## Fix

Pass "unknown" through honestly instead of faking precision:

- `update-count.ts` returns `null` for the unknowable case; the main process sets `updateAvailable` explicitly and still serves the (capped) commit log, so "See what's new" keeps working
- Desktop About page and update toast key off `updateAvailable` and render new count-free strings (`updateReadyUnknown` / `updateReadyMessageUnknown`, all 5 locales) when no exact count exists
- CLI: the official-SSH branch of `_check_via_local_git` now returns `UPDATE_AVAILABLE_NO_COUNT` (-1) unchanged — consistent with the existing shallow path — and `hermes version` prints a generic "Update available" line instead of "1 commit behind"
- **No behavior change when the count is knowable** (full clones, dev images): exact numbers are still computed and shown

## Tests

New FAIL-BEFORE coverage: desktop sentinel returns `null` (was `1`), store toast fires with count-free copy for unknown counts (was swallowed by the `<= 0` guard), CLI SSH path keeps `-1` (was `1`), `hermes version` shows the generic line.

- `vitest --project electron`: 10/10
- `vitest --project ui`: 44/44
- `pytest tests/hermes_cli/test_update_check.py`: 5/5
- `tsc` typecheck clean (3 configs); eslint clean on all touched files