### PR TITLE
fix(title): skip Paperclip session headers for instant titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -144,6 +144,13 @@ _MACHINE_PREFIXES = (
     "[System: The active model for this chat has changed to ",
 )
 
+# Paperclip's hermes_local adapter prefixes each run with a unique session
+# header. The unique suffix is beyond the instant-title window, so deriving an
+# inline title from it creates the same title for every run and triggers the
+# dedupe=False collision path. This is intentionally separate from
+# _MACHINE_PREFIXES: the background titler still owns collision recovery.
+_PAPERCLIP_SESSION_HEADER_PREFIX = "# Paperclip Hermes session"
+
 
 def _title_language() -> str:
     """Return configured title language, or empty string to match the user."""
@@ -486,6 +493,9 @@ def apply_instant_title(
     if not session_db or not session_id:
         return None
     try:
+        if user_message.lstrip().startswith(_PAPERCLIP_SESSION_HEADER_PREFIX):
+            logger.debug("Instant title skipped for Paperclip session header")
+            return None
         if not is_titleable_user_message(user_message):
             return None
         title = derive_title(user_message)

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -560,3 +560,36 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestPaperclipSessionHeaderNotTitleable:
+    """Regression: Paperclip's run header must not become an instant title."""
+
+    HEADER = (
+        "# Paperclip Hermes session — agent-123 — run-456 — "
+        "2026-08-10T12:34:56Z"
+    )
+
+    def test_instant_title_skips_header_without_touching_the_store(self):
+        from agent.title_generator import apply_instant_title
+
+        db = MagicMock()
+
+        assert apply_instant_title(db, "sess-1", self.HEADER) is None
+        db.set_auto_title.assert_not_called()
+        db.set_session_title.assert_not_called()
+
+    def test_background_titler_still_runs_after_instant_skip(self):
+        from agent.title_generator import maybe_auto_title
+
+        db = MagicMock()
+        import threading
+
+        called = threading.Event()
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            mock_auto.side_effect = lambda *args, **kwargs: called.set()
+            maybe_auto_title(db, "sess-1", self.HEADER, [])
+            assert called.wait(timeout=10), "auto-title thread never ran"
+
+        mock_auto.assert_called_once()


### PR DESCRIPTION
## Summary
- Skip the Paperclip Hermes session boilerplate on the instant-title path.
- Preserve background deduplicated titling for normal session recovery.
- Resolves SAG-9169 cosmetic title-collision errorReason pollution.

## Test plan
- `python -m pytest -p no:cacheprovider -q tests/agent/test_title_generator.py` — 35 passed
- `python -m ruff check --cache-dir "$PAPERCLIP_RUN_SCRATCH_DIR/ruff-cache-final" agent/title_generator.py tests/agent/test_title_generator.py` — all checks passed
- `git diff --check 602c9057207c0b09e01c4bf578aa018752c80c2d^ 602c9057207c0b09e01c4bf578aa018752c80c2d` — clean

Exact head: `602c9057207c0b09e01c4bf578aa018752c80c2d`
Board approval and independent QA PASS are recorded on SAG-9169.