### PR TITLE
Route Codex MCP confirmations through Hermes approvals

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -27,6 +27,68 @@ from agent.stream_single_writer import claim_stream_writer, stream_writer_is_cur
 logger = logging.getLogger(__name__)
 
 
+def _configured_mcp_elicitation_prompt_servers(
+    config: dict[str, Any] | None = None,
+) -> frozenset[str]:
+    """Return MCP names explicitly configured for Codex consent prompts.
+
+    The policy is read from each Hermes MCP entry at
+    ``elicitation.approval``. Only the literal value ``prompt`` opts a
+    server in; missing or malformed configuration fails closed.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly() or {}
+        except Exception:
+            logger.debug(
+                "codex app-server: MCP elicitation policy lookup failed",
+                exc_info=True,
+            )
+            return frozenset()
+    if not isinstance(config, dict):
+        return frozenset()
+
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return frozenset()
+
+    prompt_servers: set[str] = set()
+    for raw_name, server in servers.items():
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            continue
+        if not isinstance(server, dict) or server.get("enabled") is False:
+            continue
+        elicitation = server.get("elicitation")
+        if not isinstance(elicitation, dict):
+            continue
+        if elicitation.get("enabled") is False:
+            continue
+        approval = elicitation.get("approval")
+        if isinstance(approval, str) and approval.strip().lower() == "prompt":
+            prompt_servers.add(raw_name.strip())
+    return frozenset(prompt_servers)
+
+
+def _make_mcp_elicitation_callback(
+    approval_callback: Callable[..., str] | None,
+) -> Callable[..., str]:
+    """Adapt the shared Hermes consent router to the Codex transport."""
+
+    def _callback(message: str, description: str, *, surface: str) -> str:
+        from tools.approval import request_elicitation_consent
+
+        return request_elicitation_consent(
+            message,
+            description,
+            surface=surface,
+            approval_callback=approval_callback,
+        )
+
+    return _callback
+
+
 def _coerce_usage_int(value: Any) -> int:
     if isinstance(value, bool):
         return 0
@@ -683,9 +745,15 @@ def run_codex_app_server_turn(
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            mcp_elicitation_callback=_make_mcp_elicitation_callback(
+                approval_callback
+            ),
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,
                 auto_approve_apply_patch=auto_approve_requests,
+                prompt_mcp_elicitation_servers=(
+                    _configured_mcp_elicitation_prompt_servers()
+                ),
             ),
             on_event=make_codex_app_server_event_bridge(agent),
         )

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -87,6 +87,68 @@ def _log_codex_request_failure(
     )
 
 
+def _configured_mcp_elicitation_prompt_servers(
+    config: dict[str, Any] | None = None,
+) -> frozenset[str]:
+    """Return MCP names explicitly configured for Codex consent prompts.
+
+    The policy is read from each Hermes MCP entry at
+    ``elicitation.approval``. Only the literal value ``prompt`` opts a
+    server in; missing or malformed configuration fails closed.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly() or {}
+        except Exception:
+            logger.debug(
+                "codex app-server: MCP elicitation policy lookup failed",
+                exc_info=True,
+            )
+            return frozenset()
+    if not isinstance(config, dict):
+        return frozenset()
+
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return frozenset()
+
+    prompt_servers: set[str] = set()
+    for raw_name, server in servers.items():
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            continue
+        if not isinstance(server, dict) or server.get("enabled") is False:
+            continue
+        elicitation = server.get("elicitation")
+        if not isinstance(elicitation, dict):
+            continue
+        if elicitation.get("enabled") is False:
+            continue
+        approval = elicitation.get("approval")
+        if isinstance(approval, str) and approval.strip().lower() == "prompt":
+            prompt_servers.add(raw_name.strip())
+    return frozenset(prompt_servers)
+
+
+def _make_mcp_elicitation_callback(
+    approval_callback: Callable[..., str] | None,
+) -> Callable[..., str]:
+    """Adapt the shared Hermes consent router to the Codex transport."""
+
+    def _callback(message: str, description: str, *, surface: str) -> str:
+        from tools.approval import request_elicitation_consent
+
+        return request_elicitation_consent(
+            message,
+            description,
+            surface=surface,
+            approval_callback=approval_callback,
+        )
+
+    return _callback
+
+
 def _coerce_usage_int(value: Any) -> int:
     if isinstance(value, bool):
         return 0
@@ -757,9 +819,15 @@ def run_codex_app_server_turn(
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            mcp_elicitation_callback=_make_mcp_elicitation_callback(
+                approval_callback
+            ),
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,
                 auto_approve_apply_patch=auto_approve_requests,
+                prompt_mcp_elicitation_servers=(
+                    _configured_mcp_elicitation_prompt_servers()
+                ),
             ),
             on_event=make_codex_app_server_event_bridge(agent),
         )

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -260,6 +260,21 @@ class _ServerRequestRouting:
 
     auto_approve_exec: bool = False
     auto_approve_apply_patch: bool = False
+    prompt_mcp_elicitation_servers: frozenset[str] = frozenset()
+
+
+def _is_empty_confirmation_elicitation(params: dict) -> bool:
+    """Return whether Codex is asking for a binary form confirmation."""
+    if params.get("mode") != "form":
+        return False
+    schema = params.get("requestedSchema")
+    if not isinstance(schema, dict):
+        return False
+    return (
+        schema.get("type") == "object"
+        and schema.get("properties") == {}
+        and schema.get("required") in (None, [])
+    )
 
 
 class CodexAppServerSession:
@@ -279,6 +294,7 @@ class CodexAppServerSession:
         codex_home: Optional[str] = None,
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
+        mcp_elicitation_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
@@ -293,6 +309,7 @@ class CodexAppServerSession:
             )
         )
         self._approval_callback = approval_callback
+        self._mcp_elicitation_callback = mcp_elicitation_callback
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
         self._routing = request_routing or _ServerRequestRouting()
         self._client_factory = client_factory or CodexAppServerClient
@@ -1026,25 +1043,7 @@ class CodexAppServerSession:
             # shouldn't be silently accepted.
             self._client.respond(rid, {"decision": "decline"})
         elif method == "mcpServer/elicitation/request":
-            # Codex's MCP layer asks the user for structured input on
-            # behalf of an MCP server (e.g. tool-call confirmation,
-            # OAuth, form data). For our own hermes-tools callback we
-            # auto-accept — the user already approved Hermes' tools
-            # by enabling the runtime, and we never expose anything
-            # codex's built-in shell can't already do. For other MCP
-            # servers we decline so the user explicitly opts in via
-            # codex's own auth flow.
-            server_name = params.get("serverName") or ""
-            if server_name == "hermes-tools":
-                self._client.respond(
-                    rid,
-                    {"action": "accept", "content": None, "_meta": None},
-                )
-            else:
-                self._client.respond(
-                    rid,
-                    {"action": "decline", "content": None, "_meta": None},
-                )
+            self._client.respond(rid, self._decide_mcp_elicitation(params))
         else:
             # Unknown server request — codex can extend this surface. Reject
             # cleanly so codex doesn't hang waiting for us.
@@ -1134,6 +1133,58 @@ class CodexAppServerSession:
                 logger.exception("approval_callback raised on apply_patch")
                 return "decline"
         return "decline"
+
+    def _decide_mcp_elicitation(self, params: dict) -> dict:
+        """Route an MCP confirmation through Hermes' consent UI.
+
+        Codex uses an empty form schema for binary MCP tool-call approval.
+        Only that shape is compatible with Hermes' existing approval UI.
+        URL elicitations and forms requesting user-provided fields remain
+        fail-closed: accepting either without collecting their input would
+        produce a misleading or schema-invalid response.
+        """
+        response = {"action": "decline", "content": None, "_meta": None}
+        raw_server_name = params.get("serverName")
+        if not isinstance(raw_server_name, str) or not raw_server_name.strip():
+            return response
+        server_name = raw_server_name.strip()
+
+        # The internal callback remains separately trusted. It only exposes
+        # Hermes tools that the user already enabled for this runtime.
+        if server_name == "hermes-tools":
+            return {"action": "accept", "content": None, "_meta": None}
+
+        if server_name not in self._routing.prompt_mcp_elicitation_servers:
+            return response
+        if not _is_empty_confirmation_elicitation(params):
+            return response
+        if self._mcp_elicitation_callback is None:
+            return response
+
+        raw_message = params.get("message")
+        message = (
+            raw_message
+            if isinstance(raw_message, str) and raw_message.strip()
+            else f"Allow MCP server '{server_name}' to perform this action?"
+        )
+        description = (
+            f"Codex requests confirmation for MCP server '{server_name}'."
+        )
+        try:
+            action = self._mcp_elicitation_callback(
+                message,
+                description,
+                surface=f"mcp-elicitation/{server_name}",
+            )
+        except Exception:
+            logger.exception(
+                "MCP elicitation callback raised for server %s", server_name
+            )
+            return response
+
+        if action in {"accept", "decline", "cancel"}:
+            response["action"] = action
+        return response
 
     def _track_pending_file_change(self, note: dict) -> None:
         """Maintain self._pending_file_changes from item/started + item/completed

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1146,6 +1146,8 @@ platform_toolsets:
 #     Lower it below the server's session TTL for servers that expire idle
 #     sessions quickly (e.g. Unreal Engine editor MCP, ~15s), otherwise idle
 #     tool calls hit an expired session and pay a slow reconnect. Floored at 5s.
+#   elicitation.approval: set to "prompt" to opt this server into Hermes
+#     approval prompts when using the Codex app-server runtime (default: deny)
 #
 # mcp_servers:
 #   time:
@@ -1156,6 +1158,10 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-filesystem", "/home/user"]
 #   notion:
 #     url: https://mcp.notion.com/mcp
+#   todoist:
+#     url: https://ai.todoist.net/mcp
+#     elicitation:
+#       approval: prompt
 #   github:
 #     command: npx
 #     args: ["-y", "@modelcontextprotocol/server-github"]

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1313,6 +1313,8 @@ platform_toolsets:
 #     Lower it below the server's session TTL for servers that expire idle
 #     sessions quickly (e.g. Unreal Engine editor MCP, ~15s), otherwise idle
 #     tool calls hit an expired session and pay a slow reconnect. Floored at 5s.
+#   elicitation.approval: set to "prompt" to opt this server into Hermes
+#     approval prompts when using the Codex app-server runtime (default: deny)
 #
 # mcp_servers:
 #   time:
@@ -1323,6 +1325,10 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-filesystem", "/home/user"]
 #   notion:
 #     url: https://mcp.notion.com/mcp
+#   todoist:
+#     url: https://ai.todoist.net/mcp
+#     elicitation:
+#       approval: prompt
 #   github:
 #     command: npx
 #     args: ["-y", "@modelcontextprotocol/server-github"]

--- a/contributors/emails/tonyholmes@gmail.com
+++ b/contributors/emails/tonyholmes@gmail.com
@@ -1,0 +1,2 @@
+tonyholmes69
+# PR #83440

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -506,6 +506,200 @@ class TestCompactThread:
 
 class TestServerRequestRouting:
 
+    def test_allowlisted_mcp_confirmation_uses_hermes_consent(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "mcpServer/elicitation/request",
+            request_id="elic-todoist",
+            serverName="todoist",
+            mode="form",
+            message="Allow Todoist to complete this task?",
+            requestedSchema={"type": "object", "properties": {}},
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        captured = {}
+
+        def consent(message, description, *, surface):
+            captured.update(
+                message=message,
+                description=description,
+                surface=surface,
+            )
+            return "accept"
+
+        session = make_session(
+            client,
+            mcp_elicitation_callback=consent,
+            request_routing=_ServerRequestRouting(
+                prompt_mcp_elicitation_servers=frozenset({"todoist"})
+            ),
+        )
+        session.run_turn("complete it", turn_timeout=1.0)
+
+        assert ("elic-todoist", {
+            "action": "accept", "content": None, "_meta": None,
+        }) in client.responses
+        assert captured == {
+            "message": "Allow Todoist to complete this task?",
+            "description": "Codex requests confirmation for MCP server 'todoist'.",
+            "surface": "mcp-elicitation/todoist",
+        }
+
+    @pytest.mark.parametrize(
+        "answer,expected_action",
+        [("decline", "decline"), ("cancel", "cancel"), ("invalid", "decline")],
+    )
+    def test_mcp_consent_preserves_only_known_outcomes(self, answer, expected_action):
+        client = FakeClient()
+        client.queue_server_request(
+            "mcpServer/elicitation/request",
+            request_id="elic-result",
+            serverName="todoist",
+            mode="form",
+            message="Allow Todoist to update a task?",
+            requestedSchema={"type": "object", "properties": {}},
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        session = make_session(
+            client,
+            mcp_elicitation_callback=lambda *_args, **_kwargs: answer,
+            request_routing=_ServerRequestRouting(
+                prompt_mcp_elicitation_servers=frozenset({"todoist"})
+            ),
+        )
+        session.run_turn("update it", turn_timeout=1.0)
+
+        assert ("elic-result", {
+            "action": expected_action, "content": None, "_meta": None,
+        }) in client.responses
+
+    @pytest.mark.parametrize(
+        "server_name,mode,schema",
+        [
+            ("not-allowlisted", "form", {"type": "object", "properties": {}}),
+            ("todoist", "url", None),
+            (
+                "todoist",
+                "form",
+                {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                },
+            ),
+            ("todoist", "form", {"type": "object", "properties": {}}),
+        ],
+    )
+    def test_unsupported_or_unhandled_mcp_elicitation_fails_closed(
+        self, server_name, mode, schema,
+    ):
+        client = FakeClient()
+        params = {
+            "serverName": server_name,
+            "mode": mode,
+            "message": "request",
+        }
+        if schema is not None:
+            params["requestedSchema"] = schema
+        client.queue_server_request(
+            "mcpServer/elicitation/request",
+            request_id="elic-decline",
+            **params,
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        consent = None
+        if not (
+            server_name == "todoist"
+            and mode == "form"
+            and schema == {"type": "object", "properties": {}}
+        ):
+            consent = lambda *_args, **_kwargs: pytest.fail(
+                "unsupported elicitation must not prompt"
+            )
+        session = make_session(
+            client,
+            mcp_elicitation_callback=consent,
+            request_routing=_ServerRequestRouting(
+                prompt_mcp_elicitation_servers=frozenset({"todoist"})
+            ),
+        )
+        session.run_turn("hi", turn_timeout=1.0)
+
+        assert ("elic-decline", {
+            "action": "decline", "content": None, "_meta": None,
+        }) in client.responses
+
+    def test_hermes_tools_remains_trusted_without_prompt(self):
+        client = FakeClient()
+        client.queue_server_request(
+            "mcpServer/elicitation/request",
+            request_id="elic-hermes",
+            serverName="hermes-tools",
+            mode="form",
+            message="callback",
+            requestedSchema={"type": "object", "properties": {}},
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        session = make_session(
+            client,
+            mcp_elicitation_callback=lambda *_args, **_kwargs: pytest.fail(
+                "hermes-tools should not prompt"
+            ),
+        )
+        session.run_turn("hi", turn_timeout=1.0)
+
+        assert ("elic-hermes", {
+            "action": "accept", "content": None, "_meta": None,
+        }) in client.responses
+
+    def test_malformed_server_name_fails_closed_without_prompt(self):
+        session = make_session(
+            FakeClient(),
+            mcp_elicitation_callback=lambda *_args, **_kwargs: pytest.fail(
+                "malformed elicitation must not prompt"
+            ),
+            request_routing=_ServerRequestRouting(
+                prompt_mcp_elicitation_servers=frozenset({"todoist"})
+            ),
+        )
+
+        assert session._decide_mcp_elicitation({
+            "serverName": {"unexpected": "object"},
+            "mode": "form",
+            "requestedSchema": {"type": "object", "properties": {}},
+        }) == {"action": "decline", "content": None, "_meta": None}
+
+    def test_mcp_consent_callback_exception_fails_closed(self):
+        def broken_consent(*_args, **_kwargs):
+            raise RuntimeError("approval surface unavailable")
+
+        session = make_session(
+            FakeClient(),
+            mcp_elicitation_callback=broken_consent,
+            request_routing=_ServerRequestRouting(
+                prompt_mcp_elicitation_servers=frozenset({"todoist"})
+            ),
+        )
+
+        assert session._decide_mcp_elicitation({
+            "serverName": "todoist",
+            "mode": "form",
+            "message": "confirm",
+            "requestedSchema": {"type": "object", "properties": {}},
+        }) == {"action": "decline", "content": None, "_meta": None}
+
 
 
     def test_unknown_server_request_replied_with_error(self):
@@ -895,4 +1089,3 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -18,6 +18,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import run_agent
+from agent.codex_runtime import (
+    _configured_mcp_elicitation_prompt_servers,
+    _make_mcp_elicitation_callback,
+)
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
 
 
@@ -72,7 +76,109 @@ class TestApiModeAccepted:
         assert agent.api_mode == "codex_app_server"
 
 
+class TestConfiguredMcpElicitationPromptServers:
+    def test_reads_policy_through_hermes_config_loader(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "mcp_servers:\n"
+            "  todoist:\n"
+            "    url: https://ai.todoist.net/mcp\n"
+            "    elicitation:\n"
+            "      approval: prompt\n",
+            encoding="utf-8",
+        )
+        from hermes_cli import config as config_mod
+
+        monkeypatch.setitem(
+            config_mod.load_config_readonly.__globals__,
+            "get_config_path",
+            lambda: config_file,
+        )
+
+        assert _configured_mcp_elicitation_prompt_servers() == frozenset(
+            {"todoist"}
+        )
+
+    def test_only_explicit_prompt_servers_are_enabled(self):
+        config = {
+            "mcp_servers": {
+                "todoist": {
+                    "enabled": True,
+                    "elicitation": {"approval": "prompt"},
+                },
+                "github": {"elicitation": {"approval": "deny"}},
+                "disabled": {
+                    "enabled": False,
+                    "elicitation": {"approval": "prompt"},
+                },
+                "elicitation-disabled": {
+                    "elicitation": {"enabled": False, "approval": "prompt"},
+                },
+                "implicit": {"url": "https://example.test/mcp"},
+            }
+        }
+
+        assert _configured_mcp_elicitation_prompt_servers(config) == frozenset(
+            {"todoist"}
+        )
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {},
+            [],
+            {"mcp_servers": []},
+            {"mcp_servers": {"todoist": {"elicitation": "prompt"}}},
+            {"mcp_servers": {"todoist": {"elicitation": {"approval": True}}}},
+        ],
+    )
+    def test_malformed_or_missing_policy_fails_closed(self, config):
+        assert _configured_mcp_elicitation_prompt_servers(config) == frozenset()
+
+    def test_config_read_error_fails_closed(self):
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            side_effect=RuntimeError("config unavailable"),
+        ):
+            assert _configured_mcp_elicitation_prompt_servers() == frozenset()
+
+    def test_consent_adapter_reuses_shared_approval_router(self):
+        cli_callback = object()
+        callback = _make_mcp_elicitation_callback(cli_callback)
+        with patch(
+            "tools.approval.request_elicitation_consent",
+            return_value="accept",
+        ) as consent:
+            result = callback(
+                "Allow Todoist to update a task?",
+                "Todoist write",
+                surface="mcp-elicitation/todoist",
+            )
+
+        assert result == "accept"
+        consent.assert_called_once_with(
+            "Allow Todoist to update a task?",
+            "Todoist write",
+            surface="mcp-elicitation/todoist",
+            approval_callback=cli_callback,
+        )
+
+
 class TestRunConversationCodexPath:
+    def test_codex_session_receives_mcp_prompt_policy(self, fake_session, monkeypatch):
+        monkeypatch.setattr(
+            "agent.codex_runtime._configured_mcp_elicitation_prompt_servers",
+            lambda: frozenset({"todoist"}),
+        )
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert agent._codex_session._routing.prompt_mcp_elicitation_servers == (
+            frozenset({"todoist"})
+        )
+        assert agent._codex_session._mcp_elicitation_callback is not None
+
     def test_run_conversation_returns_codex_shape(self, fake_session):
         agent = _make_codex_agent()
         # No background review fork during tests

--- a/tests/tools/test_mcp_elicitation.py
+++ b/tests/tools/test_mcp_elicitation.py
@@ -22,6 +22,7 @@ from tools.mcp_tool import (  # noqa: E402
     ElicitationHandler,
     _format_elicitation_schema_summary,
 )
+from tools.approval import request_elicitation_consent  # noqa: E402
 
 
 def _form_params(message="please confirm", schema=None):
@@ -153,6 +154,32 @@ class TestElicitationHandlerFailureModes:
 
         assert result.action == "cancel"
         assert handler.metrics["errors"] == 1
+
+
+class TestElicitationConsentCliRouting:
+    def test_registered_cli_callback_reaches_shared_prompt(self):
+        callback = object()
+        with (
+            patch("tools.approval._is_gateway_approval_context", return_value=False),
+            patch(
+                "tools.approval.prompt_dangerous_approval", return_value="once"
+            ) as prompt,
+        ):
+            result = request_elicitation_consent(
+                "Allow Todoist to update a task?",
+                "Todoist write",
+                surface="mcp-elicitation/todoist",
+                approval_callback=callback,
+            )
+
+        assert result == "accept"
+        prompt.assert_called_once_with(
+            "Allow Todoist to update a task?",
+            "Todoist write",
+            timeout_seconds=None,
+            allow_permanent=False,
+            approval_callback=callback,
+        )
 
 
 class TestElicitationHandlerWiring:

--- a/tests/tools/test_mcp_elicitation.py
+++ b/tests/tools/test_mcp_elicitation.py
@@ -22,6 +22,7 @@ from tools.mcp_tool import (  # noqa: E402
     ElicitationHandler,
     _format_elicitation_schema_summary,
 )
+from tools.approval import request_elicitation_consent  # noqa: E402
 
 
 def _form_params(message="please confirm", schema=None):
@@ -186,6 +187,32 @@ class TestElicitationHandlerFailureModes:
 
         assert result.action == "cancel"
         assert handler.metrics["errors"] == 1
+
+
+class TestElicitationConsentCliRouting:
+    def test_registered_cli_callback_reaches_shared_prompt(self):
+        callback = object()
+        with (
+            patch("tools.approval._is_gateway_approval_context", return_value=False),
+            patch(
+                "tools.approval.prompt_dangerous_approval", return_value="once"
+            ) as prompt,
+        ):
+            result = request_elicitation_consent(
+                "Allow Todoist to update a task?",
+                "Todoist write",
+                surface="mcp-elicitation/todoist",
+                approval_callback=callback,
+            )
+
+        assert result == "accept"
+        prompt.assert_called_once_with(
+            "Allow Todoist to update a task?",
+            "Todoist write",
+            timeout_seconds=None,
+            allow_permanent=False,
+            approval_callback=callback,
+        )
 
 
 class TestElicitationHandlerWiring:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4468,6 +4468,7 @@ def request_elicitation_consent(
     *,
     timeout_seconds: int | None = None,
     surface: str = "mcp-elicitation",
+    approval_callback=None,
 ) -> str:
     """Route an MCP elicitation request to whichever approval surface owns
     the active session and return a normalized result.
@@ -4475,7 +4476,9 @@ def request_elicitation_consent(
     Gateway sessions (Telegram, Slack, Discord, etc.) go through
     ``_await_gateway_decision`` so the notify_cb posts a message and the
     agent thread blocks until the user responds via the platform UI.
-    CLI/TUI sessions go through ``prompt_dangerous_approval``.
+    CLI/TUI sessions go through ``prompt_dangerous_approval``. When supplied,
+    ``approval_callback`` preserves the active CLI/TUI's registered input
+    handler instead of falling back to direct prompt_toolkit input.
 
     Always fails closed: missing notify_cb in a gateway session, timeouts,
     and exceptions all map to ``"decline"`` so a server treats them as
@@ -4533,6 +4536,7 @@ def request_elicitation_consent(
             description,
             timeout_seconds=timeout_seconds,
             allow_permanent=False,
+            approval_callback=approval_callback,
         )
     except Exception as exc:
         logger.error(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -5642,6 +5642,7 @@ def request_elicitation_consent(
     *,
     timeout_seconds: int | None = None,
     surface: str = "mcp-elicitation",
+    approval_callback=None,
 ) -> str:
     """Route an MCP elicitation request to whichever approval surface owns
     the active session and return a normalized result.
@@ -5649,7 +5650,9 @@ def request_elicitation_consent(
     Gateway sessions (Telegram, Slack, Discord, etc.) go through
     ``_await_gateway_decision`` so the notify_cb posts a message and the
     agent thread blocks until the user responds via the platform UI.
-    CLI/TUI sessions go through ``prompt_dangerous_approval``.
+    CLI/TUI sessions go through ``prompt_dangerous_approval``. When supplied,
+    ``approval_callback`` preserves the active CLI/TUI's registered input
+    handler instead of falling back to direct prompt_toolkit input.
 
     Always fails closed: missing notify_cb in a gateway session, timeouts,
     and exceptions all map to ``"decline"`` so a server treats them as
@@ -5707,6 +5710,7 @@ def request_elicitation_consent(
             description,
             timeout_seconds=timeout_seconds,
             allow_permanent=False,
+            approval_callback=approval_callback,
         )
     except Exception as exc:
         logger.error(

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -39,6 +39,10 @@ mcp_servers:
       exclude: []
       resources: true
       prompts: true
+    elicitation:
+      enabled: true
+      timeout: 300
+      approval: prompt  # explicit opt-in for Codex app-server confirmations
 ```
 
 ## Server keys
@@ -65,7 +69,7 @@ mcp_servers:
 | `tools` | mapping | both | Filtering and utility-tool policy |
 | `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
-| `elicitation` | mapping | both | Server-initiated user-input requests. `enabled` (default `true`) and `timeout` in seconds (default `300`). Form-mode requests route through the approval surface; URL-mode is declined (see MCP guide) |
+| `elicitation` | mapping | both | Server-initiated user-input requests. `enabled` (default `true`) and `timeout` in seconds (default `300`) control native Hermes MCP. With the Codex app-server runtime, `approval: prompt` explicitly allows this server's binary confirmations to use the Hermes approval surface; missing or invalid policy is denied. URL-mode and forms requiring input remain declined (see MCP guide) |
 | `trust` | string | both | Trust tier: `full` (default) or `untrusted`. On an `untrusted` server, every write-capable tool call (any tool without a `readOnlyHint: true` annotation) requires user approval through the standard approval surface before it runs. `readOnlyHint` is a server-supplied *hint* — a lying server can at most skip approval for tools it claims are read-only, never gain extra access — so mark any server you don't fully control as `untrusted`. Unrecognized values are treated as `untrusted` (fail-closed) |
 
 ## Environment variable references

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -39,6 +39,10 @@ mcp_servers:
       exclude: []
       resources: true
       prompts: true
+    elicitation:
+      enabled: true
+      timeout: 300
+      approval: prompt  # explicit opt-in for Codex app-server confirmations
 ```
 
 ## Server keys
@@ -66,7 +70,7 @@ mcp_servers:
 | `tools` | mapping | both | Filtering and utility-tool policy |
 | `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
-| `elicitation` | mapping | both | Server-initiated user-input requests. `enabled` (default `true`) and `timeout` in seconds (default `300`). Form-mode requests route through the approval surface; URL-mode is declined (see MCP guide) |
+| `elicitation` | mapping | both | Server-initiated user-input requests. `enabled` (default `true`) and `timeout` in seconds (default `300`) control native Hermes MCP. With the Codex app-server runtime, `approval: prompt` explicitly allows this server's binary confirmations to use the Hermes approval surface; missing or invalid policy is denied. URL-mode and forms requiring input remain declined (see MCP guide) |
 | `trust` | string | both | Trust tier: `full` (default) or `untrusted`. On an `untrusted` server, every write-capable tool call (any tool without a `readOnlyHint: true` annotation) requires user approval through the standard approval surface before it runs. `readOnlyHint` is a server-supplied *hint* — a lying server can at most skip approval for tools it claims are read-only, never gain extra access — so mark any server you don't fully control as `untrusted`. Unrecognized values are treated as `untrusted` (fail-closed) |
 
 ## Environment variable references

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -789,6 +789,23 @@ mcp_servers:
 
 The 5-minute default timeout mirrors the gateway approval default so users on async surfaces have time to respond before the server gives up. Per-server metrics (requests, accepted, declined, errors) are tracked on the handler.
 
+When Hermes uses the **Codex app-server runtime**, MCP servers are migrated
+into Codex and their confirmation requests return through the Codex bridge.
+Opt in each trusted server explicitly to route binary confirmations through
+the same Hermes approval surface:
+
+```yaml
+mcp_servers:
+  todoist:
+    url: "https://ai.todoist.net/mcp"
+    elicitation:
+      approval: prompt
+```
+
+The Codex bridge stays fail-closed when this setting is absent or invalid.
+It prompts only for binary confirmations (form mode with no requested input);
+URL elicitations and forms that require the user to supply values are declined.
+
 ## Running Hermes as an MCP server
 
 In addition to connecting **to** MCP servers, Hermes can also **be** an MCP server. This lets other MCP-capable agents (Claude Code, Cursor, Codex, or any MCP client) use Hermes's messaging capabilities — list conversations, read message history, and send messages across all your connected platforms.

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -828,6 +828,23 @@ mcp_servers:
 
 The 5-minute default timeout mirrors the gateway approval default so users on async surfaces have time to respond before the server gives up. Per-server metrics (requests, accepted, declined, errors) are tracked on the handler.
 
+When Hermes uses the **Codex app-server runtime**, MCP servers are migrated
+into Codex and their confirmation requests return through the Codex bridge.
+Opt in each trusted server explicitly to route binary confirmations through
+the same Hermes approval surface:
+
+```yaml
+mcp_servers:
+  todoist:
+    url: "https://ai.todoist.net/mcp"
+    elicitation:
+      approval: prompt
+```
+
+The Codex bridge stays fail-closed when this setting is absent or invalid.
+It prompts only for binary confirmations (form mode with no requested input);
+URL elicitations and forms that require the user to supply values are declined.
+
 ## Running Hermes as an MCP server
 
 In addition to connecting **to** MCP servers, Hermes can also **be** an MCP server. This lets other MCP-capable agents (Claude Code, Cursor, Codex, or any MCP client) use Hermes's messaging capabilities — list conversations, read message history, and send messages across all your connected platforms.


### PR DESCRIPTION
## What does this PR do?

Routes Codex app-server MCP binary confirmation requests through Hermes' existing approval infrastructure for explicitly opted-in MCP servers.

The goal is not to special-case or auto-approve Todoist. It is to make the Codex runtime reuse Hermes' existing `request_elicitation_consent(...)` flow instead of unconditionally declining third-party `mcpServer/elicitation/request` requests.

### Root cause

The Codex app-server bridge auto-accepted the internal `hermes-tools` callback but hardcoded `decline` for every third-party MCP elicitation. MCP servers that require confirmation for protected mutations therefore surfaced `user rejected MCP tool call`, even though Hermes already had an interactive approval UI.

The new policy is explicit and fail-closed:

```yaml
mcp_servers:
  todoist:
    url: https://ai.todoist.net/mcp
    elicitation:
      approval: prompt
```

Only binary form confirmations with no requested input are prompted. URL elicitations, field-bearing forms, malformed requests, callback failures, disabled servers, and unconfigured servers remain denied.

## Related Issue / Work

No exact Todoist issue was found.

Related: #66995 changes the same Codex elicitation surface but auto-accepts confirmations from configured servers and also includes unrelated web-search provenance changes. This PR deliberately requires a human Hermes approval prompt, preserves accept/decline/cancel outcomes, and keeps the change focused on reusing the existing approval infrastructure.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/codex_app_server_session.py`
  - routes eligible Codex MCP confirmation requests through a Hermes consent callback
  - preserves the trusted `hermes-tools` behavior
  - fails closed for unsupported, unconfigured, or malformed requests
- `agent/codex_runtime.py`
  - reads the explicit per-server `elicitation.approval: prompt` policy from Hermes config
  - adapts the active Hermes approval callback to `request_elicitation_consent(...)`
- `tools/approval.py`
  - allows the existing elicitation router to use the active CLI/TUI approval callback
- `cli-config.yaml.example` and `website/docs/`
  - document the opt-in and security boundary
- `tests/`
  - cover allow/decline/cancel, malformed configuration, unsupported elicitation forms, callback failures, trusted internal behavior, config loading, and runtime wiring
- `contributors/emails/tonyholmes@gmail.com`
  - adds the repository-required contributor attribution mapping

## How to Test

1. Configure a remote MCP server that emits binary confirmations:

   ```yaml
   mcp_servers:
     todoist:
       enabled: true
       url: https://ai.todoist.net/mcp
       elicitation:
         approval: prompt
   ```

2. Start Hermes with `model.openai_runtime: codex_app_server`.
3. Ask Codex to perform a protected Todoist mutation, such as rescheduling an existing task.
4. Confirm Hermes displays its approval UI rather than immediately returning `user rejected MCP tool call`.
5. Select **Allow once** and verify the mutation completes.
6. Remove `approval: prompt` and verify the same elicitation fails closed.
7. Run the focused automated suite:

   ```bash
   scripts/run_tests.sh \
     tests/agent/transports/test_codex_app_server_session.py \
     tests/run_agent/test_codex_app_server_integration.py \
     tests/tools/test_mcp_elicitation.py
   ```

## Validation

- Focused automated suite: **97 passed**
- Broader approval suites: **98 passed**; one unrelated macOS `/tmp` vs `/private/tmp` assertion reproduces on untouched upstream `main`
- `ruff check .`: passed
- `python scripts/check-windows-footguns.py --all`: passed
- `git diff --check`: passed
- Contributor attribution audit: passed
- Live smoke test with GPT-5.6 Luna through Codex app-server on **macOS 26.6.1 / Python 3.12**:
  - low-risk Todoist task creation completed without an approval prompt
  - a protected mutation displayed the Hermes approval UI
  - selecting **Allow once** completed the write
  - a separate read confirmed the updated due date
- Full upstream CI is currently awaiting maintainer approval for this first-time contributor workflow; this PR does not claim a full-suite green run yet.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing issues and PRs for duplicates and related work
- [x] My PR contains only changes related to this fix and required contributor housekeeping
- [ ] Full `scripts/run_tests.sh` suite is green — upstream CI is awaiting maintainer approval
- [x] I've added tests for the bug fix
- [x] I've tested on macOS 26.6.1 with Python 3.12

### Documentation & Housekeeping

- [x] I've updated the relevant MCP documentation
- [x] I've updated `cli-config.yaml.example` for the new config policy
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no contributor workflow or core tool-schema contract changed
- [x] I've considered cross-platform impact; the blocking Windows-footgun check passes
- [x] Tool descriptions/schemas: N/A; this does not change a model tool schema

## Screenshots / Logs

The live smoke test displayed:

> Allow the todoist MCP server to run tool "reschedule-tasks"?

Choosing **Allow once** completed the protected Todoist update, and a separate read confirmed the new due date.
