### PR TITLE
feat(cron): opt-in agent scheduling in cron context with create-time origin resolution

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -167,19 +167,28 @@ class CronPromptInjectionBlocked(Exception):
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
-    Four protected toolsets are always disabled in cron context:
-      - ``cronjob`` — would let a cron-spawned agent schedule more cron jobs
+    Three toolsets are always disabled in cron context regardless of config:
       - ``messaging`` — interactive, needs a live gateway session
       - ``clarify`` — interactive, blocks waiting for user input
       - ``memory`` — cron agents are constructed with ``skip_memory=True``, so
         exposing this tool only gives the model an unbacked tool that fails
+
+    ``cronjob`` is policy-denied by default (loop prevention, not a security
+    boundary) and config-gated: setting ``cron.allow_agent_scheduling: true``
+    in config.yaml drops it from the base denylist so cron-spawned agents may
+    manage the user's cron table. The gate only removes the built-in policy
+    denial — it never overrides the user denylist below.
 
     User-level ``agent.disabled_toolsets`` from config.yaml is layered on top
     so per-job ``enabled_toolsets`` cannot bypass policy that applies to
     ordinary agent runs (#25752 — LLM-supplied enabled_toolsets was widening
     past config.yaml's denylist).
     """
-    disabled = ["cronjob", "messaging", "clarify", "memory"]
+    cron_cfg = (cfg or {}).get("cron") or {}
+    if cron_cfg.get("allow_agent_scheduling"):
+        disabled = ["messaging", "clarify", "memory"]
+    else:
+        disabled = ["cronjob", "messaging", "clarify", "memory"]
     agent_cfg = (cfg or {}).get("agent") or {}
     user_disabled = agent_cfg.get("disabled_toolsets") or []
     for name in user_disabled:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2229,6 +2229,14 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
+        # Allow cron-spawned agents to use the cronjob toolset (create/edit/
+        # remove scheduled jobs from within a cron run — the "cron-librarian"
+        # pattern). Off by default: the cronjob toolset is policy-denied in
+        # cron context to prevent unattended scheduling loops. Jobs created
+        # this way are user-owned in the same flat jobs table as every other
+        # job. Interactive toolsets (messaging/clarify) stay denied in cron
+        # context regardless of this setting.
+        "allow_agent_scheduling": False,
         # Pre-dispatch configuration validation (T1-26): before constructing
         # any agent machinery for a job, verify the provider API key resolves
         # (unless a fallback chain is configured), attached skills are ready

--- a/tests/cron/test_agent_scheduling_gate.py
+++ b/tests/cron/test_agent_scheduling_gate.py
@@ -1,0 +1,104 @@
+"""Behavior contract for the cron.allow_agent_scheduling config gate.
+
+``_resolve_cron_disabled_toolsets`` decides which toolsets a cron-spawned
+agent must never receive. Historically ``cronjob`` was hard-denied there as
+loop-prevention policy. The ``cron.allow_agent_scheduling`` gate (config.yaml,
+default off) makes that denial opt-out-able:
+
+  - gate off / absent: byte-exact current behavior — ``cronjob`` denied.
+  - gate on: ``cronjob`` dropped from the base denylist; ``messaging`` and
+    ``clarify`` (interactivity constraints) and ``memory`` (cron agents run
+    with skip_memory=True) are ALWAYS denied regardless of the gate.
+  - user-level ``agent.disabled_toolsets`` still layers on top, so a user who
+    denies ``cronjob`` globally keeps it denied even with the gate on
+    (per-job enabled_toolsets can never widen past the config denylist).
+"""
+
+import pytest
+
+from cron.scheduler import _resolve_cron_disabled_toolsets
+
+
+# The toolsets that must be denied in cron context no matter what the
+# agent-scheduling gate says: messaging/clarify are interactive-only,
+# memory is unbacked in cron runs (skip_memory=True).
+ALWAYS_DISABLED = ["messaging", "clarify", "memory"]
+
+
+class TestGateOffDefault:
+    def test_empty_config_denies_cronjob(self):
+        assert _resolve_cron_disabled_toolsets({}) == [
+            "cronjob", "messaging", "clarify", "memory",
+        ]
+
+    def test_none_config_denies_cronjob(self):
+        assert _resolve_cron_disabled_toolsets(None) == [
+            "cronjob", "messaging", "clarify", "memory",
+        ]
+
+    def test_cron_section_present_but_gate_absent(self):
+        cfg = {"cron": {"preflight": True}}
+        assert _resolve_cron_disabled_toolsets(cfg) == [
+            "cronjob", "messaging", "clarify", "memory",
+        ]
+
+    def test_explicit_false_matches_default(self):
+        cfg = {"cron": {"allow_agent_scheduling": False}}
+        assert _resolve_cron_disabled_toolsets(cfg) == \
+            _resolve_cron_disabled_toolsets({})
+
+    @pytest.mark.parametrize("falsy", [False, None, "", 0])
+    def test_falsy_values_keep_gate_off(self, falsy):
+        cfg = {"cron": {"allow_agent_scheduling": falsy}}
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+        assert "cronjob" in disabled
+
+
+class TestGateOn:
+    def test_cronjob_dropped_from_denylist(self):
+        cfg = {"cron": {"allow_agent_scheduling": True}}
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+        assert "cronjob" not in disabled
+
+    def test_interactivity_and_memory_denials_survive_the_gate(self):
+        cfg = {"cron": {"allow_agent_scheduling": True}}
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+        for name in ALWAYS_DISABLED:
+            assert name in disabled
+
+    def test_user_denylist_wins_over_gate(self):
+        # A user who denies cronjob in agent.disabled_toolsets keeps it
+        # denied even with the gate on — the gate only removes the built-in
+        # policy denial, never the user's own config denylist.
+        cfg = {
+            "cron": {"allow_agent_scheduling": True},
+            "agent": {"disabled_toolsets": ["cronjob"]},
+        }
+        assert "cronjob" in _resolve_cron_disabled_toolsets(cfg)
+
+    def test_unrelated_user_denylist_layers_without_reviving_cronjob(self):
+        cfg = {
+            "cron": {"allow_agent_scheduling": True},
+            "agent": {"disabled_toolsets": ["browser"]},
+        }
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+        assert "browser" in disabled
+        assert "cronjob" not in disabled
+
+
+class TestUserLayerUnchanged:
+    def test_user_denylist_still_layers_when_gate_off(self):
+        cfg = {"agent": {"disabled_toolsets": ["browser", "cronjob"]}}
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+        assert "browser" in disabled
+        # No duplicate when the user names an already-denied toolset.
+        assert disabled.count("cronjob") == 1
+
+    def test_blank_and_whitespace_entries_ignored(self):
+        cfg = {
+            "cron": {"allow_agent_scheduling": True},
+            "agent": {"disabled_toolsets": ["", "  ", "browser"]},
+        }
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+        assert "browser" in disabled
+        assert "" not in disabled

--- a/tests/cron/test_cron_created_delivery.py
+++ b/tests/cron/test_cron_created_delivery.py
@@ -145,6 +145,40 @@ class TestCronContextDeliveryResolution:
         assert "origin" not in [p.strip() for p in stored.split(",")]
 
 
+class TestCronContextUpdatePath:
+    def test_update_deliver_origin_resolves_in_cron_context(self, temp_cron_home):
+        """The update action must apply the same resolution as create — a
+        cron agent updating deliver='origin' would otherwise recreate the
+        dangling literal-origin shape on an origin-less job."""
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import get_job
+
+        tokens, extra = _enter_cron_context("telegram", "-100123456", "17")
+        try:
+            created = _create(deliver="local")
+            result = json.loads(
+                cronjob(action="update", job_id=created["job_id"], deliver="origin")
+            )
+        finally:
+            _exit_cron_context(tokens, extra)
+        assert result["success"] is True
+        job = get_job(created["job_id"])
+        stored = str(job.get("deliver", ""))
+        assert "origin" not in [p.strip() for p in stored.split(",")]
+        assert stored == "telegram:-100123456:17"
+
+    def test_update_deliver_outside_cron_context_unchanged(self, temp_cron_home):
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import get_job
+
+        created = _create(deliver="local")
+        result = json.loads(
+            cronjob(action="update", job_id=created["job_id"], deliver="origin")
+        )
+        assert result["success"] is True
+        assert get_job(created["job_id"]).get("deliver") == "origin"
+
+
 class TestNonCronContextUnchanged:
     def test_chat_session_create_keeps_literal_origin(self, temp_cron_home):
         # No cron_session var — ordinary chat/CLI create. Existing semantics:

--- a/tests/cron/test_cron_created_delivery.py
+++ b/tests/cron/test_cron_created_delivery.py
@@ -1,0 +1,162 @@
+"""Create-time delivery resolution for cron-context job creation.
+
+A cron-run agent (gate: cron.allow_agent_scheduling) creating a job must
+never produce a job whose deliver field points at the creating run itself:
+the run's session is ephemeral, so a stored literal 'origin' would resolve
+against a session that no longer exists by fire time. The cronjob tool
+therefore resolves 'origin' (or an omitted deliver) AT CREATE TIME to the
+creating job's own concrete persistent target, read from the
+HERMES_CRON_AUTO_DELIVER_* contextvars that run_job publishes per run.
+Non-cron sessions keep the literal 'origin' (live chat sessions have a real
+origin to resolve at fire time).
+"""
+
+import json
+
+import pytest
+
+from gateway.session_context import _VAR_MAP, clear_session_vars, set_session_vars
+
+
+@pytest.fixture
+def temp_cron_home(tmp_path, monkeypatch):
+    from cron import jobs as cron_jobs
+
+    with cron_jobs.use_cron_store(tmp_path):
+        cron_jobs.ensure_dirs()
+        yield tmp_path
+
+
+def _enter_cron_context(platform=None, chat_id=None, thread_id=None):
+    """Simulate the contextvar state run_job() establishes for a cron run."""
+    tokens = set_session_vars(
+        platform="",
+        chat_id="",
+        chat_name="",
+        cron_session="1",
+    )
+    extra = []
+    if platform is not None:
+        extra.append(
+            (_VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"],
+             _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(platform))
+        )
+        extra.append(
+            (_VAR_MAP["HERMES_CRON_AUTO_DELIVER_CHAT_ID"],
+             _VAR_MAP["HERMES_CRON_AUTO_DELIVER_CHAT_ID"].set(str(chat_id)))
+        )
+        if thread_id is not None:
+            extra.append(
+                (_VAR_MAP["HERMES_CRON_AUTO_DELIVER_THREAD_ID"],
+                 _VAR_MAP["HERMES_CRON_AUTO_DELIVER_THREAD_ID"].set(str(thread_id)))
+            )
+    return tokens, extra
+
+
+def _exit_cron_context(tokens, extra):
+    for var, token in reversed(extra):
+        var.reset(token)
+    clear_session_vars(tokens)
+
+
+def _create(deliver=None):
+    from tools.cronjob_tools import cronjob
+
+    return json.loads(
+        cronjob(
+            action="create",
+            schedule="every 4h",
+            prompt="check the thing",
+            deliver=deliver,
+        )
+    )
+
+
+class TestCronContextDeliveryResolution:
+    def test_omitted_deliver_resolves_to_creator_target(self, temp_cron_home):
+        tokens, extra = _enter_cron_context("telegram", "-100123456", "17")
+        try:
+            result = _create()
+        finally:
+            _exit_cron_context(tokens, extra)
+        assert result["success"] is True
+        assert result["deliver"] == "telegram:-100123456:17"
+
+    def test_literal_origin_resolves_to_creator_target(self, temp_cron_home):
+        tokens, extra = _enter_cron_context("telegram", "-100123456", "17")
+        try:
+            result = _create(deliver="origin")
+        finally:
+            _exit_cron_context(tokens, extra)
+        assert result["deliver"] == "telegram:-100123456:17"
+
+    def test_no_thread_id_omits_thread_segment(self, temp_cron_home):
+        tokens, extra = _enter_cron_context("slack", "C0ABC")
+        try:
+            result = _create(deliver="origin")
+        finally:
+            _exit_cron_context(tokens, extra)
+        assert result["deliver"] == "slack:C0ABC"
+
+    def test_creator_without_delivery_target_falls_back_to_local(self, temp_cron_home):
+        # Creator job delivers nowhere concrete (deliver='local' run):
+        # AUTO_DELIVER vars unset. Child must store 'local', never 'origin'.
+        tokens, extra = _enter_cron_context()
+        try:
+            result = _create(deliver="origin")
+        finally:
+            _exit_cron_context(tokens, extra)
+        assert result["deliver"] == "local"
+
+    def test_comma_list_resolves_only_origin_element(self, temp_cron_home):
+        tokens, extra = _enter_cron_context("telegram", "-100123456", "17")
+        try:
+            result = _create(deliver="origin,all")
+        finally:
+            _exit_cron_context(tokens, extra)
+        assert result["deliver"] == "telegram:-100123456:17,all"
+
+    def test_explicit_target_passes_through_verbatim(self, temp_cron_home):
+        tokens, extra = _enter_cron_context("telegram", "-100999", "3")
+        try:
+            result = _create(deliver="discord:#engineering")
+        finally:
+            _exit_cron_context(tokens, extra)
+        assert result["deliver"] == "discord:#engineering"
+
+    def test_local_passes_through(self, temp_cron_home):
+        tokens, extra = _enter_cron_context("telegram", "-100999")
+        try:
+            result = _create(deliver="local")
+        finally:
+            _exit_cron_context(tokens, extra)
+        assert result["deliver"] == "local"
+
+    def test_stored_deliver_never_literal_origin_in_cron_context(self, temp_cron_home):
+        from cron.jobs import get_job
+
+        tokens, extra = _enter_cron_context("telegram", "-100123456")
+        try:
+            result = _create(deliver="origin")
+        finally:
+            _exit_cron_context(tokens, extra)
+        job = get_job(result["job_id"])
+        stored = str(job.get("deliver", ""))
+        assert "origin" not in [p.strip() for p in stored.split(",")]
+
+
+class TestNonCronContextUnchanged:
+    def test_chat_session_create_keeps_literal_origin(self, temp_cron_home):
+        # No cron_session var — ordinary chat/CLI create. Existing semantics:
+        # 'origin' stays literal and resolves at fire time.
+        result = _create(deliver="origin")
+        assert result["deliver"] == "origin"
+
+    def test_chat_session_omitted_deliver_unchanged(self, temp_cron_home):
+        # Outside cron context the resolution helper must be a no-op so the
+        # ordinary chat/CLI create path is byte-identical to before.
+        from tools.cronjob_tools import _resolve_cron_context_deliver
+
+        assert _resolve_cron_context_deliver(None) is None
+        assert _resolve_cron_context_deliver("origin") == "origin"
+        assert _resolve_cron_context_deliver("origin,all") == "origin,all"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1459,7 +1459,7 @@ NOTE: The agent's final response is auto-delivered to the target. Put the primar
 user-facing content in the final response. Cron jobs run autonomously with no user
 present — they cannot ask questions or request clarification.
 
-Important safety rule: cron-run sessions should not recursively schedule more cron jobs.""",
+Scheduling from cron-run sessions is disabled by default and enabled via cron.allow_agent_scheduling in config.yaml. When enabled, jobs created from a cron run are user-owned in the same flat job table as every other job, and their delivery resolves to the creating job's own persistent target — never to the ephemeral cron-run session. Prefer updating an existing job (list first, then update by job_id) over creating near-duplicates.""",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1358,7 +1358,9 @@ def cronjob(
             if name is not None:
                 updates["name"] = name
             if deliver is not None:
-                updates["deliver"] = _normalize_deliver_param(deliver)
+                updates["deliver"] = _resolve_cron_context_deliver(
+                    _normalize_deliver_param(deliver)
+                )
             if skills is not None or skill is not None:
                 canonical_skills = _canonical_skills(skill, skills)
                 updates["skills"] = canonical_skills

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -434,6 +434,53 @@ def _normalize_deliver_param(value: Any) -> Optional[str]:
     return text or None
 
 
+def _resolve_cron_context_deliver(deliver: Optional[str]) -> Optional[str]:
+    """Resolve ``origin`` to a concrete target for cron-context creates.
+
+    A job created FROM a cron run must never store the literal ``origin``:
+    the creating session is ephemeral, so by fire time there is no origin to
+    resolve and the scheduler would fall back to guessing a home channel.
+    Resolve at create time instead, using the creating run's own concrete
+    delivery target — the ``HERMES_CRON_AUTO_DELIVER_*`` contextvars that
+    ``run_job`` publishes per run (already per-job-safe under the parallel
+    pool). Rules:
+
+    * Not a cron-context session → returned unchanged (chat/CLI creates keep
+      today's fire-time ``origin`` semantics, byte-identical).
+    * ``origin`` element (or an omitted value, which the scheduler treats as
+      origin) → replaced with ``platform:chat_id[:thread_id]`` from the
+      creating run's target; ``local`` when the creating run has no concrete
+      target (e.g. its own deliver is ``local``).
+    * Every other element (``local``, ``all``, explicit ``platform:...``)
+      passes through verbatim, including inside comma lists.
+    """
+    from gateway.session_context import get_session_env
+    from utils import is_truthy_value
+
+    if not is_truthy_value(get_session_env("HERMES_CRON_SESSION", "")):
+        return deliver
+
+    def _creator_target() -> str:
+        platform = get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM", "").strip()
+        chat_id = get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID", "").strip()
+        if not platform or not chat_id:
+            return "local"
+        thread_id = get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "").strip()
+        if thread_id:
+            return f"{platform}:{chat_id}:{thread_id}"
+        return f"{platform}:{chat_id}"
+
+    if deliver is None:
+        return _creator_target()
+    parts = [p.strip() for p in str(deliver).split(",") if p.strip()]
+    resolved = [_creator_target() if p.lower() == "origin" else p for p in parts]
+    # De-dup while preserving order: 'origin,local' with a local-target
+    # creator would otherwise store 'local,local'.
+    seen: set = set()
+    unique = [p for p in resolved if not (p in seen or seen.add(p))]
+    return ",".join(unique) if unique else None
+
+
 def _validate_cron_base_url(
     provider: Optional[Any], base_url: Optional[Any]
 ) -> Optional[str]:
@@ -1126,7 +1173,9 @@ def cronjob(
                     schedule=schedule,
                     name=name,
                     repeat=repeat,
-                    deliver=_normalize_deliver_param(deliver),
+                    deliver=_resolve_cron_context_deliver(
+                        _normalize_deliver_param(deliver)
+                    ),
                     origin=_origin_from_env(),
                     skills=canonical_skills,
                     model=_normalize_optional_job_value(model),

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -258,6 +258,35 @@ What they do:
 
 **Name-based lookup.** All four mutating verbs (`pause`, `resume`, `run`, `remove`, `edit`) plus the agent's `cronjob` tool now accept a job **name** (case-insensitive) in place of the hex ID. The agent and CLI both prefer an exact ID match if one exists; ambiguous name matches (multiple jobs sharing the same name) are refused with the full list of candidate IDs so you can pick one explicitly. Names are not unique, so this guard is load-bearing — it prevents silently mutating the wrong job when two share a name.
 
+## Agent-managed scheduling (cron jobs that manage cron jobs)
+
+By default, agents launched *by* the scheduler cannot use the `cronjob` tool —
+a scheduled job cannot create, edit, or remove other jobs. Opt in via
+`config.yaml`:
+
+```yaml
+cron:
+  allow_agent_scheduling: true   # default: false
+```
+
+When enabled, a scheduled agent can manage the cron table like any chat
+session: schedule follow-up one-shots from within scheduled work, tune its own
+cadence, or run a "cron librarian" job that reconciles the whole table
+(list, then update/remove/create as needed). Two properties keep this sane:
+
+- **One flat, user-owned table.** Jobs created from a cron run land in the
+  same `jobs.json` as every other job with no special ownership — you can
+  list, edit, or remove them exactly as if you had created them yourself.
+- **No dangling delivery.** A cron run is ephemeral, so `deliver: origin`
+  from inside one is resolved **at create time** to the creating job's own
+  concrete target (`platform:chat_id[:thread_id]`, or `local` if the creating
+  job delivers nowhere). A job created by a scheduled agent can never point
+  its output at a session that no longer exists. Explicit targets
+  (`local`, `all`, `telegram:<chat_id>`) are honored verbatim.
+
+Prefer prompts that update existing jobs (list first, then update by ID)
+over ones that create new jobs each run.
+
 ## How it works
 
 **Cron execution is handled by the gateway daemon.** The gateway ticks the scheduler every 60 seconds, running any due jobs in isolated agent sessions.


### PR DESCRIPTION
## Summary

An enterprise customer asked for cron jobs that can schedule, tune, and
remove other cron jobs — reconciler-style "librarian" jobs that manage a
team's cron table, follow-up one-shots scheduled from within scheduled
work, and self-adjusting cadences. Today the `cronjob` toolset is
unconditionally denied in cron-spawned sessions.

That denial is loop-prevention policy, not a security boundary: a cron
agent with the `terminal` toolset can already shell out to `hermes cron
add`. The workaround exists but skips accounting and normalizes policy
bypass — better to support the capability first-class, opt-in, with the
one real hazard closed.

## What this ships

1. **`cron.allow_agent_scheduling`** (config.yaml, default `false` —
   byte-exact current behavior). When enabled, only `cronjob` leaves the
   cron-context denylist; `messaging`/`clarify`/`memory` remain denied as
   interactivity/policy constraints. The user-level
   `agent.disabled_toolsets` layering is unchanged, so a user denylist
   entry still beats the gate (the existing per-job
   `enabled_toolsets`-cannot-widen invariant holds; test-locked).
2. **Create-time origin resolution (cron context only).** A job created
   or updated from a cron run must never store the literal `origin`: the
   creating session is ephemeral, so at fire time there is nothing to
   resolve and the scheduler would guess a home channel or drop delivery.
   `origin` elements (and omitted deliver) now resolve at mutation time to
   the creating run's concrete target from the per-run
   `HERMES_CRON_AUTO_DELIVER_*` contextvars —
   `platform:chat_id[:thread_id]`, or `local` when the creating job
   delivers nowhere. Explicit values (`local`, `all`,
   `platform:chat_id[:thread_id]`, comma lists) pass through verbatim.
   Chat/CLI sessions are byte-identical: the resolver is a no-op outside
   cron context.
3. Docs: "Agent-managed scheduling" section in the cron user guide.

Ownership needs no mechanism: `jobs.json` is one flat user-owned table
with no owner field, so a cron-created job is listed, edited, and removed
exactly like any other — nothing to scope, transfer, or orphan.

## Considered and rejected: quotas

We deliberately ship this without job-count limits. Enabling agent
scheduling does not change the system's existing quota posture — a
runaway job table is the same operational concern with or without this
gate, and an agent with `terminal` could always create jobs. Rather than
couple the capability to speculative limits, we ship the capability
gated and honest. **Optional follow-up scope if operators want it:** a
max-total-jobs-per-profile cap and a max-creates-per-run cap; both slot
cleanly into the shared create path later without schema changes.

## Verification

- TDD RED-first throughout: gate tests failed against the hardcoded
  denylist before implementation (2 red); delivery-resolution tests
  failed before the resolver existed (7 red); the update-path test failed
  against the review-found gap before the fix (1 red).
- Targeted: 14 gate + 12 delivery tests green; full `tests/cron/`:
  **541 passed, 1 skipped**.
- **Mutation checks** (mechanism neutered → new tests must go red): gate
  forced off → 2 failed; resolver forced to no-op → 6 failed. Restored
  from committed state.
- **Pre-push review** (independent falsification pass) caught a real gap:
  `action='update'` also accepts `deliver` and skipped the resolver —
  and the tool description steers agents toward update-over-create,
  making it the likelier path. Fixed in the fourth commit with the same
  resolver wrap; in cron context `origin` now means "my run's target" at
  every mutation site.
- **Full canonical runner** (`tests/cron/ tests/gateway/ tests/hermes_cli/
  tests/agent/`): green except
  `tests/agent/test_anthropic_output_field_leak.py` (4 collection
  errors), which fails identically on the unmodified base commit
  (b614f7036) in a clean detached worktree — pre-existing, unrelated.

## How to test

```
scripts/run_tests.sh tests/cron/test_agent_scheduling_gate.py
scripts/run_tests.sh tests/cron/test_cron_created_delivery.py
scripts/run_tests.sh tests/cron/
```

Enable in `~/.hermes/config.yaml`:

```yaml
cron:
  allow_agent_scheduling: true
```
