### PR TITLE
fix(state): reap dead read connections safely

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2521,15 +2521,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # read-only connections so they never queue behind writer flushes on
         # self._lock. See _read_ctx().
         self._read_local = threading.local()
-        # Strong set of all live read connections across all threads.  We
-        # hold a reference so short-lived reader threads' connections are
-        # not GC'd without close() — that would leak tracked fds in
-        # _live_connections.  close() drains this set.
-        self._read_conns: "set[sqlite3.Connection]" = set()
+        # Live read connections keyed by their owning thread. We hold a strong
+        # reference so short-lived reader threads' connections are not GC'd
+        # without close() — that would leak tracked fds in _live_connections.
+        # Connections whose owner thread has exited are reaped at runtime;
+        # close() waits for active read contexts, then drains whatever remains.
+        self._read_conns: "dict[sqlite3.Connection, threading.Thread]" = {}
         self._read_conns_lock = threading.Lock()
-        # Set when close() begins.  _get_read_conn checks this under the
-        # lock so a reader that finishes opening after the drain finds the
-        # shutdown in progress and closes its own connection immediately.
+        self._read_conns_drained = threading.Condition(self._read_conns_lock)
+        self._read_conn_leases: "dict[sqlite3.Connection, int]" = {}
+        self._read_conn_openers = 0
+        # Set when close() begins. _get_read_conn rejects new opens; any open
+        # already in flight registers its connection for the teardown drain.
         self._read_conns_closed = False
         self._wal_active = False
         self._write_count = 0
@@ -2777,58 +2780,132 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not self._wal_active or self.read_only:
             return None
         conn = getattr(self._read_local, "conn", None)
-        if conn is not None:
-            return conn
-        if getattr(self._read_local, "failed", False):
-            return None
-        try:
-            conn = _connect_tracked_db(
-                f"file:{self.db_path}?mode=ro",
-                tracking_path=self.db_path,
-                uri=True,
-                timeout=5.0,
-                isolation_level=None,
-            )
-            conn.row_factory = sqlite3.Row
-            apply_database_pragmas(conn, db_label="state.db")
-            # Load the CJK tokenizer extension on this connection so
-            # messages_fts_cjk queries work on the read path. The .so
-            # registers the tokenizer in the connection's in-memory
-            # registry, not the database file, so mode=ro is fine.
-            if self._fts_cjk_loaded:
-                load_fts5_cjk_extension(conn)
-            with self._read_conns_lock:
-                if self._read_conns_closed:
-                    # close() already drained — don't register; close
-                    # immediately so no tracked fd leaks.
-                    conn.close()
-                    self._read_local.failed = True
+        # close() can run from another thread. Do not let the thread-local fast
+        # path return a removed connection or start another open after teardown.
+        # Register the in-flight open under the same lock so close() cannot
+        # finish while an unregistered connection still exists.
+        with self._read_conns_drained:
+            if self._read_conns_closed:
+                self._read_local.conn = None
+                return None
+            if conn is not None:
+                if conn not in self._read_conns:
+                    self._read_local.conn = None
                     return None
-                self._read_conns.add(conn)
-        except sqlite3.Error:
-            # Mark this thread failed so we don't retry the open on every
-            # query; the locked writer connection still serves reads.
-            self._read_local.failed = True
-            logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
-            return None
-        self._read_local.conn = conn
-        return conn
+                return conn
+            if getattr(self._read_local, "failed", False):
+                return None
+            self._read_conn_openers += 1
+        registered = False
+        try:
+            try:
+                conn = _connect_tracked_db(
+                    f"file:{self.db_path}?mode=ro",
+                    tracking_path=self.db_path,
+                    uri=True,
+                    # Dead workers are reaped from a different thread, so their
+                    # connections must allow cross-thread close.
+                    check_same_thread=False,
+                    timeout=5.0,
+                    isolation_level=None,
+                )
+                conn.row_factory = sqlite3.Row
+                apply_database_pragmas(conn, db_label="state.db")
+                # Load the CJK tokenizer extension on this connection so
+                # messages_fts_cjk queries work on the read path. The .so
+                # registers the tokenizer in the connection's in-memory
+                # registry, not the database file, so mode=ro is fine.
+                if self._fts_cjk_loaded:
+                    load_fts5_cjk_extension(conn)
+                with self._read_conns_drained:
+                    if self._read_conns_closed:
+                        # close() is waiting for this opener. Register the
+                        # connection so its teardown drain owns the close.
+                        self._read_conns[conn] = threading.current_thread()
+                        registered = True
+                        self._read_local.failed = True
+                        return None
+                    # Bound descriptor usage by live reader concurrency rather
+                    # than the number of historical worker threads (#75269).
+                    self._reap_dead_read_conns()
+                    self._read_conns[conn] = threading.current_thread()
+                    registered = True
+            except sqlite3.Error:
+                # Mark this thread failed so we don't retry the open on every
+                # query; the locked writer connection still serves reads.
+                self._read_local.failed = True
+                logger.debug(
+                    "read-only connection open failed for %s", self.db_path, exc_info=True
+                )
+                return None
+            self._read_local.conn = conn
+            return conn
+        finally:
+            if conn is not None and not registered:
+                try:
+                    conn.close()
+                except Exception as exc:
+                    # Preserve ownership when setup failed and close did too,
+                    # so runtime reaping or teardown can retry later.
+                    logger.debug("failed read connection setup cleanup: %s", exc)
+                    with self._read_conns_drained:
+                        self._read_conns[conn] = threading.current_thread()
+            with self._read_conns_drained:
+                self._read_conn_openers -= 1
+                self._read_conns_drained.notify_all()
+
+    def _reap_dead_read_conns(self) -> None:
+        """Close read connections whose owning thread has exited.
+
+        Caller must hold ``_read_conns_lock``. A finished worker can no
+        longer use its thread-local connection, so cross-thread close is safe.
+        """
+        dead = [
+            conn
+            for conn, owner in self._read_conns.items()
+            if not owner.is_alive() and not self._read_conn_leases.get(conn, 0)
+        ]
+        for conn in dead:
+            try:
+                conn.close()
+            except Exception as exc:
+                # Keep failed closes tracked so a later reap/close can retry.
+                logger.debug("read connection reap failed for %s: %s", self.db_path, exc)
+                continue
+            self._read_conns.pop(conn, None)
+            self._read_conn_leases.pop(conn, None)
 
     @contextmanager
     def _read_ctx(self):
         """Yield a connection for read-only statements.
 
-        WAL: a per-thread read-only connection with NO lock — recall queries
-        never convoy behind writer flushes (the gateway shares one SessionDB
-        across every agent, so this lock was a global choke point).
+        WAL: a per-thread read-only connection with no writer lock — recall
+        queries never convoy behind writer flushes (the gateway shares one
+        SessionDB across every agent, so this lock was a global choke point).
         Non-WAL or read-conn failure: the shared writer connection under
         self._lock, byte-for-byte the legacy behavior.
         """
         conn = self._get_read_conn()
         if conn is not None:
-            yield conn
+            with self._read_conns_drained:
+                if self._read_conns_closed or conn not in self._read_conns:
+                    raise RuntimeError("SessionDB is closed")
+                self._read_conn_leases[conn] = self._read_conn_leases.get(conn, 0) + 1
+            try:
+                yield conn
+            finally:
+                with self._read_conns_drained:
+                    remaining = self._read_conn_leases.get(conn, 1) - 1
+                    if remaining:
+                        self._read_conn_leases[conn] = remaining
+                    else:
+                        self._read_conn_leases.pop(conn, None)
+                        self._read_conns_drained.notify_all()
             return
         with self._lock:
+            with self._read_conns_lock:
+                if self._read_conns_closed:
+                    raise RuntimeError("SessionDB is closed")
             yield self._conn
 
     # ── Core write helper ──
@@ -3388,6 +3465,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         checkpoint so exiting writer processes help shrink the WAL file.
         Read-only connections never request a checkpoint.
         """
+        with self._read_conns_drained:
+            current_conn = getattr(self._read_local, "conn", None)
+            if current_conn is not None and self._read_conn_leases.get(current_conn, 0):
+                raise RuntimeError("cannot close SessionDB from an active read context")
         self._stop_token_writer()
         # The atexit hook holds a strong reference to this instance (bound
         # method); without unregistering, every closed SessionDB stays
@@ -3398,19 +3479,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Close all read-only connections across all threads.  Per-thread
         # connections live in threading.local() and would otherwise be GC'd
         # without calling close(), leaking tracked fds in _live_connections.
-        # The strong set holds references so short-lived reader threads'
-        # connections survive until close() drains them.  Setting the closed
-        # flag under the lock prevents a reader from registering a new
-        # connection after the drain.
-        with self._read_conns_lock:
+        # _read_conns holds references so short-lived reader threads'
+        # connections survive until they are reaped or drained here. Setting
+        # the closed flag under the lock prevents new connections and leases;
+        # waiting for current leases prevents cross-thread close from racing a
+        # reader that already holds a connection.
+        with self._read_conns_drained:
             self._read_conns_closed = True
+            while self._read_conn_openers or self._read_conn_leases:
+                self._read_conns_drained.wait()
             read_conns = list(self._read_conns)
-            self._read_conns.clear()
-        for conn in read_conns:
-            try:
-                conn.close()
-            except Exception:
-                pass
+            for conn in read_conns:
+                try:
+                    conn.close()
+                except Exception as exc:
+                    # Keep failed closes tracked so repeated close() can retry.
+                    logger.debug("read connection close failed for %s: %s", self.db_path, exc)
+                    continue
+                self._read_conns.pop(conn, None)
+                self._read_conn_leases.pop(conn, None)
         self._read_local.conn = None
         with self._lock:
             if self._conn:

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -167,3 +167,391 @@ def test_session_resume_reads_do_not_take_writer_lock(db):
         assert len(done["ancestor_prefix"]) == 2
     finally:
         db._lock.release()
+
+
+# ── #75269: finished-thread read connections must be reaped at runtime ──
+
+
+def _force_read_path(d):
+    """Activate the per-thread read-only split on runtimes where WAL is off."""
+    d._wal_active = True
+
+
+def test_finished_read_threads_do_not_accumulate_conns(tmp_path):
+    """A long-lived SessionDB must not retain a read conn per historical worker."""
+    import gc
+
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+
+        def read_once():
+            assert d._get_read_conn() is not None
+
+        for _ in range(40):
+            worker = threading.Thread(target=read_once)
+            worker.start()
+            worker.join(timeout=10)
+            assert not worker.is_alive()
+
+        gc.collect()
+        retained = len(d._read_conns)
+        assert retained == 1, (
+            f"finished worker threads retained {retained} read connections; "
+            "only the final worker's connection may remain (#75269)"
+        )
+    finally:
+        d.close()
+
+
+def test_reaped_connection_is_actually_closed(tmp_path):
+    """A connection whose owning thread exited must be closed on reap."""
+    import sqlite3 as _sqlite3
+
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+        holder = {}
+
+        def worker_open():
+            holder["conn"] = d._get_read_conn()
+
+        worker = threading.Thread(target=worker_open)
+        worker.start()
+        worker.join(timeout=10)
+        assert not worker.is_alive()
+        victim = holder["conn"]
+        assert victim is not None
+
+        def worker_reap():
+            assert d._get_read_conn() is not None
+
+        reaper = threading.Thread(target=worker_reap)
+        reaper.start()
+        reaper.join(timeout=10)
+        assert not reaper.is_alive()
+
+        assert victim not in d._read_conns, "dead-thread connection was not reaped"
+        with pytest.raises(_sqlite3.ProgrammingError):
+            victim.execute("SELECT 1")
+    finally:
+        d.close()
+
+
+def test_live_thread_connection_not_reaped(tmp_path):
+    """A connection whose owner thread is still alive must survive a reap."""
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+        ready = threading.Event()
+        release = threading.Event()
+        live_conn = {}
+
+        def hold():
+            live_conn["conn"] = d._get_read_conn()
+            ready.set()
+            release.wait(timeout=10)
+
+        keeper = threading.Thread(target=hold)
+        keeper.start()
+        assert ready.wait(timeout=10)
+        conn = live_conn["conn"]
+        assert conn is not None
+
+        for _ in range(5):
+            worker = threading.Thread(target=lambda: d._get_read_conn())
+            worker.start()
+            worker.join(timeout=10)
+
+        assert keeper.is_alive(), "live reader thread died unexpectedly"
+        assert conn in d._read_conns, "live-thread connection was wrongly reaped"
+
+        release.set()
+        keeper.join(timeout=10)
+    finally:
+        d.close()
+
+
+def test_reaping_is_thread_safe_under_concurrency(tmp_path):
+    """Concurrent readers and reaping must not raise."""
+    import time
+
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+        d.append_message("s1", role="user", content="concurrency smoke")
+        errors = []
+
+        def reader():
+            try:
+                for _ in range(20):
+                    d.get_session("s1")
+                    d._get_read_conn()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(8)]
+        for index, thread in enumerate(threads):
+            thread.start()
+            if index % 2:
+                time.sleep(0.001)
+        for thread in threads:
+            thread.join(timeout=20)
+
+        assert not errors, f"concurrent read/reap raised: {errors!r}"
+        assert not any(thread.is_alive() for thread in threads)
+    finally:
+        d.close()
+
+
+def test_close_waits_for_active_read_context(tmp_path, monkeypatch):
+    """Teardown must not close a read connection while its owner is using it."""
+    d = SessionDB(db_path=tmp_path / "state.db")
+    release = threading.Event()
+    reader_done = threading.Event()
+    close_done = threading.Event()
+    victim_closed = threading.Event()
+    entered = threading.Event()
+    errors = []
+    threads = []
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+        holder = {}
+
+        def reader():
+            try:
+                with d._read_ctx() as conn:
+                    assert conn is not None
+                    holder["conn"] = conn
+                    entered.set()
+                    assert release.wait(timeout=10)
+                    assert conn.execute("SELECT 1").fetchone()[0] == 1
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                reader_done.set()
+
+        reader_thread = threading.Thread(target=reader)
+        threads.append(reader_thread)
+        reader_thread.start()
+        assert entered.wait(timeout=10)
+
+        victim = holder["conn"]
+        original_close = type(victim).close
+
+        def observed_close(conn):
+            try:
+                return original_close(conn)
+            finally:
+                if conn is victim:
+                    victim_closed.set()
+
+        monkeypatch.setattr(type(victim), "close", observed_close)
+
+        def closer():
+            try:
+                d.close()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                close_done.set()
+
+        close_thread = threading.Thread(target=closer)
+        threads.append(close_thread)
+        close_thread.start()
+
+        assert not victim_closed.wait(timeout=1), (
+            "close() closed a read connection while its context was still active"
+        )
+        assert not close_done.is_set(), (
+            "close() returned before the active reader drained"
+        )
+
+        release.set()
+        assert reader_done.wait(timeout=10)
+        assert close_done.wait(timeout=10)
+        assert victim_closed.is_set()
+        assert not errors, f"reader/closer race raised: {errors!r}"
+    finally:
+        release.set()
+        for thread in threads:
+            thread.join(timeout=10)
+        d.close()
+
+
+def test_cached_read_connection_is_not_returned_after_close(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session(session_id="s1", source="cli", model="m")
+    _force_read_path(d)
+    assert d._get_read_conn() is not None
+
+    d.close()
+
+    assert d._get_read_conn() is None
+    with pytest.raises(RuntimeError, match="SessionDB is closed"):
+        with d._read_ctx():
+            pass
+    d.close()
+
+
+def test_close_from_active_read_context_fails_without_deadlock(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+
+        with d._read_ctx():
+            with pytest.raises(RuntimeError, match="active read context"):
+                d.close()
+    finally:
+        d.close()
+
+
+def test_failed_reap_remains_tracked_for_retry(tmp_path, monkeypatch):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+        holder = {}
+
+        def worker_open():
+            holder["conn"] = d._get_read_conn()
+
+        worker = threading.Thread(target=worker_open)
+        worker.start()
+        worker.join(timeout=10)
+        assert not worker.is_alive()
+        victim = holder["conn"]
+        assert victim is not None
+        original_close = type(victim).close
+
+        def failing_close(conn):
+            if conn is victim:
+                raise RuntimeError("synthetic close failure")
+            return original_close(conn)
+
+        monkeypatch.setattr(type(victim), "close", failing_close)
+        with d._read_conns_lock:
+            d._reap_dead_read_conns()
+        assert victim in d._read_conns
+
+        monkeypatch.setattr(type(victim), "close", original_close)
+        with d._read_conns_lock:
+            d._reap_dead_read_conns()
+        assert victim not in d._read_conns
+    finally:
+        d.close()
+
+
+def test_read_connection_finishing_open_after_close_is_closed(tmp_path, monkeypatch):
+    import sqlite3 as _sqlite3
+
+    import hermes_state as hs
+
+    d = SessionDB(db_path=tmp_path / "state.db")
+    opened = threading.Event()
+    release = threading.Event()
+    close_started = threading.Event()
+    close_done = threading.Event()
+    holder = {}
+    errors = []
+    worker = None
+    closer = None
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+        real_connect = hs._connect_tracked_db
+
+        def delayed_connect(*args, **kwargs):
+            conn = real_connect(*args, **kwargs)
+            holder["conn"] = conn
+            opened.set()
+            assert release.wait(timeout=10)
+            return conn
+
+        monkeypatch.setattr(hs, "_connect_tracked_db", delayed_connect)
+
+        def open_read_connection():
+            try:
+                holder["result"] = d._get_read_conn()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        worker = threading.Thread(target=open_read_connection)
+        worker.start()
+        assert opened.wait(timeout=10)
+
+        def close_database():
+            close_started.set()
+            try:
+                d.close()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                close_done.set()
+
+        closer = threading.Thread(target=close_database)
+        closer.start()
+        assert close_started.wait(timeout=10)
+        assert not close_done.wait(timeout=1), (
+            "close() returned while a read connection was still opening"
+        )
+
+        release.set()
+        worker.join(timeout=10)
+        closer.join(timeout=10)
+
+        assert not worker.is_alive()
+        assert not closer.is_alive()
+        assert close_done.is_set()
+        assert not errors
+        assert holder["result"] is None
+        assert holder["conn"] not in d._read_conns
+        with pytest.raises(_sqlite3.ProgrammingError):
+            holder["conn"].execute("SELECT 1")
+    finally:
+        release.set()
+        if worker is not None:
+            worker.join(timeout=10)
+        if closer is not None:
+            closer.join(timeout=10)
+        d.close()
+
+
+def test_failed_close_remains_tracked_for_retry(tmp_path, monkeypatch):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+        holder = {}
+
+        def worker_open():
+            holder["conn"] = d._get_read_conn()
+
+        worker = threading.Thread(target=worker_open)
+        worker.start()
+        worker.join(timeout=10)
+        assert not worker.is_alive()
+        victim = holder["conn"]
+        assert victim is not None
+        original_close = type(victim).close
+
+        def failing_close(conn):
+            if conn is victim:
+                raise RuntimeError("synthetic close failure")
+            return original_close(conn)
+
+        monkeypatch.setattr(type(victim), "close", failing_close)
+        d.close()
+        assert victim in d._read_conns
+
+        monkeypatch.setattr(type(victim), "close", original_close)
+        d.close()
+        assert victim not in d._read_conns
+    finally:
+        d.close()


### PR DESCRIPTION
## What
Reap per-thread SQLite read connections after their worker thread exits, while making read-open and teardown races safe.

## Why
`SessionDB` retained every historical worker's read-only connection until gateway shutdown. In a long-lived gateway this grows the open-FD count until EMFILE. Raising the launchd limit only masks the leak.

## Safety
The reaper closes only connections owned by terminated threads. Active read contexts carry leases; shutdown waits for active readers and in-flight opens before closing connections.

## Verification
- `scripts/run_tests.sh tests/test_session_db_read_path_split.py -q` — 13 passed, 5 skipped.
- `ruff check hermes_state.py tests/test_session_db_read_path_split.py` — passed.
- Isolated 40-worker reproduction: retained read connections reduced from 40 to 1; FD growth was 1.
- The five skips are existing WAL-only assertions; the local SQLite 3.50.4 runtime deliberately uses DELETE journal mode because of the WAL-reset bug.

## Scope
No gateway, LaunchAgent, or FD-limit configuration change.

Requested by: @fredcamaral