### PR TITLE
feat: composio optional skill — 1000+ SaaS connectors via one API key

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3723,6 +3723,13 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
         "advanced": True,
     },
+    "COMPOSIO_API_KEY": {
+        "description": "Composio API key for the composio connectors skill (1000+ SaaS apps: Gmail, Notion, Slack, Linear, ...)",
+        "prompt": "Composio API key",
+        "url": "https://app.composio.dev/",
+        "password": True,
+        "category": "tool",
+    },
     "TAVILY_API_KEY": {
         "description": "Tavily API key for AI-native web search and extract",
         "prompt": "Tavily API key",

--- a/optional-skills/productivity/composio/SKILL.md
+++ b/optional-skills/productivity/composio/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: composio
+description: "Reach 1000+ SaaS apps (Gmail, Notion, Slack) via Composio."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [composio, connectors, saas, oauth, gmail, notion, slack, linear, github]
+    category: productivity
+---
+
+# Composio Connectors Skill
+
+Execute actions on 1000+ SaaS services — Gmail, Google Calendar/Drive, GitHub,
+Slack, Notion, Linear, Airtable, HubSpot, Jira, and more — through Composio's
+hosted connector platform. Composio manages the OAuth flows and stores the
+connected accounts; Hermes only holds one `COMPOSIO_API_KEY`. This skill does
+NOT archive or index data — it performs live reads and actions.
+
+## When to Use
+
+- The user asks to read/send email, manage calendar events, query Notion,
+  file Linear/Jira issues, post to Slack, or touch any workplace SaaS app
+  for which no dedicated Hermes skill exists.
+- Prefer a dedicated skill when one exists (e.g. `himalaya` for raw IMAP,
+  `xurl` for X) — Composio is the broad fallback, not the specialist.
+
+## Prerequisites
+
+- `COMPOSIO_API_KEY` in `~/.hermes/.env` — create at https://app.composio.dev
+- `composio` Python package: `pip install composio` (auto-prompted by the
+  helper script when missing)
+- Per-service accounts are connected once via OAuth (see Connecting below)
+
+## How to Run
+
+All operations go through the helper script via `terminal`:
+
+```bash
+python3 scripts/composio_cli.py toolkits                    # what's connected
+python3 scripts/composio_cli.py search "send an email"      # find a tool
+python3 scripts/composio_cli.py schema GMAIL_SEND_EMAIL     # its arguments
+python3 scripts/composio_cli.py execute GMAIL_SEND_EMAIL \
+    --args '{"recipient_email": "a@b.com", "subject": "Hi", "body": "..."}'
+```
+
+Every command prints one JSON object. `"successful": false` + `"error"` on
+failure (exit code 1).
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `toolkits` | List connected accounts (what you can use right now) |
+| `tools <toolkit>` | List tools in one toolkit (`gmail`, `github`, `notion`, ...) |
+| `search <query>` | Free-text search for tools across all toolkits |
+| `schema <TOOL_SLUG>` | Input schema for one tool |
+| `execute <TOOL_SLUG> --args '<json>'` | Run the tool |
+| `connect <toolkit>` | Start OAuth for a new service (prints a URL) |
+| `wait <request_id>` | Block until a pending connection completes |
+
+Tool slugs look like `GMAIL_SEND_EMAIL`, `GITHUB_LIST_REPOS_FOR_USER`,
+`NOTION_SEARCH_NOTION_PAGE`. The `--user` flag (default `hermes`, override
+with `COMPOSIO_USER_ID`) scopes connected accounts; use distinct user ids if
+multiple people's accounts must stay isolated.
+
+## Procedure
+
+1. **Check connections first**: run `toolkits`. If the needed service is
+   missing, run `connect <toolkit>`, deliver the printed `redirect_url` to
+   the user, and ask them to open it and grant access. Then `wait <id>` or
+   simply retry.
+2. **Discover the right tool**: `search` with a natural-language phrase, or
+   `tools <toolkit>` to browse. Don't guess slugs.
+3. **Get the schema** before executing anything with non-obvious arguments.
+4. **Execute** with exact JSON arguments. Read `data` from the response.
+5. For multi-step jobs (e.g. "summarize today's emails then post to Slack"),
+   chain execute calls; keep intermediate JSON in files if large.
+
+## Pitfalls
+
+- `connect` requires the USER to open the OAuth URL in their browser — the
+  agent cannot complete OAuth itself. Always hand the URL to the user and
+  wait for confirmation.
+- Search returns at most 20 results; refine the query rather than paging.
+- Composio slugs are versioned server-side; the helper executes latest.
+  If a tool's behavior seems off, re-fetch the `schema` — arguments drift.
+- A 4xx from `execute` usually means a missing/expired connected account
+  for that toolkit — re-run `toolkits` and reconnect, don't retry blindly.
+- Do not fabricate slugs from memory of other deployments; always confirm
+  with `search`/`tools` output from THIS account.
+
+## Verification
+
+- `toolkits` returns `"successful": true` with your API key → wiring works.
+- After `connect` + OAuth grant, the toolkit appears in `toolkits` output.
+- After `execute`, check `"successful": true` and inspect `data`; treat
+  `error` text as the source of truth, not the exit code alone.

--- a/optional-skills/productivity/composio/scripts/composio_cli.py
+++ b/optional-skills/productivity/composio/scripts/composio_cli.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Composio CLI helper for the Hermes composio skill.
+
+Thin wrapper over the Composio Python SDK (https://docs.composio.dev) that
+gives the agent a shell-friendly JSON interface to 1000+ SaaS toolkits
+(Gmail, GitHub, Slack, Notion, Linear, Google Drive/Calendar, Airtable, ...).
+
+Composio hosts the OAuth flows and stores connected accounts, so Hermes
+never handles third-party refresh tokens — only the single COMPOSIO_API_KEY.
+
+Usage:
+    python3 composio_cli.py toolkits                      # connected accounts
+    python3 composio_cli.py tools <toolkit>               # list a toolkit's tools
+    python3 composio_cli.py search <query>                # search tools by text
+    python3 composio_cli.py schema <TOOL_SLUG>            # input schema for a tool
+    python3 composio_cli.py execute <TOOL_SLUG> --args '{"k": "v"}'
+    python3 composio_cli.py connect <toolkit>             # start OAuth, prints URL
+    python3 composio_cli.py wait <connection_request_id>  # poll until connected
+
+All commands print a single JSON object to stdout. Errors come back as
+{"successful": false, "error": "..."} with exit code 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import NoReturn
+
+DEFAULT_USER_ID = os.environ.get("COMPOSIO_USER_ID", "hermes")
+MAX_SEARCH_RESULTS = 20
+
+
+def _fail(msg: str, code: int = 1) -> NoReturn:
+    print(json.dumps({"successful": False, "error": msg}))
+    sys.exit(code)
+
+
+def _get_client():
+    api_key = (os.environ.get("COMPOSIO_API_KEY") or "").strip()
+    if not api_key:
+        _fail(
+            "COMPOSIO_API_KEY is not set. Add it to ~/.hermes/.env "
+            "(create a key at https://app.composio.dev)."
+        )
+    try:
+        from composio import Composio  # type: ignore[attr-defined]
+    except ImportError:
+        _fail(
+            "The 'composio' package is not installed. "
+            f"Install with: {sys.executable} -m pip install composio"
+        )
+    return Composio(api_key=api_key)
+
+
+def _tool_summaries(raw: object) -> list[dict]:
+    """Reduce Composio tool entries to name/description/required params."""
+    out: list[dict] = []
+    for entry in raw if isinstance(raw, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        fn = entry.get("function") or {}
+        params = fn.get("parameters") or {}
+        out.append(
+            {
+                "name": fn.get("name", ""),
+                "description": (fn.get("description") or "")[:300],
+                "required_params": params.get("required", []),
+            }
+        )
+    return out
+
+
+def cmd_toolkits(client, args) -> dict:
+    """List connected accounts (which toolkits are usable right now)."""
+    accounts = client.connected_accounts.list(user_ids=[args.user])
+    items = getattr(accounts, "items", None) or []
+    out = []
+    for acct in items:
+        toolkit = getattr(acct, "toolkit", None)
+        out.append(
+            {
+                "id": getattr(acct, "id", ""),
+                "toolkit": getattr(toolkit, "slug", "") or str(toolkit or ""),
+                "status": str(getattr(acct, "status", "")),
+            }
+        )
+    return {"successful": True, "connected_accounts": out, "count": len(out)}
+
+
+def cmd_tools(client, args) -> dict:
+    raw = client.tools.get(args.user, toolkits=[args.toolkit.strip()])
+    tools = _tool_summaries(raw)
+    return {
+        "successful": True,
+        "toolkit": args.toolkit,
+        "tools": tools,
+        "count": len(tools),
+    }
+
+
+def cmd_search(client, args) -> dict:
+    raw = client.tools.get(args.user, search=args.query.strip())
+    items = raw[:MAX_SEARCH_RESULTS] if isinstance(raw, list) else []
+    tools = _tool_summaries(items)
+    return {"successful": True, "query": args.query, "tools": tools, "count": len(tools)}
+
+
+def cmd_schema(client, args) -> dict:
+    slug = args.slug.strip()
+    raw = client.tools.get(args.user, search=slug)
+    for entry in raw if isinstance(raw, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        fn = entry.get("function") or {}
+        if fn.get("name") == slug:
+            return {
+                "successful": True,
+                "name": fn.get("name"),
+                "description": fn.get("description", ""),
+                "parameters": fn.get("parameters", {}),
+            }
+    return {"successful": False, "error": f"tool {slug!r} not found"}
+
+
+def cmd_execute(client, args) -> dict:
+    try:
+        arguments = json.loads(args.args) if args.args else {}
+    except json.JSONDecodeError as exc:
+        return {"successful": False, "error": f"--args is not valid JSON: {exc}"}
+    if not isinstance(arguments, dict):
+        return {"successful": False, "error": "--args must be a JSON object"}
+
+    # Version pinning is per-toolkit; callers here don't know toolkit versions
+    # in advance, so ask the SDK to run the latest.
+    result = client.tools.execute(
+        args.slug.strip(),
+        user_id=args.user,
+        arguments=arguments,
+        dangerously_skip_version_check=True,
+    )
+    if isinstance(result, dict):
+        return {
+            "successful": bool(result.get("successful", False)),
+            "error": result.get("error"),
+            "data": result.get("data", {}),
+        }
+    return {
+        "successful": bool(getattr(result, "successful", False)),
+        "error": getattr(result, "error", None),
+        "data": getattr(result, "data", {}),
+    }
+
+
+def cmd_connect(client, args) -> dict:
+    """Start an OAuth connection for a toolkit; user opens the printed URL."""
+    toolkit = args.toolkit.strip().lower()
+    # Preferred: one-call authorize (Composio-managed auth config).
+    try:
+        req = client.toolkits.authorize(user_id=args.user, toolkit=toolkit)
+        return {
+            "successful": True,
+            "toolkit": toolkit,
+            "redirect_url": getattr(req, "redirect_url", None),
+            "connection_request_id": getattr(req, "id", None),
+            "note": "Open redirect_url in a browser to grant access, then run "
+            "'wait <connection_request_id>' or retry your command.",
+        }
+    except Exception:
+        pass
+    # Fallback: explicit auth config + connected account initiation.
+    auth_config = client.auth_configs.create(
+        toolkit=toolkit, options={"type": "use_composio_managed_auth"}
+    )
+    req = client.connected_accounts.initiate(
+        user_id=args.user, auth_config_id=getattr(auth_config, "id", auth_config)
+    )
+    return {
+        "successful": True,
+        "toolkit": toolkit,
+        "redirect_url": getattr(req, "redirect_url", None),
+        "connection_request_id": getattr(req, "id", None),
+        "note": "Open redirect_url in a browser to grant access.",
+    }
+
+
+def cmd_wait(client, args) -> dict:
+    acct = client.connected_accounts.wait_for_connection(
+        args.request_id, timeout=float(args.timeout)
+    )
+    return {
+        "successful": True,
+        "connected_account_id": getattr(acct, "id", ""),
+        "status": str(getattr(acct, "status", "")),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Composio CLI helper for the Hermes composio skill."
+    )
+    p.add_argument(
+        "--user",
+        default=DEFAULT_USER_ID,
+        help="Composio user_id scoping connected accounts (default: %(default)s)",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("toolkits", help="List connected accounts")
+
+    sp = sub.add_parser("tools", help="List tools in a toolkit")
+    sp.add_argument("toolkit")
+
+    sp = sub.add_parser("search", help="Search tools across all toolkits")
+    sp.add_argument("query")
+
+    sp = sub.add_parser("schema", help="Show a tool's input schema")
+    sp.add_argument("slug")
+
+    sp = sub.add_parser("execute", help="Execute a tool by slug")
+    sp.add_argument("slug")
+    sp.add_argument("--args", default="", help="JSON object of tool arguments")
+
+    sp = sub.add_parser("connect", help="Start OAuth for a toolkit")
+    sp.add_argument("toolkit")
+
+    sp = sub.add_parser("wait", help="Wait for a pending connection")
+    sp.add_argument("request_id")
+    sp.add_argument("--timeout", default="120", help="Seconds to wait (default 120)")
+
+    return p
+
+
+HANDLERS = {
+    "toolkits": cmd_toolkits,
+    "tools": cmd_tools,
+    "search": cmd_search,
+    "schema": cmd_schema,
+    "execute": cmd_execute,
+    "connect": cmd_connect,
+    "wait": cmd_wait,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    client = _get_client()
+    try:
+        result = HANDLERS[args.cmd](client, args)
+    except Exception as exc:  # surface the wire error, never swallow it
+        result = {"successful": False, "error": f"{type(exc).__name__}: {exc}"}
+    print(json.dumps(result, indent=2, default=str))
+    return 0 if result.get("successful") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_composio_skill.py
+++ b/tests/skills/test_composio_skill.py
@@ -1,0 +1,155 @@
+"""Tests for the composio optional skill (optional-skills/productivity/composio)."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "productivity"
+    / "composio"
+)
+SCRIPT = SKILL_DIR / "scripts" / "composio_cli.py"
+
+
+@pytest.fixture
+def cli(monkeypatch):
+    """Import the helper script as a module with a stubbed composio SDK."""
+    fake_sdk = types.ModuleType("composio")
+    fake_sdk.Composio = MagicMock(name="Composio")
+    monkeypatch.setitem(sys.modules, "composio", fake_sdk)
+    monkeypatch.setenv("COMPOSIO_API_KEY", "test-key")
+
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("composio_cli_under_test", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_skill_md_frontmatter():
+    text = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^description: \"?(.*?)\"?$", text, re.MULTILINE)
+    assert m, "SKILL.md must have a description"
+    assert len(m.group(1)) <= 60, f"description too long: {len(m.group(1))}"
+    assert m.group(1).endswith(".")
+    for section in ("## When to Use", "## Prerequisites", "## How to Run",
+                    "## Quick Reference", "## Procedure", "## Pitfalls",
+                    "## Verification"):
+        assert section in text, f"missing section: {section}"
+
+
+def test_missing_api_key_fails_closed(cli, monkeypatch, capsys):
+    monkeypatch.delenv("COMPOSIO_API_KEY", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        cli._get_client()
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["successful"] is False
+    assert "COMPOSIO_API_KEY" in out["error"]
+
+
+def test_tool_summaries_shape(cli):
+    raw = [
+        {
+            "function": {
+                "name": "GMAIL_SEND_EMAIL",
+                "description": "Send an email via Gmail",
+                "parameters": {"required": ["recipient_email"]},
+            }
+        },
+        "not-a-dict",
+        {"no_function_key": True},
+    ]
+    tools = cli._tool_summaries(raw)
+    assert len(tools) == 2  # junk string skipped, dict-without-function kept as empty
+    assert tools[0] == {
+        "name": "GMAIL_SEND_EMAIL",
+        "description": "Send an email via Gmail",
+        "required_params": ["recipient_email"],
+    }
+    assert cli._tool_summaries("garbage") == []
+
+
+def test_execute_dict_result(cli):
+    client = MagicMock()
+    client.tools.execute.return_value = {
+        "successful": True,
+        "error": None,
+        "data": {"id": "msg_1"},
+    }
+    args = types.SimpleNamespace(slug="GMAIL_SEND_EMAIL", args='{"x": 1}', user="hermes")
+    result = cli.cmd_execute(client, args)
+    assert result == {"successful": True, "error": None, "data": {"id": "msg_1"}}
+    client.tools.execute.assert_called_once()
+    kwargs = client.tools.execute.call_args.kwargs
+    assert kwargs["user_id"] == "hermes"
+    assert kwargs["arguments"] == {"x": 1}
+
+
+def test_execute_rejects_bad_json(cli):
+    client = MagicMock()
+    args = types.SimpleNamespace(slug="X", args="{not json", user="hermes")
+    result = cli.cmd_execute(client, args)
+    assert result["successful"] is False
+    assert "JSON" in result["error"]
+    client.tools.execute.assert_not_called()
+
+    args2 = types.SimpleNamespace(slug="X", args='["list"]', user="hermes")
+    result2 = cli.cmd_execute(client, args2)
+    assert result2["successful"] is False
+    client.tools.execute.assert_not_called()
+
+
+def test_schema_finds_exact_slug(cli):
+    client = MagicMock()
+    client.tools.get.return_value = [
+        {"function": {"name": "OTHER_TOOL", "parameters": {}}},
+        {
+            "function": {
+                "name": "NOTION_SEARCH",
+                "description": "Search Notion",
+                "parameters": {"properties": {"q": {"type": "string"}}},
+            }
+        },
+    ]
+    args = types.SimpleNamespace(slug="NOTION_SEARCH", user="hermes")
+    result = cli.cmd_schema(client, args)
+    assert result["successful"] is True
+    assert result["name"] == "NOTION_SEARCH"
+    assert "properties" in result["parameters"]
+
+    args_missing = types.SimpleNamespace(slug="NOPE", user="hermes")
+    assert cli.cmd_schema(client, args_missing)["successful"] is False
+
+
+def test_main_wire_error_surfaced(cli, monkeypatch, capsys):
+    """Exceptions from the SDK surface as the wire error, never swallowed."""
+    client = MagicMock()
+    client.tools.get.side_effect = RuntimeError("boom from composio")
+    monkeypatch.setattr(cli, "_get_client", lambda: client)
+    rc = cli.main(["search", "anything"])
+    assert rc == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["successful"] is False
+    assert "boom from composio" in out["error"]
+
+
+def test_env_var_registered_in_config_defaults():
+    """COMPOSIO_API_KEY must be a documented .env secret."""
+    from hermes_cli.config_defaults import OPTIONAL_ENV_VARS
+
+    entry = OPTIONAL_ENV_VARS.get("COMPOSIO_API_KEY")
+    assert entry is not None
+    assert entry["password"] is True
+    assert entry["category"] == "tool"
+    assert entry.get("url")


### PR DESCRIPTION
## Summary
New `composio` optional skill: the agent can now act on 1000+ SaaS apps — Gmail, Google Calendar/Drive, GitHub, Slack, Notion, Linear, Airtable, HubSpot, Jira, and more — through Composio's hosted connector platform, with OAuth flows and connected accounts managed by Composio. One `COMPOSIO_API_KEY` in `.env` unlocks the whole surface. Second step of the Centaur-2.0-parity track ("connect to everything you have access to"), on the footprint ladder's preferred rung: CLI helper + skill, zero model-tool schema cost.

## Changes
- `optional-skills/productivity/composio/scripts/composio_cli.py`: typer-free stdlib CLI over the Composio Python SDK — `toolkits` / `tools` / `search` / `schema` / `execute` / `connect` / `wait`, JSON-only output, fail-closed on missing key, wire errors surfaced verbatim
- `optional-skills/productivity/composio/SKILL.md`: modern section order, ≤60-char description, `terminal`-driven workflow, OAuth-handoff pitfall documented (agent hands the URL to the user, never completes OAuth itself)
- `hermes_cli/config_defaults.py`: `COMPOSIO_API_KEY` registered in `OPTIONAL_ENV_VARS` (password, category `tool`)
- `tests/skills/test_composio_skill.py`: 8 tests — frontmatter contract, fail-closed key check, arg validation, schema lookup, error surfacing, env-var registration

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/skills/test_composio_skill.py` | 8 passed, 0 failed |
| Live no-key run (`composio_cli.py toolkits`) | fail-closed JSON error + exit 1 |
| SKILL.md description length | 56 chars |

Install: `hermes skills install official/productivity/composio`

## Infographic

![Hermes × Composio connectors](https://v3b.fal.media/files/b/0aa5d0ef/C_RH7B28zcxFEbE1Q1qlI_xu0h9OZg.png)
