### PR TITLE
fix(google-chat): keep top-level space messages in one session

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1889,9 +1889,10 @@ class GoogleChatAdapter(BasePlatformAdapter):
         #   message). Isolate session by chat_id+thread_id, AND keep
         #   the bot's reply inside that thread.
         #
-        # For groups, threads ARE meaningful conversational containers
-        # (Telegram forum / Discord thread parity); always isolate AND
-        # always reply in-thread.
+        # Google Chat spaces are inline-threaded: the API assigns a fresh
+        # thread to every top-level message. Treat the first message in a
+        # thread as part of the space-level conversation, while a thread
+        # that already has a message remains an intentional side-thread.
         if chat_type == "dm":
             is_side_thread = prev_thread_count > 0
             session_thread_id = thread_name if is_side_thread else None
@@ -1903,10 +1904,12 @@ class GoogleChatAdapter(BasePlatformAdapter):
             elif space_name:
                 self._last_inbound_thread.pop(space_name, None)
         else:
-            session_thread_id = thread_name
-            # Groups always reply in-thread.
-            if thread_name and space_name:
+            is_side_thread = prev_thread_count > 0
+            session_thread_id = thread_name if is_side_thread else None
+            if thread_name and space_name and is_side_thread:
                 self._last_inbound_thread[space_name] = thread_name
+            elif space_name:
+                self._last_inbound_thread.pop(space_name, None)
 
         source = self.build_source(
             chat_id=space_name,

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -655,18 +655,41 @@ class TestBuildMessageEvent:
 
 
     @pytest.mark.asyncio
-    async def test_group_keeps_thread_id_on_source(self, adapter):
-        """In group spaces, threads are real conversational containers —
-        keep thread_id on the source from the FIRST message so different
-        threads get isolated sessions (Telegram forum / Discord thread
-        parity)."""
+    async def test_group_first_message_uses_main_session(self, adapter):
+        """A top-level space message uses the space-level session key."""
         env = _make_chat_envelope(text="ping", thread_name="spaces/G/threads/T1")
         env["chat"]["messagePayload"]["space"]["spaceType"] = "SPACE"
         env["chat"]["messagePayload"]["message"]["space"]["spaceType"] = "SPACE"
+        env["chat"]["messagePayload"]["space"]["name"] = "spaces/G"
+        env["chat"]["messagePayload"]["message"]["space"]["name"] = "spaces/G"
         msg = env["chat"]["messagePayload"]["message"]
         event = await adapter._build_message_event(msg, env)
         assert event.source.chat_type == "group"
-        assert event.source.thread_id == "spaces/G/threads/T1"
+        assert event.source.thread_id is None
+        assert "spaces/G" not in adapter._last_inbound_thread
+
+    @pytest.mark.asyncio
+    async def test_group_second_message_in_same_thread_is_side_thread(self, adapter):
+        """A deliberate reply in an existing thread remains isolated."""
+        env1 = _make_chat_envelope(text="first", thread_name="spaces/G/threads/T1")
+        env1["chat"]["messagePayload"]["space"]["spaceType"] = "SPACE"
+        env1["chat"]["messagePayload"]["message"]["space"]["spaceType"] = "SPACE"
+        env1["chat"]["messagePayload"]["space"]["name"] = "spaces/G"
+        env1["chat"]["messagePayload"]["message"]["space"]["name"] = "spaces/G"
+        await adapter._build_message_event(
+            env1["chat"]["messagePayload"]["message"], env1
+        )
+
+        env2 = _make_chat_envelope(text="reply", thread_name="spaces/G/threads/T1")
+        env2["chat"]["messagePayload"]["space"]["spaceType"] = "SPACE"
+        env2["chat"]["messagePayload"]["message"]["space"]["spaceType"] = "SPACE"
+        env2["chat"]["messagePayload"]["space"]["name"] = "spaces/G"
+        env2["chat"]["messagePayload"]["message"]["space"]["name"] = "spaces/G"
+        event2 = await adapter._build_message_event(
+            env2["chat"]["messagePayload"]["message"], env2
+        )
+        assert event2.source.thread_id == "spaces/G/threads/T1"
+        assert adapter._last_inbound_thread["spaces/G"] == "spaces/G/threads/T1"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Closes #83353.

Google Chat spaces assign a fresh thread resource to every top-level message. The adapter now treats the first message in a thread as the space-level conversation while preserving thread-scoped sessions for deliberate replies.

## Validation

- uv run --extra dev pytest tests/gateway/test_google_chat.py -q (64 passed; one pre-existing coroutine warning)
- uv run --extra dev ruff check plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py
- git diff --check