### PR TITLE
Fix Telegram clarify custom text handling

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15009,7 +15009,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # with an empty response.
             if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
                 _resolved = _clarify_mod.resolve_text_response_for_session(
-                    _quick_key, _raw_clarify_reply,
+                    _quick_key,
+                    _raw_clarify_reply,
+                    # Telegram chats are serialized behind the active agent
+                    # turn. Treat any next text as the clarify prompt's
+                    # free-form "Other" response so it cannot sit silently in
+                    # the follow-up queue for up to clarify_timeout. Threaded
+                    # platforms keep the strict numeric/exact-label behavior
+                    # because their prose may be an unrelated follow-up.
+                    accept_custom=source.platform == Platform.TELEGRAM,
                 )
                 if _resolved:
                     logger.info(

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -34,6 +34,7 @@ from gateway.session import SessionSource
 
 
 SESSION_KEY = "agent:main:slack:dm:D123:1111.2222"
+TELEGRAM_SESSION_KEY = "agent:main:telegram:dm:123456789:999"
 
 
 class _StubAdapter(BasePlatformAdapter):
@@ -69,6 +70,21 @@ def _event(text):
             thread_id="1111.2222",
         ),
         message_id="msg1",
+    )
+
+
+def _telegram_event(text):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123456789",
+            chat_type="dm",
+            user_id="123456789",
+            thread_id="999",
+        ),
+        message_id="msg2",
     )
 
 
@@ -132,6 +148,34 @@ async def test_thread_prose_not_swallowed_by_native_multi_choice_clarify():
 
 
 @pytest.mark.asyncio
+async def test_telegram_prose_resolves_native_multi_choice_as_custom_other():
+    """Telegram's next text should answer a blocking clarify without an extra tap."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _StubAdapter()
+    runner = _make_runner(adapter)
+    runner._session_key_for_source = lambda source: TELEGRAM_SESSION_KEY
+    cm.register(
+        "cl-telegram",
+        TELEGRAM_SESSION_KEY,
+        "What should I automate?",
+        ["create PRs", "review PRs"],
+    )
+
+    custom = "Inspect the existing PR automation first"
+    result = await _dispatch(runner, _telegram_event(custom))
+
+    assert result == ""
+    with cm._lock:
+        entry = cm._entries.get("cl-telegram")
+    assert entry is not None
+    assert entry.event.is_set()
+    assert entry.response == custom
+    _clear_clarify_state()
+
+
+@pytest.mark.asyncio
 async def test_prose_still_accepted_after_other_flips_text_capture():
     """After the user taps 'Other', free text IS the answer — must resolve."""
     _clear_clarify_state()
@@ -151,5 +195,3 @@ async def test_prose_still_accepted_after_other_flips_text_capture():
     assert entry.event.is_set()
     assert entry.response == "a carousel actually"
     _clear_clarify_state()
-
-

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -341,3 +341,25 @@ class TestMultiSelectTextFallback:
         from tools import clarify_gateway as cm
         entry = cm.register("s4", "sk", "Q?", ["A", "B"])
         assert cm._coerce_text_response(entry, "b") == "B"
+
+    def test_single_select_accepts_custom_prose_when_platform_opts_in(self):
+        from tools import clarify_gateway as cm
+        cm.register("s5", "sk", "Q?", ["A", "B"])
+        custom = "Use the repository's existing PR automation"
+        assert cm.resolve_text_response_for_session(
+            "sk",
+            custom,
+            accept_custom=True,
+        ) is True
+        assert cm.wait_for_response("s5", timeout=0.1) == custom
+
+    def test_multi_select_accepts_custom_prose_when_platform_opts_in(self):
+        from tools import clarify_gateway as cm
+        cm.register("m4", "sk", "Q?", ["A", "B"], multi_select=True)
+        custom = "Use neither option"
+        assert cm.resolve_text_response_for_session(
+            "sk",
+            custom,
+            accept_custom=True,
+        ) is True
+        assert cm.wait_for_response("m4", timeout=0.1) == custom

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -201,13 +201,19 @@ def get_pending_for_session(
         return None
 
 
-def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
+def _coerce_text_response(
+    entry: _ClarifyEntry,
+    response: str,
+    *,
+    accept_custom: bool = False,
+) -> Optional[str]:
     """Map typed choice replies to canonical choice text, otherwise keep or reject custom text.
 
     For native interactive multi-choice clarifies (button UI, awaiting_text=False):
       - Accept numeric selections ("2" → choice[1])
       - Accept exact choice label matches (case-insensitive)
-      - Reject arbitrary prose (return None) so the message continues as a normal turn
+      - Accept arbitrary prose as an "Other" answer when ``accept_custom`` is true
+      - Otherwise reject arbitrary prose so the message continues as a normal turn
 
     For multi-select clarifies (entry.multi_select=True):
       - Accept several numbers separated by commas and/or spaces ("1,3" / "1 3")
@@ -235,9 +241,10 @@ def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
         coerced = _coerce_multi_select_text(entry, text)
         if coerced is not None:
             return coerced
-        # Not a parseable selection — accept as custom text only in
-        # awaiting_text mode (the "Other" path); otherwise reject.
-        return text if entry.awaiting_text else None
+        # Not a parseable selection — accept as custom text in explicit
+        # "Other" mode or when the messaging platform opts into treating
+        # its next serialized message as an implicit "Other" response.
+        return text if entry.awaiting_text or accept_custom else None
 
     # Try numeric selection first (always valid for multi-choice)
     try:
@@ -255,7 +262,7 @@ def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
 
     # For text fallback or awaiting_text mode, accept custom text
     # For native interactive multi-choice mode, reject arbitrary prose
-    if entry.awaiting_text:
+    if entry.awaiting_text or accept_custom:
         return text
 
     return None
@@ -313,17 +320,28 @@ def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
     return _json.dumps(selected, ensure_ascii=False)
 
 
-def resolve_text_response_for_session(session_key: str, response: str) -> bool:
+def resolve_text_response_for_session(
+    session_key: str,
+    response: str,
+    *,
+    accept_custom: bool = False,
+) -> bool:
     """Resolve the oldest pending clarify in ``session_key`` from typed text.
 
-    Returns False if no pending clarify exists or if the response was rejected
-    (arbitrary prose for native interactive multi-choice clarifies).
+    Returns False if no pending clarify exists or if the response was rejected.
+    Platforms with a serialized conversation, such as Telegram, may pass
+    ``accept_custom=True`` so the next text message acts like choosing
+    "Other" and typing a response in one step.
     """
     entry = get_pending_for_session(session_key, include_choice_prompts=True)
     if entry is None:
         return False
 
-    coerced = _coerce_text_response(entry, response)
+    coerced = _coerce_text_response(
+        entry,
+        response,
+        accept_custom=accept_custom,
+    )
     if coerced is None:
         # Response rejected: message should continue as a normal turn
         return False


### PR DESCRIPTION
## What changed

- allow Telegram users to answer a pending multi-choice `clarify` prompt with arbitrary text in one step
- treat that text as the prompt's custom `Other` response for both single-select and multi-select prompts
- preserve strict numeric/exact-label handling on threaded platforms such as Slack
- add unit and gateway regression coverage for both behaviors

## Why

Telegram sessions serialize follow-up messages behind the active agent turn. When a multi-choice `clarify` prompt was pending, arbitrary text did not resolve it and was queued behind the blocked turn. The bot appeared unresponsive until the user selected a button, sent a numeric/exact-label choice, or the one-hour clarify timeout elapsed.

For Telegram, the next non-command text message is unambiguous user input for the blocking prompt and should behave like selecting `Other` and typing the answer. Slash commands continue to bypass clarify handling.

## User impact

Telegram users can naturally reply to a clarify question without first tapping the `Other` button. Slack and other platforms retain the existing protection against swallowing unrelated threaded follow-ups.

## Validation

- rebased onto current upstream `main`
- `python -m pytest -q tests/tools/test_clarify_gateway.py tests/gateway/test_clarify_thread_followup_not_swallowed.py`
- 28 tests passed
- `git diff --check`
- Python syntax compilation of all four changed files