### PR TITLE
fix(whatsapp): stop local bridge impersonation from hijacking messages

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -547,6 +547,25 @@ def resolve_whatsapp_bridge_dir() -> Path:
             dirs_exist_ok=True,
             ignore=shutil.ignore_patterns("node_modules"),
         )
+        # copytree overlays changed files but does not remove packaged source
+        # files deleted by an update. Reconcile those stale paths after the
+        # copy while leaving the dependency tree under npm's ownership.
+        mirrored_paths = sorted(
+            hermes_home_bridge.rglob("*"),
+            key=lambda path: len(path.parts),
+            reverse=True,
+        )
+        for mirrored_path in mirrored_paths:
+            relative_path = mirrored_path.relative_to(hermes_home_bridge)
+            if relative_path.parts[0] == "node_modules":
+                continue
+            install_path = install_bridge / relative_path
+            if install_path.exists() or install_path.is_symlink():
+                continue
+            if mirrored_path.is_dir() and not mirrored_path.is_symlink():
+                mirrored_path.rmdir()
+            else:
+                mirrored_path.unlink()
         return hermes_home_bridge
     except Exception:
         return hermes_home_bridge if hermes_home_bridge.exists() else install_bridge

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -541,31 +541,41 @@ def resolve_whatsapp_bridge_dir() -> Path:
     # hash stamp owns dependency refreshes independently.
     try:
         hermes_home_bridge.parent.mkdir(parents=True, exist_ok=True)
+        if hermes_home_bridge.exists():
+            # copytree overlays changed files but cannot remove deleted source
+            # paths or replace a file with a directory (and vice versa).
+            # Reconcile deepest paths first, leaving npm's dependency tree
+            # untouched, before copying the current packaged sources.
+            mirrored_paths = sorted(
+                hermes_home_bridge.rglob("*"),
+                key=lambda path: len(path.parts),
+                reverse=True,
+            )
+            for mirrored_path in mirrored_paths:
+                relative_path = mirrored_path.relative_to(hermes_home_bridge)
+                if relative_path.parts[0] == "node_modules":
+                    continue
+                install_path = install_bridge / relative_path
+                install_exists = install_path.exists() or install_path.is_symlink()
+                same_type = (
+                    install_exists
+                    and not mirrored_path.is_symlink()
+                    and mirrored_path.is_dir() == install_path.is_dir()
+                )
+                if same_type:
+                    continue
+                if mirrored_path.is_dir() and not mirrored_path.is_symlink():
+                    mirrored_path.rmdir()
+                else:
+                    mirrored_path.unlink()
         shutil.copytree(
             install_bridge,
             hermes_home_bridge,
             dirs_exist_ok=True,
             ignore=shutil.ignore_patterns("node_modules"),
         )
-        # copytree overlays changed files but does not remove packaged source
-        # files deleted by an update. Reconcile those stale paths after the
-        # copy while leaving the dependency tree under npm's ownership.
-        mirrored_paths = sorted(
-            hermes_home_bridge.rglob("*"),
-            key=lambda path: len(path.parts),
-            reverse=True,
-        )
-        for mirrored_path in mirrored_paths:
-            relative_path = mirrored_path.relative_to(hermes_home_bridge)
-            if relative_path.parts[0] == "node_modules":
-                continue
-            install_path = install_bridge / relative_path
-            if install_path.exists() or install_path.is_symlink():
-                continue
-            if mirrored_path.is_dir() and not mirrored_path.is_symlink():
-                mirrored_path.rmdir()
-            else:
-                mirrored_path.unlink()
         return hermes_home_bridge
     except Exception:
-        return hermes_home_bridge if hermes_home_bridge.exists() else install_bridge
+        # Never execute a mirror that may have been only partly reconciled or
+        # refreshed. The packaged tree is read-only but remains authoritative.
+        return install_bridge

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -535,18 +535,18 @@ def resolve_whatsapp_bridge_dir() -> Path:
     if install_writable:
         return install_bridge
 
-    # Install dir is read-only, mirror to HERMES_HOME if needed
-    if hermes_home_bridge.exists():
-        return hermes_home_bridge
-
-    # Mirror the bridge source to HERMES_HOME
+    # Install dir is read-only. Refresh packaged source files on every
+    # resolution so an existing writable mirror cannot keep running bridge
+    # code from before an update. Preserve node_modules; the adapter's package
+    # hash stamp owns dependency refreshes independently.
     try:
         hermes_home_bridge.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(
             install_bridge,
             hermes_home_bridge,
-            dirs_exist_ok=False,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns("node_modules"),
         )
         return hermes_home_bridge
     except Exception:
-        return install_bridge
+        return hermes_home_bridge if hermes_home_bridge.exists() else install_bridge

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -462,6 +462,36 @@ def _health_response_is_authenticated(data: Any, token: str, challenge: str) -> 
     )
 
 
+async def _request_authenticated_bridge_health(
+    session: Any,
+    base_url: str,
+    token: str,
+    timeout: Any,
+) -> Optional[Dict[str, Any]]:
+    """Authenticate a bridge before sending it the bearer credential."""
+    challenge = secrets.token_urlsafe(24)
+    async with session.get(
+        f"{base_url}/auth-proof",
+        headers={"X-Hermes-Bridge-Challenge": challenge},
+        timeout=timeout,
+    ) as resp:
+        if resp.status != 200:
+            return None
+        proof_data = await resp.json()
+    if not _health_response_is_authenticated(proof_data, token, challenge):
+        return None
+
+    async with session.get(
+        f"{base_url}/health",
+        headers=_bridge_auth_headers(token),
+        timeout=timeout,
+    ) as resp:
+        if resp.status != 200:
+            return None
+        data = await resp.json()
+    return data if isinstance(data, dict) else None
+
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
@@ -727,57 +757,50 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             import aiohttp
             try:
                 async with aiohttp.ClientSession() as session:
-                    challenge = secrets.token_urlsafe(24)
-                    async with session.get(
-                        f"http://127.0.0.1:{self._bridge_port}/health",
-                        headers=_bridge_auth_headers(self._bridge_token, challenge),
-                        timeout=aiohttp.ClientTimeout(total=2)
-                    ) as resp:
-                        if resp.status == 200:
-                            data = await resp.json()
-                            if not _health_response_is_authenticated(
-                                data, self._bridge_token, challenge
+                    data = await _request_authenticated_bridge_health(
+                        session,
+                        f"http://127.0.0.1:{self._bridge_port}",
+                        self._bridge_token,
+                        aiohttp.ClientTimeout(total=2),
+                    )
+                    if data is not None:
+                        bridge_status = data.get("status", "unknown")
+                        if bridge_status == "connected":
+                            # Staleness handshake: only reuse a running
+                            # bridge if it is serving the same bridge.js
+                            # that is on disk right now.  A long-lived
+                            # bridge survives gateway restarts AND
+                            # `hermes update`, so without this check it
+                            # keeps serving pre-update code forever
+                            # (e.g. no inbound media download).  Old
+                            # bridges that don't report scriptHash are
+                            # treated as stale by definition.
+                            running_hash = data.get("scriptHash", "")
+                            disk_hash = _bridge_source_hash(bridge_path)
+                            running_read_receipts = bool(data.get("sendReadReceipts", False))
+                            config_matches = running_read_receipts == self._send_read_receipts
+                            if (
+                                running_hash
+                                and disk_hash
+                                and running_hash == disk_hash
+                                and config_matches
                             ):
-                                raise PermissionError(
-                                    "existing WhatsApp bridge failed authentication"
+                                print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
+                                self._mark_connected()
+                                self._bridge_process = None  # Not managed by us
+                                self._http_session = aiohttp.ClientSession(
+                                    headers=_bridge_auth_headers(self._bridge_token)
                                 )
-                            bridge_status = data.get("status", "unknown")
-                            if bridge_status == "connected":
-                                # Staleness handshake: only reuse a running
-                                # bridge if it is serving the same bridge.js
-                                # that is on disk right now.  A long-lived
-                                # bridge survives gateway restarts AND
-                                # `hermes update`, so without this check it
-                                # keeps serving pre-update code forever
-                                # (e.g. no inbound media download).  Old
-                                # bridges that don't report scriptHash are
-                                # treated as stale by definition.
-                                running_hash = data.get("scriptHash", "")
-                                disk_hash = _bridge_source_hash(bridge_path)
-                                running_read_receipts = bool(data.get("sendReadReceipts", False))
-                                config_matches = running_read_receipts == self._send_read_receipts
-                                if (
-                                    running_hash
-                                    and disk_hash
-                                    and running_hash == disk_hash
-                                    and config_matches
-                                ):
-                                    print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
-                                    self._mark_connected()
-                                    self._bridge_process = None  # Not managed by us
-                                    self._http_session = aiohttp.ClientSession(
-                                        headers=_bridge_auth_headers(self._bridge_token)
-                                    )
-                                    self._poll_task = asyncio.create_task(self._poll_messages())
-                                    return True
-                                stale_reason = (
-                                    f"running={running_hash or 'unversioned'}, disk={disk_hash}"
-                                    if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
-                                )
-                                print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
-                            else:
-                                print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
+                                self._poll_task = asyncio.create_task(self._poll_messages())
+                                return True
+                            stale_reason = (
+                                f"running={running_hash or 'unversioned'}, disk={disk_hash}"
+                                if running_hash != disk_hash
+                                else "send_read_receipts config changed"
+                            )
+                            print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
+                        else:
+                            print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
             except Exception:
                 pass  # Bridge not running, start a new one
             
@@ -872,22 +895,19 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     return False
                 try:
                     async with aiohttp.ClientSession() as session:
-                        challenge = secrets.token_urlsafe(24)
-                        async with session.get(
-                            f"http://127.0.0.1:{self._bridge_port}/health",
-                            headers=_bridge_auth_headers(self._bridge_token, challenge),
-                            timeout=aiohttp.ClientTimeout(total=2)
-                        ) as resp:
-                            if resp.status == 200:
-                                data = await resp.json()
-                                if not _health_response_is_authenticated(
-                                    data, self._bridge_token, challenge
-                                ):
-                                    continue
-                                http_ready = True
-                                if data.get("status") == "connected":
-                                    print(f"[{self.name}] Bridge ready (status: connected)")
-                                    break
+                        authenticated_data = await _request_authenticated_bridge_health(
+                            session,
+                            f"http://127.0.0.1:{self._bridge_port}",
+                            self._bridge_token,
+                            aiohttp.ClientTimeout(total=2),
+                        )
+                        if authenticated_data is None:
+                            continue
+                        data = authenticated_data
+                        http_ready = True
+                        if data.get("status") == "connected":
+                            print(f"[{self.name}] Bridge ready (status: connected)")
+                            break
                 except Exception:
                     continue
 
@@ -910,21 +930,18 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         return False
                     try:
                         async with aiohttp.ClientSession() as session:
-                            challenge = secrets.token_urlsafe(24)
-                            async with session.get(
-                                f"http://127.0.0.1:{self._bridge_port}/health",
-                                headers=_bridge_auth_headers(self._bridge_token, challenge),
-                                timeout=aiohttp.ClientTimeout(total=2)
-                            ) as resp:
-                                if resp.status == 200:
-                                    data = await resp.json()
-                                    if not _health_response_is_authenticated(
-                                        data, self._bridge_token, challenge
-                                    ):
-                                        continue
-                                    if data.get("status") == "connected":
-                                        print(f"[{self.name}] Bridge ready (status: connected)")
-                                        break
+                            authenticated_data = await _request_authenticated_bridge_health(
+                                session,
+                                f"http://127.0.0.1:{self._bridge_port}",
+                                self._bridge_token,
+                                aiohttp.ClientTimeout(total=2),
+                            )
+                            if authenticated_data is None:
+                                continue
+                            data = authenticated_data
+                            if data.get("status") == "connected":
+                                print(f"[{self.name}] Bridge ready (status: connected)")
+                                break
                     except Exception:
                         continue
                 else:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -16,6 +16,7 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+from contextlib import contextmanager
 import hashlib
 import hmac
 import logging
@@ -377,33 +378,67 @@ def _bridge_source_hash(bridge_path: Path) -> str:
     return digest.hexdigest()[:16]
 
 
+@contextmanager
+def _bridge_token_lock(lock_path: Path):
+    """Hold a crash-released cross-process lock for bridge-token updates."""
+    handle = open(lock_path, "a+b")
+    locked = False
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            if lock_path.stat().st_size == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        locked = True
+        yield
+    finally:
+        try:
+            if locked and os.name == "nt":
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            elif locked:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
+
+
 def _load_or_create_bridge_token(session_path: Path) -> str:
     """Return the persistent per-session secret used to authenticate bridge IPC."""
     session_path.mkdir(parents=True, exist_ok=True)
     token_path = session_path / ".bridge-token"
-    try:
-        existing = token_path.read_text(encoding="utf-8").strip()
-        if len(existing) >= 32:
-            return existing
-    except OSError:
-        pass
+    lock_path = token_path.with_name(f"{token_path.name}.lock")
 
-    token = secrets.token_urlsafe(32)
-    temp_path = token_path.with_name(
-        f"{token_path.name}.{secrets.token_hex(8)}.tmp"
-    )
-    fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(token)
+    with _bridge_token_lock(lock_path):
         try:
-            temp_path.chmod(0o600)
+            existing = token_path.read_text(encoding="utf-8").strip()
+            if len(existing) >= 32:
+                return existing
         except OSError:
             pass
-        os.replace(temp_path, token_path)
-    finally:
-        temp_path.unlink(missing_ok=True)
-    return token
+
+        token = secrets.token_urlsafe(32)
+        temp_path = token_path.with_name(
+            f"{token_path.name}.{secrets.token_hex(8)}.tmp"
+        )
+        fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as token_file:
+                token_file.write(token)
+            try:
+                temp_path.chmod(0o600)
+            except OSError:
+                pass
+            os.replace(temp_path, token_path)
+        finally:
+            temp_path.unlink(missing_ok=True)
+        return token
 
 
 def _bridge_auth_headers(token: str, challenge: str = "") -> Dict[str, str]:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1873,7 +1873,9 @@ async def _standalone_send(
         # a caption is never silently repeated across a multi-file send.
         media_caption = caption if (caption and len(media) == 1) else None
         last_message_id = None
-        bridge_url = f"http://localhost:{bridge_port}"
+        # Match the bridge's IPv4-only bind exactly. Using localhost could
+        # select ::1 and authenticate a different process on the same port.
+        bridge_url = f"http://127.0.0.1:{bridge_port}"
         auth_headers = _bridge_auth_headers(bridge_token)
         async with aiohttp.ClientSession() as session:
             health = await _request_authenticated_bridge_health(

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1873,15 +1873,25 @@ async def _standalone_send(
         # a caption is never silently repeated across a multi-file send.
         media_caption = caption if (caption and len(media) == 1) else None
         last_message_id = None
-        async with aiohttp.ClientSession(
-            headers=_bridge_auth_headers(bridge_token)
-        ) as session:
+        bridge_url = f"http://localhost:{bridge_port}"
+        auth_headers = _bridge_auth_headers(bridge_token)
+        async with aiohttp.ClientSession() as session:
+            health = await _request_authenticated_bridge_health(
+                session,
+                bridge_url,
+                bridge_token,
+                aiohttp.ClientTimeout(total=2),
+            )
+            if health is None:
+                return {"error": "WhatsApp bridge failed authentication"}
+
             # 1) Text first (skip the /send call when this chunk is media-only
             #    or when the text is delivered as the media caption instead).
             if text.strip() and not media_caption:
                 async with session.post(
-                    f"http://localhost:{bridge_port}/send",
+                    f"{bridge_url}/send",
                     json={"chatId": normalized_chat_id, "message": text},
+                    headers=auth_headers,
                     timeout=aiohttp.ClientTimeout(total=30),
                 ) as resp:
                     if resp.status != 200:
@@ -1903,8 +1913,9 @@ async def _standalone_send(
                     if media_caption:
                         try:
                             async with session.post(
-                                f"http://localhost:{bridge_port}/send",
+                                f"{bridge_url}/send",
                                 json={"chatId": normalized_chat_id, "message": media_caption},
+                                headers=auth_headers,
                                 timeout=aiohttp.ClientTimeout(total=30),
                             ) as resp:
                                 if resp.status == 200:
@@ -1923,8 +1934,9 @@ async def _standalone_send(
                 if media_caption:
                     payload["caption"] = media_caption
                 async with session.post(
-                    f"http://localhost:{bridge_port}/send-media",
+                    f"{bridge_url}/send-media",
                     json=payload,
+                    headers=auth_headers,
                     timeout=aiohttp.ClientTimeout(total=120),
                 ) as resp:
                     if resp.status != 200:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1809,6 +1809,11 @@ async def _standalone_send(
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         bridge_port = extra.get("bridge_port", 3000)
+        session_path = Path(extra.get(
+            "session_path",
+            get_hermes_dir("platforms/whatsapp/session", "whatsapp/session"),
+        ))
+        bridge_token = _load_or_create_bridge_token(session_path)
         normalized_chat_id = to_whatsapp_jid(chat_id)
         media = media_files or []
         text = message or ""
@@ -1816,7 +1821,9 @@ async def _standalone_send(
         # a caption is never silently repeated across a multi-file send.
         media_caption = caption if (caption and len(media) == 1) else None
         last_message_id = None
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(
+            headers=_bridge_auth_headers(bridge_token)
+        ) as session:
             # 1) Text first (skip the /send call when this chunk is media-only
             #    or when the text is delivered as the media caption instead).
             if text.strip() and not media_caption:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -358,6 +358,25 @@ def _file_content_hash(path: Path) -> str:
         return ""
 
 
+def _bridge_source_hash(bridge_path: Path) -> str:
+    """Hash the managed bridge entrypoint and its authentication helper."""
+    source_paths = [bridge_path]
+    auth_path = bridge_path.with_name("bridge_auth.js")
+    if auth_path.exists():
+        source_paths.append(auth_path)
+
+    digest = hashlib.sha256()
+    try:
+        for path in source_paths:
+            digest.update(path.name.encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+    except OSError:
+        return ""
+    return digest.hexdigest()[:16]
+
+
 def _load_or_create_bridge_token(session_path: Path) -> str:
     """Return the persistent per-session secret used to authenticate bridge IPC."""
     session_path.mkdir(parents=True, exist_ok=True)
@@ -699,7 +718,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 # bridges that don't report scriptHash are
                                 # treated as stale by definition.
                                 running_hash = data.get("scriptHash", "")
-                                disk_hash = _file_content_hash(bridge_path)
+                                disk_hash = _bridge_source_hash(bridge_path)
                                 running_read_receipts = bool(data.get("sendReadReceipts", False))
                                 config_matches = running_read_receipts == self._send_read_receipts
                                 if (

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -16,10 +16,13 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+import hashlib
+import hmac
 import logging
 import os
 import platform
 import re
+import secrets
 import signal
 import subprocess
 
@@ -355,6 +358,56 @@ def _file_content_hash(path: Path) -> str:
         return ""
 
 
+def _load_or_create_bridge_token(session_path: Path) -> str:
+    """Return the persistent per-session secret used to authenticate bridge IPC."""
+    session_path.mkdir(parents=True, exist_ok=True)
+    token_path = session_path / ".bridge-token"
+    try:
+        existing = token_path.read_text(encoding="utf-8").strip()
+        if len(existing) >= 32:
+            return existing
+    except OSError:
+        pass
+
+    token = secrets.token_urlsafe(32)
+    temp_path = token_path.with_name(
+        f"{token_path.name}.{secrets.token_hex(8)}.tmp"
+    )
+    fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(token)
+        try:
+            temp_path.chmod(0o600)
+        except OSError:
+            pass
+        os.replace(temp_path, token_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+    return token
+
+
+def _bridge_auth_headers(token: str, challenge: str = "") -> Dict[str, str]:
+    headers = {"Authorization": f"Bearer {token}"}
+    if challenge:
+        headers["X-Hermes-Bridge-Challenge"] = challenge
+    return headers
+
+
+def _bridge_auth_proof(token: str, challenge: str) -> str:
+    return hmac.new(token.encode(), challenge.encode(), hashlib.sha256).hexdigest()
+
+
+def _health_response_is_authenticated(data: Any, token: str, challenge: str) -> bool:
+    if not isinstance(data, dict):
+        return False
+    proof = data.get("authProof")
+    return isinstance(proof, str) and hmac.compare_digest(
+        proof,
+        _bridge_auth_proof(token, challenge),
+    )
+
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
@@ -461,6 +514,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._bridge_log: Optional[Path] = None
         self._poll_task: Optional[asyncio.Task] = None
         self._http_session: Optional["aiohttp.ClientSession"] = None
+        self._bridge_token: str = ""
         # Set to True by disconnect() before we SIGTERM our child bridge so
         # _check_managed_bridge_exit() can distinguish an intentional
         # shutdown-time exit (returncode -15 / -2 / 0) from a real crash.
@@ -613,17 +667,26 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
             # Ensure session directory exists
             self._session_path.mkdir(parents=True, exist_ok=True)
+            self._bridge_token = _load_or_create_bridge_token(self._session_path)
             
             # Check if bridge is already running and connected
             import aiohttp
             try:
                 async with aiohttp.ClientSession() as session:
+                    challenge = secrets.token_urlsafe(24)
                     async with session.get(
                         f"http://127.0.0.1:{self._bridge_port}/health",
+                        headers=_bridge_auth_headers(self._bridge_token, challenge),
                         timeout=aiohttp.ClientTimeout(total=2)
                     ) as resp:
                         if resp.status == 200:
                             data = await resp.json()
+                            if not _health_response_is_authenticated(
+                                data, self._bridge_token, challenge
+                            ):
+                                raise PermissionError(
+                                    "existing WhatsApp bridge failed authentication"
+                                )
                             bridge_status = data.get("status", "unknown")
                             if bridge_status == "connected":
                                 # Staleness handshake: only reuse a running
@@ -648,7 +711,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                     print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
                                     self._mark_connected()
                                     self._bridge_process = None  # Not managed by us
-                                    self._http_session = aiohttp.ClientSession()
+                                    self._http_session = aiohttp.ClientSession(
+                                        headers=_bridge_auth_headers(self._bridge_token)
+                                    )
                                     self._poll_task = asyncio.create_task(self._poll_messages())
                                     return True
                                 stale_reason = (
@@ -680,6 +745,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # can use it without the user needing to set a separate env var.
             # with_hermes_node_path() copies os.environ when called with no arg.
             bridge_env = with_hermes_node_path()
+            bridge_env["HERMES_WHATSAPP_BRIDGE_TOKEN"] = self._bridge_token
             if self._reply_prefix is not None:
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
@@ -752,13 +818,19 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     return False
                 try:
                     async with aiohttp.ClientSession() as session:
+                        challenge = secrets.token_urlsafe(24)
                         async with session.get(
                             f"http://127.0.0.1:{self._bridge_port}/health",
+                            headers=_bridge_auth_headers(self._bridge_token, challenge),
                             timeout=aiohttp.ClientTimeout(total=2)
                         ) as resp:
                             if resp.status == 200:
-                                http_ready = True
                                 data = await resp.json()
+                                if not _health_response_is_authenticated(
+                                    data, self._bridge_token, challenge
+                                ):
+                                    continue
+                                http_ready = True
                                 if data.get("status") == "connected":
                                     print(f"[{self.name}] Bridge ready (status: connected)")
                                     break
@@ -784,12 +856,18 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         return False
                     try:
                         async with aiohttp.ClientSession() as session:
+                            challenge = secrets.token_urlsafe(24)
                             async with session.get(
                                 f"http://127.0.0.1:{self._bridge_port}/health",
+                                headers=_bridge_auth_headers(self._bridge_token, challenge),
                                 timeout=aiohttp.ClientTimeout(total=2)
                             ) as resp:
                                 if resp.status == 200:
                                     data = await resp.json()
+                                    if not _health_response_is_authenticated(
+                                        data, self._bridge_token, challenge
+                                    ):
+                                        continue
                                     if data.get("status") == "connected":
                                         print(f"[{self.name}] Bridge ready (status: connected)")
                                         break
@@ -803,7 +881,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     print(f"[{self.name}]   If session expired, re-pair: hermes whatsapp")
             
             # Create a persistent HTTP session for all bridge communication
-            self._http_session = aiohttp.ClientSession()
+            self._http_session = aiohttp.ClientSession(
+                headers=_bridge_auth_headers(self._bridge_token)
+            )
 
             # Start message polling task
             self._poll_task = asyncio.create_task(self._poll_messages())

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -819,6 +819,16 @@ app.use((req, res, next) => {
   next();
 });
 
+// Prove that an existing listener already knows the session secret before the
+// Python adapter sends that listener any bearer-authenticated request.
+app.get('/auth-proof', (req, res) => {
+  const challenge = req.headers['x-hermes-bridge-challenge'];
+  if (typeof challenge !== 'string' || !challenge) {
+    return res.status(400).json({ error: 'Missing bridge challenge' });
+  }
+  res.json({ authProof: bridgeAuthProof(BRIDGE_TOKEN, challenge) });
+});
+
 // Loopback binding does not establish the caller's identity: another local
 // process can bind the configured port or call this API directly.
 app.use(createBridgeAuthMiddleware(BRIDGE_TOKEN));
@@ -1115,18 +1125,13 @@ app.get('/chat/:id', async (req, res) => {
 });
 
 // Health check
-app.get('/health', (req, res) => {
-  const challenge = req.headers['x-hermes-bridge-challenge'];
-  if (typeof challenge !== 'string' || !challenge) {
-    return res.status(400).json({ error: 'Missing bridge challenge' });
-  }
+app.get('/health', (_req, res) => {
   res.json({
     status: connectionState,
     queueLength: messageQueue.length,
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
-    authProof: bridgeAuthProof(BRIDGE_TOKEN, challenge),
   });
 });
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -33,6 +33,7 @@ import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { bridgeAuthProof, createBridgeAuthMiddleware } from './bridge_auth.js';
 import {
   buildPollPayload,
   createReconnectScheduler,
@@ -110,6 +111,7 @@ try {
 } catch {}
 const PAIR_ONLY = args.includes('--pair-only');
 const PAIR_JSON = args.includes('--pair-json');
+const BRIDGE_TOKEN = process.env.HERMES_WHATSAPP_BRIDGE_TOKEN || '';
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const WHATSAPP_DM_POLICY = String(process.env.WHATSAPP_DM_POLICY || 'open').trim().toLowerCase();
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
@@ -780,7 +782,6 @@ async function startSocket() {
 
 // HTTP server
 const app = express();
-app.use(express.json());
 
 // Host-header validation — defends against DNS rebinding.
 // The bridge binds loopback-only (127.0.0.1) but a victim browser on
@@ -812,6 +813,11 @@ app.use((req, res, next) => {
   }
   next();
 });
+
+// Loopback binding does not establish the caller's identity: another local
+// process can bind the configured port or call this API directly.
+app.use(createBridgeAuthMiddleware(BRIDGE_TOKEN));
+app.use(express.json());
 
 // Poll for new messages (long-poll style)
 app.get('/messages', (req, res) => {
@@ -1105,12 +1111,17 @@ app.get('/chat/:id', async (req, res) => {
 
 // Health check
 app.get('/health', (req, res) => {
+  const challenge = req.headers['x-hermes-bridge-challenge'];
+  if (typeof challenge !== 'string' || !challenge) {
+    return res.status(400).json({ error: 'Missing bridge challenge' });
+  }
   res.json({
     status: connectionState,
     queueLength: messageQueue.length,
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
+    authProof: bridgeAuthProof(BRIDGE_TOKEN, challenge),
   });
 });
 
@@ -1132,6 +1143,10 @@ if (PAIR_ONLY) {
     process.exit(1);
   });
 } else {
+  if (!BRIDGE_TOKEN) {
+    console.error('WhatsApp bridge authentication token is required.');
+    process.exit(1);
+  }
   app.listen(PORT, '127.0.0.1', () => {
     console.log(`🌉 WhatsApp bridge listening on port ${PORT} (mode: ${WHATSAPP_MODE})`);
     console.log(`📁 Session stored in: ${SESSION_DIR}`);

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -104,10 +104,15 @@ const AUDIO_CACHE_DIR = process.env.HERMES_AUDIO_CACHE_DIR
 // keeps serving the old behavior forever).
 let SCRIPT_HASH = '';
 try {
-  SCRIPT_HASH = createHash('sha256')
-    .update(readFileSync(fileURLToPath(import.meta.url)))
-    .digest('hex')
-    .slice(0, 16);
+  const entryPath = fileURLToPath(import.meta.url);
+  const digest = createHash('sha256');
+  for (const sourcePath of [entryPath, path.join(path.dirname(entryPath), 'bridge_auth.js')]) {
+    digest.update(path.basename(sourcePath));
+    digest.update('\0');
+    digest.update(readFileSync(sourcePath));
+    digest.update('\0');
+  }
+  SCRIPT_HASH = digest.digest('hex').slice(0, 16);
 } catch {}
 const PAIR_ONLY = args.includes('--pair-only');
 const PAIR_JSON = args.includes('--pair-json');

--- a/scripts/whatsapp-bridge/bridge_auth.js
+++ b/scripts/whatsapp-bridge/bridge_auth.js
@@ -1,0 +1,21 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+function constantTimeEqual(left, right) {
+  const leftBuffer = Buffer.from(String(left || ''), 'utf8');
+  const rightBuffer = Buffer.from(String(right || ''), 'utf8');
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export function bridgeAuthProof(token, challenge) {
+  return createHmac('sha256', String(token)).update(String(challenge)).digest('hex');
+}
+
+export function createBridgeAuthMiddleware(token) {
+  const expected = `Bearer ${token}`;
+  return (req, res, next) => {
+    if (!token || !constantTimeEqual(req.headers.authorization, expected)) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    next();
+  };
+}

--- a/scripts/whatsapp-bridge/bridge_auth.test.mjs
+++ b/scripts/whatsapp-bridge/bridge_auth.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { bridgeAuthProof, createBridgeAuthMiddleware } from './bridge_auth.js';
+
+function invokeMiddleware(middleware, authorization) {
+  const req = { headers: {} };
+  if (authorization !== undefined) req.headers.authorization = authorization;
+  const response = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+  };
+  let nextCalled = false;
+  middleware(req, response, () => { nextCalled = true; });
+  return { response, nextCalled };
+}
+
+test('bridge auth middleware rejects missing and incorrect bearer tokens', () => {
+  const middleware = createBridgeAuthMiddleware('correct-secret');
+
+  for (const authorization of [undefined, 'Bearer wrong-secret', 'Basic correct-secret']) {
+    const { response, nextCalled } = invokeMiddleware(middleware, authorization);
+    assert.equal(nextCalled, false);
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(response.body, { error: 'Unauthorized' });
+  }
+});
+
+test('bridge auth middleware accepts the exact bearer token', () => {
+  const middleware = createBridgeAuthMiddleware('correct-secret');
+  const { response, nextCalled } = invokeMiddleware(middleware, 'Bearer correct-secret');
+
+  assert.equal(nextCalled, true);
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body, null);
+});
+
+test('health proof is bound to both the secret and challenge', () => {
+  const proof = bridgeAuthProof('correct-secret', 'challenge-a');
+
+  assert.match(proof, /^[0-9a-f]{64}$/);
+  assert.notEqual(proof, bridgeAuthProof('correct-secret', 'challenge-b'));
+  assert.notEqual(proof, bridgeAuthProof('wrong-secret', 'challenge-a'));
+});

--- a/tests/gateway/test_whatsapp_bridge_auth.py
+++ b/tests/gateway/test_whatsapp_bridge_auth.py
@@ -1,5 +1,6 @@
 """Security regressions for authenticated WhatsApp bridge IPC."""
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 
@@ -12,6 +13,32 @@ def test_bridge_token_is_persistent_on_disk(tmp_path: Path):
     assert first == second
     assert len(first) >= 32
     assert (tmp_path / ".bridge-token").read_text(encoding="utf-8").strip() == first
+
+
+def test_concurrent_bridge_token_creation_reuses_exclusive_winner(
+    tmp_path: Path,
+):
+    from plugins.platforms.whatsapp import adapter
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        tokens = list(
+            executor.map(adapter._load_or_create_bridge_token, [tmp_path] * 8)
+        )
+
+    persisted = (tmp_path / ".bridge-token").read_text(encoding="utf-8").strip()
+    assert tokens == [persisted] * len(tokens)
+
+
+def test_malformed_persisted_bridge_token_is_replaced(tmp_path: Path):
+    from plugins.platforms.whatsapp.adapter import _load_or_create_bridge_token
+
+    token_path = tmp_path / ".bridge-token"
+    token_path.write_text("truncated", encoding="utf-8")
+
+    token = _load_or_create_bridge_token(tmp_path)
+
+    assert len(token) >= 32
+    assert token_path.read_text(encoding="utf-8") == token
 
 
 def test_health_authentication_requires_challenge_bound_proof():

--- a/tests/gateway/test_whatsapp_bridge_auth.py
+++ b/tests/gateway/test_whatsapp_bridge_auth.py
@@ -49,3 +49,17 @@ def test_bridge_headers_include_bearer_token_and_optional_challenge():
         "Authorization": "Bearer secret",
         "X-Hermes-Bridge-Challenge": "nonce",
     }
+
+
+def test_bridge_source_hash_changes_when_auth_helper_changes(tmp_path: Path):
+    from plugins.platforms.whatsapp.adapter import _bridge_source_hash
+
+    bridge = tmp_path / "bridge.js"
+    auth = tmp_path / "bridge_auth.js"
+    bridge.write_text("// bridge\n")
+    auth.write_text("// auth v1\n")
+    first = _bridge_source_hash(bridge)
+
+    auth.write_text("// auth v2\n")
+
+    assert _bridge_source_hash(bridge) != first

--- a/tests/gateway/test_whatsapp_bridge_auth.py
+++ b/tests/gateway/test_whatsapp_bridge_auth.py
@@ -1,0 +1,51 @@
+"""Security regressions for authenticated WhatsApp bridge IPC."""
+
+from pathlib import Path
+
+
+def test_bridge_token_is_persistent_on_disk(tmp_path: Path):
+    from plugins.platforms.whatsapp.adapter import _load_or_create_bridge_token
+
+    first = _load_or_create_bridge_token(tmp_path)
+    second = _load_or_create_bridge_token(tmp_path)
+
+    assert first == second
+    assert len(first) >= 32
+    assert (tmp_path / ".bridge-token").read_text(encoding="utf-8").strip() == first
+
+
+def test_health_authentication_requires_challenge_bound_proof():
+    from plugins.platforms.whatsapp.adapter import (
+        _bridge_auth_proof,
+        _health_response_is_authenticated,
+    )
+
+    token = "test-token-with-enough-entropy"
+    challenge = "fresh-challenge"
+    valid = {
+        "status": "connected",
+        "scriptHash": "public-script-hash",
+        "authProof": _bridge_auth_proof(token, challenge),
+    }
+
+    assert _health_response_is_authenticated(valid, token, challenge)
+    assert not _health_response_is_authenticated(
+        {**valid, "authProof": _bridge_auth_proof(token, "replayed-challenge")},
+        token,
+        challenge,
+    )
+    assert not _health_response_is_authenticated(
+        {"status": "connected", "scriptHash": "public-script-hash"},
+        token,
+        challenge,
+    )
+
+
+def test_bridge_headers_include_bearer_token_and_optional_challenge():
+    from plugins.platforms.whatsapp.adapter import _bridge_auth_headers
+
+    assert _bridge_auth_headers("secret") == {"Authorization": "Bearer secret"}
+    assert _bridge_auth_headers("secret", "nonce") == {
+        "Authorization": "Bearer secret",
+        "X-Hermes-Bridge-Challenge": "nonce",
+    }

--- a/tests/gateway/test_whatsapp_bridge_dir_resolution.py
+++ b/tests/gateway/test_whatsapp_bridge_dir_resolution.py
@@ -75,6 +75,14 @@ def test_readonly_install_refreshes_existing_mirror_without_deleting_dependencie
     removed_dir = existing / "removed-source-dir"
     removed_dir.mkdir()
     (removed_dir / "old.js").write_text("// removed upstream\n")
+    (existing / "file-to-dir").write_text("// old file\n")
+    source_dir = install_bridge / "file-to-dir"
+    source_dir.mkdir()
+    (source_dir / "current.js").write_text("// current directory\n")
+    mirror_dir = existing / "dir-to-file"
+    mirror_dir.mkdir()
+    (mirror_dir / "old.js").write_text("// old directory\n")
+    (install_bridge / "dir-to-file").write_text("// current file\n")
     node_modules = existing / "node_modules"
     node_modules.mkdir()
     dependency_marker = node_modules / "keep-me"
@@ -102,6 +110,10 @@ def test_readonly_install_refreshes_existing_mirror_without_deleting_dependencie
     assert (existing / "bridge_auth.js").read_text() == "// auth helper\n"
     assert not (existing / "removed-helper.js").exists()
     assert not removed_dir.exists()
+    assert (existing / "file-to-dir" / "current.js").read_text() == (
+        "// current directory\n"
+    )
+    assert (existing / "dir-to-file").read_text() == "// current file\n"
     assert dependency_marker.read_text() == "installed"
 
 

--- a/tests/gateway/test_whatsapp_bridge_dir_resolution.py
+++ b/tests/gateway/test_whatsapp_bridge_dir_resolution.py
@@ -71,6 +71,10 @@ def test_readonly_install_refreshes_existing_mirror_without_deleting_dependencie
     existing = hermes_home / "scripts" / "whatsapp-bridge"
     existing.mkdir(parents=True)
     (existing / "bridge.js").write_text("// stale bridge\n")
+    (existing / "removed-helper.js").write_text("// removed upstream\n")
+    removed_dir = existing / "removed-source-dir"
+    removed_dir.mkdir()
+    (removed_dir / "old.js").write_text("// removed upstream\n")
     node_modules = existing / "node_modules"
     node_modules.mkdir()
     dependency_marker = node_modules / "keep-me"
@@ -96,6 +100,8 @@ def test_readonly_install_refreshes_existing_mirror_without_deleting_dependencie
     assert resolved == existing
     assert (existing / "bridge.js").read_text() == "// bridge\n"
     assert (existing / "bridge_auth.js").read_text() == "// auth helper\n"
+    assert not (existing / "removed-helper.js").exists()
+    assert not removed_dir.exists()
     assert dependency_marker.read_text() == "installed"
 
 

--- a/tests/gateway/test_whatsapp_bridge_dir_resolution.py
+++ b/tests/gateway/test_whatsapp_bridge_dir_resolution.py
@@ -17,6 +17,7 @@ def _seed_install_tree(install_bridge: Path) -> None:
     """Create a minimal fake bridge source tree."""
     install_bridge.mkdir(parents=True, exist_ok=True)
     (install_bridge / "bridge.js").write_text("// bridge\n")
+    (install_bridge / "bridge_auth.js").write_text("// auth helper\n")
     (install_bridge / "package.json").write_text('{"name": "whatsapp-bridge"}\n')
 
 
@@ -55,6 +56,46 @@ def test_readonly_install_mirrors_to_hermes_home(tmp_path, monkeypatch):
     assert resolved == expected
     # Source was mirrored, not symlinked.
     assert (expected / "bridge.js").read_text() == "// bridge\n"
+    assert (expected / "bridge_auth.js").read_text() == "// auth helper\n"
     assert (expected / "package.json").exists()
+
+
+def test_readonly_install_refreshes_existing_mirror_without_deleting_dependencies(
+    tmp_path, monkeypatch
+):
+    install_root = tmp_path / "install"
+    install_bridge = install_root / "scripts" / "whatsapp-bridge"
+    _seed_install_tree(install_bridge)
+
+    hermes_home = tmp_path / "hermes_home"
+    existing = hermes_home / "scripts" / "whatsapp-bridge"
+    existing.mkdir(parents=True)
+    (existing / "bridge.js").write_text("// stale bridge\n")
+    node_modules = existing / "node_modules"
+    node_modules.mkdir()
+    dependency_marker = node_modules / "keep-me"
+    dependency_marker.write_text("installed")
+
+    monkeypatch.setattr(
+        whatsapp_common, "__file__",
+        str(install_root / "gateway" / "platforms" / "whatsapp_common.py"),
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+
+    real_touch = Path.touch
+
+    def fake_touch(self, *args, **kwargs):
+        if self.name == ".write_test" and install_bridge in self.parents:
+            raise PermissionError("read-only install tree")
+        return real_touch(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "touch", fake_touch)
+
+    resolved = whatsapp_common.resolve_whatsapp_bridge_dir()
+
+    assert resolved == existing
+    assert (existing / "bridge.js").read_text() == "// bridge\n"
+    assert (existing / "bridge_auth.js").read_text() == "// auth helper\n"
+    assert dependency_marker.read_text() == "installed"
 
 

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -13,6 +13,7 @@ Regression tests for two bugs in WhatsAppAdapter.connect():
 """
 
 import asyncio
+from contextlib import ExitStack
 import signal
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -94,6 +95,10 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
         patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True),
         patch.object(Path, "exists", return_value=True),
         patch.object(Path, "mkdir", return_value=None),
+        patch(
+            "plugins.platforms.whatsapp.adapter._load_or_create_bridge_token",
+            return_value="test-bridge-token-with-enough-entropy",
+        ),
         patch("subprocess.run", return_value=MagicMock(returncode=0)),
         patch("subprocess.Popen", return_value=mock_proc),
         patch("builtins.open", return_value=mock_fh),
@@ -142,8 +147,8 @@ class TestDataInitialized:
         """HTTP 200 sets http_ready but json() always raises.
 
         Without the fix, ``data`` was never assigned and the Phase 2 check
-        ``data.get("status")`` raised NameError.  With ``data = {}``, the
-        check evaluates to ``None != "connected"`` and Phase 2 runs normally.
+        ``data.get("status")`` raised NameError. The authenticated health path
+        now fails closed without ever reading an uninitialized value.
         """
         adapter = _make_adapter()
 
@@ -157,15 +162,18 @@ class TestDataInitialized:
 
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
-        with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8], \
-             patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
+        with ExitStack() as stack:
+            for item in patches:
+                stack.enter_context(item)
+            stack.enter_context(
+                patch.object(type(adapter), "_poll_messages", return_value=MagicMock())
+            )
             # Must NOT raise NameError
             result = await adapter.connect()
 
-        # connect() returns True (warn-and-proceed path)
-        assert result is True
-        assert adapter._running is True
+        # Invalid health responses are not authenticated and fail closed.
+        assert result is False
+        assert adapter._running is False
 
 
 # ---------------------------------------------------------------------------
@@ -187,8 +195,9 @@ class TestFileHandleClosedOnError:
         mock_fh = MagicMock()
         patches = _connect_patches(mock_proc, mock_fh)
 
-        with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7]:
+        with ExitStack() as stack:
+            for item in patches:
+                stack.enter_context(item)
             result = await adapter.connect()
 
         assert result is False
@@ -296,8 +305,9 @@ class TestBridgeRuntimeFailure:
         mock_fh = MagicMock()
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
-        with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8]:
+        with ExitStack() as stack:
+            for item in patches:
+                stack.enter_context(item)
             result = await adapter.connect()
 
         assert result is False

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -72,17 +72,24 @@ def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
 _TEST_BRIDGE_TOKEN = "test-bridge-token-with-enough-entropy"
 
 
-def _mock_health(json_data, *, authenticated=True):
+def _mock_health(json_data, *, authenticated=True, reflect_request_token=False):
     """Mock aiohttp.ClientSession whose GET returns 200 + *json_data*."""
     mock_session = MagicMock()
 
-    def get(_url, **kwargs):
-        payload = dict(json_data)
-        if authenticated:
+    def get(url, **kwargs):
+        if url.endswith("/auth-proof"):
+            payload = {}
             from plugins.platforms.whatsapp.adapter import _bridge_auth_proof
 
             challenge = kwargs["headers"]["X-Hermes-Bridge-Challenge"]
-            payload["authProof"] = _bridge_auth_proof(_TEST_BRIDGE_TOKEN, challenge)
+            token = _TEST_BRIDGE_TOKEN if authenticated else ""
+            if reflect_request_token:
+                authorization = kwargs["headers"].get("Authorization", "")
+                token = authorization.removeprefix("Bearer ")
+            if token:
+                payload["authProof"] = _bridge_auth_proof(token, challenge)
+        else:
+            payload = dict(json_data)
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.json = AsyncMock(return_value=payload)
@@ -90,7 +97,9 @@ def _mock_health(json_data, *, authenticated=True):
 
     mock_session.get = MagicMock(side_effect=get)
     mock_session.close = AsyncMock()
-    return MagicMock(return_value=_AsyncCM(mock_session))
+    factory = MagicMock(return_value=_AsyncCM(mock_session))
+    factory.mock_session = mock_session
+    return factory
 
 
 def _setup_bridge_dir(tmp_path: Path) -> Path:
@@ -197,6 +206,44 @@ class TestStaleBridgeHandshake:
 
         assert result is False
         mock_popen.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_listener_that_can_only_reflect_disclosed_credentials(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _bridge_source_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        disk_hash = _bridge_source_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health(
+            {
+                "status": "connected",
+                "scriptHash": disk_hash,
+                "sendReadReceipts": False,
+            },
+            authenticated=False,
+            reflect_request_token=True,
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            result = await adapter.connect()
+
+        assert result is False
+        mock_popen.assert_called_once()
+        first_request_headers = mock_client.mock_session.get.call_args_list[0].kwargs["headers"]
+        assert "Authorization" not in first_request_headers
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -69,13 +69,26 @@ def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
     return adapter
 
 
-def _mock_health(json_data):
+_TEST_BRIDGE_TOKEN = "test-bridge-token-with-enough-entropy"
+
+
+def _mock_health(json_data, *, authenticated=True):
     """Mock aiohttp.ClientSession whose GET returns 200 + *json_data*."""
-    mock_resp = MagicMock()
-    mock_resp.status = 200
-    mock_resp.json = AsyncMock(return_value=json_data)
     mock_session = MagicMock()
-    mock_session.get = MagicMock(return_value=_AsyncCM(mock_resp))
+
+    def get(_url, **kwargs):
+        payload = dict(json_data)
+        if authenticated:
+            from plugins.platforms.whatsapp.adapter import _bridge_auth_proof
+
+            challenge = kwargs["headers"]["X-Hermes-Bridge-Challenge"]
+            payload["authProof"] = _bridge_auth_proof(_TEST_BRIDGE_TOKEN, challenge)
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=payload)
+        return _AsyncCM(mock_resp)
+
+    mock_session.get = MagicMock(side_effect=get)
     mock_session.close = AsyncMock()
     return MagicMock(return_value=_AsyncCM(mock_session))
 
@@ -89,6 +102,7 @@ def _setup_bridge_dir(tmp_path: Path) -> Path:
     session_path = tmp_path / "session"
     session_path.mkdir()
     (session_path / "creds.json").write_text("{}")
+    (session_path / ".bridge-token").write_text(_TEST_BRIDGE_TOKEN)
     return bridge_dir
 
 
@@ -115,6 +129,73 @@ class TestFileContentHash:
 
 
 class TestStaleBridgeHandshake:
+
+    @pytest.mark.asyncio
+    async def test_reuses_only_authenticated_matching_bridge(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health(
+            {
+                "status": "connected",
+                "scriptHash": disk_hash,
+                "sendReadReceipts": False,
+            }
+        )
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.create_task"), \
+             patch("subprocess.Popen") as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            result = await adapter.connect()
+
+        assert result is True
+        mock_popen.assert_not_called()
+        assert mock_client.call_args_list[-1].kwargs["headers"] == {
+            "Authorization": f"Bearer {_TEST_BRIDGE_TOKEN}"
+        }
+
+    @pytest.mark.asyncio
+    async def test_rejects_matching_listener_without_auth_proof(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health(
+            {
+                "status": "connected",
+                "scriptHash": disk_hash,
+                "sendReadReceipts": False,
+            },
+            authenticated=False,
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            result = await adapter.connect()
+
+        assert result is False
+        mock_popen.assert_called_once()
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -98,6 +98,7 @@ def _setup_bridge_dir(tmp_path: Path) -> Path:
     bridge_dir = tmp_path / "whatsapp-bridge"
     bridge_dir.mkdir()
     (bridge_dir / "bridge.js").write_text("// current bridge code\n")
+    (bridge_dir / "bridge_auth.js").write_text("// current auth code\n")
     (bridge_dir / "package.json").write_text('{"name": "bridge"}\n')
     session_path = tmp_path / "session"
     session_path.mkdir()
@@ -132,7 +133,7 @@ class TestStaleBridgeHandshake:
 
     @pytest.mark.asyncio
     async def test_reuses_only_authenticated_matching_bridge(self, tmp_path):
-        from plugins.platforms.whatsapp.adapter import _file_content_hash
+        from plugins.platforms.whatsapp.adapter import _bridge_source_hash
 
         bridge_dir = _setup_bridge_dir(tmp_path)
         _fresh_node_modules(bridge_dir)
@@ -140,7 +141,7 @@ class TestStaleBridgeHandshake:
             bridge_script=str(bridge_dir / "bridge.js"),
             session_path=tmp_path / "session",
         )
-        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        disk_hash = _bridge_source_hash(bridge_dir / "bridge.js")
         mock_client = _mock_health(
             {
                 "status": "connected",
@@ -164,7 +165,7 @@ class TestStaleBridgeHandshake:
 
     @pytest.mark.asyncio
     async def test_rejects_matching_listener_without_auth_proof(self, tmp_path):
-        from plugins.platforms.whatsapp.adapter import _file_content_hash
+        from plugins.platforms.whatsapp.adapter import _bridge_source_hash
 
         bridge_dir = _setup_bridge_dir(tmp_path)
         _fresh_node_modules(bridge_dir)
@@ -172,7 +173,7 @@ class TestStaleBridgeHandshake:
             bridge_script=str(bridge_dir / "bridge.js"),
             session_path=tmp_path / "session",
         )
-        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        disk_hash = _bridge_source_hash(bridge_dir / "bridge.js")
         mock_client = _mock_health(
             {
                 "status": "connected",
@@ -200,7 +201,7 @@ class TestStaleBridgeHandshake:
 
     @pytest.mark.asyncio
     async def test_restarts_bridge_when_read_receipt_config_changed(self, tmp_path):
-        from plugins.platforms.whatsapp.adapter import _file_content_hash
+        from plugins.platforms.whatsapp.adapter import _bridge_source_hash
 
         bridge_dir = _setup_bridge_dir(tmp_path)
         _fresh_node_modules(bridge_dir)
@@ -209,7 +210,7 @@ class TestStaleBridgeHandshake:
             session_path=tmp_path / "session",
         )
         adapter._send_read_receipts = True
-        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        disk_hash = _bridge_source_hash(bridge_dir / "bridge.js")
         mock_client = _mock_health(
             {
                 "status": "connected",

--- a/tests/tools/test_whatsapp_send_message_media.py
+++ b/tests/tools/test_whatsapp_send_message_media.py
@@ -218,6 +218,7 @@ def test_standalone_delivery_authenticates_text_caption_fallback_and_media(tmp_p
             assert "headers" not in call.kwargs
         assert authenticate.await_count == 2
         for call in authenticate.await_args_list:
+            assert call.args[1] == "http://127.0.0.1:3000"
             assert call.args[2] == token
         for call in session_ctx.__aenter__.return_value.post.call_args_list:
             assert call.kwargs["headers"] == {"Authorization": f"Bearer {token}"}

--- a/tests/tools/test_whatsapp_send_message_media.py
+++ b/tests/tools/test_whatsapp_send_message_media.py
@@ -115,7 +115,11 @@ def test_text_plus_mixed_media_routes_native_types():
                 _resp(200, {"messageId": "m3"}),
             ]
         )
-        with patch("aiohttp.ClientSession", return_value=session_ctx):
+        with patch("aiohttp.ClientSession", return_value=session_ctx), \
+             patch(
+                 "plugins.platforms.whatsapp.adapter._request_authenticated_bridge_health",
+                 new=AsyncMock(return_value={"status": "connected"}),
+             ):
             res = asyncio.run(
                 _standalone_send(
                     _pconfig(),
@@ -141,7 +145,11 @@ def test_missing_captioned_file_falls_back_to_text():
     """If the single captioned file is missing, the caption is delivered as a
     plain /send message rather than being silently lost (W1)."""
     session_ctx, calls = _session_with([_resp(200, {"messageId": "t1"})])
-    with patch("aiohttp.ClientSession", return_value=session_ctx):
+    with patch("aiohttp.ClientSession", return_value=session_ctx), \
+         patch(
+             "plugins.platforms.whatsapp.adapter._request_authenticated_bridge_health",
+             new=AsyncMock(return_value={"status": "connected"}),
+         ):
         res = asyncio.run(
             _standalone_send(
                 _pconfig(),
@@ -175,7 +183,11 @@ def test_standalone_delivery_authenticates_text_caption_fallback_and_media(tmp_p
                 _resp(200, {"messageId": "fallback"}),
             ]
         )
-        with patch("aiohttp.ClientSession", return_value=session_ctx) as client_session:
+        with patch("aiohttp.ClientSession", return_value=session_ctx) as client_session, \
+             patch(
+                 "plugins.platforms.whatsapp.adapter._request_authenticated_bridge_health",
+                 new=AsyncMock(return_value={"status": "connected"}),
+             ) as authenticate:
             text_and_media = asyncio.run(
                 _standalone_send(
                     _pconfig(tmp_path),
@@ -203,6 +215,11 @@ def test_standalone_delivery_authenticates_text_caption_fallback_and_media(tmp_p
         ]
         assert client_session.call_count == 2
         for call in client_session.call_args_list:
+            assert "headers" not in call.kwargs
+        assert authenticate.await_count == 2
+        for call in authenticate.await_args_list:
+            assert call.args[2] == token
+        for call in session_ctx.__aenter__.return_value.post.call_args_list:
             assert call.kwargs["headers"] == {"Authorization": f"Bearer {token}"}
     finally:
         os.unlink(media_path)

--- a/tests/tools/test_whatsapp_send_message_media.py
+++ b/tests/tools/test_whatsapp_send_message_media.py
@@ -88,8 +88,11 @@ def _session_with(responses):
     return session_ctx, calls
 
 
-def _pconfig():
-    return SimpleNamespace(token="", extra={"bridge_port": 3000})
+def _pconfig(session_path=None):
+    extra = {"bridge_port": 3000}
+    if session_path is not None:
+        extra["session_path"] = str(session_path)
+    return SimpleNamespace(token="", extra=extra)
 
 
 def _tmpfile(suffix):
@@ -155,3 +158,51 @@ def test_missing_captioned_file_falls_back_to_text():
     assert len(calls) == 1
     assert calls[0][0].endswith("/send")
     assert calls[0][1]["message"] == "floor plan"
+
+
+def test_standalone_delivery_authenticates_text_caption_fallback_and_media(tmp_path):
+    """Every standalone bridge route uses the session's persisted bearer token."""
+    token = "persistent-standalone-bridge-token"
+    (tmp_path / ".bridge-token").write_text(token, encoding="utf-8")
+    media_path = _tmpfile(".png")
+    missing_path = str(tmp_path / "missing.png")
+
+    try:
+        session_ctx, calls = _session_with(
+            [
+                _resp(200, {"messageId": "text"}),
+                _resp(200, {"messageId": "media"}),
+                _resp(200, {"messageId": "fallback"}),
+            ]
+        )
+        with patch("aiohttp.ClientSession", return_value=session_ctx) as client_session:
+            text_and_media = asyncio.run(
+                _standalone_send(
+                    _pconfig(tmp_path),
+                    "12345",
+                    "hello",
+                    media_files=[(media_path, False)],
+                )
+            )
+            caption_fallback = asyncio.run(
+                _standalone_send(
+                    _pconfig(tmp_path),
+                    "12345",
+                    "",
+                    media_files=[(missing_path, False)],
+                    caption="fallback caption",
+                )
+            )
+
+        assert text_and_media["success"] is True
+        assert "not found" in caption_fallback["error"]
+        assert [call[0].rsplit("/", 1)[-1] for call in calls] == [
+            "send",
+            "send-media",
+            "send",
+        ]
+        assert client_session.call_count == 2
+        for call in client_session.call_args_list:
+            assert call.kwargs["headers"] == {"Authorization": f"Bearer {token}"}
+    finally:
+        os.unlink(media_path)


### PR DESCRIPTION
## What does this PR do?

This change prevents an arbitrary local process from impersonating the WhatsApp bridge and intercepting or forging messages. It gives each WhatsApp session a persistent random secret, authenticates every bridge API request, and requires a challenge-bound proof before an existing listener can be reused. Legitimate bridge reuse across gateway restarts remains supported.

### Symptom

A process that binds the configured local bridge port before Hermes starts can return the public bridge source hash from `/health`. Hermes then adopts that process as the WhatsApp bridge, accepts forged inbound messages from it, and sends outbound message payloads to it.

### Impact

On a shared or compromised machine, another local process can silently read WhatsApp message traffic handled by Hermes or impersonate the user through bridge operations. The remote blast radius was not measured; the verified boundary is any process able to bind and serve the local bridge port under the same host.

### Bug Cause

**Trigger:** `plugins/platforms/whatsapp/adapter.py` / `WhatsAppAdapter.connect()` reuses a listener whose unauthenticated `/health` response reports `connected` and the expected source hash.

**Causal chain:**
1. A local process binds the configured bridge port before the managed bridge starts.
2. The adapter sends unauthenticated HTTP requests and treats the public source hash as sufficient identity for listener reuse.
3. The impostor receives outbound requests and supplies forged inbound responses as though it were the user's bridge.

**Why it is wrong:** The source hash detects stale bridge code but is derivable from the shipped source, so it cannot authenticate a local process. The Host header guard only limits DNS rebinding and does not establish caller or server identity.

**Working sibling / contrast:** A bridge spawned by Hermes can receive a per-session secret without user configuration. Persisting that secret in the session directory also lets a legitimate bridge prove its identity after a gateway restart.

**Ruled out:** Binding only to `127.0.0.1` is not sufficient because the reported attacker is another process on the same host. Randomizing the port is unnecessary for identity once every endpoint and listener reuse are cryptographically authenticated.

### Fix

- Generate and persist an owner-readable per-session bridge token, then pass it only to the managed bridge process.
- Require a bearer token on every Express endpoint and configure every persistent adapter request to send it.
- Bind health responses to a fresh adapter challenge with an HMAC proof before startup readiness or listener reuse succeeds.
- Include the authentication helper in bridge staleness identity and refresh read-only installation mirrors without deleting `node_modules`.
- Add Python and Node regressions for rejection, authenticated access, legitimate reuse, token lifecycle, and stale mirrored sources.

## Related Issue

Closes #83395

## Type of Change

- [x] Security fix

## Changes Made

- `plugins/platforms/whatsapp/adapter.py` - manage the bridge secret, authenticate requests, verify health proofs, and include authentication code in source identity.
- `scripts/whatsapp-bridge/bridge.js` - protect all bridge routes and return challenge-bound health proofs.
- `scripts/whatsapp-bridge/bridge_auth.js` - provide constant-time bearer validation and HMAC proof generation.
- `gateway/platforms/whatsapp_common.py` - refresh packaged bridge mirrors while preserving installed dependencies.
- `tests/gateway/` and `scripts/whatsapp-bridge/*.test.mjs` - cover authentication, reuse, token persistence, and stale-source behavior.

## How to Test

1. Start an unauthenticated fake listener on the configured bridge port and verify Hermes refuses to adopt it.
2. Start the managed bridge, verify missing or incorrect credentials receive HTTP 401, then restart the gateway and verify the authenticated existing bridge is reused.
3. Run the focused automated suites (verified locally: 12 Python tests and 25 Node tests passed on the reviewed tip):

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_bridge_auth.py tests/gateway/test_whatsapp_bridge_dir_resolution.py tests/gateway/test_whatsapp_stale_bridge.py
node --test scripts/whatsapp-bridge/*.test.mjs
node --check scripts/whatsapp-bridge/bridge.js
node --check scripts/whatsapp-bridge/bridge_auth.js
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 with Python 3.11 and Node.js

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - this change preserves the existing user-facing configuration.
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no contributor workflow changed.
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); token permissions use portable best-effort hardening.
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed.

## Screenshots / Logs

N/A - the verification is process and HTTP behavior covered by the commands above.
