### PR TITLE
fix(desktop): use available width for chat

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -451,7 +451,7 @@
     --sticky-human-top: 0.23rem;
     --file-tree-row-height: 1.375rem;
 
-    --composer-width: 48.75rem;
+    --composer-width: 100%;
     --composer-control-size: 1.5rem;
     --composer-control-primary-size: 1.625rem;
     --composer-control-gap: 0.25rem;


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

This causes the chat window in the desktop app to use the full available page width, for both the response and chat input boxes. 

This fixes overly narrow UI styling, making full use of available screen space and makes reading long responses much easier. 

I considered whether this needs a toggle button between old/new behaviour in the appearance settings, but I can't think of a use case where you wouldn't want the UI to fill the available width.

## Related Issue

Partially addresses:
#38969 
#75270

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

A one line CSS change. Changed CSS variable `--composer-width` from fixed `48.75rem` to `100%`.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Launch Hermes Windows Desktop app.
2. Open an existing chat, or start a new one and get a response from a model.
3. Observe the wider UI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [N/A] I've run `pytest tests/ -q` and all tests pass
- [N/A] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Old:

<img width="2559" height="1389" alt="1" src="https://github.com/user-attachments/assets/4c5566d0-31f6-4b1c-9e21-5c44e567380c" />

New:

<img width="2556" height="1387" alt="2" src="https://github.com/user-attachments/assets/6105d376-e371-4990-9502-2ea261a7ead6" />
