### PR TITLE
refactor(ui-tui): consolidate duplicated truthy/falsy flag parsing

### DIFF
--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -1,9 +1,7 @@
 import type { MouseTrackingMode } from '@hermes/ink'
 
 import { isTermuxTuiMode } from '../lib/termux.js'
-
-const truthy = (v?: string) => /^(?:1|true|yes|on)$/i.test((v ?? '').trim())
-const falsy = (v?: string) => /^(?:0|false|no|off)$/i.test((v ?? '').trim())
+import { truthy, falsy } from '../lib/envFlags.js'
 
 const parseToggle = (v?: string): boolean | null => {
   const raw = (v ?? '').trim()

--- a/ui-tui/src/lib/envFlags.ts
+++ b/ui-tui/src/lib/envFlags.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared terminal/env flag parsing.
+ *
+ * Consolidates the four previously-duplicated truthy/falsy regexes
+ * (forceTruecolor.ts, config/env.ts, termux.ts, theme.ts) so they cannot
+ * drift apart. Every call site already trims (and, where relevant,
+ * lowercases) its input before testing, so a single case-insensitive
+ * definition is behavior-preserving across all of them.
+ */
+const TRUE_RE = /^(?:1|true|yes|on)$/i
+const FALSE_RE = /^(?:0|false|no|off)$/i
+
+export const truthy = (value?: string): boolean => TRUE_RE.test(String(value ?? '').trim())
+
+export const falsy = (value?: string): boolean => FALSE_RE.test(String(value ?? '').trim())

--- a/ui-tui/src/lib/forceTruecolor.ts
+++ b/ui-tui/src/lib/forceTruecolor.ts
@@ -6,17 +6,16 @@
  * explicitly on terminals that support RGB but do not advertise COLORTERM.
  */
 
-const TRUE_RE = /^(?:1|true|yes|on)$/i
-const FALSE_RE = /^(?:0|false|no|off)$/i
+import { truthy, falsy } from './envFlags.js'
 
 export function shouldForceTruecolor(env: NodeJS.ProcessEnv = process.env): boolean {
   const override = (env.HERMES_TUI_TRUECOLOR ?? '').trim()
 
-  if (FALSE_RE.test(override) || 'NO_COLOR' in env) {
+  if (falsy(override) || 'NO_COLOR' in env) {
     return false
   }
 
-  return TRUE_RE.test(override)
+  return truthy(override)
 }
 
 const isAppleTerminal = (env: NodeJS.ProcessEnv = process.env) => (env.TERM_PROGRAM ?? '').trim() === 'Apple_Terminal'

--- a/ui-tui/src/lib/termux.ts
+++ b/ui-tui/src/lib/termux.ts
@@ -1,6 +1,6 @@
 const TERMUX_PREFIX = '/data/data/com.termux/files/usr'
 
-const truthy = (value?: string) => /^(?:1|true|yes|on)$/i.test(String(value ?? '').trim())
+import { truthy } from './envFlags.js'
 
 export const isTermuxEnv = (env: NodeJS.ProcessEnv = process.env): boolean => {
   const prefix = String(env.PREFIX ?? '')

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -1,6 +1,7 @@
 import type { SkinBranding, SkinColors } from '@hermes/shared/skin'
 
 import { desaturate, grayOf, liftForContrast, mix, parseColor, relativeLuminance, toHex } from './lib/color.js'
+import { truthy, falsy } from './lib/envFlags.js'
 
 export interface ThemeColors {
   primary: string
@@ -636,8 +637,7 @@ export function deriveTones(seeds: {
   }
 }
 
-const TRUE_RE = /^(?:1|true|yes|on)$/
-const FALSE_RE = /^(?:0|false|no|off)$/
+
 
 // TERM_PROGRAM fallback allow-list for terminals whose default profile is
 // light and which may not expose COLORFGBG. This currently includes Apple
@@ -707,11 +707,11 @@ export function detectLightMode(
 ): boolean {
   const lightFlag = (env.HERMES_TUI_LIGHT ?? '').trim().toLowerCase()
 
-  if (TRUE_RE.test(lightFlag)) {
+  if (truthy(lightFlag)) {
     return true
   }
 
-  if (FALSE_RE.test(lightFlag)) {
+  if (falsy(lightFlag)) {
     return false
   }
 


### PR DESCRIPTION
## Summary
Consolidates the four duplicated truthy/falsy regex definitions that parsed the same `1|true|yes|on` / `0|false|no|off` env-flag vocabulary across the TUI:

- `ui-tui/src/lib/forceTruecolor.ts`
- `ui-tui/src/config/env.ts`
- `ui-tui/src/lib/termux.ts`
- `ui-tui/src/theme.ts`

into a single shared helper at `ui-tui/src/lib/envFlags.ts` (`truthy` / `falsy`).

## Why this is safe (no behavior change)
Every call site already trims (and, where relevant, lowercases) its input before testing, so the unified case-insensitive definition is exactly behavior-preserving — `theme.ts` lowercases `lightFlag` before matching, so its previously case-sensitive `TRUE_RE`/`FALSE_RE` produce identical results through the shared helper.

## Verification
- All directly-relevant unit suites pass: forceTruecolor (10), termux (6), theme (49), themeBoot, terminalParity (3), terminalModes (13) — **91 passing**.
- `pnpm install --ignore-scripts` + `vitest run` on the affected suites.

## Scope note
The inline copy in `packages/hermes-ink/src/ink/colorize.ts:36` is intentionally left untouched — it lives in a separate package workspace and would require its own exported util rather than a cross-package import.

Generated with Claude Code (Hermes Agent).