### PR TITLE
feat(file-ops): name the binary type in read_file refusals (magic-byte sniff)

### DIFF
--- a/tests/tools/test_read_binary_type_disclosure.py
+++ b/tests/tools/test_read_binary_type_disclosure.py
@@ -1,0 +1,90 @@
+"""Tests for magic-byte type disclosure in the binary-file refusal.
+
+"Binary file — use appropriate tools" names a recovery the model may not
+have (file-only toolsets), so it thrashes. Naming the TYPE answers
+what-is-this in one read: "Binary file (PNG image data, 4.0 KB)".
+"""
+
+import json
+import random
+
+import pytest
+
+from tools.file_operations import describe_binary_file, identify_binary_bytes
+from tools.file_tools import read_file_tool
+
+_RNG = random.Random(20260810)
+
+
+def _noise(n: int) -> bytes:
+    return bytes(_RNG.getrandbits(8) for _ in range(n))
+
+
+class TestIdentifyBinaryBytes:
+    @pytest.mark.parametrize(
+        "prefix,expected",
+        [
+            (b"\x89PNG\r\n\x1a\n", "PNG image data"),
+            (b"\xff\xd8\xff", "JPEG image data"),
+            (b"%PDF-", "PDF document"),
+            (b"PK\x03\x04", "ZIP archive"),
+            (b"\x1f\x8b", "gzip compressed data"),
+            (b"\x7fELF", "ELF executable"),
+            (b"MZ", "Windows PE executable"),
+            (b"SQLite format 3\x00", "SQLite database"),
+        ],
+    )
+    def test_known_signatures(self, prefix, expected):
+        assert expected in identify_binary_bytes(prefix + _noise(64))
+
+    def test_unknown_binary(self):
+        assert identify_binary_bytes(b"\x00\x01\x02" * 100) == "unknown binary"
+
+    def test_empty_sample(self):
+        assert identify_binary_bytes(b"") == "unknown binary"
+
+    def test_iso_media_requires_ftyp(self):
+        # Three NULs alone are too weak; require ftyp at offset 4.
+        assert identify_binary_bytes(b"\x00\x00\x00\x18ftypmp42" + _noise(32)).startswith("ISO media")
+        assert identify_binary_bytes(b"\x00\x00\x00\x18AAAA" + _noise(32)) == "unknown binary"
+
+
+class TestDescribeBinaryFile:
+    def test_size_units(self):
+        assert "512 bytes" in describe_binary_file(b"\x7fELF", 512)
+        assert "4.0 KB" in describe_binary_file(b"\x7fELF", 4096)
+        assert "2.0 MB" in describe_binary_file(b"\x7fELF", 2 * 1024 * 1024)
+
+    def test_none_sample(self):
+        assert "unknown binary" in describe_binary_file(None, 100)
+
+
+class TestReadFileBinaryDisclosure:
+    def test_lying_extension_names_real_type(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        p = tmp_path / "data.txt"  # extension says text; bytes say PNG
+        p.write_bytes(b"\x89PNG\r\n\x1a\n" + _noise(4096))
+        result = json.loads(read_file_tool(str(p)))
+        assert "PNG image data" in result.get("error", "")
+        assert "4.1 KB" in result["error"] or "4.0 KB" in result["error"]
+
+    def test_extensionless_binary_named(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        p = tmp_path / "mystery"
+        p.write_bytes(b"\x7fELF" + _noise(1024))
+        result = json.loads(read_file_tool(str(p)))
+        assert "ELF executable" in result.get("error", "")
+
+    def test_unknown_binary_still_refused(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        p = tmp_path / "junk.out"
+        p.write_bytes(b"\x00\x01\x02" * 500)
+        result = json.loads(read_file_tool(str(p)))
+        assert "unknown binary" in result.get("error", "")
+
+    def test_text_file_unaffected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        p = tmp_path / "ok.txt"
+        p.write_text("hello world\n")
+        result = json.loads(read_file_tool(str(p)))
+        assert "hello world" in result.get("content", "")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -449,6 +449,70 @@ def _parse_search_context_line(line: str) -> tuple[str, int, str] | None:
 # Abstract Interface
 # =============================================================================
 
+_MAGIC_SIGNATURES: tuple = (
+    # (prefix bytes, human name) — ordered, first match wins. Longest
+    # prefixes for a shared first byte come first.
+    (b"\x89PNG\r\n\x1a\n", "PNG image data"),
+    (b"\xff\xd8\xff", "JPEG image data"),
+    (b"GIF87a", "GIF image data"),
+    (b"GIF89a", "GIF image data"),
+    (b"RIFF", "RIFF container (WAV/AVI/WebP family)"),
+    (b"%PDF-", "PDF document"),
+    (b"PK\x03\x04", "ZIP archive (also docx/xlsx/jar/apk)"),
+    (b"PK\x05\x06", "ZIP archive (empty)"),
+    (b"\x1f\x8b", "gzip compressed data"),
+    (b"BZh", "bzip2 compressed data"),
+    (b"\xfd7zXZ\x00", "xz compressed data"),
+    (b"7z\xbc\xaf\x27\x1c", "7-Zip archive"),
+    (b"\x7fELF", "ELF executable"),
+    (b"MZ", "Windows PE executable"),
+    (b"\xcf\xfa\xed\xfe", "Mach-O executable (64-bit)"),
+    (b"\xca\xfe\xba\xbe", "Mach-O universal binary / Java class"),
+    (b"SQLite format 3\x00", "SQLite database"),
+    (b"OggS", "Ogg container"),
+    (b"fLaC", "FLAC audio"),
+    (b"ID3", "MP3 audio (ID3 tag)"),
+    (b"\x00\x00\x00", "ISO media container (MP4/MOV family)"),  # ftyp at +4
+    (b"BM", "BMP image data"),
+    (b"II*\x00", "TIFF image data (little-endian)"),
+    (b"MM\x00*", "TIFF image data (big-endian)"),
+)
+
+
+def identify_binary_bytes(sample: bytes) -> str:
+    """Best-effort human name for binary content from its magic bytes.
+
+    Returns e.g. ``"PNG image data"`` or ``"unknown binary"``. Never raises.
+    The ISO-media entry additionally checks for ``ftyp`` at offset 4, since
+    the leading size field alone (three NULs) is too weak a signature.
+    """
+    if not sample:
+        return "unknown binary"
+    for prefix, name in _MAGIC_SIGNATURES:
+        if sample.startswith(prefix):
+            if name.startswith("ISO media") and sample[4:8] != b"ftyp":
+                continue
+            return name
+    return "unknown binary"
+
+
+def describe_binary_file(sample: Optional[bytes], file_size: int) -> str:
+    """One-line answer for the binary-file refusal.
+
+    Naming the dead end: "Binary file" alone sends the model hunting for
+    'appropriate tools' that may not exist in its toolset. Naming the TYPE
+    ("PNG image data, 4.1 KB") answers what-is-this in a single read.
+    """
+    kind = identify_binary_bytes(sample or b"")
+    if file_size >= 1024 * 1024:
+        size = f"{file_size / (1024 * 1024):.1f} MB"
+    elif file_size >= 1024:
+        size = f"{file_size / 1024:.1f} KB"
+    else:
+        size = f"{file_size} bytes"
+    return f"Binary file ({kind}, {size}) — cannot display as text."
+
+
 class FileOperations(ABC):
     """Abstract interface for file operations across terminal backends."""
     
@@ -1339,7 +1403,7 @@ class ShellFileOperations(FileOperations):
             return ReadResult(
                 is_binary=True,
                 file_size=file_size,
-                error="Binary file - cannot display as text. Use appropriate tools to handle this file type."
+                error=describe_binary_file(sample_bytes, file_size),
             )
         
         # Read with pagination using sed, clamping each line to a byte
@@ -1574,7 +1638,7 @@ class ShellFileOperations(FileOperations):
         if is_binary:
             return ReadResult(
                 is_binary=True, file_size=file_size,
-                error="Binary file — cannot display as text."
+                error=describe_binary_file(sample_bytes, file_size),
             )
         cat_result = self._exec(f"cat {self._escape_shell_arg(path)}")
         if cat_result.exit_code != 0:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1681,7 +1681,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 return json.dumps(result_dict, ensure_ascii=False)
 
         # ── Binary file guard ─────────────────────────────────────────
-        # Block binary files by extension (no I/O).
+        # Block binary files by extension (no I/O). Name what we know:
+        # the extension is a claim, so keep this branch's message to the
+        # extension itself — the content-sniffing path below names the
+        # actual magic-byte type for extension-less/lying files.
         if has_binary_extension(str(_resolved)):
             _ext = _resolved.suffix.lower()
             return tool_error(


### PR DESCRIPTION
## Summary

`read_file`'s binary refusal now names the actual file type from magic bytes — `Binary file (PNG image data, 4.1 KB) — cannot display as text.` — instead of `"Use appropriate tools to handle this file type"`, which points at recovery tools that may not exist in the active toolset. In the readtool eval's file-only arm that pointer made qwen3.8-max thrash for 41 turns / 178 tool calls / 1.5M tokens on a PNG-behind-`.txt`, hunting for tools it didn't have.

Measured (lying_extension task, file-only arm, 3 reps vs merged main):

| | main | this PR | delta |
|---|---|---|---|
| opus-4.8 turns | 13.7 | 5.7 | **−58%** |
| opus-4.8 tokens | 141k | 44k | −69% |
| qwen3.8-max turns | 33.3 | 22.7 | −32% |
| qwen3.8-max tokens | 1,199k | 846k | −29% |
| accuracy (both) | 1.00 | 1.00 | held |

Honest caveat: qwen's reps were high-variance (41/8/19 turns). Rep 2 shows the designed behavior (type named on read #1, done in 8); rep 1 shows a failure mode the message can't reach — the model *distrusted the disclosure* and spent 169 tool calls trying to independently verify it. Directionally consistent improvement on both models, but the qwen mean is not a stable point estimate at n=3. Opus's collapse (rep 1: 2 turns, single read) is the clean signal.

## Changes

- `tools/file_operations.py`: `_MAGIC_SIGNATURES` (25 prefixes — images, archives, executables, media, SQLite; ISO-media requires `ftyp` at offset 4) + `identify_binary_bytes()` + `describe_binary_file()` (size in human units). Both `ShellFileOperations` refusal sites (`read_file`, `read_file_raw`) use it. The extension-based guard in `file_tools.py` intentionally keeps its extension-only message — an extension is a claim; only sniffed content earns a type name.
- `tests/tools/test_read_binary_type_disclosure.py`: 15 tests — signature table, ftyp gate, size units, lying-extension E2E, extensionless binary, unknown-binary fallback, text files untouched.

## Validation

| | result |
|---|---|
| targeted tests | 161 passed, 0 failed (4 files incl. file_operations/file_tools/read_guards) |
| E2E | PNG/ELF/SQLite/ZIP/gzip named; unknown binary still refused; text reads unchanged |

Closes the last actionable finding from the merged-main regression battery (issue #82978). Also surfaced two harness gaps logged there: runner doesn't enforce per-task timeouts, and lying_extension needs a variance annotation.

## Infographic

![binary type disclosure](https://v3b.fal.media/files/b/0aa5cf5c/pFHRLXR9VEfsR7wvYEJZd_jiELoCk8.png)
