### PR TITLE
fix(windows): prevent permanent hang in bash probe under embedded stdin

### DIFF
--- a/tests/tools/test_local_bash_probe_timeout.py
+++ b/tests/tools/test_local_bash_probe_timeout.py
@@ -8,10 +8,10 @@ direct child.  With ``HERMES_GIT_BASH_PATH`` pointing at Git-for-Windows
 orphaned the real bash, which held the pipe write ends open — and the
 follow-up ``communicate()`` blocked indefinitely.
 
-These tests exercise the replacement plumbing with mocked subprocess
-primitives: the probe must escalate to a tree-kill (``taskkill /T /F``
-on Windows), bound the post-kill pipe drain, cache the failure, and
-return ``False`` — never hang.
+Per AGENTS.md ("Don't fake the host OS"), the per-OS kill arms are tested
+through ``_reap_timed_out_probe(proc, is_windows=...)`` — a parameter, not
+a patched host constant — and the end-to-end ``_bash_starts`` assertions
+are either host-agnostic or gated behind the native platform markers.
 """
 import subprocess
 from unittest.mock import MagicMock
@@ -36,103 +36,164 @@ def _clean_probe_caches():
     local_mod._bash_probe_details_cache.update(saved_details)
 
 
-def _timeout_proc(second_communicate=("", "")):
-    """A fake Popen whose first communicate() raises TimeoutExpired."""
+def _hung_proc(drain=("", "")):
+    """A fake Popen for a probe that already hit its 15s timeout."""
     proc = MagicMock()
     proc.pid = 4242
-    effects = [subprocess.TimeoutExpired(cmd="bash", timeout=15)]
-    effects.append(
-        second_communicate
-        if not isinstance(second_communicate, Exception)
-        else second_communicate
-    )
-    proc.communicate.side_effect = effects
+    proc.communicate.side_effect = [drain]
     return proc
 
 
-def test_timeout_on_windows_tree_kills_and_returns_false(monkeypatch):
-    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
-    proc = _timeout_proc()
-    run_calls = []
-
-    monkeypatch.setattr(
-        local_mod.subprocess, "Popen", MagicMock(return_value=proc)
-    )
-    monkeypatch.setattr(
-        local_mod.subprocess,
-        "run",
-        lambda args, **kw: run_calls.append(list(args)) or MagicMock(returncode=0),
-    )
-
-    ok = local_mod._bash_starts(FAKE_BASH)
-
-    assert ok is False
-    assert any(
-        call[:3] == ["taskkill", "/T", "/F"] and str(proc.pid) in call
-        for call in run_calls
-    ), f"expected a taskkill /T /F on pid {proc.pid}, got {run_calls}"
-    # The failure is cached so later candidates aren't re-probed into the
-    # same wedge, and the details cache explains the verdict.
-    assert local_mod._bash_starts_cache[FAKE_BASH] is False
-    assert "timed out" in local_mod._bash_probe_details_cache[FAKE_BASH]
+# ── the reaper, both arms as input→output ─────────────────────────────────
 
 
-def test_timeout_on_posix_kills_process_directly(monkeypatch):
-    monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
-    proc = _timeout_proc()
-    run_calls = []
+class TestReapTimedOutProbe:
 
-    monkeypatch.setattr(
-        local_mod.subprocess, "Popen", MagicMock(return_value=proc)
-    )
-    monkeypatch.setattr(
-        local_mod.subprocess,
-        "run",
-        lambda args, **kw: run_calls.append(list(args)) or MagicMock(returncode=0),
-    )
+    def test_windows_arm_tree_kills_by_pid(self, monkeypatch):
+        run_calls = []
+        monkeypatch.setattr(
+            local_mod.subprocess,
+            "run",
+            lambda args, **kw: run_calls.append(list(args)) or MagicMock(returncode=0),
+        )
+        proc = _hung_proc()
 
-    ok = local_mod._bash_starts("/usr/bin/bash")
+        local_mod._reap_timed_out_probe(proc, is_windows=True)
 
-    assert ok is False
-    proc.kill.assert_called_once()
-    assert not run_calls, "taskkill must not be used off Windows"
+        assert any(
+            call[:3] == ["taskkill", "/T", "/F"] and str(proc.pid) in call
+            for call in run_calls
+        ), f"expected taskkill /T /F on pid {proc.pid}, got {run_calls}"
+        proc.kill.assert_not_called()
+
+    def test_posix_arm_kills_process_directly(self, monkeypatch):
+        run_calls = []
+        monkeypatch.setattr(
+            local_mod.subprocess,
+            "run",
+            lambda args, **kw: run_calls.append(list(args)) or MagicMock(returncode=0),
+        )
+        proc = _hung_proc()
+
+        local_mod._reap_timed_out_probe(proc, is_windows=False)
+
+        proc.kill.assert_called_once()
+        assert not run_calls, "taskkill must not be used off Windows"
+
+    def test_taskkill_failure_still_reaches_the_bounded_drain(self, monkeypatch):
+        def exploding_run(args, **kw):
+            raise subprocess.TimeoutExpired(cmd="taskkill", timeout=10)
+
+        monkeypatch.setattr(local_mod.subprocess, "run", exploding_run)
+        proc = _hung_proc()
+
+        # Must not raise: cleanup failures stay inside the reaper so the
+        # caller's cache write always happens.
+        local_mod._reap_timed_out_probe(proc, is_windows=True)
+
+        proc.communicate.assert_called_once()
+
+    def test_orphaned_fork_child_cannot_wedge_the_drain(self, monkeypatch):
+        monkeypatch.setattr(
+            local_mod.subprocess, "run", lambda args, **kw: MagicMock(returncode=0)
+        )
+        proc = _hung_proc(drain=subprocess.TimeoutExpired(cmd="bash", timeout=5))
+        proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="bash", timeout=5)
+        ]
+
+        local_mod._reap_timed_out_probe(proc, is_windows=True)  # must return
 
 
-def test_orphaned_fork_child_cannot_wedge_the_drain(monkeypatch):
-    """Even if the post-kill communicate() times out again (an orphaned MSYS
-    fork child still holds the pipes and is unreachable via taskkill /T on
-    the shim's dead tree), the probe abandons the pipes and returns."""
-    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
-    proc = _timeout_proc(
-        second_communicate=subprocess.TimeoutExpired(cmd="bash", timeout=5)
-    )
-
-    monkeypatch.setattr(
-        local_mod.subprocess, "Popen", MagicMock(return_value=proc)
-    )
-    monkeypatch.setattr(
-        local_mod.subprocess, "run", lambda args, **kw: MagicMock(returncode=0)
-    )
-
-    ok = local_mod._bash_starts(FAKE_BASH)
-
-    assert ok is False
-    assert local_mod._bash_starts_cache[FAKE_BASH] is False
+# ── _bash_starts behavior, host-agnostic ──────────────────────────────────
 
 
-def test_healthy_probe_uses_devnull_stdin_and_caches_true(monkeypatch):
-    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
-    proc = MagicMock()
-    proc.pid = 4242
-    proc.returncode = 0
-    proc.communicate.return_value = ("", "")
-    popen = MagicMock(return_value=proc)
+class TestBashStartsTimeoutPath:
 
-    monkeypatch.setattr(local_mod.subprocess, "Popen", popen)
+    def _timeout_popen(self, monkeypatch):
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="bash", timeout=15),
+            ("", ""),
+        ]
+        monkeypatch.setattr(
+            local_mod.subprocess, "Popen", MagicMock(return_value=proc)
+        )
+        monkeypatch.setattr(
+            local_mod.subprocess, "run", lambda args, **kw: MagicMock(returncode=0)
+        )
+        return proc
 
-    ok = local_mod._bash_starts(FAKE_BASH)
+    def test_timeout_returns_false_and_caches_verdict(self, monkeypatch):
+        self._timeout_popen(monkeypatch)
 
-    assert ok is True
-    assert local_mod._bash_starts_cache[FAKE_BASH] is True
-    _args, kwargs = popen.call_args
-    assert kwargs.get("stdin") == subprocess.DEVNULL
+        ok = local_mod._bash_starts(FAKE_BASH)
+
+        assert ok is False
+        assert local_mod._bash_starts_cache[FAKE_BASH] is False
+        assert "timed out" in local_mod._bash_probe_details_cache[FAKE_BASH]
+
+    def test_healthy_probe_uses_devnull_stdin_and_caches_true(self, monkeypatch):
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.returncode = 0
+        proc.communicate.return_value = ("", "")
+        popen = MagicMock(return_value=proc)
+        monkeypatch.setattr(local_mod.subprocess, "Popen", popen)
+
+        ok = local_mod._bash_starts(FAKE_BASH)
+
+        assert ok is True
+        assert local_mod._bash_starts_cache[FAKE_BASH] is True
+        _args, kwargs = popen.call_args
+        assert kwargs.get("stdin") == subprocess.DEVNULL
+
+
+# ── native-arm smoke, on the real host only ───────────────────────────────
+
+
+class TestBashStartsNativeArms:
+
+    @pytest.mark.windows_only
+    def test_native_windows_timeout_invokes_taskkill(self, monkeypatch):
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="bash", timeout=15),
+            ("", ""),
+        ]
+        run_calls = []
+        monkeypatch.setattr(
+            local_mod.subprocess, "Popen", MagicMock(return_value=proc)
+        )
+        monkeypatch.setattr(
+            local_mod.subprocess,
+            "run",
+            lambda args, **kw: run_calls.append(list(args)) or MagicMock(returncode=0),
+        )
+
+        assert local_mod._bash_starts(FAKE_BASH) is False
+        assert any(call[:3] == ["taskkill", "/T", "/F"] for call in run_calls)
+
+    @pytest.mark.linux_only
+    def test_native_linux_timeout_kills_directly(self, monkeypatch):
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="bash", timeout=15),
+            ("", ""),
+        ]
+        run_calls = []
+        monkeypatch.setattr(
+            local_mod.subprocess, "Popen", MagicMock(return_value=proc)
+        )
+        monkeypatch.setattr(
+            local_mod.subprocess,
+            "run",
+            lambda args, **kw: run_calls.append(list(args)) or MagicMock(returncode=0),
+        )
+
+        assert local_mod._bash_starts("/usr/bin/bash") is False
+        proc.kill.assert_called_once()
+        assert not run_calls

--- a/tests/tools/test_local_bash_probe_timeout.py
+++ b/tests/tools/test_local_bash_probe_timeout.py
@@ -1,0 +1,138 @@
+"""Regression tests for the ``_bash_starts`` timeout path (PR #83413).
+
+On Windows, the external-program probe could wedge a process forever:
+the probe inherited the parent's stdin (a JSON-RPC pipe under ACP/gateway
+embedding), and on ``TimeoutExpired`` CPython's ``run()`` killed only the
+direct child.  With ``HERMES_GIT_BASH_PATH`` pointing at Git-for-Windows
+``bin\\bash.exe`` (a shim that spawns ``usr\\bin\\bash.exe``) the kill
+orphaned the real bash, which held the pipe write ends open — and the
+follow-up ``communicate()`` blocked indefinitely.
+
+These tests exercise the replacement plumbing with mocked subprocess
+primitives: the probe must escalate to a tree-kill (``taskkill /T /F``
+on Windows), bound the post-kill pipe drain, cache the failure, and
+return ``False`` — never hang.
+"""
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.environments import local as local_mod
+
+FAKE_BASH = r"C:\fake\git\bin\bash.exe"
+
+
+@pytest.fixture(autouse=True)
+def _clean_probe_caches():
+    saved_starts = dict(local_mod._bash_starts_cache)
+    saved_details = dict(local_mod._bash_probe_details_cache)
+    local_mod._bash_starts_cache.clear()
+    local_mod._bash_probe_details_cache.clear()
+    yield
+    local_mod._bash_starts_cache.clear()
+    local_mod._bash_starts_cache.update(saved_starts)
+    local_mod._bash_probe_details_cache.clear()
+    local_mod._bash_probe_details_cache.update(saved_details)
+
+
+def _timeout_proc(second_communicate=("", "")):
+    """A fake Popen whose first communicate() raises TimeoutExpired."""
+    proc = MagicMock()
+    proc.pid = 4242
+    effects = [subprocess.TimeoutExpired(cmd="bash", timeout=15)]
+    effects.append(
+        second_communicate
+        if not isinstance(second_communicate, Exception)
+        else second_communicate
+    )
+    proc.communicate.side_effect = effects
+    return proc
+
+
+def test_timeout_on_windows_tree_kills_and_returns_false(monkeypatch):
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    proc = _timeout_proc()
+    run_calls = []
+
+    monkeypatch.setattr(
+        local_mod.subprocess, "Popen", MagicMock(return_value=proc)
+    )
+    monkeypatch.setattr(
+        local_mod.subprocess,
+        "run",
+        lambda args, **kw: run_calls.append(list(args)) or MagicMock(returncode=0),
+    )
+
+    ok = local_mod._bash_starts(FAKE_BASH)
+
+    assert ok is False
+    assert any(
+        call[:3] == ["taskkill", "/T", "/F"] and str(proc.pid) in call
+        for call in run_calls
+    ), f"expected a taskkill /T /F on pid {proc.pid}, got {run_calls}"
+    # The failure is cached so later candidates aren't re-probed into the
+    # same wedge, and the details cache explains the verdict.
+    assert local_mod._bash_starts_cache[FAKE_BASH] is False
+    assert "timed out" in local_mod._bash_probe_details_cache[FAKE_BASH]
+
+
+def test_timeout_on_posix_kills_process_directly(monkeypatch):
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+    proc = _timeout_proc()
+    run_calls = []
+
+    monkeypatch.setattr(
+        local_mod.subprocess, "Popen", MagicMock(return_value=proc)
+    )
+    monkeypatch.setattr(
+        local_mod.subprocess,
+        "run",
+        lambda args, **kw: run_calls.append(list(args)) or MagicMock(returncode=0),
+    )
+
+    ok = local_mod._bash_starts("/usr/bin/bash")
+
+    assert ok is False
+    proc.kill.assert_called_once()
+    assert not run_calls, "taskkill must not be used off Windows"
+
+
+def test_orphaned_fork_child_cannot_wedge_the_drain(monkeypatch):
+    """Even if the post-kill communicate() times out again (an orphaned MSYS
+    fork child still holds the pipes and is unreachable via taskkill /T on
+    the shim's dead tree), the probe abandons the pipes and returns."""
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    proc = _timeout_proc(
+        second_communicate=subprocess.TimeoutExpired(cmd="bash", timeout=5)
+    )
+
+    monkeypatch.setattr(
+        local_mod.subprocess, "Popen", MagicMock(return_value=proc)
+    )
+    monkeypatch.setattr(
+        local_mod.subprocess, "run", lambda args, **kw: MagicMock(returncode=0)
+    )
+
+    ok = local_mod._bash_starts(FAKE_BASH)
+
+    assert ok is False
+    assert local_mod._bash_starts_cache[FAKE_BASH] is False
+
+
+def test_healthy_probe_uses_devnull_stdin_and_caches_true(monkeypatch):
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    proc = MagicMock()
+    proc.pid = 4242
+    proc.returncode = 0
+    proc.communicate.return_value = ("", "")
+    popen = MagicMock(return_value=proc)
+
+    monkeypatch.setattr(local_mod.subprocess, "Popen", popen)
+
+    ok = local_mod._bash_starts(FAKE_BASH)
+
+    assert ok is True
+    assert local_mod._bash_starts_cache[FAKE_BASH] is True
+    _args, kwargs = popen.call_args
+    assert kwargs.get("stdin") == subprocess.DEVNULL

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -894,6 +894,45 @@ def _git_bash_aslr_help(bash: str, details: str = "") -> str:
     )
 
 
+def _reap_timed_out_probe(proc, *, is_windows: bool) -> None:
+    """Tear down a probe process that outlived its timeout, without wedging.
+
+    Git-for-Windows ``bin\\bash.exe`` is a shim that spawns
+    ``usr\\bin\\bash.exe``.  ``proc.kill()`` would kill only the shim; the
+    orphaned real bash keeps the pipe write ends open, and the follow-up
+    ``communicate()`` (required on Windows to reap the reader threads) then
+    blocks forever — wedging environment creation for the life of the
+    process.  Kill the whole tree so the pipes hit EOF and the probe fails
+    cleanly instead.
+
+    ``is_windows`` is data, not a host probe, so both arms are unit-testable
+    as input→output (see AGENTS.md "Don't fake the host OS").
+    """
+    if is_windows:
+        try:
+            subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                capture_output=True,
+                timeout=10,
+                creationflags=windows_hide_flags(),
+            )
+        except Exception:
+            # taskkill missing or itself hung: fall through to the bounded
+            # drain — cleanup must never escape into the caller's generic
+            # handler and skip the cache write.
+            pass
+    else:
+        proc.kill()
+    try:
+        proc.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        # An orphaned MSYS fork child (parent bash died mid-fork) is not
+        # reachable via taskkill /T on the shim's tree and keeps the pipe
+        # write ends open.  Abandon the pipes — the reader threads are
+        # daemons — rather than wedge forever.
+        pass
+
+
 def _bash_starts(bash: str) -> bool:
     """True if *bash* can launch external MSYS programs.
 
@@ -922,30 +961,7 @@ def _bash_starts(bash: str) -> bool:
         try:
             stdout, stderr = proc.communicate(timeout=15)
         except subprocess.TimeoutExpired:
-            # Git-for-Windows ``bin\bash.exe`` is a shim that spawns
-            # ``usr\bin\bash.exe``.  ``proc.kill()`` would kill only the shim;
-            # the orphaned real bash keeps the pipe write ends open, and the
-            # follow-up ``communicate()`` (required on Windows to reap the
-            # reader threads) then blocks forever — wedging environment
-            # creation for the life of the process.  Kill the whole tree so
-            # the pipes hit EOF and the probe fails cleanly instead.
-            if _IS_WINDOWS:
-                subprocess.run(
-                    ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
-                    capture_output=True,
-                    timeout=10,
-                    creationflags=windows_hide_flags(),
-                )
-            else:
-                proc.kill()
-            try:
-                proc.communicate(timeout=5)
-            except subprocess.TimeoutExpired:
-                # An orphaned MSYS fork child (parent bash died mid-fork) is
-                # not reachable via taskkill /T on the shim's tree and keeps
-                # the pipe write ends open.  Abandon the pipes — the reader
-                # threads are daemons — rather than wedge forever.
-                pass
+            _reap_timed_out_probe(proc, is_windows=_IS_WINDOWS)
             _bash_probe_details_cache[bash] = "external-program probe timed out after 15s"
             logger.debug("bash probe timed out for %s", bash)
             _bash_starts_cache[bash] = False

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -908,16 +908,51 @@ def _bash_starts(bash: str) -> bool:
         return cached
 
     try:
-        result = subprocess.run(
+        # stdin=DEVNULL mirrors _run_bash: the probe must not inherit the
+        # process's own stdin (under ACP/gateway embedding that's a JSON-RPC
+        # pipe, not a console).
+        proc = subprocess.Popen(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
-            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True, encoding="utf-8", errors="replace",
-            timeout=15,
             creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
         )
-        ok = result.returncode == 0
+        try:
+            stdout, stderr = proc.communicate(timeout=15)
+        except subprocess.TimeoutExpired:
+            # Git-for-Windows ``bin\bash.exe`` is a shim that spawns
+            # ``usr\bin\bash.exe``.  ``proc.kill()`` would kill only the shim;
+            # the orphaned real bash keeps the pipe write ends open, and the
+            # follow-up ``communicate()`` (required on Windows to reap the
+            # reader threads) then blocks forever — wedging environment
+            # creation for the life of the process.  Kill the whole tree so
+            # the pipes hit EOF and the probe fails cleanly instead.
+            if _IS_WINDOWS:
+                subprocess.run(
+                    ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                    capture_output=True,
+                    timeout=10,
+                    creationflags=windows_hide_flags(),
+                )
+            else:
+                proc.kill()
+            try:
+                proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                # An orphaned MSYS fork child (parent bash died mid-fork) is
+                # not reachable via taskkill /T on the shim's tree and keeps
+                # the pipe write ends open.  Abandon the pipes — the reader
+                # threads are daemons — rather than wedge forever.
+                pass
+            _bash_probe_details_cache[bash] = "external-program probe timed out after 15s"
+            logger.debug("bash probe timed out for %s", bash)
+            _bash_starts_cache[bash] = False
+            return False
+        ok = proc.returncode == 0
         if not ok:
-            combined = f"{result.stdout or ''}{result.stderr or ''}"
+            combined = f"{stdout or ''}{stderr or ''}"
             _bash_probe_details_cache[bash] = combined.strip()[:2000]
             logger.debug("bash probe failed for %s: %s", bash, combined.strip()[:200])
     except Exception as exc:


### PR DESCRIPTION
# fix(windows): prevent permanent hang in bash probe under embedded stdin

## Symptom

On Windows, when Hermes runs embedded (ACP under Buzz Desktop, or any host where the
process's stdin is a JSON-RPC pipe rather than a console), terminal environment
creation can hang **forever**:

```
tools.terminal_tool: Creating new local environment for task default...
```

…and then nothing, for the life of the process. Every subsequent terminal call stacks
another orphaned `bash.exe` (0 CPU, dead parent). The agent composes responses but can
never execute a command. Related: #16425 (closed), which describes the same
environment class.

## Root cause — two defects compounding in `_bash_starts()`

1. **Inherited stdin.** The probe ran `subprocess.run(..., capture_output=True)` with
   no `stdin` argument. `_run_bash()` already guards against exactly this with
   `stdin=DEVNULL`; the probe predates that fix.

2. **Kill-then-block on timeout.** `HERMES_GIT_BASH_PATH` commonly points at
   Git-for-Windows `bin\bash.exe` — a shim that spawns `usr\bin\bash.exe`. On
   `TimeoutExpired`, CPython's `run()` kills only the direct child (the shim), orphaning
   the real bash, which keeps the stdout/stderr pipe write handles open. The Windows
   branch of `run()` then calls `communicate()` again **with no timeout** to reap its
   reader threads — blocking indefinitely on pipes that never reach EOF.

Reproduced on Windows 11 / Git for Windows / hermes-agent 0.20.0 (2026.8.3): probe
process observed alive 240+ seconds past its 15s timeout, parent dead, while the
gateway sat wedged in environment creation.

## Fix

- `stdin=subprocess.DEVNULL` on the probe (parity with `_run_bash`)
- On timeout, kill the whole tree (`taskkill /T /F` on Windows; `proc.kill()` elsewhere)
- Bound the post-kill pipe drain at 5s — an orphaned MSYS fork child (parent bash died
  mid-fork) is unreachable via `taskkill /T` because its parent link is dead; the
  reader threads are daemons, so abandoning the pipes is safe
- A timed-out probe now records details, caches `False`, and returns — `_find_bash()`
  proceeds to its existing candidate fallback instead of hanging the process

No behavior change on the happy path or on POSIX.
