### PR TITLE
docs(teams): correct devtunnel webhook protocol

### DIFF
--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -57,7 +57,7 @@ Teams cannot deliver messages to `localhost`. For local development, use any tun
 ```bash
 # devtunnel (Microsoft)
 devtunnel create hermes-bot --allow-anonymous
-devtunnel port create hermes-bot -p 3978 --protocol https  # replace 3978 with TEAMS_PORT if changed
+devtunnel port create hermes-bot -p 3978 --protocol http  # replace 3978 with TEAMS_PORT if changed
 devtunnel host hermes-bot
 
 # ngrok
@@ -68,6 +68,8 @@ cloudflared tunnel --url http://localhost:3978  # replace 3978 with TEAMS_PORT i
 ```
 
 Copy the `https://` URL from the output — you'll use it in the next step. Leave the tunnel running while developing.
+
+The public tunnel URL uses HTTPS, but Hermes' local webhook listener uses plain HTTP. The tunnel terminates TLS and forwards HTTP to port `3978`; do not configure the local tunnel port as HTTPS.
 
 For production, point your bot's endpoint at your server's public domain instead (see [Production Deployment](#production-deployment)).
 
@@ -232,7 +234,7 @@ If the `teams_pipeline` plugin is **not** enabled, these settings are inert — 
 
 ## Production Deployment
 
-For a permanent server, skip devtunnel and register your bot with your server's public HTTPS endpoint:
+For a permanent server, terminate TLS at a reverse proxy and forward requests to the plain HTTP Hermes listener, normally `http://127.0.0.1:3978`. Register the proxy's public HTTPS endpoint with Teams:
 
 ```bash
 teams app create \
@@ -246,7 +248,7 @@ If you've already created the bot and just need to update the endpoint:
 teams app update --id <teamsAppId> --endpoint "https://your-domain.com/api/messages"
 ```
 
-Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from the internet and that your TLS certificate is valid — Teams rejects self-signed certificates.
+Make sure the public HTTPS endpoint is reachable from the internet and uses a valid TLS certificate. Teams rejects self-signed certificates. Keep the Hermes listener behind the proxy; port `3978` does not serve HTTPS itself.
 
 ---
 
@@ -257,6 +259,7 @@ Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from 
 | `Can't find a suitable configuration file` from `docker compose` | You are not in the repo that has `docker-compose.yml`, or you are on a native install — use `hermes gateway restart` instead, or `cd` into the clone first |
 | `requirements not met` / `Teams SDK missing` / `No adapter available for teams` | Restart gateway so lazy-install can run, or install into the **Hermes venv**: `~/.hermes/hermes-agent/venv/bin/pip install microsoft-teams-apps aiohttp`. System `pip` fails on Ubuntu 24.04 (PEP 668) and would not affect the service anyway |
 | `health` endpoint works but bot doesn't respond | Check that your tunnel is still running and the bot's messaging endpoint matches the tunnel URL |
+| Logs show `"UNKNOWN / HTTP/1.0" 400` when Teams sends a message | The tunnel or reverse proxy is forwarding HTTPS to Hermes' plain HTTP listener. Terminate TLS at the proxy and forward HTTP to port `3978` |
 | `KeyError: 'teams'` in logs | Restart the container — this is fixed in the current version |
 | Bot responds with auth errors | Verify `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, and `TEAMS_TENANT_ID` are all set correctly |
 | `No inference provider configured` | Check that `ANTHROPIC_API_KEY` (or another provider key) is set in `~/.hermes/.env` |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/teams.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/teams.md
@@ -46,7 +46,7 @@ Teams 无法向 `localhost` 投递消息。本地开发时，使用任意隧道�
 ```bash
 # devtunnel（Microsoft 官方）
 devtunnel create hermes-bot --allow-anonymous
-devtunnel port create hermes-bot -p 3978 --protocol https  # 如已修改 TEAMS_PORT，请替换 3978
+devtunnel port create hermes-bot -p 3978 --protocol http  # 如已修改 TEAMS_PORT，请替换 3978
 devtunnel host hermes-bot
 
 # ngrok
@@ -57,6 +57,8 @@ cloudflared tunnel --url http://localhost:3978  # 如已修改 TEAMS_PORT，请�
 ```
 
 从输出中复制 `https://` URL——下一步会用到。开发期间保持隧道运行。
+
+公开隧道 URL 使用 HTTPS，但 Hermes 的本地 webhook 监听器使用纯 HTTP。隧道会终止 TLS，并将 HTTP 转发到 `3978` 端口；不要将本地隧道端口配置为 HTTPS。
 
 生产环境请将机器人端点指向服务器的公开域名（参见[生产部署](#production-deployment)）。
 
@@ -201,7 +203,7 @@ platforms:
 
 ## 生产部署
 
-对于永久服务器，跳过 devtunnel，使用服务器的公开 HTTPS 端点注册机器人：
+对于永久服务器，请在反向代理处终止 TLS，并将请求转发到 Hermes 的纯 HTTP 监听器，通常为 `http://127.0.0.1:3978`。使用该代理的公开 HTTPS 端点注册机器人：
 
 ```bash
 teams app create \
@@ -215,7 +217,7 @@ teams app create \
 teams app update --id <teamsAppId> --endpoint "https://your-domain.com/api/messages"
 ```
 
-确保你配置的端口（`TEAMS_PORT`，默认 `3978`）可从互联网访问，且 TLS 证书有效——Teams 会拒绝自签名证书。
+确保公开 HTTPS 端点可从互联网访问并使用有效的 TLS 证书。Teams 会拒绝自签名证书。请将 Hermes 监听器置于代理后方；`3978` 端口本身不提供 HTTPS。
 
 ---
 
@@ -224,6 +226,7 @@ teams app update --id <teamsAppId> --endpoint "https://your-domain.com/api/messa
 | 问题 | 解决方案 |
 |------|----------|
 | `health` 端点正常但机器人不响应 | 检查隧道是否仍在运行，以及机器人的消息端点是否与隧道 URL 匹配 |
+| Teams 发送消息时日志显示 `"UNKNOWN / HTTP/1.0" 400` | 隧道或反向代理正在将 HTTPS 转发到 Hermes 的纯 HTTP 监听器。请在代理处终止 TLS，并将 HTTP 转发到 `3978` 端口 |
 | 日志中出现 `KeyError: 'teams'` | 重启容器——此问题已在当前版本中修复 |
 | 机器人响应时出现认证错误 | 验证 `TEAMS_CLIENT_ID`、`TEAMS_CLIENT_SECRET` 和 `TEAMS_TENANT_ID` 是否均已正确设置 |
 | `No inference provider configured` | 检查 `~/.hermes/.env` 中是否设置了 `ANTHROPIC_API_KEY`（或其他提供商密钥） |


### PR DESCRIPTION
## What does this PR do?

Corrects the Microsoft Teams devtunnel example to describe the protocol spoken by Hermes' local webhook listener.

Hermes exposes the Teams webhook as plain HTTP on port 3978. The guide configured that local devtunnel port as HTTPS, which can forward TLS traffic directly to aiohttp and produce `"UNKNOWN / HTTP/1.0" 400` before `/api/messages` is reached. The public tunnel URL remains HTTPS; the tunnel terminates TLS and forwards HTTP locally.

The production guidance now states the same boundary explicitly: terminate TLS at a reverse proxy and forward plain HTTP to the Hermes listener.

## Related Issue

No linked issue. This was identified from a support diagnostic report that captured the malformed requests at the Teams message timestamp.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Change the devtunnel port protocol from `https` to `http` in the English and zh-Hans Teams guides.
- Explain that the public endpoint uses HTTPS while Hermes' local port 3978 uses plain HTTP.
- Clarify the TLS termination requirement for production reverse proxies.
- Add troubleshooting guidance for the resulting `"UNKNOWN / HTTP/1.0" 400` signature.

## How to Test

1. Confirm `plugins/platforms/teams/adapter.py` starts `web.TCPSite` without an SSL context, so the local webhook listener uses HTTP.
2. Confirm the devtunnel command declares `--protocol http` while the registered Teams endpoint remains an `https://` URL.
3. Run `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run; documentation-only change)
- [ ] I've added tests for my changes (not applicable; documentation-only change)
- [x] I've tested on my platform: Windows 11, with focused source and diff validation

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — protocol guidance is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.
