### PR TITLE
fix(memory): pin hindsight-client to 0.9.0

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -144,4 +144,6 @@ Available in `hybrid` and `tools` memory modes:
 
 ## Client Version
 
-Requires `hindsight-client >= 0.6.1`. The plugin auto-upgrades on session start if an older version is detected.
+Requires `hindsight-client==0.9.0`. The plugin re-pins the client on session
+start if a different version is detected. Local embedded setup installs
+`hindsight-all` alongside the same exact client constraint.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -44,6 +44,8 @@ import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
+from packaging.version import InvalidVersion, Version
+
 from agent.secret_scope import get_secret
 
 from agent.memory_provider import MemoryProvider
@@ -55,8 +57,11 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
-# Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.6.1"
+# Keep in sync with pyproject.toml, tools/lazy_deps.py ("memory.hindsight"),
+# plugin.yaml, and uv.lock. Hermes intentionally exact-pins managed SDKs so
+# eager, lazy, setup, and runtime-repair installs converge on reviewed bytes.
+_PINNED_CLIENT_VERSION = "0.9.0"
+_CLIENT_REQUIREMENT = f"hindsight-client=={_PINNED_CLIENT_VERSION}"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
@@ -77,6 +82,16 @@ _PROVIDER_DEFAULT_MODELS = {
     "lmstudio": "local-model",
     "openai_compatible": "your-model-name",
 }
+
+
+def _client_version_supported(actual: str | None) -> bool:
+    """Return whether *actual* matches the reviewed client pin exactly."""
+    if not actual:
+        return False
+    try:
+        return Version(actual) == Version(_PINNED_CLIENT_VERSION)
+    except InvalidVersion:
+        return False
 
 
 def _parse_int_setting(value: Any, default: int) -> int:
@@ -877,10 +892,12 @@ class HindsightMemoryProvider(MemoryProvider):
         env_writes: dict = {}
 
         # Step 2: Install/upgrade deps for selected mode
-        cloud_dep = f"hindsight-client>={_MIN_CLIENT_VERSION}"
+        cloud_dep = _CLIENT_REQUIREMENT
         local_dep = "hindsight-all"
         if mode == "local_embedded":
-            deps_to_install = [local_dep]
+            # hindsight-all allows a broad client range, so constrain the
+            # client in the same solve instead of accepting transitive drift.
+            deps_to_install = [local_dep, _CLIENT_REQUIREMENT]
         elif mode == "local_external":
             deps_to_install = [cloud_dep]
         else:
@@ -1451,6 +1468,56 @@ class HindsightMemoryProvider(MemoryProvider):
             return self._session_id, "append"
         return fallback_document_id, None
 
+    def _ensure_supported_client(self) -> None:
+        """Best-effort convergence on the reviewed Hindsight client pin.
+
+        Setup, lazy install, and runtime repair must resolve the same client
+        version. Route repair through lazy_deps so sealed deployments use their
+        durable dependency target instead of trying to mutate the base image.
+        """
+        try:
+            from importlib.metadata import PackageNotFoundError, version as pkg_version
+
+            try:
+                installed = pkg_version("hindsight-client")
+            except PackageNotFoundError:
+                installed = None
+        except Exception:
+            return
+
+        if _client_version_supported(installed):
+            return
+
+        logger.warning(
+            "hindsight-client %s does not match %s; attempting to reinstall...",
+            installed or "not installed",
+            _CLIENT_REQUIREMENT,
+        )
+        try:
+            from tools.lazy_deps import install_specs
+
+            outcome = install_specs([_CLIENT_REQUIREMENT], timeout=120)
+            if outcome.ok:
+                logger.info("hindsight-client converged on %s", _CLIENT_REQUIREMENT)
+            elif outcome.blocked:
+                logger.warning(
+                    "Client repair unavailable: %s. Run: uv pip install '%s'",
+                    outcome.reason,
+                    _CLIENT_REQUIREMENT,
+                )
+            else:
+                logger.warning(
+                    "Client repair failed: %s. Run: uv pip install '%s'",
+                    (outcome.stderr or "").strip() or "install error",
+                    _CLIENT_REQUIREMENT,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Client repair failed: %s. Run: uv pip install '%s'",
+                exc,
+                _CLIENT_REQUIREMENT,
+            )
+
     def initialize(self, session_id: str, **kwargs) -> None:
         self._session_id = str(session_id or "").strip()
         self._parent_session_id = str(kwargs.get("parent_session_id", "") or "").strip()
@@ -1463,28 +1530,7 @@ class HindsightMemoryProvider(MemoryProvider):
         start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         self._document_id = f"{self._session_id}-{start_ts}"
 
-        # Check client version and auto-upgrade if needed
-        try:
-            from importlib.metadata import version as pkg_version
-            from packaging.version import Version
-            installed = pkg_version("hindsight-client")
-            if Version(installed) < Version(_MIN_CLIENT_VERSION):
-                logger.warning("hindsight-client %s is outdated (need >=%s), attempting upgrade...",
-                               installed, _MIN_CLIENT_VERSION)
-                # Environment-aware install: sealed hosted venvs redirect to the
-                # durable data-volume target instead of /opt/hermes (NS-605).
-                from tools.lazy_deps import install_specs
-                outcome = install_specs([f"hindsight-client>={_MIN_CLIENT_VERSION}"], timeout=120)
-                if outcome.ok:
-                    logger.info("hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION)
-                elif outcome.blocked:
-                    logger.warning("Auto-upgrade unavailable: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                   outcome.reason, _MIN_CLIENT_VERSION)
-                else:
-                    logger.warning("Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                   (outcome.stderr or "").strip() or "install error", _MIN_CLIENT_VERSION)
-        except Exception:
-            pass  # packaging not available or other issue — proceed anyway
+        self._ensure_supported_client()
 
         self._config = _load_config()
         self._platform = str(kwargs.get("platform") or "").strip()

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.6.1"
+  - "hindsight-client==0.9.0"
 requires_env: []
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.9.0"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==1.28.1", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
@@ -386,7 +386,7 @@ exclude-newer = "14 days"
 # request-smuggling) fix in 4.4.1, published 2026-08-03. Remove after 2026-08-17.
 # aiohttp, cryptography: same shape — the advisory fixes are newer than the
 # 14-day window, so the resolver cannot see them without an exception.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false }
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, hindsight-client = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -399,10 +399,21 @@ class TestPostSetup:
         monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-local-test")
         saved_configs = []
         monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_configs.append(cfg.copy()))
+        import tools.lazy_deps as lazy_deps_mod
+        install_calls = []
+        monkeypatch.setattr(
+            lazy_deps_mod,
+            "install_specs",
+            lambda specs, **kw: install_calls.append(tuple(specs))
+            or lazy_deps_mod.InstallSpecsResult(ok=True),
+        )
 
         provider = HindsightMemoryProvider()
         provider.post_setup(str(hermes_home), {"memory": {}})
 
+        from plugins.memory.hindsight import _CLIENT_REQUIREMENT
+
+        assert install_calls == [("hindsight-all", _CLIENT_REQUIREMENT)]
         assert saved_configs[-1]["memory"]["provider"] == "hindsight"
         env_text = (hermes_home / ".env").read_text()
         assert "HINDSIGHT_LLM_API_KEY=sk-local-test\n" in env_text
@@ -1313,13 +1324,13 @@ class TestPostSetupEnvEncoding:
         assert "﻿" not in content
 
 
-class TestClientAutoUpgradeRoutesThroughLazyDeps:
-    """The initialize()-time hindsight-client auto-upgrade must go through
+class TestClientPinConvergenceRoutesThroughLazyDeps:
+    """The initialize()-time hindsight-client repair must go through
     lazy_deps.install_specs() (environment-aware, durable-target on sealed
     hosted venvs) — never a direct `uv pip install --python sys.executable`
     subprocess, which fails with EROFS/EACCES on immutable images (NS-605)."""
 
-    def _init_with_outdated_client(self, tmp_path, monkeypatch, outcome):
+    def _init_with_client_version(self, tmp_path, monkeypatch, outcome, installed):
         import importlib.metadata as md
         import subprocess as subprocess_mod
         import tools.lazy_deps as lazy_deps_mod
@@ -1331,8 +1342,7 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
             "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
         )
 
-        # Simulate an installed-but-outdated client.
-        monkeypatch.setattr(md, "version", lambda name: "0.0.1")
+        monkeypatch.setattr(md, "version", lambda name: installed)
 
         calls = []
         monkeypatch.setattr(
@@ -1349,14 +1359,29 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         provider.initialize(session_id="s", hermes_home=str(tmp_path), platform="cli")
         return calls
 
-    def test_upgrade_uses_install_specs_not_subprocess(self, tmp_path, monkeypatch):
-        from plugins.memory.hindsight import _MIN_CLIENT_VERSION
+    @pytest.mark.parametrize("installed", ["0.8.5", "0.9.1", "invalid"])
+    def test_version_drift_uses_exact_install_spec(
+        self, tmp_path, monkeypatch, installed
+    ):
+        from plugins.memory.hindsight import _CLIENT_REQUIREMENT
         from tools.lazy_deps import InstallSpecsResult
 
-        calls = self._init_with_outdated_client(
-            tmp_path, monkeypatch, InstallSpecsResult(ok=True)
+        calls = self._init_with_client_version(
+            tmp_path, monkeypatch, InstallSpecsResult(ok=True), installed
         )
-        assert calls == [(f"hindsight-client>={_MIN_CLIENT_VERSION}",)]
+        assert calls == [(_CLIENT_REQUIREMENT,)]
+
+    def test_matching_pin_is_left_untouched(self, tmp_path, monkeypatch):
+        from plugins.memory.hindsight import _PINNED_CLIENT_VERSION
+        from tools.lazy_deps import InstallSpecsResult
+
+        calls = self._init_with_client_version(
+            tmp_path,
+            monkeypatch,
+            InstallSpecsResult(ok=True),
+            _PINNED_CLIENT_VERSION,
+        )
+        assert calls == []
 
     def test_blocked_upgrade_is_nonfatal_and_surfaces_reason(
         self, tmp_path, monkeypatch, caplog
@@ -1365,10 +1390,11 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         from tools.lazy_deps import InstallSpecsResult
 
         with caplog.at_level(logging.WARNING):
-            calls = self._init_with_outdated_client(
+            calls = self._init_with_client_version(
                 tmp_path, monkeypatch,
                 InstallSpecsResult(ok=False, blocked=True,
                                    reason="runtime installs are disabled on this deployment"),
+                "0.8.5",
             )
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -4,6 +4,7 @@ import tomllib
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -246,6 +247,38 @@ def test_pyproject_pins_are_internally_consistent():
         "pyproject.toml exact-pins the same package to different versions "
         "across [project.dependencies] / extras: " + str(conflicts)
     )
+
+
+def test_hindsight_client_pin_is_consistent_across_managed_surfaces():
+    """Every Hermes-managed Hindsight install path must use one exact pin."""
+    pyproject = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    pyproject_specs = pyproject["project"]["optional-dependencies"]["hindsight"]
+    lazy_specs = _lazy_deps_by_feature()["memory.hindsight"]
+    plugin = yaml.safe_load(
+        (REPO_ROOT / "plugins/memory/hindsight/plugin.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    plugin_specs = plugin["pip_dependencies"]
+
+    provider_source = (
+        REPO_ROOT / "plugins/memory/hindsight/__init__.py"
+    ).read_text(encoding="utf-8")
+    match = re.search(
+        r'^_PINNED_CLIENT_VERSION\s*=\s*["\']([^"\']+)["\']',
+        provider_source,
+        re.MULTILINE,
+    )
+    assert match, "provider is missing _PINNED_CLIENT_VERSION"
+    version = match.group(1)
+    requirement = f"hindsight-client=={version}"
+
+    assert pyproject_specs == [requirement]
+    assert lazy_specs == [requirement]
+    assert plugin_specs == [requirement]
+    assert _locked_versions("hindsight-client") == {version}
 
 
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,7 +191,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.9.0",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/uv.lock
+++ b/uv.lock
@@ -12,12 +12,13 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
+h2 = false
 vercel = false
 aiohttp = false
+hindsight-client = false
 cryptography = false
 nemo-relay = false
 huggingface-hub = false
-h2 = false
 
 [manifest]
 overrides = [
@@ -1856,7 +1857,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.9.0" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
@@ -1951,7 +1952,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-client"
-version = "0.6.1"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1961,9 +1962,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/26/8b8efa4be21fc3ba12ade3b1353d87f9837ec0d3ec2607e8adbf85bc9c63/hindsight_client-0.6.1.tar.gz", hash = "sha256:314d0bb9e13622e15586ba1586a799726d405b27bc20d78872474b5d6d96cd51", size = 99833, upload-time = "2026-05-08T13:01:23.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/be/ecb3537daa76ac0596c48870da29955a46e171090111ff78a86820b1020d/hindsight_client-0.9.0.tar.gz", hash = "sha256:ed1c3455efc1d458dd68c7d4b282d6283a0e32d9b9909fa5e21b21b22f8b02ab", size = 140545, upload-time = "2026-08-07T16:17:20.876Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/a1d0bc33ef933ecc52e76dc1514163594d25836a5d303c256a61bb61445d/hindsight_client-0.6.1-py3-none-any.whl", hash = "sha256:9fdda176ab50f7cec8d7339c6608c148f0cd9ad7e65d9d76192f2db730bc330a", size = 249379, upload-time = "2026-05-08T13:01:22.035Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1c/9560bfe762e697512f284b91f5c848424cca9034642fb6d20a9c8730bb71/hindsight_client-0.9.0-py3-none-any.whl", hash = "sha256:ba16ee921ff652a3fa0bc3392aba9ce440b457327a44a1cd168e7c3762926181", size = 343365, upload-time = "2026-08-07T16:17:19.51Z" },
 ]
 
 [[package]]

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -432,7 +432,7 @@ hermes config set memory.provider hindsight
 echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 ```
 
-The setup wizard installs dependencies automatically and only installs what's needed for the selected mode (`hindsight-client` for cloud, `hindsight-all` for local). Requires `hindsight-client >= 0.4.22` (auto-upgraded on session start if outdated).
+The setup wizard installs dependencies automatically and only installs what's needed for the selected mode (`hindsight-client` for cloud or local-external, `hindsight-all` plus the exact client constraint for local-embedded). Requires `hindsight-client==0.9.0` (re-pinned on session start if a different version is installed).
 
 **Local mode UI:** `hindsight-embed -p hermes ui start`
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -344,7 +344,7 @@ hermes config set memory.provider hindsight
 echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 ```
 
-安装向导会自动安装依赖，并仅安装所选模式所需的内容（云端用 `hindsight-client`，本地用 `hindsight-all`）。需要 `hindsight-client >= 0.4.22`（会话启动时若版本过旧则自动升级）。
+安装向导会自动安装依赖，并仅安装所选模式所需的内容（云端或本地外部模式使用 `hindsight-client`；本地嵌入模式使用 `hindsight-all` 并同时施加精确的客户端约束）。需要 `hindsight-client==0.9.0`（会话启动时若安装了其他版本，将自动重新固定到该版本）。
 
 **本地模式 UI：** `hindsight-embed -p hermes ui start`
 


### PR DESCRIPTION
## Summary

- bump every Hermes-managed Hindsight client surface from `0.6.1` to the reviewed exact pin `0.9.0`
- converge eager, lazy, setup, local-embedded, and runtime-repair paths on `hindsight-client==0.9.0`
- preserve current main's environment-aware `lazy_deps.install_specs()` repair path for sealed deployments
- re-pin missing, invalid, older, or newer client versions without making provider initialization fatal
- add cross-surface drift guards, provider regression tests, and updated English/Chinese documentation

## Why a successor

This is a current-main successor to #61263, not a clean-room duplicate.

#61263 established the exact-pin and install-path convergence design for `0.8.5`, but its branch no longer merges cleanly and its `<0.9` boundary excludes the current stable client. This PR ports that design to `0.9.0` on current `main` and adapts it to the newer lazy-dependency repair path that routes installs to durable targets on sealed deployments.

Nikita Popov (`@arcticloud`), author of #61263, is credited as a co-author on the commit.

Closes #61198.
Addresses #39424.

## Behavior

- cloud and local-external setup install the exact client pin
- local-embedded setup installs `hindsight-all` and constrains its transitive client in the same solve
- session initialization leaves `0.9.0` untouched and repairs drift on either side of the pin
- blocked or failed runtime repair remains non-fatal and emits an actionable install hint
- metadata tests keep provider, plugin, optional extra, lazy dependency, and lockfile versions aligned

## Verification

- `uv lock --check`
- `ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py tests/test_packaging_metadata.py tools/lazy_deps.py`
- 164 focused provider/metadata/lazy-dependency tests passed; 2 expected Windows-only skips on macOS
- 13 CLI memory setup/status/reset tests passed
- structured Codex autoreview (`gpt-5.6-sol`, P0-P2): no accepted/actionable findings
- branch rebased onto `49c632310dd6877302e8dfa92e740b0ceddb97b8`
