### PR TITLE
fix(tests): refuse bare pytest to prevent working-tree mutation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Run e2e tests
         run: |
           source .venv/bin/activate
-          python -m pytest tests/e2e/ -v --tb=short
+          scripts/run_tests.sh tests/e2e/ -v --tb=short
         env:
           OPENROUTER_API_KEY: ""
           OPENAI_API_KEY: ""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,13 +201,10 @@ ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
 ### Run tests
 
 ```bash
-# Preferred — matches CI (hermetic `env -i`, per-file subprocess isolation
-# via run_tests_parallel.py, worker count auto-scaled); see AGENTS.md
+# Required — matches CI (hermetic `env -i`, per-file subprocess isolation
+# via run_tests_parallel.py, worker count auto-scaled); see AGENTS.md.
+# Bare `pytest tests/` is refused (can mutate your working tree).
 scripts/run_tests.sh
-
-# Alternative (activate the venv first). The wrapper is still recommended
-# for parity with GitHub Actions before you open a PR:
-pytest tests/ -v
 ```
 
 ---
@@ -944,7 +941,7 @@ refactor/description   # Code restructuring
 
 ### Before submitting
 
-1. **Run tests**: `scripts/run_tests.sh` (recommended; same as CI) or `pytest tests/ -v` with the project venv activated
+1. **Run tests**: `scripts/run_tests.sh` (same as CI; bare `pytest` is refused — it can mutate your working tree)
 2. **Test manually**: Run `hermes` and exercise the code path you changed
 3. **Check cross-platform impact**: If you touch file I/O, process management, or terminal handling, consider macOS, Linux, and WSL2
 4. **Keep PRs focused**: One logical change per PR. Don't mix a bug fix with a refactor with a new feature.

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -746,6 +746,15 @@ def _make_stdio_glyph_safe() -> None:
 
 def main() -> int:
     _make_stdio_glyph_safe()
+    # Mark every per-file pytest subprocess as "launched by the canonical
+    # runner". tests/conftest.py refuses to collect without this, so a bare
+    # `pytest tests/` cannot silently run against the real working tree
+    # (an unguarded run wiped uncommitted changes mid-suite).
+    #
+    # Set here rather than on run_tests.sh's `env -i` line so that invoking
+    # this driver directly is equally covered, and because the children
+    # inherit it via `env=os.environ` in _run_one_file.
+    os.environ["HERMES_TEST_RUNNER"] = "1"
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1082,8 +1082,35 @@ _OS_MARKS = {
 }
 
 
+_CANONICAL_RUNNER_ENV = "HERMES_TEST_RUNNER"
+_BARE_PYTEST_ESCAPE_ENV = "HERMES_ALLOW_BARE_PYTEST"
+
+
+def _require_canonical_test_runner() -> None:
+    """Refuse collection unless launched by the canonical test runner.
+
+    Bare ``pytest tests/`` bypasses the hermetic env and per-file isolation
+    from ``scripts/run_tests.sh`` / ``run_tests_parallel.py`` and can mutate
+    the real working tree (git operations against the checkout).
+    """
+    if os.environ.get(_BARE_PYTEST_ESCAPE_ENV) == "1":
+        return
+    if os.environ.get(_CANONICAL_RUNNER_ENV):
+        return
+    raise pytest.UsageError(
+        "Refusing to run tests without the canonical runner.\n\n"
+        "Bare `pytest` can mutate your working tree (tests may trigger git "
+        "operations against the real checkout). Use the isolated runner "
+        "instead:\n\n"
+        "    scripts/run_tests.sh [paths...]\n\n"
+        "For deliberate one-off debugging only:\n\n"
+        "    HERMES_ALLOW_BARE_PYTEST=1 pytest ...\n"
+    )
+
+
 def pytest_configure(config):  # noqa: D401 — pytest hook
     """Register markers used by hermetic conftest."""
+    _require_canonical_test_runner()
     config.addinivalue_line(
         "markers",
         f"{_LIVE_SYSTEM_GUARD_BYPASS_MARK}: bypass the live-system guard "


### PR DESCRIPTION
## What

Bare `pytest tests/` is now refused at collection time unless the canonical runner set `HERMES_TEST_RUNNER=1`. An escape hatch (`HERMES_ALLOW_BARE_PYTEST=1`) is provided for deliberate one-off debugging.

## Why

The canonical runner (`scripts/run_tests.sh` → `run_tests_parallel.py`) provides three isolation layers that bare `pytest tests/` does not:

1. **`env -i`** — hermetic environment with blanked env vars (no credentials, no `HERMES_HOME` pointing at real state)
2. **Per-file subprocess isolation** — each test file runs in its own `python -m pytest <file>` subprocess via `run_tests_parallel.py`
3. **`pytest_live_guard.py` plugin** (if present at `~/.hermes/pytest_live_guard.py`)

The existing live-system guard in `conftest.py` (lines ~1146-1400) wraps `subprocess.run`/`subprocess.Popen` to block calls that would run `hermes update` (which does `git fetch origin + git pull`) against the real checkout. However it is **reactive** — it only covers specific patterns (`hermes update`, systemctl, process-killers). Other git-mutation paths are not guarded.

The per-path guard `_pytest_owns_live_checkout` (used in `hermes_cli/update_cmd.py`, `hermes_cli/_early_recovery.py`) protects individual call sites but requires every new mutation path to opt in.

This fix is **structural**: refuse collection entirely unless launched by the canonical runner. The guard fires in `pytest_configure()`, before any test collection runs, so it is fail-fast.

## The failure mode (real, not theoretical)

Uncommitted changes to `cli.py`, `gateway/run.py`, and `hermes_cli/commands.py` were wiped mid-test-run while developing the `/end` session-closeout command. The test suite passed green, but the working tree changes were gone. A new contributor running `pytest tests/` (as the old CONTRIBUTING.md suggested) would hit the same failure.

## How to test

```bash
# Bare pytest is now refused:
$ pytest tests/ --co -q
ERROR: Refusing to run tests without the canonical runner.

Bare `pytest` can mutate your working tree (tests may trigger git
operations against the real checkout). Use the isolated runner instead:

    scripts/run_tests.sh [paths...]

For deliberate one-off debugging only:

    HERMES_ALLOW_BARE_PYTEST=1 pytest ...

# Escape hatch works:
$ HERMES_ALLOW_BARE_PYTEST=1 pytest tests/ --co -q
29796/29848 tests collected (52 deselected) in 27.57s

# Canonical runner works (sets HERMES_TEST_RUNNER=1):
$ scripts/run_tests.sh tests/foo.py -q
```

## What changed (4 files, +41/-8)

- **`tests/conftest.py`** — `_require_canonical_test_runner()` guard called from `pytest_configure()`. Checks `HERMES_TEST_RUNNER` env var (set by runner) or `HERMES_ALLOW_BARE_PYTEST=1` (escape hatch). Raises `pytest.UsageError` with a message pointing to `scripts/run_tests.sh`.
- **`scripts/run_tests_parallel.py`** — Sets `os.environ["HERMES_TEST_RUNNER"] = "1"` at the top of `main()`, before spawning per-file subprocesses. Children inherit via `env=os.environ`.
- **`CONTRIBUTING.md`** — Updated docs: "Preferred" → "Required", removed `pytest tests/ -v` alternative, noted bare pytest is refused.
- **`.github/workflows/tests.yml`** — E2E test step changed from bare `python -m pytest tests/e2e/` to `scripts/run_tests.sh tests/e2e/` so CI doesn't trip the new guard.

## Platforms tested

macOS 14+ (arm64), Python 3.11, pytest 9.1.1.

## Related

- #76339 (per-path guard for update auto-branch-switch) — complementary, not overlapping. This PR prevents the entire class of bare-pytest runs; that PR guards a specific mutation path that could still fire under the escape hatch.