### PR TITLE
fix(buzz): resolve @mentions to pubkeys so agent-to-agent pings work

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -100,6 +100,12 @@ _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
 
+# Mention-resolution caches: member lists are cheap to refetch but hit on
+# every publish containing "@", so a short TTL amortizes the CLI round-trip;
+# display names change rarely, but must not survive a rename forever.
+_MEMBER_CACHE_TTL = 60.0
+_PROFILE_NAME_TTL = 300.0
+
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
 _WS_AUTH_TIMEOUT = 20.0
@@ -608,7 +614,19 @@ class BuzzAdapter(BasePlatformAdapter):
         to harvesting recent channel traffic (authors plus prior mention
         tags), which can over-approximate; ``send()`` recovers from any
         resulting non-member mention by retrying without mention flags.
+
+        The member list is cached per channel for ``_MEMBER_CACHE_TTL``
+        seconds so a chatty agent doesn't pay a CLI round-trip on every
+        publish; membership drift inside the TTL window is covered by the
+        same ``send()`` recovery retry.
         """
+        cache: Dict[str, Tuple[float, List[str]]] = getattr(
+            self, "_member_cache", {}
+        )
+        self._member_cache = cache
+        cached = cache.get(str(chat_id))
+        if cached is not None and (time.monotonic() - cached[0]) < _MEMBER_CACHE_TTL:
+            return list(cached[1])
         code, out, _err = await self._run_cli(
             ["channels", "members", "--channel", str(chat_id)]
         )
@@ -624,6 +642,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 if pk and pk not in pks:
                     pks.append(pk)
             if pks:
+                cache[str(chat_id)] = (time.monotonic(), list(pks))
                 return pks
         candidates: List[str] = []
         code, out, _err = await self._run_cli(
@@ -642,19 +661,25 @@ class BuzzAdapter(BasePlatformAdapter):
                                 candidates.append(tpk)
             except ValueError:
                 pass
+        if candidates:
+            cache[str(chat_id)] = (time.monotonic(), list(candidates))
         return candidates
 
     async def _profile_display_name(self, pubkey: str) -> str:
         """Display name for *pubkey* via ``users get --pubkey``, cached.
 
         Bare ``users get`` may return only our own profile
-        (relay-dependent), so lookups are per-pubkey.
+        (relay-dependent), so lookups are per-pubkey.  Entries expire after
+        ``_PROFILE_NAME_TTL`` seconds so a renamed member resolves under
+        their new display name without a process restart.
         """
-        cache: Dict[str, str] = getattr(self, "_profile_name_cache", {})
+        cache: Dict[str, Tuple[float, str]] = getattr(
+            self, "_profile_name_cache", {}
+        )
         self._profile_name_cache = cache
-        name = cache.get(pubkey)
-        if name is not None:
-            return name
+        cached = cache.get(pubkey)
+        if cached is not None and (time.monotonic() - cached[0]) < _PROFILE_NAME_TTL:
+            return cached[1]
         name = ""
         code, out, _err = await self._run_cli(["users", "get", "--pubkey", pubkey])
         if code == 0:
@@ -673,7 +698,7 @@ class BuzzAdapter(BasePlatformAdapter):
                         ).strip()
                     except ValueError:
                         pass
-        cache[pubkey] = name
+        cache[pubkey] = (time.monotonic(), name)
         return name
 
     async def _mention_pubkeys_for(self, chat_id: str, content: str) -> List[str]:
@@ -687,12 +712,13 @@ class BuzzAdapter(BasePlatformAdapter):
         while downgrading everything unresolvable to presentation-only text.
 
         Matching is mention-token semantics, not substring, bounded on both
-        sides: the ``@`` must start a token ("email@Fizz", "x@Fizz", and
-        "@@Fizz" do NOT wake Fizz) and the name must be followed by a
-        non-word character or end-of-text ("@Riley!!" tags Riley;
-        "@FizzBuzz" does NOT tag a member named Fizz).  Longer names match
-        first and consume their span, so "@Hermes Matt" prefers the member
-        "Hermes Matt" over a member "Hermes".
+        sides with Unicode-aware word classes: the ``@`` must start a token
+        ("email@Fizz", "x@Fizz", "@@Fizz", and "山田@Fizz" do NOT wake
+        Fizz) and the name must be followed by a non-word character or
+        end-of-text ("@Riley!!" tags Riley; "@FizzBuzz" does NOT tag a
+        member named Fizz).  Longer names match first and consume their
+        span, so "@Hermes Matt" prefers the member "Hermes Matt" over a
+        member "Hermes".
 
         Duplicate display names are ambiguous: the span is consumed but no
         one is tagged (presentation-only), mirroring how Buzz treats
@@ -718,7 +744,7 @@ class BuzzAdapter(BasePlatformAdapter):
         text = content
         for key in sorted(by_name, key=len, reverse=True):
             pattern = re.compile(
-                r"(?<![0-9A-Za-z_@])@" + re.escape(display[key]) + r"(?![0-9A-Za-z_])",
+                r"(?<![\w@])@" + re.escape(display[key]) + r"(?!\w)",
                 re.IGNORECASE,
             )
             if pattern.search(text):

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -686,34 +686,49 @@ class BuzzAdapter(BasePlatformAdapter):
         member name we find keeps genuine mentions notifying (p-tags intact)
         while downgrading everything unresolvable to presentation-only text.
 
-        Matching is mention-token semantics, not substring: the name must be
-        followed by a non-word character or end-of-text ("@Riley!!" tags
-        Riley; "@FizzBuzz" does NOT tag a member named Fizz).  Longer names
-        match first and consume their span, so "@Hermes Matt" prefers the
-        member "Hermes Matt" over a member "Hermes".
+        Matching is mention-token semantics, not substring, bounded on both
+        sides: the ``@`` must start a token ("email@Fizz", "x@Fizz", and
+        "@@Fizz" do NOT wake Fizz) and the name must be followed by a
+        non-word character or end-of-text ("@Riley!!" tags Riley;
+        "@FizzBuzz" does NOT tag a member named Fizz).  Longer names match
+        first and consume their span, so "@Hermes Matt" prefers the member
+        "Hermes Matt" over a member "Hermes".
+
+        Duplicate display names are ambiguous: the span is consumed but no
+        one is tagged (presentation-only), mirroring how Buzz treats
+        ambiguous names — never pick an arbitrary member.
         """
         if "@" not in content:
             return []
-        entries: List[Tuple[str, str]] = []
+        by_name: Dict[str, List[str]] = {}
+        display: Dict[str, str] = {}
         self_pk = getattr(self, "_self_pubkey", None)
         for pk in await self._channel_member_pubkeys(chat_id):
             if pk == self_pk:
                 continue
             name = await self._profile_display_name(pk)
-            if name:
-                entries.append((name, pk))
-        entries.sort(key=lambda e: len(e[0]), reverse=True)
+            if not name:
+                continue
+            key = name.lower()
+            by_name.setdefault(key, [])
+            if pk not in by_name[key]:
+                by_name[key].append(pk)
+            display.setdefault(key, name)
         found: List[str] = []
         text = content
-        for name, pk in entries:
+        for key in sorted(by_name, key=len, reverse=True):
             pattern = re.compile(
-                "@" + re.escape(name) + r"(?![0-9A-Za-z_])", re.IGNORECASE
+                r"(?<![0-9A-Za-z_@])@" + re.escape(display[key]) + r"(?![0-9A-Za-z_])",
+                re.IGNORECASE,
             )
             if pattern.search(text):
-                if pk not in found:
-                    found.append(pk)
-                # Consume the span so a shorter member name that is a prefix
-                # of this one cannot double-match the same mention.
+                pks = by_name[key]
+                if len(pks) == 1 and pks[0] not in found:
+                    found.append(pks[0])
+                # Consume the span either way: a shorter member name that is
+                # a prefix of this one must not double-match, and an
+                # ambiguous name must stay presentation-only rather than
+                # falling through to a partial match.
                 text = pattern.sub("\x00", text)
         return found
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -599,26 +599,32 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
-    async def _mention_pubkeys_for(self, chat_id: str, content: str) -> List[str]:
-        """Resolve ``@Name`` references in *content* to member pubkeys.
+    async def _channel_member_pubkeys(self, chat_id: str) -> List[str]:
+        """Candidate pubkeys for mention resolution, membership-accurate.
 
-        The CLI hard-fails a publish when any @token fails to resolve to a
-        current member, and LLM prose is full of @-shaped tokens — including
-        real mentions with trailing punctuation ("@Riley!!") the CLI's own
-        parser rejects.  Passing explicit ``--mention`` pubkeys for every
-        member name we find keeps genuine mentions notifying (p-tags intact)
-        while downgrading everything unresolvable to presentation-only text.
-
-        Bare ``users get`` may return only our own profile (relay-dependent),
-        so candidate pubkeys are harvested from recent channel traffic
-        (authors plus prior mention tags) and resolved to display names one
-        at a time via ``users get --pubkey``, cached for the process
-        lifetime.
+        Primary source is ``channels members`` — the relay's membership
+        contract — because a ``--mention`` for a non-member makes the CLI
+        reject the whole publish.  CLIs without that subcommand fall back
+        to harvesting recent channel traffic (authors plus prior mention
+        tags), which can over-approximate; ``send()`` recovers from any
+        resulting non-member mention by retrying without mention flags.
         """
-        if "@" not in content:
-            return []
-        cache: Dict[str, str] = getattr(self, "_profile_name_cache", {})
-        self._profile_name_cache = cache
+        code, out, _err = await self._run_cli(
+            ["channels", "members", "--channel", str(chat_id)]
+        )
+        if code == 0:
+            pks: List[str] = []
+            try:
+                rows = json.loads(out or "[]")
+            except ValueError:
+                rows = []
+            for row in rows:
+                pk = row.get("pubkey") if isinstance(row, dict) else row
+                pk = str(pk or "").lower()
+                if pk and pk not in pks:
+                    pks.append(pk)
+            if pks:
+                return pks
         candidates: List[str] = []
         code, out, _err = await self._run_cli(
             ["messages", "get", "--channel", str(chat_id), "--limit", "50"]
@@ -636,33 +642,79 @@ class BuzzAdapter(BasePlatformAdapter):
                                 candidates.append(tpk)
             except ValueError:
                 pass
-        low = content.lower()
-        found: List[str] = []
+        return candidates
+
+    async def _profile_display_name(self, pubkey: str) -> str:
+        """Display name for *pubkey* via ``users get --pubkey``, cached.
+
+        Bare ``users get`` may return only our own profile
+        (relay-dependent), so lookups are per-pubkey.
+        """
+        cache: Dict[str, str] = getattr(self, "_profile_name_cache", {})
+        self._profile_name_cache = cache
+        name = cache.get(pubkey)
+        if name is not None:
+            return name
+        name = ""
+        code, out, _err = await self._run_cli(["users", "get", "--pubkey", pubkey])
+        if code == 0:
+            try:
+                profiles = json.loads(out or "[]")
+            except ValueError:
+                profiles = []
+            if profiles and isinstance(profiles[0], dict):
+                p0 = profiles[0]
+                name = str(p0.get("display_name") or p0.get("name") or "").strip()
+                if not name and p0.get("content"):
+                    try:
+                        prof = json.loads(p0["content"])
+                        name = str(
+                            prof.get("display_name") or prof.get("name") or ""
+                        ).strip()
+                    except ValueError:
+                        pass
+        cache[pubkey] = name
+        return name
+
+    async def _mention_pubkeys_for(self, chat_id: str, content: str) -> List[str]:
+        """Resolve ``@Name`` references in *content* to member pubkeys.
+
+        The CLI hard-fails a publish when any @token fails to resolve to a
+        current member, and LLM prose is full of @-shaped tokens — including
+        real mentions with trailing punctuation ("@Riley!!") the CLI's own
+        parser rejects.  Passing explicit ``--mention`` pubkeys for every
+        member name we find keeps genuine mentions notifying (p-tags intact)
+        while downgrading everything unresolvable to presentation-only text.
+
+        Matching is mention-token semantics, not substring: the name must be
+        followed by a non-word character or end-of-text ("@Riley!!" tags
+        Riley; "@FizzBuzz" does NOT tag a member named Fizz).  Longer names
+        match first and consume their span, so "@Hermes Matt" prefers the
+        member "Hermes Matt" over a member "Hermes".
+        """
+        if "@" not in content:
+            return []
+        entries: List[Tuple[str, str]] = []
         self_pk = getattr(self, "_self_pubkey", None)
-        for pk in candidates:
+        for pk in await self._channel_member_pubkeys(chat_id):
             if pk == self_pk:
                 continue
-            name = cache.get(pk)
-            if name is None:
-                name = ""
-                code, out, _err = await self._run_cli(["users", "get", "--pubkey", pk])
-                if code == 0:
-                    try:
-                        profiles = json.loads(out or "[]")
-                    except ValueError:
-                        profiles = []
-                    if profiles and isinstance(profiles[0], dict):
-                        p0 = profiles[0]
-                        name = str(p0.get("display_name") or p0.get("name") or "").strip()
-                        if not name and p0.get("content"):
-                            try:
-                                prof = json.loads(p0["content"])
-                                name = str(prof.get("display_name") or prof.get("name") or "").strip()
-                            except ValueError:
-                                pass
-                cache[pk] = name
-            if name and ("@" + name.lower()) in low and pk not in found:
-                found.append(pk)
+            name = await self._profile_display_name(pk)
+            if name:
+                entries.append((name, pk))
+        entries.sort(key=lambda e: len(e[0]), reverse=True)
+        found: List[str] = []
+        text = content
+        for name, pk in entries:
+            pattern = re.compile(
+                "@" + re.escape(name) + r"(?![0-9A-Za-z_])", re.IGNORECASE
+            )
+            if pattern.search(text):
+                if pk not in found:
+                    found.append(pk)
+                # Consume the span so a shorter member name that is a prefix
+                # of this one cannot double-match the same mention.
+                text = pattern.sub("\x00", text)
         return found
 
     async def send(
@@ -678,9 +730,20 @@ class BuzzAdapter(BasePlatformAdapter):
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
             args += ["--reply-to", str(reply_target)]
+        mention_args: List[str] = []
         for pk in await self._mention_pubkeys_for(chat_id, content):
-            args += ["--mention", pk]
-        code, out, err = await self._run_cli(args, input_text=content)
+            mention_args += ["--mention", pk]
+        code, out, err = await self._run_cli(args + mention_args, input_text=content)
+        if (
+            code != 0
+            and mention_args
+            and "not channel members" in (err or "")
+        ):
+            # Membership drifted between resolution and publish (or the
+            # fallback candidate source over-approximated): never let a
+            # stale mention kill the message — deliver it without the
+            # explicit mentions rather than not at all.
+            code, out, err = await self._run_cli(args, input_text=content)
         if code != 0 and "does not match a current channel member" in (err or ""):
             # Even with resolved mentions attached, prose can still contain
             # @-shaped tokens that resolve to nothing ("just @-mention me").

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -599,6 +599,72 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
+    async def _mention_pubkeys_for(self, chat_id: str, content: str) -> List[str]:
+        """Resolve ``@Name`` references in *content* to member pubkeys.
+
+        The CLI hard-fails a publish when any @token fails to resolve to a
+        current member, and LLM prose is full of @-shaped tokens — including
+        real mentions with trailing punctuation ("@Riley!!") the CLI's own
+        parser rejects.  Passing explicit ``--mention`` pubkeys for every
+        member name we find keeps genuine mentions notifying (p-tags intact)
+        while downgrading everything unresolvable to presentation-only text.
+
+        Bare ``users get`` may return only our own profile (relay-dependent),
+        so candidate pubkeys are harvested from recent channel traffic
+        (authors plus prior mention tags) and resolved to display names one
+        at a time via ``users get --pubkey``, cached for the process
+        lifetime.
+        """
+        if "@" not in content:
+            return []
+        cache: Dict[str, str] = getattr(self, "_profile_name_cache", {})
+        self._profile_name_cache = cache
+        candidates: List[str] = []
+        code, out, _err = await self._run_cli(
+            ["messages", "get", "--channel", str(chat_id), "--limit", "50"]
+        )
+        if code == 0:
+            try:
+                for msg in json.loads(out or "[]"):
+                    pk = str(msg.get("pubkey") or "").lower()
+                    if pk and pk not in candidates:
+                        candidates.append(pk)
+                    for t in msg.get("tags") or []:
+                        if isinstance(t, list) and len(t) > 1 and t[0] == "p":
+                            tpk = str(t[1]).lower()
+                            if tpk and tpk not in candidates:
+                                candidates.append(tpk)
+            except ValueError:
+                pass
+        low = content.lower()
+        found: List[str] = []
+        self_pk = getattr(self, "_self_pubkey", None)
+        for pk in candidates:
+            if pk == self_pk:
+                continue
+            name = cache.get(pk)
+            if name is None:
+                name = ""
+                code, out, _err = await self._run_cli(["users", "get", "--pubkey", pk])
+                if code == 0:
+                    try:
+                        profiles = json.loads(out or "[]")
+                    except ValueError:
+                        profiles = []
+                    if profiles and isinstance(profiles[0], dict):
+                        p0 = profiles[0]
+                        name = str(p0.get("display_name") or p0.get("name") or "").strip()
+                        if not name and p0.get("content"):
+                            try:
+                                prof = json.loads(p0["content"])
+                                name = str(prof.get("display_name") or prof.get("name") or "").strip()
+                            except ValueError:
+                                pass
+                cache[pk] = name
+            if name and ("@" + name.lower()) in low and pk not in found:
+                found.append(pk)
+        return found
+
     async def send(
         self,
         chat_id: str,
@@ -612,7 +678,21 @@ class BuzzAdapter(BasePlatformAdapter):
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
             args += ["--reply-to", str(reply_target)]
+        for pk in await self._mention_pubkeys_for(chat_id, content):
+            args += ["--mention", pk]
         code, out, err = await self._run_cli(args, input_text=content)
+        if code != 0 and "does not match a current channel member" in (err or ""):
+            # Even with resolved mentions attached, prose can still contain
+            # @-shaped tokens that resolve to nothing ("just @-mention me").
+            # Supplying any explicit identity downgrades unresolvable @names
+            # to presentation-only text while uniquely resolved member names
+            # still notify, so retry once mentioning our own pubkey —
+            # self-mentions are already suppressed by the echo de-dupe in
+            # the poll loop.
+            if getattr(self, "_self_pubkey", None):
+                code, out, err = await self._run_cli(
+                    args + ["--mention", self._self_pubkey], input_text=content
+                )
         if code != 0:
             return SendResult(
                 success=False,

--- a/tests/gateway/test_buzz_mention_resolution.py
+++ b/tests/gateway/test_buzz_mention_resolution.py
@@ -159,6 +159,12 @@ class TestMentionTokenMatching:
         assert await self._resolve("@@Fizz") == []
 
     @pytest.mark.asyncio
+    async def test_left_boundary_is_unicode_aware(self):
+        # 山 is a word character: "山田@Fizz" is email-shaped text in a
+        # non-ASCII script, not a mention.
+        assert await self._resolve("山田@Fizz") == []
+
+    @pytest.mark.asyncio
     async def test_no_at_sign_short_circuits_without_cli_calls(self):
         adapter = _make_adapter()
         cli = _wire(adapter, _ScriptedCli())
@@ -191,6 +197,43 @@ class TestMentionTokenMatching:
             profiles={SELF_PUBKEY: "Chip", FIZZ_PUBKEY: "Fizz"},
         )
         assert result == [FIZZ_PUBKEY]
+
+
+# ── caching ───────────────────────────────────────────────────────────────
+
+
+class TestResolutionCaching:
+
+    @pytest.mark.asyncio
+    async def test_member_list_cached_within_ttl(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members(FIZZ_PUBKEY))
+        cli.script("users", "get", _profile(FIZZ_PUBKEY, "Fizz"))
+
+        assert await adapter._mention_pubkeys_for(CHANNEL, "@Fizz one") == [FIZZ_PUBKEY]
+        assert await adapter._mention_pubkeys_for(CHANNEL, "@Fizz two") == [FIZZ_PUBKEY]
+
+        member_calls = [c for c in cli.calls if (c[0][0], c[0][1]) == ("channels", "members")]
+        assert len(member_calls) == 1, "second resolve must hit the member cache"
+
+    @pytest.mark.asyncio
+    async def test_profile_name_expires_after_ttl(self, monkeypatch):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members(FIZZ_PUBKEY))
+        cli.script("users", "get", _profile(FIZZ_PUBKEY, "Fizz"))
+        cli.script("users", "get", _profile(FIZZ_PUBKEY, "FizzRenamed"))
+
+        clock = [1000.0]
+        monkeypatch.setattr(_buzz_mod.time, "monotonic", lambda: clock[0])
+
+        assert await adapter._mention_pubkeys_for(CHANNEL, "@Fizz hi") == [FIZZ_PUBKEY]
+        # Inside both TTLs: rename not visible yet, no new lookups needed.
+        assert await adapter._mention_pubkeys_for(CHANNEL, "@FizzRenamed hi") == []
+        # Past the name TTL (and member TTL): the rename resolves.
+        clock[0] += _buzz_mod._PROFILE_NAME_TTL + 1
+        assert await adapter._mention_pubkeys_for(CHANNEL, "@FizzRenamed hi") == [FIZZ_PUBKEY]
 
 
 # ── send() recovery paths ─────────────────────────────────────────────────

--- a/tests/gateway/test_buzz_mention_resolution.py
+++ b/tests/gateway/test_buzz_mention_resolution.py
@@ -1,0 +1,261 @@
+"""Tests for the Buzz adapter's @mention resolution (PR #83414).
+
+Covers ``_mention_pubkeys_for`` / ``_channel_member_pubkeys`` and the
+``send()`` recovery paths: membership-accurate candidate sourcing, token
+boundaries on both sides of the @name, duplicate-name ambiguity, and the
+non-member / unresolvable-token publish retries.
+"""
+
+import json
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_buzz_mod = load_plugin_adapter("buzz")
+
+BuzzAdapter = _buzz_mod.BuzzAdapter
+
+SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
+FIZZ_PUBKEY = "b" * 64
+BUZZ_PUBKEY = "c" * 64
+DUPE_PUBKEY = "d" * 64
+CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
+
+_ENV_VARS = (
+    "BUZZ_RELAY_URL",
+    "BUZZ_PRIVATE_KEY",
+    "BUZZ_CHANNELS",
+    "BUZZ_HOME_CHANNEL",
+    "BUZZ_ALLOWED_USERS",
+    "BUZZ_ALLOW_ALL_USERS",
+    "BUZZ_POLL_INTERVAL",
+    "BUZZ_CLI_PATH",
+    "BUZZ_CREDENTIALS_FILE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path / "no-creds")
+    yield
+
+
+def _make_adapter(extra=None):
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"relay_url": "https://test.relay", **(extra or {})})
+    adapter = BuzzAdapter(cfg)
+    adapter._self_pubkey = SELF_PUBKEY
+    adapter._private_key = "nsec1test"
+    return adapter
+
+
+class _ScriptedCli:
+    """Fake ``_run_cli`` that routes on the buzz subcommand and records calls."""
+
+    def __init__(self):
+        self.responses = {}
+        self.calls = []
+
+    def script(self, group, cmd, payload, code=0, stderr=""):
+        stdout = payload if isinstance(payload, str) else json.dumps(payload)
+        self.responses.setdefault((group, cmd), []).append((code, stdout, stderr))
+
+    async def __call__(self, args, *, input_text=None):
+        self.calls.append((list(args), input_text))
+        queue = self.responses.get((args[0], args[1]), [])
+        if len(queue) > 1:
+            return queue.pop(0)
+        if queue:
+            return queue[0]
+        return 0, "[]", ""
+
+
+def _wire(adapter, cli):
+    adapter._run_cli = cli
+    return cli
+
+
+def _members(*pubkeys):
+    return [{"pubkey": pk} for pk in pubkeys]
+
+
+def _profile(pubkey, name):
+    return [{"pubkey": pubkey, "display_name": name}]
+
+
+# ── candidate sourcing ────────────────────────────────────────────────────
+
+
+class TestChannelMemberPubkeys:
+
+    @pytest.mark.asyncio
+    async def test_members_subcommand_is_primary_source(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members(FIZZ_PUBKEY, BUZZ_PUBKEY))
+
+        pks = await adapter._channel_member_pubkeys(CHANNEL)
+
+        assert pks == [FIZZ_PUBKEY, BUZZ_PUBKEY]
+        assert ("messages", "get") not in {(c[0][0], c[0][1]) for c in cli.calls}
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_recent_traffic_when_members_unavailable(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", "", code=1, stderr="unknown subcommand")
+        cli.script(
+            "messages",
+            "get",
+            [
+                {"pubkey": FIZZ_PUBKEY, "tags": [["p", BUZZ_PUBKEY]]},
+            ],
+        )
+
+        pks = await adapter._channel_member_pubkeys(CHANNEL)
+
+        assert FIZZ_PUBKEY in pks and BUZZ_PUBKEY in pks
+
+
+# ── token matching ────────────────────────────────────────────────────────
+
+
+class TestMentionTokenMatching:
+
+    async def _resolve(self, content, members=None, profiles=None):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members(*(members or [FIZZ_PUBKEY])))
+        for pk, name in (profiles or {FIZZ_PUBKEY: "Fizz"}).items():
+            cli.script("users", "get", _profile(pk, name))
+        return await adapter._mention_pubkeys_for(CHANNEL, content)
+
+    @pytest.mark.asyncio
+    async def test_clean_mention_resolves(self):
+        assert await self._resolve("hey @Fizz, ping") == [FIZZ_PUBKEY]
+
+    @pytest.mark.asyncio
+    async def test_trailing_punctuation_resolves(self):
+        assert await self._resolve("@Fizz!! wake up") == [FIZZ_PUBKEY]
+
+    @pytest.mark.asyncio
+    async def test_right_boundary_rejects_longer_token(self):
+        assert await self._resolve("@FizzBuzz is a game") == []
+
+    @pytest.mark.asyncio
+    async def test_left_boundary_rejects_email_like_text(self):
+        assert await self._resolve("mail me at email@Fizz today") == []
+
+    @pytest.mark.asyncio
+    async def test_left_boundary_rejects_adjacent_word_char(self):
+        assert await self._resolve("x@Fizz") == []
+
+    @pytest.mark.asyncio
+    async def test_left_boundary_rejects_double_at(self):
+        assert await self._resolve("@@Fizz") == []
+
+    @pytest.mark.asyncio
+    async def test_no_at_sign_short_circuits_without_cli_calls(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        assert await adapter._mention_pubkeys_for(CHANNEL, "no mentions here") == []
+        assert cli.calls == []
+
+    @pytest.mark.asyncio
+    async def test_longest_name_wins_and_consumes_span(self):
+        result = await self._resolve(
+            "@Hermes Matt please review",
+            members=[FIZZ_PUBKEY, BUZZ_PUBKEY],
+            profiles={FIZZ_PUBKEY: "Hermes Matt", BUZZ_PUBKEY: "Hermes"},
+        )
+        assert result == [FIZZ_PUBKEY]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_display_names_tag_nobody(self):
+        result = await self._resolve(
+            "@Fizz which one of you is real",
+            members=[FIZZ_PUBKEY, DUPE_PUBKEY],
+            profiles={FIZZ_PUBKEY: "Fizz", DUPE_PUBKEY: "Fizz"},
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_self_is_never_a_candidate(self):
+        result = await self._resolve(
+            "@Chip and @Fizz",
+            members=[SELF_PUBKEY, FIZZ_PUBKEY],
+            profiles={SELF_PUBKEY: "Chip", FIZZ_PUBKEY: "Fizz"},
+        )
+        assert result == [FIZZ_PUBKEY]
+
+
+# ── send() recovery paths ─────────────────────────────────────────────────
+
+
+class TestSendRecovery:
+
+    def _sending_adapter(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members(FIZZ_PUBKEY))
+        cli.script("users", "get", _profile(FIZZ_PUBKEY, "Fizz"))
+        return adapter, cli
+
+    def _send_calls(self, cli):
+        return [c for c in cli.calls if (c[0][0], c[0][1]) == ("messages", "send")]
+
+    @pytest.mark.asyncio
+    async def test_resolved_mention_attached_to_publish(self):
+        adapter, cli = self._sending_adapter()
+        cli.script("messages", "send", {"accepted": True, "event_id": "e1"})
+
+        result = await adapter.send(CHANNEL, "@Fizz hello")
+
+        assert result.success
+        sends = self._send_calls(cli)
+        assert len(sends) == 1
+        assert ["--mention", FIZZ_PUBKEY] == sends[0][0][-2:]
+
+    @pytest.mark.asyncio
+    async def test_non_member_mention_retries_without_mentions(self):
+        adapter, cli = self._sending_adapter()
+        cli.script(
+            "messages", "send", "",
+            code=1,
+            stderr=json.dumps({"error": "user_error", "message": "mentioned pubkeys are not channel members"}),
+        )
+        cli.script("messages", "send", {"accepted": True, "event_id": "e2"})
+
+        result = await adapter.send(CHANNEL, "@Fizz hello")
+
+        assert result.success
+        sends = self._send_calls(cli)
+        assert len(sends) == 2
+        assert "--mention" in sends[0][0]
+        assert "--mention" not in sends[1][0]
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_token_retries_with_self_mention(self):
+        adapter = _make_adapter()
+        cli = _wire(adapter, _ScriptedCli())
+        cli.script("channels", "members", _members())  # nobody to resolve
+        cli.script(
+            "messages", "send", "",
+            code=1,
+            stderr=json.dumps({
+                "error": "user_error",
+                "message": "mention '@-mention' does not match a current channel member",
+            }),
+        )
+        cli.script("messages", "send", {"accepted": True, "event_id": "e3"})
+
+        result = await adapter.send(CHANNEL, "just @-mention me")
+
+        assert result.success
+        sends = self._send_calls(cli)
+        assert len(sends) == 2
+        assert ["--mention", SELF_PUBKEY] == sends[1][0][-2:]


### PR DESCRIPTION
# fix(buzz): resolve @mentions to pubkeys so agent-to-agent pings work

## Symptoms (hermes-agent 0.20.0, live community relay)

**1. Whole replies silently dropped.** The buzz CLI refuses to publish when *any*
@-shaped token in the content fails to resolve to a channel member. LLM prose contains
such tokens constantly — a reply including the phrase "just @-mention me" produced:

```
[Buzz] Send failed: user_error: mention '@-mention' does not match a current
channel member; retry with --mention <pubkey> (exit 1) — trying plain-text fallback
[Buzz] Fallback send also failed: (same error)
```

The gateway logs `response ready`, the user sees nothing. From the operator's side the
agent looks alive but mute.

**2. Mentions post without p-tags, so other agents never wake.** Even a clean
`@Riley` can post as plain text: bare `users get` may return only the caller's own
profile (so the CLI has no name to resolve against), and trailing punctuation
(`@Riley!!`) defeats the parser. Mention-subscribed agents (e.g. any buzz-acp harness
with `subscribe=Mentions`) are never notified. Net effect: **agent-to-agent
conversation on Buzz silently doesn't work** — each side posts into the channel, and
neither side's harness ever triggers.

## Fix (all in `send()`)

- **`_mention_pubkeys_for()`** — harvest candidate pubkeys from recent channel
  traffic (message authors + prior mention p-tags), resolve each to a display name
  via `users get --pubkey <pk>` (works even when the bare listing is empty), cache
  per process, and pass `--mention <pubkey>` for every member name @-referenced in
  the content. Genuine mentions keep their p-tags; matching tolerates trailing
  punctuation.
- **Retry-once fallback** — if the publish still bounces on an unresolvable token,
  resend with `--mention <self>`. Per the CLI contract, any explicit identity
  downgrades unresolved @names to presentation-only text; self-mentions are already
  suppressed by the poll loop's echo de-dupe, so this is invisible.

## Verification

Live on a hosted community relay (`*.communities.buzz.xyz`): a deepseek-powered
Hermes gateway agent and a claude-agent-acp managed agent completed a multi-turn,
task-splitting collaboration. Hermes's `@<agent>` mentions render as real mention
chips and wake the other agent's mention subscription; prose @-tokens no longer
drop replies.
