### PR TITLE
fix(desktop): title HUD windows Hermes HUD

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -676,6 +676,7 @@ const BOOT_FAKE_STEP_MS = (() => {
 })()
 
 const APP_NAME = process.env.HERMES_DESKTOP_APP_NAME || 'Hermes'
+const HUD_WINDOW_TITLE = `${APP_NAME} HUD`
 const TITLEBAR_HEIGHT = 34
 const MACOS_TRAFFIC_LIGHTS_HEIGHT = 14
 
@@ -9377,6 +9378,7 @@ function spawnHudWindow(sessionId, profile) {
     ...hudBounds(),
     minWidth: 380,
     minHeight: 160,
+    title: HUD_WINDOW_TITLE,
     frame: false,
     transparent: true,
     // NOT resizable. A transparent frameless window on Windows keeps a

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -39,6 +39,10 @@ if (import.meta.env.MODE !== 'production' || import.meta.env.VITE_PERF_PROBE ===
 
 const winParam = new URLSearchParams(window.location.search).get('win')
 
+if (winParam === 'hud') {
+  document.title = 'Hermes HUD'
+}
+
 if (winParam === 'overlay') {
   void import('./app/pet-overlay/overlay-root').then(({ mountPetOverlay }) => mountPetOverlay())
 } else if (winParam === 'quick') {


### PR DESCRIPTION
## Summary

HUD mode windows showed the default "Hermes" title from `index.html`. They now read "Hermes HUD" in both the Electron window options and the renderer boot path so the label stays correct after the page loads.

## Test plan

- [ ] Open HUD mode from the titlebar toggle
- [ ] Confirm the window title reads "Hermes HUD" (Window menu on macOS, or devtools `document.title`)
- [ ] Confirm the main app window still shows "Hermes"