### PR TITLE
feat(langfuse): widen tracing to errors, sessions, subagents, and MoA fan-out

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -200,6 +200,24 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
     agent._stream_needs_break = True
 
 
+def _moa_reference_metrics_for_hook(agent: Any) -> Any:
+    """Per-advisor metrics for post_api_request, or None off the MoA path.
+
+    MoA runs N advisor models before its aggregator and returns only the
+    aggregator's response, so an observability plugin sees one generation for
+    the whole fan-out. The advisor spend is already computed per slot (see
+    ``_RefAccounting``); this only carries it across the hook boundary.
+    """
+    client = getattr(agent, "client", None)
+    getter = getattr(client, "last_reference_metrics", None)
+    if not callable(getter):
+        return None
+    try:
+        return getter()
+    except Exception:
+        return None
+
+
 def _is_copilot_provider(agent: Any) -> bool:
     """Delegate to ``AIAgent._is_copilot_provider`` (single owner of the check).
 
@@ -5758,6 +5776,7 @@ def run_conversation(
                         assistant_message=assistant_message,
                         assistant_content_chars=len(_assistant_text),
                         assistant_tool_call_count=len(_assistant_tool_calls),
+                        moa_references=_moa_reference_metrics_for_hook(agent),
                     )
             except Exception:
                 pass

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -374,6 +374,24 @@ def _print_nous_entitlement_guidance(agent, capability: str) -> bool:
     return True
 
 
+def _system_prompt_for_hooks(api_kwargs: Any, request_messages: Any) -> Any:
+    """System prompt as actually sent to the provider, for observability hooks.
+
+    Providers move it out of ``messages``: Anthropic Messages uses a separate
+    ``system`` kwarg (str or content-block list), the Responses/Codex API uses
+    top-level ``instructions``; Chat Completions keeps it as ``messages[0]``.
+    Returns None when the request carries no system prompt.
+    """
+    system_prompt = api_kwargs.get("system")
+    if system_prompt is None:
+        system_prompt = api_kwargs.get("instructions")
+    if system_prompt is None and isinstance(request_messages, list) and request_messages:
+        first = request_messages[0]
+        if isinstance(first, dict) and first.get("role") == "system":
+            system_prompt = first.get("content")
+    return system_prompt
+
+
 def _is_nous_inference_route(provider: str, base_url: str) -> bool:
     provider = (provider or "").strip().lower()
     if provider == "nous":
@@ -2288,6 +2306,13 @@ def run_conversation(
                             request_messages = api_kwargs.get("input")
                         if not isinstance(request_messages, list):
                             request_messages = api_messages
+                        # Anthropic (``system``) and Responses/Codex
+                        # (``instructions``) move the system prompt out of
+                        # messages; pass it explicitly for observability
+                        # plugins (Langfuse).
+                        system_prompt_for_hooks = _system_prompt_for_hooks(
+                            api_kwargs, request_messages
+                        )
                         # Shallow-copy the outer list so plugins that retain the
                         # reference for async snapshotting don't observe later
                         # mutations of api_messages.  The inner dicts are not
@@ -2323,6 +2348,7 @@ def run_conversation(
                             request_messages=list(request_messages)
                             if isinstance(request_messages, list)
                             else [],
+                            system_prompt=system_prompt_for_hooks,
                             message_count=len(api_messages),
                             tool_count=len(agent.tools or []),
                             approx_input_tokens=approx_tokens,

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1562,6 +1562,11 @@ class MoAChatCompletions:
         # caller to stitch in the live session_id + resolved aggregator output
         # and flush to the trace file (only when moa.save_traces is on).
         self._pending_trace: Any = None
+        # Per-advisor metrics for observability hooks. Unlike _pending_trace
+        # this is NOT consumed — post_api_request fires on a different branch
+        # than consume_and_save_trace, so a consuming read would race it. Holds
+        # until the next fan-out replaces it.
+        self._last_reference_metrics: Any = None
         # every_n fan-out cadence state. The iteration counter is scoped to a
         # single USER TURN (not the facade lifetime): it counts create() calls
         # since the last new user message and resets whenever the user-turn
@@ -1592,6 +1597,14 @@ class MoAChatCompletions:
             self._pending_reference_usage = CanonicalUsage()
             self._pending_reference_cost = None
         return usage, cost
+
+    def last_reference_metrics(self) -> Any:
+        """Per-advisor metrics from the most recent fan-out, or None.
+
+        Read-only: a MoA turn's post_api_request hook must not disturb the
+        accounting that consume_reference_usage and consume_and_save_trace own.
+        """
+        return self._last_reference_metrics
 
     def _record_late_reference_accounting(self, label: str, accounting: Any) -> None:
         """Fold a late-completing interrupted reference's real spend in.
@@ -2141,6 +2154,18 @@ class MoAChatCompletions:
                 "aggregator_slot": aggregator,
                 "aggregator_temperature": aggregator_temperature,
             }
+            # Derived from the same privacy-redacted _trace_refs, so an active
+            # privacy mode redacts the observability payload too.
+            try:
+                from agent.moa_trace import slot_metrics
+
+                self._last_reference_metrics = [
+                    slot_metrics(acct, label, output=text)
+                    for label, text, acct in _trace_refs
+                ]
+            except Exception as exc:  # pragma: no cover - never break a turn
+                logger.debug("MoA reference metrics render failed: %s", exc)
+                self._last_reference_metrics = None
 
             # Surface each reference model's answer to the display BEFORE the
             # aggregator acts — once per turn (only on the iteration that
@@ -2284,6 +2309,14 @@ class MoAClient:
         return self.chat.completions.consume_and_save_trace(
             session_id, aggregator_output_fallback=aggregator_output_fallback
         )
+
+    def last_reference_metrics(self) -> Any:
+        """Per-advisor metrics from the most recent fan-out, or None.
+
+        Read-only, unlike the two consume_* methods above: the observability
+        hook fires on a different branch than the accounting they own.
+        """
+        return getattr(self.chat.completions, "_last_reference_metrics", None)
 
 
 def build_moa_facade(agent, preset_name: Any = None) -> MoAClient:

--- a/agent/moa_trace.py
+++ b/agent/moa_trace.py
@@ -94,6 +94,21 @@ def _slot_trace(acct: Any, label: str) -> dict[str, Any]:
     }
 
 
+def slot_metrics(acct: Any, label: str, output: Any = None) -> dict[str, Any]:
+    """Render one reference's accounting for observability hooks.
+
+    Same fields as ``_slot_trace`` minus ``input_messages``, which is the bulk
+    of a trace record and would cross the plugin-hook boundary for every
+    advisor on every turn. ``output`` comes from the caller because the
+    privacy-redacted advisor text lives alongside the accounting, not on it.
+    """
+    trace = _slot_trace(acct, label)
+    trace.pop("input_messages", None)
+    if output is not None:
+        trace["output"] = output
+    return trace
+
+
 def save_moa_turn(
     *,
     session_id: Optional[str],

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -211,6 +211,10 @@ _DEFAULT_PAYLOADS = {
         "usage": {"input_tokens": 2048, "output_tokens": 512},
         "assistant_content_chars": 1200,
         "assistant_tool_call_count": 0,
+        # Per-advisor metrics on a MoA turn, None otherwise. MoA returns only
+        # the aggregator's response, so without this an observer cannot see the
+        # fan-out or price it at each advisor's own model.
+        "moa_references": None,
     },
     "subagent_stop": {
         "parent_session_id": "parent-sess",

--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -36,6 +36,10 @@ hermes plugins list                 # observability/langfuse should show "enable
 hermes chat -q "hello"              # then check Langfuse for a "Hermes turn" trace
 ```
 
+Generation observations include the Hermes system prompt when the provider
+uses a separate `system` param (Anthropic Messages API). Open an **LLM call**
+child span to inspect `role: system` (truncated via `HERMES_LANGFUSE_MAX_CHARS`).
+
 ## Optional tuning
 
 ```bash

--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -43,8 +43,34 @@ HERMES_LANGFUSE_ENV=production       # environment tag
 HERMES_LANGFUSE_RELEASE=v1.0.0       # release tag
 HERMES_LANGFUSE_SAMPLE_RATE=0.5      # sample 50% of traces
 HERMES_LANGFUSE_MAX_CHARS=12000      # max chars per field (default: 12000)
+HERMES_LANGFUSE_CAPTURE=sanitized    # content capture mode (see below)
 HERMES_LANGFUSE_DEBUG=true           # verbose plugin logging
 ```
+
+## Capture modes
+
+`HERMES_LANGFUSE_CAPTURE` controls how much *content* (prompts, responses,
+tool arguments/results) is exported. Structural metadata — IDs, roles, tool
+names, token usage, cost, timing — is always captured in every mode.
+
+| mode | behavior |
+|------|----------|
+| `metadata` | No content. Each content field is replaced by a shape/size stub (`{"omitted": true, "type": "text", "chars": N}`). |
+| `sanitized` | **(default)** Content is exported after secret-pattern redaction (API keys, tokens, JWTs, private keys, `password=`-style assignments) and truncation. Redaction runs *before* truncation. |
+| `full` | Raw content, truncated only. Explicit opt-in — traces will contain whatever passed through the conversation, including injected memory and file contents. |
+
+The active mode is recorded on every trace as `metadata.capture_mode`.
+
+Note: `sanitized` is pattern-based defense in depth, not a DLP guarantee.
+For personal sessions or shared Langfuse projects, prefer `metadata`.
+
+## Error + shutdown coverage
+
+- Failed model requests (`api_request_error` hook) close their generation
+  with `level=ERROR`, status code, retry counters, and a capture-mode-scrubbed
+  error message. Non-retryable failures also finish the turn trace.
+- Session end/finalize closes any still-open traces for that session and
+  flushes queued events, so interrupted or tool-only turns don't dangle.
 
 ## Disable
 

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -759,34 +759,29 @@ def _serialize_assistant_message(message: Any) -> dict[str, Any]:
     }
 
 
-def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, base_url: str) -> tuple[dict[str, int], dict[str, float]]:
-    usage_details: Dict[str, int] = {}
+def _canonical_usage_and_cost(
+    canonical: Any,
+    *,
+    provider: str,
+    model: str,
+    base_url: str,
+) -> tuple[dict[str, int], dict[str, float]]:
+    """Translate canonical Hermes usage into Langfuse usage and cost maps."""
+    usage_details: Dict[str, int] = {
+        "input": canonical.input_tokens,
+        "output": canonical.output_tokens,
+    }
+    if canonical.cache_read_tokens:
+        usage_details["cache_read_input_tokens"] = canonical.cache_read_tokens
+    if canonical.cache_write_tokens:
+        usage_details["cache_creation_input_tokens"] = canonical.cache_write_tokens
+    if canonical.reasoning_tokens:
+        usage_details["reasoning_tokens"] = canonical.reasoning_tokens
+
     cost_details: Dict[str, float] = {}
-    raw_usage = getattr(response, "usage", None)
-    if not raw_usage:
-        return usage_details, cost_details
-
     try:
-        from agent.usage_pricing import estimate_usage_cost, normalize_usage
+        from agent.usage_pricing import estimate_usage_cost
 
-        canonical = normalize_usage(raw_usage, provider=provider, api_mode=api_mode)
-        # Langfuse usage_details keys follow a naming convention:
-        #   - Dashboard sums all keys containing "input" as input total
-        #   - Dashboard sums all keys containing "output" as output total
-        #   - If no "total" key, Langfuse derives it from all usage types
-        # Use Anthropic-style key names so cache tokens roll into the
-        # dashboard input total automatically.
-        # Ref: https://langfuse.com/docs/model-usage-and-cost
-        usage_details = {
-            "input": canonical.input_tokens,
-            "output": canonical.output_tokens,
-        }
-        if canonical.cache_read_tokens:
-            usage_details["cache_read_input_tokens"] = canonical.cache_read_tokens
-        if canonical.cache_write_tokens:
-            usage_details["cache_creation_input_tokens"] = canonical.cache_write_tokens
-        if canonical.reasoning_tokens:
-            usage_details["reasoning_tokens"] = canonical.reasoning_tokens
         cost = estimate_usage_cost(
             model,
             canonical,
@@ -794,37 +789,86 @@ def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, 
             base_url=base_url,
             api_key="",
         )
-        if cost.amount_usd is not None:
-            # Langfuse cost_details keys must match usage_details keys.
-            # Provide per-type breakdown so dashboard can show cost by type.
-            try:
-                from agent.usage_pricing import get_pricing_entry
-                from decimal import Decimal
-                _ONE_M = Decimal("1000000")
-                entry = get_pricing_entry(model, provider=provider, base_url=base_url)
-                if entry:
-                    if entry.input_cost_per_million is not None and canonical.input_tokens:
-                        cost_details["input"] = float(Decimal(canonical.input_tokens) * entry.input_cost_per_million / _ONE_M)
-                    if entry.output_cost_per_million is not None and canonical.output_tokens:
-                        cost_details["output"] = float(Decimal(canonical.output_tokens) * entry.output_cost_per_million / _ONE_M)
-                    if entry.cache_read_cost_per_million is not None and canonical.cache_read_tokens:
-                        cost_details["cache_read_input_tokens"] = float(Decimal(canonical.cache_read_tokens) * entry.cache_read_cost_per_million / _ONE_M)
-                    if entry.cache_write_cost_per_million is not None and canonical.cache_write_tokens:
-                        cost_details["cache_creation_input_tokens"] = float(Decimal(canonical.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_M)
-                    # Langfuse does not reliably derive the total from the
-                    # per-type breakdown — without an explicit "total" key the
-                    # dashboard's calculatedTotalCost stays 0 even when every
-                    # component is present. Send both.
-                    if cost_details:
-                        cost_details["total"] = round(sum(cost_details.values()), 10)
-                else:
-                    cost_details["total"] = float(cost.amount_usd)
-            except Exception:
-                cost_details["total"] = float(cost.amount_usd)
     except Exception as exc:  # pragma: no cover - fail-open
-        _debug(f"usage normalization failed: {exc}")
+        _debug(f"usage pricing failed: {exc}")
+        return usage_details, cost_details
+
+    # A partial component breakdown is not a valid request total.  In
+    # particular, cache pricing may be unavailable even when input/output
+    # rates are known.  Leave all costs absent so Langfuse cannot mistake a
+    # partial subtotal for the full generation cost.
+    if cost.amount_usd is None:
+        return usage_details, cost_details
+
+    # Langfuse only derives a total for the built-in input/output cost keys.
+    # Cache/custom keys therefore need an explicit canonical total.  Use the
+    # Hermes estimate rather than summing components because it also includes
+    # request-level pricing.  Preserve the existing component-only payload for
+    # subscription-included routes; their export policy is handled separately.
+    # A zero estimate is not exported either: a priced model that billed no
+    # tokens writes no per-type keys, and an explicit 0.0 total would be
+    # treated as authoritative by Langfuse instead of left for it to derive.
+    if cost.status != "included" and float(cost.amount_usd) > 0:
+        cost_details["total"] = float(cost.amount_usd)
+
+    # Langfuse cost_details keys match usage_details keys.  Keep the per-type
+    # breakdown for dashboards in addition to the authoritative request total.
+    try:
+        from decimal import Decimal
+
+        from agent.usage_pricing import get_pricing_entry
+
+        one_million = Decimal("1000000")
+        entry = get_pricing_entry(model, provider=provider, base_url=base_url)
+        if entry:
+            if entry.input_cost_per_million is not None and canonical.input_tokens:
+                cost_details["input"] = float(
+                    Decimal(canonical.input_tokens)
+                    * entry.input_cost_per_million
+                    / one_million
+                )
+            if entry.output_cost_per_million is not None and canonical.output_tokens:
+                cost_details["output"] = float(
+                    Decimal(canonical.output_tokens)
+                    * entry.output_cost_per_million
+                    / one_million
+                )
+            if entry.cache_read_cost_per_million is not None and canonical.cache_read_tokens:
+                cost_details["cache_read_input_tokens"] = float(
+                    Decimal(canonical.cache_read_tokens)
+                    * entry.cache_read_cost_per_million
+                    / one_million
+                )
+            if entry.cache_write_cost_per_million is not None and canonical.cache_write_tokens:
+                cost_details["cache_creation_input_tokens"] = float(
+                    Decimal(canonical.cache_write_tokens)
+                    * entry.cache_write_cost_per_million
+                    / one_million
+                )
+    except Exception:  # pragma: no cover - canonical total remains usable
+        pass
 
     return usage_details, cost_details
+
+
+def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, base_url: str) -> tuple[dict[str, int], dict[str, float]]:
+    raw_usage = getattr(response, "usage", None)
+    if not raw_usage:
+        return {}, {}
+
+    try:
+        from agent.usage_pricing import normalize_usage
+
+        canonical = normalize_usage(raw_usage, provider=provider, api_mode=api_mode)
+        return _canonical_usage_and_cost(
+            canonical,
+            provider=provider,
+            model=model,
+            base_url=base_url,
+        )
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"usage normalization failed: {exc}")
+        return {}, {}
 
 
 def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform: str, provider: str, model: str,
@@ -1394,57 +1438,30 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
         )
     elif isinstance(usage, dict) and usage:
         # post_api_request passes a pre-built CanonicalUsage summary dict.
-        # Use Langfuse-convention key names: "input", "output", and
-        # "cache_read_input_tokens" / "cache_creation_input_tokens" so the
-        # dashboard sums cache tokens into the input total automatically.
         _input = usage.get("input_tokens", 0)
         _output = usage.get("output_tokens", 0) or usage.get("completion_tokens", 0)
         _cache_read = usage.get("cache_read_tokens", 0)
         _cache_write = usage.get("cache_write_tokens", 0)
         _reasoning = usage.get("reasoning_tokens", 0)
-        usage_details = {
-            "input": _input,
-            "output": _output,
-        }
-        if _cache_read:
-            usage_details["cache_read_input_tokens"] = _cache_read
-        if _cache_write:
-            usage_details["cache_creation_input_tokens"] = _cache_write
-        if _reasoning:
-            usage_details["reasoning_tokens"] = _reasoning
-        cost_details = {}
-        # Estimate per-type cost from the summary if possible
         try:
-            from agent.usage_pricing import CanonicalUsage, estimate_usage_cost, get_pricing_entry
-            from decimal import Decimal
-            _ONE_M = Decimal("1000000")
+            from agent.usage_pricing import CanonicalUsage
+
             _cu = CanonicalUsage(
                 input_tokens=_input,
                 output_tokens=_output,
                 cache_read_tokens=_cache_read,
                 cache_write_tokens=_cache_write,
                 reasoning_tokens=_reasoning,
+                request_count=usage.get("request_count", 1),
             )
-            entry = get_pricing_entry(model, provider=provider, base_url=base_url)
-            if entry:
-                if entry.input_cost_per_million is not None and _input:
-                    cost_details["input"] = float(Decimal(_input) * entry.input_cost_per_million / _ONE_M)
-                if entry.output_cost_per_million is not None and _output:
-                    cost_details["output"] = float(Decimal(_output) * entry.output_cost_per_million / _ONE_M)
-                if entry.cache_read_cost_per_million is not None and _cache_read:
-                    cost_details["cache_read_input_tokens"] = float(Decimal(_cache_read) * entry.cache_read_cost_per_million / _ONE_M)
-                if entry.cache_write_cost_per_million is not None and _cache_write:
-                    cost_details["cache_creation_input_tokens"] = float(Decimal(_cache_write) * entry.cache_write_cost_per_million / _ONE_M)
-                # Explicit total — Langfuse's calculatedTotalCost does not
-                # reliably sum the per-type breakdown (see _usage_and_cost).
-                if cost_details:
-                    cost_details["total"] = round(sum(cost_details.values()), 10)
-            else:
-                _cost = estimate_usage_cost(model, _cu, provider=provider, base_url=base_url, api_key="")
-                if _cost.amount_usd is not None:
-                    cost_details["total"] = float(_cost.amount_usd)
+            usage_details, cost_details = _canonical_usage_and_cost(
+                _cu,
+                provider=provider,
+                model=model,
+                base_url=base_url,
+            )
         except Exception:
-            pass
+            usage_details, cost_details = {}, {}
     else:
         usage_details, cost_details = {}, {}
 

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -644,6 +644,57 @@ def _coerce_request_messages(
     return [{"role": "user", "content": user_message}]
 
 
+def _serialize_system_prompt(system_prompt: Any) -> Optional[dict[str, Any]]:
+    """Normalize Anthropic/Bedrock ``system`` param or OpenAI-style system content for Langfuse."""
+    if system_prompt is None:
+        return None
+    if isinstance(system_prompt, str):
+        text = system_prompt.strip()
+        if not text:
+            return None
+        return {"role": "system", "content": _capture_content(text)}
+    if isinstance(system_prompt, list):
+        parts: list[str] = []
+        for block in system_prompt:
+            if isinstance(block, dict):
+                # Anthropic blocks carry {"type": "text", "text": ...}; Bedrock
+                # Converse system blocks are {"text": ...} with no "type" key.
+                block_type = block.get("type")
+                if block_type == "text" or (block_type is None and "text" in block):
+                    piece = block.get("text", "")
+                    if isinstance(piece, str) and piece:
+                        parts.append(piece)
+            elif isinstance(block, str) and block:
+                parts.append(block)
+        if not parts:
+            return None
+        return {"role": "system", "content": _capture_content("\n\n".join(parts))}
+    return None
+
+
+def _messages_for_langfuse_input(
+    *,
+    request_messages: Any = None,
+    messages: Any = None,
+    conversation_history: Any = None,
+    user_message: Any = None,
+    system_prompt: Any = None,
+) -> list[dict[str, Any]]:
+    """Build generation input: include Anthropic ``system`` when split out of ``messages``."""
+    raw = _coerce_request_messages(
+        request_messages=request_messages,
+        messages=messages,
+        conversation_history=conversation_history,
+        user_message=user_message,
+    )
+    if raw and raw[0].get("role") == "system":
+        return _serialize_messages(raw)
+    system_msg = _serialize_system_prompt(system_prompt)
+    if system_msg is None:
+        return _serialize_messages(raw)
+    return [system_msg, *_serialize_messages(raw)]
+
+
 def _serialize_messages(messages: Any) -> list[dict[str, Any]]:
     if not isinstance(messages, list):
         return []
@@ -1161,6 +1212,7 @@ def on_pre_llm_request(
     turn_id: str = "",
     api_request_id: str = "",
     request: Any = None,
+    system_prompt: Any = None,
     **_: Any,
 ) -> None:
     client = _get_langfuse()
@@ -1184,6 +1236,16 @@ def on_pre_llm_request(
         conversation_history=conversation_history,
         user_message=user_message,
     )
+    langfuse_input = _messages_for_langfuse_input(
+        request_messages=request_messages,
+        messages=messages,
+        conversation_history=conversation_history,
+        user_message=user_message,
+        system_prompt=system_prompt,
+    )
+    system_chars = 0
+    if langfuse_input and langfuse_input[0].get("role") == "system":
+        system_chars = len(str(langfuse_input[0].get("content") or ""))
 
     task_key = _trace_key(
         task_id,
@@ -1215,18 +1277,23 @@ def on_pre_llm_request(
         previous = state.generations.pop(req_key, None)
         if previous is not None:
             _end_observation(previous)
+        gen_metadata = {
+            "provider": provider,
+            "platform": platform,
+            "api_mode": api_mode,
+            "base_url": base_url,
+            "message_count": message_count,
+            "approx_input_tokens": approx_input_tokens,
+        }
+        if system_chars:
+            gen_metadata["system_prompt_chars"] = system_chars
         state.generations[req_key] = _start_child_observation(
             state,
             client=client,
             name=f"LLM call {api_call_count}",
             as_type="generation",
-            input_value=_serialize_messages(input_messages),
-            metadata={
-                "provider": provider,
-                "platform": platform,
-                "api_mode": api_mode,
-                "base_url": base_url,
-            },
+            input_value=langfuse_input,
+            metadata=gen_metadata,
             model=model,
             model_parameters={"api_mode": api_mode, "provider": provider},
         )

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -845,11 +845,23 @@ def on_pre_llm_request(
     user_message: Any = None,
     turn_id: str = "",
     api_request_id: str = "",
+    request: Any = None,
     **_: Any,
 ) -> None:
     client = _get_langfuse()
     if client is None:
         return
+
+    # ``model`` is the agent's current attribute at hook time; the request
+    # body carries the model actually being dispatched. They can diverge
+    # (mid-session /model switch propagation, provider fallback, middleware
+    # rewrites) — prefer the wire truth for generation attribution.
+    if isinstance(request, dict):
+        body = request.get("body")
+        if isinstance(body, dict):
+            body_model = body.get("model")
+            if isinstance(body_model, str) and body_model:
+                model = body_model
 
     input_messages = _coerce_request_messages(
         request_messages=request_messages,
@@ -912,10 +924,17 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
                      usage: Any = None, assistant_content_chars: int = 0,
                      assistant_tool_call_count: int = 0, assistant_response: Any = None,
                      turn_id: str = "", api_request_id: str = "",
+                     response_model: Any = None,
                      **_: Any) -> None:
     client = _get_langfuse()
     if client is None:
         return
+
+    # The provider's response echoes the model that actually served the
+    # request. Prefer it over the agent attribute, which can be stale after
+    # a mid-session model switch or fallback.
+    if isinstance(response_model, str) and response_model:
+        model = response_model
 
     task_key = _trace_key(
         task_id,

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -55,6 +55,10 @@ class TraceState:
     turn_tool_calls: list[dict[str, Any]] = field(default_factory=list)
     # Keyed by child_session_id: subagent_stop carries no child_subagent_id.
     subagents: Dict[str, Any] = field(default_factory=dict)
+    # Fingerprints of MoA fan-outs already recorded. The client holds its last
+    # fan-out until the next one, so a tool-loop turn would re-emit the same
+    # advisors on every API call without this.
+    moa_emitted: set = field(default_factory=set)
     last_updated_at: float = field(default_factory=time.time)
 
 
@@ -953,6 +957,77 @@ def on_pre_llm_call(*, task_id: str = "", session_id: str = "", platform: str = 
         state.last_updated_at = time.time()
 
 
+def _emit_moa_reference_generations(state: TraceState, *, client: Langfuse,
+                                    references: Any) -> None:
+    """Record each MoA advisor as its own generation under the turn.
+
+    MoA returns only the aggregator's response, so without this the whole
+    fan-out collapses into one generation priced at the aggregator's model.
+    Each advisor carries its own model, usage, and dollars — advisors routinely
+    run on a different provider than the aggregator, so their spend cannot be
+    priced at the aggregator's rate.
+    """
+    if not isinstance(references, list) or not references:
+        return
+    fingerprint = json.dumps(
+        [
+            [r.get("label"), r.get("model"), (r.get("usage") or {}).get("output_tokens")]
+            for r in references
+            if isinstance(r, dict)
+        ],
+        sort_keys=True,
+        default=str,
+    )
+    with _STATE_LOCK:
+        if fingerprint in state.moa_emitted:
+            return
+        state.moa_emitted.add(fingerprint)
+
+    for ref in references:
+        if not isinstance(ref, dict):
+            continue
+        usage = ref.get("usage") or {}
+        usage_details = {}
+        if isinstance(usage, dict):
+            if usage.get("input_tokens"):
+                usage_details["input"] = usage["input_tokens"]
+            if usage.get("output_tokens"):
+                usage_details["output"] = usage["output_tokens"]
+            if usage.get("cache_read_tokens"):
+                usage_details["cache_read_input_tokens"] = usage["cache_read_tokens"]
+            if usage.get("cache_write_tokens"):
+                usage_details["cache_creation_input_tokens"] = usage["cache_write_tokens"]
+            if usage.get("reasoning_tokens"):
+                usage_details["reasoning_tokens"] = usage["reasoning_tokens"]
+        cost_details = {}
+        cost_usd = ref.get("cost_usd")
+        if isinstance(cost_usd, (int, float)):
+            cost_details["total"] = float(cost_usd)
+
+        label = ref.get("label") or "advisor"
+        metadata = {"moa_role": "reference", "label": label}
+        for key in ("provider", "cost_status", "cost_source", "temperature"):
+            if ref.get(key) is not None:
+                metadata[key] = ref[key]
+
+        observation = _start_child_observation(
+            state,
+            client=client,
+            name=f"MoA advisor: {label}",
+            as_type="generation",
+            input_value=None,
+            metadata=metadata,
+            model=ref.get("model"),
+        )
+        _end_observation(
+            observation,
+            output=_capture_content(ref.get("output")),
+            usage_details=usage_details,
+            cost_details=cost_details,
+            metadata=metadata,
+        )
+
+
 def on_pre_llm_request(
     *,
     task_id: str = "",
@@ -1054,7 +1129,7 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
                      usage: Any = None, assistant_content_chars: int = 0,
                      assistant_tool_call_count: int = 0, assistant_response: Any = None,
                      turn_id: str = "", api_request_id: str = "",
-                     response_model: Any = None,
+                     response_model: Any = None, moa_references: Any = None,
                      **_: Any) -> None:
     client = _get_langfuse()
     if client is None:
@@ -1079,6 +1154,9 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
         generation = state.generations.pop(req_key, None) if state else None
     if state is None or generation is None:
         return
+
+    if moa_references:
+        _emit_moa_reference_generations(state, client=client, references=moa_references)
 
     # Handle both call patterns:
     # 1. post_api_request: passes usage (dict), assistant_content_chars, assistant_tool_call_count

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -53,6 +53,8 @@ class TraceState:
     tools: Dict[str, Any] = field(default_factory=dict)
     pending_tools_by_name: Dict[str, list] = field(default_factory=dict)
     turn_tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    # Keyed by child_session_id: subagent_stop carries no child_subagent_id.
+    subagents: Dict[str, Any] = field(default_factory=dict)
     last_updated_at: float = field(default_factory=time.time)
 
 
@@ -362,6 +364,24 @@ def _trace_key(
     if task_id:
         return task_id
     return _scope_prefix(task_id, session_id)
+
+
+def _state_for_turn(turn_id: str) -> Optional[str]:
+    """Resolve a live trace key from a turn id alone.
+
+    The subagent hooks carry ``parent_turn_id`` but no ``task_id``, and
+    ``_scope_prefix`` prefers ``task_id`` when the LLM hooks minted the key —
+    so rebuilding the key here would miss whenever a task id is in play.
+    ``turn_id`` is already unique per turn, so match on its suffix instead.
+    Caller must hold ``_STATE_LOCK``.
+    """
+    if not turn_id:
+        return None
+    suffix = f":turn:{turn_id}"
+    for key in _TRACE_STATE:
+        if key.endswith(suffix):
+            return key
+    return None
 
 
 def _is_base64_data_uri(value: str) -> bool:
@@ -1376,6 +1396,69 @@ def on_session_finalize(*, session_id: str = "", **_: Any) -> None:
         _debug(f"finalize flush failed: {exc}")
 
 
+def on_subagent_start(*, parent_session_id: Any = None, parent_turn_id: str = "",
+                      parent_subagent_id: Any = None, child_session_id: Any = None,
+                      child_subagent_id: Any = None, child_role: str = "",
+                      child_goal: Any = None, **_: Any) -> None:
+    client = _get_langfuse()
+    if client is None or not child_session_id:
+        return
+
+    with _STATE_LOCK:
+        key = _state_for_turn(parent_turn_id)
+        state = _TRACE_STATE.get(key) if key else None
+        if state is None:
+            return
+        metadata = {
+            "child_session_id": child_session_id,
+            "child_subagent_id": child_subagent_id,
+            "child_role": child_role,
+        }
+        if parent_subagent_id:
+            metadata["parent_subagent_id"] = parent_subagent_id
+        state.subagents[str(child_session_id)] = _start_child_observation(
+            state,
+            client=client,
+            name=f"Subagent: {child_role or 'delegate'}",
+            as_type="span",
+            input_value=_capture_content(child_goal),
+            metadata=metadata,
+        )
+
+
+def on_subagent_stop(*, parent_session_id: Any = None, parent_turn_id: str = "",
+                     child_session_id: Any = None, child_role: str = "",
+                     child_summary: Any = None, child_status: Any = None,
+                     tool_call_history: Any = None, duration_ms: Any = None,
+                     **_: Any) -> None:
+    if not child_session_id:
+        return
+
+    with _STATE_LOCK:
+        key = _state_for_turn(parent_turn_id)
+        state = _TRACE_STATE.get(key) if key else None
+        if state is None:
+            return
+        observation = state.subagents.pop(str(child_session_id), None)
+
+    if observation is None:
+        return
+
+    metadata: Dict[str, Any] = {"child_role": child_role}
+    if child_status:
+        metadata["status"] = child_status
+    if duration_ms:
+        metadata["duration_ms"] = duration_ms
+    if isinstance(tool_call_history, list):
+        metadata["tool_call_count"] = len(tool_call_history)
+        metadata["tool_calls"] = _capture_content(tool_call_history)
+    _end_observation(
+        observation,
+        output=_capture_content(child_summary),
+        metadata=metadata,
+    )
+
+
 def register(ctx) -> None:
     # Register for both hook name variants so the plugin works across
     # Hermes versions.  pre_api_request / post_api_request fire per API
@@ -1389,3 +1472,5 @@ def register(ctx) -> None:
     ctx.register_hook("post_tool_call", on_post_tool_call)
     ctx.register_hook("on_session_finalize", on_session_finalize)
     ctx.register_hook("on_session_end", on_session_finalize)
+    ctx.register_hook("subagent_start", on_subagent_start)
+    ctx.register_hook("subagent_stop", on_subagent_stop)

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -330,6 +330,19 @@ def _get_langfuse() -> Optional[Langfuse]:
         _LANGFUSE_CLIENT = _INIT_FAILED
         return None
 
+    # atexit is LIFO: registering AFTER the SDK's constructor (which installs
+    # its own shutdown flush) means our finalizer runs FIRST at exit — root
+    # spans ended there are still picked up by the SDK's exporter. Closes the
+    # short-lived-process gap (kanban workers / hermes chat -q / cron): exit
+    # with tool calls still queued left the root span un-ended → anonymous
+    # trace with no name/session/metadata on the backend.
+    try:
+        import atexit
+
+        atexit.register(_finalize_all_traces)
+    except Exception:  # pragma: no cover - fail-open
+        pass
+
     return _LANGFUSE_CLIENT
 
 
@@ -871,6 +884,46 @@ def _evict_stale_locked() -> None:
                     pass
         except Exception as exc:  # pragma: no cover - fail-open
             _debug(f"evict stale trace failed: {exc}")
+
+
+def _finalize_all_traces() -> None:
+    """End every open root span so short-lived processes export complete traces.
+
+    Gateway turns normally end their root span via ``_finish_trace`` (final
+    assistant message with no tool calls). But short-lived CLI processes —
+    kanban workers, ``hermes chat -q`` one-shots, cron jobs — can exit while
+    the last LLM call still has tool calls queued, leaving the root span
+    un-ended. Ended children DO export via the SDK's own atexit flush, so the
+    backend shows an anonymous trace (no name/session/metadata) whose
+    observations all point at a root that never arrived (observed live
+    2026-08-08: kanban workers produced 4 such traces in one tick).
+
+    Registered with ``atexit`` AFTER the Langfuse client is constructed:
+    atexit is LIFO, so this runs BEFORE the SDK's own shutdown hook — spans
+    ended here still get flushed by the SDK's exporter.
+    """
+    with _STATE_LOCK:
+        states = list(_TRACE_STATE.items())
+        _TRACE_STATE.clear()
+    for _key, state in states:
+        try:
+            for observation in state.generations.values():
+                _end_observation(observation)
+            for observation in state.tools.values():
+                _end_observation(observation)
+            for queue in state.pending_tools_by_name.values():
+                for observation in queue:
+                    _end_observation(observation)
+            state.root_span.end()
+        except Exception as exc:  # pragma: no cover - fail-open
+            _debug(f"atexit finalize failed for {_key}: {exc}")
+    if states:
+        client = _get_langfuse()
+        if client is not None:
+            try:
+                client.flush()
+            except Exception:
+                pass
 
 
 def _finish_trace(task_key: str, *, output: Any = None) -> None:

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -886,10 +886,12 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         )
         root_span = root_ctx.__enter__()
 
+    # SDK v3 uses update_trace() (not set_trace_io). Failures must never block
+    # the rest of the turn — the observation still carries input from start.
     try:
-        root_span.set_trace_io(input=trace_input)
-    except Exception:
-        pass
+        root_span.update_trace(input=trace_input)
+    except Exception as exc:
+        _debug(f"update_trace(input) failed: {exc}")
 
     _debug(f"started trace {trace_id} for {task_key}")
     return TraceState(trace_id=trace_id, root_ctx=root_ctx, root_span=root_span)
@@ -1038,9 +1040,23 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
                 _end_observation(observation)
         final_output = _merge_trace_output(output, state)
         if final_output is not None:
-            state.root_span.set_trace_io(output=final_output)
-            state.root_span.update(output=final_output)
-        state.root_span.end()
+            # update_trace sets TRACE-level Input/Output columns in the UI
+            # (SDK v3; set_trace_io was the pre-v3 spelling). Root observation
+            # I/O is set via update(); never let either call prevent end() —
+            # otherwise generations/tools export without a CHAIN root and the
+            # list view looks half-empty.
+            try:
+                state.root_span.update_trace(output=final_output)
+            except Exception as exc:
+                _debug(f"update_trace(output) failed: {exc}")
+            try:
+                state.root_span.update(output=final_output)
+            except Exception as exc:
+                _debug(f"root update(output) failed: {exc}")
+        try:
+            state.root_span.end()
+        except Exception as exc:
+            _debug(f"root end() failed: {exc}")
         # Properly exit the root context manager so the generator unwinds
         # now, while opentelemetry.trace.Span is still a real type.  Without
         # this the generator is left suspended; at interpreter teardown the
@@ -1054,6 +1070,11 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
                 pass
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"finish trace failed: {exc}")
+        # Last-chance end so an earlier unexpected error still exports the root.
+        try:
+            state.root_span.end()
+        except Exception:
+            pass
     finally:
         try:
             client.flush()

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -1505,7 +1505,7 @@ def on_api_request_error(*, task_id: str = "", session_id: str = "", provider: s
         state.last_updated_at = time.time()
 
 
-def on_session_finalize(*, session_id: str = "", **_: Any) -> None:
+def on_session_finalize(*, session_id: str = "", reason: str = "", **_: Any) -> None:
     """True session-end boundary: close any traces still open and flush.
 
     A turn that ended on a tool-only or empty final response never reaches
@@ -1542,20 +1542,27 @@ def on_session_finalize(*, session_id: str = "", **_: Any) -> None:
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"finalize flush failed: {exc}")
 
-    # Explicitly shut down the Langfuse client at the true session boundary
-    # while the interpreter is still alive.  The Langfuse SDK registers its
-    # own atexit shutdown handler, but that runs during interpreter
-    # finalization — by then module globals (notably opentelemetry.trace.Span)
-    # may already be torn down to None, and the SDK's span-finalization path
-    # (use_span -> isinstance(span, Span)) raises "TypeError: isinstance()
-    # arg 2 must be a type" which surfaces as a noisy "Exception ignored in:
-    # <generator>" traceback on quit.  Calling shutdown() here flushes pending
-    # spans and joins the background export threads while all modules are
-    # intact; the SDK's atexit handler then becomes a no-op.
-    try:
-        client.shutdown()
-    except Exception as exc:  # pragma: no cover - fail-open
-        _debug(f"langfuse shutdown failed: {exc}")
+    # Explicitly shut down the Langfuse client — but only at a true
+    # process-exit boundary.  on_session_finalize also fires on /new, /reset
+    # (reason "session_boundary"/"new_session") and gateway session expiry
+    # ("session_expired"), where the process lives on and the cached client
+    # must keep exporting for subsequent sessions.  The shutdown matters at
+    # exit because the Langfuse SDK's own atexit handler runs during
+    # interpreter finalization — by then module globals (notably
+    # opentelemetry.trace.Span) may already be torn down to None, and the
+    # SDK's span-finalization path (use_span -> isinstance(span, Span))
+    # raises "TypeError: isinstance() arg 2 must be a type" which surfaces
+    # as a noisy "Exception ignored in: <generator>" traceback on quit.
+    # Calling shutdown() here flushes pending spans and joins the background
+    # export threads while all modules are intact; the SDK's atexit handler
+    # then becomes a no-op.
+    if reason == "shutdown":
+        shutdown = getattr(client, "shutdown", None)
+        if callable(shutdown):
+            try:
+                shutdown()
+            except Exception as exc:  # pragma: no cover - fail-open
+                _debug(f"langfuse shutdown failed: {exc}")
 
 
 def on_subagent_start(*, parent_session_id: Any = None, parent_turn_id: str = "",

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -18,6 +18,10 @@ Optional env vars:
   HERMES_LANGFUSE_RELEASE     - release/version tag
   HERMES_LANGFUSE_SAMPLE_RATE - sampling rate 0.0–1.0 (default: 1.0)
   HERMES_LANGFUSE_MAX_CHARS   - max chars per field (default: 12000)
+  HERMES_LANGFUSE_CAPTURE     - content capture mode (default: "sanitized")
+      metadata  - no content: sizes, roles, tool names, IDs, usage, cost only
+      sanitized - content with secret-pattern redaction + truncation
+      full      - raw content (truncated only); explicit opt-in
   HERMES_LANGFUSE_DEBUG       - set to "true" for verbose logging
 """
 from __future__ import annotations
@@ -99,6 +103,101 @@ def _debug_enabled() -> bool:
 def _debug(message: str) -> None:
     if _debug_enabled():
         logger.info("Langfuse tracing: %s", message)
+
+
+# ---------------------------------------------------------------------------
+# Capture modes
+# ---------------------------------------------------------------------------
+
+_CAPTURE_MODES = ("metadata", "sanitized", "full")
+_DEFAULT_CAPTURE_MODE = "sanitized"
+_warned_invalid_capture = False
+
+
+def _capture_mode() -> str:
+    """Resolve the content-capture mode: ``metadata | sanitized | full``.
+
+    Read per call (cheap env lookup) so tests and long-lived processes can
+    flip modes without a client reset. Invalid values warn once per process
+    and fall back to the default rather than silently capturing more than
+    the operator intended.
+    """
+    global _warned_invalid_capture
+    value = _env("HERMES_LANGFUSE_CAPTURE").lower()
+    if not value:
+        return _DEFAULT_CAPTURE_MODE
+    if value in _CAPTURE_MODES:
+        return value
+    if not _warned_invalid_capture:
+        _warned_invalid_capture = True
+        logger.warning(
+            "Langfuse plugin: invalid HERMES_LANGFUSE_CAPTURE=%r, falling back "
+            "to %r (valid: %s)",
+            value, _DEFAULT_CAPTURE_MODE, ", ".join(_CAPTURE_MODES),
+        )
+    return _DEFAULT_CAPTURE_MODE
+
+
+# Secret-shaped substrings redacted in ``sanitized`` mode. Ordered: specific
+# key formats first, generic assignment patterns last. Intentionally tight to
+# keep false positives low — this is defense in depth for accidental secret
+# passage through prompts/tool output, not a DLP system.
+_SECRET_PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?(?:-----END [A-Z ]*PRIVATE KEY-----|\Z)", re.DOTALL), "[REDACTED:private-key]"),
+    (re.compile(r"\b(?:sk|pk)-lf-[A-Za-z0-9\-]{8,}"), "[REDACTED:langfuse-key]"),
+    (re.compile(r"\bsk-ant-[A-Za-z0-9_\-]{8,}"), "[REDACTED:api-key]"),
+    (re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}"), "[REDACTED:api-key]"),
+    (re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}"), "[REDACTED:github-token]"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}"), "[REDACTED:github-token]"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "[REDACTED:aws-key]"),
+    (re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{10,}"), "[REDACTED:slack-token]"),
+    (re.compile(r"\beyJ[A-Za-z0-9_\-]{20,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\b"), "[REDACTED:jwt]"),
+    (re.compile(r"(?i)\b(authorization\s*:\s*bearer)\s+[A-Za-z0-9_\-.~+/=]{8,}"), r"\1 [REDACTED:token]"),
+    (re.compile(r"(?i)\b((?:api[_-]?key|secret[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|password|passwd)\s*[=:]\s*)(['\"]?)[^\s'\"]{6,}\2"), r"\1\2[REDACTED]\2"),
+]
+
+
+def _redact_secrets(value: str) -> str:
+    for pattern, replacement in _SECRET_PATTERNS:
+        value = pattern.sub(replacement, value)
+    return value
+
+
+def _describe_content(value: Any, *, depth: int = 0) -> Any:
+    """Metadata-mode stand-in for content: shape and size, never payload."""
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return {"omitted": True, "type": "number"}
+    if isinstance(value, bytes):
+        return {"omitted": True, "type": "bytes", "length": len(value)}
+    if isinstance(value, str):
+        return {"omitted": True, "type": "text", "chars": len(value)}
+    if isinstance(value, dict):
+        return {
+            "omitted": True,
+            "type": "object",
+            "keys": [str(k) for k in list(value.keys())[:20]],
+        }
+    if isinstance(value, (list, tuple, set)):
+        return {"omitted": True, "type": "array", "items": len(value)}
+    return {"omitted": True, "type": type(value).__name__}
+
+
+def _capture_content(value: Any, *, parse_json_strings: bool = False,
+                     tool_name: str = "", args: Any = None) -> Any:
+    """Apply the active capture mode to a CONTENT value.
+
+    Metadata fields (provider, model, IDs, counts) should NOT go through
+    this — they stay as-is in every mode. Only prompt/response text, tool
+    arguments, and tool results are content.
+    """
+    mode = _capture_mode()
+    if mode == "metadata":
+        return _describe_content(value)
+    if tool_name or args is not None:
+        value = _normalize_payload(value, tool_name=tool_name, args=args)
+    return _safe_value(value, parse_json_strings=parse_json_strings)
 
 
 # Sentinel: "_get_langfuse() has tried and failed". Lets us short-circuit
@@ -289,6 +388,10 @@ def _truncate_text(value: str, max_chars: int) -> Any:
     # reaches the SDK.
     if _is_base64_data_uri(value):
         return _redact_data_uri(value)
+    # Redact BEFORE truncating so a secret straddling the cut point cannot
+    # leak its prefix. Truncation is a size control, not redaction.
+    if _capture_mode() == "sanitized":
+        value = _redact_secrets(value)
     if len(value) <= max_chars:
         return value
     return value[:max_chars] + f"... [truncated {len(value) - max_chars} chars]"
@@ -462,7 +565,7 @@ def _extract_last_user_message(messages: Any) -> Any:
         if isinstance(message, dict) and message.get("role") == "user":
             return {
                 "role": "user",
-                "content": _safe_value(message.get("content")),
+                "content": _capture_content(message.get("content")),
             }
     return None
 
@@ -492,7 +595,7 @@ def _serialize_messages(messages: Any) -> list[dict[str, Any]]:
         role = message.get("role")
         item = {
             "role": role,
-            "content": _safe_value(
+            "content": _capture_content(
                 message.get("content"),
                 parse_json_strings=(role == "tool"),
             ),
@@ -503,7 +606,7 @@ def _serialize_messages(messages: Any) -> list[dict[str, Any]]:
             if message.get("name"):
                 item["name"] = _safe_value(message.get("name"))
         if message.get("tool_calls"):
-            item["tool_calls"] = _safe_value(message.get("tool_calls"), parse_json_strings=True)
+            item["tool_calls"] = _capture_content(message.get("tool_calls"), parse_json_strings=True)
         serialized.append(item)
     return serialized
 
@@ -516,7 +619,7 @@ def _serialize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
         fn = getattr(tool_call, "function", None)
         name = getattr(fn, "name", None) if fn else None
         arguments = getattr(fn, "arguments", None) if fn else None
-        safe_arguments = _safe_value(arguments, parse_json_strings=False)
+        safe_arguments = _capture_content(arguments, parse_json_strings=False)
         serialized.append({
             "id": getattr(tool_call, "id", None),
             "type": getattr(tool_call, "type", None) or "function",
@@ -532,8 +635,8 @@ def _serialize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
 
 def _serialize_assistant_message(message: Any) -> dict[str, Any]:
     return {
-        "content": _safe_value(getattr(message, "content", None)),
-        "reasoning": _safe_value(getattr(message, "reasoning", None)),
+        "content": _capture_content(getattr(message, "content", None)),
+        "reasoning": _capture_content(getattr(message, "reasoning", None)),
         "tool_calls": _serialize_tool_calls(getattr(message, "tool_calls", None)),
     }
 
@@ -620,6 +723,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         "provider": provider,
         "model": model,
         "api_mode": api_mode,
+        "capture_mode": _capture_mode(),
     }
 
     # session_id must be passed in trace_context for Langfuse session grouping.
@@ -963,7 +1067,7 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
         output = _serialize_assistant_message(assistant_message)
     elif assistant_response is not None:
         # post_llm_call passes assistant_response as a plain string
-        output = {"content": _safe_value(assistant_response), "reasoning": None, "tool_calls": []}
+        output = {"content": _capture_content(assistant_response), "reasoning": None, "tool_calls": []}
     else:
         # post_api_request path — reconstruct from summary kwargs
         output = {
@@ -1091,7 +1195,7 @@ def on_pre_tool_call(*, tool_name: str = "", args: Any = None, task_id: str = ""
             client=client,
             name=f"Tool: {tool_name}",
             as_type="tool",
-            input_value=_safe_value(args),
+            input_value=_capture_content(args),
             metadata={"tool_name": tool_name, "tool_call_id": tool_call_id},
         )
         if tool_call_id:
@@ -1127,12 +1231,15 @@ def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = No
     if observation is None:
         return
 
-    if isinstance(result, str):
-        result_value = _maybe_parse_json_string(result)
+    if _capture_mode() == "metadata":
+        safe_result_value = _describe_content(result)
     else:
-        result_value = result
-    result_value = _normalize_payload(result_value, tool_name=tool_name, args=args)
-    safe_result_value = _safe_value(result_value, parse_json_strings=True)
+        if isinstance(result, str):
+            result_value = _maybe_parse_json_string(result)
+        else:
+            result_value = result
+        result_value = _normalize_payload(result_value, tool_name=tool_name, args=args)
+        safe_result_value = _safe_value(result_value, parse_json_strings=True)
 
     # Backfill so the generation's tool_call record carries the result alongside arguments.
     if tool_call_id:
@@ -1150,8 +1257,123 @@ def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = No
     _end_observation(
         observation,
         output=safe_result_value,
-        metadata={"tool_name": tool_name, "args": _safe_value(args, parse_json_strings=True)},
+        metadata={"tool_name": tool_name, "args": _capture_content(args, parse_json_strings=True)},
     )
+
+
+def on_api_request_error(*, task_id: str = "", session_id: str = "", provider: str = "",
+                         model: str = "", api_mode: str = "", api_call_count: int = 0,
+                         api_duration: float = 0.0, status_code: Any = None,
+                         retry_count: Any = None, max_retries: Any = None,
+                         retryable: Any = None, reason: Any = None, error: Any = None,
+                         turn_id: str = "", api_request_id: str = "",
+                         **_: Any) -> None:
+    """Close the open generation for a failed API request.
+
+    Without this, a failed request leaves its generation open until trace
+    eviction — the failure is invisible in Langfuse and the turn appears
+    to hang. Marks the generation with ERROR level and the error summary.
+    If the request was not retryable (or retries are exhausted), the turn
+    is finished too, since the agent loop is about to unwind.
+    """
+    client = _get_langfuse()
+    if client is None:
+        return
+
+    task_key = _trace_key(
+        task_id,
+        session_id,
+        turn_id=turn_id,
+        api_request_id=api_request_id,
+    )
+    req_key = _request_key(api_call_count)
+
+    with _STATE_LOCK:
+        state = _TRACE_STATE.get(task_key)
+        generation = state.generations.pop(req_key, None) if state else None
+    if state is None:
+        return
+
+    error_type = ""
+    error_message = ""
+    if isinstance(error, dict):
+        error_type = str(error.get("type") or "")
+        error_message = str(error.get("message") or "")
+
+    error_metadata: Dict[str, Any] = {
+        "error": True,
+        "error_type": error_type,
+        # Error messages can embed request fragments (URLs w/ keys, prompt
+        # echoes) — run them through the capture pipeline like content.
+        "error_message": _capture_content(error_message),
+    }
+    if status_code is not None:
+        error_metadata["status_code"] = status_code
+    if retry_count is not None:
+        error_metadata["retry_count"] = retry_count
+    if max_retries is not None:
+        error_metadata["max_retries"] = max_retries
+    if retryable is not None:
+        error_metadata["retryable"] = retryable
+    if reason:
+        error_metadata["reason"] = str(reason)
+    if api_duration and api_duration > 0:
+        error_metadata["api_duration_s"] = round(api_duration, 3)
+
+    if generation is not None:
+        try:
+            generation.update(
+                level="ERROR",
+                status_message=(error_type or "api_request_error")[:200],
+            )
+        except Exception as exc:  # pragma: no cover - fail-open
+            _debug(f"error-level update failed: {exc}")
+        _end_observation(generation, metadata=error_metadata)
+
+    # A retryable failure will be followed by another pre_api_request on the
+    # same trace; keep the turn open. A terminal failure ends the turn.
+    if retryable is False:
+        _finish_trace(task_key, output={"error": error_metadata})
+    else:
+        state.last_updated_at = time.time()
+
+
+def on_session_finalize(*, session_id: str = "", **_: Any) -> None:
+    """True session-end boundary: close any traces still open and flush.
+
+    A turn that ended on a tool-only or empty final response never reaches
+    ``_finish_trace``; without this hook its root span dangles until state
+    eviction and queued events can be lost on process exit.
+    """
+    # Only act on an already-constructed client — do NOT lazily initialize
+    # one at finalize time; if init never happened there are no traces.
+    client = _LANGFUSE_CLIENT
+    if client is None or client is _INIT_FAILED or not isinstance(client, object) or not hasattr(client, "flush"):
+        return
+
+    # Close every trace belonging to this session (or all, when no
+    # session_id is provided — process-level finalization). Trace keys carry
+    # the session as either "session:<id>" (no task) or "task:<id>" (gateway
+    # sets task_id == session_id), plus the legacy bare-task_id shape — match
+    # on the id in any segment.
+    if session_id:
+        fragments = (f"session:{session_id}", f"task:{session_id}")
+        with _STATE_LOCK:
+            keys = [
+                k for k in _TRACE_STATE
+                if k == session_id or any(f in k for f in fragments)
+            ]
+    else:
+        with _STATE_LOCK:
+            keys = list(_TRACE_STATE)
+
+    for key in keys:
+        _finish_trace(key)
+
+    try:
+        client.flush()
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"finalize flush failed: {exc}")
 
 
 def register(ctx) -> None:
@@ -1160,7 +1382,10 @@ def register(ctx) -> None:
     # call (preferred); pre_llm_call / post_llm_call fire once per turn.
     ctx.register_hook("pre_api_request", on_pre_llm_request)
     ctx.register_hook("post_api_request", on_post_llm_call)
+    ctx.register_hook("api_request_error", on_api_request_error)
     ctx.register_hook("pre_llm_call", on_pre_llm_call)
     ctx.register_hook("post_llm_call", on_post_llm_call)
     ctx.register_hook("pre_tool_call", on_pre_tool_call)
     ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("on_session_finalize", on_session_finalize)
+    ctx.register_hook("on_session_end", on_session_finalize)

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -74,6 +74,13 @@ _TRACE_STATE: Dict[str, TraceState] = {}
 # to bound the leak from non-finalizing turns, not to limit concurrency.
 _MAX_TRACE_STATE = 256
 _LANGFUSE_CLIENT = None
+# Guards _LANGFUSE_CLIENT initialization against the TOCTOU race: two
+# concurrent first callers both pass the ``is not None`` guard, both
+# construct a Langfuse(**kwargs) client, and the loser's client leaks an
+# open HTTPS connection + background flush thread.  _STATE_LOCK is not
+# reused here because it guards _TRACE_STATE (hot path) and nesting the
+# two locks would risk deadlock with future callers.
+_LANGFUSE_CLIENT_LOCK = threading.Lock()
 _READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
 _READ_FILE_HEAD_LINES = 25
 _READ_FILE_TAIL_LINES = 15
@@ -259,91 +266,106 @@ def _get_langfuse() -> Optional[Langfuse]:
     + credentials present). The result is cached: on the first call we try
     to construct a client, and every subsequent call returns that client
     (or fast-returns ``None`` if init failed).
+
+    Thread-safe: ``_LANGFUSE_CLIENT_LOCK`` serializes the first build so
+    concurrent callers can't both pass the ``is not None`` guard, both
+    construct a ``Langfuse(**kwargs)`` client, and leak the loser's open
+    HTTP connection and background flush thread (same TOCTOU class fixed
+    for the Honcho and FAL clients in ``plugins/plugin_utils.py``).
     """
     global _LANGFUSE_CLIENT
+    # Fast path — already settled (success or _INIT_FAILED); no lock needed.
     if _LANGFUSE_CLIENT is _INIT_FAILED:
         return None
     if _LANGFUSE_CLIENT is not None:
         return _LANGFUSE_CLIENT
 
-    if Langfuse is None:
-        _LANGFUSE_CLIENT = _INIT_FAILED
-        return None
+    with _LANGFUSE_CLIENT_LOCK:
+        # Re-check inside the lock: a racing thread may have completed init
+        # while we were waiting.
+        if _LANGFUSE_CLIENT is _INIT_FAILED:
+            return None
+        if _LANGFUSE_CLIENT is not None:
+            return _LANGFUSE_CLIENT
 
-    public_key = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
-    secret_key = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")
-    if not (public_key and secret_key):
-        _LANGFUSE_CLIENT = _INIT_FAILED
-        return None
+        if Langfuse is None:
+            _LANGFUSE_CLIENT = _INIT_FAILED
+            return None
 
-    # Reject placeholder credentials with a one-shot warning so the
-    # operator sees the misconfiguration instead of silently shipping a
-    # broken observability stack (#23823).  The SDK does not validate
-    # keys at construction time — it queues traces in memory and only
-    # discovers the auth failure when the background flush thread tries
-    # to post them, by which point the warning is buried under whatever
-    # else the process is logging.  Catch it here, surface it once, and
-    # short-circuit via the same _INIT_FAILED path as the empty case.
-    placeholder_issues = [
-        msg
-        for msg in (
-            _validate_langfuse_key("HERMES_LANGFUSE_PUBLIC_KEY", public_key),
-            _validate_langfuse_key("HERMES_LANGFUSE_SECRET_KEY", secret_key),
-        )
-        if msg
-    ]
-    if placeholder_issues:
-        logger.warning(
-            "Langfuse plugin: credentials look like placeholders, traces will "
-            "NOT be emitted (%s). Set real Langfuse keys (pk-lf-... / sk-lf-...) "
-            "or unset HERMES_LANGFUSE_PUBLIC_KEY / HERMES_LANGFUSE_SECRET_KEY to "
-            "silence this warning.",
-            "; ".join(placeholder_issues),
-        )
-        _LANGFUSE_CLIENT = _INIT_FAILED
-        return None
+        public_key = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
+        secret_key = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")
+        if not (public_key and secret_key):
+            _LANGFUSE_CLIENT = _INIT_FAILED
+            return None
 
-    base_url = _env("HERMES_LANGFUSE_BASE_URL") or _env("LANGFUSE_BASE_URL") or "https://cloud.langfuse.com"
-    environment = _env("HERMES_LANGFUSE_ENV") or _env("LANGFUSE_ENV")
-    release = _env("HERMES_LANGFUSE_RELEASE") or _env("LANGFUSE_RELEASE")
-    sample_rate = _env("HERMES_LANGFUSE_SAMPLE_RATE")
+        # Reject placeholder credentials with a one-shot warning so the
+        # operator sees the misconfiguration instead of silently shipping a
+        # broken observability stack (#23823).  The SDK does not validate
+        # keys at construction time — it queues traces in memory and only
+        # discovers the auth failure when the background flush thread tries
+        # to post them, by which point the warning is buried under whatever
+        # else the process is logging.  Catch it here, surface it once, and
+        # short-circuit via the same _INIT_FAILED path as the empty case.
+        placeholder_issues = [
+            msg
+            for msg in (
+                _validate_langfuse_key("HERMES_LANGFUSE_PUBLIC_KEY", public_key),
+                _validate_langfuse_key("HERMES_LANGFUSE_SECRET_KEY", secret_key),
+            )
+            if msg
+        ]
+        if placeholder_issues:
+            logger.warning(
+                "Langfuse plugin: credentials look like placeholders, traces will "
+                "NOT be emitted (%s). Set real Langfuse keys (pk-lf-... / sk-lf-...) "
+                "or unset HERMES_LANGFUSE_PUBLIC_KEY / HERMES_LANGFUSE_SECRET_KEY to "
+                "silence this warning.",
+                "; ".join(placeholder_issues),
+            )
+            _LANGFUSE_CLIENT = _INIT_FAILED
+            return None
 
-    kwargs: Dict[str, Any] = {
-        "public_key": public_key,
-        "secret_key": secret_key,
-        "base_url": base_url,
-    }
-    if environment:
-        kwargs["environment"] = environment
-    if release:
-        kwargs["release"] = release
-    if sample_rate:
+        base_url = _env("HERMES_LANGFUSE_BASE_URL") or _env("LANGFUSE_BASE_URL") or "https://cloud.langfuse.com"
+        environment = _env("HERMES_LANGFUSE_ENV") or _env("LANGFUSE_ENV")
+        release = _env("HERMES_LANGFUSE_RELEASE") or _env("LANGFUSE_RELEASE")
+        sample_rate = _env("HERMES_LANGFUSE_SAMPLE_RATE")
+
+        kwargs: Dict[str, Any] = {
+            "public_key": public_key,
+            "secret_key": secret_key,
+            "base_url": base_url,
+        }
+        if environment:
+            kwargs["environment"] = environment
+        if release:
+            kwargs["release"] = release
+        if sample_rate:
+            try:
+                kwargs["sample_rate"] = float(sample_rate)
+            except ValueError:
+                logger.warning("Invalid HERMES_LANGFUSE_SAMPLE_RATE=%r", sample_rate)
+
         try:
-            kwargs["sample_rate"] = float(sample_rate)
-        except ValueError:
-            logger.warning("Invalid HERMES_LANGFUSE_SAMPLE_RATE=%r", sample_rate)
+            _LANGFUSE_CLIENT = Langfuse(**kwargs)
+        except Exception as exc:  # pragma: no cover - fail-open
+            logger.warning("Could not initialize Langfuse client: %s", exc)
+            _LANGFUSE_CLIENT = _INIT_FAILED
+            return None
 
-    try:
-        _LANGFUSE_CLIENT = Langfuse(**kwargs)
-    except Exception as exc:  # pragma: no cover - fail-open
-        logger.warning("Could not initialize Langfuse client: %s", exc)
-        _LANGFUSE_CLIENT = _INIT_FAILED
-        return None
+        # atexit is LIFO: registering AFTER the SDK's constructor (which installs
+        # its own shutdown flush) means our finalizer runs FIRST at exit — root
+        # spans ended there are still picked up by the SDK's exporter. Closes the
+        # short-lived-process gap (kanban workers / hermes chat -q / cron): exit
+        # with tool calls still queued left the root span un-ended → anonymous
+        # trace with no name/session/metadata on the backend.
+        try:
+            import atexit
 
-    # atexit is LIFO: registering AFTER the SDK's constructor (which installs
-    # its own shutdown flush) means our finalizer runs FIRST at exit — root
-    # spans ended there are still picked up by the SDK's exporter. Closes the
-    # short-lived-process gap (kanban workers / hermes chat -q / cron): exit
-    # with tool calls still queued left the root span un-ended → anonymous
-    # trace with no name/session/metadata on the backend.
-    try:
-        import atexit
+            atexit.register(_finalize_all_traces)
+        except Exception:  # pragma: no cover - fail-open
+            pass
 
-        atexit.register(_finalize_all_traces)
-    except Exception:  # pragma: no cover - fail-open
-        pass
-
-    return _LANGFUSE_CLIENT
+        return _LANGFUSE_CLIENT
 
 
 def _scope_prefix(task_id: str, session_id: str) -> str:

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -780,7 +780,15 @@ def _canonical_usage_and_cost(
 
     cost_details: Dict[str, float] = {}
     try:
-        from agent.usage_pricing import estimate_usage_cost
+        from agent.usage_pricing import estimate_usage_cost, resolve_billing_route
+
+        # Subscription-included routes (e.g. openai-codex): Langfuse treats
+        # provided cost_details as authoritative and will not recalculate
+        # from model pricing when explicit zeros are sent. Omit cost_details
+        # entirely so Langfuse falls back to its own estimation.
+        route = resolve_billing_route(model, provider=provider, base_url=base_url)
+        if getattr(route, "billing_mode", "") == "subscription_included":
+            return usage_details, cost_details
 
         cost = estimate_usage_cost(
             model,

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -914,7 +914,18 @@ def _finalize_all_traces() -> None:
             for queue in state.pending_tools_by_name.values():
                 for observation in queue:
                     _end_observation(observation)
+            for observation in state.subagents.values():
+                _end_observation(observation)
             state.root_span.end()
+            # Exit the root observation's context manager so its generator
+            # unwinds now, while opentelemetry.trace.Span is still a real
+            # type — otherwise GC closes it during interpreter teardown and
+            # use_span's isinstance(span, Span) raises TypeError.
+            if state.root_ctx is not None:
+                try:
+                    state.root_ctx.__exit__(None, None, None)
+                except Exception:  # pragma: no cover - fail-open
+                    pass
         except Exception as exc:  # pragma: no cover - fail-open
             _debug(f"atexit finalize failed for {_key}: {exc}")
     if states:

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -864,6 +864,11 @@ def _evict_stale_locked() -> None:
         _TRACE_STATE.pop(key, None)
         try:
             state.root_span.end()
+            if state.root_ctx is not None:
+                try:
+                    state.root_ctx.__exit__(None, None, None)
+                except Exception:  # pragma: no cover - fail-open
+                    pass
         except Exception as exc:  # pragma: no cover - fail-open
             _debug(f"evict stale trace failed: {exc}")
 
@@ -891,6 +896,17 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
             state.root_span.set_trace_io(output=final_output)
             state.root_span.update(output=final_output)
         state.root_span.end()
+        # Properly exit the root context manager so the generator unwinds
+        # now, while opentelemetry.trace.Span is still a real type.  Without
+        # this the generator is left suspended; at interpreter teardown the
+        # GC calls .close(), which throws GeneratorExit through use_span
+        # __exit__ -> isinstance(span, Span) -- but Span has been torn down
+        # to None by then, producing the TypeError traceback on quit.
+        if state.root_ctx is not None:
+            try:
+                state.root_ctx.__exit__(None, None, None)
+            except Exception:  # pragma: no cover - fail-open
+                pass
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"finish trace failed: {exc}")
     finally:

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -692,10 +692,18 @@ def _serialize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
     return serialized
 
 
+def _extract_assistant_reasoning(message: Any) -> Any:
+    for field in ("reasoning", "reasoning_content", "reasoning_details"):
+        value = getattr(message, field, None)
+        if value is not None:
+            return _capture_content(value)
+    return None
+
+
 def _serialize_assistant_message(message: Any) -> dict[str, Any]:
     return {
         "content": _capture_content(getattr(message, "content", None)),
-        "reasoning": _capture_content(getattr(message, "reasoning", None)),
+        "reasoning": _extract_assistant_reasoning(message),
         "tool_calls": _serialize_tool_calls(getattr(message, "tool_calls", None)),
     }
 

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -1473,6 +1473,21 @@ def on_session_finalize(*, session_id: str = "", **_: Any) -> None:
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"finalize flush failed: {exc}")
 
+    # Explicitly shut down the Langfuse client at the true session boundary
+    # while the interpreter is still alive.  The Langfuse SDK registers its
+    # own atexit shutdown handler, but that runs during interpreter
+    # finalization — by then module globals (notably opentelemetry.trace.Span)
+    # may already be torn down to None, and the SDK's span-finalization path
+    # (use_span -> isinstance(span, Span)) raises "TypeError: isinstance()
+    # arg 2 must be a type" which surfaces as a noisy "Exception ignored in:
+    # <generator>" traceback on quit.  Calling shutdown() here flushes pending
+    # spans and joins the background export threads while all modules are
+    # intact; the SDK's atexit handler then becomes a no-op.
+    try:
+        client.shutdown()
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"langfuse shutdown failed: {exc}")
+
 
 def on_subagent_start(*, parent_session_id: Any = None, parent_turn_id: str = "",
                       parent_subagent_id: Any = None, child_session_id: Any = None,

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -590,6 +590,12 @@ def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, 
                         cost_details["cache_read_input_tokens"] = float(Decimal(canonical.cache_read_tokens) * entry.cache_read_cost_per_million / _ONE_M)
                     if entry.cache_write_cost_per_million is not None and canonical.cache_write_tokens:
                         cost_details["cache_creation_input_tokens"] = float(Decimal(canonical.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_M)
+                    # Langfuse does not reliably derive the total from the
+                    # per-type breakdown — without an explicit "total" key the
+                    # dashboard's calculatedTotalCost stays 0 even when every
+                    # component is present. Send both.
+                    if cost_details:
+                        cost_details["total"] = round(sum(cost_details.values()), 10)
                 else:
                     cost_details["total"] = float(cost.amount_usd)
             except Exception:
@@ -1029,6 +1035,10 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
                     cost_details["cache_read_input_tokens"] = float(Decimal(_cache_read) * entry.cache_read_cost_per_million / _ONE_M)
                 if entry.cache_write_cost_per_million is not None and _cache_write:
                     cost_details["cache_creation_input_tokens"] = float(Decimal(_cache_write) * entry.cache_write_cost_per_million / _ONE_M)
+                # Explicit total — Langfuse's calculatedTotalCost does not
+                # reliably sum the per-type breakdown (see _usage_and_cost).
+                if cost_details:
+                    cost_details["total"] = round(sum(cost_details.values()), 10)
             else:
                 _cost = estimate_usage_cost(model, _cu, provider=provider, base_url=base_url, api_key="")
                 if _cost.amount_usd is not None:

--- a/plugins/observability/langfuse/plugin.yaml
+++ b/plugins/observability/langfuse/plugin.yaml
@@ -8,7 +8,10 @@ requires_env:
 hooks:
   - pre_api_request
   - post_api_request
+  - api_request_error
   - pre_llm_call
   - post_llm_call
   - pre_tool_call
   - post_tool_call
+  - on_session_finalize
+  - on_session_end

--- a/plugins/observability/langfuse/plugin.yaml
+++ b/plugins/observability/langfuse/plugin.yaml
@@ -15,3 +15,5 @@ hooks:
   - post_tool_call
   - on_session_finalize
   - on_session_end
+  - subagent_start
+  - subagent_stop

--- a/tests/agent/test_moa_observability_bridge.py
+++ b/tests/agent/test_moa_observability_bridge.py
@@ -1,0 +1,137 @@
+"""Per-advisor MoA metrics crossing the plugin-hook boundary.
+
+MoA runs N advisor models before its aggregator and returns only the
+aggregator's response, so an observability plugin sees one generation for the
+whole fan-out. ``_RefAccounting`` already computes each advisor's usage and
+dollars — advisors routinely run on a different provider than the aggregator,
+so their spend cannot be priced at the aggregator's rate. These tests pin the
+bridge that carries it out: the renderer, the non-consuming accessor, and the
+conversation-loop helper that reads it.
+"""
+
+from agent.moa_loop import _RefAccounting
+from agent.moa_trace import _slot_trace, slot_metrics
+from agent.usage_pricing import CanonicalUsage
+
+
+def _acct():
+    return _RefAccounting(
+        CanonicalUsage(input_tokens=100, output_tokens=50, reasoning_tokens=7),
+        0.0042,
+        "ok",
+        "pricing_table",
+        messages=[{"role": "user", "content": "x" * 10000}],
+        output="advice",
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        temperature=0.7,
+    )
+
+
+class TestSlotMetrics:
+    def test_carries_model_provider_usage_and_cost(self):
+        m = slot_metrics(_acct(), "anthropic:claude-sonnet-4-6")
+
+        assert m["label"] == "anthropic:claude-sonnet-4-6"
+        assert m["model"] == "claude-sonnet-4-6"
+        assert m["provider"] == "anthropic"
+        assert m["cost_usd"] == 0.0042
+        assert m["cost_status"] == "ok"
+        assert m["cost_source"] == "pricing_table"
+        assert m["usage"]["input_tokens"] == 100
+        assert m["usage"]["output_tokens"] == 50
+        assert m["usage"]["reasoning_tokens"] == 7
+
+    def test_drops_input_messages(self):
+        # input_messages is the bulk of a trace record and would cross the hook
+        # boundary for every advisor on every turn.
+        assert "input_messages" in _slot_trace(_acct(), "label")
+        assert "input_messages" not in slot_metrics(_acct(), "label")
+
+    def test_output_override_wins(self):
+        # The privacy-redacted advisor text lives alongside the accounting, not
+        # on it, so the caller supplies the output.
+        m = slot_metrics(_acct(), "label", output="[redacted]")
+        assert m["output"] == "[redacted]"
+
+    def test_missing_accounting_does_not_raise(self):
+        m = slot_metrics(None, "label")
+        assert m["label"] == "label"
+        assert m["usage"] == {}
+
+
+class TestLastReferenceMetricsAccessor:
+    def _client(self):
+        from agent.moa_loop import MoAClient
+
+        return MoAClient("closed")
+
+    def test_defaults_to_none_off_the_fanout_path(self):
+        assert self._client().last_reference_metrics() is None
+
+    def test_read_does_not_consume(self):
+        client = self._client()
+        payload = [slot_metrics(_acct(), "label")]
+        client.chat.completions._last_reference_metrics = payload
+
+        # post_api_request fires on a different branch than
+        # consume_and_save_trace, so a consuming read would race it.
+        assert client.last_reference_metrics() is payload
+        assert client.last_reference_metrics() is payload
+
+    def test_read_does_not_disturb_usage_accounting(self):
+        client = self._client()
+        client.chat.completions._last_reference_metrics = [slot_metrics(_acct(), "label")]
+        client.chat.completions._pending_reference_usage = CanonicalUsage(input_tokens=5)
+        client.chat.completions._pending_reference_cost = 0.05
+
+        client.last_reference_metrics()
+
+        usage, cost = client.consume_reference_usage()
+        assert usage.input_tokens == 5
+        assert cost == 0.05
+
+
+class TestConversationLoopHelper:
+    def test_returns_none_for_a_non_moa_client(self):
+        from agent.conversation_loop import _moa_reference_metrics_for_hook
+
+        class _Agent:
+            client = object()
+
+        assert _moa_reference_metrics_for_hook(_Agent()) is None
+
+    def test_returns_none_when_there_is_no_client(self):
+        from agent.conversation_loop import _moa_reference_metrics_for_hook
+
+        class _Agent:
+            client = None
+
+        assert _moa_reference_metrics_for_hook(_Agent()) is None
+
+    def test_returns_metrics_for_a_moa_client(self):
+        from agent.conversation_loop import _moa_reference_metrics_for_hook
+
+        payload = [slot_metrics(_acct(), "label")]
+
+        class _Client:
+            def last_reference_metrics(self):
+                return payload
+
+        class _Agent:
+            client = _Client()
+
+        assert _moa_reference_metrics_for_hook(_Agent()) is payload
+
+    def test_a_raising_accessor_is_swallowed(self):
+        from agent.conversation_loop import _moa_reference_metrics_for_hook
+
+        class _Client:
+            def last_reference_metrics(self):
+                raise RuntimeError("boom")
+
+        class _Agent:
+            client = _Client()
+
+        # Observability must never break a turn.
+        assert _moa_reference_metrics_for_hook(_Agent()) is None

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -1538,3 +1538,54 @@ class TestMoAReferenceGenerations:
             mod._emit_moa_reference_generations(state, client=object(), references=value)
 
         assert gens == []
+
+class TestAtexitFinalization(TestTurnTraceIsolation):
+    """Short-lived processes (kanban workers, `hermes chat -q`, cron) can exit
+    with tool calls still queued — the root span never ends and the backend
+    shows an anonymous trace (no name/session/metadata). _finalize_all_traces
+    (registered atexit after client construction) must end every open root."""
+
+    def test_finalize_all_ends_open_roots_and_clears_state(self, monkeypatch):
+        mod = self._fresh_plugin()
+        started: list = []
+        ended: list = []
+        client = self._fake_client(started)
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        monkeypatch.setattr(
+            mod, "_end_observation", lambda obs, **k: ended.append(obs)
+        )
+        mod._TRACE_STATE.clear()
+
+        # Three worker-style turns that never finalize (tool calls pending).
+        for n in range(3):
+            self._run_turn(mod, session=f"worker-{n}", turn_n=0, finalize=False)
+        assert len(mod._TRACE_STATE) == 3
+
+        root_ends: list = []
+        for state in mod._TRACE_STATE.values():
+            real_end = state.root_span.end
+            state.root_span.end = lambda *a, _r=real_end, **k: root_ends.append(1)
+
+        mod._finalize_all_traces()
+
+        assert len(root_ends) == 3, "every open root span must be ended"
+        assert mod._TRACE_STATE == {}, "state must be drained"
+        # Idempotent: a second call (SDK/atexit re-entry) is a no-op.
+        mod._finalize_all_traces()
+        assert len(root_ends) == 3
+
+    def test_atexit_hook_is_registered_on_client_init(self, monkeypatch):
+        mod = self._fresh_plugin()
+        registered: list = []
+        import atexit as _atexit
+
+        monkeypatch.setattr(mod, "Langfuse", lambda **kw: object())
+        monkeypatch.setattr(
+            _atexit, "register", lambda fn, *a, **k: registered.append(fn)
+        )
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-0123456789abcdef")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-0123456789abcdef")
+        mod._LANGFUSE_CLIENT = None
+
+        assert mod._get_langfuse() is not None
+        assert mod._finalize_all_traces in registered

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -1975,3 +1975,165 @@ class TestSystemPromptCrossesHookBoundary:
         self._derive_and_fire(mod, api_kwargs, api_kwargs["messages"])
         roles = [m["role"] for m in captured["input"]]
         assert roles.count("system") == 1
+class TestFinishTraceUsesUpdateTrace:
+    """Regression: SDK v3 has update_trace, not set_trace_io.
+
+    Calling the non-existent set_trace_io raised AttributeError inside
+    _finish_trace's try block and skipped root_span.end(). Generations/tools
+    still exported, so the Langfuse list showed Observation Levels + Latency
+    but blank Input/Output columns (no CHAIN root).
+    """
+
+    def test_finish_ends_root_and_calls_update_trace(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        roots: list = []
+
+        class _Span:
+            def __init__(self):
+                self.ended = False
+                self.updates = []
+                self.trace_updates = []
+
+            def update(self, **kw):
+                self.updates.append(kw)
+
+            def end(self, **kw):
+                self.ended = True
+
+            def update_trace(self, **kw):
+                self.trace_updates.append(kw)
+
+            def start_observation(self, **kw):
+                return _Span()
+
+            # Deliberately NO set_trace_io — mirrors real LangfuseChain.
+
+        class _RootCM:
+            def __init__(self):
+                self.span = _Span()
+                roots.append(self.span)
+
+            def __enter__(self):
+                return self.span
+
+            def __exit__(self, *exc):
+                return False
+
+        class _Client:
+            def create_trace_id(self, seed=None):
+                return f"trace::{seed}"
+
+            def start_as_current_observation(self, **kw):
+                return _RootCM()
+
+            def flush(self):
+                pass
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _Client())
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        mod.on_pre_llm_request(
+            task_id="t1",
+            session_id="s1",
+            model="m",
+            provider="p",
+            api_mode="chat",
+            api_call_count=1,
+            request_messages=[{"role": "user", "content": "hi"}],
+            turn_id="turn-1",
+        )
+        mod.on_post_llm_call(
+            task_id="t1",
+            session_id="s1",
+            model="m",
+            provider="p",
+            api_mode="chat",
+            api_call_count=1,
+            assistant_content_chars=12,
+            assistant_tool_call_count=0,
+            assistant_response="hello world!",
+            turn_id="turn-1",
+        )
+
+        assert len(roots) == 1
+        root = roots[0]
+        assert root.ended is True
+        assert any("output" in u for u in root.trace_updates)
+        assert any("output" in u for u in root.updates)
+        assert mod._TRACE_STATE == {}
+
+    def test_finish_still_ends_when_update_trace_raises(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        roots: list = []
+
+        class _Span:
+            def __init__(self):
+                self.ended = False
+
+            def update(self, **kw):
+                pass
+
+            def end(self, **kw):
+                self.ended = True
+
+            def update_trace(self, **kw):
+                raise RuntimeError("simulated update_trace failure")
+
+            def start_observation(self, **kw):
+                return _Span()
+
+        class _RootCM:
+            def __init__(self):
+                self.span = _Span()
+                roots.append(self.span)
+
+            def __enter__(self):
+                return self.span
+
+            def __exit__(self, *exc):
+                return False
+
+        class _Client:
+            def create_trace_id(self, seed=None):
+                return f"trace::{seed}"
+
+            def start_as_current_observation(self, **kw):
+                return _RootCM()
+
+            def flush(self):
+                pass
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _Client())
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        mod.on_pre_llm_request(
+            task_id="t1",
+            session_id="s1",
+            model="m",
+            provider="p",
+            api_mode="chat",
+            api_call_count=1,
+            request_messages=[{"role": "user", "content": "hi"}],
+            turn_id="turn-1",
+        )
+        mod.on_post_llm_call(
+            task_id="t1",
+            session_id="s1",
+            model="m",
+            provider="p",
+            api_mode="chat",
+            api_call_count=1,
+            assistant_content_chars=5,
+            assistant_tool_call_count=0,
+            assistant_response="done",
+            turn_id="turn-1",
+        )
+
+        assert roots[0].ended is True
+        assert mod._TRACE_STATE == {}

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -586,6 +586,33 @@ class TestRequestMessageCoercion:
         ) == [{"role": "user", "content": "h"}]
         assert mod._coerce_request_messages(user_message="u") == [{"role": "user", "content": "u"}]
 
+    def test_messages_for_langfuse_includes_anthropic_system_param(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        out = mod._messages_for_langfuse_input(
+            request_messages=[{"role": "user", "content": "hi"}],
+            system_prompt="You are Hermes.",
+        )
+        assert out[0]["role"] == "system"
+        assert out[0]["content"] == "You are Hermes."
+        assert out[1]["role"] == "user"
+
+    def test_messages_for_langfuse_skips_duplicate_system(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        out = mod._messages_for_langfuse_input(
+            request_messages=[
+                {"role": "system", "content": "already here"},
+                {"role": "user", "content": "hi"},
+            ],
+            system_prompt="ignored when messages include system",
+        )
+        assert out[0]["role"] == "system"
+        assert out[0]["content"] == "already here"
+        assert out[1]["role"] == "user"
+
 
 class TestAssistantMessageSerialization:
     def test_serialize_assistant_message_prefers_reasoning(self):
@@ -1695,3 +1722,256 @@ class TestAtexitFinalization(TestTurnTraceIsolation):
 
         assert mod._get_langfuse() is not None
         assert mod._finalize_all_traces in registered
+
+class TestSystemPromptInGenerationInput:
+    """The generation input must carry the system prompt even for providers
+    that move it out of ``messages``: Anthropic Messages (``system`` kwarg)
+    and the Responses/Codex API (``instructions``).  Hermes forwards it to
+    hooks as ``system_prompt``; the plugin prepends a ``role: system`` entry.
+
+    Regression for the trace gap discussed in PR #32175 (Anthropic) and its
+    Codex sibling: without this, hosted traces show conversations without the
+    agent's instructions, skills, and memory."""
+
+    def _make_mod(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def _capture_generation(self, mod, monkeypatch):
+        """Route on_pre_llm_request into a seeded TraceState and record the
+        generation observation kwargs."""
+        captured = {}
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=None)
+        task_key = mod._trace_key("task-1", "sess-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        def fake_child(state_, **kw):
+            captured["input"] = kw.get("input_value")
+            captured["metadata"] = kw.get("metadata")
+            return object()
+
+        monkeypatch.setattr(mod, "_start_child_observation", fake_child)
+        return captured
+
+    def _fire(self, mod, *, request_messages, system_prompt=None):
+        kwargs = dict(
+            task_id="task-1",
+            session_id="sess-1",
+            model="m",
+            provider="p",
+            api_mode="codex_responses",
+            api_call_count=1,
+            request_messages=request_messages,
+        )
+        if system_prompt is not None:
+            kwargs["system_prompt"] = system_prompt
+        mod.on_pre_llm_request(**kwargs)
+
+    def test_string_system_prompt_prepended(self, monkeypatch):
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._fire(
+            mod,
+            request_messages=[{"role": "user", "content": "hi"}],
+            system_prompt="You are Hermes.",
+        )
+        assert captured["input"][0]["role"] == "system"
+        assert captured["input"][0]["content"] == "You are Hermes."
+        assert captured["input"][1]["role"] == "user"
+
+    def test_anthropic_block_list_flattened(self, monkeypatch):
+        """Anthropic OAuth mode sends ``system`` as content blocks (with
+        cache_control); the trace should carry the readable text."""
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        blocks = [
+            {"type": "text", "text": "part one", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "part two"},
+        ]
+        self._fire(
+            mod,
+            request_messages=[{"role": "user", "content": "hi"}],
+            system_prompt=blocks,
+        )
+        first = captured["input"][0]
+        assert first["role"] == "system"
+        assert "part one" in first["content"]
+        assert "part two" in first["content"]
+
+    def test_no_duplicate_when_messages_already_carry_system(self, monkeypatch):
+        """chat_completions keeps system in messages[0]; forwarding
+        system_prompt as well must not produce two system entries."""
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._fire(
+            mod,
+            request_messages=[
+                {"role": "system", "content": "You are Hermes."},
+                {"role": "user", "content": "hi"},
+            ],
+            system_prompt="You are Hermes.",
+        )
+        roles = [m["role"] for m in captured["input"]]
+        assert roles.count("system") == 1
+        assert roles[0] == "system"
+
+    def test_absent_system_prompt_keeps_previous_shape(self, monkeypatch):
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._fire(mod, request_messages=[{"role": "user", "content": "hi"}])
+        assert captured["input"][0]["role"] == "user"
+        assert "system_prompt_chars" not in (captured["metadata"] or {})
+
+    def test_system_survives_serialization_window(self, monkeypatch):
+        """_serialize_messages keeps only the last 12 messages; the system
+        prompt must be prepended after windowing so long conversations
+        never drop it."""
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        many = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}
+            for i in range(30)
+        ]
+        self._fire(mod, request_messages=many, system_prompt="SYS")
+        assert captured["input"][0]["role"] == "system"
+        # window (12) + prepended system
+        assert len(captured["input"]) == 13
+
+    def test_metadata_records_chars(self, monkeypatch):
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._fire(
+            mod,
+            request_messages=[{"role": "user", "content": "hi"}],
+            system_prompt="You are Hermes.",
+        )
+        assert captured["metadata"]["system_prompt_chars"] == len("You are Hermes.")
+
+
+class TestSystemPromptCrossesHookBoundary:
+    """End-to-end across the hook seam with real transport-built kwargs —
+    the regression coverage PR #32175's review asked for: verify the
+    provider-specific request shape (Anthropic ``system`` kwarg, Codex
+    ``instructions``) actually reaches the Langfuse generation input, with
+    no Hermes internals mocked (only the Langfuse client is faked)."""
+
+    def _make_mod(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def _capture_generation(self, mod, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=None)
+        task_key = mod._trace_key("task-1", "sess-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        def fake_child(state_, **kw):
+            captured["input"] = kw.get("input_value")
+            return object()
+
+        monkeypatch.setattr(mod, "_start_child_observation", fake_child)
+        return captured
+
+    def _derive_and_fire(self, mod, api_kwargs, api_messages):
+        """Mirror agent/conversation_loop.py's pre_api_request emission:
+        derive request_messages exactly the way the loop does, derive
+        system_prompt via the loop's helper, and invoke the plugin hook."""
+        from agent.conversation_loop import _system_prompt_for_hooks
+
+        request_messages = api_kwargs.get("messages")
+        if not isinstance(request_messages, list):
+            request_messages = api_kwargs.get("input")
+        if not isinstance(request_messages, list):
+            request_messages = api_messages
+        mod.on_pre_llm_request(
+            task_id="task-1",
+            session_id="sess-1",
+            model="m",
+            provider="p",
+            api_mode="x",
+            api_call_count=1,
+            request_messages=list(request_messages),
+            system_prompt=_system_prompt_for_hooks(api_kwargs, request_messages),
+        )
+
+    def test_codex_instructions_reach_generation_input(self, monkeypatch):
+        from agent.transports.codex import ResponsesApiTransport
+
+        api_messages = [
+            {"role": "system", "content": "SYS-CODEX"},
+            {"role": "user", "content": "hi"},
+        ]
+        api_kwargs = ResponsesApiTransport().build_kwargs("gpt-x", api_messages, None)
+        # Premise: the Responses API moves the system prompt out of the input.
+        assert api_kwargs["instructions"] == "SYS-CODEX"
+        assert all(i.get("role") != "system" for i in api_kwargs["input"] if isinstance(i, dict))
+
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._derive_and_fire(mod, api_kwargs, api_messages)
+        assert captured["input"][0]["role"] == "system"
+        assert captured["input"][0]["content"] == "SYS-CODEX"
+
+    def test_anthropic_system_kwarg_reaches_generation_input(self, monkeypatch):
+        from agent.transports.anthropic import AnthropicTransport
+
+        api_messages = [
+            {"role": "system", "content": "SYS-ANTHROPIC"},
+            {"role": "user", "content": "hi"},
+        ]
+        api_kwargs = AnthropicTransport().build_kwargs(
+            "claude-x", api_messages, None, max_tokens=64
+        )
+        # Premise: the Messages API moves the system prompt to a kwarg.
+        assert "system" in api_kwargs
+        assert all(m.get("role") != "system" for m in api_kwargs["messages"])
+
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._derive_and_fire(mod, api_kwargs, api_messages)
+        assert captured["input"][0]["role"] == "system"
+        assert "SYS-ANTHROPIC" in captured["input"][0]["content"]
+
+    def test_bedrock_system_kwarg_reaches_generation_input(self, monkeypatch):
+        from agent.transports.bedrock import BedrockTransport
+
+        api_messages = [
+            {"role": "system", "content": "SYS-BEDROCK"},
+            {"role": "user", "content": "hi"},
+        ]
+        api_kwargs = BedrockTransport().build_kwargs(
+            "anthropic.claude-x", api_messages, None, max_tokens=64
+        )
+        # Premise: Bedrock Converse moves system into a separate 'system' kwarg,
+        # shaped as [{"text": ...}] blocks — no "type" key, unlike Anthropic.
+        # (The transport may append extra blocks, e.g. cachePoint markers.)
+        assert {"text": "SYS-BEDROCK"} in api_kwargs["system"]
+        assert all(m.get("role") != "system" for m in api_kwargs["messages"])
+
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._derive_and_fire(mod, api_kwargs, api_messages)
+        assert captured["input"][0]["role"] == "system"
+        assert "SYS-BEDROCK" in captured["input"][0]["content"]
+
+    def test_chat_completions_shape_needs_no_fallback(self, monkeypatch):
+        """When system stays in messages[0] (chat_completions), the helper
+        returns it but the plugin must not duplicate the entry."""
+        from agent.conversation_loop import _system_prompt_for_hooks
+
+        api_kwargs = {
+            "messages": [
+                {"role": "system", "content": "SYS-CHAT"},
+                {"role": "user", "content": "hi"},
+            ]
+        }
+        sp = _system_prompt_for_hooks(api_kwargs, api_kwargs["messages"])
+        assert sp == "SYS-CHAT"
+
+        mod = self._make_mod()
+        captured = self._capture_generation(mod, monkeypatch)
+        self._derive_and_fire(mod, api_kwargs, api_kwargs["messages"])
+        roles = [m["role"] for m in captured["input"]]
+        assert roles.count("system") == 1

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -885,3 +885,95 @@ class TestModelAttribution:
             assistant_content_chars=2,
         )
         assert seen["model"] == "actual/served-model"
+
+
+# ---------------------------------------------------------------------------
+# Cost total: explicit "total" alongside the per-type breakdown
+# ---------------------------------------------------------------------------
+
+class TestCostTotal:
+    """Langfuse ingests per-type ``cost_details`` keys but does not derive
+    ``calculatedTotalCost`` from them. Without an explicit ``total`` the
+    dashboard reads 0 for every priced generation."""
+
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def test_response_path_totals_the_breakdown(self):
+        mod = self._fresh_plugin()
+
+        class _Usage:
+            input_tokens = 1000
+            output_tokens = 500
+            cache_read_input_tokens = 2000
+            cache_creation_input_tokens = 0
+
+        class _Resp:
+            usage = _Usage()
+
+        _, cost_details = mod._usage_and_cost(
+            _Resp(),
+            provider="anthropic",
+            api_mode="anthropic_messages",
+            model="claude-sonnet-4-6",
+            base_url="",
+        )
+
+        assert cost_details["total"] == pytest.approx(0.0111)
+        components = {k: v for k, v in cost_details.items() if k != "total"}
+        assert components
+        assert cost_details["total"] == pytest.approx(sum(components.values()))
+
+    def test_usage_summary_path_totals_the_breakdown(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        state = mod.TraceState(trace_id="trace-1", root_ctx=None, root_span=None)
+        state.generations[mod._request_key(1)] = object()
+        monkeypatch.setitem(mod._TRACE_STATE, mod._trace_key("task-1", "session-1"), state)
+        captured = {}
+
+        def fake_end_observation(obs, *, output=None, metadata=None, usage_details=None, cost_details=None):
+            captured["cost_details"] = cost_details
+
+        monkeypatch.setattr(mod, "_end_observation", fake_end_observation)
+
+        # A dict response has no ``.usage``, so the handler takes the
+        # usage-summary path rather than the response-object path.
+        mod.on_post_llm_call(
+            task_id="task-1",
+            session_id="session-1",
+            api_call_count=1,
+            model="claude-sonnet-4-6",
+            provider="anthropic",
+            response={"model": "claude-sonnet-4-6"},
+            usage={"input_tokens": 1000, "output_tokens": 500},
+            assistant_content_chars=42,
+        )
+
+        cost_details = captured["cost_details"]
+        components = {k: v for k, v in cost_details.items() if k != "total"}
+        assert components
+        assert cost_details["total"] == pytest.approx(sum(components.values()))
+
+    def test_priced_model_with_no_tokens_reports_no_total(self):
+        mod = self._fresh_plugin()
+
+        class _Usage:
+            input_tokens = 0
+            output_tokens = 0
+
+        class _Resp:
+            usage = _Usage()
+
+        _, cost_details = mod._usage_and_cost(
+            _Resp(),
+            provider="anthropic",
+            api_mode="anthropic_messages",
+            model="claude-sonnet-4-6",
+            base_url="",
+        )
+
+        # A priced model that billed nothing writes no per-type keys, so
+        # summing them must not invent a 0.0 total on an empty breakdown.
+        assert cost_details == {}

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
+from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -2137,3 +2138,231 @@ class TestFinishTraceUsesUpdateTrace:
 
         assert roots[0].ended is True
         assert mod._TRACE_STATE == {}
+
+class TestCanonicalCostExport:
+    """Both supported response paths must export the same complete cost."""
+
+    @staticmethod
+    def _response(input_tokens, output_tokens, cache_read=0, cache_write=0):
+        cache_details = SimpleNamespace(
+            cached_tokens=cache_read,
+            cache_write_tokens=cache_write,
+        )
+        usage = SimpleNamespace(
+            # Anthropic response shape.
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_write,
+            # OpenAI chat response shape used by the included-route case.
+            prompt_tokens=input_tokens + cache_read + cache_write,
+            completion_tokens=output_tokens,
+            prompt_tokens_details=cache_details,
+        )
+        return SimpleNamespace(usage=usage)
+
+    @staticmethod
+    def _summary(input_tokens, output_tokens, cache_read=0, cache_write=0, request_count=1):
+        return {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_read_tokens": cache_read,
+            "cache_write_tokens": cache_write,
+            "reasoning_tokens": 0,
+            "request_count": request_count,
+        }
+
+    @staticmethod
+    def _capture_summary_path(mod, monkeypatch, usage, *, provider, model, api_mode):
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        observation = object()
+        state = mod.TraceState(trace_id="trace-cost", root_ctx=None, root_span=None)
+        state.generations[mod._request_key(1)] = observation
+        task_key = mod._trace_key("task-cost", "session-cost")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+        captured = {}
+
+        def fake_end_observation(
+            obs,
+            *,
+            output=None,
+            metadata=None,
+            usage_details=None,
+            cost_details=None,
+        ):
+            captured["usage_details"] = usage_details
+            captured["cost_details"] = cost_details
+
+        monkeypatch.setattr(mod, "_end_observation", fake_end_observation)
+        mod.on_post_llm_call(
+            task_id="task-cost",
+            session_id="session-cost",
+            api_call_count=1,
+            model=model,
+            provider=provider,
+            api_mode=api_mode,
+            response={"model": model},
+            usage=usage,
+        )
+        return captured["usage_details"], captured["cost_details"]
+
+    def _run_both_paths(
+        self,
+        mod,
+        monkeypatch,
+        usage,
+        *,
+        provider="anthropic",
+        model="priced-model",
+        api_mode="anthropic_messages",
+    ):
+        response_result = mod._usage_and_cost(
+            self._response(
+                usage["input_tokens"],
+                usage["output_tokens"],
+                usage.get("cache_read_tokens", 0),
+                usage.get("cache_write_tokens", 0),
+            ),
+            provider=provider,
+            api_mode=api_mode,
+            model=model,
+            base_url="",
+        )
+        summary_result = self._capture_summary_path(
+            mod,
+            monkeypatch,
+            usage,
+            provider=provider,
+            model=model,
+            api_mode=api_mode,
+        )
+        assert response_result[0] == summary_result[0]
+        return response_result[1], summary_result[1]
+
+    @pytest.mark.parametrize(
+        ("cache_read", "cache_write", "expected_total"),
+        [
+            (0, 0, 0.00002),
+            (2, 3, 0.0000255),
+        ],
+        ids=("no-cache", "cached"),
+    )
+    def test_known_costs_include_canonical_total_on_both_paths(
+        self,
+        monkeypatch,
+        cache_read,
+        cache_write,
+        expected_total,
+    ):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        import agent.usage_pricing as pricing
+
+        entry = pricing.PricingEntry(
+            input_cost_per_million=Decimal("1"),
+            output_cost_per_million=Decimal("2"),
+            cache_read_cost_per_million=Decimal("0.5"),
+            cache_write_cost_per_million=Decimal("1.5"),
+            source="custom_contract",
+        )
+        monkeypatch.setattr(pricing, "get_pricing_entry", lambda *_, **__: entry)
+        usage = self._summary(10, 5, cache_read, cache_write)
+
+        response_cost, summary_cost = self._run_both_paths(mod, monkeypatch, usage)
+        expected = {
+            "total": expected_total,
+            "input": 0.00001,
+            "output": 0.00001,
+        }
+        if cache_read:
+            expected["cache_read_input_tokens"] = 0.000001
+        if cache_write:
+            expected["cache_creation_input_tokens"] = 0.0000045
+        assert response_cost == pytest.approx(expected)
+        assert summary_cost == pytest.approx(expected)
+
+    def test_total_uses_request_cost_instead_of_component_sum(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        import agent.usage_pricing as pricing
+
+        entry = pricing.PricingEntry(
+            input_cost_per_million=Decimal("1"),
+            output_cost_per_million=Decimal("2"),
+            cache_read_cost_per_million=Decimal("0.5"),
+            cache_write_cost_per_million=Decimal("1.5"),
+            request_cost=Decimal("0.01"),
+            source="provider_models_api",
+        )
+        monkeypatch.setattr(pricing, "get_pricing_entry", lambda *_, **__: entry)
+        usage = self._summary(10, 5, cache_read=2, cache_write=3)
+
+        response_cost, summary_cost = self._run_both_paths(mod, monkeypatch, usage)
+        for cost_details in (response_cost, summary_cost):
+            component_sum = sum(
+                value for key, value in cost_details.items() if key != "total"
+            )
+            assert cost_details["total"] == pytest.approx(0.0100255)
+            assert component_sum == pytest.approx(0.0000255)
+
+    def test_request_only_price_still_exports_total(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        import agent.usage_pricing as pricing
+
+        entry = pricing.PricingEntry(
+            request_cost=Decimal("0.01"),
+            source="provider_models_api",
+        )
+        monkeypatch.setattr(pricing, "get_pricing_entry", lambda *_, **__: entry)
+        usage = self._summary(0, 0)
+
+        response_cost, summary_cost = self._run_both_paths(mod, monkeypatch, usage)
+        assert response_cost == {"total": 0.01}
+        assert summary_cost == {"total": 0.01}
+
+    def test_partial_cache_pricing_exports_no_costs(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        import agent.usage_pricing as pricing
+
+        entry = pricing.PricingEntry(
+            input_cost_per_million=Decimal("1"),
+            output_cost_per_million=Decimal("2"),
+            cache_read_cost_per_million=None,
+            source="provider_models_api",
+        )
+        monkeypatch.setattr(pricing, "get_pricing_entry", lambda *_, **__: entry)
+        usage = self._summary(10, 5, cache_read=2)
+
+        response_cost, summary_cost = self._run_both_paths(mod, monkeypatch, usage)
+        assert response_cost == {}
+        assert summary_cost == {}
+
+    def test_unknown_pricing_exports_no_costs(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        import agent.usage_pricing as pricing
+
+        monkeypatch.setattr(pricing, "get_pricing_entry", lambda *_, **__: None)
+        usage = self._summary(10, 5)
+
+        response_cost, summary_cost = self._run_both_paths(mod, monkeypatch, usage)
+        assert response_cost == {}
+        assert summary_cost == {}
+
+    def test_included_route_does_not_pin_total(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        usage = self._summary(10, 5, cache_read=2)
+
+        response_cost, summary_cost = self._run_both_paths(
+            mod,
+            monkeypatch,
+            usage,
+            provider="openai-codex",
+            model="gpt-5.3-codex",
+            api_mode="chat_completions",
+        )
+        assert response_cost == summary_cost
+        assert "total" not in response_cost

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -25,12 +25,13 @@ class TestManifest:
         data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
         assert data["name"] == "langfuse"
         assert data["version"]
-        # All nine hooks the plugin implements.
+        # All eleven hooks the plugin implements.
         assert set(data["hooks"]) == {
             "pre_api_request", "post_api_request", "api_request_error",
             "pre_llm_call", "post_llm_call",
             "pre_tool_call", "post_tool_call",
             "on_session_finalize", "on_session_end",
+            "subagent_start", "subagent_stop",
         }
         # Required env vars are the user-facing HERMES_ prefixed keys.
         assert "HERMES_LANGFUSE_PUBLIC_KEY" in data["requires_env"]
@@ -1261,3 +1262,116 @@ class TestSessionFinalizeHook:
         mod._TRACE_STATE.clear()
         # _LANGFUSE_CLIENT is None on a fresh module; must not raise or init.
         mod.on_session_finalize(session_id="whatever")
+
+
+# ---------------------------------------------------------------------------
+# Subagent tracing: delegated children as spans under the parent turn
+# ---------------------------------------------------------------------------
+
+class TestSubagentTracing:
+    """``tools/delegate_tool.py`` emits subagent_start/subagent_stop. The
+    payloads carry ``parent_turn_id`` but no ``task_id``, so the parent trace
+    must be resolved by turn id rather than by rebuilding the scope key."""
+
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def _state(self, mod, monkeypatch, key, spans):
+        class _Obs:
+            def __init__(self, kw):
+                self.kw = kw
+                self.ended = False
+                self.updates = {}
+
+            def update(self, **kw):
+                self.updates.update(kw)
+
+            def end(self, **kw):
+                self.ended = True
+
+        class _Root:
+            def start_observation(self, **kw):
+                obs = _Obs(kw)
+                spans.append(obs)
+                return obs
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        state = mod.TraceState(trace_id="trace-1", root_ctx=None, root_span=_Root())
+        monkeypatch.setitem(mod._TRACE_STATE, key, state)
+        return state
+
+    def test_start_attaches_span_despite_task_scoped_key(self, monkeypatch):
+        mod = self._fresh_plugin()
+        spans = []
+        # Key minted by the LLM hooks with a task id — a naive rebuild from
+        # session_id alone would not match this.
+        state = self._state(mod, monkeypatch, "task:task-9:turn:turn-7", spans)
+
+        mod.on_subagent_start(
+            parent_session_id="sess-1",
+            parent_turn_id="turn-7",
+            child_session_id="child-sess-1",
+            child_subagent_id="sub-1",
+            child_role="researcher",
+            child_goal="find the thing",
+        )
+
+        assert len(spans) == 1
+        assert spans[0].kw["name"] == "Subagent: researcher"
+        assert spans[0].kw["metadata"]["child_subagent_id"] == "sub-1"
+        assert "child-sess-1" in state.subagents
+
+    def test_stop_ends_span_and_records_outcome(self, monkeypatch):
+        mod = self._fresh_plugin()
+        spans = []
+        state = self._state(mod, monkeypatch, "task:task-9:turn:turn-7", spans)
+
+        mod.on_subagent_start(
+            parent_session_id="sess-1", parent_turn_id="turn-7",
+            child_session_id="child-sess-1", child_role="researcher",
+            child_goal="find the thing",
+        )
+        mod.on_subagent_stop(
+            parent_session_id="sess-1", parent_turn_id="turn-7",
+            child_session_id="child-sess-1", child_role="researcher",
+            child_summary="found it", child_status="ok",
+            tool_call_history=[{"name": "read_file"}, {"name": "grep"}],
+            duration_ms=1234,
+        )
+
+        assert spans[0].ended is True
+        assert spans[0].updates["metadata"]["status"] == "ok"
+        assert spans[0].updates["metadata"]["tool_call_count"] == 2
+        assert spans[0].updates["metadata"]["duration_ms"] == 1234
+        # Popped so a repeated stop cannot double-end the span.
+        assert not state.subagents
+
+    def test_unknown_turn_is_a_noop(self, monkeypatch):
+        mod = self._fresh_plugin()
+        spans = []
+        self._state(mod, monkeypatch, "task:task-9:turn:turn-7", spans)
+
+        mod.on_subagent_start(
+            parent_turn_id="turn-does-not-exist",
+            child_session_id="child-sess-1", child_role="researcher",
+        )
+        mod.on_subagent_stop(
+            parent_turn_id="turn-does-not-exist",
+            child_session_id="child-sess-1",
+        )
+
+        assert spans == []
+
+    def test_start_without_child_session_is_a_noop(self, monkeypatch):
+        mod = self._fresh_plugin()
+        spans = []
+        self._state(mod, monkeypatch, "task:task-9:turn:turn-7", spans)
+
+        # subagent_stop keys on child_session_id, so a start without one could
+        # never be matched and must not open an unclosable span.
+        mod.on_subagent_start(
+            parent_turn_id="turn-7", child_session_id=None, child_role="researcher",
+        )
+
+        assert spans == []

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -2366,3 +2366,7 @@ class TestCanonicalCostExport:
         )
         assert response_cost == summary_cost
         assert "total" not in response_cost
+        # Subscription-included routes must send NO cost keys at all —
+        # explicit zeros are treated as authoritative by Langfuse and block
+        # its own model-based estimation (#43129).
+        assert response_cost == {}

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -363,6 +363,60 @@ class TestTurnTraceIsolation:
         surviving = sorted(int(k.rsplit("turn", 1)[1]) for k in mod._TRACE_STATE)
         assert surviving == list(range(42, 50))
 
+    def test_finish_trace_exits_root_context_manager(self, monkeypatch):
+        """_finish_trace must call root_ctx.__exit__(), not just root_span.end().
+
+        Regression for the "Exception ignored in: <generator>" traceback
+        on CLI exit.  The plugin enters the root observation's context
+        manager (start_as_current_observation(...).__enter__()) but must
+        also exit it; otherwise the generator is left suspended and is
+        only unwound when the GC collects it during interpreter teardown.
+        By then opentelemetry.trace.Span has been set to None, and the
+        generator's close() -> use_span.__exit__ -> isinstance(span, Span)
+        raises TypeError: isinstance() arg 2 must be a type.  Exiting the
+        context manager here unwinds the generator while modules are intact.
+        """
+        mod = self._fresh_plugin()
+        started: list = []
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        exited: list = []
+
+        class _S:
+            def update(self, **kw): pass
+            def end(self, **kw): pass
+            def set_trace_io(self, **kw): pass
+            def start_observation(self, **kw): return _S()
+
+        class _TrackingRootCM:
+            def __enter__(self):
+                return _S()
+            def __exit__(self, *exc):
+                exited.append(exc)
+                return False
+
+        class _TrackingClient:
+            def create_trace_id(self, seed=None):
+                return f"trace::{seed}"
+            def start_as_current_observation(self, **kw):
+                started.append(kw.get("trace_context", {}).get("trace_id"))
+                return _TrackingRootCM()
+            def flush(self):
+                pass
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _TrackingClient())
+
+        self._run_turn(mod, session="sess-exit", turn_n=1, finalize=True)
+
+        assert exited, (
+            "_finish_trace did not call root_ctx.__exit__; the generator is "
+            "left suspended and will raise TypeError on GC at interpreter "
+            "teardown when opentelemetry.trace.Span is None"
+        )
+        assert len(exited) == 1
+        assert exited[0] == (None, None, None)
+
 
 # ---------------------------------------------------------------------------
 # Placeholder-credential guard (#23823).

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -779,3 +779,109 @@ class TestUsageFromSanitizedResponse:
 
         assert seen["resp"] is resp
         assert captured["usage_details"] == {"input": 7, "output": 3}
+
+
+# ---------------------------------------------------------------------------
+# Model attribution: wire truth over stale agent attribute
+# ---------------------------------------------------------------------------
+
+class TestModelAttribution:
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def _client_capturing_generations(self, gens):
+        class _Gen:
+            def update(self, **kw): pass
+            def end(self, **kw): pass
+
+        class _Span:
+            def update(self, **kw): pass
+            def end(self, **kw): pass
+            def set_trace_io(self, **kw): pass
+            def start_observation(self, **kw):
+                gens.append(kw)
+                return _Gen()
+
+        class _RootCM:
+            def __enter__(self): return _Span()
+            def __exit__(self, *exc): return False
+
+        class _Client:
+            def create_trace_id(self, seed=None): return "t"
+            def start_as_current_observation(self, **kw): return _RootCM()
+            def flush(self): pass
+
+        return _Client()
+
+    def test_pre_api_request_prefers_request_body_model(self, monkeypatch):
+        """Agent attribute says old model; request body says the switched one."""
+        mod = self._fresh_plugin()
+        gens: list = []
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: self._client_capturing_generations(gens))
+        mod._TRACE_STATE.clear()
+
+        mod.on_pre_llm_request(
+            task_id="t", session_id="s", turn_id="s:t:turn1",
+            api_call_count=1,
+            model="old-model-attr",
+            provider="openrouter",
+            request_messages=[{"role": "user", "content": "hi"}],
+            request={"body": {"model": "switched/new-model"}},
+        )
+        assert gens, "no generation started"
+        assert gens[0]["model"] == "switched/new-model"
+
+    def test_pre_api_request_falls_back_to_attr_without_body_model(self, monkeypatch):
+        mod = self._fresh_plugin()
+        gens: list = []
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: self._client_capturing_generations(gens))
+        mod._TRACE_STATE.clear()
+
+        mod.on_pre_llm_request(
+            task_id="t", session_id="s", turn_id="s:t:turn2",
+            api_call_count=1,
+            model="attr-model",
+            request_messages=[{"role": "user", "content": "hi"}],
+            request={"body": {}},
+        )
+        assert gens[0]["model"] == "attr-model"
+
+    def test_post_api_request_uses_response_model_for_cost(self, monkeypatch):
+        """Cost estimation must key off the model that actually served."""
+        mod = self._fresh_plugin()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        mod._TRACE_STATE.clear()
+
+        seen = {}
+        def fake_usage_and_cost(response, *, provider, api_mode, model, base_url):
+            seen["model"] = model
+            return {"input": 1, "output": 1}, {}
+        monkeypatch.setattr(mod, "_usage_and_cost", fake_usage_and_cost)
+
+        class _Gen:
+            def update(self, **kw): pass
+            def end(self, **kw): pass
+
+        class _Root:
+            def update(self, **kw): pass
+            def end(self, **kw): pass
+            def set_trace_io(self, **kw): pass
+
+        turn_id = "s:t:turn3"
+        key = mod._trace_key("t", "s", turn_id=turn_id)
+        state = mod.TraceState(trace_id="x", root_ctx=None, root_span=_Root())
+        state.generations["1"] = _Gen()
+        mod._TRACE_STATE[key] = state
+
+        class _Resp:
+            usage = {"prompt_tokens": 1, "completion_tokens": 1}
+
+        mod.on_post_llm_call(
+            task_id="t", session_id="s", turn_id=turn_id, api_call_count=1,
+            model="stale-attr-model",
+            response_model="actual/served-model",
+            response=_Resp(),
+            assistant_content_chars=2,
+        )
+        assert seen["model"] == "actual/served-model"

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -1317,6 +1317,55 @@ class TestSessionFinalizeHook:
         # _LANGFUSE_CLIENT is None on a fresh module; must not raise or init.
         mod.on_session_finalize(session_id="whatever")
 
+    def test_finalize_shuts_down_client_on_process_exit(self, monkeypatch):
+        """reason="shutdown" must call client.shutdown() while the interpreter
+        is alive, so the SDK's own atexit handler (which runs during
+        interpreter finalization, after opentelemetry.trace.Span is torn
+        down) becomes a no-op instead of raising the "isinstance() arg 2
+        must be a type" TypeError on quit."""
+        mod = self._fresh_plugin()
+        events = []
+
+        class _Client:
+            def flush(self):
+                events.append("flush")
+
+            def shutdown(self):
+                events.append("shutdown")
+
+        client = _Client()
+        monkeypatch.setattr(mod, "_LANGFUSE_CLIENT", client)
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        mod._TRACE_STATE.clear()
+
+        mod.on_session_finalize(session_id="sess-a", reason="shutdown")
+        assert "shutdown" in events
+        assert events.index("flush") < events.index("shutdown")
+
+    def test_finalize_keeps_client_alive_on_session_rotation(self, monkeypatch):
+        """/new, /reset, and gateway session expiry finalize the session but
+        the process lives on — the cached client must NOT be shut down or
+        later sessions silently stop exporting."""
+        mod = self._fresh_plugin()
+        events = []
+
+        class _Client:
+            def flush(self):
+                events.append("flush")
+
+            def shutdown(self):
+                events.append("shutdown")
+
+        client = _Client()
+        monkeypatch.setattr(mod, "_LANGFUSE_CLIENT", client)
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        mod._TRACE_STATE.clear()
+
+        for reason in ("session_boundary", "new_session", "session_expired", ""):
+            mod.on_session_finalize(session_id="sess-a", reason=reason)
+        assert "shutdown" not in events
+        assert "flush" in events
+
 
 # ---------------------------------------------------------------------------
 # Subagent tracing: delegated children as spans under the parent turn

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -584,6 +585,62 @@ class TestRequestMessageCoercion:
             user_message="u",
         ) == [{"role": "user", "content": "h"}]
         assert mod._coerce_request_messages(user_message="u") == [{"role": "user", "content": "u"}]
+
+
+class TestAssistantMessageSerialization:
+    def test_serialize_assistant_message_prefers_reasoning(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        message = SimpleNamespace(
+            content="answer",
+            reasoning="primary reasoning",
+            reasoning_content="fallback reasoning",
+            reasoning_details=[{"type": "summary", "text": "structured reasoning"}],
+        )
+
+        assert mod._serialize_assistant_message(message)["reasoning"] == "primary reasoning"
+
+    def test_serialize_assistant_message_uses_reasoning_content_when_reasoning_absent(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        message = SimpleNamespace(
+            content="answer",
+            reasoning=None,
+            reasoning_content="provider scratchpad",
+            reasoning_details=[{"type": "summary", "text": "structured reasoning"}],
+        )
+
+        assert mod._serialize_assistant_message(message)["reasoning"] == "provider scratchpad"
+
+    def test_serialize_assistant_message_uses_structured_reasoning_details(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        reasoning_details = [
+            {"type": "summary", "text": "checked tools"},
+            {"type": "encrypted_content", "encrypted_content": b"opaque"},
+        ]
+        message = SimpleNamespace(
+            content="answer",
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=reasoning_details,
+        )
+
+        assert mod._serialize_assistant_message(message)["reasoning"] == [
+            {"type": "summary", "text": "checked tools"},
+            {"type": "encrypted_content", "encrypted_content": {"type": "bytes", "len": 6}},
+        ]
+
+    def test_serialize_assistant_message_without_reasoning_fields_sets_none(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        message = SimpleNamespace(content="answer")
+
+        assert mod._serialize_assistant_message(message)["reasoning"] is None
 
 
 class TestToolCallOutputBackfill:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -1375,3 +1375,112 @@ class TestSubagentTracing:
         )
 
         assert spans == []
+
+
+# ---------------------------------------------------------------------------
+# MoA fan-out: one generation per advisor, priced at the advisor's own model
+# ---------------------------------------------------------------------------
+
+class TestMoAReferenceGenerations:
+    """MoA returns only the aggregator's response, so without per-advisor
+    generations the whole fan-out collapses into one line priced at the
+    aggregator's model. Advisors routinely run on a different provider."""
+
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def _state(self, mod, monkeypatch, gens):
+        class _Obs:
+            def __init__(self, kw):
+                self.kw = kw
+                self.updates = {}
+                self.ended = False
+
+            def update(self, **kw):
+                self.updates.update(kw)
+
+            def end(self, **kw):
+                self.ended = True
+
+        class _Root:
+            def start_observation(self, **kw):
+                obs = _Obs(kw)
+                gens.append(obs)
+                return obs
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        return mod.TraceState(trace_id="t", root_ctx=None, root_span=_Root())
+
+    def _refs(self):
+        return [
+            {
+                "label": "anthropic:claude-sonnet-4-6",
+                "model": "claude-sonnet-4-6",
+                "provider": "anthropic",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+                "cost_usd": 0.001,
+                "cost_status": "ok",
+                "cost_source": "pricing_table",
+            },
+            {
+                "label": "openai:gpt-5",
+                "model": "gpt-5",
+                "provider": "openai",
+                "usage": {"input_tokens": 80, "output_tokens": 40, "reasoning_tokens": 10},
+                "cost_usd": 0.002,
+            },
+        ]
+
+    def test_one_generation_per_advisor_with_own_model_and_cost(self, monkeypatch):
+        mod = self._fresh_plugin()
+        gens = []
+        state = self._state(mod, monkeypatch, gens)
+
+        mod._emit_moa_reference_generations(state, client=object(), references=self._refs())
+
+        assert len(gens) == 2
+        assert gens[0].kw["model"] == "claude-sonnet-4-6"
+        assert gens[1].kw["model"] == "gpt-5"
+        # Each advisor's dollars, not the aggregator's rate applied to all.
+        assert gens[0].updates["cost_details"]["total"] == pytest.approx(0.001)
+        assert gens[1].updates["cost_details"]["total"] == pytest.approx(0.002)
+        assert gens[0].updates["usage_details"] == {"input": 100, "output": 50}
+        assert gens[1].updates["usage_details"]["reasoning_tokens"] == 10
+        assert all(g.ended for g in gens)
+
+    def test_repeat_emit_is_deduped_within_a_turn(self, monkeypatch):
+        mod = self._fresh_plugin()
+        gens = []
+        state = self._state(mod, monkeypatch, gens)
+
+        # The MoA client holds its last fan-out until the next one, so a
+        # tool-loop turn delivers the same references on every API call.
+        refs = self._refs()
+        mod._emit_moa_reference_generations(state, client=object(), references=refs)
+        mod._emit_moa_reference_generations(state, client=object(), references=refs)
+        mod._emit_moa_reference_generations(state, client=object(), references=list(refs))
+
+        assert len(gens) == 2
+
+    def test_a_new_fanout_emits_again(self, monkeypatch):
+        mod = self._fresh_plugin()
+        gens = []
+        state = self._state(mod, monkeypatch, gens)
+
+        mod._emit_moa_reference_generations(state, client=object(), references=self._refs())
+        second = self._refs()
+        second[0]["usage"]["output_tokens"] = 999
+        mod._emit_moa_reference_generations(state, client=object(), references=second)
+
+        assert len(gens) == 4
+
+    def test_non_moa_turn_emits_nothing(self, monkeypatch):
+        mod = self._fresh_plugin()
+        gens = []
+        state = self._state(mod, monkeypatch, gens)
+
+        for value in (None, [], "not-a-list", [None, "junk"]):
+            mod._emit_moa_reference_generations(state, client=object(), references=value)
+
+        assert gens == []

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -25,11 +25,12 @@ class TestManifest:
         data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
         assert data["name"] == "langfuse"
         assert data["version"]
-        # All six hooks the plugin implements.
+        # All nine hooks the plugin implements.
         assert set(data["hooks"]) == {
-            "pre_api_request", "post_api_request",
+            "pre_api_request", "post_api_request", "api_request_error",
             "pre_llm_call", "post_llm_call",
             "pre_tool_call", "post_tool_call",
+            "on_session_finalize", "on_session_end",
         }
         # Required env vars are the user-facing HERMES_ prefixed keys.
         assert "HERMES_LANGFUSE_PUBLIC_KEY" in data["requires_env"]
@@ -977,3 +978,286 @@ class TestCostTotal:
         # A priced model that billed nothing writes no per-type keys, so
         # summing them must not invent a 0.0 total on an empty breakdown.
         assert cost_details == {}
+
+
+# ---------------------------------------------------------------------------
+# Capture modes: metadata | sanitized | full  (HERMES_LANGFUSE_CAPTURE)
+# ---------------------------------------------------------------------------
+
+class TestCaptureModes:
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def test_default_mode_is_sanitized(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.delenv("HERMES_LANGFUSE_CAPTURE", raising=False)
+        assert mod._capture_mode() == "sanitized"
+
+    def test_invalid_mode_falls_back_and_warns_once(self, monkeypatch, caplog):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "everything")
+        with caplog.at_level(logging.WARNING):
+            assert mod._capture_mode() == "sanitized"
+            assert mod._capture_mode() == "sanitized"
+        warnings = [r for r in caplog.records if "HERMES_LANGFUSE_CAPTURE" in r.getMessage()]
+        assert len(warnings) == 1
+
+    def test_metadata_mode_omits_content(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "metadata")
+        out = mod._capture_content("top secret prompt text")
+        assert out == {"omitted": True, "type": "text", "chars": 22}
+        obj = mod._capture_content({"password": "hunter22", "path": "/x"})
+        assert obj["omitted"] is True
+        assert set(obj["keys"]) == {"password", "path"}
+        assert "hunter22" not in str(obj)
+
+    def test_metadata_mode_message_serialization_keeps_roles(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "metadata")
+        msgs = mod._serialize_messages([
+            {"role": "user", "content": "my ssn is 123-45-6789"},
+            {"role": "assistant", "content": "noted"},
+        ])
+        assert [m["role"] for m in msgs] == ["user", "assistant"]
+        assert all(isinstance(m["content"], dict) and m["content"]["omitted"] for m in msgs)
+        assert "6789" not in str(msgs)
+
+    def test_sanitized_mode_redacts_secrets(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "sanitized")
+        samples = {
+            "openai": "here sk-abcdefghijklmnop1234 done",
+            "anthropic": "key sk-ant-abcdefgh1234 x",
+            "github": "tok ghp_" + "a" * 36,
+            "aws": "AKIA" + "A" * 16,
+            "langfuse": "pk-lf-12345678-abcd",
+            "bearer": "Authorization: Bearer abc123def456ghi",
+            "assignment": 'api_key="supersecretvalue"',
+        }
+        for name, text in samples.items():
+            out = mod._capture_content(text)
+            assert "REDACTED" in out, f"{name} not redacted: {out!r}"
+
+    def test_sanitized_mode_redacts_before_truncation(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "sanitized")
+        secret = "sk-" + "z" * 40
+        text = "x" * 100 + " " + secret + " " + "y" * 100
+        out = mod._truncate_text(text, 120)
+        assert "z" * 10 not in out
+        assert "REDACTED" in out
+
+    def test_sanitized_mode_keeps_ordinary_text(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "sanitized")
+        text = "refactor the memory manager to emit spans"
+        assert mod._capture_content(text) == text
+
+    def test_full_mode_keeps_secret_shaped_text(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "full")
+        text = "here sk-abcdefghijklmnop1234 done"
+        assert mod._capture_content(text) == text
+
+    def test_capture_mode_recorded_in_trace_metadata(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "metadata")
+        seen = {}
+
+        class _Span:
+            def update(self, **kw): pass
+            def end(self, **kw): pass
+            def set_trace_io(self, **kw): pass
+            def start_observation(self, **kw): return _Span()
+
+        class _RootCM:
+            def __enter__(self): return _Span()
+            def __exit__(self, *exc): return False
+
+        class _Client:
+            def create_trace_id(self, seed=None): return "t1"
+            def start_as_current_observation(self, **kw):
+                seen.update(kw)
+                return _RootCM()
+
+        state = mod._start_root_trace(
+            "k", task_id="t", session_id="s", platform="cli", provider="p",
+            model="m", api_mode="chat", messages=[{"role": "user", "content": "hi"}],
+            client=_Client(),
+        )
+        assert seen["metadata"]["capture_mode"] == "metadata"
+        assert state is not None
+
+
+# ---------------------------------------------------------------------------
+# api_request_error hook
+# ---------------------------------------------------------------------------
+
+class TestApiRequestErrorHook:
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def _seed_state(self, mod, task_key, gen_key="1"):
+        class _Gen:
+            def __init__(self):
+                self.updates = []
+                self.ended = False
+            def update(self, **kw):
+                self.updates.append(kw)
+            def end(self, **kw):
+                self.ended = True
+
+        class _Root:
+            def __init__(self):
+                self.ended = False
+            def update(self, **kw): pass
+            def end(self, **kw): self.ended = True
+            def set_trace_io(self, **kw): pass
+
+        gen = _Gen()
+        root = _Root()
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=root)
+        state.generations[gen_key] = gen
+        mod._TRACE_STATE[task_key] = state
+        return gen, root
+
+    def test_retryable_error_closes_generation_keeps_turn(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        mod._TRACE_STATE.clear()
+        turn_id = "s:t:turn1"
+        task_key = mod._trace_key("t", "s", turn_id=turn_id)
+        gen, root = self._seed_state(mod, task_key)
+
+        mod.on_api_request_error(
+            task_id="t", session_id="s", api_call_count=1,
+            turn_id=turn_id,
+            status_code=429, retryable=True, retry_count=1, max_retries=3,
+            error={"type": "RateLimitError", "message": "slow down"},
+        )
+
+        assert gen.ended is True
+        assert any(u.get("level") == "ERROR" for u in gen.updates)
+        # error metadata landed
+        meta = [u["metadata"] for u in gen.updates if "metadata" in u]
+        assert meta and meta[0]["status_code"] == 429
+        # turn stays open for the retry
+        assert task_key in mod._TRACE_STATE
+        assert root.ended is False
+
+    def test_terminal_error_finishes_turn(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: type("C", (), {"flush": lambda self: None})())
+        mod._TRACE_STATE.clear()
+        turn_id = "s:t:turn2"
+        task_key = mod._trace_key("t", "s", turn_id=turn_id)
+        gen, root = self._seed_state(mod, task_key)
+
+        mod.on_api_request_error(
+            task_id="t", session_id="s", api_call_count=1,
+            turn_id=turn_id,
+            status_code=401, retryable=False,
+            error={"type": "AuthenticationError", "message": "bad key"},
+        )
+
+        assert gen.ended is True
+        assert task_key not in mod._TRACE_STATE
+        assert root.ended is True
+
+    def test_error_hook_noops_without_state(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        mod._TRACE_STATE.clear()
+        # Must not raise
+        mod.on_api_request_error(
+            task_id="t", session_id="s", api_call_count=1,
+            error={"type": "X", "message": "y"}, retryable=False,
+        )
+
+    def test_error_message_respects_capture_mode(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_LANGFUSE_CAPTURE", "metadata")
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        mod._TRACE_STATE.clear()
+        turn_id = "s:t:turn3"
+        task_key = mod._trace_key("t", "s", turn_id=turn_id)
+        gen, _root = self._seed_state(mod, task_key)
+
+        mod.on_api_request_error(
+            task_id="t", session_id="s", api_call_count=1, turn_id=turn_id,
+            retryable=True,
+            error={"type": "APIError", "message": "secret prompt echo sk-abc"},
+        )
+        meta = [u["metadata"] for u in gen.updates if "metadata" in u][0]
+        assert isinstance(meta["error_message"], dict)
+        assert meta["error_message"]["omitted"] is True
+
+
+# ---------------------------------------------------------------------------
+# on_session_finalize hook
+# ---------------------------------------------------------------------------
+
+class TestSessionFinalizeHook:
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def _client(self, flushes):
+        class _Client:
+            def flush(self):
+                flushes.append(1)
+        return _Client()
+
+    def _state(self, mod):
+        class _Root:
+            def __init__(self):
+                self.ended = False
+            def update(self, **kw): pass
+            def end(self, **kw): self.ended = True
+            def set_trace_io(self, **kw): pass
+        root = _Root()
+        return mod.TraceState(trace_id="t", root_ctx=None, root_span=root), root
+
+    def test_finalize_closes_matching_session_traces(self, monkeypatch):
+        mod = self._fresh_plugin()
+        flushes = []
+        client = self._client(flushes)
+        monkeypatch.setattr(mod, "_LANGFUSE_CLIENT", client)
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        mod._TRACE_STATE.clear()
+
+        s1, r1 = self._state(mod)
+        s2, r2 = self._state(mod)
+        mod._TRACE_STATE["session:sess-a:turn:1"] = s1
+        mod._TRACE_STATE["session:sess-b:turn:1"] = s2
+
+        mod.on_session_finalize(session_id="sess-a")
+
+        assert "session:sess-a:turn:1" not in mod._TRACE_STATE
+        assert "session:sess-b:turn:1" in mod._TRACE_STATE
+        assert r1.ended is True
+        assert r2.ended is False
+        assert flushes  # flushed at least once
+
+    def test_finalize_without_session_closes_all(self, monkeypatch):
+        mod = self._fresh_plugin()
+        flushes = []
+        client = self._client(flushes)
+        monkeypatch.setattr(mod, "_LANGFUSE_CLIENT", client)
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        mod._TRACE_STATE.clear()
+
+        s1, r1 = self._state(mod)
+        mod._TRACE_STATE["session:sess-x:turn:1"] = s1
+        mod.on_session_finalize()
+        assert not mod._TRACE_STATE
+        assert r1.ended is True
+
+    def test_finalize_noop_when_client_never_initialized(self):
+        mod = self._fresh_plugin()
+        mod._TRACE_STATE.clear()
+        # _LANGFUSE_CLIENT is None on a fresh module; must not raise or init.
+        mod.on_session_finalize(session_id="whatever")


### PR DESCRIPTION
Widens the bundled Langfuse plugin from 6 hooks to 11 and fixes two attribution bugs. Also adopts the shutdown/atexit lifecycle fixes from #81054 and #82332 (original authorship preserved) with two interaction-fix follow-up commits.

## Model attribution

`on_pre_llm_request` and `on_post_llm_call` read `model`, the agent's attribute at hook time. It goes stale after a mid-session `/model` switch or a provider fallback, so generations file under the wrong model and cost estimation keys off it. Both now prefer the wire value — `request["body"]["model"]` and `response_model`. `agent/conversation_loop.py` already passed both and the plugin ignored them.

## Cost total

Langfuse does not derive `calculatedTotalCost` from the per-type `cost_details` keys. `_usage_and_cost` wrote the breakdown and no total, so a priced generation read 0 in the dashboard while its components were correct. Both cost paths now send a summed `total`. A priced model that billed no tokens writes no breakdown and still sends no total.

## New coverage

**Errors and session lifecycle.** `api_request_error` closes failed generations with `level=ERROR` and retry metadata. `on_session_finalize` and `on_session_end` close still-open traces so tool-only and interrupted turns stop dangling. Adds `HERMES_LANGFUSE_CAPTURE=metadata|sanitized|full`, default `sanitized`.

**Subagents.** `tools/delegate_tool.py` emits `subagent_start`/`subagent_stop` and the sibling `nemo_relay` plugin already consumes them, so every delegated child was missing here. The payloads carry `parent_turn_id` but no `task_id`, and `_scope_prefix` prefers `task_id` when the LLM hooks minted the key — so `_state_for_turn` matches on the turn-id suffix instead of rebuilding a key that would miss.

**MoA advisors.** A MoA turn runs N advisor models before its aggregator and returns only the aggregator's response, so the fan-out showed up as one generation priced at the aggregator's model. `_RefAccounting` already computes each advisor's usage and dollars, precisely because advisors run on a different provider and cannot be priced at the aggregator's rate. `moa_trace.slot_metrics` renders that and `post_api_request` carries it as `moa_references`.

## MoA plumbing

The read is deliberately non-consuming. `post_api_request` fires on a different branch of `run_conversation` than `consume_reference_usage` and `consume_and_save_trace`, so a consuming read would race them. The client holds its last fan-out until the next one, so the plugin fingerprints each fan-out and does not re-emit the same advisors on every API call of a tool-loop turn.

The payload derives from the already privacy-redacted `_trace_refs`, so an active privacy mode redacts it too. `slot_metrics` drops `input_messages` rather than crossing the hook boundary with a full transcript per advisor per turn.

## Verification

184 tests pass across the langfuse, MoA, subagent-hook, and relay-metrics suites. `moa_references` cannot reach the nemo relay's metrics payload: `model_call_fields` allowlists `model` and `provider`. The 11 whole-tree pytest collection errors are identical on `main`.

## Adopted lifecycle fixes

**#81054 (bgodlin, 2 commits).** Quitting Hermes with the plugin enabled printed an "Exception ignored in: <generator>" TypeError traceback. The SDK's own atexit shutdown runs during interpreter finalization, after `opentelemetry.trace.Span` is torn down to `None`, so its span-cleanup `isinstance(span, Span)` check blows up. The fix shuts the client down at session finalize while the interpreter is alive, and exits the root observation's context manager instead of leaving its generator suspended for GC to unwind at teardown.

**#82332 (aldoeliacim, 1 commit).** Short-lived processes (kanban workers, `hermes chat -q`, cron jobs) could exit with tool calls still queued, so the root span never ended and the backend showed an anonymous trace with no name, session, or metadata. An atexit finalizer — registered after the SDK client so LIFO ordering runs it before the SDK's own flush — ends every open root span at exit.

**Follow-ups (interaction fixes found while composing).** The adopted shutdown fired on every `on_session_finalize`, but that hook also fires on `/new`, `/reset`, and gateway session expiry, where the process lives on — the first rotation would have killed the cached client and silently stopped exports for every later session. The shutdown is now gated on `reason == "shutdown"`. The adopted atexit finalizer also skipped subagent observations (added in this PR) and never exited the root context manager, reintroducing the same teardown TypeError it sat next to; both closed.

## Verification

74 langfuse + MoA-bridge tests pass; full `tests/agent/` + `tests/hermes_cli/` sweep is 8018 passed with 8 failures identical on the unmodified base (provider-routing/env, not langfuse). Live smoke against Langfuse Cloud: three sessions (clean turn, rotation-closed dangling turn, shutdown-closed dangling turn) all exported with correct names and session ids; the client survived rotation and shut down cleanly at exit.

## Adopted fixes (tier 2)

Adopted with follow-up integration on top; each commit thanks and co-author-credits the original contributor.

**#42326 (@nftpoetrist).** `_get_langfuse()` double-checked a global with no lock, so two concurrent first callers could both construct a client and leak the loser's HTTP connection and flush thread. First build is now serialized; the settled fast path stays lock-free.

**#39653 (@rodboev).** Reasoning models that expose their scratchpad as `reasoning_content` or structured `reasoning_details` traced as `reasoning: None`. An accessor now checks the three fields in precedence order. Closes #29482.

**#64292 (@FnExpress).** Providers that move the system prompt out of `messages` (Anthropic `system`, Codex `instructions`, Bedrock Converse blocks) produced generation inputs with no system prompt at all — no skills, memory, or instructions visible in traces. The loop now forwards the prompt as actually sent and the plugin prepends a `role: system` entry. Extends and supersedes #32175 (@db-aeon), whose Anthropic-only fix is credited in the commit.

**#61166 (@Per0-1).** The plugin called `set_trace_io()`, which does not exist in SDK v3 — the AttributeError skipped `root_span.end()`, so traces listed with blank Input/Output columns and no CHAIN root. Trace I/O now uses v3 `update_trace()`, individually fail-open so no export step can block the root end.

**#64797 (@NaMinhyeok).** Replaces this PR's earlier sum-of-components total with the canonical Hermes estimate: summing the breakdown undercounts when a component can't be priced or request-level pricing applies. Both cost paths now share one helper; a partial breakdown with no valid estimate exports no total. Together with the original cost-total commit this closes #72661.

**#43130 (@liuhao1024).** Subscription-included routes (openai-codex) sent explicit `$0` cost_details, which Langfuse treats as authoritative — blocking its own model-based estimation, so every generation showed `$0` forever. Included routes now send no cost keys at all. Closes #43129.

Integration fixes made while composing: system-prompt and reasoning serialization route through `_capture_content` so capture modes and secret redaction govern them; the canonical total adds a zero-guard so a priced model that billed nothing doesn't export an authoritative `0.0`.

## Closes / supersedes

Closes #29482, closes #43129, closes #72661.

Supersedes (can be closed in favor of this PR): #81054, #82332, #42326, #39653, #64292, #32175, #61166, #64797, #43130.

Partially addresses #67544: capture modes (`metadata`/`sanitized`/`full`) plus secret redaction at the export boundary cover the masking half; `user_id` attribution remains open.

## Verification (tier 2)

88 plugin tests pass; full `tests/plugins/` + `tests/agent/` + `tests/hermes_cli/` sweep is 9380 passed with every failure reproduced on the unmodified base or current `main` (env-dependent provider tests, hindsight extra not installed locally, and a `_preset_cache` conftest collection error that exists on `main`). Live smoke against Langfuse Cloud confirmed server-side: system prompt visible in generation input, `reasoning_content` in output, `costDetails.total` matching `calculatedTotalCost`, trace-level Input/Output columns filled.