### PR TITLE
fix(desktop): probe git candidates before selecting one

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -349,6 +349,9 @@ import {
   revalidateSuspectPooledRemoteBackends
 } from './remote-liveness'
 import { resolveRemoteOauthTicket, rosterSourceEnumerationTimeoutMs } from './remote-oauth-ticket'
+import { missingRendererAssets } from './renderer-bundle'
+import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { selectGitBinary as _selectGitBinary } from './select-git-binary'
 import {
   applyRemoteRequestHeaders,
   createRegistryGatewayWsUrlHandler,
@@ -2956,33 +2959,47 @@ function makeDashboardReadyFile() {
 // standard Git-for-Windows locations, then PATH. Cached after first probe.
 let _gitBinaryCache = null
 
+// A candidate can exist on disk and still be unusable. PortableGit under
+// %LOCALAPPDATA%\hermes\git ships `cmd\git.exe` as a small launcher that
+// re-execs the real binary under `mingw64\`; if that payload is missing —
+// an interrupted or partially-cleaned PortableGit install — the launcher is
+// still a file, so an existence-only check selects it and every later
+// candidate is skipped. It then fails at spawn time with
+//
+//   error launching git: The system cannot find the path specified.
+//
+// which surfaces to the user as "Couldn't check for updates. Check your
+// connection and try again." — pointing at the network instead of at git,
+// on a machine with a perfectly good Git-for-Windows one entry further down
+// the list. Probe the candidate before committing to it.
+function gitBinaryRuns(candidate) {
+  try {
+    execFileSync(candidate, ['--version'], {
+      stdio: 'ignore',
+      timeout: 5000,
+      windowsHide: true
+    })
+
+    return true
+  } catch {
+    return false
+  }
+}
+
 function resolveGitBinary() {
   if (_gitBinaryCache) {
     return _gitBinaryCache
   }
 
-  if (!IS_WINDOWS) {
-    _gitBinaryCache = findOnPath('git') || 'git'
-
-    return _gitBinaryCache
-  }
-
-  const localAppData = process.env.LOCALAPPDATA || ''
-  const candidates = []
-
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'cmd', 'git.exe'))
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'bin', 'git.exe'))
-  }
-
-  candidates.push(path.join(process.env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'cmd', 'git.exe'))
-  candidates.push(path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'cmd', 'git.exe'))
-
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'Programs', 'Git', 'cmd', 'git.exe'))
-  }
-
-  _gitBinaryCache = candidates.find(fileExists) || findOnPath('git') || 'git'
+  // Candidate selection lives in ./select-git-binary so it is unit-testable
+  // without booting Electron — see select-git-binary.test.ts.
+  _gitBinaryCache = _selectGitBinary({
+    isWindows: IS_WINDOWS,
+    env: process.env,
+    fileExists,
+    binaryRuns: gitBinaryRuns,
+    findOnPath
+  })
 
   return _gitBinaryCache
 }

--- a/apps/desktop/electron/select-git-binary.test.ts
+++ b/apps/desktop/electron/select-git-binary.test.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { selectGitBinary } from './select-git-binary'
+
+const WIN_ENV = {
+  LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local',
+  ProgramFiles: 'C:\\Program Files',
+  'ProgramFiles(x86)': 'C:\\Program Files (x86)'
+}
+
+const HERMES_GIT = 'C:\\Users\\test\\AppData\\Local\\hermes\\git\\cmd\\git.exe'
+const PROGRAM_FILES_GIT = 'C:\\Program Files\\Git\\cmd\\git.exe'
+
+const yes = () => true
+const no = () => false
+
+test('a broken first candidate is skipped for one that runs', () => {
+  // The real incident: install.ps1 left hermes\git\cmd\git.exe on disk
+  // without its mingw64 payload, so it exists but cannot execute.
+  const result = selectGitBinary({
+    isWindows: true,
+    env: WIN_ENV,
+    fileExists: (p: string) => p === HERMES_GIT || p === PROGRAM_FILES_GIT,
+    binaryRuns: (p: string) => p !== HERMES_GIT,
+    findOnPath: () => null
+  })
+
+  assert.equal(result, PROGRAM_FILES_GIT)
+})
+
+test('the first candidate wins when it both exists and runs', () => {
+  const result = selectGitBinary({
+    isWindows: true,
+    env: WIN_ENV,
+    fileExists: (p: string) => p === HERMES_GIT || p === PROGRAM_FILES_GIT,
+    binaryRuns: yes,
+    findOnPath: () => null
+  })
+
+  assert.equal(result, HERMES_GIT)
+})
+
+test('when no candidate runs, fall back to the first that exists', () => {
+  // Probing may be impossible (execution policy, AV interposing on spawn).
+  // Falling back preserves the pre-probe behaviour rather than skipping a
+  // git that would have worked.
+  const result = selectGitBinary({
+    isWindows: true,
+    env: WIN_ENV,
+    fileExists: (p: string) => p === HERMES_GIT || p === PROGRAM_FILES_GIT,
+    binaryRuns: no,
+    findOnPath: () => null
+  })
+
+  assert.equal(result, HERMES_GIT)
+})
+
+test('no candidate on disk falls through to PATH', () => {
+  const result = selectGitBinary({
+    isWindows: true,
+    env: WIN_ENV,
+    fileExists: no,
+    binaryRuns: no,
+    findOnPath: () => 'D:\\tools\\git.exe'
+  })
+
+  assert.equal(result, 'D:\\tools\\git.exe')
+})
+
+test('nothing found anywhere falls back to bare git', () => {
+  const result = selectGitBinary({
+    isWindows: true,
+    env: WIN_ENV,
+    fileExists: no,
+    binaryRuns: no,
+    findOnPath: () => null
+  })
+
+  assert.equal(result, 'git')
+})
+
+test('a runnable later candidate beats an existing-but-broken earlier one across all slots', () => {
+  const userGit = 'C:\\Users\\test\\AppData\\Local\\Programs\\Git\\cmd\\git.exe'
+
+  const result = selectGitBinary({
+    isWindows: true,
+    env: WIN_ENV,
+    fileExists: yes,          // every candidate exists
+    binaryRuns: (p: string) => p === userGit,   // only the last one runs
+    findOnPath: () => null
+  })
+
+  assert.equal(result, userGit)
+})
+
+test('non-Windows uses PATH', () => {
+  const result = selectGitBinary({
+    isWindows: false,
+    env: {},
+    fileExists: no,
+    binaryRuns: no,
+    findOnPath: () => '/usr/bin/git'
+  })
+
+  assert.equal(result, '/usr/bin/git')
+})
+
+test('non-Windows with no git on PATH falls back to bare git', () => {
+  const result = selectGitBinary({
+    isWindows: false,
+    env: {},
+    fileExists: no,
+    binaryRuns: no,
+    findOnPath: () => null
+  })
+
+  assert.equal(result, 'git')
+})
+
+test('empty LOCALAPPDATA drops the hermes candidates without throwing', () => {
+  const result = selectGitBinary({
+    isWindows: true,
+    env: { LOCALAPPDATA: '', ProgramFiles: 'C:\\Program Files' },
+    fileExists: (p: string) => p === PROGRAM_FILES_GIT,
+    binaryRuns: yes,
+    findOnPath: () => null
+  })
+
+  assert.equal(result, PROGRAM_FILES_GIT)
+})
+
+test('the probe is not consulted for candidates that do not exist', () => {
+  // Probing a non-existent path costs a failed spawn per candidate.
+  const probed: string[] = []
+  selectGitBinary({
+    isWindows: true,
+    env: WIN_ENV,
+    fileExists: (p: string) => p === PROGRAM_FILES_GIT,
+    binaryRuns: (p: string) => {
+      probed.push(p)
+
+      return true
+    },
+    findOnPath: () => null
+  })
+
+  assert.deepEqual(probed, [PROGRAM_FILES_GIT])
+})

--- a/apps/desktop/electron/select-git-binary.ts
+++ b/apps/desktop/electron/select-git-binary.ts
@@ -1,0 +1,69 @@
+import path from 'node:path'
+
+export interface GitBinaryOptions {
+  isWindows: boolean
+  env: Record<string, string | undefined>
+  fileExists: (filePath: string) => boolean
+  /** Probe: does this candidate actually execute (`git --version`)? */
+  binaryRuns: (filePath: string) => boolean
+  findOnPath?: (command: string) => string | null
+}
+
+/**
+ * Choose which git executable to use.
+ *
+ * On Windows a candidate can exist on disk and still be unusable: install.ps1
+ * lays down `%LOCALAPPDATA%\hermes\git\cmd\git.exe`, and if the PortableGit
+ * payload (`mingw64\`) is missing or half-extracted, spawning it fails with
+ *
+ *   error launching git: The system cannot find the path specified.
+ *
+ * which surfaces as "Couldn't check for updates. Check your connection and
+ * try again." — blaming the network on a machine with a perfectly good Git
+ * for Windows one entry further down the list. So prefer a candidate that
+ * both exists *and* runs.
+ *
+ * Fall back to the first candidate that merely exists when no probe
+ * succeeds, so behaviour is unchanged where the probe itself cannot run
+ * (locked-down execution policy, AV interposing on spawn) rather than
+ * skipping a git that would have worked.
+ *
+ * Resolution order (first match wins):
+ *   1. a candidate that exists and runs
+ *   2. a candidate that merely exists
+ *   3. git on PATH
+ *   4. bare 'git'
+ */
+export function selectGitBinary(opts: GitBinaryOptions): string {
+  const { isWindows, env, fileExists, binaryRuns, findOnPath } = opts
+
+  if (!isWindows) {
+    return (findOnPath ? findOnPath('git') : null) || 'git'
+  }
+
+  const localAppData = env.LOCALAPPDATA || ''
+  const candidates: string[] = []
+
+  // Candidate paths are Windows paths regardless of host platform (tests run
+  // on POSIX CI hosts too), so join with win32 semantics explicitly.
+  const joinWin = path.win32.join
+
+  if (localAppData) {
+    candidates.push(joinWin(localAppData, 'hermes', 'git', 'cmd', 'git.exe'))
+    candidates.push(joinWin(localAppData, 'hermes', 'git', 'bin', 'git.exe'))
+  }
+
+  candidates.push(joinWin(env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'cmd', 'git.exe'))
+  candidates.push(joinWin(env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'cmd', 'git.exe'))
+
+  if (localAppData) {
+    candidates.push(joinWin(localAppData, 'Programs', 'Git', 'cmd', 'git.exe'))
+  }
+
+  return (
+    candidates.find(c => fileExists(c) && binaryRuns(c)) ||
+    candidates.find(fileExists) ||
+    (findOnPath ? findOnPath('git') : null) ||
+    'git'
+  )
+}


### PR DESCRIPTION
## What does this PR do?

`resolveGitBinary()` selects the first candidate that exists on disk. A candidate can exist and still be unusable — and when that happens, every later candidate is skipped, including a perfectly good Git-for-Windows.

PortableGit under `%LOCALAPPDATA%\hermes\git` ships `cmd\git.exe` as a small launcher that re-execs the real binary under `mingw64\`. If that payload is missing — interrupted install, partially-cleaned uninstall — the launcher is still a file, so `candidates.find(fileExists)` selects it. Running it gives:

```
error launching git: The system cannot find the path specified.
```

Every `runGit()` call then fails, `checkUpdates()` returns `fetch-failed`, and the UI renders:

> **Couldn't check for updates** — Check your connection and try again.

…which points the user at their network. It isn't the network.

## Observed

On a Windows 11 machine, `%LOCALAPPDATA%\hermes\git\` contained **only** `cmd\git.exe` (46 KB, no `mingw64\`, no `bin\`), while `C:\Program Files\Git\cmd\git.exe` (git 2.54.0) was installed and working the entire time.

```
> "%LOCALAPPDATA%\hermes\git\cmd\git.exe" --version
error launching git: The system cannot find the path specified.

> "C:\Program Files\Git\cmd\git.exe" --version
git version 2.54.0.windows.1

> "C:\Program Files\Git\cmd\git.exe" -c windows.appendAtomically=false fetch --quiet origin main
(exit 0)
```

`git fetch` from a shell succeeded; the in-app update check could not, and blamed the connection.

## Fix

Probe each candidate with `--version` and prefer the first that actually runs.

If **no** candidate runs, fall back to the first that merely exists — so behaviour is unchanged when the probe itself cannot execute (locked-down execution policy, AV interposing on spawn) rather than skipping a git that would have worked. `execFileSync` is already imported, and the result stays cached behind `_gitBinaryCache`, so the probe runs at most once per process.

## Relationship to existing work

- **#61494** is the *inverse* failure: git found at **no** candidate path (UGit install), falling through to `findOnPath`.
- **#75703** adds `bin\` candidates and unifies discovery with `findGitBash()`.

Both use existence-only checks, so neither covers a candidate that exists but cannot execute. This change is orthogonal and composes with either — if #75703 lands first, this still applies to the unified candidate list.

## Verification

- Reproduced the selection against the real broken stub: existence-only picks the non-functional launcher; probed selection returns `C:\Program Files\Git\cmd\git.exe`.
- `npx tsc -p tsconfig.electron.json --noEmit` — clean.
- `npx vitest run --project electron` — **19 failed / 991 passed with *and* without this change** (byte-identical pre-existing failures on this host, none git-resolution related).

Windows 11, Electron 40.10.2, git 2.54.0.windows.1.