### PR TITLE
Return Conduit decisions to originating Hermes sessions

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -547,6 +547,25 @@ class PluginContext:
             cli._pending_input.put(msg)
         return True
 
+    def inject_message_for_session(
+        self,
+        session_id: str,
+        content: str,
+        role: str = "user",
+    ) -> bool:
+        """Inject only when the requested interactive session is still active.
+
+        Background adapters use this bounded interface instead of a process-
+        global injection when delivery must remain attached to the interaction
+        that originated an asynchronous request.
+        """
+        cli = self._manager._cli_ref
+        if cli is None or not session_id:
+            return False
+        if str(getattr(cli, "session_id", "")) != session_id:
+            return False
+        return self.inject_message(content, role=role)
+
     # -- CLI command registration --------------------------------------------
 
     def register_cli_command(

--- a/plugins/conduit-decision-return/README.md
+++ b/plugins/conduit-decision-return/README.md
@@ -1,0 +1,24 @@
+# Conduit Decision Return
+
+This optional bundled plugin binds Conduit Decision Returns to Hermes' exact
+originating interactive CLI session. It does not grant effect authority and it
+does not poll. The MCP adapter performs one canonical `get_decision` read on
+notification (and once after reconnect for outstanding origins), then injects
+that canonical result only if the recorded Hermes session is still active.
+
+Enable the plugin and the matching MCP server option:
+
+```yaml
+plugins:
+  enabled:
+    - conduit-decision-return
+
+mcp_servers:
+  conduit:
+    command: conduit-mcp
+    decision_return: true
+```
+
+Both legs must advertise the exact experimental capability
+`io.conduit/decision-return: {version: 1}`. Without either opt-in, Hermes uses
+its ordinary MCP client unchanged.

--- a/plugins/conduit-decision-return/__init__.py
+++ b/plugins/conduit-decision-return/__init__.py
@@ -1,0 +1,16 @@
+"""Exact-session wake binding for the optional Conduit MCP Return adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.conduit_decision_return import decision_return_bridge
+
+
+def register(ctx: Any) -> None:
+    decision_return_bridge.set_waker(ctx.inject_message_for_session)
+
+    def forget_finalized_session(session_id: str = "", **_: Any) -> None:
+        decision_return_bridge.forget_session(session_id)
+
+    ctx.register_hook("on_session_finalize", forget_finalized_session)

--- a/plugins/conduit-decision-return/plugin.yaml
+++ b/plugins/conduit-decision-return/plugin.yaml
@@ -1,0 +1,6 @@
+name: conduit-decision-return
+version: 0.1.0
+description: "Resume the exact Hermes CLI session when an originated Conduit Decision returns from human custody."
+author: "Conduit"
+hooks:
+  - on_session_finalize

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1,10 +1,12 @@
 """Tests for the Hermes plugin system (hermes_cli.plugins)."""
 
-import logging
 import json
+import logging
+import queue
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -769,6 +771,23 @@ class TestThreadToolWhitelist:
 
 class TestPluginContext:
     """Tests for the PluginContext facade."""
+
+    def test_inject_message_for_session_rejects_stale_origin(self):
+        manager = PluginManager()
+        manager._cli_ref = SimpleNamespace(
+            session_id="active-session",
+            _agent_running=False,
+            _pending_input=queue.Queue(),
+            _interrupt_queue=queue.Queue(),
+        )
+        context = PluginContext(
+            PluginManifest(name="return-test", source="bundled"), manager
+        )
+
+        assert not context.inject_message_for_session("stale-session", "wrong")
+        assert manager._cli_ref._pending_input.empty()
+        assert context.inject_message_for_session("active-session", "continue")
+        assert manager._cli_ref._pending_input.get_nowait() == "continue"
 
 
 

--- a/tests/tools/test_conduit_decision_return.py
+++ b/tests/tools/test_conduit_decision_return.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import anyio
+import pytest
+from mcp import types as mcp_types
+
+from tools.conduit_decision_return import (
+    CONDUIT_DECISION_RETURN_CAPABILITY,
+    ConduitClientSession,
+    ConduitDecisionReturnBridge,
+    ConduitDecisionReturnNotification,
+    compatible_server_capability,
+)
+
+
+def _result(decision_id: str, status: str = "ready") -> SimpleNamespace:
+    return SimpleNamespace(
+        isError=False,
+        structuredContent={
+            "decision": {
+                "request": {"id": decision_id, "title": "Bounded test"},
+                "response": None if status == "ready" else {
+                    "kind": "approve_reject",
+                    "decision": "approve",
+                },
+                "status": status,
+            }
+        },
+        content=[],
+    )
+
+
+def test_capability_and_notification_contract_are_exact() -> None:
+    assert compatible_server_capability(SimpleNamespace(
+        experimental={CONDUIT_DECISION_RETURN_CAPABILITY: {"version": 1}},
+    ))
+    assert not compatible_server_capability(SimpleNamespace(
+        experimental={CONDUIT_DECISION_RETURN_CAPABILITY: {"version": 1, "extra": True}},
+    ))
+    assert not compatible_server_capability(SimpleNamespace(experimental={}))
+
+    parsed = ConduitDecisionReturnNotification.model_validate({
+        "method": "notifications/conduit/decision-return",
+        "params": {"version": 1, "decision_id": "dec_1", "stream_seq": 3},
+    })
+    assert parsed.params.decision_id == "dec_1"
+    with pytest.raises(Exception):
+        ConduitDecisionReturnNotification.model_validate({
+            "method": "notifications/conduit/decision-return",
+            "params": {
+                "version": 1,
+                "decision_id": "dec_1",
+                "stream_seq": 3,
+                "title": "must not travel unsolicited",
+            },
+        })
+
+
+@pytest.mark.asyncio
+async def test_extended_client_advertises_return_capability_during_initialize() -> None:
+    incoming_send, incoming_receive = anyio.create_memory_object_stream(1)
+    outgoing_send, _outgoing_receive = anyio.create_memory_object_stream(1)
+    session = ConduitClientSession(incoming_receive, outgoing_send)
+    result = mcp_types.InitializeResult(
+        protocolVersion=mcp_types.LATEST_PROTOCOL_VERSION,
+        capabilities=mcp_types.ServerCapabilities(
+            experimental={CONDUIT_DECISION_RETURN_CAPABILITY: {"version": 1}}
+        ),
+        serverInfo=mcp_types.Implementation(name="fixture", version="1"),
+    )
+    session.send_request = AsyncMock(return_value=result)
+    session.send_notification = AsyncMock()
+
+    assert await session.initialize() is result
+    request = session.send_request.await_args.args[0]
+    assert request.root.params.capabilities.experimental == {
+        CONDUIT_DECISION_RETURN_CAPABILITY: {"version": 1}
+    }
+    session.send_notification.assert_awaited_once()
+    await incoming_send.aclose()
+    await outgoing_send.aclose()
+
+
+@pytest.mark.asyncio
+async def test_return_reads_canonical_decision_and_wakes_only_recorded_session() -> None:
+    calls: list[tuple[str, dict]] = []
+    wakes: list[tuple[str, str]] = []
+
+    class Session:
+        async def call_tool(self, name: str, arguments: dict):
+            calls.append((name, arguments))
+            return _result(arguments["decision_id"], "responded")
+
+    server = SimpleNamespace(
+        name="conduit",
+        session=Session(),
+        _rpc_lock=asyncio.Lock(),
+        initialize_result=SimpleNamespace(capabilities=SimpleNamespace(
+            experimental={CONDUIT_DECISION_RETURN_CAPABILITY: {"version": 1}},
+        )),
+    )
+    bridge = ConduitDecisionReturnBridge(max_origins=4)
+    bridge.set_waker(lambda session_id, content: wakes.append((session_id, content)) or True)
+    bridge.register_tool_result(
+        server_name="conduit",
+        tool_name="create_decision",
+        session_id="session-a",
+        result=_result("dec_return"),
+    )
+
+    await bridge.handle_notification(server, {
+        "method": "notifications/conduit/decision-return",
+        "params": {"version": 1, "decision_id": "dec_return", "stream_seq": 3},
+    })
+    await bridge.wait_idle()
+
+    assert calls == [("get_decision", {"decision_id": "dec_return"})]
+    assert len(wakes) == 1
+    assert wakes[0][0] == "session-a"
+    assert '"status":"responded"' in wakes[0][1]
+
+    # At-least-once transport must not produce duplicate continuation turns.
+    await bridge.handle_notification(server, {
+        "method": "notifications/conduit/decision-return",
+        "params": {"version": 1, "decision_id": "dec_return", "stream_seq": 3},
+    })
+    await bridge.wait_idle()
+    assert len(wakes) == 1
+
+    await bridge.handle_notification(server, {
+        "method": "notifications/conduit/decision-return",
+        "params": {"version": 1, "decision_id": "dec_return", "stream_seq": 4},
+    })
+    await bridge.wait_idle()
+    assert len(wakes) == 2
+    assert calls[-1] == ("get_decision", {"decision_id": "dec_return"})
+
+
+@pytest.mark.asyncio
+async def test_unknown_unready_and_wrong_server_returns_do_not_wake() -> None:
+    wakes: list[str] = []
+
+    class Session:
+        async def call_tool(self, _name: str, arguments: dict):
+            return _result(arguments["decision_id"], "ready")
+
+    server = SimpleNamespace(
+        name="conduit",
+        session=Session(),
+        _rpc_lock=asyncio.Lock(),
+        initialize_result=SimpleNamespace(capabilities=SimpleNamespace(
+            experimental={CONDUIT_DECISION_RETURN_CAPABILITY: {"version": 1}},
+        )),
+    )
+    bridge = ConduitDecisionReturnBridge(max_origins=2)
+    bridge.set_waker(lambda _session_id, content: wakes.append(content) or True)
+    bridge.register_tool_result(
+        server_name="conduit",
+        tool_name="create_decision",
+        session_id="session-a",
+        result=_result("dec_known"),
+    )
+    for decision_id in ("dec_unknown", "dec_known"):
+        await bridge.handle_notification(server, {
+            "method": "notifications/conduit/decision-return",
+            "params": {"version": 1, "decision_id": decision_id, "stream_seq": 2},
+        })
+    await bridge.wait_idle()
+    assert wakes == []
+
+    other = SimpleNamespace(**{**server.__dict__, "name": "other"})
+    await bridge.handle_notification(other, {
+        "method": "notifications/conduit/decision-return",
+        "params": {"version": 1, "decision_id": "dec_known", "stream_seq": 4},
+    })
+    await bridge.wait_idle()
+    assert wakes == []
+
+
+@pytest.mark.asyncio
+async def test_reverse_order_returns_route_to_their_exact_originators() -> None:
+    wakes: list[tuple[str, str]] = []
+
+    class Session:
+        async def call_tool(self, _name: str, arguments: dict):
+            return _result(arguments["decision_id"], "responded")
+
+    server = SimpleNamespace(
+        name="conduit",
+        session=Session(),
+        _rpc_lock=asyncio.Lock(),
+        initialize_result=SimpleNamespace(capabilities=SimpleNamespace(
+            experimental={CONDUIT_DECISION_RETURN_CAPABILITY: {"version": 1}},
+        )),
+    )
+    bridge = ConduitDecisionReturnBridge(max_origins=4)
+    bridge.set_waker(
+        lambda session_id, content: wakes.append((session_id, content)) or True
+    )
+    for decision_id, session_id in (("dec_a", "session-a"), ("dec_b", "session-b")):
+        bridge.register_tool_result(
+            server_name="conduit",
+            tool_name="create_decision",
+            session_id=session_id,
+            result=_result(decision_id),
+        )
+
+    for decision_id in ("dec_b", "dec_a"):
+        await bridge.handle_notification(server, {
+            "method": "notifications/conduit/decision-return",
+            "params": {"version": 1, "decision_id": decision_id, "stream_seq": 3},
+        })
+        await bridge.wait_idle()
+
+    assert [session_id for session_id, _ in wakes] == ["session-b", "session-a"]
+    assert "decision_id=dec_b" in wakes[0][1]
+    assert "decision_id=dec_a" in wakes[1][1]
+
+@pytest.mark.asyncio
+async def test_reconnect_reconciles_once_without_periodic_polling() -> None:
+    calls = 0
+    wakes: list[str] = []
+
+    class Session:
+        async def call_tool(self, _name: str, arguments: dict):
+            nonlocal calls
+            calls += 1
+            return _result(arguments["decision_id"], "responded")
+
+    server = SimpleNamespace(
+        name="conduit",
+        session=Session(),
+        _rpc_lock=asyncio.Lock(),
+        initialize_result=SimpleNamespace(capabilities=SimpleNamespace(
+            experimental={CONDUIT_DECISION_RETURN_CAPABILITY: {"version": 1}},
+        )),
+    )
+    bridge = ConduitDecisionReturnBridge(max_origins=2)
+    bridge.set_waker(lambda session_id, _content: wakes.append(session_id) or True)
+    bridge.register_tool_result(
+        server_name="conduit",
+        tool_name="create_decision",
+        session_id="session-a",
+        result=_result("dec_reconcile"),
+    )
+
+    await bridge.reconcile(server)
+    await bridge.wait_idle()
+    await bridge.reconcile(server)
+    await bridge.wait_idle()
+
+    assert calls == 1
+    assert wakes == ["session-a"]
+
+
+@pytest.mark.asyncio
+async def test_immediate_read_closes_response_before_registration_race() -> None:
+    wakes: list[str] = []
+
+    class Session:
+        async def call_tool(self, _name: str, arguments: dict):
+            return _result(arguments["decision_id"], "responded")
+
+    server = SimpleNamespace(
+        name="conduit",
+        session=Session(),
+        _rpc_lock=asyncio.Lock(),
+        initialize_result=SimpleNamespace(capabilities=SimpleNamespace(
+            experimental={CONDUIT_DECISION_RETURN_CAPABILITY: {"version": 1}},
+        )),
+    )
+    bridge = ConduitDecisionReturnBridge(max_origins=2)
+    bridge.set_waker(lambda session_id, _content: wakes.append(session_id) or True)
+    decision_id = bridge.register_tool_result(
+        server_name="conduit",
+        tool_name="create_decision",
+        session_id="session-race",
+        result=_result("dec_race"),
+    )
+    assert decision_id == "dec_race"
+
+    await bridge.reconcile_decision(server, decision_id)
+    await bridge.wait_idle()
+
+    assert wakes == ["session-race"]
+    await bridge.handle_notification(server, {
+        "method": "notifications/conduit/decision-return",
+        "params": {"version": 1, "decision_id": "dec_race", "stream_seq": 3},
+    })
+    await bridge.wait_idle()
+    assert wakes == ["session-race"]

--- a/tests/tools/test_conduit_decision_return.py
+++ b/tests/tools/test_conduit_decision_return.py
@@ -13,6 +13,7 @@ from tools.conduit_decision_return import (
     ConduitClientSession,
     ConduitDecisionReturnBridge,
     ConduitDecisionReturnNotification,
+    ConduitServerNotification,
     compatible_server_capability,
 )
 
@@ -57,6 +58,24 @@ def test_capability_and_notification_contract_are_exact() -> None:
                 "stream_seq": 3,
                 "title": "must not travel unsolicited",
             },
+        })
+
+
+def test_extended_notification_union_accepts_exact_jsonrpc_envelope() -> None:
+    wrapped = ConduitServerNotification.model_validate({
+        "jsonrpc": "2.0",
+        "method": "notifications/conduit/decision-return",
+        "params": {"version": 1, "decision_id": "dec_wire", "stream_seq": 3},
+    })
+
+    assert isinstance(wrapped.root, ConduitDecisionReturnNotification)
+    assert wrapped.root.jsonrpc == "2.0"
+
+    with pytest.raises(Exception):
+        ConduitServerNotification.model_validate({
+            "jsonrpc": "1.0",
+            "method": "notifications/conduit/decision-return",
+            "params": {"version": 1, "decision_id": "dec_wire", "stream_seq": 3},
         })
 
 

--- a/tests/tools/test_conduit_decision_return.py
+++ b/tests/tools/test_conduit_decision_return.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import anyio
 import pytest
+from pydantic import ValidationError
 from mcp import types as mcp_types
 
 from tools.conduit_decision_return import (
@@ -71,7 +72,7 @@ def test_extended_notification_union_accepts_exact_jsonrpc_envelope() -> None:
     assert isinstance(wrapped.root, ConduitDecisionReturnNotification)
     assert wrapped.root.jsonrpc == "2.0"
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         ConduitServerNotification.model_validate({
             "jsonrpc": "1.0",
             "method": "notifications/conduit/decision-return",

--- a/tests/tools/test_mcp_conduit_decision_return.py
+++ b/tests/tools/test_mcp_conduit_decision_return.py
@@ -33,6 +33,26 @@ async def test_opted_in_message_handler_routes_closed_return_notification() -> N
     handled.assert_awaited_once_with(server, notification)
 
 
+@pytest.mark.asyncio
+async def test_opted_in_message_handler_preserves_stock_list_changed() -> None:
+    from mcp.types import ToolListChangedNotification
+
+    server = mcp_tool.MCPServerTask("conduit")
+    server._config = {"decision_return": True}
+    wrapped = ConduitServerNotification(
+        root=ToolListChangedNotification(
+            method="notifications/tools/list_changed"
+        )
+    )
+
+    with patch.object(
+        mcp_tool.MCPServerTask, "_schedule_tools_refresh"
+    ) as scheduled:
+        await server._make_message_handler()(wrapped)
+
+    scheduled.assert_called_once_with()
+
+
 def _run_mcp_call(coro_or_factory, timeout=30):
     coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
     loop = asyncio.new_event_loop()

--- a/tests/tools/test_mcp_conduit_decision_return.py
+++ b/tests/tools/test_mcp_conduit_decision_return.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools import mcp_tool
+from tools.conduit_decision_return import (
+    ConduitDecisionReturnNotification,
+    ConduitServerNotification,
+    decision_return_bridge,
+)
+
+
+@pytest.mark.asyncio
+async def test_opted_in_message_handler_routes_closed_return_notification() -> None:
+    server = mcp_tool.MCPServerTask("conduit")
+    server._config = {"decision_return": True}
+    notification = ConduitDecisionReturnNotification.model_validate({
+        "method": "notifications/conduit/decision-return",
+        "params": {"version": 1, "decision_id": "dec_routed", "stream_seq": 3},
+    })
+    wrapped = ConduitServerNotification(root=notification)
+
+    with patch.object(
+        decision_return_bridge, "handle_notification", new=AsyncMock()
+    ) as handled:
+        await server._make_message_handler()(wrapped)
+
+    handled.assert_awaited_once_with(server, notification)
+
+
+def _run_mcp_call(coro_or_factory, timeout=30):
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+    loop = asyncio.new_event_loop()
+    try:
+        async def run():
+            server = mcp_tool._servers["conduit"]
+            server._rpc_lock = asyncio.Lock()
+            return await coro
+        return loop.run_until_complete(run())
+    finally:
+        loop.close()
+
+
+def test_create_result_is_correlated_before_handler_returns() -> None:
+    result = SimpleNamespace(
+        isError=False,
+        content=[],
+        structuredContent={
+            "decision": {
+                "request": {"id": "dec_origin"},
+                "response": None,
+                "status": "ready",
+            }
+        },
+    )
+    session = SimpleNamespace(call_tool=AsyncMock(return_value=result))
+    server = SimpleNamespace(
+        name="conduit",
+        session=session,
+        _rpc_lock=None,
+        _config={"decision_return": True},
+    )
+    with patch.dict(mcp_tool._servers, {"conduit": server}), patch(
+        "tools.mcp_tool._run_on_mcp_loop", side_effect=_run_mcp_call
+    ), patch.object(
+        decision_return_bridge,
+        "register_tool_result",
+        return_value="dec_origin",
+    ) as registered, patch.object(
+        decision_return_bridge,
+        "reconcile_decision",
+        new=AsyncMock(),
+    ) as reconciled:
+        handler = mcp_tool._make_tool_handler("conduit", "create_decision", 30.0)
+        payload = json.loads(handler({}, session_id="session-origin"))
+
+    assert payload["result"]["decision"]["request"]["id"] == "dec_origin"
+    registered.assert_called_once_with(
+        server_name="conduit",
+        tool_name="create_decision",
+        session_id="session-origin",
+        result=result,
+    )
+    reconciled.assert_awaited_once_with(server, "dec_origin")
+
+
+def test_decision_return_client_session_is_strictly_opt_in() -> None:
+    assert mcp_tool._mcp_client_session_class({}) is mcp_tool.ClientSession
+    assert (
+        mcp_tool._mcp_client_session_class({"decision_return": True})
+        is not mcp_tool.ClientSession
+    )
+    assert (
+        mcp_tool._mcp_client_session_class({"decision_return": "true"})
+        is mcp_tool.ClientSession
+    )

--- a/tools/conduit_decision_return.py
+++ b/tools/conduit_decision_return.py
@@ -1,0 +1,376 @@
+"""Bounded Conduit Decision Return support for Hermes MCP sessions.
+
+This module owns the complete optional adapter: the closed notification
+contract, origin correlation, canonical same-connection read, exact-session
+wake callback, duplicate suppression, and reconnect reconciliation.  The
+ordinary MCP path does not depend on it unless a server explicitly sets
+``decision_return: true``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+import hashlib
+import json
+import logging
+import threading
+import time
+from typing import Any, Callable, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, RootModel
+
+
+logger = logging.getLogger(__name__)
+
+CONDUIT_DECISION_RETURN_CAPABILITY = "io.conduit/decision-return"
+CONDUIT_DECISION_RETURN_METHOD = "notifications/conduit/decision-return"
+CONDUIT_DECISION_RETURN_VERSION = 1
+MAX_DECISION_ID_LENGTH = 1024
+TERMINAL_STATUSES = frozenset({"responded", "cancelled", "superseded", "expired"})
+
+
+class _DecisionReturnParams(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    version: int = Field(ge=1, le=1)
+    decision_id: str = Field(min_length=1, max_length=MAX_DECISION_ID_LENGTH)
+    stream_seq: int = Field(gt=0)
+
+
+class ConduitDecisionReturnNotification(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    method: str = Field(pattern=r"^notifications/conduit/decision-return$")
+    params: _DecisionReturnParams
+
+
+def compatible_server_capability(capabilities: Any) -> bool:
+    """Return whether capabilities advertise exactly Return protocol v1."""
+    experimental = getattr(capabilities, "experimental", None)
+    if not isinstance(experimental, dict):
+        return False
+    value = experimental.get(CONDUIT_DECISION_RETURN_CAPABILITY)
+    return (
+        isinstance(value, dict)
+        and set(value) == {"version"}
+        and value.get("version") == CONDUIT_DECISION_RETURN_VERSION
+    )
+
+
+class _Origin(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    server_name: str
+    session_id: str
+
+
+class ConduitDecisionReturnBridge:
+    """Correlate returned Decisions to the exact originating Hermes session."""
+
+    def __init__(self, *, max_origins: int = 256) -> None:
+        self._max_origins = max(1, max_origins)
+        self._origins: OrderedDict[str, _Origin] = OrderedDict()
+        self._consumed: OrderedDict[str, int] = OrderedDict()
+        self._fingerprints: dict[str, str] = {}
+        self._inflight: set[tuple[str, int]] = set()
+        self._tasks: set[asyncio.Task[None]] = set()
+        self._last_reconcile: dict[str, float] = {}
+        self._waker: Optional[Callable[[str, str], bool]] = None
+        self._state_lock = threading.RLock()
+
+    def set_waker(self, waker: Optional[Callable[[str, str], bool]]) -> None:
+        """Install the host-owned exact-session wake function."""
+        with self._state_lock:
+            self._waker = waker
+
+    def forget_session(self, session_id: str) -> None:
+        """Drop correlations when an interactive session is finalized/reset."""
+        if not session_id:
+            return
+        with self._state_lock:
+            for decision_id, origin in list(self._origins.items()):
+                if origin.session_id == session_id:
+                    self._origins.pop(decision_id, None)
+                    self._consumed.pop(decision_id, None)
+                    self._fingerprints.pop(decision_id, None)
+
+    def register_tool_result(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        session_id: str,
+        result: Any,
+    ) -> Optional[str]:
+        """Record only successful creation results before the tool call yields."""
+        if tool_name not in {"create_decision", "create_evidenced_decision"}:
+            return None
+        if not server_name or not session_id or getattr(result, "isError", False):
+            return None
+        structured = getattr(result, "structuredContent", None)
+        if not isinstance(structured, dict):
+            return None
+        decision = structured.get("decision")
+        request = decision.get("request") if isinstance(decision, dict) else None
+        decision_id = request.get("id") if isinstance(request, dict) else None
+        if (
+            not isinstance(decision_id, str)
+            or not decision_id
+            or len(decision_id) > MAX_DECISION_ID_LENGTH
+        ):
+            return None
+        with self._state_lock:
+            self._origins.pop(decision_id, None)
+            self._origins[decision_id] = _Origin(
+                server_name=server_name,
+                session_id=session_id,
+            )
+            self._consumed.pop(decision_id, None)
+            self._fingerprints.pop(decision_id, None)
+            while len(self._origins) > self._max_origins:
+                expired_id, _ = self._origins.popitem(last=False)
+                self._consumed.pop(expired_id, None)
+                self._fingerprints.pop(expired_id, None)
+        return decision_id
+
+    async def reconcile_decision(self, server: Any, decision_id: str) -> None:
+        """Close the response-before-registration race with one immediate read."""
+        capabilities = getattr(
+            getattr(server, "initialize_result", None), "capabilities", None
+        )
+        if not compatible_server_capability(capabilities):
+            return
+        with self._state_lock:
+            origin = self._origins.get(decision_id)
+            key = (decision_id, 0)
+            if (
+                origin is None
+                or origin.server_name != getattr(server, "name", None)
+                or key in self._inflight
+            ):
+                return
+            self._inflight.add(key)
+        self._spawn_delivery(server, decision_id, 0)
+
+    async def handle_notification(self, server: Any, notification: Any) -> None:
+        """Validate and enqueue a Return without blocking the MCP receive loop."""
+        capabilities = getattr(
+            getattr(server, "initialize_result", None), "capabilities", None
+        )
+        if not compatible_server_capability(capabilities):
+            return
+        if isinstance(notification, ConduitDecisionReturnNotification):
+            parsed = notification
+        else:
+            try:
+                parsed = ConduitDecisionReturnNotification.model_validate(notification)
+            except Exception:
+                return
+        decision_id = parsed.params.decision_id
+        stream_seq = parsed.params.stream_seq
+        with self._state_lock:
+            origin = self._origins.get(decision_id)
+            if origin is None or origin.server_name != getattr(server, "name", None):
+                return
+            if self._consumed.get(decision_id, 0) >= stream_seq:
+                return
+            key = (decision_id, stream_seq)
+            if key in self._inflight:
+                return
+            self._inflight.add(key)
+        self._spawn_delivery(server, decision_id, stream_seq)
+
+    async def reconcile(self, server: Any) -> None:
+        """Perform one bounded read of outstanding origins after attachment."""
+        capabilities = getattr(
+            getattr(server, "initialize_result", None), "capabilities", None
+        )
+        if not compatible_server_capability(capabilities):
+            return
+        server_name = str(getattr(server, "name", ""))
+        now = time.monotonic()
+        with self._state_lock:
+            if now - self._last_reconcile.get(server_name, 0.0) < 2.0:
+                return
+            self._last_reconcile[server_name] = now
+            candidates = [
+                decision_id
+                for decision_id, origin in self._origins.items()
+                if origin.server_name == server_name
+                and decision_id not in self._consumed
+                and (decision_id, 0) not in self._inflight
+            ]
+            for decision_id in candidates:
+                self._inflight.add((decision_id, 0))
+        for decision_id in candidates:
+            self._spawn_delivery(server, decision_id, 0)
+
+    def _spawn_delivery(self, server: Any, decision_id: str, stream_seq: int) -> None:
+        task = asyncio.create_task(
+            self._deliver(server, decision_id, stream_seq),
+            name=f"conduit-return:{getattr(server, 'name', 'server')}",
+        )
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _deliver(self, server: Any, decision_id: str, stream_seq: int) -> None:
+        key = (decision_id, stream_seq)
+        try:
+            session = getattr(server, "session", None)
+            if session is None:
+                return
+            async with server._rpc_lock:
+                result = await session.call_tool(
+                    "get_decision", arguments={"decision_id": decision_id}
+                )
+            if getattr(result, "isError", False):
+                return
+            structured = getattr(result, "structuredContent", None)
+            decision = structured.get("decision") if isinstance(structured, dict) else None
+            request = decision.get("request") if isinstance(decision, dict) else None
+            if (
+                not isinstance(decision, dict)
+                or not isinstance(request, dict)
+                or request.get("id") != decision_id
+                or decision.get("status") not in TERMINAL_STATUSES
+            ):
+                return
+            with self._state_lock:
+                origin = self._origins.get(decision_id)
+                waker = self._waker
+            if origin is None or origin.server_name != getattr(server, "name", None):
+                return
+            if waker is None:
+                return
+            canonical = json.dumps(decision, ensure_ascii=False, separators=(",", ":"))
+            fingerprint = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+            with self._state_lock:
+                previous_seq = self._consumed.get(decision_id)
+                previous_fingerprint = self._fingerprints.get(decision_id)
+            if (
+                previous_seq == 0
+                and stream_seq > 0
+                and previous_fingerprint == fingerprint
+            ):
+                with self._state_lock:
+                    self._consumed[decision_id] = stream_seq
+                return
+            message = (
+                "[Conduit Decision Return]\n"
+                "The Decision below was read canonically through the same Conduit "
+                "connection and belongs to this originating session. Continue from "
+                "the human custody result; this Return grants no additional effect "
+                "authority.\n"
+                f"decision_id={decision_id}\n"
+                f"stream_seq={stream_seq}\n"
+                f"canonical_decision={canonical}"
+            )
+            if not waker(origin.session_id, message):
+                return
+            with self._state_lock:
+                self._consumed.pop(decision_id, None)
+                self._consumed[decision_id] = stream_seq
+                self._fingerprints[decision_id] = fingerprint
+                while len(self._consumed) > self._max_origins:
+                    expired_id, _ = self._consumed.popitem(last=False)
+                    self._fingerprints.pop(expired_id, None)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Conduit Decision Return delivery failed", exc_info=True)
+        finally:
+            with self._state_lock:
+                self._inflight.discard(key)
+
+    async def wait_idle(self) -> None:
+        """Test/cleanup seam: wait until currently scheduled deliveries settle."""
+        while self._tasks:
+            await asyncio.gather(*tuple(self._tasks), return_exceptions=True)
+
+
+decision_return_bridge = ConduitDecisionReturnBridge()
+
+
+# The Python MCP SDK models server notifications as a closed union.  Extend
+# that one validation boundary only for explicitly enabled Conduit sessions.
+try:
+    from mcp import ClientSession as _ClientSession, types as _mcp_types
+    from mcp.client.session import (
+        SUPPORTED_PROTOCOL_VERSIONS as _SUPPORTED_PROTOCOL_VERSIONS,
+        _default_elicitation_callback,
+        _default_list_roots_callback,
+        _default_sampling_callback,
+    )
+
+    _stock_notification_union = _mcp_types.ServerNotification.model_fields[
+        "root"
+    ].annotation
+    _extended_notification_union = Union[
+        _stock_notification_union, ConduitDecisionReturnNotification
+    ]
+
+    class ConduitServerNotification(RootModel[_extended_notification_union]):
+        root: _extended_notification_union
+
+
+    class ConduitClientSession(_ClientSession):
+        """ClientSession advertising and accepting only Return protocol v1."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            self._receive_notification_type = ConduitServerNotification
+
+        async def initialize(self) -> Any:
+            sampling = (
+                (self._sampling_capabilities or _mcp_types.SamplingCapability())
+                if self._sampling_callback is not _default_sampling_callback
+                else None
+            )
+            elicitation = (
+                _mcp_types.ElicitationCapability(
+                    form=_mcp_types.FormElicitationCapability(),
+                    url=_mcp_types.UrlElicitationCapability(),
+                )
+                if self._elicitation_callback is not _default_elicitation_callback
+                else None
+            )
+            roots = (
+                _mcp_types.RootsCapability(listChanged=True)
+                if self._list_roots_callback is not _default_list_roots_callback
+                else None
+            )
+            result = await self.send_request(
+                _mcp_types.ClientRequest(
+                    _mcp_types.InitializeRequest(
+                        params=_mcp_types.InitializeRequestParams(
+                            protocolVersion=_mcp_types.LATEST_PROTOCOL_VERSION,
+                            capabilities=_mcp_types.ClientCapabilities(
+                                sampling=sampling,
+                                elicitation=elicitation,
+                                experimental={
+                                    CONDUIT_DECISION_RETURN_CAPABILITY: {"version": 1}
+                                },
+                                roots=roots,
+                                tasks=self._task_handlers.build_capability(),
+                            ),
+                            clientInfo=self._client_info,
+                        )
+                    )
+                ),
+                _mcp_types.InitializeResult,
+            )
+            if result.protocolVersion not in _SUPPORTED_PROTOCOL_VERSIONS:
+                raise RuntimeError(
+                    "Unsupported protocol version from the server: "
+                    f"{result.protocolVersion}"
+                )
+            self._server_capabilities = result.capabilities
+            await self.send_notification(
+                _mcp_types.ClientNotification(_mcp_types.InitializedNotification())
+            )
+            return result
+
+except ImportError:  # pragma: no cover - MCP is an optional Hermes extra.
+    ConduitClientSession = None  # type: ignore[assignment,misc]
+    ConduitServerNotification = None  # type: ignore[assignment,misc]

--- a/tools/conduit_decision_return.py
+++ b/tools/conduit_decision_return.py
@@ -16,7 +16,7 @@ import json
 import logging
 import threading
 import time
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
@@ -41,6 +41,7 @@ class _DecisionReturnParams(BaseModel):
 class ConduitDecisionReturnNotification(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
 
+    jsonrpc: Literal["2.0"] = "2.0"
     method: str = Field(pattern=r"^notifications/conduit/decision-return$")
     params: _DecisionReturnParams
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -253,7 +253,7 @@ _MCP_SDK_LAZY_SYMBOLS = frozenset({
     "CreateMessageResult", "CreateMessageResultWithTools", "ErrorData",
     "SamplingCapability", "SamplingToolsCapability", "TextContent",
     "ToolUseContent", "ElicitRequestParams", "ElicitResult",
-    "ServerNotification", "ToolListChangedNotification",
+    "ToolListChangedNotification",
     "PromptListChangedNotification", "ResourceListChangedNotification",
 })
 
@@ -288,8 +288,8 @@ def _ensure_mcp_sdk() -> bool:
     global CreateMessageResult, CreateMessageResultWithTools, ErrorData
     global SamplingCapability, SamplingToolsCapability, TextContent, ToolUseContent
     global ElicitRequestParams, ElicitResult
-    global ServerNotification, ToolListChangedNotification
-    global PromptListChangedNotification, ResourceListChangedNotification
+    global ToolListChangedNotification, PromptListChangedNotification
+    global ResourceListChangedNotification
 
     if not _MCP_AVAILABLE:
         return False
@@ -351,7 +351,6 @@ def _ensure_mcp_sdk() -> bool:
             # Notification types for dynamic tool discovery (tools/list_changed)
             try:
                 from mcp.types import (
-                    ServerNotification,
                     ToolListChangedNotification,
                     PromptListChangedNotification,
                     ResourceListChangedNotification,
@@ -2311,8 +2310,8 @@ class MCPServerTask:
                 ):
                     await decision_return_bridge.handle_notification(self, root)
                     return
-                if _MCP_NOTIFICATION_TYPES and isinstance(message, ServerNotification):
-                    match message.root:
+                if _MCP_NOTIFICATION_TYPES:
+                    match root:
                         case ToolListChangedNotification():
                             logger.info(
                                 "MCP server '%s': received tools/list_changed notification",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -236,6 +236,9 @@ if not _MCP_AVAILABLE:
     logger.debug("mcp package not installed -- MCP tool support disabled")
 
 ClientSession: Any = None
+ConduitClientSession: Any = None
+ConduitDecisionReturnNotification: Any = None
+decision_return_bridge: Any = None
 _MCP_SDK_IMPORT_ATTEMPTED = False
 _MCP_SDK_IMPORT_LOCK = threading.Lock()
 
@@ -279,6 +282,8 @@ def _ensure_mcp_sdk() -> bool:
     global _MCP_MESSAGE_HANDLER_SUPPORTED, _MCP_LOGGING_CALLBACK_SUPPORTED
     global _MCP_NEW_HTTP, LATEST_PROTOCOL_VERSION, sse_client
     global ClientSession, StdioServerParameters, stdio_client
+    global ConduitClientSession, ConduitDecisionReturnNotification
+    global decision_return_bridge
     global streamablehttp_client, streamable_http_client
     global CreateMessageResult, CreateMessageResultWithTools, ErrorData
     global SamplingCapability, SamplingToolsCapability, TextContent, ToolUseContent
@@ -354,6 +359,11 @@ def _ensure_mcp_sdk() -> bool:
                 _MCP_NOTIFICATION_TYPES = True
             except ImportError:
                 logger.debug("MCP notification types not available -- dynamic tool discovery disabled")
+            from tools.conduit_decision_return import (
+                ConduitClientSession,
+                ConduitDecisionReturnNotification,
+                decision_return_bridge,
+            )
         except ImportError:
             logger.debug("mcp package not installed -- MCP tool support disabled")
 
@@ -385,6 +395,14 @@ def _check_message_handler_support() -> bool:
         return "message_handler" in inspect.signature(ClientSession).parameters
     except (TypeError, ValueError):
         return False
+
+
+def _mcp_client_session_class(config: dict):
+    """Select the extended client only for an explicit boolean opt-in."""
+    _ensure_mcp_sdk()
+    if config.get("decision_return") is True and ConduitClientSession is not None:
+        return ConduitClientSession
+    return ClientSession
 
 
 def _check_logging_callback_support() -> bool:
@@ -2285,6 +2303,14 @@ class MCPServerTask:
                 if isinstance(message, Exception):
                     logger.debug("MCP message handler (%s): exception: %s", self.name, message)
                     return
+                root = getattr(message, "root", None)
+                if (
+                    self._config.get("decision_return") is True
+                    and ConduitDecisionReturnNotification is not None
+                    and isinstance(root, ConduitDecisionReturnNotification)
+                ):
+                    await decision_return_bridge.handle_notification(self, root)
+                    return
                 if _MCP_NOTIFICATION_TYPES and isinstance(message, ServerNotification):
                     match message.root:
                         case ToolListChangedNotification():
@@ -2749,7 +2775,7 @@ class MCPServerTask:
                         for _pid in new_pids:
                             _stdio_pids[_pid] = self.name
                         _stdio_pgids.update(new_pgids)
-                async with ClientSession(
+                async with _mcp_client_session_class(config)(
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
                     # Bound the MCP handshake. A stdio server that never
@@ -2771,6 +2797,8 @@ class MCPServerTask:
                     )
                     self.session = session
                     self._mark_lifecycle_started()
+                    if config.get("decision_return") is True:
+                        await decision_return_bridge.reconcile(self)
                     await self._discover_tools()
                     self._ready.set()
                     # Session is live again: clear any breaker state from a
@@ -3121,7 +3149,7 @@ class MCPServerTask:
                 _sse_kwargs["httpx_client_factory"] = _mcp_http_client_factory
             try:
                 async with sse_client(**_sse_kwargs) as (read_stream, write_stream):
-                    async with ClientSession(
+                    async with _mcp_client_session_class(config)(
                         read_stream, write_stream, **sampling_kwargs
                     ) as session:
                         # Bound the handshake — same orphaned-task hang as the
@@ -3132,6 +3160,8 @@ class MCPServerTask:
                             session.initialize(), timeout=float(connect_timeout)
                         )
                         self.session = session
+                        if config.get("decision_return") is True:
+                            await decision_return_bridge.reconcile(self)
                         await self._discover_tools()
                         self._ready.set()
                         # Session is live again: clear any breaker state from a
@@ -3185,12 +3215,14 @@ class MCPServerTask:
                     async with streamable_http_client(url, http_client=http_client) as (
                         read_stream, write_stream, _get_session_id,
                     ):
-                        async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                        async with _mcp_client_session_class(config)(read_stream, write_stream, **sampling_kwargs) as session:
                             # Bound the handshake (#59349) — see stdio path.
                             self.initialize_result = await asyncio.wait_for(
                                 session.initialize(), timeout=float(connect_timeout)
                             )
                             self.session = session
+                            if config.get("decision_return") is True:
+                                await decision_return_bridge.reconcile(self)
                             await self._discover_tools()
                             self._ready.set()
                             # Session is live again: clear any breaker state from
@@ -3232,12 +3264,14 @@ class MCPServerTask:
                 async with streamablehttp_client(url, **_http_kwargs) as (
                     read_stream, write_stream, _get_session_id,
                 ):
-                    async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                    async with _mcp_client_session_class(config)(read_stream, write_stream, **sampling_kwargs) as session:
                         # Bound the handshake (#59349) — see stdio path.
                         self.initialize_result = await asyncio.wait_for(
                             session.initialize(), timeout=float(connect_timeout)
                         )
                         self.session = session
+                        if config.get("decision_return") is True:
+                            await decision_return_bridge.reconcile(self)
                         await self._discover_tools()
                         self._ready.set()
                         # Session is live again: clear any breaker state from a
@@ -5411,6 +5445,20 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     result = await server.session.call_tool(tool_name, arguments=args)
                 finally:
                     server._pending_call_context = None
+            if (
+                getattr(server, "_config", {}).get("decision_return") is True
+                and decision_return_bridge is not None
+            ):
+                registered_decision_id = decision_return_bridge.register_tool_result(
+                    server_name=server_name,
+                    tool_name=tool_name,
+                    session_id=str(kwargs.get("session_id") or ""),
+                    result=result,
+                )
+                if registered_decision_id is not None:
+                    await decision_return_bridge.reconcile_decision(
+                        server, registered_decision_id
+                    )
             # The RPC round-trip completed — the session is demonstrably
             # healthy at the transport level (even if the tool itself
             # returned isError). Clear the rapid-drop budget (#62212).


### PR DESCRIPTION
## Summary
- add a capability-gated Conduit Decision Return bridge that resumes the originating Hermes session when a decision is finalized
- preserve stock MCP notification handling while dispatching the custom notification
- enforce strict JSON-RPC 2.0 Decision Return envelopes and bounded replay/correction behavior

## Validation
- focused Decision Return tests: 8 passed after final review remediation
- full implementation-focused suite: 54 passed
- Python compile check and `git diff --check`: clean
- live walkthrough: ordinary return, duplicate replay, correction, finalized interaction, Host restart/reload recovery, disconnect recovery, and no-authority refusal all passed

## Review
- adversarial implementation review: PASS_WITH_FINDINGS; finding remediated
- bounded post-review code review: Standards PASS after precise `ValidationError` assertion; Spec PASS

Companion Conduit PR: https://github.com/ValkaEdda/conduit/pull/13