### PR TITLE
feat(slack): add single-surface agent progress controls

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9229,10 +9229,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         busy_text_mode = self._effective_busy_text_mode(event.source)
         effective_mode = self._busy_input_mode
-        # EZ-525: an authorized plain-text reply in an active Slack thread is
-        # steering input, regardless of the workspace-wide busy mode. Media,
-        # internal completions, approvals, and commands retain their existing
-        # queue/interrupt paths. A failed steer still falls back to FIFO below.
+        busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
+        # EZ-525: authorized plain-text replies in an active Slack thread steer
+        # when the workspace is not explicitly in queue mode. Queue stays
+        # queue — do not silently override busy_input_mode / busy_text_mode.
+        # Media, internal completions, approvals, and commands keep their
+        # existing paths. A failed steer still falls back to FIFO below.
         _slack_plain_text_reply = bool(
             event.source.platform == Platform.SLACK
             and event.source.thread_id
@@ -9240,7 +9242,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             and not event.media_urls
             and not event.media_types
         )
-        if _slack_plain_text_reply:
+        _queue_configured = (
+            self._busy_input_mode == "queue" or busy_text_mode == "queue"
+        )
+        if _slack_plain_text_reply and not _queue_configured:
             effective_mode = "steer"
         if (
             event.message_type == MessageType.TEXT
@@ -14792,7 +14797,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Do not truncate/rewrite its transcript until the interrupted adapter
         # task has fully unwound and flushed. The retry re-enters through the
         # canonical /retry command under the adapter's normal session guard.
-        expected_invalidation_generation = generation + 1
+        # Read the generation stop actually produced — do not assume +1.
+        post_stop = self._peek_session_state(session_key)
+        expected_invalidation_generation = (
+            int(post_stop.persistent.run_generation)
+            if post_stop is not None
+            else None
+        )
+        if expected_invalidation_generation is None:
+            return False
         handle_message = getattr(adapter, "handle_message", None) if adapter is not None else None
         if active_task is None or not callable(handle_message):
             return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9228,13 +9228,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         running_agent = _busy_state.turn.agent if _busy_state else None
 
         busy_text_mode = self._effective_busy_text_mode(event.source)
-        effective_mode = self._busy_input_mode
-        busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
-        # EZ-525: authorized plain-text replies in an active Slack thread steer
-        # when the workspace is not explicitly in queue mode. Queue stays
-        # queue — do not silently override busy_input_mode / busy_text_mode.
-        # Media, internal completions, approvals, and commands keep their
-        # existing paths. A failed steer still falls back to FIFO below.
+        # Keep the profile-routed mode from above. Overwriting with the
+        # workspace-wide default would break multiplex steer/queue (#83648).
+        # EZ-525: authorized Slack thread replies steer unless the routed
+        # mode is already queue. Media, internal completions, approvals,
+        # and commands keep their existing paths.
         _slack_plain_text_reply = bool(
             event.source.platform == Platform.SLACK
             and event.source.thread_id
@@ -9243,7 +9241,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             and not event.media_types
         )
         _queue_configured = (
-            self._busy_input_mode == "queue" or busy_text_mode == "queue"
+            effective_mode == "queue" or busy_text_mode == "queue"
         )
         if _slack_plain_text_reply and not _queue_configured:
             effective_mode = "steer"
@@ -14739,7 +14737,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         thread_ts = str(payload.get("thread_ts") or "")
         user_id = str(payload.get("user_id") or "")
         session_key = str(payload.get("session_key") or "")
-        generation = int(payload.get("generation") or 0)
+        try:
+            generation = int(payload.get("generation") or 0)
+        except (TypeError, ValueError):
+            return False
         if not channel_id or not user_id or not session_key or not generation:
             return False
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3839,6 +3839,43 @@ class TurnRunner:
                     ctx._live_status_adapter.set_status_text(ctx.source.chat_id, None)
             except Exception as _ls_err:
                 logger.debug("live status update failed: %s", _ls_err)
+        # EZ-525: completed todo results are the authoritative full snapshot.
+        # Project them through a platform capability seam before the ordinary
+        # progress-bubble gates, because Slack intentionally keeps tool_progress
+        # off. Never inspect tool.started args: merge calls contain partial state.
+        if (
+            event_type == "tool.completed"
+            and tool_name == "todo"
+            and ctx._run_still_current()
+        ):
+            _todo_adapter = ctx._status_adapter or ctx._live_status_adapter
+            _project_todo = getattr(_todo_adapter, "project_todo_progress", None)
+            if callable(_project_todo):
+                try:
+                    _todo_result = kwargs.get("result")
+                    if isinstance(_todo_result, str):
+                        _todo_snapshot = json.loads(_todo_result)
+                    elif isinstance(_todo_result, dict):
+                        _todo_snapshot = _todo_result
+                    else:
+                        _todo_snapshot = None
+                    if isinstance(_todo_snapshot, dict):
+                        safe_schedule_threadsafe(
+                            _project_todo(
+                                ctx.source.chat_id,
+                                _todo_snapshot,
+                                metadata=ctx._status_thread_metadata,
+                                session_key=ctx.session_key or "",
+                                generation=ctx.run_generation or 0,
+                                user_id=ctx.source.user_id or "",
+                                chat_type=ctx.source.chat_type or "group",
+                            ),
+                            ctx._loop_for_step,
+                            logger=logger,
+                            log_message="Slack todo projection scheduling error",
+                        )
+                except Exception as _todo_err:
+                    logger.debug("todo progress projection failed: %s", _todo_err)
         # "log" mode: append tool.started lines to the log queue and stay
         # silent in chat. Handled before the progress_queue guard because
         # log mode runs without a chat progress queue.
@@ -5042,6 +5079,9 @@ class TurnRunner:
                 ctx.needs_progress_queue
                 or ctx.log_mode_enabled
                 or ctx._live_status_adapter is not None
+                or callable(
+                    getattr(ctx._status_adapter, "project_todo_progress", None)
+                )
             )
             else None
         )
@@ -9188,6 +9228,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         running_agent = _busy_state.turn.agent if _busy_state else None
 
         busy_text_mode = self._effective_busy_text_mode(event.source)
+        effective_mode = self._busy_input_mode
+        # EZ-525: an authorized plain-text reply in an active Slack thread is
+        # steering input, regardless of the workspace-wide busy mode. Media,
+        # internal completions, approvals, and commands retain their existing
+        # queue/interrupt paths. A failed steer still falls back to FIFO below.
+        _slack_plain_text_reply = bool(
+            event.source.platform == Platform.SLACK
+            and event.source.thread_id
+            and event.message_type == MessageType.TEXT
+            and not event.media_urls
+            and not event.media_types
+        )
+        if _slack_plain_text_reply:
+            effective_mode = "steer"
         if (
             event.message_type == MessageType.TEXT
             and busy_text_mode == "queue"
@@ -9328,6 +9382,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass  # don't let interrupt failure block the ack
 
+        # Slack thread steering (including FIFO fallback) is intentionally
+        # silent: native activity status remains the only working UI.
+        if _slack_plain_text_reply:
+            logger.debug("Slack busy input ack suppressed for session %s", session_key)
+            return True
+
         # Check if busy ack is disabled — skip sending but still process the input.
         # Placed before debounce so we don't stamp a "last ack" timestamp that was
         # never actually delivered.
@@ -9341,7 +9401,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # read just to discover that no ack will be sent.
         _BUSY_ACK_COOLDOWN = 30
         now = time.time()
-        last_ack = _busy_state.turn.busy_ack_ts if _busy_state else 0
+        last_ack = getattr(getattr(_busy_state, "turn", None), "busy_ack_ts", 0)
+        if not isinstance(last_ack, (int, float)):
+            last_ack = getattr(self, "_busy_ack_ts", {}).get(session_key, 0)
         if now - last_ack < _BUSY_ACK_COOLDOWN:
             return True  # interrupt sent (if not queue), ack already delivered recently
 
@@ -14657,6 +14719,164 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from hermes_cli.proxy_cli import format_status_text
 
         return format_status_text()
+
+    async def handle_slack_todo_action(
+        self,
+        action: str,
+        payload: Dict[str, Any],
+    ) -> bool:
+        """Execute a validated Slack todo-card control via canonical gateway paths."""
+        if action not in {"stop", "restart"}:
+            return False
+
+        team_id = str(payload.get("team_id") or "")
+        channel_id = str(payload.get("channel_id") or "")
+        thread_ts = str(payload.get("thread_ts") or "")
+        user_id = str(payload.get("user_id") or "")
+        session_key = str(payload.get("session_key") or "")
+        generation = int(payload.get("generation") or 0)
+        if not channel_id or not user_id or not session_key or not generation:
+            return False
+
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id=channel_id,
+            chat_type=str(payload.get("chat_type") or "group"),
+            user_id=user_id,
+            scope_id=team_id or None,
+            thread_id=thread_ts or None,
+        )
+        if not self._is_user_authorized(source):
+            return False
+        if self._session_key_for_source(source) != session_key:
+            return False
+
+        adapter = self._adapter_for_source(source)
+        active = getattr(adapter, "_active_sessions", {}).get(session_key) if adapter else None
+        if getattr(active, "_hermes_run_generation", None) != generation:
+            return False
+
+        active_task = (
+            getattr(adapter, "_session_tasks", {}).get(session_key)
+            if adapter is not None
+            else None
+        )
+        expected_session_id = ""
+        if action == "restart":
+            if active_task is None or active_task.done():
+                return False
+            try:
+                session_entry = await self.async_session_store.get_or_create_session(source)
+                expected_session_id = str(session_entry.session_id or "")
+            except Exception:
+                logger.warning(
+                    "Slack todo restart could not resolve the active transcript",
+                    exc_info=True,
+                )
+                return False
+            if not expected_session_id:
+                return False
+
+        control_event = MessageEvent(
+            text="/stop" if action == "stop" else "/retry",
+            message_type=MessageType.COMMAND,
+            source=source,
+            message_id=str(payload.get("message_ts") or ""),
+            raw_message={"hermes_todo_control": action},
+        )
+        await self._busy_stop_command(control_event, session_key, source)
+        if action == "stop":
+            return True
+
+        # Restart means retry the current turn, never restart the gateway.
+        # Do not truncate/rewrite its transcript until the interrupted adapter
+        # task has fully unwound and flushed. The retry re-enters through the
+        # canonical /retry command under the adapter's normal session guard.
+        expected_invalidation_generation = generation + 1
+        handle_message = getattr(adapter, "handle_message", None) if adapter is not None else None
+        if active_task is None or not callable(handle_message):
+            return False
+
+        async def _mark_restart_failed() -> None:
+            try:
+                finalizer = getattr(adapter, "finalize_todo_progress", None)
+                if not callable(finalizer):
+                    return
+                result = finalizer(
+                    session_key,
+                    generation,
+                    "failure",
+                    overwrite_closed=True,
+                )
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                logger.debug(
+                    "Failed to mark deferred Slack todo restart as failed",
+                    exc_info=True,
+                )
+
+        async def _restart_after_old_turn() -> None:
+            try:
+                try:
+                    await asyncio.shield(active_task)
+                except asyncio.CancelledError:
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise
+                    # The old session task itself was cancelled; its finally
+                    # path has still completed before the task became done.
+                except Exception:
+                    # A failed old turn is still safe to retry once finalized.
+                    pass
+
+                if not self._is_session_run_current(
+                    session_key, expected_invalidation_generation
+                ):
+                    logger.info(
+                        "Dropping stale Slack todo restart for session %s",
+                        session_key,
+                    )
+                    await _mark_restart_failed()
+                    return
+                if session_key in getattr(adapter, "_active_sessions", {}):
+                    logger.info(
+                        "Dropping Slack todo restart because session %s is active again",
+                        session_key,
+                    )
+                    await _mark_restart_failed()
+                    return
+                current_entry = await self.async_session_store.get_or_create_session(source)
+                if str(current_entry.session_id or "") != expected_session_id:
+                    logger.info(
+                        "Dropping Slack todo restart after conversation changed for %s",
+                        session_key,
+                    )
+                    await _mark_restart_failed()
+                    return
+                retry_dispatch = handle_message(control_event)
+                if inspect.isawaitable(retry_dispatch):
+                    await retry_dispatch
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "Deferred Slack todo restart failed for session %s",
+                    session_key,
+                    exc_info=True,
+                )
+                await _mark_restart_failed()
+
+        restart_task = asyncio.create_task(_restart_after_old_turn())
+        tracker = getattr(adapter, "_background_tasks", None)
+        if not isinstance(tracker, set):
+            tracker = getattr(self, "_slack_todo_restart_tasks", None)
+            if not isinstance(tracker, set):
+                tracker = set()
+                self._slack_todo_restart_tasks = tracker
+        tracker.add(restart_task)
+        restart_task.add_done_callback(tracker.discard)
+        return True
 
     async def _busy_stop_command(self, event: MessageEvent, quick_key: str, source):
         # /stop must hard-kill the session when an agent is running.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2550,58 +2550,46 @@ class GatewaySlashCommandsMixin:
         self._ephemeral_system_prompt = new_prompt
         return t("gateway.personality.set_to", name=name)
 
-    async def _handle_retry_command(self, event: MessageEvent) -> str:
-        """Handle /retry command - re-send the last user message."""
+    async def _prepare_retry_event(self, event: MessageEvent) -> Optional[MessageEvent]:
+        """Truncate the failed turn and build its canonical retry event."""
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
         history = await self.async_session_store.load_transcript(session_entry.session_id)
-        
-        # Find the last *real* user message. Timeline bookkeeping rows carry
-        # role=user + display_kind (model_switch / async_delegation_complete /
-        # auto_continue / hidden); clients never count them as user turns.
-        # Without this filter /retry rewrote the transcript around a marker
-        # and re-sent opaque bookkeeping text (same class as the TUI ordinal).
-        last_user_msg = None
-        last_user_idx = None
-        # is_user_originated_turn: excludes display_kind bookkeeping AND
-        # compaction handoffs (durable role=user, sometimes without
-        # display_kind on legacy sessions; #80622) — /retry must never
-        # re-send a reference-only summary as if the user asked it.
+
+        # Skip bookkeeping and compaction handoff rows; only retry a real user turn.
         from agent.context_compressor import is_user_originated_turn
 
+        last_user_msg = None
+        last_user_idx = None
         for i in range(len(history) - 1, -1, -1):
             msg = history[i]
             if is_user_originated_turn(msg):
                 last_user_msg = msg.get("content", "")
                 last_user_idx = i
                 break
-        
-        if not last_user_msg:
-            return t("gateway.retry.no_previous")
-        
-        # Truncate history to before the last user message and persist only the
-        # live view. After in-place compaction the pre-compaction transcript
-        # lives on as active=0/compacted=1 rows under this same session id, and
-        # a bare rewrite (active_only=False) would DELETE them (same class as
-        # #61145). /retry never intends to purge archived history, so avoid a
-        # separate existence probe: it could fail open or race with the write.
-        truncated = history[:last_user_idx]
-        await self.async_session_store.rewrite_transcript(
-            session_entry.session_id, truncated, active_only=True
-        )
-        # Reset stored token count — transcript was truncated
-        session_entry.last_prompt_tokens = 0
+        if not last_user_msg or last_user_idx is None:
+            return None
 
-        # Re-send by creating a fake text event with the old message
-        retry_event = MessageEvent(
+        # Preserve archived compacted rows; only rewrite the active transcript.
+        await self.async_session_store.rewrite_transcript(
+            session_entry.session_id,
+            history[:last_user_idx],
+            active_only=True,
+        )
+        session_entry.last_prompt_tokens = 0
+        return MessageEvent(
             text=last_user_msg,
             message_type=MessageType.TEXT,
             source=source,
             raw_message=event.raw_message,
             channel_prompt=event.channel_prompt,
         )
-        
-        # Let the normal message handler process it
+
+    async def _handle_retry_command(self, event: MessageEvent) -> str:
+        """Handle /retry command - re-send the last user message."""
+        retry_event = await self._prepare_retry_event(event)
+        if retry_event is None:
+            return t("gateway.retry.no_previous")
         return await self._handle_message(retry_event)
 
     async def _handle_goal_command(self, event: "MessageEvent") -> str:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2776,6 +2776,8 @@ class SlackAdapter(BasePlatformAdapter):
             self._todo_progress_lock = asyncio.Lock()
         if not hasattr(self, "_TODO_PROGRESS_MAX"):
             self._TODO_PROGRESS_MAX = 2000
+        if not hasattr(self, "_todo_progress_by_run"):
+            self._todo_progress_by_run = {}
 
     def _trim_todo_progress_states(self) -> None:
         if len(self._todo_progress_states) <= self._TODO_PROGRESS_MAX:
@@ -2786,6 +2788,7 @@ class SlackAdapter(BasePlatformAdapter):
         for key, state in stale:
             self._todo_progress_states.pop(key, None)
             self._todo_progress_tokens.pop(state.token, None)
+            self._todo_progress_by_run.pop((state.session_key, state.generation), None)
 
     async def project_todo_progress(
         self,
@@ -2825,12 +2828,22 @@ class SlackAdapter(BasePlatformAdapter):
                     return False
                 if generation > state.generation:
                     self._todo_progress_tokens.pop(state.token, None)
+                    self._todo_progress_by_run.pop(
+                        (state.session_key, state.generation), None
+                    )
                     state.generation = generation
                     state.user_id = str(user_id or "")
                     state.token = secrets.token_urlsafe(18)
                     state.action_consumed = False
                     state.closed = False
                     self._todo_progress_tokens[state.token] = route
+                    self._todo_progress_by_run[
+                        (state.session_key, state.generation)
+                    ] = route
+                else:
+                    self._todo_progress_by_run[
+                        (state.session_key, state.generation)
+                    ] = route
                 state.snapshot = snapshot
                 state.revision += 1
                 state.updated_at = time.monotonic()
@@ -2907,6 +2920,7 @@ class SlackAdapter(BasePlatformAdapter):
             )
             self._todo_progress_states[route] = state
             self._todo_progress_tokens[token] = route
+            self._todo_progress_by_run[(state.session_key, state.generation)] = route
             self._trim_todo_progress_states()
             return True
 
@@ -2925,19 +2939,15 @@ class SlackAdapter(BasePlatformAdapter):
         except (TypeError, ValueError):
             return False
         async with self._todo_progress_lock:
-            match = next(
-                (
-                    (route, state)
-                    for route, state in self._todo_progress_states.items()
-                    if state.session_key == str(session_key)
-                    and state.generation == generation
-                    and (overwrite_closed or not state.closed)
-                ),
-                None,
-            )
-            if match is None:
+            route = self._todo_progress_by_run.get((str(session_key), generation))
+            state = self._todo_progress_states.get(route) if route is not None else None
+            if (
+                state is None
+                or state.session_key != str(session_key)
+                or state.generation != generation
+                or (state.closed and not overwrite_closed)
+            ):
                 return False
-            _route, state = match
             state.closed = True
             state.action_consumed = True
             state.revision += 1

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2790,6 +2790,16 @@ class SlackAdapter(BasePlatformAdapter):
             self._todo_progress_tokens.pop(state.token, None)
             self._todo_progress_by_run.pop((state.session_key, state.generation), None)
 
+    def _open_todo_generation(self, session_key: str) -> int:
+        """Return the newest still-open card generation for a session, if any."""
+        self._ensure_todo_progress_state()
+        open_generations = [
+            state.generation
+            for state in self._todo_progress_states.values()
+            if state.session_key == str(session_key) and not state.closed
+        ]
+        return max(open_generations) if open_generations else 0
+
     async def project_todo_progress(
         self,
         chat_id: str,
@@ -4134,8 +4144,9 @@ class SlackAdapter(BasePlatformAdapter):
         self, event: MessageEvent, outcome: ProcessingOutcome
     ) -> None:
         """Resolve todo UI, then swap the optional outcome reaction."""
-        # Finalize only the generation that actually completed. A late callback
-        # from an interrupted run cannot close a newer retry's card.
+        # Finalize only a card owned by this completing generation. A late
+        # callback must not close a newer retry's card: finalize matches
+        # session+generation and ignores already-closed states.
         try:
             runner = getattr(self, "gateway_runner", None)
             if runner is None:
@@ -4144,11 +4155,13 @@ class SlackAdapter(BasePlatformAdapter):
             if callable(session_key_fn):
                 session_key = str(session_key_fn(event.source))
                 active = self._active_sessions.get(session_key)
-                generation = getattr(active, "_hermes_run_generation", 0) or 0
+                generation = getattr(active, "_hermes_run_generation", None)
+                if not generation:
+                    generation = self._open_todo_generation(session_key)
                 if generation:
                     await self.finalize_todo_progress(
                         session_key,
-                        generation,
+                        int(generation),
                         terminal_status=outcome.value,
                     )
         except Exception:
@@ -7054,7 +7067,9 @@ class SlackAdapter(BasePlatformAdapter):
         if not normalized_user_id:
             return False
 
-        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        runner = getattr(self, "gateway_runner", None)
+        if runner is None:
+            runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import time
 import unicodedata
 from dataclasses import dataclass, field
@@ -60,9 +61,19 @@ from gateway.platforms.base import (
 )
 
 try:  # sibling module; support both package and flat plugin-dir import
-    from .block_kit import render_blocks, sanitize_blocks
+    from .block_kit import (
+        render_blocks,
+        render_todo_progress,
+        sanitize_blocks,
+        todo_progress_eligible,
+    )
 except ImportError:  # pragma: no cover - plugin loaded outside package context
-    from block_kit import render_blocks, sanitize_blocks  # type: ignore
+    from block_kit import (  # type: ignore
+        render_blocks,
+        render_todo_progress,
+        sanitize_blocks,
+        todo_progress_eligible,
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -863,6 +874,26 @@ def _is_slack_voice_clip(file_obj: Dict[str, Any]) -> bool:
     return name.startswith("audio_message")
 
 
+@dataclass
+class _TodoProgressState:
+    """One server-owned Slack plan card, reused across todo updates/retries."""
+
+    team_id: str
+    channel_id: str
+    chat_type: str
+    thread_ts: str
+    session_key: str
+    generation: int
+    user_id: str
+    message_ts: str
+    token: str
+    snapshot: Dict[str, Any]
+    revision: int = 1
+    action_consumed: bool = False
+    closed: bool = False
+    updated_at: float = field(default_factory=time.monotonic)
+
+
 class SlackAdapter(BasePlatformAdapter):
     """
     Slack bot adapter using Socket Mode.
@@ -993,6 +1024,17 @@ class SlackAdapter(BasePlatformAdapter):
         # dozens of out-of-order status messages.
         self._status_message_ids: Dict[Tuple[str, str, str], str] = {}
         self._STATUS_MESSAGE_IDS_MAX = 2000
+        # EZ-525: one bounded, non-streaming todo card per Slack thread/session.
+        # The opaque action token is only a lookup key; routing, ownership, and
+        # generation are validated against this server-side state.
+        self._todo_progress_states: Dict[
+            Tuple[str, str, str, str], _TodoProgressState
+        ] = {}
+        self._todo_progress_tokens: Dict[
+            str, Tuple[str, str, str, str]
+        ] = {}
+        self._todo_progress_lock = asyncio.Lock()
+        self._TODO_PROGRESS_MAX = 2000
         # Cache for _fetch_thread_context results: cache_key → _ThreadContextCache
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
         self._THREAD_CACHE_TTL = 60.0
@@ -2102,6 +2144,12 @@ class SlackAdapter(BasePlatformAdapter):
 
             self._app.action("hermes_feedback")(self._handle_feedback_action)
 
+            # EZ-525 long-run plan controls. Values are opaque tokens; the
+            # handler validates route, owner, message id, and run generation
+            # against adapter-owned state before touching the gateway.
+            self._app.action("hermes_todo_stop")(self._handle_todo_action)
+            self._app.action("hermes_todo_restart")(self._handle_todo_action)
+
             # Register Block Kit action handlers for clarify buttons
             # (interactive multiple-choice prompts; see tools/clarify_gateway.py).
             # Choice buttons use indexed action IDs so each ID is unique within
@@ -2717,6 +2765,311 @@ class SlackAdapter(BasePlatformAdapter):
                     self._status_message_ids.pop(stale, None)
             self._status_message_ids[key] = str(result.message_id)
         return result
+
+    def _ensure_todo_progress_state(self) -> None:
+        """Initialize EZ-525 state for partial test doubles and old pickles."""
+        if not hasattr(self, "_todo_progress_states"):
+            self._todo_progress_states = {}
+        if not hasattr(self, "_todo_progress_tokens"):
+            self._todo_progress_tokens = {}
+        if not hasattr(self, "_todo_progress_lock"):
+            self._todo_progress_lock = asyncio.Lock()
+        if not hasattr(self, "_TODO_PROGRESS_MAX"):
+            self._TODO_PROGRESS_MAX = 2000
+
+    def _trim_todo_progress_states(self) -> None:
+        if len(self._todo_progress_states) <= self._TODO_PROGRESS_MAX:
+            return
+        stale = sorted(
+            self._todo_progress_states.items(), key=lambda pair: pair[1].updated_at
+        )[: self._TODO_PROGRESS_MAX // 2]
+        for key, state in stale:
+            self._todo_progress_states.pop(key, None)
+            self._todo_progress_tokens.pop(state.token, None)
+
+    async def project_todo_progress(
+        self,
+        chat_id: str,
+        snapshot: Dict[str, Any],
+        *,
+        metadata: Optional[Dict[str, Any]],
+        session_key: str,
+        generation: int,
+        user_id: str,
+        chat_type: str = "group",
+    ) -> bool:
+        """Post/update the one non-streaming todo card for a Slack run.
+
+        The first eligible snapshot may create one message. Every later
+        snapshot, including a newer retry generation, edits that same ts. Once
+        a state is terminal, late callbacks are ignored. Slack failures are
+        best-effort and never fall back to a replacement post.
+        """
+        self._ensure_todo_progress_state()
+        if not self._app or self._is_ignored_channel(chat_id):
+            return False
+        team_id = str(self._metadata_team_id(metadata) or self._channel_team.get(chat_id, ""))
+        thread_ts = str(self._resolve_thread_ts(None, metadata) or "")
+        route = (team_id, str(chat_id), thread_ts, str(session_key))
+        try:
+            generation = int(generation)
+        except (TypeError, ValueError):
+            return False
+
+        async with self._todo_progress_lock:
+            state = self._todo_progress_states.get(route)
+            if state is not None:
+                if generation < state.generation or (
+                    generation == state.generation and state.closed
+                ):
+                    return False
+                if generation > state.generation:
+                    self._todo_progress_tokens.pop(state.token, None)
+                    state.generation = generation
+                    state.user_id = str(user_id or "")
+                    state.token = secrets.token_urlsafe(18)
+                    state.action_consumed = False
+                    state.closed = False
+                    self._todo_progress_tokens[state.token] = route
+                state.snapshot = snapshot
+                state.revision += 1
+                state.updated_at = time.monotonic()
+                rendered = render_todo_progress(
+                    snapshot,
+                    active=True,
+                    generation=state.generation,
+                    revision=state.revision,
+                    action_token=state.token,
+                )
+                if rendered is None:
+                    return False
+                text, blocks = rendered
+                try:
+                    await self._get_client(
+                        chat_id, team_id=team_id or None
+                    ).chat_update(
+                        channel=chat_id,
+                        ts=state.message_ts,
+                        text=text,
+                        blocks=sanitize_blocks(blocks),
+                    )
+                    return True
+                except Exception as exc:
+                    logger.debug(
+                        "[Slack] todo progress update failed; preserving single-card state: %s",
+                        exc,
+                    )
+                    return False
+
+            if not todo_progress_eligible(snapshot):
+                return False
+            token = secrets.token_urlsafe(18)
+            rendered = render_todo_progress(
+                snapshot,
+                active=True,
+                generation=generation,
+                revision=1,
+                action_token=token,
+            )
+            if rendered is None:
+                return False
+            text, blocks = rendered
+            kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "text": text,
+                "blocks": sanitize_blocks(blocks),
+            }
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+            try:
+                result = await self._get_client(
+                    chat_id, team_id=team_id or None
+                ).chat_postMessage(**kwargs)
+            except Exception as exc:
+                # Do not retry as plain text: that would leave an untracked WIP
+                # message and defeat the native-status fallback.
+                logger.debug("[Slack] todo progress post failed; using native status: %s", exc)
+                return False
+            message_ts = str((result or {}).get("ts") or "")
+            if not message_ts:
+                return False
+            state = _TodoProgressState(
+                team_id=team_id,
+                channel_id=str(chat_id),
+                chat_type=str(chat_type or "group"),
+                thread_ts=thread_ts,
+                session_key=str(session_key),
+                generation=generation,
+                user_id=str(user_id or ""),
+                message_ts=message_ts,
+                token=token,
+                snapshot=snapshot,
+            )
+            self._todo_progress_states[route] = state
+            self._todo_progress_tokens[token] = route
+            self._trim_todo_progress_states()
+            return True
+
+    async def finalize_todo_progress(
+        self,
+        session_key: str,
+        generation: int,
+        terminal_status: str,
+        *,
+        overwrite_closed: bool = False,
+    ) -> bool:
+        """Make the owned plan card terminal and remove active controls."""
+        self._ensure_todo_progress_state()
+        try:
+            generation = int(generation)
+        except (TypeError, ValueError):
+            return False
+        async with self._todo_progress_lock:
+            match = next(
+                (
+                    (route, state)
+                    for route, state in self._todo_progress_states.items()
+                    if state.session_key == str(session_key)
+                    and state.generation == generation
+                    and (overwrite_closed or not state.closed)
+                ),
+                None,
+            )
+            if match is None:
+                return False
+            _route, state = match
+            state.closed = True
+            state.action_consumed = True
+            state.revision += 1
+            state.updated_at = time.monotonic()
+            self._todo_progress_tokens.pop(state.token, None)
+            rendered = render_todo_progress(
+                state.snapshot,
+                active=False,
+                terminal_status=terminal_status,
+                generation=state.generation,
+                revision=state.revision,
+            )
+            if rendered is None:
+                return False
+            text, blocks = rendered
+            try:
+                await self._get_client(
+                    state.channel_id, team_id=state.team_id or None
+                ).chat_update(
+                    channel=state.channel_id,
+                    ts=state.message_ts,
+                    text=text,
+                    blocks=sanitize_blocks(blocks),
+                )
+                return True
+            except Exception as exc:
+                logger.debug("[Slack] todo progress finalization failed: %s", exc)
+                return False
+
+    async def _handle_todo_action(self, ack, body, action) -> None:
+        """Validate and dispatch stop/restart for the exact owned run."""
+        await ack()
+        self._ensure_todo_progress_state()
+        action_id = str((action or {}).get("action_id") or "")
+        if action_id not in {"hermes_todo_stop", "hermes_todo_restart"}:
+            return
+        token = str((action or {}).get("value") or "")
+        team_id = str((body.get("team") or {}).get("id") or "")
+        channel_id = str((body.get("channel") or {}).get("id") or "")
+        user_id = str((body.get("user") or {}).get("id") or "")
+        message = body.get("message") or {}
+        container = body.get("container") or {}
+        message_ts = str(message.get("ts") or container.get("message_ts") or "")
+        thread_ts = str(message.get("thread_ts") or container.get("thread_ts") or "")
+
+        payload: Optional[Dict[str, Any]] = None
+        async with self._todo_progress_lock:
+            route = self._todo_progress_tokens.get(token)
+            state = self._todo_progress_states.get(route) if route else None
+            if state is None or state.closed or state.action_consumed:
+                return
+            if not self._is_interactive_user_authorized(
+                user_id,
+                channel_id=channel_id,
+                team_id=team_id,
+                user_name=(body.get("user") or {}).get("name"),
+            ):
+                return
+            if (
+                team_id != state.team_id
+                or channel_id != state.channel_id
+                or thread_ts != state.thread_ts
+                or message_ts != state.message_ts
+                or user_id != state.user_id
+            ):
+                return
+            active = self._active_sessions.get(state.session_key)
+            if getattr(active, "_hermes_run_generation", None) != state.generation:
+                return
+            state.action_consumed = True
+            state.closed = True
+            state.revision += 1
+            state.updated_at = time.monotonic()
+            self._todo_progress_tokens.pop(state.token, None)
+            label = "stopped" if action_id == "hermes_todo_stop" else "restarting"
+            rendered = render_todo_progress(
+                state.snapshot,
+                active=False,
+                terminal_status=label,
+                generation=state.generation,
+                revision=state.revision,
+            )
+            if rendered is not None:
+                text, blocks = rendered
+                try:
+                    await self._get_client(
+                        state.channel_id, team_id=state.team_id or None
+                    ).chat_update(
+                        channel=state.channel_id,
+                        ts=state.message_ts,
+                        text=text,
+                        blocks=sanitize_blocks(blocks),
+                    )
+                except Exception:
+                    logger.debug("[Slack] todo control UI update failed", exc_info=True)
+            payload = {
+                "team_id": state.team_id,
+                "channel_id": state.channel_id,
+                "chat_type": state.chat_type,
+                "thread_ts": state.thread_ts,
+                "session_key": state.session_key,
+                "generation": state.generation,
+                "user_id": state.user_id,
+                "message_ts": state.message_ts,
+            }
+
+        runner = getattr(self, "gateway_runner", None)
+        if runner is None:
+            runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        handler = getattr(runner, "handle_slack_todo_action", None)
+        dispatch_ok = False
+        if callable(handler) and payload is not None:
+            try:
+                result = handler(
+                    "stop" if action_id == "hermes_todo_stop" else "restart",
+                    payload,
+                )
+                if inspect.isawaitable(result):
+                    result = await result
+                dispatch_ok = bool(result)
+            except Exception:
+                logger.warning("[Slack] todo action dispatch failed", exc_info=True)
+        if not dispatch_ok and payload is not None:
+            # The control was already consumed and closed above so the old
+            # run's completion cannot overwrite it. If dispatch itself failed,
+            # replace that terminal label explicitly without reopening it.
+            await self.finalize_todo_progress(
+                payload["session_key"],
+                payload["generation"],
+                terminal_status="failure",
+                overwrite_closed=True,
+            )
 
     async def edit_message(
         self,
@@ -3770,7 +4123,27 @@ class SlackAdapter(BasePlatformAdapter):
     async def on_processing_complete(
         self, event: MessageEvent, outcome: ProcessingOutcome
     ) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction."""
+        """Resolve todo UI, then swap the optional outcome reaction."""
+        # Finalize only the generation that actually completed. A late callback
+        # from an interrupted run cannot close a newer retry's card.
+        try:
+            runner = getattr(self, "gateway_runner", None)
+            if runner is None:
+                runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+            session_key_fn = getattr(runner, "_session_key_for_source", None)
+            if callable(session_key_fn):
+                session_key = str(session_key_fn(event.source))
+                active = self._active_sessions.get(session_key)
+                generation = getattr(active, "_hermes_run_generation", 0) or 0
+                if generation:
+                    await self.finalize_todo_progress(
+                        session_key,
+                        generation,
+                        terminal_status=outcome.value,
+                    )
+        except Exception:
+            logger.debug("[Slack] todo progress finalization failed", exc_info=True)
+
         if not self._reactions_enabled():
             return
         ts = getattr(event, "message_id", None)

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -56,7 +56,12 @@ _TODO_TERMINAL = frozenset({"completed", "cancelled"})
 _TODO_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
 _TODO_FENCED_CODE_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 _TODO_LOCAL_PATH_RE = re.compile(
-    r"(?:(?:/Users|/home|/private/var|/tmp)/[^\s,;:]+|~/[^\s,;:]+)"
+    r"(?:"
+    r"(?:/Users|/home|/private/var|/tmp)/[^\s,;:]+"
+    r"|~/[^\s,;:]+"
+    r"|[A-Za-z]:\\[^\s,;]+"
+    r"|\\\\[^\s,;]+"
+    r")"
 )
 _TODO_SECRET_RE = re.compile(
     r"(?i)\b(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;]+"

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -42,6 +42,175 @@ MAX_TABLE_CHARS = 10000  # aggregate across all cells
 
 Block = Dict[str, Any]
 
+# Todo progress is deliberately rendered with ordinary, non-streaming Block Kit
+# primitives.  Slack's token-stream APIs are a separate transport and caused
+# permanent WIP-message spam when combined with tool calls.  Keeping this
+# projection pure also makes the privacy boundary testable before any API call.
+_TODO_STATUS = {
+    "pending": ("○", "pending"),
+    "in_progress": ("🔄", "in progress"),
+    "completed": ("✅", "complete"),
+    "cancelled": ("❌", "cancelled"),
+}
+_TODO_TERMINAL = frozenset({"completed", "cancelled"})
+_TODO_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+_TODO_FENCED_CODE_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
+_TODO_LOCAL_PATH_RE = re.compile(
+    r"(?:(?:/Users|/home|/private/var|/tmp)/[^\s,;:]+|~/[^\s,;:]+)"
+)
+_TODO_SECRET_RE = re.compile(
+    r"(?i)\b(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;]+"
+)
+_TODO_CREDENTIAL_RE = re.compile(
+    r"(?i)\b(?:bearer\s+)?(?:sk-[a-z0-9_-]{12,}|xox[baprs]-[a-z0-9-]{12,}|gh[pousr]_[a-z0-9]{12,})"
+)
+
+
+def _todo_text(value: Any, *, limit: int = 180) -> str:
+    """Return public-safe, bounded text for a todo row.
+
+    Todo content is model-authored and may contain a copied command, local path,
+    tool argument, or credential-shaped value.  The Slack plan surface is a
+    shared-channel UI, not a trace viewer, so those details are removed here.
+    """
+    text = str(value or "")
+    text = _TODO_FENCED_CODE_RE.sub("[command hidden]", text)
+    text = _TODO_INLINE_CODE_RE.sub("[command hidden]", text)
+    text = _TODO_LOCAL_PATH_RE.sub("[local path hidden]", text)
+    text = _TODO_SECRET_RE.sub(lambda m: f"{m.group(1)}=[hidden]", text)
+    text = _TODO_CREDENTIAL_RE.sub("[credential hidden]", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    # Slack mrkdwn requires these three characters to be escaped.
+    text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    if not text:
+        text = "working step"
+    if len(text) > limit:
+        text = text[: limit - 1].rstrip() + "…"
+    return text
+
+
+def _todo_rows(snapshot: Any) -> Optional[List[Dict[str, str]]]:
+    """Validate the authoritative todo-tool snapshot and return safe rows."""
+    if not isinstance(snapshot, dict):
+        return None
+    raw = snapshot.get("todos")
+    if not isinstance(raw, list) or not raw:
+        return None
+    rows: List[Dict[str, str]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "pending").strip().lower()
+        if status not in _TODO_STATUS:
+            status = "pending"
+        rows.append(
+            {
+                "id": str(item.get("id") or index)[:80],
+                "content": _todo_text(item.get("content")),
+                "status": status,
+            }
+        )
+    return rows or None
+
+
+def todo_progress_eligible(snapshot: Any) -> bool:
+    """Long-work gate: short tasks stay on Slack's native ephemeral status."""
+    rows = _todo_rows(snapshot)
+    if not rows:
+        return False
+    non_terminal = sum(row["status"] not in _TODO_TERMINAL for row in rows)
+    return non_terminal > 0 and (len(rows) >= 3 or non_terminal >= 2)
+
+
+def render_todo_progress(
+    snapshot: Any,
+    *,
+    active: bool = True,
+    terminal_status: Optional[str] = None,
+    generation: int = 0,
+    revision: int = 0,
+    action_token: Optional[str] = None,
+) -> Optional[Tuple[str, List[Block]]]:
+    """Render one bounded Slack progress surface from canonical todo state.
+
+    Returns ``(fallback_text, blocks)`` or ``None`` when the snapshot is too
+    small or invalid.  Revisions rotate ``block_id`` as required by Slack when
+    a message is updated in place.
+    """
+    rows = _todo_rows(snapshot)
+    if not rows:
+        return None
+
+    visible = rows[:20]
+    lines = []
+    for row in visible:
+        symbol, _label = _TODO_STATUS[row["status"]]
+        lines.append(f"{symbol} {row['content']}")
+    if len(rows) > len(visible):
+        lines.append(f"… plus {len(rows) - len(visible)} more steps")
+
+    completed = sum(row["status"] == "completed" for row in rows)
+    cancelled = sum(row["status"] == "cancelled" for row in rows)
+    terminal = str(terminal_status or "").strip().lower()
+    if not active:
+        if terminal in {"complete", "completed", "success"}:
+            fallback = f"completed {completed}/{len(rows)} steps"
+            context = "✅ finished"
+        elif terminal == "restarting":
+            fallback = f"restarting after {completed}/{len(rows)} steps"
+            context = "🔄 restarting"
+        elif terminal in {"cancelled", "canceled", "stopped"}:
+            fallback = f"stopped after {completed}/{len(rows)} steps"
+            context = "⛔ stopped"
+        else:
+            fallback = f"failed after {completed}/{len(rows)} steps"
+            context = "❌ failed"
+    else:
+        fallback = f"working through {len(rows)} steps ({completed} complete)"
+        context = f"{completed}/{len(rows)} complete"
+        if cancelled:
+            context += f" · {cancelled} cancelled"
+
+    block_id = f"hermes_todo_{int(generation)}_{int(revision)}"[:255]
+    body = "\n".join(lines)
+    if len(body) > MAX_SECTION_TEXT:
+        body = body[: MAX_SECTION_TEXT - 1].rstrip() + "…"
+    blocks: List[Block] = [
+        {
+            "type": "section",
+            "block_id": block_id,
+            "text": {"type": "mrkdwn", "text": body},
+        },
+        {
+            "type": "context",
+            "block_id": f"{block_id}_status"[:255],
+            "elements": [{"type": "mrkdwn", "text": context}],
+        },
+    ]
+    if active and action_token:
+        blocks.append(
+            {
+                "type": "actions",
+                "block_id": f"{block_id}_actions"[:255],
+                "elements": [
+                    {
+                        "type": "button",
+                        "action_id": "hermes_todo_stop",
+                        "text": {"type": "plain_text", "text": "stop"},
+                        "style": "danger",
+                        "value": action_token,
+                    },
+                    {
+                        "type": "button",
+                        "action_id": "hermes_todo_restart",
+                        "text": {"type": "plain_text", "text": "restart"},
+                        "value": action_token,
+                    },
+                ],
+            }
+        )
+    return fallback, blocks
+
 # ----------------------------------------------------------------------------
 # Line classification
 # ----------------------------------------------------------------------------

--- a/tests/gateway/test_slack_todo_progress.py
+++ b/tests/gateway/test_slack_todo_progress.py
@@ -59,7 +59,9 @@ def _event(text="change direction", user_id="U1"):
 
 def test_todo_renderer_is_private_bounded_and_interactive():
     snapshot = _snapshot()
-    snapshot["todos"][0]["content"] += " bearer sk-live-example123456"
+    snapshot["todos"][0]["content"] += (
+        " bearer sk-live-example123456 C:\\Users\\aditya\\.env \\\\server\\share\\secret"
+    )
 
     assert todo_progress_eligible(snapshot)
     rendered = render_todo_progress(
@@ -77,6 +79,8 @@ def test_todo_renderer_is_private_bounded_and_interactive():
     assert "hermes_todo_stop" in blob
     assert "hermes_todo_restart" in blob
     assert "/Users/" not in blob
+    assert "C:\\\\Users" not in blob
+    assert "\\\\server" not in blob
     assert "secret" not in blob
     assert "sk-live" not in blob
 
@@ -247,6 +251,7 @@ def _steering_runner(agent):
     runner.adapters = {Platform.SLACK: adapter}
     runner._busy_input_mode = "interrupt"
     runner._busy_text_mode = "interrupt"
+    runner._draining = False
     runner._is_user_authorized = lambda source: True
     state = SimpleNamespace(turn=SimpleNamespace(agent=agent), busy_ack_ts=0.0)
     runner._peek_session_state = MagicMock(return_value=state)
@@ -289,6 +294,23 @@ async def test_failed_slack_steer_queues_fifo_without_ack():
     adapter._send_with_retry.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_queued_workspace_does_not_force_slack_thread_steer():
+    agent = MagicMock()
+    agent.steer.return_value = True
+    agent.active_children = set()
+    runner, adapter = _steering_runner(agent)
+    runner._busy_input_mode = "queue"
+    runner._busy_text_mode = "queue"
+    event = _event()
+    session_key = "slack:T1:C1:111.1"
+
+    assert await runner._handle_active_session_busy_message(event, session_key) is False
+
+    agent.steer.assert_not_called()
+    adapter._send_with_retry.assert_not_awaited()
+
+
 def _control_runner(active_generation=5):
     runner = object.__new__(GatewayRunner)
     session_key = "slack:T1:C1:111.1"
@@ -304,6 +326,11 @@ def _control_runner(active_generation=5):
     runner._session_key_for_source = lambda source: session_key
     runner._adapter_for_source = lambda source: adapter
     runner._busy_stop_command = AsyncMock()
+    runner._peek_session_state = MagicMock(
+        return_value=SimpleNamespace(
+            persistent=SimpleNamespace(run_generation=active_generation + 1)
+        )
+    )
     runner._is_session_run_current = MagicMock(return_value=True)
     async_store = MagicMock()
     async_store.get_or_create_session = AsyncMock(

--- a/tests/gateway/test_slack_todo_progress.py
+++ b/tests/gateway/test_slack_todo_progress.py
@@ -447,3 +447,60 @@ async def test_gateway_rejects_stale_control_generation():
 
     runner._busy_stop_command.assert_not_awaited()
     adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_non_integer_control_generation():
+    runner, adapter, session_key, _active_task = _control_runner()
+    payload = _control_payload(session_key)
+    payload["generation"] = "not-a-generation"
+
+    assert not await runner.handle_slack_todo_action("stop", payload)
+
+    runner._busy_stop_command.assert_not_awaited()
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_late_complete_does_not_overwrite_stopped_card():
+    adapter, client, _runner, state, body = await _project_action_card()
+    await adapter._handle_todo_action(
+        AsyncMock(),
+        body,
+        {"action_id": "hermes_todo_stop", "value": state.token},
+    )
+    client.chat_update.reset_mock()
+
+    newer = asyncio.Event()
+    setattr(newer, "_hermes_run_generation", 13)
+    adapter._active_sessions[state.session_key] = newer
+    await adapter.on_processing_complete(_event(), ProcessingOutcome.SUCCESS)
+
+    client.chat_update.assert_not_awaited()
+    assert state.closed is True
+    assert next(iter(adapter._todo_progress_states.values())).generation == 7
+
+
+@pytest.mark.asyncio
+async def test_complete_without_active_session_still_closes_card():
+    adapter, client = _slack_adapter()
+    session_key = "slack:T1:C1:111.1"
+    assert await adapter.project_todo_progress(
+        "C1",
+        _snapshot(),
+        metadata={"team_id": "T1", "thread_id": "111.1"},
+        session_key=session_key,
+        generation=4,
+        user_id="U1",
+    )
+    runner = MagicMock()
+    runner._session_key_for_source = MagicMock(return_value=session_key)
+    setattr(adapter, "gateway_runner", runner)
+
+    await adapter.on_processing_complete(_event(), ProcessingOutcome.SUCCESS)
+
+    assert next(iter(adapter._todo_progress_states.values())).closed is True
+    assert all(
+        block["type"] != "actions"
+        for block in client.chat_update.await_args.kwargs["blocks"]
+    )

--- a/tests/gateway/test_slack_todo_progress.py
+++ b/tests/gateway/test_slack_todo_progress.py
@@ -1,0 +1,422 @@
+"""Regression coverage for EZ-525's single-surface Slack agent UX."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+from gateway.run import GatewayRunner, TurnRunner
+from gateway.session import SessionSource
+from plugins.platforms.slack.adapter import SlackAdapter
+from plugins.platforms.slack.block_kit import render_todo_progress, todo_progress_eligible
+
+
+def _snapshot(second_status="in_progress", third_status="pending"):
+    return {
+        "todos": [
+            {"content": "inspect /Users/aditya/.env TOKEN=secret", "status": "completed"},
+            {"content": "implement", "status": second_status},
+            {"content": "verify", "status": third_status},
+        ]
+    }
+
+
+def _slack_adapter():
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake", extra={}))
+    adapter._app = MagicMock()
+    client = AsyncMock()
+    client.chat_postMessage = AsyncMock(return_value={"ts": "111.222"})
+    client.chat_update = AsyncMock(return_value={"ts": "111.222"})
+    adapter._get_client = MagicMock(return_value=client)
+    adapter.stop_typing = AsyncMock()
+    adapter._running = True
+    return adapter, client
+
+
+def _source(user_id="U1", chat_type="group"):
+    return SessionSource(
+        platform=Platform.SLACK,
+        scope_id="T1",
+        chat_id="C1",
+        chat_type=chat_type,
+        user_id=user_id,
+        thread_id="111.1",
+    )
+
+
+def _event(text="change direction", user_id="U1"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_source(user_id),
+        message_id="111.2",
+    )
+
+
+def test_todo_renderer_is_private_bounded_and_interactive():
+    snapshot = _snapshot()
+    snapshot["todos"][0]["content"] += " bearer sk-live-example123456"
+
+    assert todo_progress_eligible(snapshot)
+    rendered = render_todo_progress(
+        snapshot,
+        active=True,
+        generation=3,
+        revision=1,
+        action_token="opaque-token",
+    )
+
+    assert rendered is not None
+    _, blocks = rendered
+    assert [block["type"] for block in blocks] == ["section", "context", "actions"]
+    blob = str(blocks)
+    assert "hermes_todo_stop" in blob
+    assert "hermes_todo_restart" in blob
+    assert "/Users/" not in blob
+    assert "secret" not in blob
+    assert "sk-live" not in blob
+
+
+def test_todo_card_only_opens_for_active_multistep_work():
+    assert not todo_progress_eligible(
+        {"todos": [{"content": "one", "status": "pending"}]}
+    )
+    assert not todo_progress_eligible(
+        {
+            "todos": [
+                {"content": "one", "status": "completed"},
+                {"content": "two", "status": "completed"},
+                {"content": "three", "status": "cancelled"},
+            ]
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_projection_updates_one_message_and_final_delivery_removes_controls():
+    adapter, client = _slack_adapter()
+    session_key = "slack:T1:C1:111.1"
+    metadata = {"team_id": "T1", "thread_id": "111.1"}
+
+    assert await adapter.project_todo_progress(
+        "C1",
+        _snapshot(),
+        metadata=metadata,
+        session_key=session_key,
+        generation=12,
+        user_id="U1",
+    )
+    assert await adapter.project_todo_progress(
+        "C1",
+        _snapshot("completed", "completed"),
+        metadata=metadata,
+        session_key=session_key,
+        generation=12,
+        user_id="U1",
+    )
+
+    active = asyncio.Event()
+    setattr(active, "_hermes_run_generation", 12)
+    adapter._active_sessions[session_key] = active
+    runner = MagicMock()
+    runner._session_key_for_source = MagicMock(return_value=session_key)
+    setattr(adapter, "gateway_runner", runner)
+    await adapter.on_processing_complete(_event(), ProcessingOutcome.SUCCESS)
+
+    client.chat_postMessage.assert_awaited_once()
+    assert client.chat_update.await_count == 2
+    assert all(
+        block["type"] != "actions"
+        for block in client.chat_update.await_args.kwargs["blocks"]
+    )
+    assert next(iter(adapter._todo_progress_states.values())).closed is True
+
+
+async def _project_action_card(active_generation=7):
+    adapter, client = _slack_adapter()
+    session_key = "slack:T1:C1:111.1"
+    active = asyncio.Event()
+    setattr(active, "_hermes_run_generation", active_generation)
+    adapter._active_sessions[session_key] = active
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    runner = MagicMock()
+    runner.handle_slack_todo_action = AsyncMock(return_value=True)
+    setattr(adapter, "gateway_runner", runner)
+    await adapter.project_todo_progress(
+        "C1",
+        _snapshot(),
+        metadata={"team_id": "T1", "thread_id": "111.1"},
+        session_key=session_key,
+        generation=7,
+        user_id="U1",
+    )
+    state = next(iter(adapter._todo_progress_states.values()))
+    body = {
+        "team": {"id": "T1"},
+        "channel": {"id": "C1"},
+        "message": {"ts": "111.222", "thread_ts": "111.1"},
+        "user": {"id": "U1"},
+    }
+    return adapter, client, runner, state, body
+
+
+@pytest.mark.asyncio
+async def test_control_is_generation_owned_authorized_and_one_shot():
+    adapter, client, runner, state, body = await _project_action_card()
+    action = {"action_id": "hermes_todo_stop", "value": state.token}
+
+    await adapter._handle_todo_action(AsyncMock(), body, action)
+    await adapter._handle_todo_action(AsyncMock(), body, action)
+
+    runner.handle_slack_todo_action.assert_awaited_once()
+    assert state.closed is True
+    assert state.token not in adapter._todo_progress_tokens
+    assert not await adapter.finalize_todo_progress(
+        state.session_key, state.generation, "success"
+    )
+    client.chat_update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stale_or_different_user_control_cannot_mutate_card():
+    adapter, client, runner, state, body = await _project_action_card(active_generation=8)
+    await adapter._handle_todo_action(
+        AsyncMock(),
+        body,
+        {"action_id": "hermes_todo_restart", "value": state.token},
+    )
+    runner.handle_slack_todo_action.assert_not_awaited()
+    client.chat_update.assert_not_awaited()
+
+    adapter, client, runner, state, body = await _project_action_card()
+    body["user"]["id"] = "U2"
+    await adapter._handle_todo_action(
+        AsyncMock(),
+        body,
+        {"action_id": "hermes_todo_stop", "value": state.token},
+    )
+    runner.handle_slack_todo_action.assert_not_awaited()
+    client.chat_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_only_completed_todo_results_project_to_slack():
+    projector = SimpleNamespace(project_todo_progress=AsyncMock(return_value=True))
+    ctx = SimpleNamespace(
+        _live_status_adapter=None,
+        _live_status_mode="off",
+        _run_still_current=lambda: True,
+        _status_adapter=projector,
+        _status_thread_metadata={"team_id": "T1", "thread_id": "111.1"},
+        source=_source(),
+        session_key="slack:T1:C1:111.1",
+        run_generation=9,
+        _loop_for_step=asyncio.get_running_loop(),
+        log_queue=None,
+        progress_queue=None,
+    )
+    result = json.dumps(_snapshot())
+    turn_runner = object.__new__(TurnRunner)
+    turn_runner._ctx = ctx
+
+    turn_runner.progress_callback("tool.started", "todo", "", {}, result=result)
+    turn_runner.progress_callback("tool.completed", "todo", "", {}, result=result)
+    await asyncio.sleep(0.01)
+
+    projector.project_todo_progress.assert_awaited_once()
+    kwargs = projector.project_todo_progress.await_args.kwargs
+    assert kwargs["session_key"] == "slack:T1:C1:111.1"
+    assert kwargs["generation"] == 9
+    assert kwargs["user_id"] == "U1"
+
+
+def _steering_runner(agent):
+    runner = object.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.platform = Platform.SLACK
+    adapter._text_debounce = {}
+    adapter._busy_text_debounce_seconds = 0.6
+    runner.adapters = {Platform.SLACK: adapter}
+    runner._busy_input_mode = "interrupt"
+    runner._busy_text_mode = "interrupt"
+    runner._is_user_authorized = lambda source: True
+    state = SimpleNamespace(turn=SimpleNamespace(agent=agent), busy_ack_ts=0.0)
+    runner._peek_session_state = MagicMock(return_value=state)
+    runner._agent_has_active_subagents = MagicMock(return_value=False)
+    runner._session_has_compression_in_flight = AsyncMock(return_value=False)
+    runner._prepare_busy_steer_text = AsyncMock(return_value="change direction")
+    runner._queue_or_replace_pending_event = MagicMock()
+    runner._adapter_for_source = lambda source: adapter
+    return runner, adapter
+
+
+@pytest.mark.asyncio
+async def test_slack_active_thread_reply_steers_silently():
+    agent = MagicMock()
+    agent.steer.return_value = True
+    agent.active_children = set()
+    runner, adapter = _steering_runner(agent)
+    event = _event()
+    session_key = "slack:T1:C1:111.1"
+
+    assert await runner._handle_active_session_busy_message(event, session_key)
+
+    agent.steer.assert_called_once()
+    runner._queue_or_replace_pending_event.assert_not_called()
+    adapter._send_with_retry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_slack_steer_queues_fifo_without_ack():
+    agent = MagicMock()
+    agent.steer.return_value = False
+    agent.active_children = set()
+    runner, adapter = _steering_runner(agent)
+    event = _event()
+    session_key = "slack:T1:C1:111.1"
+
+    assert await runner._handle_active_session_busy_message(event, session_key)
+
+    runner._queue_or_replace_pending_event.assert_called_once_with(session_key, event)
+    adapter._send_with_retry.assert_not_awaited()
+
+
+def _control_runner(active_generation=5):
+    runner = object.__new__(GatewayRunner)
+    session_key = "slack:T1:C1:111.1"
+    active = asyncio.Event()
+    setattr(active, "_hermes_run_generation", active_generation)
+    active_task = asyncio.get_running_loop().create_future()
+    adapter = MagicMock()
+    adapter._active_sessions = {session_key: active}
+    adapter._session_tasks = {session_key: active_task}
+    adapter._background_tasks = set()
+    adapter.handle_message = AsyncMock()
+    runner._is_user_authorized = lambda source: True
+    runner._session_key_for_source = lambda source: session_key
+    runner._adapter_for_source = lambda source: adapter
+    runner._busy_stop_command = AsyncMock()
+    runner._is_session_run_current = MagicMock(return_value=True)
+    async_store = MagicMock()
+    async_store.get_or_create_session = AsyncMock(
+        return_value=SimpleNamespace(session_id="S1")
+    )
+    runner.session_store = MagicMock()
+    async_store._store = runner.session_store
+    runner._async_session_store = async_store
+    return runner, adapter, session_key, active_task
+
+
+def _control_payload(session_key, generation=5):
+    return {
+        "team_id": "T1",
+        "channel_id": "C1",
+        "chat_type": "group",
+        "thread_ts": "111.1",
+        "message_ts": "111.222",
+        "user_id": "U1",
+        "session_key": session_key,
+        "generation": generation,
+    }
+
+
+@pytest.mark.asyncio
+async def test_stop_control_uses_canonical_busy_stop_path():
+    runner, adapter, session_key, _active_task = _control_runner()
+
+    assert await runner.handle_slack_todo_action(
+        "stop", _control_payload(session_key)
+    )
+
+    runner._busy_stop_command.assert_awaited_once()
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_restart_control_stops_then_retries_current_turn():
+    runner, adapter, session_key, active_task = _control_runner()
+
+    assert await runner.handle_slack_todo_action(
+        "restart", _control_payload(session_key)
+    )
+
+    runner._busy_stop_command.assert_awaited_once()
+    adapter.handle_message.assert_not_awaited()
+
+    adapter._active_sessions.pop(session_key)
+    active_task.set_result(None)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    adapter.handle_message.assert_awaited_once()
+    retry_event = adapter.handle_message.await_args.args[0]
+    assert retry_event.text == "/retry"
+    assert retry_event.message_type is MessageType.COMMAND
+    runner._is_session_run_current.assert_called_once_with(session_key, 6)
+
+
+@pytest.mark.asyncio
+async def test_restart_drops_if_a_newer_generation_wins_the_race():
+    runner, adapter, session_key, active_task = _control_runner()
+
+    assert await runner.handle_slack_todo_action(
+        "restart", _control_payload(session_key)
+    )
+    runner._is_session_run_current.return_value = False
+    adapter._active_sessions.pop(session_key)
+    active_task.set_result(None)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_restart_drops_if_the_conversation_session_changed():
+    runner, adapter, session_key, active_task = _control_runner()
+    runner._async_session_store.get_or_create_session.side_effect = [
+        SimpleNamespace(session_id="S1"),
+        SimpleNamespace(session_id="S2"),
+    ]
+
+    assert await runner.handle_slack_todo_action(
+        "restart", _control_payload(session_key)
+    )
+    adapter._active_sessions.pop(session_key)
+    active_task.set_result(None)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flat_slack_control_uses_threadless_session_source():
+    runner, adapter, session_key, _active_task = _control_runner()
+    payload = _control_payload(session_key)
+    payload["thread_ts"] = ""
+
+    assert await runner.handle_slack_todo_action("stop", payload)
+
+    event = runner._busy_stop_command.await_args.args[0]
+    assert event.source.thread_id is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_stale_control_generation():
+    runner, adapter, session_key, _active_task = _control_runner(active_generation=6)
+
+    assert not await runner.handle_slack_todo_action(
+        "stop", _control_payload(session_key, generation=5)
+    )
+
+    runner._busy_stop_command.assert_not_awaited()
+    adapter.handle_message.assert_not_awaited()


### PR DESCRIPTION
## what changed

- adds one Slack Block Kit progress card for eligible multi-step todo runs
- edits that card in place instead of posting one message per step
- keeps short runs on native Slack status only
- silently steers authorized replies in an active Slack thread, with FIFO queue fallback
- adds stop and restart controls scoped to workspace, channel, thread, owner, message, session, and run generation
- closes controls atomically so the interrupted turn cannot overwrite the selected terminal state
- waits for the old turn to finish before `/retry` can rewrite the transcript
- redacts local paths, inline commands, token assignments, and common credential formats

## verification

- `33 passed` in the focused progress, retry, stop, and interruption suite
- `328 passed` across `tests/gateway/test_slack*.py`
- Ruff, Python compilation, and diff checks pass
- independent security review completed; its two high issues and one medium issue were fixed and covered by regressions

## scope

- no production deploy
- no gateway restart
- no credential or config changes
- Baremetrics work remains outside this PR

Linear: https://linear.app/itsezmoney/issue/EZ-525/slack-native-progress-steering-stoprestart-and-anti-spam-ux
