### PR TITLE
fix(kanban): baseline notifier kinds during migration

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1364,6 +1364,15 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Durable cutovers for event kinds newly added to the gateway notifier.
+-- A kind is baselined exactly once, at the current global event id, so an
+-- upgrade cannot reinterpret older rows as newly deliverable notifications.
+CREATE TABLE IF NOT EXISTS kanban_notify_kind_baselines (
+    kind              TEXT PRIMARY KEY,
+    baseline_event_id INTEGER NOT NULL,
+    created_at        INTEGER NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -2521,6 +2530,23 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         if "delivery_metadata" not in notify_cols:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "delivery_metadata", "delivery_metadata TEXT"
+            )
+
+    # Migration-time notifier cutovers. This must run while opening/upgrading
+    # the schema, not lazily on the first gateway poll: an event created after
+    # startup but before that poll is genuinely new and must still deliver.
+    # INSERT OR IGNORE makes the recorded boundary durable across restarts.
+    baseline_table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+        "AND name = 'kanban_notify_kind_baselines'"
+    ).fetchone()
+    if baseline_table_exists:
+        for kind in ("block_loop_detected",):
+            conn.execute(
+                "INSERT OR IGNORE INTO kanban_notify_kind_baselines "
+                "(kind, baseline_event_id, created_at) "
+                "VALUES (?, COALESCE((SELECT MAX(id) FROM task_events), 0), ?)",
+                (kind, int(time.time())),
             )
 
     # One-shot backfill: any task that is 'running' before runs existed
@@ -9978,9 +10004,12 @@ def unseen_events_for_sub(
     cursor = int(row["last_event_id"])
     kind_list = list(kinds) if kinds else None
     q = (
-        "SELECT * FROM task_events WHERE task_id = ? AND id > ? "
-        + ("AND kind IN (" + ",".join("?" * len(kind_list)) + ") " if kind_list else "")
-        + "ORDER BY id ASC"
+        "SELECT e.* FROM task_events AS e "
+        "LEFT JOIN kanban_notify_kind_baselines AS b ON b.kind = e.kind "
+        "WHERE e.task_id = ? AND e.id > ? "
+        "AND (b.baseline_event_id IS NULL OR e.id > b.baseline_event_id) "
+        + ("AND e.kind IN (" + ",".join("?" * len(kind_list)) + ") " if kind_list else "")
+        + "ORDER BY e.id ASC"
     )
     params: list[Any] = [task_id, cursor]
     if kind_list:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sqlite3
 import subprocess
 import threading
 import time
@@ -151,6 +152,7 @@ def test_notify_sub_crud(kanban_home):
         conn.close()
 
 
+
 def test_notify_claim_is_single_owner_and_rewindable(kanban_home):
     conn1 = kb.connect()
     conn2 = kb.connect()
@@ -203,6 +205,87 @@ def test_notify_claim_is_single_owner_and_rewindable(kanban_home):
     finally:
         conn1.close()
         conn2.close()
+
+
+def _make_legacy_notifier_db(db_path):
+    """Create a pre-baseline DB with subscriptions followed by old events."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(kb.SCHEMA_SQL)
+    task_id = kb.create_task(conn, title="legacy task", assignee="w")
+    for chat_id in ("all-kinds", "block-only", "completed-only"):
+        kb.add_notify_sub(
+            conn, task_id=task_id, platform="telegram", chat_id=chat_id,
+        )
+    kb._append_event(conn, task_id, "block_loop_detected", {"old": True})
+    kb._append_event(conn, task_id, "completed", {"summary": "historical"})
+    conn.execute("DROP TABLE kanban_notify_kind_baselines")
+    conn.commit()
+    conn.close()
+    return task_id
+
+
+def test_legacy_notify_migration_baselines_before_first_claim(tmp_path):
+    db_path = tmp_path / "legacy-notifier.db"
+    task_id = _make_legacy_notifier_db(db_path)
+
+    # Opening the legacy DB is the production migration path. The event added
+    # immediately afterward is genuinely new even though no notifier has polled.
+    with kb.connect(db_path) as conn:
+        baseline = conn.execute(
+            "SELECT baseline_event_id FROM kanban_notify_kind_baselines "
+            "WHERE kind = 'block_loop_detected'"
+        ).fetchone()["baseline_event_id"]
+        kb._append_event(conn, task_id, "block_loop_detected", {"old": False})
+
+    # A restart reruns migration idempotently without moving the cutover.
+    with kb.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT baseline_event_id FROM kanban_notify_kind_baselines "
+            "WHERE kind = 'block_loop_detected'"
+        ).fetchone()["baseline_event_id"] == baseline
+
+        _, _, all_kinds = kb.claim_unseen_events_for_sub(
+            conn, task_id=task_id, platform="telegram", chat_id="all-kinds",
+            kinds=["completed", "block_loop_detected"],
+        )
+        assert [(event.kind, event.payload) for event in all_kinds] == [
+            ("completed", {"summary": "historical"}),
+            ("block_loop_detected", {"old": False}),
+        ]
+        _, _, block_only = kb.claim_unseen_events_for_sub(
+            conn, task_id=task_id, platform="telegram", chat_id="block-only",
+            kinds=["block_loop_detected"],
+        )
+        assert [event.payload for event in block_only] == [{"old": False}]
+        _, _, completed_only = kb.claim_unseen_events_for_sub(
+            conn, task_id=task_id, platform="telegram", chat_id="completed-only",
+            kinds=["completed"],
+        )
+        assert [event.payload for event in completed_only] == [
+            {"summary": "historical"}
+        ]
+
+
+def test_legacy_notify_migration_preserves_rewind_retry(tmp_path):
+    db_path = tmp_path / "legacy-notifier-retry.db"
+    task_id = _make_legacy_notifier_db(db_path)
+    with kb.connect(db_path) as conn:
+        kb._append_event(conn, task_id, "block_loop_detected", {"attempt": 1})
+        old_cursor, claimed_cursor, events = kb.claim_unseen_events_for_sub(
+            conn, task_id=task_id, platform="telegram", chat_id="block-only",
+            kinds=["block_loop_detected"],
+        )
+        assert [event.payload for event in events] == [{"attempt": 1}]
+        assert kb.rewind_notify_cursor(
+            conn, task_id=task_id, platform="telegram", chat_id="block-only",
+            claimed_cursor=claimed_cursor, old_cursor=old_cursor,
+        )
+        _, _, retried = kb.claim_unseen_events_for_sub(
+            conn, task_id=task_id, platform="telegram", chat_id="block-only",
+            kinds=["block_loop_detected"],
+        )
+        assert [event.payload for event in retried] == [{"attempt": 1}]
 
 
 # ---------------------------------------------------------------------------
@@ -1406,5 +1489,3 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
-


### PR DESCRIPTION
## Summary

Prevent historical Kanban notifications from replaying when the notifier begins consuming a newly introduced event kind.

The migration records a durable per-kind cursor baseline at the current global event maximum. Notification reads then exclude pre-baseline events for that kind while preserving delivery of events created after migration, including events created before the first poll.

## Why

Expanding the notifier's event-kind filter previously allowed historical events of the newly consumed kind to replay once after an upgrade. A lazy first-poll baseline is unsafe because it can suppress a genuinely new event created after startup but before the first poll; this implementation performs the cutover durably during schema migration instead.

## Verification

- Independent exact-head review: `SHIP`, no findings.
- Exact base: `03da1606bcee38acddaf77028108122170ecfdea`
- Candidate: `c4f11a9d92f06ad6aeb9cb3c780274e2aeb9bf17`
- Candidate tree: `47d1565ed213ecdc2e6801e5ef3b7b98adbb44c0`
- Binary diff SHA-256: `0a2525dfa5f68d2a2423bfa0b9380f2b63fc63a445c58d439c9f72515bf97e3e`
- Real temporary SQLite scenarios passed for:
  - historical new-kind suppression,
  - post-migration/pre-first-poll delivery,
  - multiple independent subscriptions and event-kind filters,
  - restart/idempotency,
  - rewind/retry behavior.
- `py_compile` passed for both changed files.

## Scope and risk

Two files only: the Kanban DB migration/read path and focused regression tests. No lazy gateway initialization path is added. No configuration changes, deployment, or runtime migration was performed as part of this PR.

## Rollback

Revert this single commit. Existing notifier cursors are otherwise unchanged; the new per-kind baseline table is additive and migration-driven.
