### PR TITLE
fix: isolate profile gateway restart environments

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -885,7 +885,12 @@ def _prepare_profile_gateway_update_restart(profile: str, pid: int) -> str | Non
 
 
 def _profile_from_gateway_argv(run_argv: list[str]) -> str | None:
-    """Return a validated explicit profile from a captured gateway argv."""
+    """Return a validated explicit profile from a captured gateway argv.
+
+    Keep the accepted spellings aligned with ``main._apply_profile_override``:
+    ``-p NAME``, ``--profile NAME``, and ``--profile=NAME``.  Hermes pre-parses
+    these flags itself, so argparse's attached ``-pNAME`` spelling is not valid.
+    """
     profile: str | None = None
     for index, arg in enumerate(run_argv):
         if arg in {"--profile", "-p"} and index + 1 < len(run_argv):
@@ -937,14 +942,17 @@ def _profile_gateway_restart_env(profile: str) -> dict[str, str]:
     profile's tokens and integration settings into every restarted gateway.
     For a cross-profile restart, remove all known profile-managed variables
     plus every secret defined by the source profile, then install only the
-    target profile's secret scope.  Same-profile restarts preserve shell-only
-    credential injection for backwards compatibility.
+    target profile's secret scope and runtime identity.  Process-level values
+    outside those profile-managed sets (for example ``PATH``) remain intact.
+    Same-profile restarts preserve shell-only credential injection for
+    backwards compatibility.
     """
     from agent.secret_scope import build_profile_secret_scope
     from hermes_cli.config import _EXTRA_ENV_KEYS
     from hermes_cli.config_defaults import OPTIONAL_ENV_VARS
-    from hermes_cli.profiles import get_profile_dir
+    from hermes_cli.profiles import get_profile_dir, normalize_profile_name
 
+    profile = normalize_profile_name(profile)
     restart_env = dict(os.environ)
     source_home = Path(get_hermes_home()).resolve()
     target_home = Path(get_profile_dir(profile)).resolve()
@@ -959,6 +967,12 @@ def _profile_gateway_restart_env(profile: str) -> dict[str, str]:
     for key in profile_managed_keys:
         restart_env.pop(key, None)
     restart_env.update(target_secrets)
+    # Pin the child to the target even when its argv is bare (the default
+    # profile) and overwrite any stale source-profile identity inherited from
+    # the updater or supplied by a hand-edited target .env.
+    restart_env["HERMES_HOME"] = str(target_home)
+    restart_env["HERMES_PROFILE"] = profile
+    restart_env["HERMES_PROFILE_NAME"] = profile
     return restart_env
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -884,6 +884,29 @@ def _prepare_profile_gateway_update_restart(profile: str, pid: int) -> str | Non
     return None
 
 
+def _profile_from_gateway_argv(run_argv: list[str]) -> str | None:
+    """Return a validated explicit profile from a captured gateway argv."""
+    profile: str | None = None
+    for index, arg in enumerate(run_argv):
+        if arg in {"--profile", "-p"} and index + 1 < len(run_argv):
+            profile = run_argv[index + 1]
+            break
+        if arg.startswith("--profile="):
+            profile = arg.partition("=")[2]
+            break
+    if not profile:
+        return None
+
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    try:
+        profile = normalize_profile_name(profile)
+        validate_profile_name(profile)
+    except ValueError:
+        return None
+    return profile
+
+
 def launch_detached_gateway_restart_by_cmdline(
     old_pid: int, run_argv: list[str]
 ) -> bool:
@@ -897,17 +920,65 @@ def launch_detached_gateway_restart_by_cmdline(
     """
     if old_pid <= 0 or not run_argv:
         return False
-    return _spawn_gateway_restart_watcher(old_pid, list(run_argv))
+    profile = _profile_from_gateway_argv(run_argv)
+    watcher_env = _profile_gateway_restart_env(profile) if profile else None
+    return _spawn_gateway_restart_watcher(
+        old_pid,
+        list(run_argv),
+        watcher_env=watcher_env,
+    )
+
+
+def _profile_gateway_restart_env(profile: str) -> dict[str, str]:
+    """Build a profile-isolated environment for a gateway restart.
+
+    ``hermes update`` can restart gateways for every profile from one updater
+    process.  Reusing that process's full environment leaks the updater
+    profile's tokens and integration settings into every restarted gateway.
+    For a cross-profile restart, remove all known profile-managed variables
+    plus every secret defined by the source profile, then install only the
+    target profile's secret scope.  Same-profile restarts preserve shell-only
+    credential injection for backwards compatibility.
+    """
+    from agent.secret_scope import build_profile_secret_scope
+    from hermes_cli.config import _EXTRA_ENV_KEYS
+    from hermes_cli.config_defaults import OPTIONAL_ENV_VARS
+    from hermes_cli.profiles import get_profile_dir
+
+    restart_env = dict(os.environ)
+    source_home = Path(get_hermes_home()).resolve()
+    target_home = Path(get_profile_dir(profile)).resolve()
+    if source_home == target_home:
+        return restart_env
+
+    source_secrets = build_profile_secret_scope(source_home)
+    target_secrets = build_profile_secret_scope(target_home)
+    profile_managed_keys = (
+        set(OPTIONAL_ENV_VARS) | set(_EXTRA_ENV_KEYS) | set(source_secrets)
+    )
+    for key in profile_managed_keys:
+        restart_env.pop(key, None)
+    restart_env.update(target_secrets)
+    return restart_env
 
 
 def launch_detached_profile_gateway_restart(profile: str, old_pid: int) -> bool:
     """Relaunch a manually-run profile gateway after its current PID exits."""
     if old_pid <= 0:
         return False
-    return _spawn_gateway_restart_watcher(old_pid, _gateway_run_args_for_profile(profile))
+    return _spawn_gateway_restart_watcher(
+        old_pid,
+        _gateway_run_args_for_profile(profile),
+        watcher_env=_profile_gateway_restart_env(profile),
+    )
 
 
-def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
+def _spawn_gateway_restart_watcher(
+    old_pid: int,
+    run_argv: list[str],
+    *,
+    watcher_env: dict[str, str] | None = None,
+) -> bool:
     """Spawn the detached watcher that respawns ``run_argv`` once ``old_pid`` exits."""
     if old_pid <= 0 or not run_argv:
         return False
@@ -1045,6 +1116,7 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
             watcher_argv,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            env=watcher_env,
             **windows_detach_popen_kwargs(),
         )
     except OSError:
@@ -1063,6 +1135,7 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
                 watcher_argv,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                env=watcher_env,
                 **fallback_kwargs,
             )
         except OSError:

--- a/tests/hermes_cli/test_gateway_profile_restart_env.py
+++ b/tests/hermes_cli/test_gateway_profile_restart_env.py
@@ -1,0 +1,113 @@
+"""Cross-profile gateway restart environment isolation."""
+
+from pathlib import Path
+
+import hermes_cli.gateway as gateway
+
+
+def test_cross_profile_restart_env_replaces_source_profile_secrets(
+    monkeypatch, tmp_path: Path
+):
+    source_home = tmp_path / "default"
+    target_home = tmp_path / "profiles" / "testing"
+    source_home.mkdir()
+    target_home.mkdir(parents=True)
+
+    (source_home / ".env").write_text(
+        "DISCORD_BOT_TOKEN=source-token\n"
+        "DISCORD_ALLOWED_USERS=source-user\n"
+        "CUSTOM_PLUGIN_SECRET=source-secret\n",
+        encoding="utf-8",
+    )
+    (target_home / ".env").write_text(
+        "OPENROUTER_API_KEY=target-provider-key\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: source_home)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir", lambda _profile: target_home
+    )
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "inherited-source-token")
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "inherited-source-user")
+    monkeypatch.setenv("CUSTOM_PLUGIN_SECRET", "inherited-source-secret")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "inherited-source-provider-key")
+    monkeypatch.setenv("PATH", "safe-path")
+
+    restart_env = gateway._profile_gateway_restart_env("testing")
+
+    assert "DISCORD_BOT_TOKEN" not in restart_env
+    assert "DISCORD_ALLOWED_USERS" not in restart_env
+    assert "CUSTOM_PLUGIN_SECRET" not in restart_env
+    assert restart_env["OPENROUTER_API_KEY"] == "target-provider-key"
+    assert restart_env["PATH"] == "safe-path"
+
+
+def test_same_profile_restart_env_preserves_shell_credentials(monkeypatch, tmp_path):
+    profile_home = tmp_path / "testing"
+    profile_home.mkdir()
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: profile_home)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir", lambda _profile: profile_home
+    )
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "shell-only-token")
+
+    restart_env = gateway._profile_gateway_restart_env("testing")
+
+    assert restart_env["DISCORD_BOT_TOKEN"] == "shell-only-token"
+
+
+def test_profile_restart_passes_isolated_env_to_watcher(monkeypatch):
+    isolated_env = {"PATH": "safe-path", "HERMES_HOME": "target-home"}
+    popen_calls = []
+
+    monkeypatch.setattr(gateway.sys, "platform", "linux")
+    monkeypatch.setattr(
+        gateway,
+        "_gateway_run_args_for_profile",
+        lambda _profile: ["python", "-m", "hermes_cli.main", "gateway", "run"],
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_profile_gateway_restart_env",
+        lambda _profile: isolated_env,
+    )
+    monkeypatch.setattr(
+        gateway.subprocess,
+        "Popen",
+        lambda *args, **kwargs: popen_calls.append((args, kwargs)),
+    )
+
+    assert gateway.launch_detached_profile_gateway_restart("testing", 1234) is True
+
+    assert len(popen_calls) == 1
+    assert popen_calls[0][1]["env"] is isolated_env
+
+
+def test_captured_profile_cmdline_restart_uses_isolated_env(monkeypatch):
+    isolated_env = {"PATH": "safe-path", "HERMES_HOME": "target-home"}
+    spawn_calls = []
+    run_argv = [
+        "python",
+        "-m",
+        "hermes_cli.main",
+        "--profile",
+        "testing",
+        "gateway",
+        "run",
+    ]
+
+    monkeypatch.setattr(
+        gateway,
+        "_profile_gateway_restart_env",
+        lambda _profile: isolated_env,
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_spawn_gateway_restart_watcher",
+        lambda *args, **kwargs: spawn_calls.append((args, kwargs)) or True,
+    )
+
+    assert gateway.launch_detached_gateway_restart_by_cmdline(1234, run_argv) is True
+
+    assert spawn_calls == [((1234, run_argv), {"watcher_env": isolated_env})]

--- a/tests/hermes_cli/test_gateway_profile_restart_env.py
+++ b/tests/hermes_cli/test_gateway_profile_restart_env.py
@@ -2,14 +2,16 @@
 
 from pathlib import Path
 
+import pytest
+
 import hermes_cli.gateway as gateway
 
 
 def test_cross_profile_restart_env_replaces_source_profile_secrets(
     monkeypatch, tmp_path: Path
 ):
-    source_home = tmp_path / "default"
-    target_home = tmp_path / "profiles" / "testing"
+    source_home = tmp_path / "hermes"
+    target_home = source_home / "profiles" / "testing"
     source_home.mkdir()
     target_home.mkdir(parents=True)
 
@@ -24,10 +26,10 @@ def test_cross_profile_restart_env_replaces_source_profile_secrets(
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(gateway, "get_hermes_home", lambda: source_home)
-    monkeypatch.setattr(
-        "hermes_cli.profiles.get_profile_dir", lambda _profile: target_home
-    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(source_home))
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+    monkeypatch.setenv("HERMES_PROFILE_NAME", "default")
     monkeypatch.setenv("DISCORD_BOT_TOKEN", "inherited-source-token")
     monkeypatch.setenv("DISCORD_ALLOWED_USERS", "inherited-source-user")
     monkeypatch.setenv("CUSTOM_PLUGIN_SECRET", "inherited-source-secret")
@@ -40,16 +42,17 @@ def test_cross_profile_restart_env_replaces_source_profile_secrets(
     assert "DISCORD_ALLOWED_USERS" not in restart_env
     assert "CUSTOM_PLUGIN_SECRET" not in restart_env
     assert restart_env["OPENROUTER_API_KEY"] == "target-provider-key"
+    assert restart_env["HERMES_HOME"] == str(target_home.resolve())
+    assert restart_env["HERMES_PROFILE"] == "testing"
+    assert restart_env["HERMES_PROFILE_NAME"] == "testing"
     assert restart_env["PATH"] == "safe-path"
 
 
 def test_same_profile_restart_env_preserves_shell_credentials(monkeypatch, tmp_path):
-    profile_home = tmp_path / "testing"
-    profile_home.mkdir()
-    monkeypatch.setattr(gateway, "get_hermes_home", lambda: profile_home)
-    monkeypatch.setattr(
-        "hermes_cli.profiles.get_profile_dir", lambda _profile: profile_home
-    )
+    profile_home = tmp_path / "hermes" / "profiles" / "testing"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
     monkeypatch.setenv("DISCORD_BOT_TOKEN", "shell-only-token")
 
     restart_env = gateway._profile_gateway_restart_env("testing")
@@ -57,11 +60,39 @@ def test_same_profile_restart_env_preserves_shell_credentials(monkeypatch, tmp_p
     assert restart_env["DISCORD_BOT_TOKEN"] == "shell-only-token"
 
 
+def test_named_profile_restart_to_default_pins_default_identity(monkeypatch, tmp_path):
+    default_home = tmp_path / "hermes"
+    source_home = default_home / "profiles" / "testing"
+    source_home.mkdir(parents=True)
+
+    (source_home / ".env").write_text(
+        "DISCORD_BOT_TOKEN=source-token\n",
+        encoding="utf-8",
+    )
+    (default_home / ".env").write_text(
+        "OPENROUTER_API_KEY=default-provider-key\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(source_home))
+    monkeypatch.setenv("HERMES_PROFILE", "testing")
+    monkeypatch.setenv("HERMES_PROFILE_NAME", "testing")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "inherited-source-token")
+
+    restart_env = gateway._profile_gateway_restart_env("default")
+
+    assert "DISCORD_BOT_TOKEN" not in restart_env
+    assert restart_env["OPENROUTER_API_KEY"] == "default-provider-key"
+    assert restart_env["HERMES_HOME"] == str(default_home.resolve())
+    assert restart_env["HERMES_PROFILE"] == "default"
+    assert restart_env["HERMES_PROFILE_NAME"] == "default"
+
+
 def test_profile_restart_passes_isolated_env_to_watcher(monkeypatch):
     isolated_env = {"PATH": "safe-path", "HERMES_HOME": "target-home"}
     popen_calls = []
 
-    monkeypatch.setattr(gateway.sys, "platform", "linux")
     monkeypatch.setattr(
         gateway,
         "_gateway_run_args_for_profile",
@@ -84,15 +115,25 @@ def test_profile_restart_passes_isolated_env_to_watcher(monkeypatch):
     assert popen_calls[0][1]["env"] is isolated_env
 
 
-def test_captured_profile_cmdline_restart_uses_isolated_env(monkeypatch):
+@pytest.mark.parametrize(
+    "profile_args",
+    [
+        ["--profile", "testing"],
+        ["-p", "testing"],
+        ["--profile=testing"],
+    ],
+)
+def test_captured_profile_cmdline_restart_uses_isolated_env(
+    monkeypatch, profile_args
+):
     isolated_env = {"PATH": "safe-path", "HERMES_HOME": "target-home"}
+    profile_calls = []
     spawn_calls = []
     run_argv = [
         "python",
         "-m",
         "hermes_cli.main",
-        "--profile",
-        "testing",
+        *profile_args,
         "gateway",
         "run",
     ]
@@ -100,7 +141,7 @@ def test_captured_profile_cmdline_restart_uses_isolated_env(monkeypatch):
     monkeypatch.setattr(
         gateway,
         "_profile_gateway_restart_env",
-        lambda _profile: isolated_env,
+        lambda profile: profile_calls.append(profile) or isolated_env,
     )
     monkeypatch.setattr(
         gateway,
@@ -110,4 +151,21 @@ def test_captured_profile_cmdline_restart_uses_isolated_env(monkeypatch):
 
     assert gateway.launch_detached_gateway_restart_by_cmdline(1234, run_argv) is True
 
+    assert profile_calls == ["testing"]
     assert spawn_calls == [((1234, run_argv), {"watcher_env": isolated_env})]
+
+
+def test_attached_short_profile_is_not_treated_as_a_hermes_selector():
+    run_argv = [
+        "python",
+        "-m",
+        "hermes_cli.main",
+        "-ptesting",
+        "gateway",
+        "run",
+    ]
+
+    # Keep this aligned with main._apply_profile_override(), which accepts
+    # ``-p testing`` and ``--profile=testing`` but not argparse's attached
+    # short-option spelling.
+    assert gateway._profile_from_gateway_argv(run_argv) is None


### PR DESCRIPTION
## Summary
- prevent cross-profile gateway restarts from inheriting source-profile credentials
- remove source-profile secret scope and Hermes-managed profile variables before loading the target profile environment
- pin `HERMES_HOME`, `HERMES_PROFILE`, and `HERMES_PROFILE_NAME` to the target profile, including bare default-profile restarts
- apply the same isolation to explicit `--profile` / `-p` captured-command-line fallbacks while preserving same-profile shell credentials

## Why
A gateway restarted during `hermes update` can target a different profile than the updater process. Reusing the updater environment lets the target gateway retain credentials and runtime identity from the source profile even when those values are absent from the target profile.

## Review follow-up
- captured argv parsing now has regression coverage for the three spellings accepted by `_apply_profile_override`: `-p NAME`, `--profile NAME`, and `--profile=NAME`; attached `-pNAME` is intentionally rejected because the Hermes pre-parser does not accept it
- profile-managed variables are intentionally replaced from the target profile; process-level values outside those sets, such as `PATH`, are preserved and covered

## Test plan
- `42 passed` across the focused gateway restart/update suite (8 files)
- `4 passed` for detached-watcher Windows contract checks
- Ruff passed for both changed Python files
- `git diff --check` passed

All test credentials are synthetic.
