### PR TITLE
fix(disk-cleanup): protect managed dependency trees

### DIFF
--- a/contributors/emails/samgithub@pm.me
+++ b/contributors/emails/samgithub@pm.me
@@ -1,0 +1,2 @@
+samrusani
+# PR #83385 (disk-cleanup)

--- a/plugins/disk-cleanup/README.md
+++ b/plugins/disk-cleanup/README.md
@@ -13,7 +13,7 @@ never needs to remember to call a tool.
 
 | Hook | Behaviour |
 |---|---|
-| `post_tool_call` | When `write_file` / `terminal` / `patch` creates a file matching `test_*`, `tmp_*`, or `*.test.*` inside `HERMES_HOME`, track it silently as `test` / `temp` / `cron-output`. |
+| `post_tool_call` | When `write_file` / `terminal` / `patch` references a file matching `test_*`, `tmp_*`, or `*.test.*` inside `HERMES_HOME`, track it silently as `test`. Cache and cron-output paths use their respective categories. |
 | `on_session_end` | If any test files were auto-tracked during this turn, run `quick` cleanup (no prompts). |
 
 Deletion rules (same as the original PR):
@@ -46,6 +46,8 @@ Deletion rules (same as the original PR):
 - The state directory `$HERMES_HOME/disk-cleanup/` is itself excluded
 - `$HERMES_HOME/logs/`, `memories/`, `sessions/`, `skills/`, `plugins/`,
   and config files are never tracked
+- Hermes-managed `node/` and `lsp/` installs, plus dependency trees such as
+  `node_modules/`, `venv/`, `.venv/`, and `site-packages/`, are never tracked
 - Backup/restore is scoped to `tracked.json` — the plugin never touches
   agent logs
 - Atomic writes: `.tmp` → backup → rename

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -581,12 +581,19 @@ def guess_category(path: Path) -> Optional[str]:
             "disk-cleanup", "logs", "memories", "sessions", "config.yaml",
             "skills", "plugins", ".env", "USER.md", "MEMORY.md", "SOUL.md",
             "auth.json", "hermes-agent",
+            # Hermes-managed runtime and language-server installations.
+            "node", "lsp",
             # User-authored and project trees — never auto-delete files
             # inside these just because they happen to be named test_* or
             # tmp_* (#75403, also #32164, #37721).
             "patches", "projects", "skins", "themes", "contributors",
             "profiles", "backups", "optional-skills",
         }:
+            return None
+        if not _EMPTY_DIR_SWEEP_PRUNE_DIRS.isdisjoint(rel.parts):
+            # Dependency and virtual-environment trees contain upstream test
+            # fixtures whose names are not evidence that Hermes created them
+            # (#83378).
             return None
         if top == "cron" or top == "cronjobs":
             # Only files under the disposable ``output/`` subtree are

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -115,6 +115,42 @@ class TestGuessCategory:
         # Even though it matches test_* pattern, logs/ is excluded.
         assert dg.guess_category(p) is None
 
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            "node/lib/node_modules/npm/node_modules/node-gyp/gyp/test_gyp.py",
+            "lsp/node_modules/pyright/dist/typeshed-fallback/stubs/anyio/"
+            "tmp_storages.pyi",
+        ],
+    )
+    def test_skips_hermes_managed_tool_install_trees(
+        self, _isolate_env, relative_path
+    ):
+        dg = _load_lib()
+        p = _isolate_env / relative_path
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+        assert dg.guess_category(p) is None
+
+    @pytest.mark.parametrize(
+        "dependency_dir", ["node_modules", "venv", ".venv", "site-packages"]
+    )
+    def test_skips_dependency_install_trees(
+        self, _isolate_env, dependency_dir
+    ):
+        dg = _load_lib()
+        p = _isolate_env / "workspace" / dependency_dir / "pkg" / "tmp_state.py"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+        assert dg.guess_category(p) is None
+
+    def test_dependency_named_parent_is_not_overmatched(self, _isolate_env):
+        dg = _load_lib()
+        p = _isolate_env / "node_modules_backup" / "test_fixture.py"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+        assert dg.guess_category(p) == "test"
+
     def test_cron_subtree_categorised(self, _isolate_env):
         dg = _load_lib()
         # Only files under ``cron/output/`` are disposable run artifacts.
@@ -223,6 +259,31 @@ class TestStaleCronEntryMigration:
         summary = dg.quick()
         assert summary["deleted"] == 1, "valid old cron-output should be deleted"
         assert not run_md.exists()
+
+
+class TestStaleTestEntryMigration:
+    def test_quick_skips_stale_tool_install_entry(self, _isolate_env):
+        dg = _load_lib()
+        p = (
+            _isolate_env
+            / "node/lib/node_modules/npm/node_modules/node-gyp/gyp/test_gyp.py"
+        )
+        p.parent.mkdir(parents=True)
+        p.write_text("upstream fixture")
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(p),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": p.stat().st_size,
+        }]))
+
+        summary = dg.quick()
+        assert summary["deleted"] == 0
+        assert p.read_text() == "upstream fixture"
+        assert json.loads(tracked_file.read_text()) == []
 
 
 class TestTrackForgetQuick:


### PR DESCRIPTION
## What does this PR do?

Prevents the disk-cleanup plugin from auto-classifying files inside Hermes-managed tool installations or dependency trees as disposable solely because their basenames match `test_*`, `tmp_*`, or `*.test.*`.

The classifier now protects the managed `node/` and `lsp/` roots and skips exact dependency-directory components already pruned by the empty-directory sweep (`node_modules`, `venv`, `.venv`, and `site-packages`). This also lets the existing stale-`test` revalidation path discard old tracking entries without deleting the installed files.

The README now states the existing `tmp_*` behavior accurately: those names use the immediate `test` category, while cache paths use the seven-day `temp` category.

## Related Issue

Fixes #83378

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/disk-cleanup/disk_cleanup.py`: protect managed runtime roots and exact dependency-tree components during auto-classification.
- `tests/plugins/test_disk_cleanup_plugin.py`: cover the reported npm/Pyright paths, nested dependency trees, exact-component matching, ordinary disposable files, and stale tracking entries.
- `plugins/disk-cleanup/README.md`: document protected install trees and clarify the current `tmp_*` category.
- `contributors/emails/samgithub@pm.me`: map the commit email to `samrusani` using the repository-prescribed contributor-attribution flow.

## How to Test

1. Before the production change, run the new focused regressions. The six managed/dependency-tree cases fail because `guess_category()` returns `"test"`; the ordinary-file control passes.
2. Run `scripts/run_tests.sh tests/plugins/test_disk_cleanup_plugin.py -q`.
3. Run `ruff check plugins/disk-cleanup/disk_cleanup.py tests/plugins/test_disk_cleanup_plugin.py` and `git diff --check`.

Result: 35 plugin tests passed; focused Ruff and diff checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure `pathlib` component checks
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is a path-classification fix.