### PR TITLE
feat(web): add native ChatGPT dashboard themes

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16411,6 +16411,21 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
     {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
     {"name": "nous-blue",     "label": "Nous Blue",           "description": "Light mode — vivid Nous-blue accents on cream canvas"},
+    {
+        "name": "chatgpt-auto",
+        "label": "ChatGPT Auto",
+        "description": "Follows your system light/dark appearance automatically",
+    },
+    {
+        "name": "chatgpt-dark",
+        "label": "ChatGPT Dark",
+        "description": "OpenAI-inspired neutral dark theme",
+    },
+    {
+        "name": "chatgpt-light",
+        "label": "ChatGPT Light",
+        "description": "OpenAI-inspired warm daytime theme",
+    },
     {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
     {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -587,6 +587,7 @@ export default function App() {
               background: "var(--component-sidebar-background)",
               clipPath: "var(--component-sidebar-clip-path)",
               borderImage: "var(--component-sidebar-border-image)",
+              boxShadow: "var(--component-sidebar-box-shadow)",
             }}
           >
             <div

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -168,7 +168,7 @@ function Block({
   switch (block.type) {
     case "code":
       return (
-        <pre className="bg-secondary/60 border border-border px-3 py-2.5 text-xs font-mono leading-relaxed overflow-x-auto">
+        <pre className="rounded-[var(--radius)] bg-secondary/60 border border-border px-3 py-2.5 text-xs font-mono leading-relaxed overflow-x-auto">
           <code>
             {block.content}
             {caret}

--- a/web/src/themes/context.tsx
+++ b/web/src/themes/context.tsx
@@ -409,6 +409,12 @@ function applyTheme(theme: DashboardTheme) {
 // ---------------------------------------------------------------------------
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
+  /** System appearance used by the virtual `chatgpt-auto` theme. */
+  const [systemPrefersDark, setSystemPrefersDark] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  });
+
   /** Name of the currently active theme (built-in id or user YAML name). */
   const [themeName, setThemeName] = useState<string>(() => {
     if (typeof window === "undefined") return "default";
@@ -421,6 +427,20 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     }
     return migrated;
   });
+
+  // Re-resolve Auto immediately whenever the OS/browser appearance changes.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemPrefersDark(event.matches);
+    };
+
+    setSystemPrefersDark(media.matches);
+    media.addEventListener("change", handleChange);
+    return () => media.removeEventListener("change", handleChange);
+  }, []);
 
   /** All selectable themes (shown in the picker). Starts with just the
    *  built-ins; the API call below merges in user themes. */
@@ -452,13 +472,19 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // only when neither a built-in nor a user theme is found.
   const resolveTheme = useCallback(
     (name: string): DashboardTheme => {
+      if (name === "chatgpt-auto") {
+        return systemPrefersDark
+          ? BUILTIN_THEMES["chatgpt-dark"]
+          : BUILTIN_THEMES["chatgpt-light"];
+      }
+
       return (
         BUILTIN_THEMES[name] ??
         userThemeDefs[name] ??
         defaultTheme
       );
     },
-    [userThemeDefs],
+    [userThemeDefs, systemPrefersDark],
   );
 
   // Apply the active theme (and re-assert the font override at its tail)

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -18,6 +18,8 @@ import type { DashboardTheme, ThemeTypography, ThemeLayout } from "./types";
 /** Default system stack — neutral, safe fallback for every platform. */
 const SYSTEM_SANS =
   'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+const CHATGPT_SANS =
+  '-apple-system-body, ui-sans-serif, -apple-system, system-ui, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol"';
 const SYSTEM_MONO =
   'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace';
 
@@ -33,6 +35,111 @@ const DEFAULT_LAYOUT: ThemeLayout = {
   radius: "0.5rem",
   density: "comfortable",
 };
+
+/**
+ * Hermes components intentionally carry a strong display identity through
+ * utility classes such as font-expanded/font-compressed, uppercase labels,
+ * wide tracking, and square bordered panels.  Palette tokens alone cannot
+ * neutralize those component-level declarations, so the ChatGPT themes use
+ * the theme system's scoped CSS layer to make the rendered controls consume
+ * the ChatGPT typography and shape language.  The style element is removed
+ * automatically whenever another theme becomes active.
+ */
+const CHATGPT_COMPONENT_CSS = `
+  #root .font-expanded,
+  #root .font-compressed,
+  #root .font-mondwest,
+  #root .font-display {
+    font-family: var(--theme-font-sans) !important;
+    font-stretch: normal !important;
+    letter-spacing: normal !important;
+  }
+
+  #root {
+    font-weight: 450;
+  }
+
+  #app-sidebar nav a,
+  #app-sidebar nav button,
+  #app-sidebar [class*="tracking-"],
+  #app-sidebar [class*="uppercase"] {
+    font-family: var(--theme-font-sans) !important;
+    font-size: 0.9375rem !important;
+    font-weight: 450 !important;
+    letter-spacing: normal !important;
+    text-transform: none !important;
+  }
+
+  #app-sidebar nav a {
+    margin-inline: 0.5rem;
+    padding-inline: 0.75rem;
+    border-radius: 0.5rem;
+  }
+
+  header h1,
+  main h1,
+  main h2,
+  main h3,
+  main [class*="tracking-"] {
+    font-family: var(--theme-font-sans) !important;
+    font-stretch: normal !important;
+    letter-spacing: normal !important;
+    text-transform: none !important;
+  }
+
+  header h1 {
+    font-size: 1.125rem !important;
+    font-weight: 600 !important;
+    line-height: 1.5rem !important;
+  }
+
+  main p,
+  main li,
+  main td,
+  main th,
+  main label,
+  main input,
+  main textarea,
+  main select {
+    font-weight: 450;
+  }
+
+  main button,
+  #app-sidebar button {
+    font-weight: 500;
+  }
+
+  main .font-compressed,
+  main .font-mondwest {
+    font-weight: 500 !important;
+  }
+
+  main .border {
+    border-color: var(--color-border) !important;
+    border-radius: var(--radius) !important;
+  }
+
+  main div.border:not([role="radiogroup"]),
+  main section.border,
+  main article.border {
+    background-color: var(--color-card) !important;
+  }
+
+  main button,
+  main input,
+  main textarea,
+  main select,
+  [role="dialog"],
+  [role="listbox"] {
+    border-radius: var(--radius) !important;
+  }
+
+  main pre,
+  main code,
+  main kbd {
+    letter-spacing: normal !important;
+  }
+`;
 
 // ---------------------------------------------------------------------------
 // Themes
@@ -228,10 +335,169 @@ export const defaultLargeTheme: DashboardTheme = {
   },
 };
 
+export const chatgptDarkTheme: DashboardTheme = {
+  name: "chatgpt-dark",
+  label: "ChatGPT Dark",
+  description: "OpenAI-inspired neutral dark theme",
+  palette: {
+    background: { hex: "#212121", alpha: 1 },
+    midground: { hex: "#ECECEC", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(255,255,255,0)",
+    noiseOpacity: 0,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: CHATGPT_SANS,
+    fontMono: `"SF Mono", ${SYSTEM_MONO}`,
+    baseSize: "17px",
+    lineHeight: "1.5",
+    letterSpacing: "0",
+  },
+  layout: { ...DEFAULT_LAYOUT, radius: "0.625rem" },
+  componentStyles: {
+    sidebar: {
+      background: "#171717",
+      boxShadow: "1px 0 0 rgba(255, 255, 255, 0.05)",
+    },
+  },
+  customCSS: CHATGPT_COMPONENT_CSS,
+  terminalBackground: "#212121",
+  terminalForeground: "#ECECEC",
+  colorOverrides: {
+    card: "#2F2F2F",
+    cardForeground: "#ECECEC",
+
+    popover: "#303030",
+    popoverForeground: "#ECECEC",
+
+    primary: "#ECECEC",
+    primaryForeground: "#0D0D0D",
+
+    secondary: "#303030",
+    secondaryForeground: "#ECECEC",
+
+    muted: "#2F2F2F",
+    mutedForeground: "#CDCDCD",
+
+    accent: "#414141",
+    accentForeground: "#ECECEC",
+
+    destructive: "#E86872",
+    destructiveForeground: "#FFFFFF",
+
+    success: "#57C785",
+
+    /* Hermes gold/yellow -> warm OpenAI-style off-white */
+    warning: "#F1EEE7",
+
+    border: "#525252",
+    input: "#414141",
+    ring: "#9B9B9B",
+  },
+  seriesColors: {
+    inputTokenAccent: "#F1EEE7",
+    outputTokenAccent: "#9B9B9B",
+  },
+  swatchColors: ["#212121", "#ECECEC", "#414141"],
+};
+
+
+export const chatgptLightTheme: DashboardTheme = {
+  name: "chatgpt-light",
+  label: "ChatGPT Light",
+  description: "ChatGPT's neutral light interface palette",
+  palette: {
+    /* Current ChatGPT neutral canvas and primary text. */
+    background: { hex: "#FCFCFC", alpha: 1 },
+    midground: { hex: "#0D0D0D", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(0,0,0,0)",
+    noiseOpacity: 0,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: CHATGPT_SANS,
+    fontMono: `"SF Mono", ${SYSTEM_MONO}`,
+    baseSize: "17px",
+    lineHeight: "1.5",
+    letterSpacing: "0",
+  },
+  layout: { ...DEFAULT_LAYOUT, radius: "0.625rem" },
+  componentStyles: {
+    sidebar: {
+      background: "#F9F9F9",
+      boxShadow: "1px 0 0 rgba(0, 0, 0, 0.05)",
+    },
+  },
+  customCSS: CHATGPT_COMPONENT_CSS,
+  terminalBackground: "#FCFCFC",
+  terminalForeground: "#0D0D0D",
+  colorOverrides: {
+    /* Elevated surfaces sit one step above the #fcfcfc canvas. */
+    card: "#FFFFFF",
+    cardForeground: "#0D0D0D",
+
+    popover: "#FFFFFF",
+    popoverForeground: "#0D0D0D",
+
+    primary: "#0D0D0D",
+    primaryForeground: "#FFFFFF",
+
+    secondary: "#E8E8E8",
+    secondaryForeground: "#0D0D0D",
+
+    muted: "#F3F3F3",
+    mutedForeground: "#5D5D5D",
+
+    accent: "#ECECEC",
+    accentForeground: "#0D0D0D",
+
+    destructive: "#D94B56",
+    destructiveForeground: "#FFFFFF",
+
+    success: "#2F9D65",
+
+    /* Warm neutral replacement for Hermes yellow */
+    warning: "#71695C",
+
+    border: "#E6E6E6",
+    input: "#D8D8D8",
+    ring: "#676767",
+  },
+  seriesColors: {
+    inputTokenAccent: "#6C6458",
+    outputTokenAccent: "#555555",
+  },
+  swatchColors: ["#FCFCFC", "#0D0D0D", "#ECECEC"],
+};
+
+export const chatgptAutoTheme: DashboardTheme = {
+  // Virtual built-in resolved by ThemeProvider to the current system variant.
+  name: "chatgpt-auto",
+  label: "ChatGPT Auto",
+  description: "Follows your system light/dark appearance automatically",
+  palette: chatgptDarkTheme.palette,
+  typography: chatgptDarkTheme.typography,
+  layout: chatgptDarkTheme.layout,
+  terminalBackground: chatgptDarkTheme.terminalBackground,
+  terminalForeground: chatgptDarkTheme.terminalForeground,
+  colorOverrides: chatgptDarkTheme.colorOverrides,
+  componentStyles: chatgptDarkTheme.componentStyles,
+  customCSS: CHATGPT_COMPONENT_CSS,
+  seriesColors: chatgptDarkTheme.seriesColors,
+  swatchColors: ["#171717", "#F7F7F5", "#AFAFAF"],
+};
+
 export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   default: defaultTheme,
   "default-large": defaultLargeTheme,
   "nous-blue": nousBlueTheme,
+
+  "chatgpt-auto": chatgptAutoTheme,
+  "chatgpt-dark": chatgptDarkTheme,
+  "chatgpt-light": chatgptLightTheme,
+
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,


### PR DESCRIPTION
## What changed

- adds ChatGPT Dark, ChatGPT Light, and ChatGPT Auto to the built-in dashboard themes
- keeps `chatgpt-auto` persisted while resolving live to the system light/dark preference
- updates automatically when `prefers-color-scheme` changes
- maps measured ChatGPT neutral palettes, system typography, surface hierarchy, borders, and radii onto Hermes
- scopes component-level typography and shape refinements to the ChatGPT themes
- adds sidebar shadow support through the existing component-style variable system
- rounds rendered Markdown code blocks using the active theme radius

## Why

This provides a durable, repository-native version of the customized dashboard appearance so it can be reviewed, rebased, and reapplied when Hermes upgrades change the web UI.

The root issue was that palette and typography tokens alone did not override Hermes' component-level display fonts, uppercase tracking, square panels, and translucent surface utilities. The ChatGPT themes therefore use Hermes' existing theme-scoped CSS mechanism to neutralize those declarations only while a ChatGPT theme is active.

## User impact

Users can select explicit ChatGPT Dark or Light themes, or choose ChatGPT Auto to follow system appearance live. Other built-in and user themes are unaffected.

## Validation

- `git diff --check`
- TypeScript/Vite production build via `npm run build`
- live `hermes-dashboard` restart and service health check
- browser verification of Dark, Light, and Auto
- computed-style verification for font family, size, weight, tracking, canvas/card/sidebar colors, borders, radii, and sidebar edge treatment
