### PR TITLE
fix(state,desktop,runtime): EMFILE cascade — bounded WAL read pool, orphan serve reap, nofile floor

### DIFF
--- a/apps/desktop/electron/backend-child.ts
+++ b/apps/desktop/electron/backend-child.ts
@@ -6,15 +6,18 @@
  * Node's `child.kill()` only signals the direct child. On Windows a backend
  * that spawned its own grandchildren (a `hermes` REPL, a pty terminal
  * session, the gateway) survives a plain SIGTERM and keeps files (e.g. the
- * venv shim) locked. So on Windows we tree-kill via `forceKillProcessTree`;
- * everywhere else a plain SIGTERM is correct and sufficient (POSIX has no
- * mandatory locks, and the backend is not spawned detached so there's no
- * process-group to negative-pid-kill).
+ * venv shim) locked. So on Windows we tree-kill via `forceKillProcessTree`.
+ *
+ * On POSIX the backend IS spawned into its own session/process-group
+ * (start_new_session=True), so `child.kill('SIGTERM')` would only reach the
+ * backend and orphan its MCP grandchildren (the leak in #serve-orphans). We
+ * signal the whole group via `process.kill(-pid, ...)` instead, falling back
+ * to the direct child if the group send fails.
  *
  * Extracted into its own dependency-free module (no electron import) so the
- * SIGTERM-vs-tree-kill branching can be asserted directly with a fake child
- * object and a spy `forceKillProcessTree`, instead of grepping main.ts source
- * text for the function body.
+ * tree-kill / group-kill branching can be asserted directly with a fake child
+ * object and spy kill functions, instead of grepping main.ts source text for
+ * the function body.
  */
 
 export interface StopBackendChildDeps {
@@ -22,6 +25,12 @@ export interface StopBackendChildDeps {
   isWindows?: boolean
   /** Windows tree-kill implementation (real: taskkill /T /F via execFileSync). */
   forceKillProcessTree: (pid: number) => void
+  /**
+   * POSIX group-signal implementation. Real: process.kill(-pgid, signal).
+   * Injectable so the negative-pid group send is asserted in tests without a
+   * live process group. Defaults to process.kill.
+   */
+  killGroup?: (pgid: number, signal: string) => void
 }
 
 export interface StopBackendTreesForUpdateDeps {
@@ -52,10 +61,19 @@ export function stopBackendChild(child: KillableChild | null | undefined, deps: 
   }
 
   const isWindows = deps.isWindows ?? process.platform === 'win32'
+  const killGroup = deps.killGroup ?? ((pgid: number, signal: string) => process.kill(pgid, signal))
 
   try {
     if (isWindows && Number.isInteger(child.pid)) {
       deps.forceKillProcessTree(child.pid as number)
+    } else if (Number.isInteger(child.pid)) {
+      // POSIX: pgid == pid (start_new_session). Signal the whole group so MCP
+      // grandchildren die too; fall back to the direct child on failure.
+      try {
+        killGroup(-(child.pid as number), 'SIGTERM')
+      } catch {
+        child.kill('SIGTERM')
+      }
     } else {
       child.kill('SIGTERM')
     }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8070,6 +8070,14 @@ async function waitForBackendExit(child, timeoutMs = 5000) {
       try {
         if (IS_WINDOWS && Number.isInteger(child.pid)) {
           forceKillProcessTree(child.pid)
+        } else if (Number.isInteger(child.pid)) {
+          // POSIX: SIGKILL the whole group (pgid==pid, start_new_session) so
+          // MCP grandchildren die with the backend. Fall back to the child.
+          try {
+            process.kill(-child.pid, 'SIGKILL')
+          } catch {
+            child.kill('SIGKILL')
+          }
         } else {
           child.kill('SIGKILL')
         }
@@ -8297,6 +8305,11 @@ async function spawnPoolBackend(profile, entry) {
         // Marks this dashboard backend as desktop-spawned so it runs the cron
         // scheduler tick loop (the gateway isn't running under the app).
         HERMES_DESKTOP: '1',
+        // Our PID so the backend's parent-death watchdog self-exits if we die
+        // uncleanly (crash / SIGKILL / update handoff) instead of leaking a
+        // serving backend + its MCP child subtree. See web_server.py
+        // _start_parent_death_watchdog.
+        HERMES_PARENT_PID: String(process.pid),
         HERMES_WEB_DIST: webDist,
         ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
       },
@@ -8590,6 +8603,11 @@ async function startHermes() {
           // Marks this dashboard backend as desktop-spawned so it runs the cron
           // scheduler tick loop (the gateway isn't running under the app).
           HERMES_DESKTOP: '1',
+          // Our PID so the backend's parent-death watchdog self-exits if we die
+          // uncleanly (crash / SIGKILL / update handoff) instead of leaking a
+          // serving backend + its MCP child subtree. See web_server.py
+          // _start_parent_death_watchdog.
+          HERMES_PARENT_PID: String(process.pid),
           HERMES_WEB_DIST: webDist,
           ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
         },

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -65,17 +65,34 @@ test('stopBackendChild tree-kills on Windows when the child has a pid', () => {
   assert.deepEqual(calls, [], 'SIGTERM must not be sent when the Windows tree-kill path is taken')
 })
 
-test('stopBackendChild sends SIGTERM on non-Windows platforms', () => {
+test('stopBackendChild group-SIGTERMs on POSIX (negative pgid) when the child has a pid', () => {
   const { child, calls } = makeChild({ pid: 4242 })
   const treeKillCalls: number[] = []
+  const groupKills: Array<[number, string]> = []
 
   stopBackendChild(child, {
     forceKillProcessTree: (pid: number) => treeKillCalls.push(pid),
-    isWindows: false
+    isWindows: false,
+    killGroup: (pgid, signal) => groupKills.push([pgid, signal])
   })
 
-  assert.deepEqual(calls, ['SIGTERM'])
+  assert.deepEqual(groupKills, [[-4242, 'SIGTERM']], 'must signal the whole process group')
+  assert.deepEqual(calls, [], 'direct child.kill must not run when the group send succeeds')
   assert.deepEqual(treeKillCalls, [], 'tree-kill must not run off Windows')
+})
+
+test('stopBackendChild falls back to direct SIGTERM on POSIX when the group send throws', () => {
+  const { child, calls } = makeChild({ pid: 4242 })
+
+  stopBackendChild(child, {
+    forceKillProcessTree: () => {},
+    isWindows: false,
+    killGroup: () => {
+      throw new Error('ESRCH: no such process group')
+    }
+  })
+
+  assert.deepEqual(calls, ['SIGTERM'], 'must fall back to signalling the direct child')
 })
 
 test('stopBackendChild falls back to SIGTERM on Windows when the pid is not an integer', () => {

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -19,6 +19,16 @@ database:
   # journal_size_limit: 67108864 # cap the WAL/journal file size in bytes
 
 # =============================================================================
+# Runtime Limits
+# =============================================================================
+# Long-running Hermes server processes raise their RLIMIT_NOFILE soft limit to
+# this value when the operating system permits it. The value is clamped to the
+# hard limit and never lowers an already higher soft limit. Set to 0, false, or
+# null to disable the adjustment. Default: 4096.
+runtime:
+  nofile_soft_limit: 4096
+
+# =============================================================================
 # Model Configuration
 # =============================================================================
 model:

--- a/contributors/emails/XiaoZAZA@users.noreply.github.com
+++ b/contributors/emails/XiaoZAZA@users.noreply.github.com
@@ -1,0 +1,1 @@
+XiaoZAZA

--- a/contributors/emails/phull@phullcutz.de
+++ b/contributors/emails/phull@phullcutz.de
@@ -1,0 +1,1 @@
+leonphull

--- a/contributors/emails/zqw3719222@163.com
+++ b/contributors/emails/zqw3719222@163.com
@@ -1,0 +1,1 @@
+cadezhou

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27158,6 +27158,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                  Useful for systemd services to avoid restart-loop deadlocks
                  when the previous process hasn't fully exited yet.
     """
+    from hermes_cli.resource_limits import apply_nofile_soft_limit
+
+    apply_nofile_soft_limit()
+
     # Snapshot the checkout revision now, while sys.modules still matches disk,
     # so a later `git pull` under this long-lived process can be detected (and
     # risky work like model switching refused) instead of crashing on a stale

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -20,6 +20,11 @@ DEFAULT_CONFIG = {
         "wal_autocheckpoint": None,
         "journal_size_limit": None,
     },
+    # Soft file-descriptor limit for long-running Hermes server processes.
+    # Clamped to the OS hard limit; 0/false/null disables the adjustment.
+    "runtime": {
+        "nofile_soft_limit": 4096,
+    },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -525,12 +525,147 @@ def _exclude_pids_from_env() -> set[int]:
     return out
 
 
+# --- SSH remote-backend lock ownership -------------------------------------
+#
+# ``backend.lock.json`` is the ownership record the Desktop SSH runtime writes
+# on the *remote* host for every ``hermes serve`` backend it spawns over SSH
+# (see apps/desktop/electron/remote-lifecycle.ts). A backend started from
+# another client/machine — e.g. a MacBook driving a ``hermes serve`` on a Mac
+# Mini over SSH — is a *legitimate, lock-owned* backend even though it has no
+# parent on this host (sshd has long since exited, reparenting it to pid 1).
+#
+# The orphan reap must NEVER kill a PID that a valid ``backend.lock.json``
+# claims as its owner. Doing so murdered a real production SSH remote backend
+# on a Mac Mini the first time the local Desktop app rebooted. The lock file is
+# the source of truth for "is this serve legitimately owned by some client",
+# regardless of which machine started it.
+
+# Mirror the schema constants in remote-lifecycle.ts (the writer). Bumping one
+# side without the other makes the lock unreadable on purpose, which is the
+# safe failure mode for reuse — but for the reap we only ever *spare*, so a
+# mismatched-schema record is simply ignored (never used to kill).
+_LOCKFILE_SCHEMA_VERSION = 2
+_PROTOCOL_VERSION = 1
+_REMOTE_LOCK_SUBDIR = "desktop-ssh"
+_HEX32 = set("0123456789abcdef")
+_HEX16 = _HEX32
+
+
+def _hermes_home_dir() -> Path:
+    """Resolved Hermes home (HERMES_HOME override or ~/.hermes)."""
+    override = os.environ.get("HERMES_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".hermes"
+
+
+def _valid_lockfile_payload(parsed: object, ownership_id: str) -> bool:
+    """Validate a parsed ``backend.lock.json`` body, mirroring readLockfile().
+
+    Returns True only when every structural field the SSH runtime writes is
+    present and well-formed. A lock that fails validation is ignored (treated
+    as "no ownership claim"), which never causes a kill — the reap only ever
+    *adds* lock-owned PIDs to its spare-set.
+    """
+    if not isinstance(parsed, dict):
+        return False
+    if parsed.get("schemaVersion") != _LOCKFILE_SCHEMA_VERSION:
+        return False
+    if parsed.get("protocolVersion") != _PROTOCOL_VERSION:
+        return False
+    if parsed.get("ownershipId") != ownership_id:
+        return False
+    spawn_nonce = parsed.get("spawnNonce")
+    if not isinstance(spawn_nonce, str) or len(spawn_nonce) != 16:
+        return False
+    if set(spawn_nonce) - _HEX16:
+        return False
+    token_fp = parsed.get("tokenFingerprint")
+    if not isinstance(token_fp, str) or len(token_fp) != 32 or set(token_fp) - _HEX32:
+        return False
+    pid = parsed.get("pid")
+    if not isinstance(pid, int) or pid <= 0 or pid > 4194304:
+        return False
+    port = parsed.get("port")
+    if not isinstance(port, int) or port < 0 or port > 65535:
+        return False
+    # String fields must be present and bounded (the writer enforces <=1024).
+    for field in ("profile", "hermesPath", "hermesHome", "logPath", "startedAt"):
+        value = parsed.get(field)
+        if not isinstance(value, str) or len(value) > 1024:
+            return False
+    # logPath is written as ``{lock_root}/{ownershipId}/{spawnNonce}.log``. We
+    # only check the suffix so a relocated HERMES_HOME (different leading path)
+    # doesn't falsely reject a legitimate remote-owned backend — a false reject
+    # here would re-introduce the exact kill we're fixing.
+    log_path = parsed["logPath"]
+    if not log_path.endswith(f"/{ownership_id}/{spawn_nonce}.log"):
+        return False
+    return True
+
+
+def _lock_owned_serve_pids(base_dir: Path | None = None) -> set[int]:
+    """PIDs claimed as owners by valid ``backend.lock.json`` records on this host.
+
+    Scans ``{hermes_home}/desktop-ssh/<ownershipId>/backend.lock.json`` (the
+    same directory the Desktop SSH runtime writes to). Any PID a valid lock
+    names is a legitimately-owned backend — including backends another client
+    or machine started over SSH — and must be spared by the orphan reap.
+
+    Best-effort: any read/parse/IO error for a single record is swallowed and
+    that record contributes no PID. Never raises.
+    """
+    import json
+
+    root = base_dir if base_dir is not None else (
+        _hermes_home_dir() / _REMOTE_LOCK_SUBDIR
+    )
+    owned: set[int] = set()
+    if not root.is_dir():
+        return owned
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return owned
+    for entry in entries:
+        try:
+            if not entry.is_dir():
+                continue
+        except OSError:
+            continue
+        ownership_id = entry.name
+        # Mirror validateOwnershipId(): exactly 32 lowercase hex chars.
+        if len(ownership_id) != 32 or set(ownership_id) - _HEX32:
+            continue
+        lock_path = entry / "backend.lock.json"
+        try:
+            if not lock_path.is_file():
+                continue
+            with open(lock_path, "rb") as handle:
+                data = handle.read()
+        except OSError:
+            continue
+        if len(data) > 65536:
+            continue
+        try:
+            parsed = json.loads(data)
+        except (UnicodeDecodeError, ValueError):
+            continue
+        if _valid_lockfile_payload(parsed, ownership_id):
+            try:
+                owned.add(int(parsed["pid"]))
+            except (TypeError, ValueError):
+                continue
+    return owned
+
+
 def _reap_orphaned_desktop_local_serves(
     *,
     reason: str = "orphaned desktop-local hermes serve",
     signal_term=None,
     signal_kill=None,
     sleep_fn=None,
+    lock_owned_pids_fn=None,
 ) -> dict[str, list]:
     """Kill leftover Desktop-local ``hermes serve`` backends with no parent.
 
@@ -548,6 +683,10 @@ def _reap_orphaned_desktop_local_serves(
     - only the Desktop-local spawn shape (loopback + ``--port 0``)
     - only processes whose current ppid is 1 (or 0 on some supervisors)
     - never self / never HERMES_DESKTOP_CHILD_PID entries
+    - never a PID a valid ``backend.lock.json`` claims as its owner — that is
+      a legitimately lock-owned backend, *including SSH remote backends started
+      by another client/machine* which legitimately sit at ppid 1 after sshd
+      exits. Killing those is a production incident, not cleanup.
     - never fixed-port remote serves (e.g. ``--port 9119``)
     - best-effort; failures never raise to the caller
     """
@@ -560,6 +699,8 @@ def _reap_orphaned_desktop_local_serves(
         signal_kill = getattr(_signal, "SIGKILL", _signal.SIGTERM)
     if sleep_fn is None:
         sleep_fn = _time.sleep
+    if lock_owned_pids_fn is None:
+        lock_owned_pids_fn = _lock_owned_serve_pids
 
     if sys.platform == "win32":
         # Windows desktop uses taskkill tree teardown; orphan scan here is POSIX.
@@ -572,15 +713,33 @@ def _reap_orphaned_desktop_local_serves(
         exclude.add(os.getppid())
     except Exception:
         pass
+    # Spare every PID a valid backend.lock.json owns — SSH remote backends
+    # started by other clients/machines are legitimate, lock-owned owners even
+    # though they are orphaned (ppid 1) on this host. (#78872 regression)
+    try:
+        exclude |= set(lock_owned_pids_fn())
+    except Exception:
+        # Best-effort: never let lock scanning block or widen the reap.
+        pass
 
     try:
         scanned = _scan_dashboard_processes(exclude_pids=exclude)
     except Exception:
         return {"matched": [], "killed": [], "failed": []}
 
+    # Re-read lock ownership defensively: the scan above already filtered
+    # exclude PIDs, but a lock file may have been written between the scan and
+    # now. Defense in depth — never kill a freshly-claimed owner.
+    try:
+        owned_now = set(lock_owned_pids_fn())
+    except Exception:
+        owned_now = set()
+
     targets: list[tuple[int, str]] = []
     for pid, cmd in scanned:
         if not _is_desktop_local_serve_cmdline(cmd):
+            continue
+        if pid in owned_now:
             continue
         ppid = _process_ppid(pid)
         if ppid is None:

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -456,3 +456,188 @@ def _detect_concurrent_hermes_instances(
             matches.append((int(pid), str(name)))
 
     return matches
+
+
+def _is_desktop_local_serve_cmdline(command: str) -> bool:
+    """True for the Desktop-local serve spawn shape (loopback + ephemeral port).
+
+    Desktop primary/pool backends launch as::
+
+        hermes serve --host 127.0.0.1 --port 0
+        hermes serve --isolated --host 127.0.0.1 --port 0 ...
+
+    Intentional long-lived headless serves (e.g. ``--host <tailscale-ip>
+    --port 9119``) must never match — those are operator-managed remote
+    backends and may legitimately run with ppid 1 under launchd/nohup.
+    """
+    cmd = command.lower()
+    if "serve" not in cmd:
+        return False
+    if "hermes" not in cmd and "hermes_cli" not in cmd:
+        return False
+    # Ephemeral desktop bind: host loopback + port 0 (exact tokens).
+    has_loopback = (
+        "--host 127.0.0.1" in cmd
+        or "--host=127.0.0.1" in cmd
+        or "--host localhost" in cmd
+        or "--host=localhost" in cmd
+    )
+    has_ephemeral = "--port 0" in cmd or "--port=0" in cmd
+    if not (has_loopback and has_ephemeral):
+        return False
+    # Spare anything with a concrete non-zero port flag first (defensive).
+    # (port 0 already required above.)
+    return True
+
+
+def _process_ppid(pid: int) -> int | None:
+    """Best-effort parent pid lookup. None on failure."""
+    try:
+        if sys.platform == "win32":
+            return None  # Windows orphan reap is handled by desktop tree-kill.
+        result = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+        if result.returncode != 0 or not result.stdout:
+            return None
+        return int(result.stdout.strip().split()[0])
+    except (ValueError, FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def _exclude_pids_from_env() -> set[int]:
+    """PIDs Desktop marks as live backends (HERMES_DESKTOP_CHILD_PID)."""
+    raw = os.environ.get("HERMES_DESKTOP_CHILD_PID", "")
+    out: set[int] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.add(int(part))
+        except ValueError:
+            continue
+    return out
+
+
+def _reap_orphaned_desktop_local_serves(
+    *,
+    reason: str = "orphaned desktop-local hermes serve",
+    signal_term=None,
+    signal_kill=None,
+    sleep_fn=None,
+) -> dict[str, list]:
+    """Kill leftover Desktop-local ``hermes serve`` backends with no parent.
+
+    When Electron dies uncleanly (crash / SIGKILL / update handoff), local
+    ``serve --host 127.0.0.1 --port 0`` children can be reparented to pid 1 and
+    keep their full MCP trees alive. The next Desktop boot then stacks a fresh
+    backend on top of the corpses until the machine hits EMFILE and the UI
+    loses tabs/sidebar.
+
+    The parent-death watchdog prevents *future* orphans once a backend is
+    running under HERMES_PARENT_PID; this helper clears *already* orphaned
+    corpses at the start of a new Desktop backend.
+
+    Safety:
+    - only the Desktop-local spawn shape (loopback + ``--port 0``)
+    - only processes whose current ppid is 1 (or 0 on some supervisors)
+    - never self / never HERMES_DESKTOP_CHILD_PID entries
+    - never fixed-port remote serves (e.g. ``--port 9119``)
+    - best-effort; failures never raise to the caller
+    """
+    import signal as _signal
+    import time as _time
+
+    if signal_term is None:
+        signal_term = _signal.SIGTERM
+    if signal_kill is None:
+        signal_kill = getattr(_signal, "SIGKILL", _signal.SIGTERM)
+    if sleep_fn is None:
+        sleep_fn = _time.sleep
+
+    if sys.platform == "win32":
+        # Windows desktop uses taskkill tree teardown; orphan scan here is POSIX.
+        return {"matched": [], "killed": [], "failed": []}
+
+    exclude = _exclude_pids_from_env()
+    exclude.add(os.getpid())
+    # Also spare our direct parent (the desktop / sshd wrapper).
+    try:
+        exclude.add(os.getppid())
+    except Exception:
+        pass
+
+    try:
+        scanned = _scan_dashboard_processes(exclude_pids=exclude)
+    except Exception:
+        return {"matched": [], "killed": [], "failed": []}
+
+    targets: list[tuple[int, str]] = []
+    for pid, cmd in scanned:
+        if not _is_desktop_local_serve_cmdline(cmd):
+            continue
+        ppid = _process_ppid(pid)
+        if ppid is None:
+            continue
+        # Orphaned under init/launchd.
+        if ppid not in (0, 1):
+            continue
+        targets.append((pid, cmd))
+
+    if not targets:
+        return {"matched": [], "killed": [], "failed": []}
+
+    matched = [pid for pid, _ in targets]
+    killed: list[int] = []
+    failed: list[int] = []
+
+    for pid, _cmd in targets:
+        try:
+            os.kill(pid, signal_term)
+        except ProcessLookupError:
+            continue
+        except PermissionError:
+            failed.append(pid)
+            continue
+        except OSError:
+            failed.append(pid)
+            continue
+
+    # Brief grace, then SIGKILL survivors.
+    sleep_fn(1.5)
+    for pid, _cmd in targets:
+        if pid in failed:
+            continue
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            killed.append(pid)
+            continue
+        except OSError:
+            killed.append(pid)
+            continue
+        try:
+            os.kill(pid, signal_kill)
+            killed.append(pid)
+        except ProcessLookupError:
+            killed.append(pid)
+        except OSError:
+            failed.append(pid)
+
+    if matched:
+        try:
+            print(
+                f"⟲ Reaped {len(killed)} orphaned desktop-local serve "
+                f"backend(s) ({reason}): {killed or matched}"
+            )
+        except Exception:
+            pass
+
+    return {"matched": matched, "killed": killed, "failed": failed}
+

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -770,15 +770,16 @@ def _reap_orphaned_desktop_local_serves(
 
     # Brief grace, then SIGKILL survivors.
     sleep_fn(1.5)
+    # psutil.pid_exists for the liveness probe: os.kill(pid, 0) is a
+    # Windows footgun (sends CTRL_C_EVENT, bpo-14484). This path is
+    # POSIX-only (win32 early-returns above), but the linter blocks the
+    # pattern everywhere and psutil is a core dependency anyway.
+    import psutil
+
     for pid, _cmd in targets:
         if pid in failed:
             continue
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            killed.append(pid)
-            continue
-        except OSError:
+        if not psutil.pid_exists(pid):
             killed.append(pid)
             continue
         try:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4129,6 +4129,28 @@ def generate_launchd_plist() -> str:
     )
     prog_args_xml = "\n        ".join(prog_args)
 
+    # Persist the configured RLIMIT_NOFILE floor into the service definition
+    # itself. launchd starts children with a soft limit of 256 by default;
+    # without this block every plist rewrite (e.g. `hermes gateway start`)
+    # would silently strip a manually-added limit and reintroduce EMFILE
+    # crashes under load. The in-process floor (resource_limits.py) still
+    # applies as a second layer for non-launchd launches.
+    nofile_block = ""
+    try:
+        from hermes_cli.resource_limits import configured_nofile_soft_limit
+
+        nofile_target = configured_nofile_soft_limit()
+    except Exception:
+        nofile_target = None
+    if nofile_target:
+        nofile_block = f"""
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{nofile_target}</integer>
+    </dict>
+"""
+
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -4175,7 +4197,7 @@ def generate_launchd_plist() -> str:
 
     <key>ExitTimeOut</key>
     <integer>25</integer>
-
+{nofile_block}
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10411,6 +10411,15 @@ def cmd_dashboard(args):
         else:
             os.execvpe(sys.executable, reexec_argv, env)
 
+    # Apply the final process/profile policy after dashboard routing, but before
+    # importing the web server or opening dashboard state. Applying it before a
+    # named-profile re-exec could leak that profile's higher limit into the
+    # machine/default dashboard, whose lower policy intentionally cannot undo it.
+    # This also covers Desktop SSH's isolated `serve` child, which does not route.
+    from hermes_cli.resource_limits import apply_nofile_soft_limit
+
+    apply_nofile_soft_limit()
+
     if _token_file:
         _ssh_session_token = _read_ssh_session_token_file(_token_file)
 

--- a/hermes_cli/resource_limits.py
+++ b/hermes_cli/resource_limits.py
@@ -1,0 +1,119 @@
+"""Best-effort process resource-limit adjustments for long-running services.
+
+The public helper in this module is shared by the gateway and the dashboard/
+serve entrypoints. It deliberately has no user-facing environment-variable
+control: the target comes from the profile's canonical ``config.yaml`` loader.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+try:  # ``resource`` is POSIX-only (and unavailable on Windows).
+    import resource as _resource
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - Windows only
+    _resource = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_NOFILE_SOFT_LIMIT = int(DEFAULT_CONFIG["runtime"]["nofile_soft_limit"])
+_MISSING = object()
+
+
+def _configured_nofile_soft_limit(
+    config: Mapping[str, Any] | None,
+) -> int | None:
+    """Resolve ``runtime.nofile_soft_limit`` from a loaded config.
+
+    A missing key uses the default. Explicit ``0``, ``false``, and ``null``
+    disable the adjustment. Other non-integer or negative values are invalid
+    and are ignored (the caller fails open without changing the process limit).
+    """
+    if config is None:
+        try:
+            # Use Hermes's real, profile-aware loader rather than reading YAML
+            # here. This also applies managed-scope overlays and defaults.
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly()
+        except Exception:
+            logger.debug("Could not load config for RLIMIT_NOFILE", exc_info=True)
+            return None
+
+    if not isinstance(config, Mapping):
+        return None
+
+    runtime = config.get("runtime", _MISSING)
+    if runtime is _MISSING:
+        return DEFAULT_NOFILE_SOFT_LIMIT
+    if not isinstance(runtime, Mapping):
+        return None
+
+    raw_value = runtime.get("nofile_soft_limit", _MISSING)
+    if raw_value is _MISSING:
+        return DEFAULT_NOFILE_SOFT_LIMIT
+    if raw_value is None or raw_value is False:
+        return None
+    if raw_value is True or not isinstance(raw_value, int):
+        return None
+    if raw_value <= 0:
+        return None
+    return raw_value
+
+
+def apply_nofile_soft_limit(
+    config: Mapping[str, Any] | None = None,
+) -> bool:
+    """Raise this process's ``RLIMIT_NOFILE`` soft limit when possible.
+
+    The target defaults to :data:`DEFAULT_NOFILE_SOFT_LIMIT` and can be set with
+    ``runtime.nofile_soft_limit``. The target is clamped to a finite hard limit,
+    never lowers an existing higher soft limit, and returns ``False`` for an
+    explicit opt-out or when the platform/sandbox refuses the operation.
+
+    This is intentionally best-effort. Unsupported platforms, malformed
+    settings, and denied ``setrlimit`` calls must never prevent a server from
+    starting.
+    """
+    if _resource is None:
+        return False
+
+    target = _configured_nofile_soft_limit(config)
+    if target is None:
+        return False
+
+    try:
+        nofile = _resource.RLIMIT_NOFILE
+        current_soft, current_hard = _resource.getrlimit(nofile)
+        # On platforms where RLIM_INFINITY is represented as -1, ordinary
+        # integer ordering would make an unlimited soft limit look lower than
+        # every positive target. Never replace infinity with a finite limit.
+        if current_soft == getattr(_resource, "RLIM_INFINITY", object()):
+            return False
+        if current_soft >= target:
+            return False
+
+        if current_hard == getattr(_resource, "RLIM_INFINITY", object()):
+            new_soft = target
+        else:
+            new_soft = min(target, current_hard)
+        if new_soft <= current_soft:
+            return False
+
+        _resource.setrlimit(nofile, (new_soft, current_hard))
+        return True
+    except Exception:
+        # This helper runs before server startup and must fail open for
+        # unsupported/sandboxed environments and denied resource changes.
+        logger.debug("Could not raise RLIMIT_NOFILE soft limit", exc_info=True)
+        return False
+
+
+__all__ = [
+    "DEFAULT_NOFILE_SOFT_LIMIT",
+    "apply_nofile_soft_limit",
+]

--- a/hermes_cli/resource_limits.py
+++ b/hermes_cli/resource_limits.py
@@ -65,6 +65,18 @@ def _configured_nofile_soft_limit(
     return raw_value
 
 
+def configured_nofile_soft_limit(
+    config: Mapping[str, Any] | None = None,
+) -> int | None:
+    """Public accessor for the resolved ``runtime.nofile_soft_limit`` target.
+
+    Used by service-definition generators (e.g. the launchd plist) so the
+    persisted service limits and the in-process floor share one config knob.
+    Returns ``None`` when the adjustment is disabled or unresolvable.
+    """
+    return _configured_nofile_soft_limit(config)
+
+
 def apply_nofile_soft_limit(
     config: Mapping[str, Any] | None = None,
 ) -> bool:
@@ -116,4 +128,5 @@ def apply_nofile_soft_limit(
 __all__ = [
     "DEFAULT_NOFILE_SOFT_LIMIT",
     "apply_nofile_soft_limit",
+    "configured_nofile_soft_limit",
 ]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -239,6 +239,19 @@ async def _lifespan(app: "FastAPI"):
     cron_stop: "threading.Event | None" = None
     cron_thread: "threading.Thread | None" = None
     if os.getenv("HERMES_DESKTOP") == "1":
+        # Before forking a fresh gateway, reap any orphan left by a previous
+        # serve session. Graceful shutdown reaps the managed child, but an
+        # abnormal exit (crash, SIGKILL, power loss, forced update) reparents
+        # the old gateway to launchd (PPID=1). It keeps holding the QQ
+        # WebSocket, and a newly forked gateway then races the same credential,
+        # splitting messages across parallel session trees (#77276).
+        try:
+            from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
+
+            _reap_unsupervised_gateway_orphans()
+        except Exception:
+            _log.exception("Desktop startup: orphan gateway reap failed")
+
         cron_stop = threading.Event()
         cron_thread = threading.Thread(
             target=_start_desktop_cron_ticker,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17893,6 +17893,19 @@ def start_server(
             # serving — leaking the whole backend + its MCP child subtree
             # (each MCP watchdog is parented to THIS process, so os._exit here
             # cascades their teardown). Same pattern as
+            # Clear corpses left by a previous unclean Desktop exit before we
+            # stack another backend + MCP tree (EMFILE / missing tabs).
+            # Parent-death watchdog only protects *this* process going forward.
+            if os.getenv("HERMES_DESKTOP") == "1":
+                try:
+                    from hermes_cli.dashboard_procs import (
+                        _reap_orphaned_desktop_local_serves,
+                    )
+
+                    _reap_orphaned_desktop_local_serves()
+                except Exception as exc:
+                    _log.debug("orphan desktop-local serve reap skipped: %s", exc)
+
             # tui_gateway/slash_worker.py::_start_parent_death_watchdog. No-op
             # for standalone `hermes serve` (no HERMES_PARENT_PID env).
             _start_parent_death_watchdog()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17639,6 +17639,49 @@ def _maybe_open_browser(
     threading.Thread(target=_open, daemon=True).start()
 
 
+def _is_serve_orphaned(original_ppid: int, getppid=os.getppid) -> bool:
+    """True when this process lost its original spawning parent (ppid changed)."""
+    return getppid() != original_ppid
+
+
+def _start_parent_death_watchdog() -> None:
+    """Exit when the desktop parent that spawned this backend dies.
+
+    The desktop passes its own PID via HERMES_PARENT_PID. When that process
+    vanishes (crash, SIGKILL, update handoff exiting before it reaps us) this
+    orphaned backend would otherwise keep serving forever and leak its MCP
+    child subtree. os._exit propagates to the MCP watchdogs parented here.
+
+    No-op for standalone `hermes serve` (env unset). Poll interval tunable via
+    HERMES_SERVE_WATCHDOG_POLL_S.
+    """
+    raw = os.environ.get("HERMES_PARENT_PID")
+    if not raw:
+        return
+    try:
+        original_ppid = int(raw)
+    except (TypeError, ValueError):
+        return
+    try:
+        poll = max(0.5, float(os.environ.get("HERMES_SERVE_WATCHDOG_POLL_S", "2.0")))
+    except (TypeError, ValueError):
+        poll = 2.0
+
+    def _loop() -> None:
+        while not _is_serve_orphaned(original_ppid):
+            time.sleep(poll)
+        os._exit(0)
+
+    threading.Thread(target=_loop, daemon=True, name="serve-parent-watchdog").start()
+
+
+def _demo() -> None:
+    # orphan iff current ppid differs from the recorded spawning parent
+    assert _is_serve_orphaned(999999999, getppid=lambda: 1) is True
+    assert _is_serve_orphaned(42, getppid=lambda: 42) is False
+    print("web_server parent-death watchdog self-check: OK")
+
+
 def start_server(
     host: str = "127.0.0.1",
     port: int = 9119,
@@ -17843,6 +17886,16 @@ def start_server(
             await server.startup()
             if server.should_exit:
                 return
+
+            # Parent-death watchdog. The desktop spawns us and is supposed to
+            # SIGTERM us on quit, but a crash / SIGKILL / update handoff that
+            # exits before reaping leaves us orphaned (ppid→1) yet still
+            # serving — leaking the whole backend + its MCP child subtree
+            # (each MCP watchdog is parented to THIS process, so os._exit here
+            # cascades their teardown). Same pattern as
+            # tui_gateway/slash_worker.py::_start_parent_death_watchdog. No-op
+            # for standalone `hermes serve` (no HERMES_PARENT_PID env).
+            _start_parent_death_watchdog()
 
             actual_port = _read_bound_port(server, fallback=port)
             app.state.bound_port = actual_port

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1052,6 +1052,10 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # `doctor.live_probe_timeout` is the only schema-surfaced doctor field —
     # fold it into general rather than spawning a one-field orphan category.
     "doctor": "general",
+    # `runtime.nofile_soft_limit` (#78873) is the only schema-surfaced runtime
+    # field — fold it into the agent tab rather than spawning a one-field
+    # orphan category.
+    "runtime": "agent",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -339,6 +339,24 @@ DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 # query; short enough that transient fd pressure doesn't strand the read pool.
 _READ_OPEN_RETRY_SECONDS = 60.0
 
+# Hard ceiling on read-only connections ALIVE at once per SessionDB — pooled
+# idle ones and checked-out ones together.
+#
+# Deliberately one constant for both the pool's maxsize and the permit count,
+# because bounding only the pool bounds the wrong thing. A LifoQueue caps how
+# many connections are *returned*; it says nothing about how many are *open*.
+# With an open-on-miss checkout, N readers arriving on an empty pool all miss,
+# all open, and peak at N — the surplus is closed on release, so nothing
+# accumulates forever, but EMFILE is a peak-instant condition and the burst
+# that empties the pool is exactly the burst that exhausts the fd table.
+#
+# So a connection holds a permit for its whole lifetime: acquired in
+# _get_read_conn() before the open, released in _close_read_conn() after the
+# close. Once permits are gone the read path degrades to the locked writer
+# connection instead of opening more descriptors — slower under load, which is
+# the correct trade against a process-wide wedge the supervisor cannot see.
+_READ_POOL_MAX = 8
+
 # Import-time snapshot used by _default_db_path() to detect a deliberately
 # re-pointed DEFAULT_DB_PATH (tests monkeypatch the constant directly).
 _IMPORT_DEFAULT_DB_PATH = DEFAULT_DB_PATH
@@ -2539,8 +2557,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Same bug class as the closing(...) fix in gateway/readiness.py
         # (#69678 / #69567).
         self._read_pool: "queue.LifoQueue[sqlite3.Connection]" = queue.LifoQueue(
-            maxsize=8
+            maxsize=_READ_POOL_MAX
         )
+        # One permit per live read connection, held from before the open in
+        # _get_read_conn() until after the close in _close_read_conn().  This
+        # is what bounds PEAK descriptors; _read_pool alone bounds only the
+        # idle set.  See _READ_POOL_MAX.  Acquired non-blocking on purpose: a
+        # reader that cannot get a permit must degrade to the writer lock, not
+        # queue here — blocking would convert fd exhaustion into a stall, which
+        # is the same outage with a different stack trace.
+        self._read_permits = threading.BoundedSemaphore(_READ_POOL_MAX)
+        # Count of reads that found no permit and fell back to the locked
+        # writer connection. Not load-bearing; it is the only externally
+        # visible signal that the ceiling is actually being reached, so a
+        # too-small _READ_POOL_MAX is diagnosable from a running process
+        # instead of inferred from latency.
+        self._read_permit_exhausted = 0
         self._read_conns_lock = threading.Lock()
         # Set when close() begins.  _read_ctx checks this under the lock
         # before returning a connection to the pool, so a reader still in
@@ -2817,6 +2849,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 < _READ_OPEN_RETRY_SECONDS
             ):
                 return None
+        # Take the descriptor permit BEFORE the open, so concurrent openers
+        # race for permits rather than for file descriptors. Non-blocking:
+        # losing the race means "use the writer connection", not "wait".
+        if not self._read_permits.acquire(blocking=False):
+            with self._read_conns_lock:
+                self._read_permit_exhausted += 1
+            logger.debug(
+                "read pool at capacity (%d) for %s; serving this read from the "
+                "locked writer connection",
+                _READ_POOL_MAX,
+                self.db_path,
+            )
+            return None
+        # Bound before the try: the except handlers close it if the open
+        # half-succeeded, and an unbound name there would raise NameError over
+        # the top of the real failure.
+        conn = None
         try:
             conn = _connect_tracked_db(
                 f"file:{self.db_path}?mode=ro",
@@ -2842,27 +2891,69 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if self._fts_cjk_loaded:
                 load_fts5_cjk_extension(conn)
         except sqlite3.Error:
+            # A partially-constructed connection — _connect_tracked_db
+            # succeeded, the CJK extension load did not — must be closed here.
+            # Dropping it on the floor still open leaves a live descriptor the
+            # tracking registry still counts: the same leak shape this pool
+            # exists to fix, one level further down.
+            self._discard_partial_read_conn(conn)
             # Back off from retrying the open on every query; the locked
             # writer connection still serves reads until the stamp expires.
             with self._read_conns_lock:
                 self._read_open_failed_at = time.monotonic()
             logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
+            self._read_permits.release()
             return None
+        except BaseException:
+            # Anything else (a non-sqlite3 extension-load failure, MemoryError,
+            # KeyboardInterrupt landing between open and return) must not
+            # strand the permit: a stranded permit is not a transient error, it
+            # permanently shrinks the read path by one slot for the life of the
+            # process.
+            self._discard_partial_read_conn(conn)
+            self._read_permits.release()
+            raise
         return conn
 
+    def _discard_partial_read_conn(self, conn) -> None:
+        """Close a connection that failed between open and hand-off.
+
+        Separate from _close_read_conn because that one releases a permit and
+        this runs on paths that release their own.
+        """
+        if conn is None:
+            return
+        try:
+            conn.close()
+        except Exception as exc:
+            logger.warning(
+                "partially-opened read conn close failed for %s: %s", self.db_path, exc
+            )
+
     def _close_read_conn(self, conn) -> None:
-        """Close a pooled read connection, reporting failures.
+        """Close a pooled read connection and release its descriptor permit.
 
         This was a bare ``except Exception: pass``, which silently swallowed
         the sqlite3.ProgrammingError raised when close() ran on a thread
         other than the one that opened the connection — the exact signature
         of the fd leak this pool fixes. A close that fails leaks a tracked
         fd, so it must not be invisible.
+
+        The permit is released even when close() raises: the descriptor is
+        already lost at that point, and withholding the permit too would turn
+        one leaked fd into a permanently narrower read path — failing twice for
+        one fault. The warning is the signal that matters.
+
+        Pairs with _get_read_conn(). Calling this on a connection that did not
+        come from there over-releases the BoundedSemaphore, which raises
+        ValueError rather than silently widening the ceiling.
         """
         try:
             conn.close()
         except Exception as exc:
             logger.warning("read-conn close failed for %s: %s", self.db_path, exc)
+        finally:
+            self._read_permits.release()
 
     def _checkout_read_conn(self) -> Optional[sqlite3.Connection]:
         """Borrow a read connection from the pool, opening one on a miss.
@@ -2872,6 +2963,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         exactly one place to exercise (and one place for a caller to bypass by
         accident). Returns None when the read path is unavailable and the
         caller must fall back to the locked writer connection.
+
+        A pool hit costs no permit — the connection it hands back is already
+        holding one. Only the miss path can open, and only _get_read_conn() can
+        take a permit, so peak live connections is bounded by _READ_POOL_MAX no
+        matter how many threads miss simultaneously.
         """
         if not self._wal_active or self.read_only:
             return None
@@ -2889,8 +2985,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         gateway shares one SessionDB across every agent, so this lock was a
         global choke point). The connection is checked out for the duration
         of the block, so no two threads ever touch it concurrently.
-        Non-WAL or read-conn failure: the shared writer connection under
-        self._lock, byte-for-byte the legacy behavior.
+        Non-WAL, read-conn failure, or _READ_POOL_MAX already reached: the
+        shared writer connection under self._lock, byte-for-byte the legacy
+        behavior.
+
+        That last case is the deliberate degradation. Past the ceiling readers
+        convoy on the writer lock instead of opening descriptors — measurably
+        slower under a burst, and the alternative is EMFILE, which takes the
+        whole process down in a way a restart-on-exit supervisor cannot see.
         """
         conn = self._checkout_read_conn()
         if conn is not None:
@@ -2906,9 +3008,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         except queue.Full:
                             pass
                 if not returned:
-                    # More concurrent readers than maxsize, or close() has
-                    # already drained: this connection is surplus. Close it
-                    # here — dropping it on the floor is what leaked the fd.
+                    # close() has already drained the pool, so this connection
+                    # is surplus. Close it here — dropping it on the floor is
+                    # what leaked the fd.
+                    #
+                    # queue.Full is now unreachable in practice (permits and
+                    # maxsize are both _READ_POOL_MAX, so there can never be a
+                    # ninth connection to return), but the branch stays: it is
+                    # load-bearing if those two ever drift apart, and a leak is
+                    # the failure mode it prevents.
                     self._close_read_conn(conn)
             return
         with self._lock:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,6 +21,7 @@ import hashlib
 import json
 import logging
 import os
+import queue
 import random
 import re
 import sqlite3
@@ -332,6 +333,11 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+
+# How long SessionDB stops attempting read-only opens after one fails, before
+# probing again. Long enough that a genuinely unreadable file isn't retried per
+# query; short enough that transient fd pressure doesn't strand the read pool.
+_READ_OPEN_RETRY_SECONDS = 60.0
 
 # Import-time snapshot used by _default_db_path() to detect a deliberately
 # re-pointed DEFAULT_DB_PATH (tests monkeypatch the constant directly).
@@ -2517,20 +2523,43 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self.read_only = read_only
 
         self._lock = threading.Lock()
-        # Read-path split (WAL only): recall/browse queries run on per-thread
-        # read-only connections so they never queue behind writer flushes on
-        # self._lock. See _read_ctx().
-        self._read_local = threading.local()
-        # Strong set of all live read connections across all threads.  We
-        # hold a reference so short-lived reader threads' connections are
-        # not GC'd without close() — that would leak tracked fds in
-        # _live_connections.  close() drains this set.
-        self._read_conns: "set[sqlite3.Connection]" = set()
+        # Read-path split (WAL only): recall/browse queries borrow a
+        # read-only connection from a bounded pool so they never queue
+        # behind writer flushes on self._lock. See _read_ctx().
+        #
+        # The pool is BOUNDED because the previous per-thread
+        # (threading.local + strong set) scheme pinned one connection per
+        # (SessionDB x thread) for the life of the process. Starlette
+        # dispatches sync routes on anyio worker threads, so a SessionDB
+        # that is never closed accumulated a connection — and two fds, the
+        # database and its -wal — for every worker thread that ever read,
+        # until the process hit the 256 soft RLIMIT_NOFILE a service manager
+        # hands it and every request failed with EMFILE while the process
+        # stayed alive, so the supervisor's restart-on-exit never fired.
+        # Same bug class as the closing(...) fix in gateway/readiness.py
+        # (#69678 / #69567).
+        self._read_pool: "queue.LifoQueue[sqlite3.Connection]" = queue.LifoQueue(
+            maxsize=8
+        )
         self._read_conns_lock = threading.Lock()
-        # Set when close() begins.  _get_read_conn checks this under the
-        # lock so a reader that finishes opening after the drain finds the
-        # shutdown in progress and closes its own connection immediately.
+        # Set when close() begins.  _read_ctx checks this under the lock
+        # before returning a connection to the pool, so a reader still in
+        # flight during the drain closes its own connection instead of
+        # re-populating a pool nobody will drain again.
         self._read_conns_closed = False
+        # "read-only opens are failing against this file" backoff stamp.
+        # Instance-wide rather than per-thread: with a shared pool the open
+        # is no longer a per-thread event, and retrying a known-bad open on
+        # every query is a syscall storm for no benefit. The locked writer
+        # connection still serves reads while the backoff holds.
+        # Deliberately a TIMESTAMP, not a sticky bool: the likeliest trigger
+        # is transient fd pressure (EMFILE) — the very condition this pool
+        # exists to prevent — and a permanent flag would demote every reader
+        # on this instance to the writer lock for the life of the process.
+        # The gateway shares one SessionDB across every agent, so that turns
+        # a momentary blip into a permanent global convoy. Expires after
+        # _READ_OPEN_RETRY_SECONDS so the read path self-heals.
+        self._read_open_failed_at = 0.0
         self._wal_active = False
         self._write_count = 0
         # One-shot guard for the runtime FTS rebuild recovery on the write
@@ -2762,7 +2791,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # ── Read-path split ──
 
     def _get_read_conn(self) -> Optional[sqlite3.Connection]:
-        """Per-thread read-only connection, or None when unavailable.
+        """Open a fresh read-only connection, or None when unavailable.
+
+        Callers must return the connection to self._read_pool (see
+        _read_ctx); this opens, it does not track.
 
         Only used under WAL: WAL readers see a consistent snapshot and never
         block on (or get blocked by) the writer, so recall/browse queries can
@@ -2776,16 +2808,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         if not self._wal_active or self.read_only:
             return None
-        conn = getattr(self._read_local, "conn", None)
-        if conn is not None:
-            return conn
-        if getattr(self._read_local, "failed", False):
-            return None
+        with self._read_conns_lock:
+            if self._read_conns_closed:
+                return None
+            if (
+                self._read_open_failed_at
+                and time.monotonic() - self._read_open_failed_at
+                < _READ_OPEN_RETRY_SECONDS
+            ):
+                return None
         try:
             conn = _connect_tracked_db(
                 f"file:{self.db_path}?mode=ro",
                 tracking_path=self.db_path,
                 uri=True,
+                # Pooled connections are borrowed by whichever thread runs
+                # the next read, and sqlite3 otherwise refuses cross-thread
+                # use ("SQLite objects created in a thread can only be used
+                # in that same thread") — including on close(), which is how
+                # the old per-thread connections became unclosable and leaked
+                # their fds. Exclusive ownership is enforced by the pool
+                # checkout/return, not by sqlite3. Matches the writer opens.
+                check_same_thread=False,
                 timeout=5.0,
                 isolation_level=None,
             )
@@ -2797,36 +2841,75 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # registry, not the database file, so mode=ro is fine.
             if self._fts_cjk_loaded:
                 load_fts5_cjk_extension(conn)
-            with self._read_conns_lock:
-                if self._read_conns_closed:
-                    # close() already drained — don't register; close
-                    # immediately so no tracked fd leaks.
-                    conn.close()
-                    self._read_local.failed = True
-                    return None
-                self._read_conns.add(conn)
         except sqlite3.Error:
-            # Mark this thread failed so we don't retry the open on every
-            # query; the locked writer connection still serves reads.
-            self._read_local.failed = True
+            # Back off from retrying the open on every query; the locked
+            # writer connection still serves reads until the stamp expires.
+            with self._read_conns_lock:
+                self._read_open_failed_at = time.monotonic()
             logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
             return None
-        self._read_local.conn = conn
         return conn
+
+    def _close_read_conn(self, conn) -> None:
+        """Close a pooled read connection, reporting failures.
+
+        This was a bare ``except Exception: pass``, which silently swallowed
+        the sqlite3.ProgrammingError raised when close() ran on a thread
+        other than the one that opened the connection — the exact signature
+        of the fd leak this pool fixes. A close that fails leaks a tracked
+        fd, so it must not be invisible.
+        """
+        try:
+            conn.close()
+        except Exception as exc:
+            logger.warning("read-conn close failed for %s: %s", self.db_path, exc)
+
+    def _checkout_read_conn(self) -> Optional[sqlite3.Connection]:
+        """Borrow a read connection from the pool, opening one on a miss.
+
+        The single acquisition seam for the read path: the WAL/read_only gate,
+        the pool checkout and the open-on-miss all live here, so there is
+        exactly one place to exercise (and one place for a caller to bypass by
+        accident). Returns None when the read path is unavailable and the
+        caller must fall back to the locked writer connection.
+        """
+        if not self._wal_active or self.read_only:
+            return None
+        try:
+            return self._read_pool.get_nowait()
+        except queue.Empty:
+            return self._get_read_conn()
 
     @contextmanager
     def _read_ctx(self):
         """Yield a connection for read-only statements.
 
-        WAL: a per-thread read-only connection with NO lock — recall queries
-        never convoy behind writer flushes (the gateway shares one SessionDB
-        across every agent, so this lock was a global choke point).
+        WAL: a read-only connection borrowed from a bounded pool with NO
+        lock — recall queries never convoy behind writer flushes (the
+        gateway shares one SessionDB across every agent, so this lock was a
+        global choke point). The connection is checked out for the duration
+        of the block, so no two threads ever touch it concurrently.
         Non-WAL or read-conn failure: the shared writer connection under
         self._lock, byte-for-byte the legacy behavior.
         """
-        conn = self._get_read_conn()
+        conn = self._checkout_read_conn()
         if conn is not None:
-            yield conn
+            try:
+                yield conn
+            finally:
+                returned = False
+                with self._read_conns_lock:
+                    if not self._read_conns_closed:
+                        try:
+                            self._read_pool.put_nowait(conn)
+                            returned = True
+                        except queue.Full:
+                            pass
+                if not returned:
+                    # More concurrent readers than maxsize, or close() has
+                    # already drained: this connection is surplus. Close it
+                    # here — dropping it on the floor is what leaked the fd.
+                    self._close_read_conn(conn)
             return
         with self._lock:
             yield self._conn
@@ -3395,23 +3478,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # (instance, function), so this removes exactly our registration;
         # no-op when the writer never started.
         atexit.unregister(self._drain_token_queue_at_exit)
-        # Close all read-only connections across all threads.  Per-thread
-        # connections live in threading.local() and would otherwise be GC'd
-        # without calling close(), leaking tracked fds in _live_connections.
-        # The strong set holds references so short-lived reader threads'
-        # connections survive until close() drains them.  Setting the closed
-        # flag under the lock prevents a reader from registering a new
-        # connection after the drain.
+        # Drain the read-only connection pool.  Setting the closed flag
+        # under the lock first means a reader still in flight closes its own
+        # connection on release instead of re-populating a pool that has
+        # already been drained.
         with self._read_conns_lock:
             self._read_conns_closed = True
-            read_conns = list(self._read_conns)
-            self._read_conns.clear()
-        for conn in read_conns:
+        while True:
             try:
-                conn.close()
-            except Exception:
-                pass
-        self._read_local.conn = None
+                conn = self._read_pool.get_nowait()
+            except queue.Empty:
+                break
+            self._close_read_conn(conn)
         with self._lock:
             if self._conn:
                 if not self.read_only:

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -967,3 +967,45 @@ def test_spawn_hermes_action_scrubs_gateway_loop_guard_env(monkeypatch, tmp_path
 
     assert "_HERMES_GATEWAY" not in captured["env"]
     assert captured["env"]["HERMES_NONINTERACTIVE"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# Desktop lifespan reaps orphan gateways at serve startup (#77276)
+# ---------------------------------------------------------------------------
+
+def test_desktop_lifespan_reaps_orphan_gateways_on_startup(
+    monkeypatch, _isolate_hermes_home
+):
+    """Starting a Desktop serve backend should reap orphan gateways left by a
+    previous serve session before forking a fresh one (#77276).
+
+    Graceful shutdown reaps the managed child, but an abnormal exit reparents
+    the old gateway to launchd (PPID=1) where it keeps holding the QQ
+    WebSocket. The lifespan calls _reap_unsupervised_gateway_orphans() once at
+    startup under HERMES_DESKTOP=1 so the stale orphan is cleared first.
+    """
+    import hermes_cli.web_server as ws
+
+    called = []
+
+    def _fake_reap():
+        called.append(True)
+        return True
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    # Keep the lifespan cheap: don't re-import the gateway module or spin up the
+    # real cron scheduler thread.
+    monkeypatch.setattr(ws, "_warm_gateway_module", lambda: None)
+    monkeypatch.setattr(ws, "_start_desktop_cron_ticker", lambda *_args: None)
+    # web_server imports the reaper lazily from hermes_cli.gateway, so patch it
+    # on that module.
+    import hermes_cli.gateway as g
+
+    monkeypatch.setattr(g, "_reap_unsupervised_gateway_orphans", _fake_reap)
+
+    client, _header = _client()
+    with client:
+        pass
+
+    assert called == [True]
+

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -232,6 +232,35 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
+    def test_launchd_plist_persists_configured_nofile_soft_limit(self, monkeypatch):
+        """The generated plist must carry SoftResourceLimits/NumberOfFiles so a
+        plist rewrite by `hermes gateway start` cannot strip the FD floor and
+        reintroduce EMFILE crashes (launchd default soft limit is 256)."""
+        import hermes_cli.resource_limits as resource_limits
+
+        monkeypatch.setattr(
+            resource_limits, "configured_nofile_soft_limit", lambda config=None: 65536
+        )
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>SoftResourceLimits</key>" in plist
+        assert "<key>NumberOfFiles</key>" in plist
+        assert "<integer>65536</integer>" in plist
+
+    def test_launchd_plist_omits_nofile_block_when_disabled(self, monkeypatch):
+        """runtime.nofile_soft_limit: 0/false/null disables the adjustment; the
+        plist must then not contain a SoftResourceLimits block at all."""
+        import hermes_cli.resource_limits as resource_limits
+
+        monkeypatch.setattr(
+            resource_limits, "configured_nofile_soft_limit", lambda config=None: None
+        )
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "SoftResourceLimits" not in plist
+
 
 
 class TestGatewayStopCleanup:

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -108,3 +108,180 @@ def test_reap_passes_child_pid_exclude_to_scan():
     exclude = scan.call_args.kwargs["exclude_pids"]
     assert 111 in exclude
     assert 999 in exclude
+
+
+# ---------------------------------------------------------------------------
+# Regression: a legitimately lock-owned SSH remote backend (started by another
+# client/machine) must survive the boot reap even though it matches the
+# Desktop-local serve shape and is orphaned at ppid 1. Production incident:
+# the local Desktop app's reboot reap killed a Mac Mini backend that a MacBook
+# had launched over SSH — its PID was the recorded owner in backend.lock.json.
+# ---------------------------------------------------------------------------
+
+import json
+from hermes_cli.dashboard_procs import (
+    _lock_owned_serve_pids,
+    _valid_lockfile_payload,
+)
+
+
+def _valid_lock_payload(pid: int, ownership_id: str, spawn_nonce: str) -> dict:
+    """A minimally-valid backend.lock.json body matching remote-lifecycle.ts."""
+    return {
+        "schemaVersion": 2,
+        "protocolVersion": 1,
+        "ownershipId": ownership_id,
+        "spawnNonce": spawn_nonce,
+        "tokenFingerprint": "a" * 32,
+        "pid": pid,
+        "port": 0,
+        "profile": "default",
+        "hermesPath": "/opt/hermes/bin/hermes",
+        "hermesHome": "~/.hermes",
+        "logPath": f"~/.hermes/desktop-ssh/{ownership_id}/{spawn_nonce}.log",
+        "startedAt": "2026-08-04T20:00:00Z",
+    }
+
+
+def test_lock_owned_serve_pids_reads_valid_backend_lock(tmp_path):
+    oid = "f" * 32
+    nonce = "d" * 16
+    lock_root = tmp_path / "desktop-ssh"
+    (lock_root / oid).mkdir(parents=True)
+    (lock_root / oid / "backend.lock.json").write_text(
+        json.dumps(_valid_lock_payload(7777, oid, nonce))
+    )
+    # A second, malformed lock (bad schemaVersion) must contribute nothing.
+    other_oid = "e" * 32
+    (lock_root / other_oid).mkdir(parents=True)
+    (lock_root / other_oid / "backend.lock.json").write_text(
+        json.dumps({**_valid_lock_payload(8888, other_oid, nonce), "schemaVersion": 99})
+    )
+    assert _lock_owned_serve_pids(base_dir=lock_root) == {7777}
+
+
+def test_valid_lockfile_payload_rejects_wrong_owner_and_shape():
+    oid = "f" * 32
+    nonce = "d" * 16
+    good = _valid_lockfile_payload(_valid_lock_payload(1, oid, nonce), oid)
+    assert good is True
+    # ownershipId must match the directory it lives in.
+    assert _valid_lockfile_payload(
+        _valid_lock_payload(1, "e" * 32, nonce), oid
+    ) is False
+    # pid out of range.
+    bad_pid = _valid_lock_payload(1, oid, nonce)
+    bad_pid["pid"] = 0
+    assert _valid_lockfile_payload(bad_pid, oid) is False
+    # port out of range.
+    bad_port = _valid_lock_payload(1, oid, nonce)
+    bad_port["port"] = 70000
+    assert _valid_lockfile_payload(bad_port, oid) is False
+    # spawnNonce wrong length.
+    bad_nonce = _valid_lock_payload(1, oid, nonce)
+    bad_nonce["spawnNonce"] = "z" * 15
+    assert _valid_lockfile_payload(bad_nonce, oid) is False
+    # logPath not ending in <oid>/<nonce>.log.
+    bad_log = _valid_lock_payload(1, oid, nonce)
+    bad_log["logPath"] = "~/.hermes/desktop-ssh/{oid}/other.log".format(oid=oid)
+    assert _valid_lockfile_payload(bad_log, oid) is False
+
+
+def test_reap_spare_lock_owned_ssh_remote_backend_of_foreign_client():
+    """The exact production-incident shape: a foreign-client SSH remote backend
+    matches the Desktop-local serve shape and is orphaned at ppid 1, but a valid
+    backend.lock.json owns its PID. The reap must NOT kill it."""
+    scanned = [
+        (555, "hermes serve --host 127.0.0.1 --port 0"),  # lock-owned remote
+        (666, "hermes serve --host 127.0.0.1 --port 0"),  # genuine orphan
+    ]
+    ppids = {555: 1, 666: 1}
+    terms: list[int] = []
+    live = {555, 666}
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid in live:
+                return None
+            raise ProcessLookupError()
+        if sig == 15:
+            terms.append(pid)
+            live.discard(pid)
+            return None
+        if sig == 9:
+            live.discard(pid)
+            return None
+        return None
+
+    # 555 is claimed by a valid backend.lock.json; 666 is not.
+    lock_owned = {555}
+
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=scanned,
+        ),
+        patch(
+            "hermes_cli.dashboard_procs._process_ppid",
+            side_effect=lambda pid: ppids.get(pid),
+        ),
+        patch("os.kill", side_effect=fake_kill),
+        patch("sys.platform", "darwin"),
+    ):
+        os.environ.pop("HERMES_DESKTOP_CHILD_PID", None)
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            lock_owned_pids_fn=lambda: lock_owned,
+        )
+
+    # Only the genuine orphan (666) is reaped; the lock-owned remote (555) lives.
+    assert set(result["matched"]) == {666}
+    assert set(terms) == {666}
+    assert 555 not in terms
+    assert set(result["killed"]) == {666}
+
+
+def test_reap_spare_lock_owned_backend_even_without_exclude_match(tmp_path):
+    """End-to-end through the real lock scanner: a backend.lock.json on disk
+    spares a matching orphaned serve even when HERMES_DESKTOP_CHILD_PID is
+    unset (foreign-client backend, not ours by env either)."""
+    oid = "a" * 32
+    nonce = "b" * 16
+    lock_root = tmp_path / "desktop-ssh"
+    (lock_root / oid).mkdir(parents=True)
+    (lock_root / oid / "backend.lock.json").write_text(
+        json.dumps(_valid_lock_payload(4242, oid, nonce))
+    )
+
+    scanned = [(4242, "hermes serve --host 127.0.0.1 --port 0")]
+    terms: list[int] = []
+
+    def fake_kill(pid, sig):
+        if sig == 15:
+            terms.append(pid)
+        return None
+
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=scanned,
+        ),
+        patch(
+            "hermes_cli.dashboard_procs._process_ppid",
+            return_value=1,
+        ),
+        patch("os.kill", side_effect=fake_kill),
+        patch("sys.platform", "darwin"),
+    ):
+        os.environ.pop("HERMES_DESKTOP_CHILD_PID", None)
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            lock_owned_pids_fn=lambda: _lock_owned_serve_pids(base_dir=lock_root),
+        )
+
+    assert terms == []
+    assert result["matched"] == []

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -1,0 +1,110 @@
+"""Orphan Desktop-local ``hermes serve`` reap at backend start.
+
+When Desktop dies uncleanly, local ``serve --host 127.0.0.1 --port 0``
+children can be reparented to pid 1 and keep full MCP trees alive. The next
+boot must clear those corpses without touching intentional fixed-port serves
+(e.g. ``--port 9119`` remote dashboards).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.dashboard_procs import (
+    _is_desktop_local_serve_cmdline,
+    _reap_orphaned_desktop_local_serves,
+)
+
+
+def test_desktop_local_serve_shape_matches_ephemeral_loopback():
+    assert _is_desktop_local_serve_cmdline(
+        "python -m hermes_cli.main serve --host 127.0.0.1 --port 0"
+    )
+    assert _is_desktop_local_serve_cmdline(
+        "hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-owner-nonce abc"
+    )
+    assert _is_desktop_local_serve_cmdline(
+        "/venv/bin/hermes serve --host=127.0.0.1 --port=0"
+    )
+
+
+def test_desktop_local_serve_shape_spares_fixed_port_and_non_serve():
+    assert not _is_desktop_local_serve_cmdline(
+        "hermes serve --host 100.106.105.2 --port 9119 --skip-build"
+    )
+    assert not _is_desktop_local_serve_cmdline(
+        "hermes serve --host 127.0.0.1 --port 9119"
+    )
+    assert not _is_desktop_local_serve_cmdline("hermes gateway run --replace")
+    assert not _is_desktop_local_serve_cmdline(
+        "vim notes about hermes serve --port 0"
+    )
+
+
+def test_reap_only_kills_ppid1_local_serves():
+    scanned = [
+        (111, "hermes serve --host 127.0.0.1 --port 0"),  # orphan local
+        (222, "hermes serve --host 127.0.0.1 --port 0"),  # still has parent
+        (333, "hermes serve --host 100.1.2.3 --port 9119"),  # fixed remote
+        (444, "hermes serve --isolated --host 127.0.0.1 --port 0"),  # orphan isolated
+    ]
+    ppids = {111: 1, 222: 50, 333: 1, 444: 1}
+    terms: list[int] = []
+    live = {111, 222, 333, 444}
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid in live:
+                return None
+            raise ProcessLookupError()
+        if sig == 15:
+            terms.append(pid)
+            live.discard(pid)
+            return None
+        if sig == 9:
+            live.discard(pid)
+            return None
+        return None
+
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=scanned,
+        ),
+        patch(
+            "hermes_cli.dashboard_procs._process_ppid",
+            side_effect=lambda pid: ppids.get(pid),
+        ),
+        patch("os.kill", side_effect=fake_kill),
+        patch("sys.platform", "darwin"),
+    ):
+        os.environ.pop("HERMES_DESKTOP_CHILD_PID", None)
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+        )
+
+    assert set(result["matched"]) == {111, 444}
+    assert set(terms) == {111, 444}
+    assert set(result["killed"]) == {111, 444}
+    assert 222 not in terms
+    assert 333 not in terms
+
+
+def test_reap_passes_child_pid_exclude_to_scan():
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=[],
+        ) as scan,
+        patch("sys.platform", "darwin"),
+        patch.dict(os.environ, {"HERMES_DESKTOP_CHILD_PID": "999,111"}, clear=False),
+    ):
+        result = _reap_orphaned_desktop_local_serves(sleep_fn=lambda _s: None)
+
+    assert result["matched"] == []
+    exclude = scan.call_args.kwargs["exclude_pids"]
+    assert 111 in exclude
+    assert 999 in exclude

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -1,0 +1,283 @@
+"""Tests for configurable RLIMIT_NOFILE startup handling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import resource_limits
+
+
+class _FakeResource:
+    RLIMIT_NOFILE = 7
+    RLIM_INFINITY = 2**63 - 1
+
+    def __init__(self, soft: int, hard: int) -> None:
+        self.limits = (soft, hard)
+        self.set_calls: list[tuple[int, tuple[int, int]]] = []
+
+    def getrlimit(self, resource: int) -> tuple[int, int]:
+        assert resource == self.RLIMIT_NOFILE
+        return self.limits
+
+    def setrlimit(self, resource: int, limits: tuple[int, int]) -> None:
+        assert resource == self.RLIMIT_NOFILE
+        self.set_calls.append((resource, limits))
+        self.limits = limits
+
+
+def test_real_config_loader_reads_runtime_nofile_setting(monkeypatch, tmp_path):
+    """The helper uses the canonical config loader, not a second YAML parser."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "runtime:\n  nofile_soft_limit: 2048\n",
+        encoding="utf-8",
+    )
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit() is True
+    assert fake_resource.set_calls == [
+        (fake_resource.RLIMIT_NOFILE, (2048, 4096)),
+    ]
+
+
+def test_default_is_clamped_to_hard_limit(monkeypatch):
+    fake_resource = _FakeResource(soft=256, hard=1024)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is True
+    assert fake_resource.limits == (1024, 1024)
+
+
+def test_never_lowers_an_already_higher_soft_limit(monkeypatch):
+    fake_resource = _FakeResource(soft=8192, hard=16384)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit(
+        {"runtime": {"nofile_soft_limit": 4096}}
+    ) is False
+    assert fake_resource.set_calls == []
+    assert fake_resource.limits == (8192, 16384)
+
+
+@pytest.mark.parametrize("disabled", [0, False, None])
+def test_explicit_values_disable(monkeypatch, disabled):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit(
+        {"runtime": {"nofile_soft_limit": disabled}}
+    ) is False
+    assert fake_resource.set_calls == []
+
+
+def test_unsupported_platform_is_a_safe_noop(monkeypatch):
+    monkeypatch.setattr(resource_limits, "_resource", None)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is False
+
+
+@pytest.mark.parametrize("invalid", [True, -1, 4096.0, "4096", object()])
+def test_invalid_values_are_safe_noops(monkeypatch, invalid):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit(
+        {"runtime": {"nofile_soft_limit": invalid}}
+    ) is False
+    assert fake_resource.set_calls == []
+
+
+def test_setrlimit_denial_is_a_safe_noop(monkeypatch):
+    class _DeniedResource(_FakeResource):
+        def setrlimit(self, resource: int, limits: tuple[int, int]) -> None:
+            raise PermissionError("simulated EPERM")
+
+    fake_resource = _DeniedResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is False
+    assert fake_resource.limits == (256, 4096)
+
+
+def test_never_lowers_an_unlimited_soft_limit(monkeypatch):
+    fake_resource = _FakeResource(soft=-1, hard=-1)
+    fake_resource.RLIM_INFINITY = -1
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is False
+    assert fake_resource.set_calls == []
+    assert fake_resource.limits == (-1, -1)
+
+
+@pytest.mark.asyncio
+async def test_gateway_startup_applies_limit_before_gateway_initialization(monkeypatch):
+    import gateway.code_skew
+    import gateway.run as gateway_run
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_nofile_soft_limit",
+        lambda: calls.append("limit"),
+    )
+
+    class _StopStartup(Exception):
+        pass
+
+    def stop_after_limit():
+        calls.append("gateway-init")
+        raise _StopStartup
+
+    monkeypatch.setattr(gateway.code_skew, "record_boot_fingerprint", stop_after_limit)
+
+    with pytest.raises(_StopStartup):
+        await gateway_run.start_gateway()
+
+    assert calls == ["limit", "gateway-init"]
+
+
+def test_serve_startup_applies_limit_before_web_server(monkeypatch):
+    from hermes_cli import main as cli_main
+    import hermes_cli.plugins
+    import hermes_cli.web_server
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_nofile_soft_limit",
+        lambda: calls.append("limit"),
+    )
+    monkeypatch.setattr(cli_main, "_sync_bundled_skills_quietly", lambda: None)
+    monkeypatch.setattr(cli_main, "_build_web_ui", lambda *args, **kwargs: True)
+    monkeypatch.setattr(cli_main, "_maybe_setup_dashboard_auth_interactively", lambda args: None)
+    monkeypatch.setattr(hermes_cli.plugins, "discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        hermes_cli.web_server,
+        "start_server",
+        lambda **kwargs: calls.append("server"),
+    )
+
+    args = SimpleNamespace(
+        status=False,
+        stop=False,
+        headless_backend=True,
+        ssh_owner_nonce=None,
+        ssh_session_token_file=None,
+        host="127.0.0.1",
+        port=0,
+        no_open=True,
+        insecure=False,
+        open_profile="",
+        isolated=True,
+        skip_build=False,
+    )
+
+    cli_main.cmd_dashboard(args)
+
+    assert calls == ["limit", "server"]
+
+
+def test_named_profile_reroute_defers_limit_to_final_process(monkeypatch, tmp_path):
+    """The launcher profile must not leak its limit across machine re-exec."""
+    from hermes_cli import main as cli_main
+    import hermes_cli.profiles
+    import hermes_constants
+    from tools.environments import local as local_environment
+
+    calls: list[str] = []
+    exec_call: dict[str, object] = {}
+
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_nofile_soft_limit",
+        lambda: calls.append("limit"),
+    )
+    monkeypatch.setattr(
+        hermes_cli.profiles,
+        "get_active_profile_name",
+        lambda: "worker",
+    )
+    monkeypatch.setattr(cli_main, "_dashboard_listening", lambda *args: False)
+    monkeypatch.setattr(
+        local_environment,
+        "build_subprocess_env",
+        lambda **kwargs: {},
+    )
+    monkeypatch.setattr(
+        hermes_constants,
+        "get_default_hermes_root",
+        lambda: tmp_path,
+    )
+
+    class _ExecCalled(Exception):
+        pass
+
+    def stop_at_exec(executable, argv, env):
+        exec_call.update(executable=executable, argv=argv, env=env)
+        raise _ExecCalled
+
+    monkeypatch.setattr(cli_main.os, "execvpe", stop_at_exec)
+
+    args = SimpleNamespace(
+        status=False,
+        stop=False,
+        headless_backend=True,
+        ssh_owner_nonce=None,
+        ssh_session_token_file=None,
+        host="127.0.0.1",
+        port=0,
+        no_open=True,
+        insecure=False,
+        open_profile="",
+        isolated=False,
+        skip_build=False,
+    )
+
+    with pytest.raises(_ExecCalled):
+        cli_main.cmd_dashboard(args)
+
+    assert calls == []
+    assert exec_call["argv"][1:5] == ["-m", "hermes_cli.main", "-p", "default"]
+    assert exec_call["env"]["HERMES_HOME"] == str(tmp_path)
+
+
+@pytest.mark.parametrize("lifecycle_flag", ["status", "stop"])
+def test_dashboard_lifecycle_flags_skip_limit_adjustment(monkeypatch, lifecycle_flag):
+    """Informational/stop-only commands must not mutate process limits."""
+    from hermes_cli import main as cli_main
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_nofile_soft_limit",
+        lambda: calls.append("limit"),
+    )
+    monkeypatch.setattr(cli_main, "_scan_dashboard_processes", lambda: [])
+    monkeypatch.setattr(cli_main, "_find_stale_dashboard_pids", lambda: [])
+
+    args = SimpleNamespace(
+        status=lifecycle_flag == "status",
+        stop=lifecycle_flag == "stop",
+        headless_backend=False,
+        ssh_owner_nonce=None,
+        ssh_session_token_file=None,
+        host="127.0.0.1",
+        port=0,
+        no_open=True,
+        insecure=False,
+        open_profile="",
+        isolated=False,
+        skip_build=False,
+    )
+
+    with pytest.raises(SystemExit):
+        cli_main.cmd_dashboard(args)
+
+    assert calls == []

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -173,7 +173,7 @@ def test_never_lowers_an_unlimited_soft_limit(monkeypatch):
     assert fake_resource.limits == (-1, -1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_gateway_startup_applies_limit_before_gateway_initialization(monkeypatch):
     import gateway.code_skew
     import gateway.run as gateway_run

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -206,6 +206,13 @@ def test_serve_startup_applies_limit_before_web_server(monkeypatch):
     import hermes_cli.plugins
     import hermes_cli.web_server
 
+    # cmd_dashboard(headless_backend=True) exports HERMES_SERVE_HEADLESS=1 into
+    # this process's environment (main.py serve path). Touch the key through
+    # monkeypatch FIRST so teardown restores the pre-test state — otherwise the
+    # leaked flag flips later web-server tests (mount_spa) into the headless
+    # 404 path.
+    monkeypatch.setenv("HERMES_SERVE_HEADLESS", "0")
+
     calls: list[str] = []
     monkeypatch.setattr(
         resource_limits,

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
 from types import SimpleNamespace
 
 import pytest
@@ -53,6 +57,19 @@ def test_default_is_clamped_to_hard_limit(monkeypatch):
     assert fake_resource.limits == (1024, 1024)
 
 
+def test_finite_soft_limit_raises_when_hard_limit_is_infinite(monkeypatch):
+    fake_resource = _FakeResource(soft=256, hard=_FakeResource.RLIM_INFINITY)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is True
+    assert fake_resource.set_calls == [
+        (
+            fake_resource.RLIMIT_NOFILE,
+            (4096, fake_resource.RLIM_INFINITY),
+        ),
+    ]
+
+
 def test_never_lowers_an_already_higher_soft_limit(monkeypatch):
     fake_resource = _FakeResource(soft=8192, hard=16384)
     monkeypatch.setattr(resource_limits, "_resource", fake_resource)
@@ -81,6 +98,36 @@ def test_unsupported_platform_is_a_safe_noop(monkeypatch):
     assert resource_limits.apply_nofile_soft_limit({}) is False
 
 
+def test_fresh_process_import_without_posix_resource_is_a_safe_noop():
+    code = textwrap.dedent(
+        """
+        import importlib.util
+        import pathlib
+        import sys
+
+        sys.modules["resource"] = None
+        module_path = pathlib.Path(sys.argv[1])
+        spec = importlib.util.spec_from_file_location(
+            "hermes_cli._resource_limits_without_posix_resource",
+            module_path,
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        assert module._resource is None
+        assert module.apply_nofile_soft_limit({}) is False
+        """
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", code, resource_limits.__file__],
+        check=True,
+        cwd=Path(resource_limits.__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+    )
+
+
 @pytest.mark.parametrize("invalid", [True, -1, 4096.0, "4096", object()])
 def test_invalid_values_are_safe_noops(monkeypatch, invalid):
     fake_resource = _FakeResource(soft=256, hard=4096)
@@ -102,6 +149,18 @@ def test_setrlimit_denial_is_a_safe_noop(monkeypatch):
 
     assert resource_limits.apply_nofile_soft_limit({}) is False
     assert fake_resource.limits == (256, 4096)
+
+
+def test_getrlimit_failure_is_a_safe_noop(monkeypatch):
+    class _BrokenResource(_FakeResource):
+        def getrlimit(self, resource: int) -> tuple[int, int]:
+            raise OSError("simulated getrlimit failure")
+
+    fake_resource = _BrokenResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is False
+    assert fake_resource.set_calls == []
 
 
 def test_never_lowers_an_unlimited_soft_limit(monkeypatch):

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -19,6 +19,16 @@ The contract pinned here: reads borrow from a BOUNDED pool, connections are
 returned and reused, surplus connections are closed rather than dropped, and
 ``close()`` actually closes them from whatever thread it runs on.
 
+Bounded means bounded at PEAK, not merely at rest. Pooling returns behind a
+``maxsize`` LifoQueue while opening unconditionally on a miss still lets a
+burst of N simultaneous readers on a cold pool open N descriptors before
+closing the surplus -- which is the exact shape of the production incident,
+since the burst that exhausts the pool is the burst that exhausts the fd
+table. Peak is held down by a permit acquired before the open and released
+after the close; past the ceiling readers degrade to the locked writer
+connection. Tests that join their workers before counting cannot see any of
+this, so the peak assertions use a barrier.
+
 These assert on the pool/registry counts, never on ``lsof``: SQLite's unix VFS
 parks a closed descriptor on a per-inode reuse list while any connection still
 holds POSIX locks on that inode, so raw descriptor counts lag the real
@@ -58,7 +68,14 @@ def _read(db):
 
 @pytest.mark.requires_wal
 def test_read_pool_is_bounded_across_many_threads(db):
-    """150 short-lived reader threads must not pin 150 connections."""
+    """150 short-lived reader threads must not pin 150 connections.
+
+    NOTE: this measures the pool AT REST -- every worker is joined before the
+    count is taken, so by construction it cannot observe how many connections
+    were open simultaneously. It is a real assertion about accumulation and a
+    non-assertion about peak. See
+    test_peak_live_connections_bounded_under_simultaneous_burst for the peak.
+    """
     maxsize = db._read_pool.maxsize
     assert maxsize > 0, "read pool must be bounded"
 
@@ -225,3 +242,145 @@ def test_fallback_to_locked_writer_when_read_conn_unavailable(db, monkeypatch):
     monkeypatch.setattr(db, "_checkout_read_conn", lambda: None)
     assert db.get_session("s1")["id"] == "s1"
     assert db.search_messages("graphiti", limit=5)
+
+
+@pytest.mark.requires_wal
+def test_peak_live_connections_bounded_under_simultaneous_burst(db):
+    """N readers checked out AT THE SAME INSTANT must not open N connections.
+
+    This is the assertion the join-then-count test above cannot make. A
+    LifoQueue with a maxsize bounds how many connections are RETURNED, not how
+    many are OPEN: with an open-on-miss checkout, 64 readers arriving on a cold
+    pool opened 64 descriptors and only then closed 56 of them on release.
+    Bounded at rest, unbounded at peak -- and EMFILE is a peak-instant
+    condition, so the process could still wedge exactly as it did in
+    production.
+
+    The barrier is the whole point: every worker holds its connection until all
+    of them have checked out, so the count below IS the simultaneous peak
+    rather than a sample of it.
+    """
+    from hermes_state import _READ_POOL_MAX
+
+    n = 64
+    assert n > _READ_POOL_MAX, "burst must exceed the ceiling to test anything"
+
+    ready = threading.Barrier(n + 1)
+    release = threading.Event()
+    checked_out = []
+    fell_back = []
+    lock = threading.Lock()
+
+    def worker():
+        conn = db._checkout_read_conn()
+        with lock:
+            (checked_out if conn is not None else fell_back).append(conn)
+        ready.wait(timeout=30)      # everyone is now holding whatever they got
+        release.wait(timeout=30)
+        if conn is not None:
+            db._close_read_conn(conn)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+
+    ready.wait(timeout=30)
+    # ---- the instant every worker is simultaneously checked out ----
+    peak_live = _live_count(db.db_path)
+    peak_checked_out = len(checked_out)
+    release.set()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert peak_checked_out <= _READ_POOL_MAX, (
+        f"{peak_checked_out} connections checked out at once; the ceiling is "
+        f"{_READ_POOL_MAX}. Peak is unbounded -- the pool bounds returns, not opens."
+    )
+    # +1 for the writer connection SessionDB always holds.
+    assert peak_live <= _READ_POOL_MAX + 1, (
+        f"{peak_live} live connections at peak, ceiling is {_READ_POOL_MAX} (+1 writer)"
+    )
+    assert fell_back, "with n > ceiling some readers must degrade to the writer path"
+    assert len(checked_out) + len(fell_back) == n, "every worker must be accounted for"
+
+
+@pytest.mark.requires_wal
+def test_exhausted_permits_fall_back_to_the_writer_connection(db):
+    """Past the ceiling the read path degrades, it does not fail or block.
+
+    A reader that cannot get a permit must serve from the locked writer
+    connection. Blocking instead would convert descriptor exhaustion into a
+    stall -- the same outage with a different stack trace.
+    """
+    from hermes_state import _READ_POOL_MAX
+
+    held = [db._checkout_read_conn() for _ in range(_READ_POOL_MAX)]
+    assert all(c is not None for c in held), "the first _READ_POOL_MAX must succeed"
+    try:
+        assert db._checkout_read_conn() is None, "ceiling must refuse the next open"
+        with db._read_ctx() as conn:
+            assert conn is db._conn, "must fall back to the shared writer connection"
+            assert conn.execute("SELECT 1").fetchone()[0] == 1, "fallback must work"
+    finally:
+        for c in held:
+            db._close_read_conn(c)
+
+    # Permits come back: the read path recovers once the burst drains.
+    recovered = db._checkout_read_conn()
+    assert recovered is not None, "permits must be released back after close"
+    db._close_read_conn(recovered)
+
+
+@pytest.mark.requires_wal
+def test_permits_are_not_stranded_by_a_failed_open(db, monkeypatch):
+    """A failed open must return its permit, or the ceiling ratchets to zero.
+
+    A permit leaked per failure is not a transient error: it permanently
+    shrinks the read path, so a burst of transient open failures would silently
+    demote every later read to the writer lock for the life of the process.
+    """
+    import sqlite3 as _sqlite3
+
+    import hermes_state as _hs
+    from hermes_state import _READ_POOL_MAX
+
+    def boom(*a, **kw):
+        raise _sqlite3.OperationalError("simulated open failure")
+
+    monkeypatch.setattr(_hs, "_connect_tracked_db", boom)
+    for _ in range(_READ_POOL_MAX * 3):
+        assert db._get_read_conn() is None
+        db._read_open_failed_at = 0.0    # defeat the backoff so every call opens
+    monkeypatch.undo()
+
+    db._read_open_failed_at = 0.0
+    held = [db._checkout_read_conn() for _ in range(_READ_POOL_MAX)]
+    try:
+        assert all(c is not None for c in held), (
+            "permits were stranded by failed opens -- the ceiling ratcheted down"
+        )
+    finally:
+        for c in held:
+            if c is not None:
+                db._close_read_conn(c)
+
+
+@pytest.mark.requires_wal
+def test_close_returns_every_permit(db):
+    """close() must release the permits its drained connections held."""
+    from hermes_state import _READ_POOL_MAX
+
+    held = [db._checkout_read_conn() for _ in range(_READ_POOL_MAX)]
+    for c in held:
+        db._read_pool.put_nowait(c)
+    assert db._read_pool.qsize() == _READ_POOL_MAX
+
+    db.close()
+    assert db._read_pool.qsize() == 0
+    assert _live_count(db.db_path) == 0
+    # BoundedSemaphore raises on over-release, so draining exactly
+    # _READ_POOL_MAX permits proves close() released neither too few nor too
+    # many.
+    for _ in range(_READ_POOL_MAX):
+        assert db._read_permits.acquire(blocking=False), "close() stranded a permit"
+    assert not db._read_permits.acquire(blocking=False), "close() over-released"

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -1,0 +1,227 @@
+"""The SessionDB read path must not leak one connection per (SessionDB x thread).
+
+``_get_read_conn`` used to cache a read-only connection in ``threading.local()``
+and pin it in a strong set (``_read_conns``) that was only ever drained by
+``close()``. Starlette dispatches sync routes on anyio worker threads, so a
+SessionDB that is never closed -- the dashboard's module-global ``_db`` and
+the per-session ``session_db`` handles -- gained a connection, and a file
+descriptor, for every worker thread that ever served a read. In production
+that walked into the 256 soft ``RLIMIT_NOFILE`` a service manager hands the
+process, after which every request failed with ``OSError`` EMFILE while the
+process stayed alive, so the supervisor's restart-on-exit never fired.
+
+Worse, those connections were opened WITHOUT ``check_same_thread=False`` (both
+writer opens pass it), so ``close()`` on them raised ``ProgrammingError`` from
+a different thread and the bare ``except Exception: pass`` hid it -- leaving
+``hermes_cli.sqlite_safe_read``'s registry permanently over-counted as well.
+
+The contract pinned here: reads borrow from a BOUNDED pool, connections are
+returned and reused, surplus connections are closed rather than dropped, and
+``close()`` actually closes them from whatever thread it runs on.
+
+These assert on the pool/registry counts, never on ``lsof``: SQLite's unix VFS
+parks a closed descriptor on a per-inode reuse list while any connection still
+holds POSIX locks on that inode, so raw descriptor counts lag the real
+connection count and make such assertions flaky.
+"""
+
+import threading
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _live_count(path) -> int:
+    """Live-connection count the tracking registry holds for *path*."""
+    import hermes_cli.sqlite_safe_read as mod
+
+    with mod._live_lock:
+        return mod._live_connections.get(mod._key(path), 0)
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session(session_id="s1", source="cli", model="m")
+    d.append_message("s1", role="user", content="hello graphiti world")
+    d.append_message("s1", role="assistant", content="the neo4j daemon is healthy")
+    yield d
+    d.close()
+
+
+def _read(db):
+    db.get_session("s1")
+    db.search_messages("graphiti", limit=5)
+    db.get_messages("s1")
+
+
+@pytest.mark.requires_wal
+def test_read_pool_is_bounded_across_many_threads(db):
+    """150 short-lived reader threads must not pin 150 connections."""
+    maxsize = db._read_pool.maxsize
+    assert maxsize > 0, "read pool must be bounded"
+
+    for _ in range(6):
+        threads = [threading.Thread(target=_read, args=(db,)) for _ in range(25)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert db._read_pool.qsize() <= maxsize
+
+    # The pre-fix code held 151 connections here (150 readers + main thread).
+    assert db._read_pool.qsize() <= maxsize
+    # +1 for the writer connection SessionDB always holds.
+    assert _live_count(db.db_path) <= maxsize + 1
+
+
+@pytest.mark.requires_wal
+def test_read_conn_returned_to_pool_and_reused(db):
+    """Sequential reads on one thread reuse a pooled connection, not a new one."""
+    with db._read_ctx() as conn:
+        first = conn
+    assert db._read_pool.qsize() >= 1, "connection was not returned to the pool"
+    with db._read_ctx() as conn:
+        assert conn is first, "pooled connection was not reused"
+
+
+@pytest.mark.requires_wal
+def test_pooled_conn_is_usable_from_another_thread(db):
+    """A pooled connection is handed between threads, so it must not be
+    bound to its creating thread (check_same_thread=False)."""
+    with db._read_ctx() as conn:
+        borrowed = conn
+
+    errors = []
+
+    def use_it():
+        try:
+            borrowed.execute("SELECT 1").fetchone()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t = threading.Thread(target=use_it)
+    t.start()
+    t.join()
+    assert not errors, f"pooled connection unusable off-thread: {errors}"
+
+
+@pytest.mark.requires_wal
+def test_close_drains_pool_from_a_foreign_thread(tmp_path):
+    """close() must actually close pooled connections, including ones opened
+    on threads that have since exited -- the swallowed ProgrammingError."""
+    d = SessionDB(db_path=tmp_path / "state2.db")
+    d.create_session(session_id="s1", source="cli", model="m")
+
+    # Populate the pool from a worker thread, then let that thread die.
+    t = threading.Thread(target=lambda: d.get_session("s1"))
+    t.start()
+    t.join()
+    assert d._read_pool.qsize() >= 1
+
+    d.close()
+    assert d._read_pool.qsize() == 0
+    # Registry back to zero proves the closes succeeded rather than raising
+    # ProgrammingError into a bare except.
+    assert _live_count(d.db_path) == 0
+
+
+@pytest.mark.requires_wal
+def test_reader_after_close_does_not_repopulate_pool(db):
+    """A read racing close() must close its connection, not refill the pool."""
+    db.close()
+    assert db._read_pool.qsize() == 0
+    # A read arriving after the drain must not open-and-requeue a connection
+    # that nothing will ever close again.
+    with db._read_ctx():
+        pass
+    assert db._read_pool.qsize() == 0
+
+
+def test_reads_are_still_correct_under_concurrency(db):
+    """Pooling must not corrupt results when threads share connections."""
+    results = []
+    errors = []
+
+    def reader():
+        try:
+            results.append(db.get_session("s1")["id"])
+            results.append(len(db.get_messages("s1")))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=reader) for _ in range(12)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors, f"concurrent reads failed: {errors}"
+    assert results.count("s1") == 12
+    assert results.count(2) == 12
+
+
+@pytest.mark.requires_wal
+def test_read_open_failure_backs_off_but_recovers(db):
+    """A failed read-only open must not permanently demote the read path.
+
+    The first version of this fix used a sticky instance-wide boolean
+    (``_read_open_failed``). Its likeliest trigger is transient fd pressure --
+    EMFILE, the very condition this pool exists to prevent -- and because the
+    gateway shares ONE SessionDB across every agent, a single blip would have
+    convoyed every subsequent reader behind the writer lock for the life of
+    the process. The stamp must expire.
+    """
+    import time as _time
+
+    from hermes_state import _READ_OPEN_RETRY_SECONDS
+
+    baseline = db._get_read_conn()
+    assert baseline is not None, "baseline read open should succeed"
+    db._close_read_conn(baseline)
+
+    db._read_open_failed_at = _time.monotonic()
+    assert db._get_read_conn() is None, "should back off immediately after a failure"
+
+    db._read_open_failed_at = _time.monotonic() - (_READ_OPEN_RETRY_SECONDS + 1)
+    recovered = db._get_read_conn()
+    assert recovered is not None, "read path must self-heal once the window expires"
+    db._close_read_conn(recovered)
+
+
+@pytest.mark.requires_wal
+def test_checkout_seam_is_the_single_acquisition_point(db):
+    """``_read_ctx`` must acquire via ``_checkout_read_conn`` and nothing else.
+
+    If a future edit re-inlines the pool checkout into ``_read_ctx``, patching
+    ``_get_read_conn`` silently exercises nothing whenever the pool is warm --
+    which is exactly how the writer-lock fallback test below would rot into a
+    no-op without failing.
+    """
+    calls = []
+    original = db._checkout_read_conn
+
+    def _spy():
+        calls.append(1)
+        return original()
+
+    db._checkout_read_conn = _spy
+    try:
+        with db._read_ctx():
+            pass
+    finally:
+        db._checkout_read_conn = original
+    assert calls, "_read_ctx must route acquisition through _checkout_read_conn"
+
+
+def test_fallback_to_locked_writer_when_read_conn_unavailable(db, monkeypatch):
+    """With no read connection available, reads still work under self._lock.
+
+    Patched at the acquisition SEAM rather than at ``_get_read_conn``: the
+    pool is consulted first, so a patched ``_get_read_conn`` is never reached
+    while the pool holds a connection and this test would pass while
+    exercising nothing.
+    """
+    monkeypatch.setattr(db, "_checkout_read_conn", lambda: None)
+    assert db.get_session("s1")["id"] == "s1"
+    assert db.search_messages("graphiti", limit=5)

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -1,11 +1,12 @@
-"""Tests for the SessionDB read-path split (per-thread read-only connections).
+"""Tests for the SessionDB read-path split (pooled read-only connections).
 
 The gateway shares ONE SessionDB across every agent, so recall/browse reads
 used to queue behind writer flushes on self._lock — a measured production
 convoy (a 0.2s FTS query stretched to 112s while 6-8 concurrent turns
 flushed tool results). These tests pin the new contract: reads run on a
-per-thread read-only connection under WAL, never touch self._lock, and fall
-back to the legacy locked path when WAL or the read connection is missing.
+read-only connection borrowed from a bounded pool under WAL, never touch
+self._lock, and fall back to the legacy locked path when WAL or the read
+connection is missing.
 """
 
 import threading
@@ -39,8 +40,19 @@ def test_read_conn_is_per_thread(db):
     assert conns[1] is not conns[2]
 
 
-def test_read_conn_reused_within_thread(db):
-    assert db._get_read_conn() is db._get_read_conn()
+@pytest.mark.requires_wal
+def test_read_conn_reused_via_pool(db):
+    """Reuse is now the pool's job, not a per-thread memo.
+
+    The old contract (``_get_read_conn()`` returns the same object twice on one
+    thread) was the leak: that memo pinned one unclosable connection per
+    (SessionDB x thread) forever. ``_get_read_conn`` now always opens a fresh
+    connection and reuse happens via checkout/return, so assert on that.
+    """
+    with db._read_ctx() as first:
+        assert first is not None
+    with db._read_ctx() as second:
+        assert second is first, "sequential readers must reuse the pooled conn"
 
 
 @pytest.mark.requires_wal

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -69,6 +69,24 @@ cannot override, via a system-level managed directory. See
 [Managed Scope](/user-guide/managed-scope).
 :::
 
+## Runtime Limits
+
+Long-running Hermes server surfaces (including the gateway and
+`hermes serve --isolated`) apply the configured `RLIMIT_NOFILE` soft limit
+during startup when the operating system supports it:
+
+```yaml
+runtime:
+  nofile_soft_limit: 4096
+```
+
+The default is `4096`. Hermes clamps the target to the operating system's hard
+limit and never lowers a process that already has a higher soft limit. Set the
+value to `0`, `false`, or `null` to disable the adjustment. On Windows and in
+sandboxes
+where the limit cannot be changed, startup continues without changing the
+limit.
+
 ## Environment Variable Substitution
 
 You can reference environment variables in `config.yaml` using `${VAR_NAME}` syntax:


### PR DESCRIPTION
## Summary

Desktop becomes usable again with multiple long-running chats: the SessionDB WAL-reader fd leak is fixed with a bounded connection pool, orphaned `hermes serve` backends are reaped at Desktop boot (with a parent-death watchdog preventing new ones), and the process nofile soft limit gets a configurable floor so a single busy backend can no longer wedge itself at macOS's 256-fd default. Fixes #78872, #75269; closes the EMFILE cascade behind #73066 / #77573 / #78312.

Root cause chain: every anyio worker thread that ever served a read pinned one read-only SQLite connection (two fds: db + wal) for the life of the process → a single healthy `serve` hit RLIMIT_NOFILE 256 within ~12–20h → `socket.accept()` wedged while the port still probed open → Desktop "could not reach the gateway". Separately, Electron dying uncleanly stranded `serve --host 127.0.0.1 --port 0` children at ppid 1, stacking corpses (17 reported) each holding full MCP trees.

## Changes

- `hermes_state.py`: bounded LIFO read-connection pool (max 8) with a lifetime permit per open — bounds PEAK descriptors, not just idle; degradation past the ceiling is the locked writer path, never EMFILE; `close()` drains from any thread (salvaged from #76700 by @Yishova)
- `hermes_cli/resource_limits.py` (new): `runtime.nofile_soft_limit` config (default 4096), applied at serve/gateway start; never lowers, never touches RLIM_INFINITY (salvaged from #77587 by @100yenadmin)
- `hermes_cli/dashboard_procs.py`: startup reap of already-orphaned Desktop-local serves — matches ONLY the `--host 127.0.0.1 --port 0` Desktop spawn shape at ppid 1; never touches PIDs claimed by a valid `backend.lock.json` (SSH remote backends legitimately sit at ppid 1) (salvaged from #78873 by @leonphull)
- `apps/desktop/electron`: parent-death watchdog + group-kill so future backend children die with Electron (salvaged from #73066 by @XiaoZAZA)
- `hermes_cli/gateway.py`: launchd plist persists the nofile limit so launchd-managed serves get it too (@leonphull)
- Orphan gateway startup reap (salvaged from #78312 by @cadezhou)

## Validation

| Check | Before (main) | After (branch) |
|---|---|---|
| Live conns after 150 real reader threads (fresh proc, real state.db, WAL) | **151** | **9** (pool 8 + writer) |
| Live conns after `close()` | leaked | 0 |
| Soft nofile in 256-limited fresh process | 256 | 4096 |
| Real double-forked orphan serves (ppid 1) after boot reap | survive | reaped (2/2) |
| Lock-owned serve (valid backend.lock.json) | n/a | **survives** |
| 800 authed `/api/sessions` requests against live `serve` | — | fd delta 0 |

Targeted tests: 457 passed, 0 failed (`test_session_db_read_conn_pool`, `test_session_db_read_path_split`, `test_resource_limits`, `test_orphan_desktop_serve_reap`, `test_gateway_service`, `test_gateway_restart_loop`, `test_hermes_state`). Desktop vitest: 14/14 (`windows-child-options`). Live cross-process E2E ran on Linux against real processes and a live `hermes serve` on port 9272 (WAL-capable SQLite 3.53.1).

Contributor commits cherry-picked with authorship preserved: @Yishova (#76700), @100yenadmin (#77587), @XiaoZAZA (#73066), @leonphull (#78873), @cadezhou (#78312).

Not included (deliberately): the renderer memory fix (#71269 is draft and conflicts with the newer parts-budget live-tail from #66470-family — needs its own design pass), FTS multimodal-sentinel bloat (#69798 conflicts extensively with current hermes_state.py — separate salvage), and any state.db retention/eviction policy (#54189 is needs-decision).

## Infographic

![Desktop long-session stability infographic](https://v3b.fal.media/files/b/0aa5d096/EL3QCRI9FJblv_1BFFVIu_1mmD4Ia9.png)
