### PR TITLE
fix(yuanbao): anchor the reconnect task and drain background tasks on disconnect

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -5073,6 +5073,24 @@ class YuanbaoAdapter(BasePlatformAdapter):
                 task.cancel()
         self._inbound_tasks.clear()
 
+        # Drain the fire-and-forget tasks registered via _track_task so none of
+        # them outlives teardown.  Their only removal path is the per-task done
+        # callback, so without this they were simply abandoned mid-flight — and
+        # an in-flight reconnect would keep trying to revive an adapter that was
+        # deliberately stopped.  Snapshot first: cancelling mutates the set via
+        # that same callback.  The current task is excluded so a shutdown driven
+        # from inside a tracked task cannot await itself.
+        current = asyncio.current_task()
+        background = [
+            task for task in self._background_tasks
+            if task is not current and not task.done()
+        ]
+        for task in background:
+            task.cancel()
+        if background:
+            await asyncio.gather(*background, return_exceptions=True)
+        self._background_tasks.clear()
+
         self._group_queues.clear()
 
         logger.info("[%s] Disconnected", self.name)

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -5077,12 +5077,14 @@ class YuanbaoAdapter(BasePlatformAdapter):
         # them outlives teardown.  Their only removal path is the per-task done
         # callback, so without this they were simply abandoned mid-flight — and
         # an in-flight reconnect would keep trying to revive an adapter that was
-        # deliberately stopped.  Snapshot first: cancelling mutates the set via
-        # that same callback.  The current task is excluded so a shutdown driven
-        # from inside a tracked task cannot await itself.
+        # deliberately stopped.  The snapshot is taken up front, matching the
+        # _inbound_tasks loop above: those done callbacks mutate
+        # _background_tasks as the cancellations land, and the gather below
+        # suspends while they do.  The current task is excluded so a shutdown
+        # driven from inside a tracked task cannot await itself.
         current = asyncio.current_task()
         background = [
-            task for task in self._background_tasks
+            task for task in list(self._background_tasks)
             if task is not current and not task.done()
         ]
         for task in background:

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -3641,7 +3641,14 @@ class ConnectionManager:
     def schedule_reconnect(self) -> None:
         """Schedule a reconnect only if running and not already reconnecting."""
         if self._adapter._running and not self._reconnecting:
-            asyncio.create_task(self._reconnect_with_backoff())
+            # Anchor the task in the adapter's background set: a bare
+            # asyncio.create_task() keeps only a weak reference, so the loop may
+            # GC the still-pending reconnect mid-flight and the adapter would
+            # then stay offline until the gateway is restarted.
+            self._adapter._track_task(asyncio.create_task(
+                self._reconnect_with_backoff(),
+                name="yuanbao-reconnect",
+            ))
 
     async def _reconnect_with_backoff(self) -> bool:
         """Reconnect with exponential backoff (1s, 2s, 4s, … up to 60s)."""

--- a/tests/test_yuanbao_task_lifecycle.py
+++ b/tests/test_yuanbao_task_lifecycle.py
@@ -1,0 +1,91 @@
+"""test_yuanbao_task_lifecycle.py - Yuanbao background-task lifecycle.
+
+``ConnectionManager.schedule_reconnect`` used a bare ``asyncio.create_task``.
+The event loop keeps only a weak reference to a task nobody else holds, so a
+pending reconnect could be garbage-collected mid-flight — after which the
+adapter never reconnects and the bot is silently offline until the gateway
+restarts. ``YuanbaoAdapter._track_task`` exists for exactly this ("Register a
+fire-and-forget task so it won't be GC'd prematurely") and is already used for
+the inbound pipeline in the same file.
+"""
+
+import sys
+import os
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import pytest
+from gateway.config import PlatformConfig
+from gateway.platforms.yuanbao import YuanbaoAdapter
+
+
+def make_config(**kwargs):
+    extra = kwargs.pop("extra", {})
+    extra.setdefault("app_id", "test_key")
+    extra.setdefault("app_secret", "test_secret")
+    extra.setdefault("ws_url", "wss://test.example.com/ws")
+    extra.setdefault("api_domain", "https://test.example.com")
+    return PlatformConfig(extra=extra, **kwargs)
+
+
+def _adapter() -> YuanbaoAdapter:
+    return YuanbaoAdapter(make_config())
+
+
+# ---------------------------------------------------------------------------
+# schedule_reconnect — the task must be strongly referenced
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_reconnect_anchors_task_against_gc():
+    """The pending reconnect must be reachable from _background_tasks."""
+    adapter = _adapter()
+    adapter._running = True
+    cm = adapter._connection
+
+    with patch.object(cm, "_reconnect_with_backoff", new_callable=AsyncMock, return_value=True):
+        cm.schedule_reconnect()
+
+        anchored = [t for t in adapter._background_tasks if t.get_name() == "yuanbao-reconnect"]
+        assert len(anchored) == 1, (
+            "reconnect task is not strongly referenced — the loop may GC it mid-flight"
+        )
+
+        await asyncio.gather(*anchored)
+
+    # _track_task's done callback releases the reference once it completes.
+    assert adapter._background_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_schedule_reconnect_is_a_noop_when_adapter_stopped():
+    """Anchoring must not weaken the existing _running guard."""
+    adapter = _adapter()
+    adapter._running = False
+    cm = adapter._connection
+
+    with patch.object(cm, "_reconnect_with_backoff", new_callable=AsyncMock) as reconnect:
+        cm.schedule_reconnect()
+
+    assert adapter._background_tasks == set()
+    reconnect.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_reconnect_is_a_noop_while_already_reconnecting():
+    """Anchoring must not weaken the existing _reconnecting guard."""
+    adapter = _adapter()
+    adapter._running = True
+    cm = adapter._connection
+    cm._reconnecting = True
+
+    with patch.object(cm, "_reconnect_with_backoff", new_callable=AsyncMock) as reconnect:
+        cm.schedule_reconnect()
+
+    assert adapter._background_tasks == set()
+    reconnect.assert_not_called()

--- a/tests/test_yuanbao_task_lifecycle.py
+++ b/tests/test_yuanbao_task_lifecycle.py
@@ -1,12 +1,23 @@
 """test_yuanbao_task_lifecycle.py - Yuanbao background-task lifecycle.
 
-``ConnectionManager.schedule_reconnect`` used a bare ``asyncio.create_task``.
-The event loop keeps only a weak reference to a task nobody else holds, so a
-pending reconnect could be garbage-collected mid-flight — after which the
-adapter never reconnects and the bot is silently offline until the gateway
-restarts. ``YuanbaoAdapter._track_task`` exists for exactly this ("Register a
-fire-and-forget task so it won't be GC'd prematurely") and is already used for
-the inbound pipeline in the same file.
+Two related defects in the fire-and-forget task lifecycle of the Yuanbao
+adapter, both of which leave a task unowned at a lifecycle boundary:
+
+* ``ConnectionManager.schedule_reconnect`` used a bare ``asyncio.create_task``.
+  The event loop keeps only a weak reference to such a task, so a pending
+  reconnect could be garbage-collected mid-flight — after which the adapter
+  never reconnects and the bot is silently offline until the gateway restarts.
+  ``YuanbaoAdapter._track_task`` exists for exactly this ("Register a
+  fire-and-forget task so it won't be GC'd prematurely") and is already used
+  for the inbound pipeline in the same file.
+
+* ``YuanbaoAdapter.disconnect`` is documented as "Cancel background tasks and
+  close the WebSocket connection", but only ever cancelled ``_inbound_tasks``.
+  Everything registered through ``_track_task`` — the inbound pipeline, the
+  recall-redaction job, and now the reconnect — landed in ``_background_tasks``,
+  whose only removal path is the per-task done callback. Those tasks were
+  therefore abandoned mid-flight at teardown, and an in-flight reconnect could
+  outlive ``disconnect()`` and revive a deliberately stopped adapter.
 """
 
 import sys
@@ -33,7 +44,11 @@ def make_config(**kwargs):
 
 
 def _adapter() -> YuanbaoAdapter:
-    return YuanbaoAdapter(make_config())
+    """A real adapter with the status-writing teardown hooks neutralised."""
+    adapter = YuanbaoAdapter(make_config())
+    adapter._mark_disconnected = lambda: None
+    adapter._release_platform_lock = lambda: None
+    return adapter
 
 
 # ---------------------------------------------------------------------------
@@ -89,3 +104,113 @@ async def test_schedule_reconnect_is_a_noop_while_already_reconnecting():
 
     assert adapter._background_tasks == set()
     reconnect.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# disconnect — background tasks must be drained, not abandoned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disconnect_drains_in_flight_background_tasks():
+    """disconnect() must cancel AND await every _track_task job."""
+    adapter = _adapter()
+    started = asyncio.Event()
+    unwound = asyncio.Event()
+
+    async def _long_running():
+        started.set()
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            unwound.set()
+            raise
+
+    task = adapter._track_task(
+        asyncio.create_task(_long_running(), name="yuanbao-test-background")
+    )
+    await started.wait()
+
+    await adapter.disconnect()
+
+    assert task.done(), "background task was abandoned by teardown"
+    assert task.cancelled()
+    # The await is the point: without it disconnect() returns before the task
+    # has had a chance to unwind, so cleanup in its except/finally never runs.
+    assert unwound.is_set(), "disconnect() returned before the task unwound"
+    assert adapter._background_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_still_cancels_inbound_tasks():
+    """The pre-existing _inbound_tasks teardown must be unaffected."""
+    adapter = _adapter()
+    started = asyncio.Event()
+
+    async def _inbound():
+        started.set()
+        await asyncio.sleep(3600)
+
+    task = asyncio.create_task(_inbound(), name="yuanbao-test-inbound")
+    adapter._inbound_tasks.add(task)
+    task.add_done_callback(adapter._inbound_tasks.discard)
+    await started.wait()
+
+    await adapter.disconnect()
+
+    assert adapter._inbound_tasks == set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_disconnect_survives_a_background_task_that_raises():
+    """One misbehaving task must not abort teardown of the others."""
+    adapter = _adapter()
+    running = asyncio.Event()
+    other_unwound = asyncio.Event()
+
+    async def _raises_on_cancel():
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            raise RuntimeError("cleanup blew up")
+
+    async def _well_behaved():
+        # Scheduled after _raises_on_cancel, so both are in flight once this
+        # event is set.
+        running.set()
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            other_unwound.set()
+            raise
+
+    bad = adapter._track_task(asyncio.create_task(_raises_on_cancel(), name="yuanbao-test-bad"))
+    good = adapter._track_task(asyncio.create_task(_well_behaved(), name="yuanbao-test-good"))
+    await running.wait()
+
+    await adapter.disconnect()
+
+    assert bad.done() and good.done()
+    assert other_unwound.is_set()
+    assert adapter._background_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_from_inside_a_tracked_task_does_not_await_itself():
+    """A shutdown driven from a tracked task must not deadlock on itself."""
+    adapter = _adapter()
+    finished = asyncio.Event()
+
+    async def _self_shutdown():
+        await adapter.disconnect()
+        finished.set()
+
+    task = adapter._track_task(
+        asyncio.create_task(_self_shutdown(), name="yuanbao-test-self-shutdown")
+    )
+
+    await asyncio.wait_for(task, timeout=5)
+
+    assert finished.is_set()


### PR DESCRIPTION
## What does this PR do?

Fixes two defects in the Yuanbao adapter's fire-and-forget task lifecycle. Both leave a task unowned at a lifecycle boundary, and the second one is created by fixing the first — which is why they belong in one PR.

**Symptom: the bot goes silently offline and never comes back.** `ConnectionManager.schedule_reconnect` launched the backoff loop with a bare `asyncio.create_task(...)` and dropped the handle:

```python
def schedule_reconnect(self) -> None:
    """Schedule a reconnect only if running and not already reconnecting."""
    if self._adapter._running and not self._reconnecting:
        asyncio.create_task(self._reconnect_with_backoff())
```

The event loop keeps only a weak reference to a task nobody else holds, so the still-pending reconnect can be garbage-collected mid-flight. When that happens there is no retry left to fire — the retry *was* the task that vanished — and the adapter stays down until the gateway is restarted. `_reconnect_with_backoff` sleeps up to 60s between attempts, so the window in which the task is pending and unreferenced is a long one.

This is the repo's own stated invariant, in two places:

- `gateway/platforms/yuanbao.py` — `_track_task`'s docstring: *"Register a fire-and-forget task so it won't be GC'd prematurely."*
- `gateway/run.py` — *"a bare `asyncio.create_task()` keeps only a weak reference, so the event loop may garbage-collect a still-pending task mid-flight."*

And the correct idiom is already used in this same file, 40 lines above at the `_flush_inbound_buffer` dispatch:

```python
adapter._track_task(asyncio.create_task(
    adapter._inbound_pipeline.execute(ctx),
    name=f"yuanbao-pipeline-{key}",
))
```

**The second half — teardown.** `YuanbaoAdapter.disconnect()` is documented as *"Cancel background tasks and close the WebSocket connection"*, but it only ever cancelled `_inbound_tasks`. Everything registered through `_track_task` lands in `_background_tasks`, and that set had no teardown path at all — its only removal path is the per-task done callback. So the inbound pipeline and the recall-redaction job were abandoned mid-flight at shutdown, with their `except`/`finally` cleanup never running.

That also closes the ordering hole the first fix would otherwise open: once the reconnect is anchored into `_background_tasks`, an in-flight one could outlive `disconnect()` and go on trying to revive an adapter that was deliberately stopped. `disconnect()` clears `_running` early, so the `schedule_reconnect` guard covers *new* schedules — it does nothing for a reconnect already past that check. Fixing the GC bug alone would trade it for a shutdown-ordering bug.

Cancel-then-gather mirrors `ConnectionManager.close()`, which already cancels and awaits `_heartbeat_task` / `_recv_task`. Three details worth calling out:

- the set is snapshotted before cancelling, because cancelling mutates it through that same done callback;
- `return_exceptions=True` stops one task raising from its cleanup path from aborting teardown for the rest;
- `asyncio.current_task()` is excluded, so a shutdown driven from inside a tracked task cannot await itself.

`_inbound_tasks` handling is left byte-identical.

### Sibling-site sweep

Every task-creation site in `gateway/platforms/yuanbao.py` was enumerated (`create_task` / `_track_task` / `_background_tasks`), and `schedule_reconnect` is the only one missing a strong reference. The rest are already anchored and are deliberately untouched:

| Site | Owner | Verdict |
|---|---|---|
| `:1160`, `:1825`, `:3602` | added to `_background_tasks` / `_track_task` | already anchored |
| `:3002`, `:3009` | added to `_inbound_tasks` | already anchored |
| `:3212`, `:3215`, `:3701`, `:3708` | assigned to `_heartbeat_task` / `_recv_task` | attribute = strong ref |
| `:4225`, `:4305` | stored in `_reply_heartbeat_tasks[chat_id]` / `_tasks[chat_id]` | dict = strong ref |
| `:3644` `schedule_reconnect` | **nothing** | **the defect** |

The same construct appears in other platform adapters (`weixin.py`, `qqbot/adapter.py`, `bluebubbles.py`) and in `gateway/run.py`. Those are deliberately out of scope here — each already has an open PR against it (`#65966`/`#26049` for weixin, `#38848`/`#74775` for qqbot, `#18395` for bluebubbles, `#45372` for run.py), and this PR stays inside one file and one adapter's lifecycle.

### Duplicate check

Searched open PRs for `schedule_reconnect`, `yuanbao reconnect`, `yuanbao disconnect`, `yuanbao background tasks`, `yuanbao GC task`, and `_track_task`: no open PR touches Yuanbao's reconnect or disconnect path. The `_track_task` / `_background_tasks` matches are all other files — `weixin.py` (#65966, #26049), `qqbot/adapter.py` (#41298), `gateway/run.py` (#17966, #6790, #45372), `gateway/platforms/base.py` (#29216, #43903) — verified by reading each one's changed-file list. The nearest open PRs that do touch `gateway/platforms/yuanbao.py` sit in unrelated regions (#74860 around `_sender_may_designate_home`, #65112, #29077, #62031, #78166, #55782), none within `schedule_reconnect` or `disconnect()`.

## Related Issue

No filed issue — found by auditing task lifecycle at shutdown/reconnect boundaries in `gateway/platforms/yuanbao.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/yuanbao.py` — `ConnectionManager.schedule_reconnect` routes its task through `self._adapter._track_task(...)` and names it `yuanbao-reconnect`. The `_running` / `_reconnecting` guards are unchanged; only ownership of the reference changes.
- `gateway/platforms/yuanbao.py` — `YuanbaoAdapter.disconnect` cancels and awaits the tasks in `_background_tasks` alongside the existing `_inbound_tasks` cancellation, then clears the set.
- `tests/test_yuanbao_task_lifecycle.py` — new; 7 regression tests.

## How to Test

1. Run the new tests: `pytest tests/test_yuanbao_task_lifecycle.py -q` → 7 passed.
2. Confirm they actually pin the fix. Revert only the `schedule_reconnect` hunk to its previous form and re-run: `test_schedule_reconnect_anchors_task_against_gc` fails with `assert 0 == 1` — the task is not in `_background_tasks`. Nothing else fails.
3. Revert only the `disconnect()` hunk and re-run: `test_disconnect_drains_in_flight_background_tasks` and `test_disconnect_survives_a_background_task_that_raises` fail, and pytest additionally logs `unhandled exception during asyncio.run() shutdown` for the abandoned task. Nothing else fails.
4. Adjacent suites, all green: `pytest tests/test_yuanbao_task_lifecycle.py tests/test_yuanbao_shutdown.py tests/test_yuanbao_reconnect_set_active.py tests/test_yuanbao_pipeline.py tests/test_yuanbao_integration.py tests/test_yuanbao_proto.py tests/test_yuanbao_markdown.py tests/gateway/test_yuanbao_forwarded_heartbeat.py tests/gateway/test_yuanbao_media_ssrf.py tests/gateway/platforms/test_yuanbao_recall_db_only.py tests/gateway/platforms/test_yuanbao_state_cleanup.py -q` → 147 passed.

Each of the four commits was also checked out on its own and its touched suite run, so the history bisects cleanly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the full Yuanbao surface plus the reconnect/shutdown suites (147 tests, listed above), not the whole repo suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (`disconnect()`'s existing docstring already described the behaviour this PR makes true)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure asyncio task bookkeeping, no platform-specific behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
