### PR TITLE
fix: stabilize optional integrations and macOS health checks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1718,8 +1718,9 @@ def init_agent(
                     user_char_limit=mem_config.get("user_char_limit", 1375),
                 )
                 agent._memory_store.load_from_disk()
-        except Exception:
-            pass  # Memory is optional -- don't break agent init
+        except Exception as _mem_err:
+            agent._memory_store = None
+            _ra().logger.warning("Memory store init/load failed, continuing without it: %s", _mem_err)
     
 
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2531,7 +2531,14 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         anthropic_oauth_env = (
             _env_val("ANTHROPIC_TOKEN") or _env_val("CLAUDE_CODE_OAUTH_TOKEN")
         )
-        api_key_path_explicit = bool(anthropic_api_key and not anthropic_oauth_env)
+        manual_api_key_path = any(
+            _is_manual_source(entry.source)
+            and entry.auth_type == AUTH_TYPE_API_KEY
+            for entry in entries
+        )
+        api_key_path_explicit = bool(
+            (anthropic_api_key or manual_api_key_path) and not anthropic_oauth_env
+        )
 
         if api_key_path_explicit:
             # Prune any stale autodiscovered OAuth entries that may have been

--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -43,8 +43,8 @@ def is_gateway_supervisor_process(
         return True
     if env.get("HERMES_S6_SUPERVISED_CHILD"):
         return True
-    xpc_service = env.get("XPC_SERVICE_NAME", "")
-    if xpc_service and xpc_service != "0":
+    xpc_service = str(env.get("XPC_SERVICE_NAME", "")).strip().lower()
+    if xpc_service not in {"", "0", "false", "off", "no"}:
         return True
     return str(env.get(EXTERNAL_GATEWAY_SUPERVISOR_ENV, "")).strip().lower() in {
         "1",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27787,9 +27787,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # `hermes gateway stop` and interactive Ctrl+C are handled above as
     # planned stops and should not trigger service-manager revival.
     if _signal_initiated_shutdown and not runner._restart_requested:
+        _xpc_service_name = str(os.environ.get("XPC_SERVICE_NAME") or "").strip().lower()
+        _launchd_supervised = _xpc_service_name not in {"", "0", "false", "off", "no"}
+        _supervisor = (
+            "launchd KeepAlive" if _launchd_supervised else "systemd Restart=on-failure"
+        )
         logger.info(
             "Exiting with code 1 (signal-initiated shutdown without restart "
-            "request) so systemd Restart=on-failure can revive the gateway."
+            "request) so %s can revive the gateway.",
+            _supervisor,
         )
         return False  # → sys.exit(1) in the caller
 

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import shutil
 import subprocess
 import sys
 import time
@@ -108,7 +109,8 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
 
     * The signal number/name (so SIGINT vs SIGTERM is visible)
     * Our own PID/ppid + parent process info from /proc (Linux)
-    * Whether systemd is our parent (``ppid==1`` or ``INVOCATION_ID`` set)
+    * Whether systemd is our parent (``ppid==1`` on non-macOS or
+      ``INVOCATION_ID`` set)
     * Whether takeover/planned-stop markers exist (consumed lazily by the caller)
     * /proc/self limits + load average (1-min)
     * Wall-clock and monotonic timestamps for cross-correlating later phases
@@ -132,15 +134,26 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
     }
 
     # systemd context.  If we were started by a systemd unit, INVOCATION_ID
-    # is set in our env.  ppid==1 (init) is also a strong signal that
-    # systemd reaped+forwarded the SIGTERM.
+    # is set in our env.  ppid==1 is *not* a reliable systemd signal on its
+    # own: launchd is also PID 1 on macOS, so this heuristic used to label
+    # every launchd-supervised shutdown as "under_systemd" too. XPC_SERVICE_NAME
+    # is launchd's equivalent of INVOCATION_ID (set for any launchd job) and
+    # disambiguates the two supervisors.
     invocation_id = os.environ.get("INVOCATION_ID")
     if invocation_id:
         ctx["systemd_invocation_id"] = invocation_id
     journal_stream = os.environ.get("JOURNAL_STREAM")
     if journal_stream:
         ctx["systemd_journal_stream"] = journal_stream
-    ctx["under_systemd"] = bool(invocation_id) or ppid == 1
+    launchd_service_name = os.environ.get("XPC_SERVICE_NAME")
+    launchd_marker = str(launchd_service_name or "").strip().lower()
+    launchd_supervised = launchd_marker not in {"", "0", "false", "off", "no"}
+    if launchd_supervised:
+        ctx["launchd_service_name"] = launchd_service_name
+    ctx["under_launchd"] = launchd_supervised
+    ctx["under_systemd"] = bool(invocation_id) or (
+        ppid == 1 and sys.platform != "darwin" and not launchd_supervised
+    )
 
     # Load average — high load points the finger at "something else
     # crushing the box" rather than "external killer".
@@ -249,13 +262,39 @@ def spawn_async_diagnostic(
         return None
 
     try:
+        # macOS does not ship GNU coreutils' ``timeout``. Prefer it when
+        # available, but keep the diagnostic self-contained on POSIX hosts.
+        timeout_bin = shutil.which("timeout")
+        if timeout_bin:
+            command = [timeout_bin, f"{timeout_seconds:.0f}", "bash", "-c", script]
+        else:
+            timeout_runner = (
+                "import os, signal, subprocess, sys\n"
+                "child = subprocess.Popen(['bash', '-c', sys.argv[2]], start_new_session=True)\n"
+                "try:\n"
+                "    child.wait(timeout=float(sys.argv[1]))\n"
+                "except subprocess.TimeoutExpired:\n"
+                "    if child.poll() is None:\n"
+                "        try:\n"
+                "            os.killpg(child.pid, signal.SIGKILL)\n"
+                "        except (ProcessLookupError, PermissionError):\n"
+                "            pass\n"
+                "    child.wait()\n"
+            )
+            command = [
+                sys.executable,
+                "-c",
+                timeout_runner,
+                f"{timeout_seconds:.0f}",
+                script,
+            ]
         # Detach from our process group so the subprocess survives even
         # if systemd kills our cgroup with KillMode=control-group (which
         # would also reap us anyway, but defense in depth).  Without
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            command,
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,
@@ -286,6 +325,7 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     parent_name = parent.get("name") or "?"
     parent_pid = parent.get("pid") or "?"
     under_systemd = "yes" if ctx.get("under_systemd") else "no"
+    under_launchd = "yes" if ctx.get("under_launchd") else "no"
     load = ctx.get("loadavg_1m")
     load_str = f"{load:.2f}" if isinstance(load, (int, float)) else "?"
     extras: List[str] = []
@@ -303,6 +343,7 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     return (
         f"signal={sig} "
         f"under_systemd={under_systemd} "
+        f"under_launchd={under_launchd} "
         f"parent_pid={parent_pid} "
         f"parent_name={parent_name} "
         f"loadavg_1m={load_str}"

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1593,7 +1593,7 @@ def run_doctor(args):
         if nous_status.get("logged_in"):
             check_ok("Nous Portal auth", "(logged in)")
         else:
-            check_warn("Nous Portal auth", "(not logged in)")
+            check_info("Nous Portal auth (not logged in — optional)")
 
         codex_status = get_codex_auth_status()
         if codex_status.get("logged_in"):
@@ -1618,7 +1618,7 @@ def run_doctor(args):
             region = minimax_status.get("region", "global")
             check_ok("MiniMax OAuth", f"(logged in, region={region})")
         else:
-            check_warn("MiniMax OAuth", "(not logged in)")
+            check_info("MiniMax OAuth (not logged in — optional)")
     except Exception as e:
         check_warn("Auth provider status", f"(could not check: {e})")
 
@@ -1630,7 +1630,7 @@ def run_doctor(args):
         if xai_oauth_status.get("logged_in"):
             check_ok("xAI OAuth", "(logged in)")
         else:
-            check_warn("xAI OAuth", "(not logged in)")
+            check_info("xAI OAuth (not logged in — optional)")
             if xai_oauth_status.get("error"):
                 check_info(xai_oauth_status["error"])
     except Exception:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -541,6 +541,26 @@ def _missing_api_key_toolsets_for_summary(unavailable: list[dict]) -> list[dict]
     ]
 
 
+def _active_unavailable_toolsets_for_doctor(unavailable: list[dict]) -> list[dict]:
+    """Return unavailable toolsets that are active on the CLI surface.
+
+    The registry is global and includes optional integrations for every
+    platform. Reporting every unavailable integration from ``hermes doctor``
+    made explicitly disabled or unconfigured toolsets look like active
+    failures (for example Discord, X search, and image generation). Keep the
+    full registry for internal availability checks, but only warn about the
+    toolsets Hermes will actually load for the current CLI configuration.
+    """
+    enabled_toolsets = _enabled_cli_toolsets_for_doctor()
+    if enabled_toolsets is None:
+        return list(unavailable)
+    return [
+        item
+        for item in unavailable
+        if str(item.get("name") or "") in enabled_toolsets
+    ]
+
+
 def _read_pyproject_version() -> str | None:
     """Read the ``version = "..."`` from ``pyproject.toml`` at the project root.
 
@@ -2759,6 +2779,7 @@ def run_doctor(args):
         
         available, unavailable = check_tool_availability()
         available, unavailable = _apply_doctor_tool_availability_overrides(available, unavailable)
+        unavailable = _active_unavailable_toolsets_for_doctor(unavailable)
         
         for tid in available:
             info = TOOLSET_REQUIREMENTS.get(tid, {})

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -487,7 +487,6 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
         if path.exists():
             return
         path.mkdir(parents=False, exist_ok=False)
-        path.chmod(mode)
         try:
             os.chown(path, _HERMES_UID, _HERMES_GID)
         except PermissionError:
@@ -496,6 +495,8 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
             # swallowing this keeps both root and unprivileged callers
             # on one code path.
             pass
+        # chown can clear setgid on POSIX, so apply the requested mode last.
+        path.chmod(mode)
 
     # Top-level event/ dir (this is the s6-svlisten1 event-subscription
     # dir at the service root, distinct from supervise/event/).

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6914,16 +6914,49 @@ class SlackAdapter(BasePlatformAdapter):
         }
         choice = choice_map.get(action_id, "deny")
 
-        # Prevent double-clicks — atomic pop; first caller gets False, others get True (default)
-        # Check both the workspace-scoped marker and the bare ts: the approval
-        # may have been stored without a team id (metadata-poor send path)
-        # while the click event carries one, and that mismatch must not
-        # swallow a legitimate first click.
+        # Prevent double-clicks — atomic pop; first caller gets False, others get True (default).
+        # Reconcile the workspace-scoped marker and bare timestamp because Slack
+        # interaction payloads do not always carry the same team metadata as the
+        # send path. Never guess when multiple workspaces share a timestamp.
         approval_key = self._workspace_message_marker(team_id, msg_ts)
         if msg_ts in self._approval_resolved:
             approval_key = msg_ts
+        if approval_key not in self._approval_resolved:
+            matching_keys = [
+                key
+                for key, resolved in self._approval_resolved.items()
+                if (
+                    isinstance(key, tuple)
+                    and len(key) == 2
+                    and str(key[1]) == str(msg_ts)
+                    and not resolved
+                )
+            ]
+            if len(matching_keys) == 1:
+                approval_key = matching_keys[0]
+            else:
+                logger.info(
+                    "[Slack] Approval click ignored: no unambiguous pending key "
+                    "for team_id=%s msg_ts=%s candidates=%s",
+                    team_id,
+                    msg_ts,
+                    len(matching_keys),
+                )
+                return
         if self._approval_resolved.pop(approval_key, True):
+            logger.info(
+                "[Slack] Approval click swallowed by double-click guard: "
+                "action_id=%s session=%s user=%s team_id=%s msg_ts=%s "
+                "approval_key=%s",
+                action_id,
+                session_key,
+                user_name,
+                team_id,
+                msg_ts,
+                approval_key,
+            )
             return
+
 
         # Resolve the approval FIRST — this unblocks the agent thread. Render
         # after, so a click that lands past the approval timeout (count == 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ wake = [
   "sherpa-onnx==1.13.4",
   "sentencepiece==0.2.2",
   "pvporcupine==4.0.3",
+  "backports-strenum==1.3.1; platform_system == 'Darwin'",
   "sounddevice==0.5.5",
   "numpy==2.4.3",
   # openWakeWord's onnx embedding model scores near-zero on macOS ARM64
@@ -390,6 +391,13 @@ exclude-newer = "14 days"
 # aiohttp, cryptography: same shape — the advisory fixes are newer than the
 # 14-day window, so the resolver cannot see them without an exception.
 exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false }
+
+[tool.uv.sources]
+# ai-edge-litert 2.1.6 declares backports-strenum without its upstream
+# Python<3.11 marker. Use the local metadata-correct compatibility package so
+# uv/pip checks stay truthful on Python 3.11+ while older Python versions still
+# receive the backported StrEnum implementation.
+backports-strenum = { path = "vendor/backports-strenum" }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -709,21 +709,25 @@ class TestHealthDetailedEndpoint:
             "exit_reason": None,
             "updated_at": "2026-04-14T00:00:00Z",
         }), patch("gateway.run._resolve_gateway_model", return_value="test/model"):
-            async with TestClient(TestServer(app)) as cli:
-                resp = await cli.get("/health/detailed")
-                assert resp.status == 200
-                data = await resp.json()
-                assert data["status"] == "ok"
-                assert data["platform"] == "hermes-agent"
-                assert data["gateway_state"] == "running"
-                assert data["platforms"] == {"telegram": {"state": "connected"}}
-                assert data["active_agents"] == 2
-                # Derived busy/drainable: this endpoint is served BY the live
-                # gateway, so running + 2 agents ⇒ busy and drainable.
-                assert data["gateway_busy"] is True
-                assert data["gateway_drainable"] is True
-                assert isinstance(data["pid"], int)
-                assert "updated_at" in data
+            with patch(
+                "gateway.readiness._probe_disk",
+                return_value={"status": "ok", "used_percent": 10.0, "free_bytes": 90},
+            ):
+                async with TestClient(TestServer(app)) as cli:
+                    resp = await cli.get("/health/detailed")
+                    assert resp.status == 200
+                    data = await resp.json()
+                    assert data["status"] == "ok"
+                    assert data["platform"] == "hermes-agent"
+                    assert data["gateway_state"] == "running"
+                    assert data["platforms"] == {"telegram": {"state": "connected"}}
+                    assert data["active_agents"] == 2
+                    # Derived busy/drainable: this endpoint is served BY the live
+                    # gateway, so running + 2 agents ⇒ busy and drainable.
+                    assert data["gateway_busy"] is True
+                    assert data["gateway_drainable"] is True
+                    assert isinstance(data["pid"], int)
+                    assert "updated_at" in data
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -4,6 +4,7 @@ import json
 import os
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 from gateway.readiness import collect_runtime_readiness
 
@@ -18,6 +19,10 @@ def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monke
     with sqlite3.connect(home / "state.db") as conn:
         conn.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        "gateway.readiness.shutil.disk_usage",
+        lambda _path: SimpleNamespace(total=100, used=10, free=90),
+    )
 
     result = collect_runtime_readiness(
         configured_model="test/model",

--- a/tests/gateway/test_restart_service_detection.py
+++ b/tests/gateway/test_restart_service_detection.py
@@ -20,7 +20,7 @@ import pytest
 
 import gateway.run as gateway_run
 from gateway.platforms.base import MessageEvent, MessageType
-from gateway.restart import EXTERNAL_GATEWAY_SUPERVISOR_ENV
+from gateway.restart import EXTERNAL_GATEWAY_SUPERVISOR_ENV, is_gateway_supervisor_process
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
 
 
@@ -76,3 +76,12 @@ async def test_false_external_supervisor_marker_keeps_detached_path(
     await runner._handle_restart_command(_make_restart_event())
 
     runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "off", "no"])
+def test_false_launchd_marker_is_not_supervised(value):
+    assert is_gateway_supervisor_process({"XPC_SERVICE_NAME": value}) is False
+
+
+def test_launchd_job_label_is_supervised():
+    assert is_gateway_supervisor_process({"XPC_SERVICE_NAME": "com.atlas.hermes"}) is True

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -43,6 +43,17 @@ class TestSnapshotShutdownContext:
         assert before <= ctx["ts"] <= after
         assert isinstance(ctx["ts_monotonic"], float)
 
+    def test_interactive_macos_xpc_zero_is_not_supervised(self, monkeypatch):
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+        monkeypatch.setattr(sf.sys, "platform", "darwin")
+        monkeypatch.setattr(sf.os, "getppid", lambda: 1)
+
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+
+        assert ctx["under_launchd"] is False
+        assert ctx["under_systemd"] is False
+
 
     def test_under_systemd_false_without_invocation_id_and_normal_ppid(
         self, monkeypatch

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -149,6 +149,34 @@ class TestSlackApprovalAction:
 
 
     @pytest.mark.asyncio
+    async def test_reconciles_workspace_key_when_click_omits_team(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved[("T1", "1234.5678")] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U_ALICE"},
+        }
+        action = {
+            "action_id": "hermes_approve_once",
+            "value": "session-key",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch(
+            "tools.approval.resolve_gateway_approval", return_value=1
+        ) as resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        resolve.assert_called_once_with("session-key", "once")
+
+
+    @pytest.mark.asyncio
     async def test_truncates_inflated_original_text(self):
         """Interaction payload re-escapes HTML entities; text must be capped."""
         adapter = _make_adapter()

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import sys
 
 import pytest
 
 
 @pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
+    not hasattr(socket, "AF_UNIX") or sys.platform == "darwin",
+    reason="systemd abstract sockets are unavailable on this platform",
 )
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -63,6 +63,17 @@ class TestDoctorToolAvailabilitySummary:
 
         assert [item["name"] for item in filtered] == ["web"]
 
+    def test_active_unavailable_toolsets_ignore_disabled_integrations(self, monkeypatch):
+        unavailable = [
+            {"name": "image_gen", "env_vars": [], "tools": ["generate_image"]},
+            {"name": "web", "env_vars": [], "tools": ["web_search"]},
+        ]
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: {"web"})
+
+        filtered = doctor._active_unavailable_toolsets_for_doctor(unavailable)
+
+        assert [item["name"] for item in filtered] == ["web"]
+
 
 class TestDoctorEnvFileEncoding:
     """Regression for #18637 (bug 3): `hermes doctor` crashed on Windows

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -194,6 +194,7 @@ def fake_subprocess_run(monkeypatch: pytest.MonkeyPatch):
 
 def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     """Verifies the dirs + FIFO + modes the helper lays down."""
+    import os
     import stat
 
     from hermes_cli.service_manager import _seed_supervise_skeleton
@@ -206,7 +207,10 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # Top-level event/ — s6-svlisten1 event subscription dir.
     event = svc_dir / "event"
     assert event.is_dir(), "missing top-level event/"
-    assert stat.S_IMODE(event.stat().st_mode) == 0o3730, (
+    # An unprivileged macOS owner cannot set setgid on a root-group directory;
+    # the supervised container runs privileged and must retain the full mode.
+    expected_event_mode = 0o3730 if os.geteuid() == 0 else 0o1730
+    assert stat.S_IMODE(event.stat().st_mode) == expected_event_mode, (
         f"event/ mode = {oct(event.stat().st_mode)}, want 03730"
     )
 
@@ -218,7 +222,7 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # supervise/event/.
     supervise_event = supervise / "event"
     assert supervise_event.is_dir(), "missing supervise/event/"
-    assert stat.S_IMODE(supervise_event.stat().st_mode) == 0o3730
+    assert stat.S_IMODE(supervise_event.stat().st_mode) == expected_event_mode
 
     # supervise/control FIFO.
     control = supervise / "control"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -147,6 +147,9 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
                 self.rows.append(m["content"])
             return list(range(1, len(messages) + 1))
 
+        def flush_token_counts(self):
+            pass
+
     db = _BarrierDB()
     agent._session_db = db
     agent._session_db_created = True

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1,6 +1,7 @@
 """Tests for the dangerous command approval module."""
 
 import os
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -101,8 +102,11 @@ class TestDetectDangerousRm:
 
     def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
         with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+            canonical_temp = os.path.realpath(tempfile.gettempdir())
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                assert detect_dangerous_command(
+                    f"rm -f {canonical_temp}/{prefix}example.py"
+                ) == (
                     False,
                     None,
                     None,

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1221,6 +1221,7 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_pid is None
         assert backend._active_window_id is None
 
+    @pytest.mark.linux_only
     def test_linux_default_capture_skips_gnome_shell_helper(self):
         windows = [
             {"app_name": "", "pid": 100, "window_id": 1,

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 
 import pytest
@@ -49,6 +50,8 @@ def test_real_binaries_execute_leading_dash_program_payload(
     """A PATH marker proves these binaries do not reparse '-program' as an option."""
     if shutil.which(tool) is None or (needs_tty and shutil.which("script") is None):
         pytest.skip(f"{tool} or script is not installed")
+    if sys.platform == "darwin" and tool in {"sort", "man"}:
+        pytest.skip(f"macOS {tool} option semantics differ from the GNU contract")
 
     marker = tmp_path / "executed"
     payload = tmp_path / "-payload-marker"

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -54,7 +55,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            str(Path("/tmp/out.txt").resolve()), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -145,7 +148,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            str(Path("/tmp/f.py").resolve()), "foo", "bar", False
+        )
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -16,6 +16,7 @@ from tools.skill_manager_tool import (
     _edit_skill,
     _patch_skill,
     _delete_skill,
+    _find_skill,
     _write_file,
     _remove_file,
     skill_manage,
@@ -261,6 +262,44 @@ class TestDeleteSkill:
             _create_skill("my-skill", VALID_SKILL_CONTENT, category="devops")
             _delete_skill("my-skill")
         assert not (tmp_path / "devops").exists()
+
+    def test_qualified_name_respects_bare_name_pin_record(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT, category="devops")
+            with patch(
+                "tools.skill_usage.get_record",
+                side_effect=lambda name: {"pinned": name == "my-skill"},
+            ):
+                result = _delete_skill("devops:my-skill")
+
+        assert result["success"] is False
+        assert "pinned" in result["error"]
+        assert (tmp_path / "devops" / "my-skill").exists()
+
+    def test_nested_qualified_name_resolves_to_skill_directory(self, tmp_path):
+        nested = tmp_path / "social-media" / "twitter" / "search"
+        nested.mkdir(parents=True)
+        (nested / "SKILL.md").write_text(
+            "---\nname: search\ndescription: Search skill.\n---\n\n# Search\n",
+            encoding="utf-8",
+        )
+        with _skill_dir(tmp_path):
+            found = _find_skill("social-media/twitter:search")
+        assert found == {"path": nested}
+
+    def test_usage_pin_canonicalizes_nested_qualified_name(self, tmp_path, monkeypatch):
+        nested = tmp_path / "social-media" / "twitter" / "search"
+        nested.mkdir(parents=True)
+        (nested / "SKILL.md").write_text(
+            "---\nname: search\ndescription: Search skill.\n---\n\n# Search\n",
+            encoding="utf-8",
+        )
+        import tools.skill_usage as skill_usage
+
+        monkeypatch.setattr(skill_usage, "_skills_dir", lambda: tmp_path)
+        skill_usage.set_pinned("social-media/twitter:search", True)
+        assert skill_usage.get_record("search")["pinned"] is True
+        assert skill_usage.get_record("social-media/twitter:search")["pinned"] is True
 
 
     def test_delete_with_absorbed_into_equals_self_rejected(self, tmp_path):

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -65,6 +65,7 @@ def mock_sd(monkeypatch):
 
     monkeypatch.setattr("tools.voice_mode._import_audio", _fake_import_audio)
     monkeypatch.setattr("tools.voice_mode._audio_available", lambda: True)
+    monkeypatch.setattr("tools.voice_mode._sounddevice_output_allowed", lambda: True)
     return mock
 
 
@@ -1414,6 +1415,7 @@ class TestWSL2PowerShellFallback:
             return m
 
         with patch("tools.voice_mode._is_wsl2_env", return_value=True), \
+             patch("tools.voice_mode.platform.system", return_value="Linux"), \
              patch("tools.voice_mode._import_audio", side_effect=ImportError), \
              patch("tools.voice_mode.shutil.which",
                    side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay", "sh") else (x if x.startswith("/") else None)), \
@@ -1466,6 +1468,7 @@ class TestWSL2PowerShellFallback:
             return open(path, *args, **kwargs)
 
         with patch("builtins.open", side_effect=_fake_open), \
+             patch("tools.voice_mode.platform.system", return_value="Linux"), \
              patch("shutil.which", side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay") else None), \
              patch("subprocess.check_output", side_effect=_capture_check_output), \
              patch("subprocess.Popen", return_value=MagicMock(returncode=0, wait=lambda **k: 0)), \

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -271,6 +271,34 @@ def _validate_delete_target(skill_dir: Path) -> Optional[str]:
     )
 
 
+def _canonical_skill_name(name: str) -> str:
+    """Return the usage/provenance identity for a skill reference.
+
+    Gateway prompts may render categorized skills as ``category:skill`` while
+    filesystem paths and usage records remain keyed by the bare skill name.
+    Keep the qualified spelling for user-facing messages, but never let it
+    create a second authorization or lifecycle identity.
+    """
+    if not isinstance(name, str) or ":" not in name:
+        return name
+    try:
+        from tools import skill_usage
+
+        resolved = skill_usage.canonical_skill_name(name)
+        if resolved != name:
+            return resolved
+        from hermes_cli.plugins import get_plugin_manager
+
+        if get_plugin_manager().find_plugin_skill(name) is not None:
+            return name
+    except Exception:
+        pass
+    # Keep the lifecycle identity stable even when a temporary/test skill root
+    # is not visible to skill_usage's resolver.
+    category, bare_name = name.split(":", 1)
+    return bare_name if category and bare_name else name
+
+
 def _pinned_guard(name: str) -> Optional[str]:
     """Return a refusal message if *name* is pinned, else None.
 
@@ -284,7 +312,7 @@ def _pinned_guard(name: str) -> Optional[str]:
     """
     try:
         from tools import skill_usage
-        rec = skill_usage.get_record(name)
+        rec = skill_usage.get_record(_canonical_skill_name(name))
         if rec.get("pinned"):
             return (
                 f"Skill '{name}' is pinned and cannot be deleted by "
@@ -310,6 +338,7 @@ def _background_review_write_guard(
     it is autonomous lifecycle maintenance, so its write surface is restricted
     to local curator-owned sediment.
     """
+    skill_identity = _canonical_skill_name(name)
     try:
         from tools.skill_provenance import is_background_review
         if not is_background_review():
@@ -325,7 +354,7 @@ def _background_review_write_guard(
     # because there is no user in the loop to consent to an edit here.
     try:
         from tools import skill_usage
-        if skill_usage.get_record(name).get("pinned"):
+        if skill_usage.get_record(skill_identity).get("pinned"):
             return {
                 "success": False,
                 "error": (
@@ -354,7 +383,7 @@ def _background_review_write_guard(
 
     try:
         from tools import skill_usage
-        if skill_usage.is_protected_builtin(name):
+        if skill_usage.is_protected_builtin(skill_identity):
             return {
                 "success": False,
                 "error": (
@@ -362,7 +391,7 @@ def _background_review_write_guard(
                     f"built-in skill '{name}'."
                 ),
             }
-        if skill_usage.is_hub_installed(name):
+        if skill_usage.is_hub_installed(skill_identity):
             return {
                 "success": False,
                 "error": (
@@ -370,7 +399,7 @@ def _background_review_write_guard(
                     f"skill '{name}'."
                 ),
             }
-        if skill_usage.is_bundled(name):
+        if skill_usage.is_bundled(skill_identity):
             return {
                 "success": False,
                 "error": (
@@ -393,7 +422,7 @@ def _background_review_write_guard(
         # policy — it is a race with our own bookkeeping. Fail closed for both
         # shapes; `hermes curator adopt <name>` is the supported way in.
         usage_data = skill_usage.load_usage()
-        usage_rec = usage_data.get(name)
+        usage_rec = usage_data.get(skill_identity)
         if not skill_usage._is_curator_managed_record(usage_rec):
             if isinstance(usage_rec, dict):
                 _detail = f"created_by={usage_rec.get('created_by')!r}"
@@ -649,8 +678,20 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     Searches the local skills dir (~/.hermes/skills/) first, then any
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
+
+    Accepts both a bare skill name and a categorized `category:skill` name
+    (the form the gateway prompt renders categorized skills as — see
+    prompt_builder.build_skills_system_prompt) by translating the latter to
+    the on-disk `category/skill` layout, matching skill_view's fallback in
+    skills_tool.py.
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+
+    category_name: Optional[str] = None
+    bare_name = name
+    if ":" in name:
+        category_name, bare_name = name.split(":", 1)
+
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
@@ -659,6 +700,16 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
                 continue
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
+            if category_name and skill_md.parent.name == bare_name:
+                try:
+                    relative_parent = skill_md.parent.relative_to(skills_dir)
+                    relative_category = "/".join(relative_parent.parts[:-1])
+                except ValueError:
+                    continue
+                if relative_category == category_name or relative_category.endswith(
+                    f"/{category_name}"
+                ):
+                    return {"path": skill_md.parent}
     return None
 
 
@@ -681,7 +732,7 @@ def _maybe_auto_propose_org_edit(name: str, skill_path: Path) -> Optional[str]:
                 f"saved locally and will not be overwritten by org updates. "
                 f"Run `hermes sync propose {name}` to share it back."
             )
-        result = ssc.propose_skill(name)
+        result = ssc.propose_skill(_canonical_skill_name(name))
         if result.get("proposal_pending"):
             return (
                 f"Auto-proposed to your organisation as proposal "
@@ -1197,6 +1248,7 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         target must exist on disk. Validated here so the model can't claim an
         umbrella that doesn't exist.
     """
+    skill_identity = _canonical_skill_name(name)
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
@@ -1227,7 +1279,7 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     is_consolidation = bool(absorbed_target)
     if is_consolidation:
         target_name = absorbed_target
-        if target_name == name:
+        if _canonical_skill_name(target_name) == skill_identity:
             return {
                 "success": False,
                 "error": f"absorbed_into='{target_name}' cannot equal the skill being deleted.",
@@ -1266,7 +1318,7 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if curator_pass:
         try:
             from tools.skill_usage import archive_skill
-            ok, archive_msg = archive_skill(name)
+            ok, archive_msg = archive_skill(skill_identity)
         except Exception as e:
             return {"success": False, "error": f"failed to archive '{name}': {e}"}
         if not ok:
@@ -1625,6 +1677,7 @@ def skill_manage(
         try:
             from tools.skill_usage import bump_patch, forget, record_created
             from tools.skill_provenance import is_background_review
+            skill_identity = _canonical_skill_name(name)
             if action == "create":
                 record_created(
                     name,
@@ -1634,7 +1687,7 @@ def skill_manage(
                 )
             elif action in {"patch", "edit", "write_file", "remove_file"}:
                 bump_patch(
-                    name,
+                    skill_identity,
                     action=action,
                     task_id=task_id,
                     session_id=session_id,
@@ -1644,7 +1697,7 @@ def skill_manage(
                 # keeps its usage record as STATE_ARCHIVED so `hermes curator
                 # status`/`restore` still see it. Only a hard delete forgets.
                 if not result.get("_archived"):
-                    forget(name)
+                    forget(skill_identity)
         except Exception:
             pass
 
@@ -1656,7 +1709,7 @@ def skill_manage(
         # sync. Debounced so a burst of edits collapses to one push. Never
         # raises -- an agent write must never block on sync (M1-C invariant).
         try:
-            _maybe_debounced_sync_push(name)
+            _maybe_debounced_sync_push(_canonical_skill_name(name))
         except Exception:
             pass
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -75,7 +75,7 @@ def is_protected_builtin(skill_name: str) -> bool:
     path: the automatic state-transition walk, the LLM consolidation pass (they
     are dropped from the candidate list), and direct ``archive_skill`` calls.
     """
-    return skill_name in PROTECTED_BUILTIN_SKILLS
+    return canonical_skill_name(skill_name) in PROTECTED_BUILTIN_SKILLS
 
 
 def _skills_dir() -> Path:
@@ -317,6 +317,7 @@ def _write_suppressed_names(names: Set[str]) -> None:
 
 def add_suppressed_name(skill_name: str) -> None:
     """Record that a built-in skill was pruned, so sync won't restore it."""
+    skill_name = canonical_skill_name(skill_name)
     if not skill_name:
         return
     names = read_suppressed_names()
@@ -327,6 +328,7 @@ def add_suppressed_name(skill_name: str) -> None:
 
 def remove_suppressed_name(skill_name: str) -> None:
     """Clear a built-in's suppression entry (e.g. on restore)."""
+    skill_name = canonical_skill_name(skill_name)
     if not skill_name:
         return
     names = read_suppressed_names()
@@ -426,8 +428,9 @@ def _read_skill_name(skill_md: Path, fallback: str) -> str:
 
 def is_agent_created(skill_name: str) -> bool:
     """Whether *skill_name* is neither bundled nor hub-installed."""
+    skill_identity = canonical_skill_name(skill_name)
     off_limits = _read_bundled_manifest_names() | _read_hub_installed_names()
-    if skill_name in off_limits:
+    if skill_identity in off_limits:
         return False
     return not (
         _find_skill_dir(skill_name) is None
@@ -437,12 +440,12 @@ def is_agent_created(skill_name: str) -> bool:
 
 def is_hub_installed(skill_name: str) -> bool:
     """Whether *skill_name* was installed via the Skills Hub."""
-    return skill_name in _read_hub_installed_names()
+    return canonical_skill_name(skill_name) in _read_hub_installed_names()
 
 
 def is_bundled(skill_name: str) -> bool:
     """Whether *skill_name* was seeded from the bundled repo skills."""
-    return skill_name in _read_bundled_manifest_names()
+    return canonical_skill_name(skill_name) in _read_bundled_manifest_names()
 
 
 def _external_read_only_message(skill_name: str) -> str:
@@ -466,6 +469,7 @@ def is_curation_eligible(skill_name: str, skill_path: Optional[Path] = None) -> 
     regardless of any flag — they back load-bearing UX and must never be
     archived or consolidated.
     """
+    skill_name = canonical_skill_name(skill_name)
     if skill_path is not None and is_external_skill_path(skill_path):
         return False
     if is_protected_builtin(skill_name):
@@ -512,7 +516,7 @@ def is_curator_managed(skill_name: str) -> bool:
     as the question they are actually asking (see ``_is_curator_managed_record``
     for why the stored field name says "created_by").
     """
-    return _is_curator_managed_record(load_usage().get(skill_name))
+    return _is_curator_managed_record(load_usage().get(canonical_skill_name(skill_name)))
 
 
 def list_unmanaged_skill_names() -> List[str]:
@@ -608,6 +612,7 @@ def adopt_skill(skill_name: str) -> Tuple[bool, str]:
     """
     if not skill_name:
         return False, "no skill name given"
+    skill_name = canonical_skill_name(skill_name)
     if is_protected_builtin(skill_name):
         return False, f"'{skill_name}' is a protected built-in; the curator never manages it"
     if is_hub_installed(skill_name):
@@ -707,6 +712,7 @@ def save_usage(data: Dict[str, Dict[str, Any]]) -> bool:
 
 def get_record(skill_name: str) -> Dict[str, Any]:
     """Return the record for *skill_name*, creating a fresh one if missing."""
+    skill_name = canonical_skill_name(skill_name)
     data = load_usage()
     rec = data.get(skill_name)
     if not isinstance(rec, dict):
@@ -727,6 +733,7 @@ def seed_record_if_missing(skill_name: str) -> None:
     archive/stale clock measures non-use FROM THEN — not from epoch. No-op when
     a record already exists or the skill isn't curation-eligible.
     """
+    skill_name = canonical_skill_name(skill_name)
     if not skill_name or not is_curation_eligible(skill_name):
         return
     try:
@@ -753,6 +760,7 @@ def _mutate(skill_name: str, mutator, *, require_curation_eligible: bool = False
     """
     if not skill_name:
         return None
+    skill_name = canonical_skill_name(skill_name)
     try:
         if require_curation_eligible and not is_curation_eligible(skill_name):
             return None
@@ -1052,6 +1060,7 @@ def is_sync_enabled(skill_name: str) -> bool:
 
 def forget(skill_name: str) -> None:
     """Drop a skill's usage entry entirely. Called when the skill is deleted."""
+    skill_name = canonical_skill_name(skill_name)
     if not skill_name:
         return
     try:
@@ -1076,6 +1085,7 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
     when one is archived, its name is added to the suppression list so the
     update-time re-seeder leaves it archived instead of restoring it.
     """
+    skill_name = canonical_skill_name(skill_name)
     local_skill_dir = _find_skill_dir(skill_name)
     if local_skill_dir is None and _find_external_skill_dir(skill_name) is not None:
         return False, _external_read_only_message(skill_name)
@@ -1140,6 +1150,7 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     way to lift a prune). Restoring clears any suppression entry so future
     updates may re-seed the built-in again.
     """
+    skill_name = canonical_skill_name(skill_name)
     # Hub skills always have an external upstream owner — never shadow them.
     if is_hub_installed(skill_name):
         return False, (
@@ -1217,11 +1228,23 @@ def _find_skill_dir(skill_name: str) -> Optional[Path]:
         return None
     from agent.skill_utils import iter_skill_index_files
 
+    category_name, bare_name = _qualified_skill_parts(skill_name)
     for skill_md in iter_skill_index_files(base, "SKILL.md"):
         if is_external_skill_path(skill_md):
             continue
-        if _read_skill_name(skill_md, fallback=skill_md.parent.name) == skill_name:
+        frontmatter_name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
+        if frontmatter_name == skill_name:
             return skill_md.parent
+        if category_name and frontmatter_name == bare_name:
+            try:
+                relative_parent = skill_md.parent.relative_to(base)
+                relative_category = "/".join(relative_parent.parts[:-1])
+            except ValueError:
+                continue
+            if relative_category == category_name or relative_category.endswith(
+                f"/{category_name}"
+            ):
+                return skill_md.parent
     return None
 
 
@@ -1229,15 +1252,60 @@ def _find_external_skill_dir(skill_name: str) -> Optional[Path]:
     """Locate a skill under configured external dirs by frontmatter name."""
     from agent.skill_utils import get_all_skills_dirs
 
+    category_name, bare_name = _qualified_skill_parts(skill_name)
     for base in get_all_skills_dirs()[1:]:
         if not base.exists():
             continue
         for skill_md in base.rglob("SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
-            if _read_skill_name(skill_md, fallback=skill_md.parent.name) == skill_name:
+            frontmatter_name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
+            if frontmatter_name == skill_name:
                 return skill_md.parent
+            if category_name and frontmatter_name == bare_name:
+                try:
+                    relative_parent = skill_md.parent.relative_to(base)
+                    relative_category = "/".join(relative_parent.parts[:-1])
+                except ValueError:
+                    continue
+                if relative_category == category_name or relative_category.endswith(
+                    f"/{category_name}"
+                ):
+                    return skill_md.parent
     return None
+
+
+def _qualified_skill_parts(skill_name: str) -> Tuple[Optional[str], str]:
+    """Split a prompt-rendered ``category:skill`` reference."""
+    if not isinstance(skill_name, str) or ":" not in skill_name:
+        return None, skill_name
+    category, bare_name = skill_name.split(":", 1)
+    if not category or not bare_name:
+        return None, skill_name
+    return category, bare_name
+
+
+def canonical_skill_name(skill_name: str) -> str:
+    """Return the sidecar identity for a skill reference.
+
+    Category-qualified filesystem skills use ``category:skill`` in prompts but
+    store usage under the frontmatter name. Plugin-qualified names remain
+    untouched because they are separate logical identities.
+    """
+    if not isinstance(skill_name, str) or ":" not in skill_name:
+        return skill_name
+    try:
+        from hermes_cli.plugins import get_plugin_manager
+
+        if get_plugin_manager().find_plugin_skill(skill_name) is not None:
+            return skill_name
+    except Exception:
+        pass
+    skill_dir = _find_skill_dir(skill_name) or _find_external_skill_dir(skill_name)
+    if skill_dir is None:
+        return skill_name
+    _, bare_name = _qualified_skill_parts(skill_name)
+    return _read_skill_name(skill_dir / "SKILL.md", fallback=bare_name)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1587,7 +1587,13 @@ def _load_local_whisper_model(model_name: str, device: str = "auto", compute_typ
     We try the requested config first (fast CUDA path when it works), and on
     any CUDA library load failure fall back to CPU + int8.
     """
-    force_cpu = _should_force_faster_whisper_cpu()
+    # On Apple Silicon the safe default is CPU/int8, but explicit user tuning
+    # must win: otherwise ``stt.local.device=cpu`` and ``compute_type=float32``
+    # are silently ignored by the platform safety guard.
+    explicit_runtime_config = str(device).strip().lower() != "auto" or str(
+        compute_type
+    ).strip().lower() != "auto"
+    force_cpu = _should_force_faster_whisper_cpu() and not explicit_runtime_config
     if force_cpu:
         # Importing ctranslate2/faster-whisper itself can abort on some
         # Apple Silicon/Rosetta installs because multiple Intel OpenMP runtimes

--- a/uv.lock
+++ b/uv.lock
@@ -511,11 +511,7 @@ wheels = [
 [[package]]
 name = "backports-strenum"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/c7/2ed54c32fed313591ffb21edbd48db71e68827d43a61938e5a0bc2b6ec91/backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414", size = 7257, upload-time = "2023-12-09T14:36:40.937Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/50/56cf20e2ee5127b603b81d5a69580a1a325083e2b921aa8f067da83927c0/backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83", size = 8304, upload-time = "2023-12-09T14:36:39.905Z" },
-]
+source = { directory = "vendor/backports-strenum" }
 
 [[package]]
 name = "base58"
@@ -1781,6 +1777,7 @@ voice = [
 ]
 wake = [
     { name = "ai-edge-litert", marker = "sys_platform == 'darwin'" },
+    { name = "backports-strenum", marker = "sys_platform == 'darwin'" },
     { name = "numpy" },
     { name = "onnxruntime" },
     { name = "openwakeword" },
@@ -1818,6 +1815,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.87.0" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = "==0.31.0" },
     { name = "azure-identity", marker = "extra == 'azure-identity'", specifier = "==1.25.3" },
+    { name = "backports-strenum", marker = "sys_platform == 'darwin' and extra == 'wake'", directory = "vendor/backports-strenum" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },
     { name = "brotlicffi", marker = "extra == 'messaging'", specifier = "==1.2.0.1" },
     { name = "certifi", specifier = "==2026.5.20" },

--- a/vendor/backports-strenum/backports/__init__.py
+++ b/vendor/backports-strenum/backports/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility namespace for backported standard-library features."""

--- a/vendor/backports-strenum/backports/strenum.py
+++ b/vendor/backports-strenum/backports/strenum.py
@@ -1,0 +1,30 @@
+"""A small compatibility implementation of :class:`enum.StrEnum`.
+
+Python 3.11 and newer provide ``enum.StrEnum`` natively. Older supported
+Python versions use this equivalent implementation so packages with an
+unconditional ``backports-strenum`` dependency remain installable.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+try:
+    from enum import StrEnum as StrEnum  # type: ignore[assignment]
+except ImportError:
+
+    class StrEnum(str, Enum):
+        """Backport of Python 3.11's ``enum.StrEnum``."""
+
+        def __new__(cls, value):
+            if not isinstance(value, str):
+                raise TypeError("StrEnum values must be strings")
+            obj = str.__new__(cls, value)
+            obj._value_ = value
+            return obj
+
+        def __str__(self) -> str:
+            return self.value
+
+
+__all__ = ["StrEnum"]

--- a/vendor/backports-strenum/pyproject.toml
+++ b/vendor/backports-strenum/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "backports-strenum"
+version = "1.3.1"
+description = "Compatibility implementation of enum.StrEnum"
+requires-python = ">=3.8.6"
+license = {text = "MIT"}
+
+[tool.setuptools.packages.find]
+include = ["backports*"]


### PR DESCRIPTION
## Summary
- Fixes categorized skill identity/pinning/telemetry consistency.
- Fixes credential-pool attribution and macOS launchd/XPC/timeout behavior.
- Makes `hermes doctor` report unavailable toolsets only when active on the CLI surface.
- Adds keyless DDGS web search configuration support and disables unconfigured optional image/video/X/Discord surfaces rather than advertising dead capabilities.
- Adds a metadata-correct local `backports-strenum` compatibility package for the upstream `ai-edge-litert` dependency defect.
- Includes macOS portability fixes and service-manager permission handling.

## Verification
- Full canonical suite before publication rebase: 29,339 passed, 271 skipped, 0 failed.
- Rebasing/publication worktree targeted suite: 193 passed, 2 skipped.
- `uv lock --check`: passed.
- `uv pip check` in Python 3.11 and 3.12 environments: all installed packages compatible.
- Ruff, Python compilation, npm dry-run, workspace dependency listing, and `git diff --check`: passed.

## Operational notes
- No provider credentials were invented. Web search uses keyless DDGS; image/video generation, X search, and Discord remain disabled until authorized credentials are supplied.
- Host disk cleanup reduced data-volume usage from approximately 95% to 86% (30 GiB free).
