### PR TITLE
fix(tools): preserve multiple todo items lacking an id in TodoStore.write

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -31,6 +31,44 @@ class TestWriteAndRead:
         ]
 
 
+    def test_write_preserves_multiple_items_without_id(self):
+        # Regression for #83389: previously, all items lacking an ``id`` were
+        # collapsed against the same `"?"` key in ``_dedupe_by_id`` and only the
+        # final one survived. Both must be preserved and assigned fallback ids.
+        store = TodoStore()
+        result = store.write([
+            {"content": "Task 1", "status": "pending"},
+            {"content": "Task 2", "status": "pending"},
+        ])
+        assert len(result) == 2
+        assert result[0]["content"] == "Task 1"
+        assert result[1]["content"] == "Task 2"
+        assert all(item["id"] for item in result)
+
+
+    def test_write_preserves_unkeyed_items_with_explicit_id_items(self):
+        # Mixed list: an explicit-id item (appearing twice) and two unkeyed
+        # items. The duplicate explicit-id must dedup to its last occurrence;
+        # the unkeyed items must each survive. ``_dedupe_by_id`` sorts the
+        # surviving positions by their original index, so the result order
+        # reflects the last occurrence of each unique id.
+        store = TodoStore()
+        result = store.write([
+            {"id": "x", "content": "Has id", "status": "pending"},
+            {"content": "No id A", "status": "pending"},
+            {"content": "No id B", "status": "pending"},
+            {"id": "x", "content": "Has id v2", "status": "in_progress"},
+        ])
+        assert len(result) == 3
+        # Order is by sorted position of last occurrence; "x" lives at idx 3
+        # (last occurrence), No id A at idx 1, No id B at idx 2.
+        assert [r["content"] for r in result] == [
+            "No id A", "No id B", "Has id v2",
+        ]
+        assert result[-1]["id"] == "x"
+        assert result[-1]["content"] == "Has id v2"
+
+
 class TestHasItems:
     def test_empty_store(self):
         store = TodoStore()

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -189,15 +189,26 @@ class TodoStore:
 
     @staticmethod
     def _dedupe_by_id(todos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Collapse duplicate ids, keeping the last occurrence in its position."""
+        """Collapse duplicate ids, keeping the last occurrence in its position.
+
+        Items without an explicit ``id`` are NOT collapsed against each other:
+        each gets a unique synthetic key so all unkeyed items survive the dedup
+        pass. ``_validate`` then assigns each survivor its own fallback id.
+        See #83389.
+        """
         last_index: Dict[str, int] = {}
         for i, item in enumerate(todos):
             if not isinstance(item, dict):
                 # Non-dict items get a synthetic key so _validate can handle them
                 last_index[f"__invalid_{i}"] = i
                 continue
-            item_id = str(item.get("id", "")).strip() or "?"
-            last_index[item_id] = i
+            item_id = str(item.get("id", "")).strip()
+            if item_id:
+                last_index[item_id] = i
+            else:
+                # Unkeyed items each get a unique synthetic key so the dedup
+                # pass cannot silently drop earlier ones.
+                last_index[f"__no_id_{i}"] = i
         return [todos[i] for i in sorted(last_index.values())]
 
 


### PR DESCRIPTION
## Problem

`TodoStore.write` (and the `todo` tool) silently dropped task items from
the list whenever multiple items were passed without an explicit `id` key
(see #83389). Two items written as `{"content": "Task 1"}` and
`{"content": "Task 2"}` ended up storing only Task 2, with no warning.

## Root cause

`TodoStore._dedupe_by_id` (in `tools/todo_tool.py`) collapsed every item
without an `id` against the same synthetic key:

```python
item_id = str(item.get("id", "")).strip() or "?"
last_index[item_id] = i
```

Each new unkeyed item overwrote the previous entry at `last_index["?"]`,
so only the **last** item in the list survived the dedup pass. The downstream
`_validate` step then ran against a single-item list, so the silently
dropped items never made it into the store — and never appeared in the
desktop todo panel or post-compression re-injection.

## Fix

Give each unkeyed item its own synthetic key so the dedup pass cannot drop
them:

```python
item_id = str(item.get("id", "")).strip()
if item_id:
    last_index[item_id] = i
else:
    last_index[f"__no_id_{i}"] = i
```

Items with an explicit `id` dedup as before (last occurrence wins, in
position order).

## Reproduction

The reporter's snippet:

```python
from tools.todo_tool import TodoStore

store = TodoStore()
result = store.write([
    {"content": "Task 1", "status": "pending"},
    {"content": "Task 2", "status": "pending"},
])
```

Before: `len(result) == 1` ("Task 1" silently dropped).
After:  `len(result) == 2` (both items preserved with fallback ids).

## Tests

Added two regression tests in `tests/tools/test_todo_tool.py`:

- `test_write_preserves_multiple_items_without_id` — covers the reporter's
  exact repro: two unkeyed items both survive.
- `test_write_preserves_unkeyed_items_with_explicit_id_items` — mixed list
  with explicit-id duplicates and unkeyed items; verifies dedup of explicit
  ids still works and unkeyed items are not silently dropped.

Both tests are verified to **fail on unpatched main** and **pass on the
patched head** (parent-commit proof gate per the project's contribution
rubric).

```
$ python -m pytest tests/tools/test_todo_tool.py -v
============================== 16 passed in 3.49s ==============================
```

## Files changed

- `tools/todo_tool.py`: `_dedupe_by_id` now assigns a unique synthetic
  key per unkeyed item instead of collapsing them all under `"?"`. Docstring
  expanded to document the new behavior.
- `tests/tools/test_todo_tool.py`: two regression tests.

Closes #83389