### PR TITLE
feat(cli): add display.auto_suggest config

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1450,6 +1450,14 @@ display:
   #   false: Hide reasoning (default)
   show_reasoning: false
 
+  # Inline ghost-text auto-suggestions while typing.
+  # When enabled, slash-command completions and history-based suggestions
+  # appear as dim ghost text as you type (press Tab to accept). Set to false
+  # to disable all ghost-text suggestions.
+  #   true:  Show ghost-text suggestions (default)
+  #   false: Disable all inline suggestions
+  auto_suggest: true
+
   # Stream tokens to the terminal as they arrive instead of waiting for the
   # full response. The response box opens on first token and text appears
   # line-by-line. Tool calls are still captured silently.

--- a/cli.py
+++ b/cli.py
@@ -16679,6 +16679,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             command_filter=cli_ref._command_available,
             skill_bundles_provider=lambda: get_skill_bundles(),
         )
+        _auto_suggest = None
+        if CLI_CONFIG["display"].get("auto_suggest", True):
+            _auto_suggest = SlashCommandAutoSuggest(
+                history_suggest=AutoSuggestFromHistory(),
+                completer=_completer,
+            )
         input_area = TextArea(
             height=Dimension(min=1, max=8, preferred=1),
             prompt=get_prompt,
@@ -16695,10 +16701,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # the UI event loop, keeping typing responsive.
             completer=ThreadedCompleter(_completer),
             complete_while_typing=True,
-            auto_suggest=SlashCommandAutoSuggest(
-                history_suggest=AutoSuggestFromHistory(),
-                completer=_completer,
-            ),
+            auto_suggest=_auto_suggest,
         )
         # Keep prompt_toolkit on its simple tempfile path. Setting
         # buffer.tempfile = "prompt.md" triggers its complex-tempfile branch,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1158,6 +1158,7 @@ DEFAULT_CONFIG = {
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
         "bell_on_complete": False,
+        "auto_suggest": True,  # Inline ghost-text suggestions (Tab to accept)
         # Stream the model's reasoning/thinking live before the response.
         # Default ON: on thinking models the reasoning phase can run tens of
         # seconds, and with this off the user stares at a spinner the whole

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -532,5 +532,19 @@ class TestRootLevelProviderOverride:
         assert "model" not in result["model"] and "name" not in result["model"]
 
 
+class TestAutoSuggestConfig:
+    """display.auto_suggest controls ghost-text inline suggestions."""
+
+    def test_auto_suggest_defaults_true(self):
+        """When display.auto_suggest is not set, defaults to True."""
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+        assert DEFAULT_CONFIG["display"]["auto_suggest"] is True
+
+    def test_auto_suggest_false_disables_in_config(self):
+        """display.auto_suggest: false is a valid config value."""
+        config = {"display": {"auto_suggest": False}}
+        assert config["display"]["auto_suggest"] is False
+
+
 
 


### PR DESCRIPTION
# What & why

Adds display.auto_suggest config key (default true). When set to false, 
passes auto_suggest=None to the TUI TextArea, disabling all inline ghost-text 
suggestions — slash-command completions and history-based suggestions alike. 
Tab dropdown completer is unaffected.

# How to test

bash
hermes config set display.auto_suggest false
restart Hermes — ghost-text suggestions are gone
hermes config set display.auto_suggest true
suggestions return

bash
uv run pytest tests/cli/test_cli_init.py::TestAutoSuggestConfig -v
2 passed
uv run pytest tests/cli/test_cli_init.py -q
29 passed (27 existing + 2 new)

# Changes

- cli.py — read config key; pass None as auto_suggest when disabled
- hermes_cli/config_defaults.py — seed default
- cli-config.yaml.example — document key
- tests/cli/test_cli_init.py — verify default and config shape

Closes #83408.