### PR TITLE
fix(web): navigate to chat when picking conversation from non-chat routes (#83405)

### DIFF
--- a/web/src/components/ChatSessionList.test.tsx
+++ b/web/src/components/ChatSessionList.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChatSessionList } from "./ChatSessionList";
+
+const getSessionsMock = vi.fn(async () => ({
+  sessions: [
+    {
+      id: "session-1",
+      title: "First conversation",
+      last_active: "2026-08-10T12:00:00Z",
+      message_count: 5,
+    },
+    {
+      id: "session-2",
+      title: "Second conversation",
+      last_active: "2026-08-10T13:00:00Z",
+      message_count: 10,
+    },
+  ],
+  total: 2,
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getSessions: (...args: unknown[]) => getSessionsMock(...args),
+  },
+}));
+
+vi.mock("@/i18n", () => ({
+  useI18n: () => ({
+    t: {
+      common: { loading: "Loading...", retry: "Retry", refresh: "Refresh" },
+      sessions: {
+        title: "Sessions",
+        newChat: "New Chat",
+        noSessions: "No sessions",
+        untitledSession: "Untitled",
+      },
+    },
+  }),
+}));
+
+function LocationSpy({ onLocation }: { onLocation: (loc: { pathname: string; search: string }) => void }) {
+  const location = useLocation();
+  onLocation(location);
+  return null;
+}
+
+describe("ChatSessionList navigation", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    getSessionsMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (root && container) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    container?.remove();
+    container = null;
+    root = null;
+  });
+
+  it("navigates to /chat?resume=<id> when clicking a session from a settings/capabilities route", async () => {
+    let currentLocation = { pathname: "/models", search: "" };
+
+    await act(async () => {
+      root?.render(
+        <MemoryRouter initialEntries={["/models"]}>
+          <LocationSpy onLocation={(loc) => { currentLocation = loc; }} />
+          <Routes>
+            <Route
+              path="/models"
+              element={<ChatSessionList activeSessionId="session-1" />}
+            />
+            <Route
+              path="/chat"
+              element={<ChatSessionList activeSessionId="session-1" />}
+            />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    // Wait for session list to render
+    const listItems = container?.querySelectorAll("button") || [];
+    expect(listItems.length).toBeGreaterThan(0);
+
+    // Click session-1 (which is activeSessionId) while on /models
+    const sessionText = Array.from(container?.querySelectorAll("span") || []).find(
+      (el) => el.textContent?.trim() === "First conversation",
+    );
+    expect(sessionText).toBeTruthy();
+
+    await act(async () => {
+      (sessionText as HTMLElement).click();
+    });
+
+    expect(currentLocation.pathname).toBe("/chat");
+    expect(currentLocation.search).toBe("?resume=session-1");
+  });
+
+  it("does not trigger navigation when re-clicking active session while already on /chat", async () => {
+    let currentLocation = { pathname: "/chat", search: "?resume=session-1" };
+
+    await act(async () => {
+      root?.render(
+        <MemoryRouter initialEntries={["/chat?resume=session-1"]}>
+          <LocationSpy onLocation={(loc) => { currentLocation = loc; }} />
+          <Routes>
+            <Route
+              path="/chat"
+              element={<ChatSessionList activeSessionId="session-1" />}
+            />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const sessionText = Array.from(container?.querySelectorAll("span") || []).find(
+      (el) => el.textContent?.trim() === "First conversation",
+    );
+    expect(sessionText).toBeTruthy();
+
+    // Click session-1 while already on /chat?resume=session-1
+    await act(async () => {
+      (sessionText as HTMLElement).click();
+    });
+
+    // Remains unchanged
+    expect(currentLocation.pathname).toBe("/chat");
+    expect(currentLocation.search).toBe("?resume=session-1");
+  });
+
+  it("navigates to /chat when clicking New Chat from a non-chat route", async () => {
+    let currentLocation = { pathname: "/models", search: "" };
+
+    await act(async () => {
+      root?.render(
+        <MemoryRouter initialEntries={["/models"]}>
+          <LocationSpy onLocation={(loc) => { currentLocation = loc; }} />
+          <Routes>
+            <Route
+              path="/models"
+              element={<ChatSessionList activeSessionId="session-1" />}
+            />
+            <Route
+              path="/chat"
+              element={<div>Chat Page</div>}
+            />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const buttons = container?.querySelectorAll("button") || [];
+    const newChatBtn = Array.from(buttons).find((b) => b.textContent?.includes("New Chat"));
+    expect(newChatBtn).toBeTruthy();
+
+    await act(async () => {
+      (newChatBtn as HTMLElement).click();
+    });
+
+    expect(currentLocation.pathname).toBe("/chat");
+    expect(currentLocation.search).toBe("");
+  });
+});

--- a/web/src/components/ChatSessionList.tsx
+++ b/web/src/components/ChatSessionList.tsx
@@ -23,7 +23,7 @@ import { ListItem } from "@nous-research/ui/ui/components/list-item";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { AlertCircle, MessageSquarePlus, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams } from "react-router";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import { useI18n } from "@/i18n";
 import { api, type SessionInfo } from "@/lib/api";
@@ -64,6 +64,8 @@ export function ChatSessionList({
 }: ChatSessionListProps) {
   const { t } = useI18n();
   const [, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [sessions, setSessions] = useState<SessionInfo[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -110,44 +112,33 @@ export function ChatSessionList({
 
   const reload = useCallback(() => setReloadNonce((n) => n + 1), []);
 
-  // Picking a row sets `/chat?resume=<id>`. Re-picking the row already in
-  // the terminal is a no-op (avoids a needless PTY teardown).
+  // Picking a row navigates to `/chat?resume=<id>`. Re-picking the row already
+  // in the terminal while on the chat page is a no-op (avoids a needless PTY
+  // teardown). When picked from another page (e.g. settings/capabilities),
+  // always navigate to `/chat?resume=<id>`.
   const pick = useCallback(
     (id: string) => {
       onPicked?.();
-      if (id === activeSessionId) return;
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          next.set("resume", id);
-          return next;
-        },
-        { replace: false },
-      );
+      const isOnChat = location.pathname === "/chat";
+      if (isOnChat && id === activeSessionId) return;
+      navigate(`/chat?resume=${encodeURIComponent(id)}`);
     },
-    [activeSessionId, onPicked, setSearchParams],
+    [activeSessionId, location.pathname, navigate, onPicked],
   );
 
   // "New chat" prefers ChatPage's robust handler (clears resume + forces a
-  // PTY respawn even from an already-fresh session). Fallback: clear the
-  // resume param ourselves, which spawns a fresh PTY whenever one was being
-  // resumed. Session management (delete/rename/export) lives on the Sessions
-  // page; this panel only switches and starts conversations.
+  // PTY respawn even from an already-fresh session). Fallback: navigate to
+  // `/chat` without a resume param, which spawns a fresh PTY. Session
+  // management (delete/rename/export) lives on the Sessions page; this panel
+  // only switches and starts conversations.
   const startNew = useCallback(() => {
     onPicked?.();
     if (onNewChat) {
       onNewChat();
       return;
     }
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        next.delete("resume");
-        return next;
-      },
-      { replace: false },
-    );
-  }, [onNewChat, onPicked, setSearchParams]);
+    navigate("/chat");
+  }, [navigate, onNewChat, onPicked]);
 
   const content = useMemo(() => {
     if (loading && sessions === null) {


### PR DESCRIPTION
### Summary of Changes
Fixes [#83405](https://github.com/NousResearch/Hermes-Agent/issues/83405) where clicking a conversation item in the `ChatSessionList` sidebar while viewing settings or capabilities pages (e.g., `/models`, `/config`, `/skills`, or `/mcp`) failed to open the conversation.

### Root Cause
`ChatSessionList` previously mutated current route query parameters via `useSearchParams()`. When clicked from a settings or capabilities page (like `/models`), `setSearchParams` updated search parameters on the current location (`/models?resume=<id>`), leaving the user stuck on the settings page. Additionally, `if (id === activeSessionId) return;` prevented returning to the active session when navigating from non-chat routes.

### Solution
1. Updated `ChatSessionList` to use `useNavigate` and `useLocation` from `react-router`.
2. When picking a conversation, check if `location.pathname === "/chat"`. If on a non-chat route, navigate to `/chat?resume=${encodeURIComponent(id)}`.
3. Added unit tests in `ChatSessionList.test.tsx` verifying navigation behavior across routes.

### Verification
- Executed `npm --workspace web run test`.
- All 28 test files and 194 tests passed.
