### PR TITLE
fix(tui): carry the configured service tier into request_overrides

### DIFF
--- a/tests/tui_gateway/test_service_tier_request_overrides.py
+++ b/tests/tui_gateway/test_service_tier_request_overrides.py
@@ -1,0 +1,92 @@
+"""A service tier set in config.yaml must actually be SENT by TUI/desktop.
+
+``_make_agent`` passes ``service_tier=`` to ``AIAgent``, which stores it on the
+agent — but no transport reads that attribute.
+``agent/transports/chat_completions.py`` emits ``service_tier`` **only** from
+``request_overrides``, and the sole writer of ``agent.request_overrides`` in the
+TUI is the runtime ``/fast`` toggle handler.
+
+So ``agent.service_tier: fast`` in config.yaml is parsed, stored, and reported
+in session info, then silently dropped on the wire for every TUI/desktop
+session — the user is billed at the standard tier while the UI reports
+Priority. The CLI and messaging gateway resolve overrides in their turn-route
+builders and are unaffected.
+
+These tests pin the kwargs actually handed to ``AIAgent``, not the config
+resolution, so they fail if the tier stops reaching the transport layer.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import tui_gateway.server as server
+
+
+def _build(tier: str | None, model: str = "gpt-5.4"):
+    """Call _make_agent with the runtime stubbed out, returning AIAgent kwargs."""
+    captured = {}
+
+    class _Agent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    fake_run_agent = MagicMock()
+    fake_run_agent.AIAgent = _Agent
+
+    resolution = MagicMock()
+    resolution.used_fallback = False
+    resolution.selected_model = model
+    resolution.runtime = {
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "***",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    with (
+        patch.dict("sys.modules", {"run_agent": fake_run_agent}),
+        patch.object(server, "_load_service_tier", return_value=tier),
+        patch.object(server, "_resolve_startup_runtime", return_value=(model, "openrouter")),
+        patch.object(server, "_resolve_runtime_with_fallback", return_value=resolution),
+        patch.object(server, "_resolve_model", return_value=model),
+        patch.object(server, "_agent_cbs", return_value={}),
+        patch.object(server, "_get_db", return_value=None),
+        patch.object(server, "_load_reasoning_config", return_value=None),
+        patch.object(server, "_load_provider_routing", return_value={}),
+        patch.object(server, "_load_fallback_model", return_value=None),
+        patch.object(server, "_load_enabled_toolsets", return_value=None),
+    ):
+        server._make_agent("sid-1", "key-1")
+
+    return captured
+
+
+def test_priority_from_config_reaches_request_overrides():
+    kwargs = _build("priority")
+
+    assert kwargs["service_tier"] == "priority"
+    assert kwargs["request_overrides"] == {"service_tier": "priority"}
+
+
+def test_anthropic_priority_sends_speed_not_service_tier():
+    """Anthropic Fast Mode uses ``speed``; the resolver must pick per provider."""
+    kwargs = _build("priority", model="claude-opus-4-6")
+
+    assert kwargs["request_overrides"] == {"speed": "fast"}
+
+
+def test_no_tier_sends_no_overrides():
+    kwargs = _build(None)
+
+    assert not kwargs.get("request_overrides")
+
+
+def test_ineligible_model_sends_no_overrides():
+    """A tier set for a model with no tier support must not invent one."""
+    kwargs = _build("priority", model="gpt-5.3-codex")
+
+    assert not kwargs.get("request_overrides")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6625,6 +6625,26 @@ def _make_agent(
                 raise RuntimeError("Auth fallback resolved without a model")
             model = resolution.selected_model
     _pr = _load_provider_routing()
+    # Resolve the tier into request_overrides here: AIAgent stores
+    # ``service_tier`` but no transport reads that attribute —
+    # ``agent/transports/chat_completions.py`` emits it only from
+    # ``request_overrides``. Passing the tier alone left it stranded on the
+    # agent, so a tier set in config.yaml was reported in session info and
+    # then dropped on the wire unless the user flipped the runtime /fast
+    # toggle (the only other writer of request_overrides).
+    _effective_tier = (
+        service_tier_override
+        if service_tier_override is not None
+        else _load_service_tier()
+    )
+    _tier_overrides = None
+    if _effective_tier:
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        try:
+            _tier_overrides = resolve_fast_mode_overrides(model)
+        except Exception:
+            _tier_overrides = None
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
@@ -6646,11 +6666,8 @@ def _make_agent(
             if reasoning_config_override is not None
             else _load_reasoning_config(str(model or ""))
         ),
-        service_tier=(
-            service_tier_override
-            if service_tier_override is not None
-            else _load_service_tier()
-        ),
+        service_tier=_effective_tier,
+        request_overrides=_tier_overrides or {},
         enabled_toolsets=_load_enabled_toolsets(_resolve_agent_platform(platform_override)),
         # OpenRouter provider-routing prefs (config.yaml `provider_routing`).
         # Mirrors the messaging gateway + CLI so the desktop/TUI honors the same


### PR DESCRIPTION
## What does this PR do?

Fixes a service tier set in `config.yaml` being silently dropped on the wire for TUI/desktop sessions.

**Before:** `agent.service_tier: fast` is parsed, stored on the agent, and reported in session info — but never sent. The user is billed at the standard tier while the UI reports Priority.

**After:** the resolved tier reaches the transport, matching what the CLI and messaging gateway already do.

## Root cause

`tui_gateway/server.py::_make_agent` passes `service_tier=` to `AIAgent`. That value is stored (`agent/agent_init.py`), but **no transport reads the attribute** — `agent/transports/chat_completions.py` emits `service_tier` only from `request_overrides`.

The only writer of `agent.request_overrides` in the TUI was the runtime `/fast` toggle handler. So the config value only ever took effect if the user *also* flipped `/fast` during the session.

The CLI (`hermes_cli/cli_agent_setup_mixin.py`) and messaging gateway (`gateway/run.py`) both resolve overrides in their turn-route builders and are unaffected — this is a TUI/desktop-only gap.

## Changes Made

- `tui_gateway/server.py`: `_make_agent` resolves the effective tier once (respecting `service_tier_override`) and passes the resulting `request_overrides` to `AIAgent`. The existing `resolve_fast_mode_overrides()` already picks the right key per provider, so Anthropic keeps getting `speed` and OpenAI `service_tier`.
- `tests/tui_gateway/test_service_tier_request_overrides.py`: pins the kwargs actually handed to `AIAgent` rather than the config resolution — OpenAI, Anthropic, no-tier, and tier-ineligible model cases.

## How to Test

```bash
python -m pytest tests/tui_gateway/test_service_tier_request_overrides.py -q
```

The two positive tests fail on current `main` with `KeyError: 'request_overrides'` and pass with this change.

Manually: set `agent.service_tier: fast` in config.yaml, start a TUI/desktop session without touching `/fast`, and confirm `service_tier: priority` now appears in the outbound request.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

Full run of `tests/tui_gateway/` + `tests/test_tui_gateway_server.py`: 948 passed, 3 pre-existing failures unrelated to this change (`test_compute_host`, `test_compute_host_phase1`, `test_entry_import_off_main_thread` — all fail identically on untouched `main` here).

## Note

Found while porting #37059 (adds `flex` as a tier value) onto current `main`. That PR needs this plumbing for `flex` to work on desktop, and currently carries an equivalent change so it stays self-contained — happy to rebase it onto this if this lands first.
