### PR TITLE
fix(skills): correct searxng-search setup instructions

### DIFF
--- a/optional-skills/research/searxng-search/SKILL.md
+++ b/optional-skills/research/searxng-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: searxng-search
 description: Free keyless meta-search aggregating 70+ engines.
-version: 1.0.1
+version: 1.1.0
 author: hermes-agent
 license: MIT
 platforms: [linux, macos]
@@ -16,19 +16,22 @@ metadata:
 
 Free meta-search using [SearXNG](https://searxng.org/) — a privacy-respecting, self-hosted search aggregator that queries 70+ search engines simultaneously.
 
-**No API key required** when using a public instance. Can also be self-hosted for full control. Automatically appears as a fallback when the main web search toolset (`FIRECRAWL_API_KEY`) is not configured.
+**No API key required**, but it does require an instance whose **JSON API is enabled**. In practice this means self-hosting: most public instances serve `format=html` only and reject `format=json` (HTTP 403), or sit behind a bot-check/CAPTCHA wall. Automatically appears as a fallback when the main web search toolset (`FIRECRAWL_API_KEY`) is not configured.
 
 ## Configuration
 
 SearXNG requires a `SEARXNG_URL` environment variable pointing to your SearXNG instance:
 
 ```bash
-# Public instances (no setup required)
-SEARXNG_URL=https://searxng.example.com
-
-# Self-hosted SearXNG
-SEARXNG_URL=http://localhost:8888
+# Self-hosted SearXNG (recommended — see "Self-Hosting" below)
+SEARXNG_URL=http://127.0.0.1:8888
 ```
+
+> **The JSON API is opt-in.** SearXNG's shipped `settings.yml` sets
+> `search.formats: [html]`. Until `json` is added to that list, every
+> `format=json` request returns HTTP 403 and Hermes reports the backend as
+> unavailable. Enabling it is a server-side change — it cannot be fixed from
+> the client.
 
 If no instance is configured, this skill is unavailable and the agent falls back to other search options.
 
@@ -126,27 +129,95 @@ for r in data.get("results", []):
 
 ## Self-Hosting SearXNG
 
-To run your own SearXNG instance:
+Self-hosting is the reliable path, because you control whether the JSON API is enabled.
+
+### Option A: Docker
 
 ```bash
-# Using Docker
-docker run -d -p 8888:8080 \
-  -v $(pwd)/searxng:/etc/searxng \
+docker run -d --name searxng -p 8888:8080 \
+  -v "$(pwd)/searxng:/etc/searxng" \
   searxng/searxng:latest
-
-# Then set
-SEARXNG_URL=http://localhost:8888
 ```
 
-Or install via pip:
+Then add `json` to `search.formats` in `./searxng/settings.yml` and restart the
+container (`docker restart searxng`). The default config is HTML-only.
+
+### Option B: From source (no container runtime)
+
+Use this when Docker/Podman/Colima are unavailable. Requires Python 3.10+;
+`uv` is a convenient way to get one without touching the system Python.
+
 ```bash
-pip install searxng
-# Edit /etc/searxng/settings.yml
-searxng-run
+git clone --depth 1 https://github.com/searxng/searxng.git ~/services/searxng
+cd ~/services/searxng
+
+uv venv --python 3.11 .venv
+uv pip install --python .venv/bin/python -r requirements.txt -r requirements-server.txt
 ```
 
-Public SearXNG instances are available at:
-- `https://searxng.example.com` (replace with any public instance)
+Create a settings file that inherits the defaults and overrides only what is
+needed (`~/services/searxng/settings.yml`):
+
+```yaml
+use_default_settings: true
+
+search:
+  formats:
+    - html
+    - json      # REQUIRED — Hermes calls /search?format=json
+
+server:
+  port: 8888
+  bind_address: "127.0.0.1"
+  secret_key: "REPLACE_ME"   # openssl rand -hex 32
+  limiter: false             # must be false, or the JSON API gets bot-challenged
+  public_instance: false
+```
+
+Run it with the bundled `granian` WSGI server:
+
+```bash
+cd ~/services/searxng
+SEARXNG_SETTINGS_PATH=$PWD/settings.yml \
+  .venv/bin/python -m granian --interface wsgi \
+  --host 127.0.0.1 --port 8888 searx.webapp:app
+```
+
+Then set `SEARXNG_URL=http://127.0.0.1:8888`.
+
+> **There is no `pip install searxng`.** SearXNG is not distributed as a
+> runnable PyPI package and provides no `searxng-run` entrypoint. The
+> `searxng` name on PyPI is an unrelated third-party stub (an MCP server at
+> version `0.0.0.dev0`). Install from source or use the container image.
+
+### Keeping it running (macOS launchd)
+
+Run it as a user agent so it survives logout/reboot and restarts on crash.
+`~/Library/LaunchAgents/com.local.searxng.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.local.searxng</string>
+    <key>ProgramArguments</key>
+    <array><string>/Users/YOU/services/searxng/run-searxng.sh</string></array>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+</dict>
+</plist>
+```
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.local.searxng.plist
+launchctl print gui/$(id -u)/com.local.searxng | grep -E "state|pid"
+```
+
+Use `launchctl bootout gui/$(id -u)/com.local.searxng` to stop it.
+
+Public instance lists live at https://searx.space/ — but check
+`format=json` support before relying on one.
 
 ## Workflow: Search then Extract
 
@@ -172,11 +243,15 @@ curl -s "${SEARXNG_URL}/search?q=fastapi+deployment&format=json&limit=3"
 
 | Problem | Likely Cause | What To Do |
 |---------|--------------|------------|
-| `SEARXNG_URL` not set | No instance configured | Use a public SearXNG instance or set up your own |
-| Connection refused | Instance not running or wrong URL | Check the URL is correct and the instance is running |
+| `SEARXNG_URL` not set | No instance configured | Set up your own instance (see Self-Hosting) |
+| HTTP 403 on `format=json` | Instance is HTML-only (`search.formats: [html]`) | Add `json` to `search.formats` and restart |
+| HTML captcha / "Verifying your browser" instead of JSON | Public instance behind a bot wall, or `limiter: true` | Self-host; set `limiter: false` and `public_instance: false` |
+| HTTP 429 | Public instance rate-limiting you | Self-host |
+| Connection refused | Instance not running or wrong URL | Check the URL and that the process is listening |
 | Empty results | Instance blocks the query | Try a different instance or self-host |
 | Slow responses | Public instance under load | Self-host or use a less-loaded public instance |
 | `json` format not supported | Old SearXNG version | Try `format=rss` or upgrade SearXNG |
+| Some engines missing from results | Upstream engine rate-limited/CAPTCHA'd | Normal for metasearch; check `unresponsive_engines` in the JSON |
 
 ## Pitfalls
 
@@ -188,8 +263,16 @@ curl -s "${SEARXNG_URL}/search?q=fastapi+deployment&format=json&limit=3"
 
 ## Instance Discovery
 
-If `SEARXNG_URL` is not set and the user asks about SearXNG, help them either:
-1. Find a public SearXNG instance (search for "public searxng instance")
-2. Set up their own with Docker or pip
+If `SEARXNG_URL` is not set and the user asks about SearXNG, guide them to
+**self-host** (see Self-Hosting above) — that is the only setup that reliably
+exposes the JSON API this skill depends on.
 
-Public instances are listed at: https://searxng.org/
+Before trusting any public instance, verify it actually serves JSON:
+
+```bash
+curl -s -m 10 "https://INSTANCE/search?q=test&format=json" | head -c 200
+# JSON starting with {"query": ... → usable
+# HTML (<!doctype html>) or HTTP 403/429 → not usable
+```
+
+Public instance lists: https://searx.space/

--- a/website/docs/user-guide/skills/optional/research/research-searxng-search.md
+++ b/website/docs/user-guide/skills/optional/research/research-searxng-search.md
@@ -33,19 +33,23 @@ The following is the complete skill definition that Hermes loads when this skill
 
 Free meta-search using [SearXNG](https://searxng.org/) — a privacy-respecting, self-hosted search aggregator that queries 70+ search engines simultaneously.
 
-**No API key required** when using a public instance. Can also be self-hosted for full control. Automatically appears as a fallback when the main web search toolset (`FIRECRAWL_API_KEY`) is not configured.
+**No API key required**, but it does require an instance whose **JSON API is enabled**. In practice this means self-hosting: most public instances serve `format=html` only and reject `format=json` (HTTP 403), or sit behind a bot-check/CAPTCHA wall. Automatically appears as a fallback when the main web search toolset (`FIRECRAWL_API_KEY`) is not configured.
 
 ## Configuration
 
 SearXNG requires a `SEARXNG_URL` environment variable pointing to your SearXNG instance:
 
 ```bash
-# Public instances (no setup required)
-SEARXNG_URL=https://searxng.example.com
-
-# Self-hosted SearXNG
-SEARXNG_URL=http://localhost:8888
+# Self-hosted SearXNG (recommended — see "Self-Hosting" below)
+SEARXNG_URL=http://127.0.0.1:8888
 ```
+
+:::warning
+The JSON API is opt-in. SearXNG's shipped `settings.yml` sets
+`search.formats: [html]`. Until `json` is added to that list, every
+`format=json` request returns HTTP 403 and Hermes reports the backend as
+unavailable. This is a server-side setting — it cannot be fixed from the client.
+:::
 
 If no instance is configured, this skill is unavailable and the agent falls back to other search options.
 
@@ -143,27 +147,70 @@ for r in data.get("results", []):
 
 ## Self-Hosting SearXNG
 
-To run your own SearXNG instance:
+Self-hosting is the reliable path, because you control whether the JSON API is enabled.
+
+### Option A: Docker
 
 ```bash
-# Using Docker
-docker run -d -p 8888:8080 \
-  -v $(pwd)/searxng:/etc/searxng \
+docker run -d --name searxng -p 8888:8080 \
+  -v "$(pwd)/searxng:/etc/searxng" \
   searxng/searxng:latest
-
-# Then set
-SEARXNG_URL=http://localhost:8888
 ```
 
-Or install via pip:
+Then add `json` to `search.formats` in `./searxng/settings.yml` and restart the
+container (`docker restart searxng`). The default config is HTML-only.
+
+### Option B: From source (no container runtime)
+
+Requires Python 3.10+. `uv` is a convenient way to get one without touching the
+system Python.
+
 ```bash
-pip install searxng
-# Edit /etc/searxng/settings.yml
-searxng-run
+git clone --depth 1 https://github.com/searxng/searxng.git ~/services/searxng
+cd ~/services/searxng
+
+uv venv --python 3.11 .venv
+uv pip install --python .venv/bin/python -r requirements.txt -r requirements-server.txt
 ```
 
-Public SearXNG instances are available at:
-- `https://searxng.example.com` (replace with any public instance)
+Create `~/services/searxng/settings.yml`:
+
+```yaml
+use_default_settings: true
+
+search:
+  formats:
+    - html
+    - json      # REQUIRED — Hermes calls /search?format=json
+
+server:
+  port: 8888
+  bind_address: "127.0.0.1"
+  secret_key: "REPLACE_ME"   # openssl rand -hex 32
+  limiter: false             # must be false, or the JSON API gets bot-challenged
+  public_instance: false
+```
+
+Run it with the bundled `granian` WSGI server, then set
+`SEARXNG_URL=http://127.0.0.1:8888`:
+
+```bash
+cd ~/services/searxng
+SEARXNG_SETTINGS_PATH=$PWD/settings.yml \
+  .venv/bin/python -m granian --interface wsgi \
+  --host 127.0.0.1 --port 8888 searx.webapp:app
+```
+
+:::warning
+There is no `pip install searxng`. SearXNG is not distributed as a runnable
+PyPI package and provides no `searxng-run` entrypoint — the `searxng` name on
+PyPI is an unrelated third-party stub. Install from source or use the
+container image.
+:::
+
+Public instance lists live at [searx.space](https://searx.space/) — but verify
+`format=json` support before relying on one, since most instances serve HTML
+only or sit behind a bot-check wall.
 
 ## Workflow: Search then Extract
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/optional/research/research-searxng-search.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/optional/research/research-searxng-search.md
@@ -33,19 +33,22 @@ description: "通过 SearXNG 免费元搜索 — 聚合 70+ 搜索引擎的结�
 
 使用 [SearXNG](https://searxng.org/) 进行免费元搜索——这是一个注重隐私的自托管搜索聚合器，可同时查询 70+ 搜索引擎。
 
-使用公共实例时**无需 API 密钥**。也可自托管以获得完全控制权。当主 web 搜索工具集（`FIRECRAWL_API_KEY`）未配置时，自动作为回退方案出现。
+**无需 API 密钥**，但需要一个**已启用 JSON API** 的实例。实际上这意味着需要自托管：大多数公共实例仅提供 `format=html`，会拒绝 `format=json`（HTTP 403），或设有机器人检测/验证码墙。当主 web 搜索工具集（`FIRECRAWL_API_KEY`）未配置时，自动作为回退方案出现。
 
 ## 配置
 
 SearXNG 需要一个 `SEARXNG_URL` 环境变量，指向你的 SearXNG 实例：
 
 ```bash
-# 公共实例（无需任何设置）
-SEARXNG_URL=https://searxng.example.com
-
-# 自托管 SearXNG
-SEARXNG_URL=http://localhost:8888
+# 自托管 SearXNG（推荐 —— 参见下方"自托管"）
+SEARXNG_URL=http://127.0.0.1:8888
 ```
+
+:::warning
+JSON API 需要手动启用。SearXNG 自带的 `settings.yml` 设置的是
+`search.formats: [html]`。在把 `json` 加入该列表之前，所有 `format=json` 请求都会
+返回 HTTP 403，Hermes 会报告该后端不可用。这是服务端设置——无法从客户端修复。
+:::
 
 如果未配置实例，此 skill 不可用，agent 将回退到其他搜索选项。
 
@@ -141,46 +144,69 @@ for r in data.get("results", []):
     print()
 ```
 
-## 方法三：searxng-data Python 包
-
-如需更结构化的访问，安装 `searxng-data` 包：
-
-```bash
-pip install searxng-data
-```
-
-```python
-from searxng_data import engines
-
-# 列出可用引擎
-print(engines.list_engines())
-```
-
-注意：此包仅提供引擎元数据，不提供搜索 API 本身。
-
 ## 自托管 SearXNG
 
-运行你自己的 SearXNG 实例：
+自托管是可靠的方案，因为你可以自行控制是否启用 JSON API。
+
+### 方案 A：Docker
 
 ```bash
-# 使用 Docker
-docker run -d -p 8888:8080 \
-  -v $(pwd)/searxng:/etc/searxng \
+docker run -d --name searxng -p 8888:8080 \
+  -v "$(pwd)/searxng:/etc/searxng" \
   searxng/searxng:latest
-
-# 然后设置
-SEARXNG_URL=http://localhost:8888
 ```
 
-或通过 pip 安装：
+然后在 `./searxng/settings.yml` 的 `search.formats` 中加入 `json`，并重启容器
+（`docker restart searxng`）。默认配置仅支持 HTML。
+
+### 方案 B：从源码安装（无需容器运行时）
+
+需要 Python 3.10+。`uv` 可以在不改动系统 Python 的情况下提供合适的版本。
+
 ```bash
-pip install searxng
-# 编辑 /etc/searxng/settings.yml
-searxng-run
+git clone --depth 1 https://github.com/searxng/searxng.git ~/services/searxng
+cd ~/services/searxng
+
+uv venv --python 3.11 .venv
+uv pip install --python .venv/bin/python -r requirements.txt -r requirements-server.txt
 ```
 
-公共 SearXNG 实例可在以下地址找到：
-- `https://searxng.example.com`（替换为任意公共实例）
+创建 `~/services/searxng/settings.yml`：
+
+```yaml
+use_default_settings: true
+
+search:
+  formats:
+    - html
+    - json      # 必需 —— Hermes 调用 /search?format=json
+
+server:
+  port: 8888
+  bind_address: "127.0.0.1"
+  secret_key: "REPLACE_ME"   # openssl rand -hex 32
+  limiter: false             # 必须为 false，否则 JSON API 会被机器人检测拦截
+  public_instance: false
+```
+
+使用自带的 `granian` WSGI 服务器运行，然后设置
+`SEARXNG_URL=http://127.0.0.1:8888`：
+
+```bash
+cd ~/services/searxng
+SEARXNG_SETTINGS_PATH=$PWD/settings.yml \
+  .venv/bin/python -m granian --interface wsgi \
+  --host 127.0.0.1 --port 8888 searx.webapp:app
+```
+
+:::warning
+不存在 `pip install searxng` 这种安装方式。SearXNG 并未作为可运行的 PyPI 包发布，
+也没有提供 `searxng-run` 入口点——PyPI 上的 `searxng` 是一个无关的第三方存根包。
+请从源码安装或使用容器镜像。
+:::
+
+公共实例列表见 [searx.space](https://searx.space/)——但在依赖某个实例之前，请先
+验证它是否支持 `format=json`，因为大多数实例仅提供 HTML 或设有机器人检测。
 
 ## 工作流：先搜索后提取
 


### PR DESCRIPTION
## Problem

Following the `searxng-search` skill end-to-end cannot produce a working backend. I hit this while configuring the `searxng` web backend and found three factual errors in the docs.

**1. The documented pip install does not exist**

```bash
pip install searxng   # installs unrelated software
searxng-run           # command does not exist
```

SearXNG is not distributed as a runnable PyPI package and ships no `searxng-run` entrypoint. The `searxng` name on PyPI is an unrelated third-party stub — an MCP server at version `0.0.0.dev0`. The zh-Hans page went further and documented a `searxng-data` package (404 on PyPI) with a `from searxng_data import engines` snippet that cannot run.

**2. The JSON API requirement was undocumented — this is the actual footgun**

`plugins/web/searxng/provider.py` calls `/search?format=json`, but upstream's shipped `settings.yml` sets:

```yaml
search:
  formats:
    - html      # json absent by default
```

Until `json` is added there, every request returns HTTP 403 and `is_available()` reports the backend as unavailable. The symptom looks like a Hermes bug but is a server-side config gap that the client cannot fix. `limiter` and `public_instance` must also stay `false`, or the JSON endpoint gets bot-challenged.

**3. Public instances were overstated**

`SEARXNG_URL=https://searxng.example.com` was presented as a working "no setup required" instance. It is a placeholder domain. I probed 10 real public instances: 6 returned HTTP 429, 1 returned 403, 2 returned HTTP 200 with a browser-verification/Anubis HTML wall instead of JSON, and 1 was unreachable. **Zero** served the JSON API.

## Changes

- Replace the pip section with a **verified from-source install** (git clone + `uv venv` + `requirements.txt`/`requirements-server.txt`, run via the bundled `granian` WSGI server) for hosts with no container runtime; fix the Docker path to mention the required formats edit.
- Document the required `settings.yml` overrides, including `json` in `search.formats`.
- Add a macOS launchd recipe so the instance survives reboot.
- Reframe public instances as verify-before-use with a `curl` JSON check; point at searx.space instead of the placeholder domain.
- Expand troubleshooting with the 403 / CAPTCHA / 429 cases, and note that partial engine coverage is normal (check `unresponsive_engines`).
- Remove the fabricated `searxng-data` section from the zh-Hans page.
- Bump skill version `1.0.1` → `1.1.0`.

## Verification

Followed the corrected instructions on a clean macOS 26.6 host with no Docker runtime:

```console
$ curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:8888/search?q=test&format=json"
200
$ # results: 25 (google cse: 20, duckduckgo: 10)
```

Hermes `web_search` through the `searxng` backend, which returned `{"success": false, "error": "SEARXNG_URL is not set"}` beforehand, now returns real results. launchd `KeepAlive` respawn verified (~2s after SIGKILL, 50 results after restart).

Docs-only change. `tests/skills/test_authoring_standards.py` passes (1154 passed).
