### PR TITLE
fix(matrix): shim mautrix trace/silly log levels for OlmMachine

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -141,6 +141,30 @@ from gateway.platforms.helpers import ThreadParticipationTracker
 
 logger = logging.getLogger(__name__)
 
+
+class _MautrixCryptoLogger(logging.LoggerAdapter):
+    """Provide mautrix's non-standard trace levels on a stdlib logger.
+
+    ``OlmMachine`` types its logger as mautrix's ``TraceLogger`` and calls
+    ``trace()``/``silly()`` while handling encrypted to-device events. Those
+    methods only exist when the ``mau.crypto`` logger was created after
+    mautrix installed its custom logger class — nothing guarantees that in
+    this process, where ``logging.getLogger("mau.crypto")`` can return a
+    plain stdlib ``Logger``. A missing ``trace()`` then raises
+    ``AttributeError`` inside the crypto handler and the room-key event is
+    dropped before it is processed, silently breaking E2EE decryption.
+    """
+
+    def trace(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        self.debug(msg, *args, **kwargs)
+
+    def silly(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        self.debug(msg, *args, **kwargs)
+
+
+def _mautrix_crypto_logger() -> _MautrixCryptoLogger:
+    return _MautrixCryptoLogger(logging.getLogger("mau.crypto"), {})
+
 _MATRIX_VOICE_WAVEFORM_BINS = 30
 
 
@@ -1919,7 +1943,14 @@ class MatrixAdapter(BasePlatformAdapter):
                             )
 
                     crypto_state = _CryptoStateStore(state_store, self._joined_rooms, client)
-                    olm = OlmMachine(client, crypto_store, crypto_state)
+                    # Pass an explicit compatibility logger: in this process
+                    # ``mau.crypto`` may be a plain stdlib Logger without
+                    # mautrix's trace()/silly() extensions, and a missing
+                    # trace() aborts encrypted to-device key events.
+                    olm = OlmMachine(
+                        client, crypto_store, crypto_state,
+                        log=_mautrix_crypto_logger(),
+                    )
                     olm.share_keys_min_trust = TrustState.UNVERIFIED
                     olm.send_keys_min_trust = TrustState.UNVERIFIED
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -67,6 +67,36 @@ from gateway.platforms.helpers import ThreadParticipationTracker
 
 logger = logging.getLogger(__name__)
 
+# mautrix.util.logging mutates logging.setLoggerClass process-wide at import
+# time — the exact coupling this shim exists to remove — so use local
+# constants (values verified against mautrix 0.21.x) instead of importing it.
+_MAUTRIX_TRACE_LEVEL = 5
+_MAUTRIX_SILLY_LEVEL = 1
+
+
+class _MautrixCryptoLogger(logging.LoggerAdapter):
+    """Provide mautrix's non-standard trace levels on a stdlib logger.
+
+    ``OlmMachine`` types its logger as mautrix's ``TraceLogger`` and calls
+    ``trace()``/``silly()`` while handling encrypted to-device events. Those
+    methods only exist when the ``mau.crypto`` logger was created after
+    mautrix installed its custom logger class — nothing guarantees that in
+    this process, where ``logging.getLogger("mau.crypto")`` can return a
+    plain stdlib ``Logger``. A missing ``trace()`` then raises
+    ``AttributeError`` inside the crypto handler and the room-key event is
+    dropped before it is processed, silently breaking E2EE decryption.
+    """
+
+    def trace(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        self.log(_MAUTRIX_TRACE_LEVEL, msg, *args, **kwargs)
+
+    def silly(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+        self.log(_MAUTRIX_SILLY_LEVEL, msg, *args, **kwargs)
+
+
+def _mautrix_crypto_logger() -> _MautrixCryptoLogger:
+    return _MautrixCryptoLogger(logging.getLogger("mau.crypto"), {})
+
 _MATRIX_VOICE_WAVEFORM_BINS = 30
 
 
@@ -1216,7 +1246,14 @@ class MatrixAdapter(BasePlatformAdapter):
                     crypto_store, crypto_db, _acct_id, _pickle_key):
                 logger.warning("Matrix: crypto pickle migration failed — E2EE may not work correctly")
             crypto_state = _CryptoStateStore(state_store, self._joined_rooms, client)
-            olm = OlmMachine(client, crypto_store, crypto_state)
+            # Pass an explicit compatibility logger: in this process
+            # ``mau.crypto`` may be a plain stdlib Logger without
+            # mautrix's trace()/silly() extensions, and a missing
+            # trace() aborts encrypted to-device key events.
+            olm = OlmMachine(
+                client, crypto_store, crypto_state,
+                log=_mautrix_crypto_logger(),
+            )
             olm.share_keys_min_trust = TrustState.UNVERIFIED
             olm.send_keys_min_trust = TrustState.UNVERIFIED
             await olm.load()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -968,7 +968,8 @@ class TestMatrixAccessTokenAuth:
 
         # Patch Client constructor to return our mock
         fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
-        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(return_value=mock_olm)
+        olm_factory = MagicMock(return_value=mock_olm)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = olm_factory
 
         import plugins.platforms.matrix.adapter as matrix_mod
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
@@ -979,6 +980,8 @@ class TestMatrixAccessTokenAuth:
 
         mock_client.whoami.assert_awaited_once()
         assert adapter._user_id == "@bot:example.org"
+        from plugins.platforms.matrix.adapter import _MautrixCryptoLogger
+        assert isinstance(olm_factory.call_args.kwargs["log"], _MautrixCryptoLogger)
 
         await adapter.disconnect()
 

--- a/tests/gateway/test_matrix_crypto_logger.py
+++ b/tests/gateway/test_matrix_crypto_logger.py
@@ -1,0 +1,60 @@
+"""Regression tests: OlmMachine's crypto logger must tolerate a plain stdlib
+``mau.crypto`` logger.
+
+OlmMachine types its logger as mautrix's ``TraceLogger`` and calls
+``trace()``/``silly()`` while handling encrypted to-device events. Nothing in
+this process guarantees ``logging.getLogger("mau.crypto")`` returns that
+custom class — when it is a plain stdlib ``Logger``, the missing ``trace()``
+raises ``AttributeError`` inside the crypto handler and the room-key event is
+dropped before processing, silently breaking E2EE decryption. The adapter
+therefore passes an explicit compatibility shim to ``OlmMachine``.
+"""
+
+import logging
+
+
+class _ListHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list = []
+
+    def emit(self, record) -> None:
+        self.records.append(record)
+
+
+def _plain_logger() -> logging.Logger:
+    # Direct construction bypasses any custom logger class installed via
+    # logging.setLoggerClass, so this is guaranteed to be a plain Logger
+    # regardless of test import order.
+    plain = logging.Logger("test.mau.crypto.plain", level=logging.DEBUG)
+    assert not hasattr(plain, "trace")
+    assert not hasattr(plain, "silly")
+    return plain
+
+
+def test_crypto_logger_shim_maps_trace_and_silly_to_debug():
+    from plugins.platforms.matrix.adapter import _MautrixCryptoLogger
+
+    plain = _plain_logger()
+    handler = _ListHandler()
+    plain.addHandler(handler)
+
+    shim = _MautrixCryptoLogger(plain, {})
+    shim.trace("encrypted to-device event")
+    shim.silly("crypto detail")
+
+    assert [r.levelno for r in handler.records] == [logging.DEBUG, logging.DEBUG]
+    assert handler.records[0].getMessage() == "encrypted to-device event"
+    assert handler.records[1].getMessage() == "crypto detail"
+
+
+def test_crypto_logger_factory_wraps_mau_crypto_logger():
+    from plugins.platforms.matrix.adapter import _mautrix_crypto_logger
+
+    shim = _mautrix_crypto_logger()
+
+    assert shim.logger is logging.getLogger("mau.crypto")
+    # The shimmed logger must offer mautrix's non-standard levels no matter
+    # which class the ambient "mau.crypto" logger happens to be.
+    assert callable(shim.trace)
+    assert callable(shim.silly)

--- a/tests/gateway/test_matrix_crypto_logger.py
+++ b/tests/gateway/test_matrix_crypto_logger.py
@@ -1,0 +1,74 @@
+"""Regression tests: OlmMachine's crypto logger must tolerate a plain stdlib
+``mau.crypto`` logger.
+
+OlmMachine types its logger as mautrix's ``TraceLogger`` and calls
+``trace()``/``silly()`` while handling encrypted to-device events. Nothing in
+this process guarantees ``logging.getLogger("mau.crypto")`` returns that
+custom class — when it is a plain stdlib ``Logger``, the missing ``trace()``
+raises ``AttributeError`` inside the crypto handler and the room-key event is
+dropped before processing, silently breaking E2EE decryption. The adapter
+therefore passes an explicit compatibility shim to ``OlmMachine``.
+"""
+
+import logging
+
+
+class _ListHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list = []
+
+    def emit(self, record) -> None:
+        self.records.append(record)
+
+
+def _plain_logger() -> logging.Logger:
+    # Direct construction bypasses any custom logger class installed via
+    # logging.setLoggerClass, so this is guaranteed to be a plain Logger
+    # regardless of test import order.
+    plain = logging.Logger("test.mau.crypto.plain", level=1)
+    assert not hasattr(plain, "trace")
+    assert not hasattr(plain, "silly")
+    return plain
+
+
+def test_crypto_logger_shim_preserves_trace_and_silly_levels():
+    from plugins.platforms.matrix.adapter import _MautrixCryptoLogger
+
+    plain = _plain_logger()
+    handler = _ListHandler()
+    plain.addHandler(handler)
+
+    shim = _MautrixCryptoLogger(plain, {})
+    shim.trace("encrypted to-device event")
+    shim.silly("crypto detail")
+
+    assert [r.levelno for r in handler.records] == [5, 1]
+    assert handler.records[0].getMessage() == "encrypted to-device event"
+    assert handler.records[1].getMessage() == "crypto detail"
+
+
+def test_crypto_logger_shim_does_not_promote_trace_or_silly_to_debug():
+    from plugins.platforms.matrix.adapter import _MautrixCryptoLogger
+
+    plain = logging.Logger("test.mau.crypto.debug", level=logging.DEBUG)
+    handler = _ListHandler()
+    plain.addHandler(handler)
+
+    shim = _MautrixCryptoLogger(plain, {})
+    shim.trace("encrypted to-device event")
+    shim.silly("crypto detail")
+
+    assert handler.records == []
+
+
+def test_crypto_logger_factory_wraps_mau_crypto_logger():
+    from plugins.platforms.matrix.adapter import _mautrix_crypto_logger
+
+    shim = _mautrix_crypto_logger()
+
+    assert shim.logger is logging.getLogger("mau.crypto")
+    # The shimmed logger must offer mautrix's non-standard levels no matter
+    # which class the ambient "mau.crypto" logger happens to be.
+    assert callable(shim.trace)
+    assert callable(shim.silly)


### PR DESCRIPTION
## What

`OlmMachine` is now constructed with an explicit compatibility logger: a small `logging.LoggerAdapter` shim (`_MautrixCryptoLogger`) that provides mautrix's non-standard `trace()`/`silly()` levels at their **native values 5 and 1**.

## Why

`OlmMachine` types its logger as mautrix's `TraceLogger` and calls `self.log.trace(...)` while handling encrypted to-device events (`mautrix/crypto/machine.py`). When no `log=` is passed it falls back to `logging.getLogger("mau.crypto")` — which, depending on import order, can be a plain stdlib `Logger` without `trace()`. The first encrypted to-device event then raises `AttributeError` inside the crypto handler and the room-key event is dropped before processing, silently breaking E2EE decryption.

The shim removes the dependency on logger-class installation order entirely.

## Implementation note

The level values are **local named constants** (`_MAUTRIX_TRACE_LEVEL = 5`, `_MAUTRIX_SILLY_LEVEL = 1`), deliberately **not** imported from `mautrix.util.logging`: importing that module executes `logging.setLoggerClass(TraceLogger)` process-wide (verified in mautrix 0.21.1, `mautrix/util/logging/trace.py`), which would reintroduce the exact import-order coupling this shim exists to remove.

## Distinguishing from adjacent E2EE fixes

- Not #14956 (PgCryptoStore device-id binding) — that fixed fresh-install store binding; this fixes a crash in the to-device event path.
- Not #71067 (fresh crypto store reports pre-joined rooms as unencrypted) — that is a state-store content gap; this is a logger-class crash.

## Tests

Rebased onto current `main` at `8977ce416`. Canonical runner results on the exact head:

- `scripts/run_tests.sh tests/gateway/test_matrix.py tests/gateway/test_matrix_crypto_logger.py tests/gateway/test_matrix_plugin_setup.py tests/gateway/test_matrix_mention.py tests/gateway/test_matrix_message_length.py` → **5 files, 136 tests passed, 0 failed**
- `ruff check` on touched files → clean
- `git diff --check` → clean

Fixes #83468