### PR TITLE
fix(teams-pipeline): support organizer-scoped meeting lookup (#83422)

### DIFF
--- a/plugins/teams_pipeline/cli.py
+++ b/plugins/teams_pipeline/cli.py
@@ -47,6 +47,11 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
     fetch_p = subs.add_parser("fetch", aliases=["test"], help="Dry-run meeting artifact resolution")
     fetch_p.add_argument("--meeting-id", default="")
     fetch_p.add_argument("--join-web-url", default="")
+    fetch_p.add_argument(
+        "--organizer-user-id",
+        default="",
+        help="Microsoft Entra user ID for organizer-scoped online meeting lookup",
+    )
     fetch_p.add_argument("--tenant-id", default="")
     fetch_p.add_argument("--call-record-id", default="")
 
@@ -306,6 +311,7 @@ def _cmd_run(args) -> None:
 def _cmd_fetch(args) -> None:
     meeting_id = str(getattr(args, "meeting_id", "") or "").strip() or None
     join_web_url = str(getattr(args, "join_web_url", "") or "").strip() or None
+    organizer_user_id = str(getattr(args, "organizer_user_id", "") or "").strip() or None
     tenant_id = str(getattr(args, "tenant_id", "") or "").strip() or None
     call_record_id = str(getattr(args, "call_record_id", "") or "").strip() or None
     if not meeting_id and not join_web_url:
@@ -319,6 +325,7 @@ def _cmd_fetch(args) -> None:
             meeting_id=meeting_id,
             join_web_url=join_web_url,
             tenant_id=tenant_id,
+            organizer_user_id=organizer_user_id,
         )
     )
     transcript_artifact, transcript_text = _run_async(fetch_preferred_transcript_text(client, meeting_ref))

--- a/plugins/teams_pipeline/meetings.py
+++ b/plugins/teams_pipeline/meetings.py
@@ -29,6 +29,9 @@ class TeamsMeetingPermissionError(TeamsMeetingError):
 
 def _meeting_path(meeting_ref: TeamsMeetingRef | str) -> str:
     meeting_id = meeting_ref.meeting_id if isinstance(meeting_ref, TeamsMeetingRef) else str(meeting_ref)
+    if isinstance(meeting_ref, TeamsMeetingRef) and meeting_ref.organizer_user_id:
+        organizer = quote(meeting_ref.organizer_user_id, safe="")
+        return f"/users/{organizer}/onlineMeetings/{quote(meeting_id, safe='')}"
     return f"/communications/onlineMeetings/{quote(meeting_id, safe='')}"
 
 
@@ -62,7 +65,12 @@ def _parse_thread_id(payload: dict[str, Any]) -> str | None:
     return payload.get("threadId")
 
 
-def _normalize_meeting_ref(payload: dict[str, Any], *, tenant_id: str | None = None) -> TeamsMeetingRef:
+def _normalize_meeting_ref(
+    payload: dict[str, Any],
+    *,
+    tenant_id: str | None = None,
+    organizer_user_id: str | None = None,
+) -> TeamsMeetingRef:
     metadata = {
         key: payload.get(key)
         for key in ("subject", "startDateTime", "endDateTime", "createdDateTime")
@@ -73,7 +81,7 @@ def _normalize_meeting_ref(payload: dict[str, Any], *, tenant_id: str | None = N
         metadata["participants"] = participants
     return TeamsMeetingRef(
         meeting_id=str(payload.get("id") or "").strip(),
-        organizer_user_id=_parse_organizer_user_id(payload),
+        organizer_user_id=organizer_user_id or _parse_organizer_user_id(payload),
         join_web_url=payload.get("joinWebUrl"),
         calendar_event_id=payload.get("calendarEventId"),
         thread_id=_parse_thread_id(payload),
@@ -140,21 +148,30 @@ async def resolve_meeting_reference(
     meeting_id: str | None = None,
     join_web_url: str | None = None,
     tenant_id: str | None = None,
+    organizer_user_id: str | None = None,
 ) -> TeamsMeetingRef:
     if meeting_id:
         try:
-            payload = await client.get_json(_meeting_path(meeting_id))
+            meeting_ref = TeamsMeetingRef(meeting_id=meeting_id, organizer_user_id=organizer_user_id)
+            payload = await client.get_json(_meeting_path(meeting_ref))
         except MicrosoftGraphAPIError as exc:
             raise _wrap_graph_error(exc, missing_message=f"Teams meeting not found: {meeting_id}") from exc
         if not isinstance(payload, dict) or not payload.get("id"):
             raise TeamsMeetingNotFoundError(f"Teams meeting not found: {meeting_id}")
-        return _normalize_meeting_ref(payload, tenant_id=tenant_id)
+        return _normalize_meeting_ref(
+            payload,
+            tenant_id=tenant_id,
+            organizer_user_id=organizer_user_id,
+        )
 
     if join_web_url:
         escaped_join_url = join_web_url.replace("'", "''")
         try:
+            lookup_path = "/communications/onlineMeetings"
+            if organizer_user_id:
+                lookup_path = f"/users/{quote(organizer_user_id, safe='')}/onlineMeetings"
             payload = await client.get_json(
-                "/communications/onlineMeetings",
+                lookup_path,
                 params={"$filter": f"JoinWebUrl eq '{escaped_join_url}'"},
             )
         except MicrosoftGraphAPIError as exc:
@@ -165,7 +182,11 @@ async def resolve_meeting_reference(
         candidates = payload.get("value") if isinstance(payload, dict) else None
         if not isinstance(candidates, list) or not candidates:
             raise TeamsMeetingNotFoundError(f"Teams meeting not found for join URL: {join_web_url}")
-        return _normalize_meeting_ref(candidates[0], tenant_id=tenant_id)
+        return _normalize_meeting_ref(
+            candidates[0],
+            tenant_id=tenant_id,
+            organizer_user_id=organizer_user_id,
+        )
 
     raise ValueError("Either meeting_id or join_web_url is required.")
 

--- a/plugins/teams_pipeline/pipeline.py
+++ b/plugins/teams_pipeline/pipeline.py
@@ -342,12 +342,14 @@ class TeamsMeetingPipeline:
         try:
             job = self._persist_job(job, status="resolving_meeting")
             notification = meeting_ref.metadata.get("notification") if isinstance(meeting_ref.metadata, dict) else {}
-            resolved_meeting = await resolve_meeting_reference(
-                self.graph_client,
-                meeting_id=meeting_ref.meeting_id,
-                join_web_url=meeting_ref.join_web_url or meeting_ref.metadata.get("join_web_url"),
-                tenant_id=meeting_ref.tenant_id,
-            )
+            resolve_kwargs = {
+                "meeting_id": meeting_ref.meeting_id,
+                "join_web_url": meeting_ref.join_web_url or meeting_ref.metadata.get("join_web_url"),
+                "tenant_id": meeting_ref.tenant_id,
+            }
+            if meeting_ref.organizer_user_id:
+                resolve_kwargs["organizer_user_id"] = meeting_ref.organizer_user_id
+            resolved_meeting = await resolve_meeting_reference(self.graph_client, **resolve_kwargs)
             job.meeting_ref = resolved_meeting
             job = self._persist_job(job, meeting_ref=resolved_meeting.to_dict())
 

--- a/tests/plugins/test_teams_pipeline_meetings.py
+++ b/tests/plugins/test_teams_pipeline_meetings.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from plugins.teams_pipeline.meetings import resolve_meeting_reference
+
+
+class FakeGraphClient:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    async def get_json(self, path, *, params=None):
+        self.calls.append((path, params))
+        return self.payload
+
+
+@pytest.mark.anyio
+async def test_join_url_can_use_organizer_scoped_graph_lookup():
+    client = FakeGraphClient({"value": [{"id": "meeting-1", "joinWebUrl": "https://teams.microsoft.com/meet/code"}]})
+
+    meeting = await resolve_meeting_reference(
+        client,
+        join_web_url="https://teams.microsoft.com/meet/code",
+        organizer_user_id="organizer-1",
+    )
+
+    assert meeting.meeting_id == "meeting-1"
+    assert meeting.organizer_user_id == "organizer-1"
+    assert client.calls == [
+        (
+            "/users/organizer-1/onlineMeetings",
+            {"$filter": "JoinWebUrl eq 'https://teams.microsoft.com/meet/code'"},
+        )
+    ]


### PR DESCRIPTION
## Summary
- add an optional `--organizer-user-id` to Teams pipeline fetch
- resolve organizer-scoped `/users/{id}/onlineMeetings` resources for short `/meet/` URLs
- preserve the organizer scope for transcript, recording, and call-record retrieval
- add an offline regression test for the Graph lookup path

Closes #83422

## Tests
- `python3 -m pytest tests/plugins/test_teams_pipeline_meetings.py tests/plugins/test_teams_pipeline_plugin.py tests/hermes_cli/test_teams_pipeline_plugin_cli.py -q` (12 passed)
- `python3 -m py_compile plugins/teams_pipeline/meetings.py plugins/teams_pipeline/cli.py plugins/teams_pipeline/pipeline.py`
- `git diff --check`