### PR TITLE
feat(skills): decorrelated review lenses for the kanban review lifecycle

### DIFF
--- a/skills/devops/sdlc-review/SKILL.md
+++ b/skills/devops/sdlc-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sdlc-review
 description: Review Kanban handoffs and route verified outcomes.
-version: 1.0.0
+version: 1.1.0
 author: Jakub Wolniewicz (@frizikk) + Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -53,6 +53,24 @@ This skill is loaded automatically by the review dispatcher. Start with `kanban_
 | Escalate | A human decision or external prerequisite is required | `kanban_block` |
 
 A requested-changes transition returns the task to its original implementer. When that implementer requests review again without naming a reviewer, the persisted reviewer provenance routes the re-review back to the same reviewer profile.
+
+## Review Lenses
+
+Vary how you look at the work on each round instead of repeating the same inspection. Decorrelated lenses catch different defect classes: a cold read of the artifact surfaces design and correctness problems that the implementer's narrative would have framed away, execution surfaces claims that do not reproduce, and a strict contract audit surfaces quiet scope drift. Repeating the round-1 lens on round 3 mostly re-finds what round 1 already found.
+
+Determine the current round from the history the task record already gives you: count the `changes_requested` entries in the "Prior attempts on this task" section of your worker context (also visible as prior runs in `kanban_show`). The current review round is that count plus one. Round 1 therefore shows zero `changes_requested` attempts; round 2 shows one; and so on.
+
+| Round | Lens | How to apply it |
+|---|---|---|
+| 1 | Artifact | Read the diff or deliverable cold, before the implementer's summary. Form an independent judgment, then compare it against the handoff narrative and investigate every mismatch. |
+| 2 | Execution | Check out the work and actually run it via `terminal`: build, test, and exercise the reported behavior yourself. Verify each handoff claim empirically instead of re-reading the artifact. |
+| 3+ | Contract | Re-read the ORIGINAL task body and acceptance criteria, then audit the deliverable strictly against them. Also verify that every item from every prior `kanban_request_changes` round actually landed. |
+
+The baseline duties in the Procedure section still apply on every round; the lens sets which inspection you lead with and weight most heavily.
+
+### Lens variation for ad-hoc review fan-outs
+
+The same principle applies outside the Kanban review lane. When spawning multiple parallel reviewers via `delegate_task`, give each reviewer a different lens — one diff-only brief, one full-context brief, one checkout-and-run brief — rather than identical briefs. Identical briefs produce correlated verdicts and duplicate findings; varied briefs cover more defect classes for the same review spend.
 
 ## Procedure
 

--- a/tests/skills/test_sdlc_review_skill.py
+++ b/tests/skills/test_sdlc_review_skill.py
@@ -19,6 +19,7 @@ REQUIRED_SECTIONS = [
     "## Prerequisites",
     "## How to Run",
     "## Quick Reference",
+    "## Review Lenses",
     "## Procedure",
     "## Pitfalls",
     "## Verification",
@@ -72,9 +73,23 @@ def test_skill_documents_native_review_actions(
 
 def test_verdicts_route_through_distinct_terminal_actions(skill_text: str) -> None:
     quick_reference = skill_text.split("## Quick Reference", 1)[1].split(
-        "## Procedure", 1
+        "## Review Lenses", 1
     )[0]
     assert "Approve" in quick_reference and "`kanban_complete`" in quick_reference
     assert "Request changes" in quick_reference
     assert "`kanban_request_changes`" in quick_reference
     assert "Escalate" in quick_reference and "`kanban_block`" in quick_reference
+
+
+def test_review_lenses_vary_per_round(skill_text: str) -> None:
+    lenses = skill_text.split("## Review Lenses", 1)[1].split("## Procedure", 1)[0]
+    # Round derivation must key off history the reviewer actually sees.
+    assert "`changes_requested`" in lenses
+    assert "Prior attempts on this task" in lenses
+    # One distinct lens per round.
+    for lens in ("Artifact", "Execution", "Contract"):
+        assert lens in lenses
+    # Execution lens must direct empirical verification via the terminal.
+    assert "`terminal`" in lenses
+    # Fan-out note: parallel reviewers get different briefs.
+    assert "`delegate_task`" in lenses


### PR DESCRIPTION
## Summary

Reviewers using the new kanban review lifecycle now vary their review lens per round instead of re-applying the same one: round 1 reads the artifact cold, round 2 executes the work via `terminal`, round 3+ audits strictly against the original acceptance criteria and prior change requests. Decorrelated lenses catch different defect classes; the same lens on round 3 re-finds the same things.

## Changes

- `skills/devops/sdlc-review/SKILL.md`: new "Review lenses" section (round keyed off the count of `changes_requested` prior attempts visible in the reviewer's own context — verified as the signal reviewers actually receive), plus a lens-variation note for parallel ad-hoc review fan-outs via `delegate_task`
- `tests/skills/test_sdlc_review_skill.py`: contract test updated for the new section

## Validation

Live-tested on an isolated board through two real review rounds (`request_review` → `claim_review_task` → `request_changes` → re-request): round 1 reviewer context contained zero `changes_requested` entries, round 2 exactly one — confirming the skill's round-derivation instruction is executable as written from what the reviewer literally sees. Contract tests green.

## Infographic

![Review lenses](https://v3b.fal.media/files/b/0aa5d138/G1w_oW_5LxK1ge4c-Y2V__VZwmF06q.png)
