### PR TITLE
feat: support editable platform messages

### DIFF
--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -179,6 +179,25 @@ class PlatformEntry:
     # targets when the gateway is not co-resident with the cron process.
     standalone_sender_fn: Optional[Callable[..., Awaitable[dict]]] = None
 
+    # ── Standalone (out-of-process) editing ──
+    # Optional: async coroutine that edits a previously sent message without
+    # a live gateway adapter.  Called by
+    # ``tools/send_message_tool._edit_via_platform`` when no in-process
+    # adapter is available (standalone CLI, cron, or any external caller
+    # that only has bot-token credentials).
+    #
+    # Signature:
+    #     async (pconfig, chat_id, message_id, message, *, thread_id=None) -> dict
+    #
+    # Returns ``{"success": True, "message_id": ...}`` on success or
+    # ``{"error": str}`` on failure.  There is no generic fallback to
+    # "send a new message" when this hook is absent or fails — editing must
+    # fail closed so callers never mistake a fresh duplicate message for an
+    # in-place update.  Plugin authors implement this the same way as
+    # ``standalone_sender_fn``: open an ephemeral connection, edit, and
+    # (if applicable) close.
+    standalone_editor_fn: Optional[Callable[..., Awaitable[dict]]] = None
+
 
 class PlatformRegistry:
     """Central registry of platform adapters.

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -333,6 +333,11 @@ def cmd_send(args: argparse.Namespace) -> None:
     # the channel directory) can see platform credentials and home channels.
     _load_hermes_env()
 
+    # --edit short-circuits the usual "no message" checks below only in that
+    # it changes which tool action is invoked; target/message resolution is
+    # otherwise identical to a normal send.
+    edit_message_id = getattr(args, "edit", None)
+
     # --list short-circuits everything else.
     if getattr(args, "list_targets", False):
         # When `--list telegram` is used, argparse stores "telegram" in the
@@ -348,7 +353,8 @@ def cmd_send(args: argparse.Namespace) -> None:
             "Examples:\n"
             "  hermes send --to telegram \"hello\"\n"
             "  hermes send --to discord:#ops --file report.md\n"
-            "  hermes send --list      # list available targets",
+            "  hermes send --list      # list available targets\n"
+            "  hermes send --to telegram:-1001234567890 --edit 42 \"updated text\"",
             file=sys.stderr,
         )
         sys.exit(_USAGE_EXIT)
@@ -380,11 +386,23 @@ def cmd_send(args: argparse.Namespace) -> None:
     # Signal/SMS/WhatsApp; live-adapter path for plugin platforms).
     #
     # It expects the standard tool-call dict and returns a JSON string.
-    tool_args = {
-        "action": "send",
-        "target": target,
-        "message": message,
-    }
+    # action='edit' is intentionally not part of the model-facing tool
+    # schema (SEND_MESSAGE_SCHEMA) — this CLI calls send_message_tool()
+    # directly with a raw dict, bypassing the schema entirely, so the
+    # dispatcher's support for 'edit' doesn't expand what the model can do.
+    if edit_message_id:
+        tool_args = {
+            "action": "edit",
+            "target": target,
+            "message_id": edit_message_id,
+            "message": message,
+        }
+    else:
+        tool_args = {
+            "action": "send",
+            "target": target,
+            "message": message,
+        }
 
     result = send_message_tool(tool_args)
     exit_code = _emit_result(
@@ -421,6 +439,8 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
             "  hermes send --to telegram \"MEDIA:/tmp/chart.png\"   # send a media attachment\n"
             "  hermes send --list                  # all platforms\n"
             "  hermes send --list telegram         # filter by platform\n"
+            "  hermes send --to telegram:-1001234567890 --edit 42 \"updated text\"\n"
+            "  hermes send --to telegram:-100123 --edit 42 --json --file report.md\n"
             "\n"
             "Exit codes: 0 ok, 1 delivery/backend error, 2 usage error."
         ),
@@ -468,6 +488,18 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
         metavar="LINE",
         default=None,
         help="Prepend a subject/header line before the message body.",
+    )
+
+    parser.add_argument(
+        "--edit",
+        metavar="MESSAGE_ID",
+        default=None,
+        help=(
+            "Edit an existing message instead of sending a new one. Requires "
+            "--to and the new text (positional, --file, or stdin). Fails "
+            "closed with a clear error on platforms without edit support -- "
+            "never falls back to sending a new message."
+        ),
     )
 
     parser.add_argument(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10107,6 +10107,128 @@ async def _standalone_send(
     )
 
 
+async def _standalone_edit(
+    pconfig,
+    chat_id,
+    message_id,
+    message,
+    *,
+    thread_id=None,
+):
+    """Out-of-process Telegram message edit via the Bot API.
+
+    Implements the ``standalone_editor_fn`` contract (see
+    ``gateway.platform_registry.PlatformEntry``) so external callers such as
+    ``hermes send --edit`` can update an existing message without a live
+    gateway adapter. Mirrors ``_standalone_send``'s
+    connection/parse-mode/fallback handling (proxy honouring, MarkdownV2 with
+    HTML auto-detection, plain-text fallback on parse failure) but calls
+    ``editMessageText`` instead of ``sendMessage``.
+
+    ``thread_id`` is accepted for signature parity with
+    ``standalone_sender_fn`` but is unused — Telegram's ``editMessageText``
+    addresses a message purely by ``chat_id`` + ``message_id`` and has no
+    topic/thread parameter.
+    """
+    token = getattr(pconfig, "token", None) or os.getenv("TELEGRAM_BOT_TOKEN", "")
+    if not token:
+        return {"error": "Telegram bot token not configured."}
+
+    try:
+        int_message_id = int(message_id)
+    except (TypeError, ValueError):
+        return {"error": f"Invalid Telegram message_id: {message_id!r}"}
+
+    try:
+        from telegram import Bot
+        from telegram.constants import ParseMode
+
+        _has_html = bool(re.search(r'<[a-zA-Z/][^>]*>', message))
+        if _has_html:
+            formatted = message
+            send_parse_mode = ParseMode.HTML
+        else:
+            try:
+                _adapter = TelegramAdapter.__new__(TelegramAdapter)
+                formatted = _adapter.format_message(message)
+            except Exception:
+                formatted = message
+            send_parse_mode = ParseMode.MARKDOWN_V2
+
+        # Honour a configured proxy — same reasoning as _send_telegram: the
+        # standalone path bypasses the live adapter's connection, so without
+        # this a proxied deployment's edits would time out even though sends
+        # succeed.
+        try:
+            from gateway.platforms.base import resolve_proxy_url
+            _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
+        except Exception:
+            _tg_proxy = None
+        if _tg_proxy:
+            try:
+                from telegram.request import HTTPXRequest
+                logger.info("send_message: standalone Telegram edit routed through proxy %s", _tg_proxy)
+                bot = Bot(
+                    token=token,
+                    request=HTTPXRequest(proxy=_tg_proxy),
+                    get_updates_request=HTTPXRequest(proxy=_tg_proxy),
+                )
+            except Exception as _proxy_err:
+                logger.warning(
+                    "send_message: failed to attach Telegram proxy for edit (%s), falling back to direct connection",
+                    _redact_telegram_error_text(_proxy_err),
+                )
+                bot = Bot(token=token)
+        else:
+            bot = Bot(token=token)
+
+        from plugins.platforms.telegram.telegram_ids import normalize_telegram_chat_id
+        int_chat_id = normalize_telegram_chat_id(chat_id)
+
+        try:
+            await bot.edit_message_text(
+                chat_id=int_chat_id,
+                message_id=int_message_id,
+                text=formatted,
+                parse_mode=send_parse_mode,
+            )
+        except Exception as edit_err:
+            err_str = str(edit_err).lower()
+            if "not modified" in err_str:
+                return {
+                    "success": True,
+                    "platform": "telegram",
+                    "chat_id": chat_id,
+                    "message_id": str(int_message_id),
+                }
+            if "parse" in err_str or "markdown" in err_str or "html" in err_str:
+                logger.warning(
+                    "Parse mode %s failed in Telegram standalone edit, falling back to plain text: %s",
+                    send_parse_mode,
+                    _redact_telegram_error_text(edit_err),
+                )
+                plain = message if _has_html else _strip_mdv2(message)
+                await bot.edit_message_text(
+                    chat_id=int_chat_id,
+                    message_id=int_message_id,
+                    text=plain,
+                    parse_mode=None,
+                )
+            else:
+                raise
+
+        return {
+            "success": True,
+            "platform": "telegram",
+            "chat_id": chat_id,
+            "message_id": str(int_message_id),
+        }
+    except ImportError:
+        return {"error": "python-telegram-bot not installed. Run: pip install python-telegram-bot"}
+    except Exception as e:
+        return {"error": f"Telegram edit failed: {_redact_telegram_error_text(e)}"}
+
+
 def interactive_setup() -> None:
     """Configure Telegram bot credentials and allowlist.
 
@@ -10265,6 +10387,7 @@ def register(ctx) -> None:
         allow_all_env="TELEGRAM_ALLOW_ALL_USERS",
         cron_deliver_env_var="TELEGRAM_HOME_CHANNEL",
         standalone_sender_fn=_standalone_send,
+        standalone_editor_fn=_standalone_edit,
         max_message_length=4096,
         emoji="✈️",
         allow_update_command=True,

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -247,6 +247,34 @@ class TestPlatformEntryExtendedFields:
         assert entry.allow_update_command is True
 
 
+class TestPlatformEntryStandaloneEditorFn:
+    """PlatformEntry must accept an optional standalone_editor_fn hook,
+    the out-of-process editing counterpart to standalone_sender_fn."""
+
+    def test_defaults_to_none(self):
+        entry = PlatformEntry(
+            name="test",
+            label="Test",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+        )
+        assert entry.standalone_editor_fn is None
+
+    def test_accepts_callable(self):
+        async def editor(pconfig, chat_id, message_id, message, *, thread_id=None):
+            return {"success": True, "message_id": message_id}
+
+        entry = PlatformEntry(
+            name="test",
+            label="Test",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            standalone_editor_fn=editor,
+        )
+        assert entry.standalone_editor_fn is editor
+        assert callable(entry.standalone_editor_fn)
+
+
 # ── Cron platform resolution ─────────────────────────────────────────
 
 

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -73,6 +73,107 @@ def fake_tool(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# --edit
+# ---------------------------------------------------------------------------
+
+
+def test_edit_dispatches_edit_action_with_message_id(fake_tool, capsys):
+    args = _parse(["--to", "telegram:-1001234567890:17585", "--edit", "42", "updated text"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 0
+    # action='edit' (never 'send') and the target/topic string is preserved
+    # verbatim for the tool layer to resolve chat_id/thread_id from.
+    assert fake_tool.calls == [
+        {
+            "action": "edit",
+            "target": "telegram:-1001234567890:17585",
+            "message_id": "42",
+            "message": "updated text",
+        }
+    ]
+
+
+def test_edit_json_mode_returns_message_id(fake_tool, capsys):
+    args = _parse(["--to", "telegram", "--edit", "42", "--json", "updated"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload.get("success") is True
+    assert payload.get("message_id") == "m123"
+
+
+def test_edit_reads_replacement_body_from_file(fake_tool, tmp_path):
+    body = tmp_path / "new.txt"
+    body.write_text("replacement from file\n")
+    args = _parse(["--to", "telegram", "--edit", "99", "--file", str(body)])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 0
+    assert fake_tool.calls[0] == {
+        "action": "edit",
+        "target": "telegram",
+        "message_id": "99",
+        "message": "replacement from file\n",
+    }
+
+
+def test_edit_missing_target_is_usage_error(fake_tool, capsys, monkeypatch):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    args = _parse(["--edit", "42", "hello"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "--to" in err
+
+
+def test_edit_missing_message_is_usage_error(fake_tool, capsys, monkeypatch):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    args = _parse(["--to", "telegram", "--edit", "42"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "no message" in err.lower()
+
+
+def test_edit_does_not_fall_back_to_send_on_platform_error(monkeypatch, capsys):
+    """When the underlying tool fails closed (no editor for the platform),
+    the CLI surfaces that as a failure -- it never retries as a plain send."""
+    import sys as _sys
+    import types as _types
+
+    calls = []
+
+    def _tool(args, **_kw):
+        calls.append(dict(args))
+        return json.dumps({
+            "error": "No message editor available for platform 'discord'. "
+            "Neither a live adapter nor a standalone_editor_fn is registered."
+        })
+
+    fake_mod = _types.ModuleType("tools.send_message_tool")
+    fake_mod.send_message_tool = _tool
+    monkeypatch.setitem(_sys.modules, "tools.send_message_tool", fake_mod)
+
+    args = _parse(["--to", "discord:#ops", "--edit", "7", "won't apply"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "no message editor available" in err.lower()
+    # Exactly one dispatch -- action='edit', no follow-up 'send' call.
+    assert calls == [{
+        "action": "edit",
+        "target": "discord:#ops",
+        "message_id": "7",
+        "message": "won't apply",
+    }]
+
+
+# ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1700,6 +1700,207 @@ class TestSendViaAdapterStandaloneFallback:
 
         assert result == {"error": "Plugin standalone send failed: boom!"}
 
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_fn_return_shape_passed_through(self, monkeypatch):
+        """Hook returns success dict: passed through unchanged."""
+        from tools.send_message_tool import _send_via_adapter
+        from gateway.platform_registry import platform_registry
+
+        async def fake_send(pconfig, chat_id, message, **kwargs):
+            return {"success": True, "message_id": "abc-123", "extra_field": "preserved"}
+
+        platform_registry.register(self._make_entry(fake_send))
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+            result = await _send_via_adapter(
+                _FakePlatform("fakeplatform"),
+                SimpleNamespace(extra={}),
+                "chat-1",
+                "hi",
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert result["success"] is True
+        assert result["message_id"] == "abc-123"
+        assert result["extra_field"] == "preserved"
+
+
+# ── _edit_via_platform standalone fallback ───────────────────────────────
+
+
+class TestEditViaPlatformStandaloneFallback:
+    """Coverage for the out-of-process plugin-platform edit path (#edit-fn).
+
+    Mirrors ``TestSendViaAdapterStandaloneFallback`` but for
+    ``_edit_via_platform``. Unlike sending, editing has no generic
+    "just send something" fallback: a platform without a registered
+    ``standalone_editor_fn`` (and no live adapter) must fail closed.
+    """
+
+    @staticmethod
+    def _make_entry(editor_fn):
+        from gateway.platform_registry import PlatformEntry
+
+        return PlatformEntry(
+            name="fakeplatform",
+            label="Fake",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            standalone_editor_fn=editor_fn,
+        )
+
+    @pytest.mark.asyncio
+    async def test_standalone_editor_fn_called_when_no_adapter(self, monkeypatch):
+        """Registry has the editor hook, runner ref returns None: the hook
+        is awaited and its result passed through."""
+        from tools.send_message_tool import _edit_via_platform
+        from gateway.platform_registry import platform_registry
+
+        recorded = {}
+
+        async def fake_edit(pconfig, chat_id, message_id, message, **kwargs):
+            recorded["pconfig"] = pconfig
+            recorded["chat_id"] = chat_id
+            recorded["message_id"] = message_id
+            recorded["message"] = message
+            recorded["kwargs"] = kwargs
+            return {"success": True, "message_id": message_id}
+
+        platform_registry.register(self._make_entry(fake_edit))
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+            pconfig = SimpleNamespace(extra={})
+            result = await _edit_via_platform(
+                _FakePlatform("fakeplatform"),
+                pconfig,
+                "room/123",
+                "42",
+                "updated text",
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert result == {"success": True, "message_id": "42"}
+        assert recorded["pconfig"] is pconfig
+        assert recorded["chat_id"] == "room/123"
+        assert recorded["message_id"] == "42"
+        assert recorded["message"] == "updated text"
+
+    @pytest.mark.asyncio
+    async def test_platform_without_editor_fails_closed(self, monkeypatch):
+        """No standalone_editor_fn and no live adapter: a stable error is
+        returned. Critically, nothing resembling a 'send' path is invoked --
+        editing must never silently degrade into posting a new message."""
+        from tools.send_message_tool import _edit_via_platform
+        from gateway.platform_registry import platform_registry
+
+        platform_registry.register(self._make_entry(None))
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+            with patch(
+                "tools.send_message_tool._send_via_adapter",
+                side_effect=AssertionError("must not fall back to sending"),
+            ):
+                result = await _edit_via_platform(
+                    _FakePlatform("fakeplatform"),
+                    SimpleNamespace(extra={}),
+                    "chat-1",
+                    "42",
+                    "won't apply",
+                )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert "error" in result
+        assert "success" not in result
+        assert "fakeplatform" in result["error"]
+        assert "standalone_editor_fn" in result["error"]
+
+
+# ── Telegram _standalone_edit ────────────────────────────────────────────
+
+
+class TestTelegramStandaloneEdit:
+    """Coverage for ``plugins.platforms.telegram.adapter._standalone_edit``,
+    the ``standalone_editor_fn`` implementation Telegram registers on its
+    ``PlatformEntry``."""
+
+    def _make_bot(self):
+        bot = MagicMock()
+        bot.edit_message_text = AsyncMock(return_value=SimpleNamespace(message_id=42))
+        return bot
+
+    @pytest.mark.asyncio
+    async def test_edit_calls_edit_message_text_and_returns_same_message_id(self, monkeypatch):
+        from plugins.platforms.telegram.adapter import _standalone_edit
+
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        pconfig = SimpleNamespace(token="tok", extra={})
+        result = await _standalone_edit(pconfig, "123", "42", "updated text")
+
+        bot.edit_message_text.assert_awaited_once()
+        kwargs = bot.edit_message_text.await_args.kwargs
+        assert kwargs["chat_id"] == 123
+        assert kwargs["message_id"] == 42
+        assert kwargs["text"] == "updated text"
+
+        assert result["success"] is True
+        assert result["message_id"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_parse_failure_retries_as_plain_text(self, monkeypatch):
+        """A parse-mode rejection from Telegram falls back to a second
+        edit_message_text call with parse_mode=None, mirroring the send
+        path's plain-text fallback."""
+        from plugins.platforms.telegram.adapter import _standalone_edit
+
+        bot = self._make_bot()
+        bot.edit_message_text = AsyncMock(
+            side_effect=[
+                Exception("Bad Request: can't parse entities: unsupported html tag"),
+                SimpleNamespace(message_id=42),
+            ]
+        )
+        _install_telegram_mock(monkeypatch, bot)
+
+        pconfig = SimpleNamespace(token="tok", extra={})
+        result = await _standalone_edit(pconfig, "123", "42", "<invalid>broken</invalid>")
+
+        assert result["success"] is True
+        assert bot.edit_message_text.await_count == 2
+        second_call = bot.edit_message_text.await_args_list[1].kwargs
+        assert second_call["parse_mode"] is None
+
+    @pytest.mark.asyncio
+    async def test_non_parse_error_never_sends_a_new_message(self, monkeypatch):
+        """A non-parse error (e.g. message-not-found) must surface as an
+        error dict, not silently fall back to posting a fresh message. The
+        mock bot only exposes edit_message_text -- if the implementation
+        ever tried to call send_message as a fallback, this would raise
+        AttributeError instead of a clean error result."""
+        from plugins.platforms.telegram.adapter import _standalone_edit
+
+        bot = MagicMock(spec=["edit_message_text"])
+        bot.edit_message_text = AsyncMock(
+            side_effect=Exception("message to edit not found")
+        )
+        _install_telegram_mock(monkeypatch, bot)
+
+        pconfig = SimpleNamespace(token="tok", extra={})
+        result = await _standalone_edit(pconfig, "123", "42", "updated text")
+
+        assert "error" in result
+        assert "success" not in result
+        bot.edit_message_text.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # _check_send_message — availability gating
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -251,6 +251,9 @@ def send_message_tool(args, **kw):
     if action == "unreact":
         return _handle_react(args, remove=True)
 
+    if action == "edit":
+        return _handle_edit(args)
+
     return _handle_send(args)
 
 
@@ -527,6 +530,103 @@ def _handle_send(args):
         return json.dumps(_error(f"Send failed: {e}"))
 
 
+def _handle_edit(args):
+    """Edit a previously sent message on a platform target.
+
+    Mirrors ``_handle_send``'s target parsing/resolution exactly (explicit
+    chat_id:thread_id refs, human-friendly channel-name resolution, home
+    channel fallback) but routes through ``_edit_via_platform`` instead of
+    ``_send_to_platform``. There is no fallback to sending a new message —
+    a platform without an editor fails closed with a stable error.
+    """
+    target = args.get("target", "")
+    message = args.get("message", "")
+    message_id = str(args.get("message_id") or "").strip()
+    if not target or not message or not message_id:
+        return tool_error(
+            "'target', 'message_id' and 'message' are required when action='edit'"
+        )
+
+    parts = target.split(":", 1)
+    platform_name = parts[0].strip().lower()
+    target_ref = parts[1].strip() if len(parts) > 1 else None
+    chat_id = None
+    thread_id = None
+
+    if target_ref:
+        chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+    else:
+        is_explicit = False
+
+    # Resolve human-friendly channel names to numeric IDs, same as send.
+    if target_ref and not is_explicit:
+        try:
+            from gateway.channel_directory import resolve_channel_name
+            resolved = resolve_channel_name(platform_name, target_ref)
+            if resolved:
+                chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+            else:
+                return json.dumps({
+                    "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                    f"Use send_message(action='list') to see available targets."
+                })
+        except Exception:
+            return json.dumps({
+                "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                f"Try using a numeric channel ID instead."
+            })
+
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return tool_error("Interrupted")
+
+    try:
+        from gateway.config import load_gateway_config, Platform
+        config = load_gateway_config()
+    except Exception as e:
+        return json.dumps(_error(f"Failed to load gateway config: {e}"))
+
+    try:
+        platform = Platform(platform_name)
+    except (ValueError, KeyError):
+        return tool_error(f"Unknown platform: {platform_name}")
+
+    pconfig = config.platforms.get(platform)
+    if not pconfig or not pconfig.enabled:
+        return tool_error(
+            f"Platform '{platform_name}' is not configured. Set up credentials "
+            f"in ~/.hermes/config.yaml or environment variables."
+        )
+
+    if not chat_id:
+        home = config.get_home_channel(platform)
+        if home:
+            chat_id = home.chat_id
+        else:
+            home_env = _HOME_CHANNEL_ENV_OVERRIDES.get(
+                platform_name, f"{platform_name.upper()}_HOME_CHANNEL"
+            )
+            return json.dumps({
+                "error": f"No home channel set for {platform_name} to determine which "
+                f"message to edit. Either specify a channel directly with "
+                f"'{platform_name}:CHANNEL_NAME', or set a home channel via: "
+                f"hermes config set {home_env} <channel_id>"
+            })
+
+    try:
+        from model_tools import _run_async
+        result = _run_async(
+            _edit_via_platform(
+                platform, pconfig, chat_id, message_id, message, thread_id=thread_id,
+            )
+        )
+        if isinstance(result, dict) and "error" in result:
+            result["error"] = _sanitize_error_text(result["error"])
+        return json.dumps(result)
+    except Exception as e:
+        return json.dumps(_error(f"Edit failed: {e}"))
+
+
 def _parse_target_ref(platform_name: str, target_ref: str):
     """Parse a tool target into chat_id/thread_id and whether it is explicit."""
     if platform_name == "telegram":
@@ -776,6 +876,89 @@ async def _send_via_adapter(
             f"running with this platform connected? For out-of-process delivery "
             f"(e.g. cron in a separate process), the platform plugin must "
             f"register a standalone_sender_fn on its PlatformEntry."
+        )
+    }
+
+
+async def _edit_via_platform(platform, pconfig, chat_id, message_id, message, *, thread_id=None):
+    """Edit an existing message on a platform, generically across adapters.
+
+    Order of attempts, mirroring ``_send_via_adapter``:
+      1. Live in-process adapter's ``edit_message()`` (available whenever
+         this call runs inside a running gateway).
+      2. The plugin's ``standalone_editor_fn`` registered on its
+         ``PlatformEntry`` (used when the gateway is not in this process).
+      3. A descriptive, stable error.
+
+    Deliberately fails closed: unlike sending, there is no third "just do
+    something" fallback. A platform with no editor returns an error instead
+    of silently creating a brand-new message, which would be indistinguishable
+    from a successful in-place edit to a caller checking only 'success'.
+    """
+    platform_name = platform.value if hasattr(platform, "value") else str(platform)
+
+    runner = None
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+
+    if runner is not None:
+        try:
+            adapter = runner.adapters.get(platform)
+        except Exception:
+            adapter = None
+        if adapter is not None:
+            try:
+                result = await adapter.edit_message(
+                    chat_id, message_id, message, finalize=True,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                return {"error": f"Edit failed: {e}"}
+            if result.success:
+                return {"success": True, "message_id": result.message_id or message_id}
+            return {"error": f"Adapter edit failed: {result.error}"}
+
+    entry = None
+    try:
+        from gateway.platform_registry import platform_registry
+        entry = platform_registry.get(platform_name)
+    except Exception:
+        entry = None
+
+    if entry is not None and entry.standalone_editor_fn is not None:
+        try:
+            result = await entry.standalone_editor_fn(
+                pconfig,
+                chat_id,
+                message_id,
+                message,
+                thread_id=thread_id,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.debug("Plugin standalone edit for %s raised", platform_name, exc_info=True)
+            return {"error": f"Plugin standalone edit failed: {e}"}
+
+        if isinstance(result, dict) and (result.get("success") or result.get("error")):
+            return result
+        return {
+            "error": (
+                f"Plugin standalone edit for '{platform_name}' returned an "
+                f"invalid result: expected a dict with 'success' or 'error' "
+                f"keys, got {type(result).__name__}"
+            )
+        }
+
+    return {
+        "error": (
+            f"No message editor available for platform '{platform_name}'. "
+            f"Neither a live adapter nor a standalone_editor_fn is registered — "
+            f"editing is not supported here."
         )
     }
 


### PR DESCRIPTION
## Summary
- return persistent platform message handles from standalone sends
- support editing an existing platform message through the Hermes send CLI
- add Telegram standalone edit support and cross-platform capability plumbing
- preserve structured send results for callers such as Hermes Dev Bridge

## Test plan
- 106 targeted tests passed after rebasing onto current upstream main
- Python bytecode compilation passed
- git diff --check passed

This enables persistent, editable notification surfaces without giving downstream services direct access to Telegram credentials.