### PR TITLE
fix(gateway): allow necessary restarts after recovery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1143,12 +1143,18 @@ def build_resume_recovery_note(
             "appear in the history — resume from the first step "
             "that has no recorded result."
         )
+    recovery_guard = (
+        "Do not blindly replay the same restart/shutdown intent: the lifecycle "
+        "command already present in history may have run. Inspect current state "
+        "before any retry. If there is a new target revision or configuration, "
+        "freshness evidence is missing, or health checks fail, create a new "
+        "restart intent; it is allowed to restart again when necessary and then "
+        "verify the new process and effective runtime."
+    )
     return (
         f"[System note: The previous turn was interrupted by "
         f"{reason_phrase}; the gateway is now back online. "
-        f"Any restart/shutdown command in the history has already "
-        f"run — do NOT re-execute or verify it. {resume_guidance} "
-        f"{tail_guidance}]"
+        f"{recovery_guard} {resume_guidance} {tail_guidance}]"
         + (f"\n\n{message}" if message else "")
     )
 

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -313,6 +313,17 @@ class TestResumePendingSystemNote:
         # But still guards against re-running already-recorded tool calls.
         assert "already appear in the history" in note
 
+    def test_restart_recovery_blocks_blind_replay_but_allows_new_necessary_intent(self):
+        note = build_resume_recovery_note("restart_timeout", "continue", interactive=True)
+        assert "Do not blindly replay the same restart/shutdown intent" in note
+        assert "new target revision or configuration" in note
+        assert "freshness evidence is missing" in note
+        assert "health checks fail" in note
+        assert "create a new restart intent" in note
+        assert "restart again" in note
+        assert "verify the new process" in note
+        assert "do NOT re-execute or verify it" not in note
+
 
     def test_resume_pending_fires_without_tool_tail(self):
         """Key improvement over PR #9934: the restart-resume note fires


### PR DESCRIPTION
## Summary

- replace the absolute restart/shutdown replay ban in the recovery note with intent-aware guidance
- permit read-only state verification after recovery
- allow one new restart intent when a new revision/configuration, missing freshness evidence, or a failed health check establishes a current necessity
- retain the guard against blindly replaying the same interrupted lifecycle command

## Tests

- `scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py::TestResumePendingSystemNote -q` (9 passed)
- `scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py -m 'not asyncio' -q` (23 passed)
- `python3 -m py_compile gateway/run.py tests/gateway/test_restart_resume_pending.py`
