### PR TITLE
fix(bluebubbles): isolate message events and add quiet acknowledgements

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -114,14 +114,18 @@ _TAPBACK_REMOVED = {
     3003: "laugh", 3004: "emphasize", 3005: "question",
 }
 
-# Webhook event types that carry user messages
-_MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+# Webhook event types that represent a new user prompt. ``updated-message``
+# repeats the same physical iMessage with a reduced payload on some
+# BlueBubbles builds; treating it as new can both duplicate the turn and fall
+# back from the group GUID to the sender's 1:1 address.
+_MESSAGE_EVENTS = {"new-message", "message"}
 
 # Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
 
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
+_SEEN_MESSAGE_GUIDS_SIZE = 2000  # Bounded idempotency window for webhook retries
 
 
 def _redact(text: str) -> str:
@@ -202,6 +206,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._seen_message_guids: OrderedDict[str, None] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -386,19 +391,29 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return False
 
         webhook_url = self._webhook_register_url
+        desired_events = ["new-message"]
 
         # Crash resilience — reuse an existing registration if present
         existing = await self._find_registered_webhooks(webhook_url)
-        if existing:
+        matching = [
+            wh for wh in existing
+            if sorted(wh.get("events") or []) == desired_events
+        ]
+        if matching and len(existing) == 1:
             logger.info(
                 "[bluebubbles] webhook already registered: %s",
                 self._webhook_register_url_for_log,
             )
             return True
+        if existing:
+            # Reconcile registrations created by older Hermes builds that also
+            # subscribed to ``updated-message``. Those events replayed one
+            # physical iMessage and could lose its group chat GUID.
+            await self._unregister_webhook()
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message"],
+            "events": desired_events,
         }
 
         try:
@@ -1026,6 +1041,27 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not sender or not (chat_guid or chat_identifier) or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
 
+        # BlueBubbles can retry a webhook delivery. Keep one bounded in-memory
+        # idempotency window so one physical iMessage GUID starts at most one
+        # Hermes turn. Do this only after the payload is validated so a malformed
+        # event cannot poison a later valid delivery for the same GUID.
+        message_guid = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+        )
+        if message_guid:
+            if message_guid in self._seen_message_guids:
+                self._seen_message_guids.move_to_end(message_guid)
+                logger.debug(
+                    "[bluebubbles] ignoring duplicate message webhook guid=%s",
+                    _redact(message_guid),
+                )
+                return web.Response(text="ok")
+            self._seen_message_guids[message_guid] = None
+            while len(self._seen_message_guids) > _SEEN_MESSAGE_GUIDS_SIZE:
+                self._seen_message_guids.popitem(last=False)
+
         session_chat_id = chat_guid or chat_identifier
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
         if is_group and self.require_mention:
@@ -1048,11 +1084,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             message_type=msg_type,
             source=source,
             raw_message=payload,
-            message_id=self._value(
-                record.get("guid"),
-                record.get("messageGuid"),
-                record.get("id"),
-            ),
+            message_id=message_guid,
             reply_to_message_id=self._value(
                 record.get("threadOriginatorGuid"),
                 record.get("associatedMessageGuid"),

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -192,6 +192,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not str(self.webhook_path).startswith("/"):
             self.webhook_path = f"/{self.webhook_path}"
         self.send_read_receipts = bool(extra.get("send_read_receipts", True))
+        _working_ack = extra.get("working_ack_emoji")
+        if _working_ack is None:
+            _working_ack = os.getenv("BLUEBUBBLES_WORKING_ACK_EMOJI", "")
+        self.working_ack_emoji = str(_working_ack or "").strip()
         _require_mention = extra.get("require_mention")
         if _require_mention is None:
             _require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
@@ -782,6 +786,28 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Tapback reactions
     # ------------------------------------------------------------------
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """Send an optional emoji-only acknowledgement to the originating chat."""
+        if (
+            not self.working_ack_emoji
+            or event.is_command()
+            or not event.source
+            or not event.source.chat_id
+        ):
+            return
+        result = await self.send(
+            event.source.chat_id,
+            self.working_ack_emoji,
+            reply_to=event.message_id,
+        )
+        if not result.success:
+            logger.debug(
+                "[%s] Working acknowledgement failed for %s: %s",
+                self.name,
+                event.source.chat_id,
+                result.error,
+            )
 
     # ------------------------------------------------------------------
     # Chat info

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -196,6 +196,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if _working_ack is None:
             _working_ack = os.getenv("BLUEBUBBLES_WORKING_ACK_EMOJI", "")
         self.working_ack_emoji = str(_working_ack or "").strip()
+        _allowed_chat_guids = extra.get("allowed_chat_guids")
+        if _allowed_chat_guids is None:
+            _allowed_chat_guids = os.getenv("BLUEBUBBLES_ALLOWED_CHAT_GUIDS", "")
+        self._allowed_chat_keys = {
+            self._chat_scope_key(chat_id)
+            for chat_id in self._parse_chat_allowlist(_allowed_chat_guids)
+            if self._chat_scope_key(chat_id)
+        }
         _require_mention = extra.get("require_mention")
         if _require_mention is None:
             _require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
@@ -934,6 +942,36 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 return candidate.strip()
         return None
 
+    @staticmethod
+    def _parse_chat_allowlist(value: Any) -> List[str]:
+        """Parse a list or JSON/comma-separated string of allowed chat GUIDs."""
+        if isinstance(value, (list, tuple, set)):
+            return [str(item).strip() for item in value if str(item).strip()]
+        if not value:
+            return []
+        text = str(value).strip()
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+            except (TypeError, ValueError):
+                parsed = None
+            if isinstance(parsed, list):
+                return [str(item).strip() for item in parsed if str(item).strip()]
+        return [item.strip() for item in re.split(r"[,\n]", text) if item.strip()]
+
+    @staticmethod
+    def _chat_scope_key(chat_id: Any) -> str:
+        """Normalize a chat GUID while ignoring BlueBubbles' service prefix."""
+        value = str(chat_id or "").strip().casefold()
+        if ";" in value:
+            return value.split(";", 1)[1]
+        return value
+
+    def _chat_is_allowed(self, chat_id: Any) -> bool:
+        if not self._allowed_chat_keys:
+            return True
+        return self._chat_scope_key(chat_id) in self._allowed_chat_keys
+
     async def _handle_webhook(self, request):
         from aiohttp import web
 
@@ -1088,8 +1126,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             while len(self._seen_message_guids) > _SEEN_MESSAGE_GUIDS_SIZE:
                 self._seen_message_guids.popitem(last=False)
 
-        session_chat_id = chat_guid or chat_identifier
+        session_chat_id = str(chat_guid or chat_identifier)
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
+        if not self._chat_is_allowed(session_chat_id):
+            logger.info(
+                "[bluebubbles] ignoring message from unapproved chat=%s",
+                _redact(str(session_chat_id)),
+            )
+            return web.Response(text="ok")
         if is_group and self.require_mention:
             if not self._message_matches_mention_patterns(text):
                 logger.debug(

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -204,6 +204,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             for chat_id in self._parse_chat_allowlist(_allowed_chat_guids)
             if self._chat_scope_key(chat_id)
         }
+        _required_participants = extra.get("required_participants")
+        if _required_participants is None:
+            _required_participants = os.getenv(
+                "BLUEBUBBLES_REQUIRED_PARTICIPANTS",
+                "",
+            )
+        self._required_participant_keys = {
+            self._participant_key(participant)
+            for participant in self._parse_chat_allowlist(_required_participants)
+            if self._participant_key(participant)
+        }
         _require_mention = extra.get("require_mention")
         if _require_mention is None:
             _require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
@@ -972,6 +983,36 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return True
         return self._chat_scope_key(chat_id) in self._allowed_chat_keys
 
+    @staticmethod
+    def _participant_key(participant: Any) -> str:
+        value = str(participant or "").strip().casefold()
+        if "@" in value:
+            return value
+        digits = re.sub(r"\D", "", value)
+        return f"+{digits}" if digits else value
+
+    async def _chat_has_required_participant(self, chat_id: str) -> bool:
+        """Require at least one configured identity to be present in the chat."""
+        if not self._required_participant_keys:
+            return True
+
+        # A BlueBubbles direct-chat GUID embeds its sole remote participant.
+        parts = str(chat_id or "").split(";", 2)
+        if len(parts) == 3 and parts[1] == "-":
+            return self._participant_key(parts[2]) in self._required_participant_keys
+
+        # Group GUIDs do not encode membership. Query the local BlueBubbles
+        # server on each inbound message so a participant leaving takes effect
+        # immediately rather than being hidden by a stale authorization cache.
+        info = await self.get_chat_info(chat_id)
+        participants = info.get("participants") or []
+        participant_keys = {
+            self._participant_key(participant)
+            for participant in participants
+            if self._participant_key(participant)
+        }
+        return bool(participant_keys & self._required_participant_keys)
+
     async def _handle_webhook(self, request):
         from aiohttp import web
 
@@ -1131,6 +1172,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not self._chat_is_allowed(session_chat_id):
             logger.info(
                 "[bluebubbles] ignoring message from unapproved chat=%s",
+                _redact(str(session_chat_id)),
+            )
+            return web.Response(text="ok")
+        if not await self._chat_has_required_participant(session_chat_id):
+            logger.info(
+                "[bluebubbles] ignoring message because required participant is absent chat=%s",
                 _redact(str(session_chat_id)),
             )
             return web.Response(text="ok")

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -196,6 +196,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if _working_ack is None:
             _working_ack = os.getenv("BLUEBUBBLES_WORKING_ACK_EMOJI", "")
         self.working_ack_emoji = str(_working_ack or "").strip()
+        _group_prompt = extra.get("group_prompt")
+        if _group_prompt is None:
+            _group_prompt = os.getenv("BLUEBUBBLES_GROUP_PROMPT", "")
+        self.group_prompt = str(_group_prompt or "").strip() or None
         _allowed_chat_guids = extra.get("allowed_chat_guids")
         if _allowed_chat_guids is None:
             _allowed_chat_guids = os.getenv("BLUEBUBBLES_ALLOWED_CHAT_GUIDS", "")
@@ -1208,6 +1212,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             ),
             media_urls=media_urls,
             media_types=media_types,
+            channel_prompt=self.group_prompt if is_group else None,
         )
         task = asyncio.create_task(self.handle_message(event))
         self._background_tasks.add(task)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -219,6 +219,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             for participant in self._parse_chat_allowlist(_required_participants)
             if self._participant_key(participant)
         }
+        # The exact-chat / required-participant gate runs synchronously at
+        # webhook intake before the event reaches GatewayRunner. When either
+        # restriction is configured, it is the authoritative access boundary:
+        # every sender in an admitted group may address Hermes, while chats
+        # outside the scope never reach gateway authorization or acknowledgements.
+        self._enforces_own_access_policy = bool(
+            self._allowed_chat_keys or self._required_participant_keys
+        )
+        _scope_policy = "allowlist" if self._enforces_own_access_policy else "open"
+        self._group_policy = _scope_policy
+        self._dm_policy = _scope_policy
         _require_mention = extra.get("require_mention")
         if _require_mention is None:
             _require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
@@ -234,6 +245,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
         self._seen_message_guids: OrderedDict[str, None] = OrderedDict()
+
+    @property
+    def enforces_own_access_policy(self) -> bool:
+        """Whether configured chat/participant scope gates intake authoritatively."""
+        return self._enforces_own_access_policy
 
     # ------------------------------------------------------------------
     # API helpers
@@ -1192,6 +1208,21 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
                 return web.Response(text="ok")
             text = self._clean_mention_text(text)
+        sender_authorized = self._is_sender_authorized(
+            sender,
+            "group" if is_group else "dm",
+            session_chat_id,
+        )
+        if sender_authorized is False:
+            # on_processing_start runs before the gateway message handler. Gate
+            # here so an unauthorized sender receives neither the standalone
+            # working acknowledgement nor an agent turn.
+            logger.info(
+                "[bluebubbles] ignoring message from unauthorized sender=%s chat=%s",
+                _redact(str(sender)),
+                _redact(str(session_chat_id)),
+            )
+            return web.Response(text="ok")
         source = self.build_source(
             chat_id=session_chat_id,
             chat_name=chat_identifier or sender,

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -413,8 +413,12 @@ class WhatsAppBehaviorMixin:
         if not self._whatsapp_require_mention():
             return True
         body = str(data.get("body") or "").strip()
+        # WhatsApp has no bot-command routing equivalent to Telegram's
+        # `/command@bot` syntax.  In a mention-gated group, a bare slash
+        # command is therefore not an address to this bot and must not bypass
+        # the explicit mention rule.
         if body.startswith("/"):
-            return True
+            return False
         if self._message_is_reply_to_bot(data):
             return True
         if self._message_mentions_bot(data):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17591,7 +17591,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # One-time prompt if no home channel is set for this platform
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
-        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
+        # A WhatsApp group is a shared conversation, never an appropriate
+        # default sink for cron and cross-platform deliveries.  Suppress the
+        # first-contact home-channel pitch there rather than inviting a group
+        # member to turn it into one.
+        if (
+            not history
+            and source.platform
+            and source.platform not in {Platform.LOCAL, Platform.WEBHOOK}
+            and not (source.platform == Platform.WHATSAPP and source.chat_type == "group")
+        ):
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
             # Multiplex: home channel may live only in the profile secret

--- a/run_agent.py
+++ b/run_agent.py
@@ -5334,6 +5334,43 @@ class AIAgent:
         singleton_key = str(singleton_now.get("api_key") or "").strip()
         active_key = str(self.api_key or "").strip()
         if singleton_key and active_key and singleton_key != active_key:
+            # An auxiliary Codex call (notably context compression) can refresh
+            # the singleton while this primary agent is still holding the old
+            # access token. The strings differ, but this is safe to adopt when
+            # their embedded claims identify the same ChatGPT account. Without
+            # this branch the 401 recovery mistakes a normal in-flight rotation
+            # for an account swap and aborts the user turn.
+            same_codex_account = False
+            if self.provider == "openai-codex":
+                try:
+                    from hermes_cli.auth import _decode_jwt_claims
+
+                    def _chatgpt_account_id(token: str) -> str:
+                        claims = _decode_jwt_claims(token)
+                        auth_claim = claims.get("https://api.openai.com/auth")
+                        if isinstance(auth_claim, dict):
+                            return str(auth_claim.get("chatgpt_account_id") or "").strip()
+                        return ""
+
+                    active_account_id = _chatgpt_account_id(active_key)
+                    singleton_account_id = _chatgpt_account_id(singleton_key)
+                    same_codex_account = (
+                        bool(active_account_id)
+                        and active_account_id == singleton_account_id
+                    )
+                except Exception:
+                    same_codex_account = False
+            if same_codex_account:
+                refreshed_base_url = str(singleton_now.get("base_url") or "").strip().rstrip("/")
+                if not refreshed_base_url:
+                    return False
+                self.api_key = singleton_key
+                self.base_url = refreshed_base_url
+                self._client_kwargs["api_key"] = self.api_key
+                self._client_kwargs["base_url"] = self.base_url
+                return self._replace_primary_openai_client(
+                    reason="openai-codex_same_account_token_rotation"
+                )
             logger.debug(
                 "%s singleton tokens differ from the active api_key; "
                 "skipping singleton force-refresh to avoid silent account swap. "

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -308,6 +308,51 @@ class TestBlueBubblesWebhookParsing:
         assert response.status == 200
         assert handled == []
 
+    @pytest.mark.asyncio
+    async def test_group_privacy_prompt_is_attached_only_to_group_turns(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            send_read_receipts=False,
+            group_prompt="Protect information learned outside this group.",
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        for payload in (
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "group-prompt-message",
+                    "text": "Rico, help us plan",
+                    "handle": {"address": "+15550000001"},
+                    "isFromMe": False,
+                    "isGroup": True,
+                    "chats": [{"guid": "any;+;group-chat"}],
+                },
+            },
+            {
+                "type": "new-message",
+                "data": {
+                    "guid": "dm-no-prompt-message",
+                    "text": "Help me privately",
+                    "handle": {"address": "+15550000001"},
+                    "isFromMe": False,
+                    "isGroup": False,
+                    "chats": [{"guid": "any;-;+15550000001"}],
+                },
+            },
+        ):
+            response = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+            assert response.status == 200
+        await asyncio.sleep(0)
+
+        assert len(handled) == 2
+        assert handled[0].channel_prompt == "Protect information learned outside this group."
+        assert handled[1].channel_prompt is None
+
     def test_webhook_can_fall_back_to_sender_when_chat_fields_missing(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         payload = {

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -240,6 +240,74 @@ class TestBlueBubblesWebhookParsing:
         assert len(handled) == 1
         assert handled[0].source.chat_id == "iMessage;-;+15550000001"
 
+    @pytest.mark.asyncio
+    async def test_required_participant_allows_only_direct_chat_with_bryan(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            required_participants=["+15550000001"],
+        )
+
+        assert await adapter._chat_has_required_participant("any;-;+15550000001")
+        assert not await adapter._chat_has_required_participant("any;-;+15550000002")
+
+    @pytest.mark.asyncio
+    async def test_required_participant_checks_group_membership(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            required_participants=["+15550000001"],
+        )
+
+        async def fake_get_chat_info(chat_id):
+            if chat_id.endswith("bryan-present"):
+                return {"participants": ["+15550000001", "+15550000002"]}
+            return {"participants": ["+15550000002", "+15550000003"]}
+
+        monkeypatch.setattr(adapter, "get_chat_info", fake_get_chat_info)
+
+        assert await adapter._chat_has_required_participant("any;+;bryan-present")
+        assert not await adapter._chat_has_required_participant("any;+;bryan-absent")
+
+    @pytest.mark.asyncio
+    async def test_webhook_silently_blocks_chat_without_required_participant(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            send_read_receipts=False,
+            required_participants=["+15550000001"],
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def missing_required_participant(chat_id):
+            return False
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(
+            adapter,
+            "_chat_has_required_participant",
+            missing_required_participant,
+        )
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "group-without-bryan-message",
+                        "text": "Rico, can you help?",
+                        "handle": {"address": "+15550000002"},
+                        "isFromMe": False,
+                        "isGroup": True,
+                        "chats": [{"guid": "any;+;group-without-bryan"}],
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert handled == []
+
     def test_webhook_can_fall_back_to_sender_when_chat_fields_missing(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         payload = {

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
 
 
 def _make_adapter(monkeypatch, **extra):
@@ -267,6 +268,23 @@ class TestBlueBubblesWebhookParsing:
         assert await adapter._chat_has_required_participant("any;+;bryan-present")
         assert not await adapter._chat_has_required_participant("any;+;bryan-absent")
 
+    def test_required_participant_policy_is_authoritative_at_gateway(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            required_participants=["+15550000001"],
+        )
+
+        assert adapter.enforces_own_access_policy is True
+        assert adapter._group_policy == "allowlist"
+        assert adapter._dm_policy == "allowlist"
+
+    def test_open_adapter_does_not_claim_authoritative_access_policy(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        assert adapter.enforces_own_access_policy is False
+        assert adapter._group_policy == "open"
+        assert adapter._dm_policy == "open"
+
     @pytest.mark.asyncio
     async def test_webhook_silently_blocks_chat_without_required_participant(self, monkeypatch):
         adapter = _make_adapter(
@@ -307,6 +325,56 @@ class TestBlueBubblesWebhookParsing:
 
         assert response.status == 200
         assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_webhook_blocks_before_ack_when_gateway_auth_rejects_sender(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            send_read_receipts=False,
+            working_ack_emoji="👀",
+            required_participants=["+15550000001"],
+        )
+        handled = []
+        sent = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_send(*args, **kwargs):
+            sent.append((args, kwargs))
+            return SendResult(success=True)
+
+        async def has_required_participant(chat_id):
+            return True
+
+        adapter.set_authorization_check(lambda user_id, chat_type, chat_id: False)
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "send", fake_send)
+        monkeypatch.setattr(
+            adapter,
+            "_chat_has_required_participant",
+            has_required_participant,
+        )
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "unauthorized-group-message",
+                        "text": "Rico, can you help?",
+                        "handle": {"address": "+15550000002"},
+                        "isFromMe": False,
+                        "isGroup": True,
+                        "chats": [{"guid": "any;+;group-with-bryan"}],
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert handled == []
+        assert sent == []
 
     @pytest.mark.asyncio
     async def test_group_privacy_prompt_is_attached_only_to_group_turns(self, monkeypatch):

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -170,6 +170,76 @@ class TestBlueBubblesWebhookParsing:
         assert second.status == 200
         assert len(handled) == 1
 
+    @pytest.mark.asyncio
+    async def test_chat_allowlist_blocks_unlisted_direct_message(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            send_read_receipts=False,
+            allowed_chat_guids=[
+                "any;+;approved-group",
+                "any;-;+15550000001",
+            ],
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "blocked-dm-message",
+                        "text": "Hello from an unapproved DM",
+                        "handle": {"address": "+15550000002"},
+                        "isFromMe": False,
+                        "isGroup": False,
+                        "chats": [{"guid": "any;-;+15550000002"}],
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_chat_allowlist_accepts_service_alias_for_approved_dm(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            send_read_receipts=False,
+            allowed_chat_guids=["any;-;+15550000001"],
+        )
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(
+            _FakeBlueBubblesRequest(
+                {
+                    "type": "new-message",
+                    "data": {
+                        "guid": "approved-dm-message",
+                        "text": "Hello from the approved DM",
+                        "handle": {"address": "+15550000001"},
+                        "isFromMe": False,
+                        "isGroup": False,
+                        "chats": [{"guid": "iMessage;-;+15550000001"}],
+                    },
+                }
+            )
+        )
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert len(handled) == 1
+        assert handled[0].source.chat_id == "iMessage;-;+15550000001"
+
     def test_webhook_can_fall_back_to_sender_when_chat_fields_missing(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         payload = {

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -116,6 +116,60 @@ class TestBlueBubblesMentionGating:
 
 class TestBlueBubblesWebhookParsing:
 
+    @pytest.mark.asyncio
+    async def test_updated_message_is_acknowledged_without_starting_a_turn(self, monkeypatch):
+        """An iMessage update must not replay the original message as a new prompt."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "msg-update-1",
+                "text": "same physical iMessage",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert handled == []
+
+    @pytest.mark.asyncio
+    async def test_duplicate_new_message_guid_is_processed_once(self, monkeypatch):
+        """Webhook retries for one physical iMessage must be idempotent."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-dedup-1",
+                "text": "one physical iMessage",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chats": [{"guid": "iMessage;+;family-group"}],
+            },
+        }
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert len(handled) == 1
+
     def test_webhook_can_fall_back_to_sender_when_chat_fields_missing(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         payload = {
@@ -374,6 +428,29 @@ class TestBlueBubblesWebhookRegistration:
         )
         assert ok is True
 
+    def test_register_subscribes_only_to_new_messages(self, monkeypatch):
+        """Message updates are metadata changes, not new user prompts."""
+        import asyncio
+        adapter = _make_adapter(monkeypatch)
+        adapter.client = self._mock_client(
+            get_response={"status": 200, "data": []},
+            post_response={"status": 200, "data": {"id": 42}},
+        )
+        posted = []
+
+        async def tracking_post(path, payload):
+            posted.append((path, payload))
+            return {"status": 200, "data": {"id": 42}}
+
+        adapter._api_post = tracking_post
+        ok = asyncio.get_event_loop().run_until_complete(adapter._register_webhook())
+
+        assert ok is True
+        assert posted == [("/api/v1/webhook", {
+            "url": adapter._webhook_register_url,
+            "events": ["new-message"],
+        })]
+
 
     def test_register_reuses_existing(self, monkeypatch):
         """Crash resilience — existing registration is reused, no POST needed."""
@@ -400,6 +477,41 @@ class TestBlueBubblesWebhookRegistration:
         )
         assert ok is True
         assert not post_called, "Should reuse existing, not POST again"
+
+    def test_register_replaces_legacy_updated_message_subscription(self, monkeypatch):
+        """Old new+updated registrations are removed before creating the quiet one."""
+        import asyncio
+        adapter = _make_adapter(monkeypatch)
+        url = adapter._webhook_register_url
+        deleted = []
+        posted = []
+        adapter.client = self._mock_client(
+            get_response={"status": 200, "data": [
+                {"id": 7, "url": url, "events": ["new-message", "updated-message"]},
+            ]},
+        )
+
+        async def mock_delete(*args, **kwargs):
+            deleted.append(args[0])
+            class R:
+                def raise_for_status(self):
+                    pass
+            return R()
+
+        async def tracking_post(path, payload):
+            posted.append((path, payload))
+            return {"status": 200, "data": {"id": 8}}
+
+        adapter.client.delete = mock_delete
+        adapter._api_post = tracking_post
+        ok = asyncio.get_event_loop().run_until_complete(adapter._register_webhook())
+
+        assert ok is True
+        assert len(deleted) == 1
+        assert posted == [("/api/v1/webhook", {
+            "url": url,
+            "events": ["new-message"],
+        })]
 
 
     # -- _unregister_webhook --

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -288,6 +288,62 @@ class TestBlueBubblesGuidResolution:
         assert "user@example.com" not in adapter._guid_cache
 
 
+class TestBlueBubblesWorkingAcknowledgement:
+    @pytest.mark.asyncio
+    async def test_sends_configured_emoji_to_exact_originating_chat(self, monkeypatch):
+        from gateway.platforms.base import MessageEvent, SendResult
+        from gateway.session import SessionSource
+
+        adapter = _make_adapter(monkeypatch, working_ack_emoji="👀")
+        sent = []
+
+        async def fake_send(chat_id, content, reply_to=None, metadata=None):
+            sent.append((chat_id, content, reply_to))
+            return SendResult(success=True, message_id="ack-guid")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        event = MessageEvent(
+            text="Please handle this",
+            source=SessionSource(
+                platform=Platform.BLUEBUBBLES,
+                chat_id="iMessage;+;group-chat",
+                chat_type="group",
+            ),
+            message_id="trigger-guid",
+        )
+
+        await adapter.on_processing_start(event)
+
+        assert sent == [("iMessage;+;group-chat", "👀", "trigger-guid")]
+
+    @pytest.mark.asyncio
+    async def test_skips_working_emoji_when_not_configured(self, monkeypatch):
+        from gateway.platforms.base import MessageEvent, SendResult
+        from gateway.session import SessionSource
+
+        adapter = _make_adapter(monkeypatch)
+        sent = []
+
+        async def fake_send(chat_id, content, reply_to=None, metadata=None):
+            sent.append((chat_id, content, reply_to))
+            return SendResult(success=True, message_id="ack-guid")
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        event = MessageEvent(
+            text="Please handle this",
+            source=SessionSource(
+                platform=Platform.BLUEBUBBLES,
+                chat_id="iMessage;+;group-chat",
+                chat_type="group",
+            ),
+            message_id="trigger-guid",
+        )
+
+        await adapter.on_processing_start(event)
+
+        assert sent == []
+
+
 class TestBlueBubblesAttachmentDownload:
     """Verify _download_attachment routes to the correct cache helper."""
 

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -99,6 +99,17 @@ def test_regex_mention_patterns_allow_custom_wake_words():
     assert adapter._should_process_message(_group_message("hey chompy")) is False
 
 
+def test_rico_fallback_pattern_requires_at_symbol():
+    adapter = _make_adapter(
+        require_mention=True,
+        mention_patterns=[r"(?<![\w@])@(?:rico|hermes)\b"],
+        group_policy="open",
+    )
+
+    assert adapter._should_process_message(_group_message("@Rico status")) is True
+    assert adapter._should_process_message(_group_message("Rico status")) is False
+
+
 def test_invalid_regex_patterns_are_ignored():
     adapter = _make_adapter(
         require_mention=True,

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -82,7 +82,9 @@ def test_group_messages_can_require_direct_trigger_via_config():
             quotedParticipant="15551230000@lid",
         )
     ) is True
-    assert adapter._should_process_message(_group_message("/status")) is True
+    # Unlike Telegram, a WhatsApp slash command has no bot-address suffix.
+    # It must not bypass a group's explicit mention requirement.
+    assert adapter._should_process_message(_group_message("/status")) is False
 
 
 def test_regex_mention_patterns_allow_custom_wake_words():

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -923,6 +925,19 @@ def _build_xai_oauth_agent(monkeypatch):
     return agent
 
 
+def _jwt_for_account(account_id: str) -> str:
+    """Build a structurally valid, unsigned test JWT with Codex account claims."""
+    payload = json.dumps(
+        {
+            "sub": f"user-{account_id}",
+            "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+        },
+        separators=(",", ":"),
+    ).encode()
+    encoded = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
 def test_build_api_kwargs_xai_oauth_sends_cache_key_via_extra_body(monkeypatch):
     """xai-oauth + codex_responses must route prompt caching via the
     ``prompt_cache_key`` body field on /v1/responses (xAI's documented
@@ -1072,6 +1087,77 @@ def test_try_refresh_codex_client_credentials_skips_xai_oauth_when_singleton_dif
 
 
 
+
+
+def test_try_refresh_codex_adopts_same_account_token_rotated_during_auxiliary_work(monkeypatch):
+    """A compression-side OAuth refresh must not strand the primary request."""
+    agent = _build_agent(monkeypatch)
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    stale = _jwt_for_account("same-account")
+    # Preserve the claims payload while changing the token string, just like a
+    # real OAuth rotation does. The account identity remains the same.
+    rotated = f"header.{stale.split('.')[1]}.rotated-signature"
+    agent.api_key = stale
+
+    refresh_calls = {"count": 0}
+    rebuilt = {"kwargs": None}
+
+    class _ExistingClient:
+        pass
+
+    class _RebuiltClient:
+        pass
+
+    def _fake_resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        if force_refresh:
+            refresh_calls["count"] += 1
+        return {
+            "api_key": rotated,
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        _fake_resolve,
+    )
+    monkeypatch.setattr(
+        run_agent,
+        "OpenAI",
+        lambda **kwargs: rebuilt.update(kwargs=kwargs) or _RebuiltClient(),
+    )
+    agent.client = _ExistingClient()
+    monkeypatch.setattr(agent, "_retire_shared_openai_client", lambda *_a, **_k: None)
+
+    assert agent._try_refresh_codex_client_credentials(force=True) is True
+    assert refresh_calls["count"] == 0
+    assert agent.api_key == rotated
+    assert rebuilt["kwargs"]["api_key"] == rotated
+
+
+def test_try_refresh_codex_rejects_rotated_token_from_different_account(monkeypatch):
+    """Codex 401 recovery must still refuse an actual cross-account swap."""
+    agent = _build_agent(monkeypatch)
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    agent.api_key = _jwt_for_account("active-account")
+    refresh_calls = {"count": 0}
+
+    def _fake_resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        if force_refresh:
+            refresh_calls["count"] += 1
+        return {
+            "api_key": _jwt_for_account("other-account"),
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        _fake_resolve,
+    )
+
+    assert agent._try_refresh_codex_client_credentials(force=True) is False
+    assert refresh_calls["count"] == 0
 
 
 def test_try_refresh_copilot_client_credentials_rebuilds_client(monkeypatch):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -466,6 +466,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `BLUEBUBBLES_ALLOWED_USERS` | Comma-separated authorized users |
 | `BLUEBUBBLES_ALLOW_ALL_USERS` | Allow all users (`true`/`false`) |
 | `BLUEBUBBLES_WORKING_ACK_EMOJI` | Optional standalone emoji sent before processing (for example, `👀`) |
+| `BLUEBUBBLES_ALLOWED_CHAT_GUIDS` | JSON or comma-separated exact group/direct conversations Hermes may answer |
 | `QQ_APP_ID` | QQ Bot App ID from [q.qq.com](https://q.qq.com) |
 | `QQ_CLIENT_SECRET` | QQ Bot App Secret from [q.qq.com](https://q.qq.com) |
 | `QQ_STT_API_KEY` | API key for external STT fallback provider (optional, used when QQ built-in ASR returns no text) |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -467,6 +467,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `BLUEBUBBLES_ALLOW_ALL_USERS` | Allow all users (`true`/`false`) |
 | `BLUEBUBBLES_WORKING_ACK_EMOJI` | Optional standalone emoji sent before processing (for example, `👀`) |
 | `BLUEBUBBLES_ALLOWED_CHAT_GUIDS` | JSON or comma-separated exact group/direct conversations Hermes may answer |
+| `BLUEBUBBLES_REQUIRED_PARTICIPANTS` | JSON or comma-separated identities; Hermes answers only chats containing one |
 | `QQ_APP_ID` | QQ Bot App ID from [q.qq.com](https://q.qq.com) |
 | `QQ_CLIENT_SECRET` | QQ Bot App Secret from [q.qq.com](https://q.qq.com) |
 | `QQ_STT_API_KEY` | API key for external STT fallback provider (optional, used when QQ built-in ASR returns no text) |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -465,6 +465,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `BLUEBUBBLES_HOME_CHANNEL` | Phone/email for cron/notification delivery |
 | `BLUEBUBBLES_ALLOWED_USERS` | Comma-separated authorized users |
 | `BLUEBUBBLES_ALLOW_ALL_USERS` | Allow all users (`true`/`false`) |
+| `BLUEBUBBLES_WORKING_ACK_EMOJI` | Optional standalone emoji sent before processing (for example, `👀`) |
 | `QQ_APP_ID` | QQ Bot App ID from [q.qq.com](https://q.qq.com) |
 | `QQ_CLIENT_SECRET` | QQ Bot App Secret from [q.qq.com](https://q.qq.com) |
 | `QQ_STT_API_KEY` | API key for external STT fallback provider (optional, used when QQ built-in ASR returns no text) |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -468,6 +468,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `BLUEBUBBLES_WORKING_ACK_EMOJI` | Optional standalone emoji sent before processing (for example, `👀`) |
 | `BLUEBUBBLES_ALLOWED_CHAT_GUIDS` | JSON or comma-separated exact group/direct conversations Hermes may answer |
 | `BLUEBUBBLES_REQUIRED_PARTICIPANTS` | JSON or comma-separated identities; Hermes answers only chats containing one |
+| `BLUEBUBBLES_GROUP_PROMPT` | Ephemeral system prompt applied only to BlueBubbles group turns |
 | `QQ_APP_ID` | QQ Bot App ID from [q.qq.com](https://q.qq.com) |
 | `QQ_CLIENT_SECRET` | QQ Bot App Secret from [q.qq.com](https://q.qq.com) |
 | `QQ_STT_API_KEY` | API key for external STT fallback provider (optional, used when QQ built-in ASR returns no text) |

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -162,6 +162,18 @@ platforms:
 
 When configured, messages from every unlisted group or direct chat are acknowledged by the webhook but ignored before the agent starts, so no working emoji or final answer is sent. Matching ignores only the BlueBubbles service prefix (`any` versus `iMessage`) while preserving the group/direct marker and conversation identifier. `BLUEBUBBLES_ALLOWED_CHAT_GUIDS` accepts a JSON or comma-separated list.
 
+To authorize conversations dynamically based on who is present, use `required_participants` instead:
+
+```yaml
+platforms:
+  bluebubbles:
+    extra:
+      required_participants:
+        - "+15550000001"
+```
+
+Hermes responds only when at least one configured identity is a current participant. Direct-chat identity is read from the chat GUID; group membership is fetched from the local BlueBubbles server on every inbound message so leaving a group takes effect immediately. If `allowed_chat_guids` is also configured, both checks must pass. `BLUEBUBBLES_REQUIRED_PARTICIPANTS` accepts a JSON or comma-separated list.
+
 ### Typing Indicators
 Shows "typing..." in the iMessage conversation while the agent is processing. Requires Private API.
 

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -134,6 +134,19 @@ Send and receive iMessages. Markdown is automatically stripped for clean plain-t
 ### Tapback Reactions
 Love, like, dislike, laugh, emphasize, and question reactions. Requires the BlueBubbles [Private API helper](https://docs.bluebubbles.app/helper-bundle/installation).
 
+### Emoji Working Acknowledgement
+
+For a lightweight acknowledgement that does not require the Private API helper, configure a standalone emoji response:
+
+```yaml
+platforms:
+  bluebubbles:
+    extra:
+      working_ack_emoji: "👀"
+```
+
+Hermes sends the emoji to the exact originating chat before processing, then sends the final answer normally. Set `BLUEBUBBLES_WORKING_ACK_EMOJI` instead if you prefer an environment variable. Leave both unset to disable it.
+
 ### Typing Indicators
 Shows "typing..." in the iMessage conversation while the agent is processing. Requires Private API.
 

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -172,7 +172,7 @@ platforms:
         - "+15550000001"
 ```
 
-Hermes responds only when at least one configured identity is a current participant. Direct-chat identity is read from the chat GUID; group membership is fetched from the local BlueBubbles server on every inbound message so leaving a group takes effect immediately. If `allowed_chat_guids` is also configured, both checks must pass. `BLUEBUBBLES_REQUIRED_PARTICIPANTS` accepts a JSON or comma-separated list.
+Hermes responds only when at least one configured identity is a current participant. Direct-chat identity is read from the chat GUID; group membership is fetched from the local BlueBubbles server on every inbound message so leaving a group takes effect immediately. When this scope is configured, the adapter treats it as the authoritative intake allowlist: any participant in an admitted group may address Hermes without separate per-sender pairing, while messages from chats outside the scope are dropped before acknowledgement. If `allowed_chat_guids` is also configured, both checks must pass. `BLUEBUBBLES_REQUIRED_PARTICIPANTS` accepts a JSON or comma-separated list.
 
 Add an ephemeral system prompt to every BlueBubbles group turn with `group_prompt`:
 

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -147,6 +147,21 @@ platforms:
 
 Hermes sends the emoji to the exact originating chat before processing, then sends the final answer normally. Set `BLUEBUBBLES_WORKING_ACK_EMOJI` instead if you prefer an environment variable. Leave both unset to disable it.
 
+### Conversation Allowlist
+
+Restrict Hermes to exact BlueBubbles conversations with `allowed_chat_guids`:
+
+```yaml
+platforms:
+  bluebubbles:
+    extra:
+      allowed_chat_guids:
+        - "any;+;approved-group-guid"
+        - "any;-;approved-direct-address"
+```
+
+When configured, messages from every unlisted group or direct chat are acknowledged by the webhook but ignored before the agent starts, so no working emoji or final answer is sent. Matching ignores only the BlueBubbles service prefix (`any` versus `iMessage`) while preserving the group/direct marker and conversation identifier. `BLUEBUBBLES_ALLOWED_CHAT_GUIDS` accepts a JSON or comma-separated list.
+
 ### Typing Indicators
 Shows "typing..." in the iMessage conversation while the agent is processing. Requires Private API.
 

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -174,6 +174,17 @@ platforms:
 
 Hermes responds only when at least one configured identity is a current participant. Direct-chat identity is read from the chat GUID; group membership is fetched from the local BlueBubbles server on every inbound message so leaving a group takes effect immediately. If `allowed_chat_guids` is also configured, both checks must pass. `BLUEBUBBLES_REQUIRED_PARTICIPANTS` accepts a JSON or comma-separated list.
 
+Add an ephemeral system prompt to every BlueBubbles group turn with `group_prompt`:
+
+```yaml
+platforms:
+  bluebubbles:
+    extra:
+      group_prompt: "Treat information learned outside this group as private."
+```
+
+The prompt is applied at API-call time only to group events; it is not persisted as a chat message and does not affect direct-message sessions. `BLUEBUBBLES_GROUP_PROMPT` provides the equivalent environment-variable override.
+
 ### Typing Indicators
 Shows "typing..." in the iMessage conversation while the agent is processing. Requires Private API.
 


### PR DESCRIPTION
## Summary
- subscribe only to `new-message`; ignore update events and deduplicate message GUIDs
- reconcile legacy webhook registrations that include `updated-message`
- add opt-in emoji-only working acknowledgements routed to the originating chat
- add exact-conversation and required-participant authorization controls
- treat configured chat/participant scope as authoritative so every participant in an admitted group can speak without separate pairing
- reject unauthorized senders before the working acknowledgement hook
- add an ephemeral group-only privacy/system prompt

## Why
Reduced `updated-message` payloads can omit the group GUID, replaying one physical iMessage and falling back to the sender DM. BlueBubbles tapbacks and typing indicators also require the Private API helper; `working_ack_emoji` provides a normal-iMessage fallback without disabling SIP.

The participant gate is a conversation-level authorization boundary: a group is admitted only while a configured identity is present. Without marking that gate authoritative, GatewayRunner can acknowledge a participant and then reject their agent turn because they lack separate sender pairing. The adapter now exposes the scoped allowlist policy and checks authorization before any acknowledgement.

## Test plan
- `uv run --with pytest --with pytest-asyncio --with aiohttp python -m pytest tests/gateway/test_bluebubbles.py -q -o "addopts=" -k "not check_requirements"`
- result: 32 passed, 1 deselected
- live local policy verification: Bryan-present group accepted, unmentioned emoji ignored, Sara DM blocked
- `ruff check` passed
- `git diff --check` passed
