### PR TITLE
feat(whatsapp): add isolated named consumers and reactions

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -362,11 +362,18 @@ def _bridge_runtime_hash(bridge_path: Path) -> str:
 
     digest = hashlib.sha256()
     try:
-        for filename in ("bridge.js", "message_consumers.js", "reaction.js"):
+        runtime_files = json.loads(
+            (bridge_path.parent / "runtime-files.json").read_text(encoding="utf-8")
+        )
+        if not isinstance(runtime_files, list) or not all(
+            isinstance(filename, str) and filename for filename in runtime_files
+        ):
+            return ""
+        for filename in runtime_files:
             digest.update(filename.encode("utf-8"))
             digest.update(b"\0")
             digest.update((bridge_path.parent / filename).read_bytes())
-    except OSError:
+    except (OSError, ValueError):
         return ""
     return digest.hexdigest()[:16]
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -356,6 +356,35 @@ def _file_content_hash(path: Path) -> str:
         return ""
 
 
+def _bridge_runtime_hash(bridge_path: Path) -> str:
+    """Hash bridge.js plus feature modules loaded by the long-lived process."""
+    import hashlib
+
+    digest = hashlib.sha256()
+    try:
+        for filename in ("bridge.js", "message_consumers.js", "reaction.js"):
+            digest.update(filename.encode("utf-8"))
+            digest.update(b"\0")
+            digest.update((bridge_path.parent / filename).read_bytes())
+    except OSError:
+        return ""
+    return digest.hexdigest()[:16]
+
+
+def _consumer_routes_json(config: Any) -> str:
+    """Return one deterministic representation for subprocess and reuse checks."""
+    extra = getattr(config, "extra", None)
+    if not isinstance(extra, dict):
+        return ""
+    routes = extra.get("consumer_routes")
+    if not routes:
+        return ""
+    try:
+        return json.dumps(routes, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return ""
+
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
@@ -571,6 +600,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # `hermes update` bumps the Baileys pin).  The stamp file records
             # the package.json hash of the last successful install.
             bridge_dir = bridge_path.parent
+            consumer_routes_json = _consumer_routes_json(self.config)
             _pkg_json = bridge_dir / "package.json"
             _dep_stamp = bridge_dir / "node_modules" / ".hermes-pkg-hash"
             _pkg_hash = _file_content_hash(_pkg_json)
@@ -628,18 +658,22 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                             bridge_status = data.get("status", "unknown")
                             if bridge_status == "connected":
                                 # Staleness handshake: only reuse a running
-                                # bridge if it is serving the same bridge.js
-                                # that is on disk right now.  A long-lived
+                                # bridge if it is serving the same runtime
+                                # modules that are on disk right now. A long-lived
                                 # bridge survives gateway restarts AND
                                 # `hermes update`, so without this check it
                                 # keeps serving pre-update code forever
                                 # (e.g. no inbound media download).  Old
-                                # bridges that don't report scriptHash are
+                                # bridges that don't report runtimeHash are
                                 # treated as stale by definition.
-                                running_hash = data.get("scriptHash", "")
-                                disk_hash = _file_content_hash(bridge_path)
+                                running_hash = data.get("runtimeHash", "")
+                                disk_hash = _bridge_runtime_hash(bridge_path)
                                 running_read_receipts = bool(data.get("sendReadReceipts", False))
-                                config_matches = running_read_receipts == self._send_read_receipts
+                                running_consumer_routes = data.get("consumerRoutesJson", "")
+                                config_matches = (
+                                    running_read_receipts == self._send_read_receipts
+                                    and running_consumer_routes == consumer_routes_json
+                                )
                                 if (
                                     running_hash
                                     and disk_hash
@@ -655,7 +689,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 stale_reason = (
                                     f"running={running_hash or 'unversioned'}, disk={disk_hash}"
                                     if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
+                                    else "WhatsApp bridge config changed"
                                 )
                                 print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
                             else:
@@ -690,12 +724,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # only by the local Node bridge. This keeps the Python gateway on
             # its unchanged default queue while another local integration can
             # poll a named queue without racing it.
-            consumer_routes = self.config.extra.get("consumer_routes")
-            if consumer_routes:
-                try:
-                    bridge_env["WHATSAPP_CONSUMER_ROUTES_JSON"] = json.dumps(consumer_routes)
-                except (TypeError, ValueError):
-                    logger.warning("[%s] Ignoring non-serializable consumer_routes", self.name)
+            if consumer_routes_json:
+                bridge_env["WHATSAPP_CONSUMER_ROUTES_JSON"] = consumer_routes_json
             # Under multiplexing, the bridge subprocess runs with a copy of
             # os.environ that does NOT contain the secondary profile's .env
             # vars.  Inject the resolved WHATSAPP_* values so the Node bridge

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -16,6 +16,7 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+import json
 import logging
 import os
 import platform
@@ -685,6 +686,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
                 "true" if self._send_read_receipts else "false"
             )
+            # Optional command routes are declared in config.yaml but consumed
+            # only by the local Node bridge. This keeps the Python gateway on
+            # its unchanged default queue while another local integration can
+            # poll a named queue without racing it.
+            consumer_routes = self.config.extra.get("consumer_routes")
+            if consumer_routes:
+                try:
+                    bridge_env["WHATSAPP_CONSUMER_ROUTES_JSON"] = json.dumps(consumer_routes)
+                except (TypeError, ValueError):
+                    logger.warning("[%s] Ignoring non-serializable consumer_routes", self.name)
             # Under multiplexing, the bridge subprocess runs with a copy of
             # os.environ that does NOT contain the secondary profile's .env
             # vars.  Inject the resolved WHATSAPP_* values so the Node bridge

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -34,6 +34,12 @@ import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
+  createMessageConsumerQueues,
+  normalizeConsumerId,
+  parseConsumerRoutes,
+  selectConsumerForEvent,
+} from './message_consumers.js';
+import {
   buildPollPayload,
   createReconnectScheduler,
   createVersionResolver,
@@ -267,9 +273,18 @@ let lidToPhone = buildLidMap();
 
 const logger = pino({ level: 'warn' });
 
-// Message queue for polling
-const messageQueue = [];
+// The gateway continues to poll the default queue.  Explicitly configured
+// command routes may instead target a named local consumer, allowing a second
+// local integration without a race to drain the one Baileys socket.
 const MAX_QUEUE_SIZE = 100;
+const messageConsumers = createMessageConsumerQueues(MAX_QUEUE_SIZE);
+const CONSUMER_ROUTES = parseConsumerRoutes(process.env.WHATSAPP_CONSUMER_ROUTES_JSON);
+
+function enqueueInboundEvent(event) {
+  const consumer = selectConsumerForEvent(event, CONSUMER_ROUTES);
+  messageConsumers.enqueue(event, consumer);
+  return consumer;
+}
 
 // Track recently sent message IDs.  Two purposes:
 //   1. Prevent echo-back loops with media in self-chat mode.
@@ -375,10 +390,7 @@ function enqueuePollUpdateEvent({ key, update, selectedOptions, aggregation }) {
     botIds: [],
     timestamp: Math.floor(Date.now() / 1000),
   };
-  messageQueue.push(event);
-  if (messageQueue.length > MAX_QUEUE_SIZE) {
-    messageQueue.shift();
-  }
+  enqueueInboundEvent(event);
 }
 
 function rememberSentId(id) {
@@ -760,7 +772,7 @@ async function startSocket() {
       }
 
       messageStore.remember(msg);
-      messageQueue.push(event);
+      const consumer = enqueueInboundEvent(event);
       emitDebugEvent({
         stage: 'queued',
         chatId: redactWhatsAppId(chatId),
@@ -769,11 +781,9 @@ async function startSocket() {
         bodyLength: event.body.length,
         hasMedia: event.hasMedia,
         mediaType: event.mediaType,
-        queueLength: messageQueue.length,
+        consumer,
+        queueLength: messageConsumers.defaultQueueLength(),
       });
-      if (messageQueue.length > MAX_QUEUE_SIZE) {
-        messageQueue.shift();
-      }
     }
   });
 }
@@ -815,8 +825,11 @@ app.use((req, res, next) => {
 
 // Poll for new messages (long-poll style)
 app.get('/messages', (req, res) => {
-  const msgs = messageQueue.splice(0, messageQueue.length);
-  res.json(msgs);
+  const consumer = normalizeConsumerId(req.query.consumer);
+  if (!consumer) {
+    return res.status(400).json({ error: 'Invalid consumer identifier' });
+  }
+  return res.json(messageConsumers.drain(consumer));
 });
 
 // Send a message
@@ -1107,7 +1120,8 @@ app.get('/chat/:id', async (req, res) => {
 app.get('/health', (req, res) => {
   res.json({
     status: connectionState,
-    queueLength: messageQueue.length,
+    queueLength: messageConsumers.defaultQueueLength(),
+    consumerQueueLengths: messageConsumers.lengths(),
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -850,6 +850,34 @@ app.get('/messages', (req, res) => {
   return res.json(messages);
 });
 
+// Lease one named-consumer message. Existing destructive polling remains
+// available for the gateway and legacy consumers.
+app.get('/messages/lease', (req, res) => {
+  const consumer = normalizeConsumerId(req.query.consumer);
+  const leaseMs = Math.min(3600000, Math.max(10000, Number(req.query.leaseMs) || 60000));
+  if (!consumer || consumer === 'default') {
+    return res.status(400).json({ error: 'A named consumer is required' });
+  }
+  const deliveries = messageConsumers.lease(consumer, leaseMs, 1);
+  if (deliveries === null) {
+    return res.status(404).json({ error: 'Consumer is not configured' });
+  }
+  return res.json(deliveries);
+});
+
+app.post('/messages/ack', (req, res) => {
+  const consumer = normalizeConsumerId(req.body?.consumer);
+  const deliveryId = typeof req.body?.deliveryId === 'string' ? req.body.deliveryId : '';
+  if (!consumer || consumer === 'default' || !deliveryId) {
+    return res.status(400).json({ error: 'consumer and deliveryId are required' });
+  }
+  const acknowledged = messageConsumers.ack(consumer, deliveryId);
+  if (acknowledged === null) {
+    return res.status(404).json({ error: 'Consumer is not configured' });
+  }
+  return res.json({ success: true, acknowledged });
+});
+
 // Send a message
 app.post('/send', async (req, res) => {
   if (!sock || connectionState !== 'connected') {

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -11,6 +11,7 @@
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
  *   POST /send-location  - Send location pin { chatId, latitude, longitude, name?, address? }
+ *   POST /react          - React to a message { chatId, messageId, emoji, fromMe?, participant? }
  *   POST /typing         - Send typing indicator { chatId }
  *   GET  /chat/:id       - Get chat info
  *   GET  /health         - Health check
@@ -33,6 +34,7 @@ import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { parseReactionRequest } from './reaction.js';
 import {
   createMessageConsumerQueues,
   normalizeConsumerId,
@@ -1064,6 +1066,26 @@ app.post('/typing', async (req, res) => {
     res.json({ success: true });
   } catch (err) {
     res.json({ success: false });
+  }
+});
+
+// React through the same serialized socket queue as message sends. The full
+// inbound key keeps direct and group reactions attached to the right message.
+app.post('/react', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected' });
+  }
+
+  const parsed = parseReactionRequest(req.body);
+  if (!parsed.ok) {
+    return res.status(400).json({ error: parsed.error });
+  }
+
+  try {
+    await sendWithTimeout(parsed.chatId, parsed.payload);
+    return res.json({ success: true, reaction: parsed.payload.react.text ? 'added' : 'removed' });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
   }
 });
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -116,7 +116,10 @@ try {
   const bridgeFile = fileURLToPath(import.meta.url);
   SCRIPT_HASH = createHash('sha256').update(readFileSync(bridgeFile)).digest('hex').slice(0, 16);
   const runtimeHasher = createHash('sha256');
-  for (const fileName of ['bridge.js', 'message_consumers.js', 'reaction.js']) {
+  const runtimeFiles = JSON.parse(
+    readFileSync(path.join(path.dirname(bridgeFile), 'runtime-files.json'), 'utf8'),
+  );
+  for (const fileName of runtimeFiles) {
     runtimeHasher.update(fileName).update('\0').update(readFileSync(path.join(path.dirname(bridgeFile), fileName)));
   }
   RUNTIME_HASH = runtimeHasher.digest('hex').slice(0, 16);

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -11,7 +11,7 @@
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
  *   POST /send-location  - Send location pin { chatId, latitude, longitude, name?, address? }
- *   POST /react          - React to a message { chatId, messageId, emoji, fromMe?, participant? }
+ *   POST /react          - React to a message { key, emoji }
  *   POST /typing         - Send typing indicator { chatId }
  *   GET  /chat/:id       - Get chat info
  *   GET  /health         - Health check
@@ -104,17 +104,22 @@ const DOCUMENT_CACHE_DIR = process.env.HERMES_DOCUMENT_CACHE_DIR
 const AUDIO_CACHE_DIR = process.env.HERMES_AUDIO_CACHE_DIR
   || path.join(process.env.HOME || '~', '.hermes', 'audio_cache');
 
-// Self-hash of this script file.  Reported in /health so the Python gateway
-// can detect a running bridge that predates the current bridge.js and
+// Runtime hash of the bridge and locally imported feature modules. Reported
+// in /health so the Python gateway can detect a running bridge that predates
+// any of the code currently on disk and
 // restart it instead of silently reusing stale code (stale-bridge trap:
 // `hermes update` updates bridge.js on disk but a long-lived bridge process
 // keeps serving the old behavior forever).
 let SCRIPT_HASH = '';
+let RUNTIME_HASH = '';
 try {
-  SCRIPT_HASH = createHash('sha256')
-    .update(readFileSync(fileURLToPath(import.meta.url)))
-    .digest('hex')
-    .slice(0, 16);
+  const bridgeFile = fileURLToPath(import.meta.url);
+  SCRIPT_HASH = createHash('sha256').update(readFileSync(bridgeFile)).digest('hex').slice(0, 16);
+  const runtimeHasher = createHash('sha256');
+  for (const fileName of ['bridge.js', 'message_consumers.js', 'reaction.js']) {
+    runtimeHasher.update(fileName).update('\0').update(readFileSync(path.join(path.dirname(bridgeFile), fileName)));
+  }
+  RUNTIME_HASH = runtimeHasher.digest('hex').slice(0, 16);
 } catch {}
 const PAIR_ONLY = args.includes('--pair-only');
 const PAIR_JSON = args.includes('--pair-json');
@@ -279,8 +284,12 @@ const logger = pino({ level: 'warn' });
 // command routes may instead target a named local consumer, allowing a second
 // local integration without a race to drain the one Baileys socket.
 const MAX_QUEUE_SIZE = 100;
-const messageConsumers = createMessageConsumerQueues(MAX_QUEUE_SIZE);
 const CONSUMER_ROUTES = parseConsumerRoutes(process.env.WHATSAPP_CONSUMER_ROUTES_JSON);
+const CONSUMER_ROUTES_JSON = process.env.WHATSAPP_CONSUMER_ROUTES_JSON || '';
+const messageConsumers = createMessageConsumerQueues(
+  MAX_QUEUE_SIZE,
+  CONSUMER_ROUTES.map(route => route.consumer),
+);
 
 function enqueueInboundEvent(event) {
   const consumer = selectConsumerForEvent(event, CONSUMER_ROUTES);
@@ -831,7 +840,11 @@ app.get('/messages', (req, res) => {
   if (!consumer) {
     return res.status(400).json({ error: 'Invalid consumer identifier' });
   }
-  return res.json(messageConsumers.drain(consumer));
+  const messages = messageConsumers.drain(consumer);
+  if (messages === null) {
+    return res.status(404).json({ error: 'Consumer is not configured' });
+  }
+  return res.json(messages);
 });
 
 // Send a message
@@ -1146,6 +1159,8 @@ app.get('/health', (req, res) => {
     consumerQueueLengths: messageConsumers.lengths(),
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
+    runtimeHash: RUNTIME_HASH,
+    consumerRoutesJson: CONSUMER_ROUTES_JSON,
     sendReadReceipts: SEND_READ_RECEIPTS,
   });
 });

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -483,12 +483,9 @@ export async function extractBridgeEvent({
     quotedText,
     hasQuotedMessage,
     botIds,
-    readReceiptKey: {
-      remoteJid: msg.key.remoteJid || chatId,
-      id: msg.key.id,
-      participant: msg.key.participant || senderId,
-      fromMe: Boolean(msg.key.fromMe),
-    },
+    // Preserve all Baileys addressing fields. This key is used for both read
+    // receipts and reactions, including LID/group variants.
+    readReceiptKey: { ...msg.key },
     timestamp: msg.messageTimestamp,
   };
 }

--- a/scripts/whatsapp-bridge/message_consumers.js
+++ b/scripts/whatsapp-bridge/message_consumers.js
@@ -1,0 +1,99 @@
+/**
+ * Bounded, named inbound-message queues for the WhatsApp bridge.
+ *
+ * The default queue preserves the existing gateway contract.  Optional named
+ * consumers may be selected by declarative routes supplied by the gateway;
+ * this keeps one Baileys socket authoritative while preventing two pollers
+ * from racing to drain the same messages.
+ */
+
+const DEFAULT_CONSUMER = 'default';
+const CONSUMER_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
+
+export function normalizeConsumerId(value) {
+  if (value === undefined || value === null || String(value).trim() === '') {
+    return DEFAULT_CONSUMER;
+  }
+  const consumer = String(value).trim().toLowerCase();
+  return CONSUMER_RE.test(consumer) ? consumer : null;
+}
+
+function normalizeRoute(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const consumer = normalizeConsumerId(raw.consumer);
+  const prefix = typeof raw.prefix === 'string' ? raw.prefix.trim() : '';
+  const chatValues = raw.chat_ids ?? raw.chatIds;
+  if (!consumer || consumer === DEFAULT_CONSUMER || !prefix || !Array.isArray(chatValues)) {
+    return null;
+  }
+  const chatIds = new Set(
+    chatValues.map(value => String(value || '').trim()).filter(Boolean),
+  );
+  if (chatIds.size === 0) return null;
+  return { consumer, prefix: prefix.toLowerCase(), chatIds };
+}
+
+export function parseConsumerRoutes(raw) {
+  if (!raw) return [];
+  let values;
+  try {
+    values = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(values)) return [];
+  return values.map(normalizeRoute).filter(Boolean).slice(0, 16);
+}
+
+export function selectConsumerForEvent(event, routes) {
+  const chatId = String(event?.chatId || '').trim();
+  const body = String(event?.body || '').trimStart().toLowerCase();
+  for (const route of routes || []) {
+    const exactPrefix = body === route.prefix;
+    const prefixedCommand = body.startsWith(`${route.prefix} `)
+      || body.startsWith(`${route.prefix}\n`);
+    if (route.chatIds.has(chatId) && (exactPrefix || prefixedCommand)) {
+      return route.consumer;
+    }
+  }
+  return DEFAULT_CONSUMER;
+}
+
+export function createMessageConsumerQueues(limit = 100) {
+  const maxQueueSize = Number.isInteger(limit) && limit > 0 ? limit : 100;
+  const defaultQueue = [];
+  const namedQueues = new Map();
+
+  function pushBounded(queue, event) {
+    queue.push(event);
+    if (queue.length > maxQueueSize) queue.shift();
+  }
+
+  function queueFor(consumer) {
+    if (consumer === DEFAULT_CONSUMER) return defaultQueue;
+    let queue = namedQueues.get(consumer);
+    if (!queue) {
+      queue = [];
+      namedQueues.set(consumer, queue);
+    }
+    return queue;
+  }
+
+  function enqueue(event, consumer = DEFAULT_CONSUMER) {
+    pushBounded(queueFor(consumer), event);
+  }
+
+  function drain(consumer = DEFAULT_CONSUMER) {
+    const queue = queueFor(consumer);
+    return queue.splice(0, queue.length);
+  }
+
+  function lengths() {
+    return Object.fromEntries([
+      [DEFAULT_CONSUMER, defaultQueue.length],
+      ...Array.from(namedQueues, ([consumer, queue]) => [consumer, queue.length]),
+    ]);
+  }
+
+  return { enqueue, drain, lengths, defaultQueueLength: () => defaultQueue.length };
+}

--- a/scripts/whatsapp-bridge/message_consumers.js
+++ b/scripts/whatsapp-bridge/message_consumers.js
@@ -46,6 +46,9 @@ export function parseConsumerRoutes(raw) {
 }
 
 export function selectConsumerForEvent(event, routes) {
+  // Named command routes are owner-DM only. A group conversation can be on
+  // the allowlist while still containing participants who are not the owner.
+  if (event?.isGroup === true) return DEFAULT_CONSUMER;
   const chatId = String(event?.chatId || '').trim();
   const body = String(event?.body || '').trimStart().toLowerCase();
   for (const route of routes || []) {
@@ -59,10 +62,15 @@ export function selectConsumerForEvent(event, routes) {
   return DEFAULT_CONSUMER;
 }
 
-export function createMessageConsumerQueues(limit = 100) {
+export function createMessageConsumerQueues(limit = 100, configuredConsumers = []) {
   const maxQueueSize = Number.isInteger(limit) && limit > 0 ? limit : 100;
   const defaultQueue = [];
-  const namedQueues = new Map();
+  const namedQueues = new Map(
+    configuredConsumers
+      .map(normalizeConsumerId)
+      .filter(consumer => consumer && consumer !== DEFAULT_CONSUMER)
+      .map(consumer => [consumer, []]),
+  );
 
   function pushBounded(queue, event) {
     queue.push(event);
@@ -71,20 +79,19 @@ export function createMessageConsumerQueues(limit = 100) {
 
   function queueFor(consumer) {
     if (consumer === DEFAULT_CONSUMER) return defaultQueue;
-    let queue = namedQueues.get(consumer);
-    if (!queue) {
-      queue = [];
-      namedQueues.set(consumer, queue);
-    }
-    return queue;
+    return namedQueues.get(consumer) || null;
   }
 
   function enqueue(event, consumer = DEFAULT_CONSUMER) {
-    pushBounded(queueFor(consumer), event);
+    const queue = queueFor(consumer);
+    if (!queue) return false;
+    pushBounded(queue, event);
+    return true;
   }
 
   function drain(consumer = DEFAULT_CONSUMER) {
     const queue = queueFor(consumer);
+    if (!queue) return null;
     return queue.splice(0, queue.length);
   }
 

--- a/scripts/whatsapp-bridge/message_consumers.js
+++ b/scripts/whatsapp-bridge/message_consumers.js
@@ -19,18 +19,29 @@ export function normalizeConsumerId(value) {
 }
 
 function normalizeRoute(raw) {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('Consumer route must be an object');
+  }
   const consumer = normalizeConsumerId(raw.consumer);
   const prefix = typeof raw.prefix === 'string' ? raw.prefix.trim() : '';
+  const matchAll = raw.match_all === true || raw.matchAll === true;
   const chatValues = raw.chat_ids ?? raw.chatIds;
-  if (!consumer || consumer === DEFAULT_CONSUMER || !prefix || !Array.isArray(chatValues)) {
-    return null;
+  if (!consumer || consumer === DEFAULT_CONSUMER) {
+    throw new Error('Consumer route requires a named non-default consumer');
+  }
+  if (Boolean(prefix) === matchAll) {
+    throw new Error('Consumer route requires exactly one of prefix or match_all');
+  }
+  if (!Array.isArray(chatValues)) {
+    throw new Error('Consumer route requires a chat_ids array');
   }
   const chatIds = new Set(
     chatValues.map(value => String(value || '').trim()).filter(Boolean),
   );
-  if (chatIds.size === 0) return null;
-  return { consumer, prefix: prefix.toLowerCase(), chatIds };
+  if (chatIds.size === 0) {
+    throw new Error('Consumer route requires at least one chat ID');
+  }
+  return { consumer, prefix: prefix.toLowerCase(), matchAll, chatIds };
 }
 
 export function parseConsumerRoutes(raw) {
@@ -38,11 +49,32 @@ export function parseConsumerRoutes(raw) {
   let values;
   try {
     values = typeof raw === 'string' ? JSON.parse(raw) : raw;
-  } catch {
-    return [];
+  } catch (error) {
+    throw new Error(`Invalid consumer routes JSON: ${error.message}`);
   }
-  if (!Array.isArray(values)) return [];
-  return values.map(normalizeRoute).filter(Boolean).slice(0, 16);
+  if (!Array.isArray(values) || values.length > 16) {
+    throw new Error('Consumer routes must be an array with at most 16 entries');
+  }
+  const routes = values.map(normalizeRoute);
+  const catchAllChats = new Set();
+  const prefixKeys = new Set();
+  for (const route of routes) {
+    for (const chatId of route.chatIds) {
+      if (route.matchAll) {
+        if (catchAllChats.has(chatId)) {
+          throw new Error(`Duplicate catch-all consumer route for chat ${chatId}`);
+        }
+        catchAllChats.add(chatId);
+      } else {
+        const key = `${chatId}\0${route.prefix}`;
+        if (prefixKeys.has(key)) {
+          throw new Error(`Duplicate prefix consumer route for chat ${chatId}`);
+        }
+        prefixKeys.add(key);
+      }
+    }
+  }
+  return routes;
 }
 
 export function selectConsumerForEvent(event, routes) {
@@ -51,11 +83,19 @@ export function selectConsumerForEvent(event, routes) {
   if (event?.isGroup === true) return DEFAULT_CONSUMER;
   const chatId = String(event?.chatId || '').trim();
   const body = String(event?.body || '').trimStart().toLowerCase();
-  for (const route of routes || []) {
+  const prefixRoutes = (routes || [])
+    .filter(route => !route.matchAll)
+    .sort((left, right) => right.prefix.length - left.prefix.length);
+  for (const route of prefixRoutes) {
     const exactPrefix = body === route.prefix;
     const prefixedCommand = body.startsWith(`${route.prefix} `)
       || body.startsWith(`${route.prefix}\n`);
     if (route.chatIds.has(chatId) && (exactPrefix || prefixedCommand)) {
+      return route.consumer;
+    }
+  }
+  for (const route of routes || []) {
+    if (route.matchAll && route.chatIds.has(chatId)) {
       return route.consumer;
     }
   }
@@ -70,6 +110,9 @@ export function createMessageConsumerQueues(limit = 100, configuredConsumers = [
       .map(normalizeConsumerId)
       .filter(consumer => consumer && consumer !== DEFAULT_CONSUMER)
       .map(consumer => [consumer, []]),
+  );
+  const leases = new Map(
+    Array.from(namedQueues, ([consumer]) => [consumer, new Map()]),
   );
 
   function pushBounded(queue, event) {
@@ -95,6 +138,32 @@ export function createMessageConsumerQueues(limit = 100, configuredConsumers = [
     return queue.splice(0, queue.length);
   }
 
+  function lease(consumer, leaseMs = 60000, maxItems = 1, now = Date.now()) {
+    const queue = queueFor(consumer);
+    const consumerLeases = leases.get(consumer);
+    if (!queue || !consumerLeases) return null;
+    for (const [deliveryId, delivery] of consumerLeases) {
+      if (delivery.expiresAt <= now) {
+        queue.unshift(delivery.event);
+        consumerLeases.delete(deliveryId);
+      }
+    }
+    const deliveries = [];
+    while (queue.length && deliveries.length < maxItems) {
+      const event = queue.shift();
+      const deliveryId = randomUUID();
+      consumerLeases.set(deliveryId, { event, expiresAt: now + leaseMs });
+      deliveries.push({ deliveryId, event });
+    }
+    return deliveries;
+  }
+
+  function ack(consumer, deliveryId) {
+    const consumerLeases = leases.get(consumer);
+    if (!consumerLeases) return null;
+    return consumerLeases.delete(deliveryId);
+  }
+
   function lengths() {
     return Object.fromEntries([
       [DEFAULT_CONSUMER, defaultQueue.length],
@@ -102,5 +171,6 @@ export function createMessageConsumerQueues(limit = 100, configuredConsumers = [
     ]);
   }
 
-  return { enqueue, drain, lengths, defaultQueueLength: () => defaultQueue.length };
+  return { enqueue, drain, lease, ack, lengths, defaultQueueLength: () => defaultQueue.length };
 }
+import { randomUUID } from 'node:crypto';

--- a/scripts/whatsapp-bridge/message_consumers.test.mjs
+++ b/scripts/whatsapp-bridge/message_consumers.test.mjs
@@ -13,14 +13,32 @@ assert.equal(normalizeConsumerId('../bad'), null);
 
 const routes = parseConsumerRoutes(JSON.stringify([
   { consumer: 'codex', prefix: '/codex', chat_ids: ['owner@lid'] },
-  { consumer: 'default', prefix: '/ignored', chat_ids: ['owner@lid'] },
+  { consumer: 'opencode', match_all: true, chat_ids: ['owner@lid'] },
 ]));
-assert.equal(routes.length, 1);
+assert.equal(routes.length, 2);
 assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/codex inspect status' }, routes), 'codex');
 assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/CODEX\ninspect status' }, routes), 'codex');
 assert.equal(selectConsumerForEvent({ chatId: 'other@lid', body: '/codex inspect status' }, routes), 'default');
-assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/codexical' }, routes), 'default');
+assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/codexical' }, routes), 'opencode');
 assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', isGroup: true, body: '/codex inspect status' }, routes), 'default');
+assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: 'plain prompt' }, routes), 'opencode');
+
+const reverseRoutes = parseConsumerRoutes(JSON.stringify([
+  { consumer: 'opencode', match_all: true, chat_ids: ['owner@lid'] },
+  { consumer: 'codex', prefix: '/codex', chat_ids: ['owner@lid'] },
+]));
+assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/codex task' }, reverseRoutes), 'codex');
+assert.throws(
+  () => parseConsumerRoutes([{ consumer: 'default', prefix: '/bad', chat_ids: ['owner@lid'] }]),
+  /non-default/,
+);
+assert.throws(
+  () => parseConsumerRoutes([
+    { consumer: 'one', match_all: true, chat_ids: ['owner@lid'] },
+    { consumer: 'two', match_all: true, chat_ids: ['owner@lid'] },
+  ]),
+  /Duplicate catch-all/,
+);
 
 const queues = createMessageConsumerQueues(2, ['codex']);
 queues.enqueue({ id: 'h1' });
@@ -30,4 +48,15 @@ queues.enqueue({ id: 'c3' }, 'codex');
 assert.deepEqual(queues.drain(), [{ id: 'h1' }]);
 assert.deepEqual(queues.drain('codex'), [{ id: 'c2' }, { id: 'c3' }]);
 assert.equal(queues.drain('unconfigured'), null);
+
+const leasedQueues = createMessageConsumerQueues(2, ['opencode']);
+leasedQueues.enqueue({ id: 'o1' }, 'opencode');
+const firstLease = leasedQueues.lease('opencode', 1000, 1, 100);
+assert.equal(firstLease.length, 1);
+assert.equal(firstLease[0].event.id, 'o1');
+assert.deepEqual(leasedQueues.lease('opencode', 1000, 1, 500), []);
+const redelivery = leasedQueues.lease('opencode', 1000, 1, 1101);
+assert.equal(redelivery[0].event.id, 'o1');
+assert.equal(leasedQueues.ack('opencode', redelivery[0].deliveryId), true);
+assert.deepEqual(leasedQueues.lease('opencode', 1000, 1, 2200), []);
 console.log('✓ named consumer routing keeps default and Codex queues isolated');

--- a/scripts/whatsapp-bridge/message_consumers.test.mjs
+++ b/scripts/whatsapp-bridge/message_consumers.test.mjs
@@ -1,0 +1,31 @@
+import { strict as assert } from 'node:assert';
+
+import {
+  createMessageConsumerQueues,
+  normalizeConsumerId,
+  parseConsumerRoutes,
+  selectConsumerForEvent,
+} from './message_consumers.js';
+
+assert.equal(normalizeConsumerId(), 'default');
+assert.equal(normalizeConsumerId('Codex_WA'), 'codex_wa');
+assert.equal(normalizeConsumerId('../bad'), null);
+
+const routes = parseConsumerRoutes(JSON.stringify([
+  { consumer: 'codex', prefix: '/codex', chat_ids: ['owner@lid'] },
+  { consumer: 'default', prefix: '/ignored', chat_ids: ['owner@lid'] },
+]));
+assert.equal(routes.length, 1);
+assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/codex inspect status' }, routes), 'codex');
+assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/CODEX\ninspect status' }, routes), 'codex');
+assert.equal(selectConsumerForEvent({ chatId: 'other@lid', body: '/codex inspect status' }, routes), 'default');
+assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/codexical' }, routes), 'default');
+
+const queues = createMessageConsumerQueues(2);
+queues.enqueue({ id: 'h1' });
+queues.enqueue({ id: 'c1' }, 'codex');
+queues.enqueue({ id: 'c2' }, 'codex');
+queues.enqueue({ id: 'c3' }, 'codex');
+assert.deepEqual(queues.drain(), [{ id: 'h1' }]);
+assert.deepEqual(queues.drain('codex'), [{ id: 'c2' }, { id: 'c3' }]);
+console.log('✓ named consumer routing keeps default and Codex queues isolated');

--- a/scripts/whatsapp-bridge/message_consumers.test.mjs
+++ b/scripts/whatsapp-bridge/message_consumers.test.mjs
@@ -20,12 +20,14 @@ assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/codex inspect
 assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/CODEX\ninspect status' }, routes), 'codex');
 assert.equal(selectConsumerForEvent({ chatId: 'other@lid', body: '/codex inspect status' }, routes), 'default');
 assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', body: '/codexical' }, routes), 'default');
+assert.equal(selectConsumerForEvent({ chatId: 'owner@lid', isGroup: true, body: '/codex inspect status' }, routes), 'default');
 
-const queues = createMessageConsumerQueues(2);
+const queues = createMessageConsumerQueues(2, ['codex']);
 queues.enqueue({ id: 'h1' });
 queues.enqueue({ id: 'c1' }, 'codex');
 queues.enqueue({ id: 'c2' }, 'codex');
 queues.enqueue({ id: 'c3' }, 'codex');
 assert.deepEqual(queues.drain(), [{ id: 'h1' }]);
 assert.deepEqual(queues.drain('codex'), [{ id: 'c2' }, { id: 'c3' }]);
+assert.equal(queues.drain('unconfigured'), null);
 console.log('✓ named consumer routing keeps default and Codex queues isolated');

--- a/scripts/whatsapp-bridge/reaction.js
+++ b/scripts/whatsapp-bridge/reaction.js
@@ -7,10 +7,13 @@ function requiredString(value, field) {
 
 export function parseReactionRequest(body) {
   const input = body && typeof body === 'object' && !Array.isArray(body) ? body : {};
-  const chatId = requiredString(input.chatId, 'chatId');
+  if (!input.key || typeof input.key !== 'object' || Array.isArray(input.key)) {
+    return { ok: false, error: 'key is required' };
+  }
+  const chatId = requiredString(input.key.remoteJid, 'key.remoteJid');
   if (!chatId.ok) return chatId;
 
-  const messageId = requiredString(input.messageId, 'messageId');
+  const messageId = requiredString(input.key.id, 'key.id');
   if (!messageId.ok) return messageId;
 
   if (typeof input.emoji !== 'string') {
@@ -23,19 +26,16 @@ export function parseReactionRequest(body) {
     return { ok: false, error: 'emoji must be at most 32 characters' };
   }
 
-  const participant = typeof input.participant === 'string' ? input.participant.trim() : '';
   return {
     ok: true,
     chatId: chatId.value,
     payload: {
       react: {
         text: input.emoji,
-        key: {
-          remoteJid: chatId.value,
-          id: messageId.value,
-          fromMe: input.fromMe === true,
-          ...(participant ? { participant } : {}),
-        },
+        // Baileys message keys may carry addressing fields beyond the common
+        // four. Preserve the exact inbound key so LID/group reactions target
+        // the original message reliably.
+        key: input.key,
       },
     },
   };

--- a/scripts/whatsapp-bridge/reaction.js
+++ b/scripts/whatsapp-bridge/reaction.js
@@ -1,0 +1,42 @@
+function requiredString(value, field) {
+  if (typeof value !== 'string' || !value.trim()) {
+    return { ok: false, error: `${field} is required` };
+  }
+  return { ok: true, value: value.trim() };
+}
+
+export function parseReactionRequest(body) {
+  const input = body && typeof body === 'object' && !Array.isArray(body) ? body : {};
+  const chatId = requiredString(input.chatId, 'chatId');
+  if (!chatId.ok) return chatId;
+
+  const messageId = requiredString(input.messageId, 'messageId');
+  if (!messageId.ok) return messageId;
+
+  if (typeof input.emoji !== 'string') {
+    return { ok: false, error: 'emoji is required' };
+  }
+  if (/\r|\n/.test(input.emoji)) {
+    return { ok: false, error: 'emoji must not contain line breaks' };
+  }
+  if (input.emoji.length > 32) {
+    return { ok: false, error: 'emoji must be at most 32 characters' };
+  }
+
+  const participant = typeof input.participant === 'string' ? input.participant.trim() : '';
+  return {
+    ok: true,
+    chatId: chatId.value,
+    payload: {
+      react: {
+        text: input.emoji,
+        key: {
+          remoteJid: chatId.value,
+          id: messageId.value,
+          fromMe: input.fromMe === true,
+          ...(participant ? { participant } : {}),
+        },
+      },
+    },
+  };
+}

--- a/scripts/whatsapp-bridge/reaction.test.mjs
+++ b/scripts/whatsapp-bridge/reaction.test.mjs
@@ -4,11 +4,14 @@ import { parseReactionRequest } from './reaction.js';
 
 {
   const parsed = parseReactionRequest({
-    chatId: '12345@g.us',
-    messageId: 'message-1',
+    key: {
+      remoteJid: '12345@g.us',
+      id: 'message-1',
+      fromMe: false,
+      participant: '67890@s.whatsapp.net',
+      addressingMode: 'lid',
+    },
     emoji: '🙌',
-    fromMe: false,
-    participant: '67890@s.whatsapp.net',
   });
 
   assert.deepStrictEqual(parsed, {
@@ -22,6 +25,7 @@ import { parseReactionRequest } from './reaction.js';
           id: 'message-1',
           fromMe: false,
           participant: '67890@s.whatsapp.net',
+          addressingMode: 'lid',
         },
       },
     },
@@ -30,8 +34,11 @@ import { parseReactionRequest } from './reaction.js';
 
 {
   const parsed = parseReactionRequest({
-    chatId: '12345@s.whatsapp.net',
-    messageId: 'message-2',
+    key: {
+      remoteJid: '12345@s.whatsapp.net',
+      id: 'message-2',
+      fromMe: false,
+    },
     emoji: '',
   });
 
@@ -52,11 +59,12 @@ import { parseReactionRequest } from './reaction.js';
 }
 
 for (const [body, error] of [
-  [{ messageId: 'message-1', emoji: '🙌' }, 'chatId is required'],
-  [{ chatId: '12345@s.whatsapp.net', emoji: '🙌' }, 'messageId is required'],
-  [{ chatId: '12345@s.whatsapp.net', messageId: 'message-1' }, 'emoji is required'],
-  [{ chatId: '12345@s.whatsapp.net', messageId: 'message-1', emoji: '🙌\nnope' }, 'emoji must not contain line breaks'],
-  [{ chatId: '12345@s.whatsapp.net', messageId: 'message-1', emoji: 'x'.repeat(33) }, 'emoji must be at most 32 characters'],
+  [{ emoji: '🙌' }, 'key is required'],
+  [{ key: { id: 'message-1' }, emoji: '🙌' }, 'key.remoteJid is required'],
+  [{ key: { remoteJid: '12345@s.whatsapp.net' }, emoji: '🙌' }, 'key.id is required'],
+  [{ key: { remoteJid: '12345@s.whatsapp.net', id: 'message-1' } }, 'emoji is required'],
+  [{ key: { remoteJid: '12345@s.whatsapp.net', id: 'message-1' }, emoji: '🙌\nnope' }, 'emoji must not contain line breaks'],
+  [{ key: { remoteJid: '12345@s.whatsapp.net', id: 'message-1' }, emoji: 'x'.repeat(33) }, 'emoji must be at most 32 characters'],
 ]) {
   assert.deepStrictEqual(parseReactionRequest(body), { ok: false, error });
 }

--- a/scripts/whatsapp-bridge/reaction.test.mjs
+++ b/scripts/whatsapp-bridge/reaction.test.mjs
@@ -1,0 +1,64 @@
+import { strict as assert } from 'node:assert';
+
+import { parseReactionRequest } from './reaction.js';
+
+{
+  const parsed = parseReactionRequest({
+    chatId: '12345@g.us',
+    messageId: 'message-1',
+    emoji: '🙌',
+    fromMe: false,
+    participant: '67890@s.whatsapp.net',
+  });
+
+  assert.deepStrictEqual(parsed, {
+    ok: true,
+    chatId: '12345@g.us',
+    payload: {
+      react: {
+        text: '🙌',
+        key: {
+          remoteJid: '12345@g.us',
+          id: 'message-1',
+          fromMe: false,
+          participant: '67890@s.whatsapp.net',
+        },
+      },
+    },
+  });
+}
+
+{
+  const parsed = parseReactionRequest({
+    chatId: '12345@s.whatsapp.net',
+    messageId: 'message-2',
+    emoji: '',
+  });
+
+  assert.deepStrictEqual(parsed, {
+    ok: true,
+    chatId: '12345@s.whatsapp.net',
+    payload: {
+      react: {
+        text: '',
+        key: {
+          remoteJid: '12345@s.whatsapp.net',
+          id: 'message-2',
+          fromMe: false,
+        },
+      },
+    },
+  });
+}
+
+for (const [body, error] of [
+  [{ messageId: 'message-1', emoji: '🙌' }, 'chatId is required'],
+  [{ chatId: '12345@s.whatsapp.net', emoji: '🙌' }, 'messageId is required'],
+  [{ chatId: '12345@s.whatsapp.net', messageId: 'message-1' }, 'emoji is required'],
+  [{ chatId: '12345@s.whatsapp.net', messageId: 'message-1', emoji: '🙌\nnope' }, 'emoji must not contain line breaks'],
+  [{ chatId: '12345@s.whatsapp.net', messageId: 'message-1', emoji: 'x'.repeat(33) }, 'emoji must be at most 32 characters'],
+]) {
+  assert.deepStrictEqual(parseReactionRequest(body), { ok: false, error });
+}
+
+console.log('✅ Reaction request tests passed.');

--- a/scripts/whatsapp-bridge/runtime-files.json
+++ b/scripts/whatsapp-bridge/runtime-files.json
@@ -1,0 +1,9 @@
+[
+  "bridge.js",
+  "allowlist.js",
+  "bridge_helpers.js",
+  "message_consumers.js",
+  "outbound_ids.js",
+  "owner_message_gate.js",
+  "reaction.js"
+]

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -7,10 +7,10 @@ long-lived bridge process therefore survived gateway restarts AND
 ``hermes update``, serving pre-update bridge.js behavior forever (e.g.
 no inbound media download → images/voice notes arrive as placeholders).
 
-The fix: bridge.js reports a hash of its own source in ``/health``
-(``scriptHash``); the adapter compares it against the bridge.js on disk
-and restarts the bridge on mismatch.  Bridges that predate the handshake
-report no hash and are treated as stale by definition.
+The fix: bridge.js reports a hash of its runtime modules in ``/health``
+(``runtimeHash``); the adapter compares it against those modules on disk and
+restarts the bridge on mismatch. Bridges that predate the handshake report no
+hash and are treated as stale by definition. Runtime config is compared too.
 
 Also covers the npm dependency-refresh stamp: deps are reinstalled when
 package.json changes, not only when node_modules is missing.
@@ -85,6 +85,8 @@ def _setup_bridge_dir(tmp_path: Path) -> Path:
     bridge_dir = tmp_path / "whatsapp-bridge"
     bridge_dir.mkdir()
     (bridge_dir / "bridge.js").write_text("// current bridge code\n")
+    (bridge_dir / "message_consumers.js").write_text("// current queue code\n")
+    (bridge_dir / "reaction.js").write_text("// current reaction code\n")
     (bridge_dir / "package.json").write_text('{"name": "bridge"}\n')
     session_path = tmp_path / "session"
     session_path.mkdir()
@@ -113,8 +115,55 @@ class TestFileContentHash:
         assert len(h) == 16
         assert h == _file_content_hash(f)  # deterministic
 
+    def test_runtime_hash_includes_imported_bridge_helpers(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _bridge_runtime_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        before = _bridge_runtime_hash(bridge_dir / "bridge.js")
+        (bridge_dir / "reaction.js").write_text("// changed reaction code\n")
+        assert _bridge_runtime_hash(bridge_dir / "bridge.js") != before
+
 
 class TestStaleBridgeHandshake:
+
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_when_consumer_routes_changed(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _bridge_runtime_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        adapter.config.extra = {
+            "consumer_routes": [
+                {"consumer": "openjaw", "prefix": "/openjaw", "chat_ids": ["owner@lid"]}
+            ]
+        }
+        mock_client = _mock_health(
+            {
+                "status": "connected",
+                "runtimeHash": _bridge_runtime_hash(bridge_dir / "bridge.js"),
+                "consumerRoutesJson": "[]",
+                "sendReadReceipts": False,
+            }
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()
+        assert mock_popen.call_args.kwargs["env"]["WHATSAPP_CONSUMER_ROUTES_JSON"].startswith("[")
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -17,12 +17,13 @@ package.json changes, not only when node_modules is missing.
 """
 
 import asyncio
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import Platform, PlatformConfig
 
 
 class _AsyncCM:
@@ -85,8 +86,16 @@ def _setup_bridge_dir(tmp_path: Path) -> Path:
     bridge_dir = tmp_path / "whatsapp-bridge"
     bridge_dir.mkdir()
     (bridge_dir / "bridge.js").write_text("// current bridge code\n")
+    (bridge_dir / "allowlist.js").write_text("// current allowlist code\n")
+    (bridge_dir / "bridge_helpers.js").write_text("// current helper code\n")
     (bridge_dir / "message_consumers.js").write_text("// current queue code\n")
+    (bridge_dir / "outbound_ids.js").write_text("// current outbound code\n")
+    (bridge_dir / "owner_message_gate.js").write_text("// current owner gate code\n")
     (bridge_dir / "reaction.js").write_text("// current reaction code\n")
+    (bridge_dir / "runtime-files.json").write_text(
+        '["bridge.js","allowlist.js","bridge_helpers.js","message_consumers.js",'
+        '"outbound_ids.js","owner_message_gate.js","reaction.js"]'
+    )
     (bridge_dir / "package.json").write_text('{"name": "bridge"}\n')
     session_path = tmp_path / "session"
     session_path.mkdir()
@@ -120,27 +129,34 @@ class TestFileContentHash:
 
         bridge_dir = _setup_bridge_dir(tmp_path)
         before = _bridge_runtime_hash(bridge_dir / "bridge.js")
-        (bridge_dir / "reaction.js").write_text("// changed reaction code\n")
+        (bridge_dir / "bridge_helpers.js").write_text("// changed helper code\n")
         assert _bridge_runtime_hash(bridge_dir / "bridge.js") != before
 
 
 class TestStaleBridgeHandshake:
 
     @pytest.mark.asyncio
-    async def test_restarts_bridge_when_consumer_routes_changed(self, tmp_path):
+    async def test_restarts_bridge_when_consumer_routes_changed(self, tmp_path, monkeypatch):
         from plugins.platforms.whatsapp.adapter import _bridge_runtime_hash
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
         bridge_dir = _setup_bridge_dir(tmp_path)
         _fresh_node_modules(bridge_dir)
-        adapter = _make_adapter(
-            bridge_script=str(bridge_dir / "bridge.js"),
-            session_path=tmp_path / "session",
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+        routes = [
+            {"consumer": "openjaw", "prefix": "/openjaw", "chat_ids": ["owner@lid"]}
+        ]
+        adapter = WhatsAppAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "bridge_script": str(bridge_dir / "bridge.js"),
+                    "bridge_port": 19876,
+                    "session_path": str(tmp_path / "session"),
+                    "consumer_routes": routes,
+                },
+            )
         )
-        adapter.config.extra = {
-            "consumer_routes": [
-                {"consumer": "openjaw", "prefix": "/openjaw", "chat_ids": ["owner@lid"]}
-            ]
-        }
         mock_client = _mock_health(
             {
                 "status": "connected",
@@ -163,7 +179,9 @@ class TestStaleBridgeHandshake:
             await adapter.connect()
 
         mock_popen.assert_called_once()
-        assert mock_popen.call_args.kwargs["env"]["WHATSAPP_CONSUMER_ROUTES_JSON"].startswith("[")
+        assert json.loads(
+            mock_popen.call_args.kwargs["env"]["WHATSAPP_CONSUMER_ROUTES_JSON"]
+        ) == routes
 
 
     @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -268,11 +268,14 @@ gateway:
 Named routes have the following safeguards:
 
 - They apply only to direct messages. Group messages always remain on Hermes's `default` queue,
-  even if a group ID appears in `chat_ids`.
-- A command matches the prefix exactly, or the prefix followed by a space or newline.
-  `/secondary-task` does not match the `/secondary` prefix.
-- Consumer IDs are lowercased and may contain letters, digits, `_`, and `-`; they must be 1–64
-  characters, cannot be `default`, and at most 16 valid routes are loaded.
+  even if a group ID appears in `chat_ids`. The direct chat JID must exactly match an entry in
+  `chat_ids`.
+- Prefix matching is case-insensitive and ignores leading whitespace. The command boundary must
+  be the end of the message, a space, or a newline, so `/secondary-task` does not match the
+  `/secondary` prefix.
+- Consumer IDs are lowercased, must start with a letter or digit, and may then contain letters,
+  digits, `_`, and `-`. They must be 1–64 characters, cannot be `default`, and at most 16 valid
+  routes are loaded.
 - Each queue holds at most 100 events and drops its oldest event when full. One inbound event is
   placed in exactly one queue.
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -238,6 +238,84 @@ gateway:
 
 Set `text_batch_delay_seconds: 0` to dispatch each message immediately (disables batching).
 
+### Named Consumer Routes (Advanced)
+
+Hermes can expose selected owner commands to another **local** process without opening a second
+WhatsApp Web session. The Baileys bridge remains the only WhatsApp client: it receives each
+message once, then places that event in either Hermes's `default` queue or one configured named
+queue. This avoids duplicate replies and competing pollers.
+
+Configure named routes under `gateway.platforms.whatsapp.extra.consumer_routes`:
+
+```yaml
+# ~/.hermes/config.yaml
+gateway:
+  platforms:
+    whatsapp:
+      extra:
+        consumer_routes:
+          - consumer: "secondary-app"
+            prefix: "/secondary"
+            chat_ids:
+              - "<owner-jid>"
+```
+
+:::warning Exact configuration path
+`consumer_routes` must be nested under `gateway.platforms.whatsapp.extra`. A top-level
+`whatsapp.consumer_routes` setting is not bridged into the WhatsApp adapter and is ignored.
+:::
+
+Named routes have the following safeguards:
+
+- They apply only to direct messages. Group messages always remain on Hermes's `default` queue,
+  even if a group ID appears in `chat_ids`.
+- A command matches the prefix exactly, or the prefix followed by a space or newline.
+  `/secondary-task` does not match the `/secondary` prefix.
+- Consumer IDs are lowercased and may contain letters, digits, `_`, and `-`; they must be 1–64
+  characters, cannot be `default`, and at most 16 valid routes are loaded.
+- Each queue holds at most 100 events and drops its oldest event when full. One inbound event is
+  placed in exactly one queue.
+
+The secondary process uses the loopback-only bridge API. The bridge defaults to
+`http://127.0.0.1:3000`; use the effective `bridge_port` if you changed it.
+
+```bash
+# Drain this consumer's queued events.
+curl --fail --silent \
+  'http://127.0.0.1:3000/messages?consumer=secondary-app'
+```
+
+Invalid consumer IDs return HTTP 400. Valid IDs that are not configured return HTTP 404 without
+creating a queue. The regular Hermes adapter polls `/messages` without a consumer parameter and
+therefore drains only the `default` queue.
+
+To acknowledge an inbound event with a native WhatsApp reaction, copy its complete
+`readReceiptKey` into the `key` field unchanged:
+
+```bash
+curl --fail --silent \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "key": {
+      "remoteJid": "<owner-jid>",
+      "id": "<inbound-message-id>",
+      "fromMe": false
+    },
+    "emoji": "🙌"
+  }' \
+  http://127.0.0.1:3000/react
+```
+
+Do not reconstruct the key from only the chat and message IDs. Group and LID-addressed messages
+can include additional fields such as `participant` or `addressingMode`; echoing the complete key
+keeps the reaction attached to the correct message. An empty `emoji` removes an existing
+reaction. Reactions share the bridge's serialized send queue with normal messages.
+
+`GET /health` reports `consumerQueueLengths` and the bridge runtime fingerprint. When Hermes next
+connects, a change to `consumer_routes`, `send_read_receipts`, or the loaded bridge modules makes
+the existing bridge stale and restarts it with the new configuration. The API remains bound to
+`127.0.0.1`; do not expose it through a public listener or reverse proxy.
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
## What does this PR do?

Adds bounded, named inbound WhatsApp consumers and a native reaction endpoint while keeping one Baileys socket authoritative.

Configured owner-DM command prefixes are routed exclusively to their named queue, so the default Hermes poller and local integrations do not race to drain the same message. Reactions preserve the complete inbound Baileys message key and use the existing serialized send queue.

The bridge reuse handshake now fingerprints the runtime helper modules and route configuration, preventing gateway restarts from silently reusing stale routing or reaction behavior.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add configured, bounded consumer queues selected by an owner-DM chat ID and exact command prefix.
- Reject unconfigured consumer polling and keep group messages on the default Hermes queue.
- Add loopback-only `POST /react` using the full inbound message key and serialized Baileys send path.
- Restart stale bridges when runtime helpers, read-receipt behavior, or consumer routes change.
- Add focused JavaScript and Python regression coverage.
- Document the supported `gateway.platforms.whatsapp.extra.consumer_routes` configuration and
  loopback consumer/reaction contract in the WhatsApp guide.

## How to Test

1. Run `for test_file in scripts/whatsapp-bridge/*.test.mjs; do node "$test_file" || exit 1; done`.
2. Run `uv run python -m pytest -q tests/gateway/test_whatsapp*.py`.
3. Run `cd website && npm run build:fast`.
4. Configure two named owner-DM prefixes, start the gateway, and confirm `/health` reports separate bounded queues and a runtime hash.
5. Poll each consumer independently and send a reaction using the event's `readReceiptKey`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

The full repository gate was attempted after installing its declared dev, messaging, and ACP extras. It showed failures and temporary-directory logging errors outside the WhatsApp slice before being stopped at 6%. The complete WhatsApp gateway slice passed: 118 passed, 2 skipped. All eight WhatsApp bridge JavaScript test files passed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live Linux validation used one loopback bridge listener and one Baileys process. `/health` reported separate empty `default`, `codex`, and `openjaw` queues; its runtime hash matched the files on disk. Invalid reaction requests returned HTTP 400, and polling an unconfigured consumer returned HTTP 404 without creating a queue.
