### PR TITLE
fix(runtime): harden stale process cleanup

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -13,9 +13,25 @@ patches on ``hermes_cli.main`` resolve unchanged.
 """
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
+
+from .process_safety import (
+    StableProcessHandle,
+    StableProcessHandleUnavailable,
+)
+
+
+_DASHBOARD_RUNTIME_PATTERNS = [
+    "hermes dashboard",
+    "hermes_cli.main dashboard",
+    "hermes_cli/main.py dashboard",
+    "hermes serve",
+    "hermes_cli.main serve",
+    "hermes_cli/main.py serve",
+]
 
 
 def _m():
@@ -23,6 +39,30 @@ def _m():
     from hermes_cli import main
 
     return main
+
+
+def _looks_like_dashboard_runtime(command: str, patterns: list[str]) -> bool:
+    """Match a server process, never a dashboard management invocation."""
+    if re.search(r"(?<![\w-])--(?:status|stop)(?![\w-])", command):
+        return False
+    return any(pattern in command for pattern in patterns)
+
+
+def _open_verified_dashboard_handle(pid: int) -> StableProcessHandle:
+    """Pin ``pid`` first, then prove the pinned identity is a dashboard."""
+    handle = StableProcessHandle.open(pid)
+    try:
+        from gateway.status import _read_process_cmdline
+
+        command = _read_process_cmdline(pid)
+        if not command or not _looks_like_dashboard_runtime(
+            command, _DASHBOARD_RUNTIME_PATTERNS
+        ):
+            raise RuntimeError("process identity changed after dashboard scan")
+        return handle
+    except Exception:
+        handle.close()
+        raise
 
 
 def _scan_dashboard_processes(
@@ -53,18 +93,18 @@ def _scan_dashboard_processes(
 
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
-    patterns = [
-        "hermes dashboard",
-        "hermes_cli.main dashboard",
-        "hermes_cli/main.py dashboard",
-        # The headless backend (`hermes serve`) is the same long-lived server
-        # under a different command name — the desktop app spawns it. Reap it
-        # on update for the same frontend/backend-mismatch reason.
-        "hermes serve",
-        "hermes_cli.main serve",
-        "hermes_cli/main.py serve",
-    ]
-    self_pid = os.getpid()
+    patterns = _DASHBOARD_RUNTIME_PATTERNS
+    self_pids = {os.getpid(), os.getppid()}
+    try:
+        import psutil
+
+        self_pids.update(
+            int(ancestor.pid) for ancestor in psutil.Process(os.getpid()).parents()
+        )
+    except Exception:
+        # This scan feeds a process-kill path. If ancestry cannot be proven,
+        # fail closed rather than risk returning the command that launched us.
+        return []
     dashboard_processes: list[tuple[int, str]] = []
 
     try:
@@ -99,14 +139,17 @@ def _scan_dashboard_processes(
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
+                    try:
+                        pid = int(pid_str)
+                    except ValueError:
+                        current_cmd = ""
+                        continue
                     if (
-                        any(p in current_cmd for p in patterns)
-                        and int(pid_str) != self_pid
+                        _looks_like_dashboard_runtime(current_cmd, patterns)
+                        and pid not in self_pids
                     ):
-                        try:
-                            dashboard_processes.append((int(pid_str), current_cmd))
-                        except ValueError:
-                            pass
+                        dashboard_processes.append((pid, current_cmd))
+                    current_cmd = ""
         else:
             # Linux / macOS: scan the process table via ps and match against
             # the same explicit patterns list used on Windows.  Using ps
@@ -133,7 +176,10 @@ def _scan_dashboard_processes(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if (
+                        _looks_like_dashboard_runtime(command, patterns)
+                        and pid not in self_pids
+                    ):
                         dashboard_processes.append((pid, command))
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
@@ -159,9 +205,9 @@ def _kill_stale_dashboard_processes(
     frontend/backend mismatches (new auth headers the old backend doesn't
     recognise → every API call 401s).
 
-    POSIX: SIGTERM, wait up to ~3s for graceful exit, SIGKILL any survivors.
-    Windows: ``taskkill /PID <pid> /F`` since there's no clean SIGTERM
-    equivalent for background console apps.
+    Linux/WSL: signal through pidfd, wait up to ~3s, then SIGKILL survivors.
+    Windows: terminate through the same ``OpenProcess`` handle used for identity
+    validation. Platforms without a stable process handle fail closed.
 
     Manually-started dashboards are not auto-restarted because we don't know
     the original launch args (--host, --port, --insecure, --tui, --no-open).
@@ -202,16 +248,38 @@ def _kill_stale_dashboard_processes(
     print()
     print(f"⟲ Stopping {len(pids)} dashboard process(es) ({reason})")
 
+    killed: list[int] = []
+    failed: list[tuple[int, str]] = []
+    handles: dict[int, StableProcessHandle] = {}
+
+    # Pin process identities before collecting any more metadata. Validation
+    # happens after the handle opens, so PID recycling can never redirect a
+    # later signal to a replacement process.
+    for pid in pids:
+        try:
+            handles[pid] = _open_verified_dashboard_handle(pid)
+        except ProcessLookupError:
+            killed.append(pid)
+        except (
+            StableProcessHandleUnavailable,
+            PermissionError,
+            OSError,
+            RuntimeError,
+        ) as exc:
+            failed.append((pid, str(exc)))
+
+    active_pids = list(handles)
+
     # Before killing, snapshot systemd cgroup info for each PID so we can
     # restart supervised services after the kill (the cgroup disappears
-    # along with the process).  Only meaningful on Linux, and only when the
+    # along with the process). Only meaningful on Linux, and only when the
     # caller asked for restarts (the `hermes update` path) — `--stop` must
     # stay a stop, not a restart.
     pid_cgroup: dict[int, str | None] = {}
     pid_service: dict[int, str | None] = {}
     pid_cmdline: dict[int, list[str]] = {}
     if restart_managed and sys.platform != "win32":
-        for pid in pids:
+        for pid in active_pids:
             cg_path = _m()._get_pid_cgroup_path(pid)
             pid_cgroup[pid] = cg_path
             pid_service[pid] = _m()._get_systemd_service_for_pid(pid)
@@ -222,66 +290,50 @@ def _kill_stale_dashboard_processes(
                 if cmdline:
                     pid_cmdline[pid] = cmdline
 
-    killed: list[int] = []
-    failed: list[tuple[int, str]] = []
+    import signal as _signal
+    import time as _time
 
-    if sys.platform == "win32":
-        for pid in pids:
+    pending: list[int] = []
+    try:
+        # SIGTERM first — each signal travels through the pinned handle.
+        for pid in active_pids:
             try:
-                result = subprocess.run(
-                    ["taskkill", "/PID", str(pid), "/F"],
-                    capture_output=True,
-                    text=True, encoding="utf-8", errors="replace",
-                    timeout=10,
-                )
-                if result.returncode == 0:
-                    killed.append(pid)
-                else:
-                    failed.append((pid, (result.stderr or result.stdout or "").strip()))
-            except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
-                failed.append((pid, str(e)))
-    else:
-        import signal as _signal
-        import time as _time
-
-        # SIGTERM first — give each process a chance to shut down cleanly
-        # (uvicorn closes its socket, flushes logs, etc.).
-        for pid in pids:
-            try:
-                os.kill(pid, _signal.SIGTERM)
+                handles[pid].send_signal(_signal.SIGTERM)
+                pending.append(pid)
             except ProcessLookupError:
-                # Already gone — count as killed.
                 killed.append(pid)
-            except (PermissionError, OSError) as e:
-                failed.append((pid, str(e)))
+            except (PermissionError, OSError) as exc:
+                failed.append((pid, str(exc)))
 
-        # Poll for exit up to ~3s total.
+        # Poll the same handles for up to ~3s total.
         deadline = _time.monotonic() + 3.0
-        pending = [
-            p for p in pids if p not in killed and p not in {f[0] for f in failed}
-        ]
         while pending and _time.monotonic() < deadline:
             _time.sleep(0.1)
-            still_pending = []
-            # On Windows, os.kill(pid, 0) is NOT a no-op. Route through
-            # the cross-platform existence check.
-            from gateway.status import _pid_exists
+            still_pending: list[int] = []
             for pid in pending:
-                if _pid_exists(pid):
-                    still_pending.append(pid)
-                else:
+                try:
+                    if handles[pid].is_alive():
+                        still_pending.append(pid)
+                    else:
+                        killed.append(pid)
+                except ProcessLookupError:
                     killed.append(pid)
+                except (PermissionError, OSError) as exc:
+                    failed.append((pid, str(exc)))
             pending = still_pending
 
-        # SIGKILL any survivors.
+        # SIGKILL any survivors, still through their original handles.
         for pid in pending:
             try:
-                os.kill(pid, _signal.SIGKILL)
+                handles[pid].send_signal(_signal.SIGKILL)
                 killed.append(pid)
             except ProcessLookupError:
                 killed.append(pid)
-            except (PermissionError, OSError) as e:
-                failed.append((pid, str(e)))
+            except (PermissionError, OSError) as exc:
+                failed.append((pid, str(exc)))
+    finally:
+        for handle in handles.values():
+            handle.close()
 
     for pid in killed:
         print(f"    ✓ stopped PID {pid}")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1118,8 +1118,10 @@ def run_doctor(args):
         if _has_provider_env_config(content):
             check_ok("API key or custom endpoint configured")
         else:
-            check_warn(f"No API key found in {_DHH}/.env")
-            issues.append("Run 'hermes setup' to configure API keys")
+            check_info(
+                f"No API-key/custom-endpoint entry in {_DHH}/.env "
+                "(OAuth, SDK, and external providers are checked separately)"
+            )
     else:
         # Also check project root as fallback
         fallback_env = PROJECT_ROOT / '.env'
@@ -1561,60 +1563,61 @@ def run_doctor(args):
     _section("Auth Providers")
 
     try:
-        from hermes_cli.auth import (
-            get_nous_auth_status_local,
-            get_codex_auth_status,
-            get_minimax_oauth_auth_status,
-        )
+        from . import auth as auth_module
+    except Exception as exc:
+        check_warn("Auth provider imports", f"(could not load: {exc})")
+    else:
+        # Read-only display: refresh-free snapshots — doctor must never trigger
+        # an OAuth refresh as a side effect of a health check. Each provider is
+        # isolated so one broken credential store cannot hide every later row.
+        try:
+            nous_status = auth_module.get_nous_auth_status_local()
+            if nous_status.get("logged_in"):
+                check_ok("Nous Portal auth", "(logged in)")
+            else:
+                check_warn("Nous Portal auth", "(not logged in)")
+        except Exception as exc:
+            check_warn("Nous Portal auth", f"(could not check: {exc})")
 
-        # Read-only display: refresh-free snapshot — doctor must never
-        # trigger an OAuth refresh as a side effect of a health check.
-        nous_status = get_nous_auth_status_local()
-        if nous_status.get("logged_in"):
-            check_ok("Nous Portal auth", "(logged in)")
-        else:
-            check_warn("Nous Portal auth", "(not logged in)")
+        try:
+            codex_status = auth_module.get_codex_auth_status()
+            if codex_status.get("logged_in"):
+                check_ok("OpenAI Codex auth", "(logged in)")
+            else:
+                check_warn("OpenAI Codex auth", "(not logged in)")
+                if codex_status.get("error"):
+                    check_info(codex_status["error"])
+                # Native OAuth uses Hermes' own device-code flow — the Codex CLI
+                # is only needed to import existing tokens from ~/.codex/auth.json.
+                if not _safe_which("codex"):
+                    check_info(
+                        "codex CLI not installed "
+                        "(optional — only required to import tokens "
+                        "from an existing Codex CLI login)"
+                    )
+        except Exception as exc:
+            check_warn("OpenAI Codex auth", f"(could not check: {exc})")
 
-        codex_status = get_codex_auth_status()
-        if codex_status.get("logged_in"):
-            check_ok("OpenAI Codex auth", "(logged in)")
-        else:
-            check_warn("OpenAI Codex auth", "(not logged in)")
-            if codex_status.get("error"):
-                check_info(codex_status["error"])
-            # Native OAuth uses Hermes' own device-code flow — the Codex CLI is
-            # only needed to import existing tokens from ~/.codex/auth.json.
-            # Attach the hint to the Codex auth row so it doesn't read as
-            # remediation for whichever provider happens to print next (#27975).
-            if not _safe_which("codex"):
-                check_info(
-                    "codex CLI not installed "
-                    "(optional — only required to import tokens "
-                    "from an existing Codex CLI login)"
-                )
+        try:
+            minimax_status = auth_module.get_minimax_oauth_auth_status()
+            if minimax_status.get("logged_in"):
+                region = minimax_status.get("region", "global")
+                check_ok("MiniMax OAuth", f"(logged in, region={region})")
+            else:
+                check_warn("MiniMax OAuth", "(not logged in)")
+        except Exception as exc:
+            check_warn("MiniMax OAuth", f"(could not check: {exc})")
 
-        minimax_status = get_minimax_oauth_auth_status()
-        if minimax_status.get("logged_in"):
-            region = minimax_status.get("region", "global")
-            check_ok("MiniMax OAuth", f"(logged in, region={region})")
-        else:
-            check_warn("MiniMax OAuth", "(not logged in)")
-    except Exception as e:
-        check_warn("Auth provider status", f"(could not check: {e})")
-
-    # xAI OAuth — separate try/except so an import failure here cannot
-    # disrupt the already-printed Nous/Codex/Gemini/MiniMax rows above.
-    try:
-        from hermes_cli.auth import get_xai_oauth_auth_status
-        xai_oauth_status = get_xai_oauth_auth_status() or {}
-        if xai_oauth_status.get("logged_in"):
-            check_ok("xAI OAuth", "(logged in)")
-        else:
-            check_warn("xAI OAuth", "(not logged in)")
-            if xai_oauth_status.get("error"):
-                check_info(xai_oauth_status["error"])
-    except Exception:
-        pass
+        try:
+            xai_oauth_status = auth_module.get_xai_oauth_auth_status() or {}
+            if xai_oauth_status.get("logged_in"):
+                check_ok("xAI OAuth", "(logged in)")
+            else:
+                check_warn("xAI OAuth", "(not logged in)")
+                if xai_oauth_status.get("error"):
+                    check_info(xai_oauth_status["error"])
+        except Exception as exc:
+            check_warn("xAI OAuth", f"(could not check: {exc})")
 
     _section("Directory Structure")
     hermes_home = HERMES_HOME

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -380,36 +380,75 @@ def _scan_gateway_pids(
         looks_like_gateway_runtime_command_line,
     )
     current_home = str(get_hermes_home().resolve())
-    # Forward slashes on both sides of the HERMES_HOME= match — see
-    # gateway.status._command_line_belongs_to_profile, which this mirrors.
-    current_home_lc = current_home.lower().replace("\\", "/")
     current_profile_arg = _profile_arg(current_home)
     current_profile_name = (
         current_profile_arg.split()[-1] if current_profile_arg else ""
     )
     current_profile_name_lc = current_profile_name.lower()
 
-    def _matches_current_profile(command: str) -> bool:
-        command_lc = command.lower().replace("\\", "/")
-        if current_profile_name:
-            return (
-                f"--profile {current_profile_name_lc}" in command_lc
-                or f"-p {current_profile_name_lc}" in command_lc
-                or f"hermes_home={current_home_lc}" in command_lc
-            )
+    def _command_context(command: str) -> tuple[str | None, str | None, bool]:
+        """Return effective profile/home arguments from a process command line."""
+        try:
+            argv = shlex.split(command, posix=not is_windows())
+        except ValueError:
+            return None, None, False
 
-        # Default-profile case: no profile flag in argv. Accept as long as
-        # the command doesn't advertise *some other* profile. HERMES_HOME
-        # may be passed via env (not visible in wmic/CIM command line) so
-        # its absence is NOT disqualifying — only a non-matching explicit
-        # HERMES_HOME= in argv is.
-        if "--profile " in command_lc or " -p " in command_lc:
+        def _unquote(value: str) -> str:
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                return value[1:-1]
+            return value
+
+        argv = [_unquote(value) for value in argv]
+        explicit_profile: str | None = None
+        explicit_home: str | None = None
+        profile_seen = False
+        index = 0
+        while index < len(argv):
+            value = argv[index]
+            value_lc = value.lower()
+            if value in {"--profile", "-p"}:
+                profile_seen = True
+                explicit_profile = argv[index + 1] if index + 1 < len(argv) else None
+                index += 2
+                continue
+            if value_lc.startswith("--profile="):
+                profile_seen = True
+                explicit_profile = value.split("=", 1)[1]
+            elif value_lc.startswith("-p="):
+                profile_seen = True
+                explicit_profile = value.split("=", 1)[1]
+            elif value_lc.startswith("hermes_home="):
+                explicit_home = value.split("=", 1)[1]
+            index += 1
+        return explicit_profile, explicit_home, profile_seen
+
+    def _matches_current_profile(command: str) -> bool:
+        explicit_profile, explicit_home, profile_seen = _command_context(command)
+        if profile_seen and explicit_profile is None:
             return False
-        if (
-            "hermes_home=" in command_lc
-            and f"hermes_home={current_home_lc}" not in command_lc
-        ):
-            return False
+
+        if explicit_home is not None:
+            normalized_home = explicit_home.replace("\\", "/")
+            expected_home = current_home.replace("\\", "/")
+            if is_windows():
+                normalized_home = normalized_home.lower()
+                expected_home = expected_home.lower()
+            home_matches = normalized_home == expected_home
+        else:
+            home_matches = False
+
+        if current_profile_name:
+            if profile_seen:
+                return (explicit_profile or "").lower() == current_profile_name_lc
+            return home_matches
+
+        # Default profile: an explicit non-default profile always belongs to
+        # another home. With no profile flag, a conflicting HERMES_HOME also
+        # disqualifies the process; otherwise this is the default invocation.
+        if profile_seen:
+            return (explicit_profile or "").lower() == "default"
+        if explicit_home is not None:
+            return home_matches
         return True
 
     def _matches_gateway_runtime(command: str) -> bool:
@@ -631,8 +670,9 @@ def find_gateway_pids(
             _append_unique_pid(pids, get_running_pid(), _exclude)
         except Exception:
             pass
-    for pid in _get_service_pids():
-        _append_unique_pid(pids, pid, _exclude)
+    if all_profiles:
+        for pid in _get_service_pids():
+            _append_unique_pid(pids, pid, _exclude)
     try:
         include_restart_managers = not supports_systemd_services()
     except Exception:

--- a/hermes_cli/process_safety.py
+++ b/hermes_cli/process_safety.py
@@ -1,0 +1,133 @@
+"""Race-safe signalling through stable kernel process handles.
+
+A PID can be recycled between identity validation and ``os.kill(pid, ...)``.
+This module opens a kernel handle first, lets callers validate while that
+identity is pinned, and sends signals through the same handle. Unsupported
+platforms fail closed instead of falling back to a recyclable PID.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+from types import TracebackType
+from typing import Any, Self
+
+
+class StableProcessHandleUnavailable(RuntimeError):
+    """The current platform cannot safely pin a process identity."""
+
+
+class StableProcessHandle:
+    """A Linux pidfd or Windows process handle bound to one process identity."""
+
+    def __init__(self, pid: int, kind: str, handle: Any, owner: Any = None):
+        self.pid = pid
+        self._kind = kind
+        self._handle = handle
+        self._owner = owner
+        self._closed = False
+
+    @classmethod
+    def open(cls, pid: int) -> Self:
+        if pid <= 0:
+            raise ProcessLookupError(pid)
+
+        if sys.platform == "win32":
+            import ctypes
+            from ctypes import wintypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.OpenProcess.argtypes = [
+                wintypes.DWORD,
+                wintypes.BOOL,
+                wintypes.DWORD,
+            ]
+            kernel32.OpenProcess.restype = wintypes.HANDLE
+            # PROCESS_TERMINATE | SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION
+            access = 0x0001 | 0x100000 | 0x1000
+            handle = kernel32.OpenProcess(access, False, pid)
+            if not handle:
+                error = getattr(ctypes, "get_last_error")()
+                if error == 5:
+                    raise PermissionError(error, "OpenProcess denied", pid)
+                raise ProcessLookupError(pid)
+            return cls(pid, "windows", handle, kernel32)
+
+        pidfd_open = getattr(os, "pidfd_open", None)
+        pidfd_send_signal = getattr(signal, "pidfd_send_signal", None)
+        if pidfd_open is not None and pidfd_send_signal is not None:
+            return cls(pid, "pidfd", pidfd_open(pid, 0))
+
+        raise StableProcessHandleUnavailable(
+            "stable process handles require Linux pidfd or Windows OpenProcess"
+        )
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("stable process handle is closed")
+
+    def send_signal(self, sig: int) -> None:
+        self._require_open()
+        if self._kind == "pidfd":
+            sender = getattr(signal, "pidfd_send_signal")
+            sender(self._handle, sig, None, 0)
+            return
+
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = self._owner
+        kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
+        kernel32.TerminateProcess.restype = wintypes.BOOL
+        if not kernel32.TerminateProcess(self._handle, 1):
+            error = getattr(ctypes, "get_last_error")()
+            if error == 5:
+                raise PermissionError(error, "TerminateProcess denied", self.pid)
+            raise ProcessLookupError(self.pid)
+
+    def is_alive(self) -> bool:
+        self._require_open()
+        if self._kind == "pidfd":
+            try:
+                sender = getattr(signal, "pidfd_send_signal")
+                sender(self._handle, 0, None, 0)
+                return True
+            except ProcessLookupError:
+                return False
+
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = self._owner
+        kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+        kernel32.WaitForSingleObject.restype = wintypes.DWORD
+        result = kernel32.WaitForSingleObject(self._handle, 0)
+        if result == 0x00000102:  # WAIT_TIMEOUT
+            return True
+        if result == 0x00000000:  # WAIT_OBJECT_0
+            return False
+        error = getattr(ctypes, "get_last_error")()
+        raise OSError(error, "WaitForSingleObject failed", self.pid)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        if self._kind == "pidfd":
+            os.close(self._handle)
+        else:
+            self._owner.CloseHandle(self._handle)
+        self._closed = True
+
+    def __enter__(self) -> Self:
+        self._require_open()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -21,6 +21,7 @@ import os
 import platform
 import re
 import signal
+import socket
 import subprocess
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -28,6 +29,10 @@ from pathlib import Path
 from typing import Dict, Optional, Any
 
 from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+from hermes_cli.process_safety import (
+    StableProcessHandle,
+    StableProcessHandleUnavailable,
+)
 from hermes_constants import (
     find_node_executable,
     get_hermes_dir,
@@ -62,84 +67,37 @@ logger = logging.getLogger(__name__)
 _OWNER_REPLY_PREFIX = "[owner reply] "
 
 
-def _listener_pids_on_port(port: int) -> list:
-    """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
+def _ensure_bridge_port_available(port: int) -> None:
+    """Fail closed if the bridge bind target is not available.
 
-    This must match only LISTEN sockets. A bare ``lsof -i :PORT`` (or
-    ``fuser PORT/tcp``) also returns *clients* whose connection merely involves
-    that port number — e.g. a browser with a tab open on a local dev server
-    sharing the port. SIGTERMing those closed the user's browser at irregular
-    intervals. Restricting to LISTEN state frees the port for a new bridge
-    without ever touching an unrelated client.
+    Port ownership is never inferred from ``lsof``, ``ss``, ``netstat``, or a
+    process command line.  The only process-signalling path is the guarded
+    bridge pidfile cleanup below.  This probe merely asks the kernel whether a
+    new IPv4 listener can bind the bridge address; an occupied or unverifiable
+    port is preserved and reported explicitly.
     """
-    pids: list = []
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
-        result = subprocess.run(
-            ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
-            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
-        )
-        for line in result.stdout.strip().splitlines():
-            try:
-                pids.append(int(line))
-            except ValueError:
-                pass
-        if pids:
-            return pids
-    except FileNotFoundError:
-        pass  # lsof not installed — fall through to ss
-    # Fallback: ss (iproute2, present on virtually every modern Linux).
-    try:
-        result = subprocess.run(
-            ["ss", "-ltnHp", f"sport = :{port}"],
-            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
-        )
-        for m in re.finditer(r"pid=(\d+)", result.stdout):
-            pids.append(int(m.group(1)))
-    except FileNotFoundError:
-        pass
-    return pids
+        exclusive_addr_use = getattr(socket, "SO_EXCLUSIVEADDRUSE", None)
+        if _IS_WINDOWS and exclusive_addr_use is not None:
+            probe.setsockopt(socket.SOL_SOCKET, exclusive_addr_use, 1)
+        elif not _IS_WINDOWS:
+            # Match normal server restart semantics so closed connections in
+            # TIME_WAIT do not look like a live listener on POSIX.
+            probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        probe.bind(("127.0.0.1", port))
+        probe.listen(1)
+    except OSError as exc:
+        raise RuntimeError(
+            f"WhatsApp bridge port {port} is still in use or unavailable after "
+            "guarded pidfile cleanup; no listener was signalled."
+        ) from exc
+    finally:
+        probe.close()
 
 
-def _kill_port_process(port: int) -> None:
-    """Kill any process *listening* on the given TCP port (a stale bridge)."""
-    try:
-        if _IS_WINDOWS:
-            from hermes_cli._subprocess_compat import windows_hide_flags
-
-            # Use netstat to find the PID bound to this port, then taskkill
-            result = subprocess.run(
-                ["netstat", "-ano", "-p", "TCP"],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
-                creationflags=windows_hide_flags(),
-            )
-            for line in result.stdout.splitlines():
-                parts = line.split()
-                if len(parts) >= 5 and parts[3] == "LISTENING":
-                    local_addr = parts[1]
-                    if local_addr.endswith(f":{port}"):
-                        try:
-                            subprocess.run(
-                                ["taskkill", "/PID", parts[4], "/F"],
-                                capture_output=True, timeout=5,
-                                creationflags=windows_hide_flags(),
-                            )
-                        except subprocess.SubprocessError:
-                            pass
-        else:
-            # POSIX: only ever signal a process LISTENING on the port. A client
-            # whose connection happens to involve this port number (a browser
-            # tab on a local dev server, etc.) must never be killed.
-            for pid in _listener_pids_on_port(port):
-                try:
-                    os.kill(pid, signal.SIGTERM)
-                except (ProcessLookupError, PermissionError, OSError):
-                    pass
-    except Exception:
-        pass
-
-
-def _bridge_pid_is_ours(pid: int, session_path: Path, expected_start) -> bool:
-    """True only if ``pid`` is alive AND still our node bridge for this session.
+def _bridge_pid_is_ours(pid: int, expected_start) -> bool:
+    """True only if ``pid`` is alive and has the recorded process identity.
 
     The PID is read from a file written by a previous run.  Once that process
     exits and is reaped the kernel can recycle the number onto an unrelated
@@ -147,26 +105,18 @@ def _bridge_pid_is_ours(pid: int, session_path: Path, expected_start) -> bool:
     which a bare-liveness ``os.kill`` then SIGTERMed, closing the whole browser
     at irregular intervals (every time the flapping bridge restarted).
 
-    Identity is confirmed two ways: the kernel start time captured when we wrote
-    the pidfile (definitive), and — for legacy pidfiles with no baseline — the
-    command line, which must contain ``node`` and this session's unique path.
-    A recycled PID (different start time / different cmdline) is never ours.
+    Identity requires the kernel start time captured when we wrote the pidfile.
+    Legacy PID-only files cannot prove ownership and therefore fail closed.
     """
     from gateway.status import _pid_exists
     if not _pid_exists(pid):
         return False
-    if expected_start is not None:
-        from gateway.status import get_process_start_time
-        # A matching (pid, start time) pair uniquely identifies the process.
-        return get_process_start_time(pid) == expected_start
-    # Legacy pidfile (no recorded start time): fall back to a command-line
-    # signature so a recycled PID is still never signalled.  If we cannot read
-    # the cmdline we refuse to kill rather than risk a stranger.
-    from gateway.status import _read_process_cmdline
-    cmdline = _read_process_cmdline(pid)
-    if not cmdline:
+    if expected_start is None:
         return False
-    return ("node" in cmdline) and (str(session_path) in cmdline)
+    from gateway.status import get_process_start_time
+
+    # A matching (pid, start time) pair uniquely identifies the process.
+    return get_process_start_time(pid) == expected_start
 
 
 def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
@@ -198,24 +148,50 @@ def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
         except OSError:
             pass
         return
-    if _bridge_pid_is_ours(pid, session_path, recorded_start):
-        try:
-            os.kill(pid, signal.SIGTERM)
-            logger.info("[whatsapp] Killed stale bridge PID %d from pidfile", pid)
-        except (ProcessLookupError, PermissionError, OSError):
-            pass
-    else:
-        from gateway.status import _pid_exists
-        if _pid_exists(pid):
-            logger.warning(
-                "[whatsapp] Not killing pidfile PID %d: it is no longer the "
-                "bridge (recycled onto an unrelated process); skipping to avoid "
-                "killing a stranger.", pid,
-            )
+    remove_pidfile = True
     try:
-        pid_file.unlink()
-    except OSError:
+        # Open the kernel handle BEFORE validating PID metadata. Even if the
+        # numeric PID is recycled after this point, the handle remains bound to
+        # the original process identity and can never signal its replacement.
+        with StableProcessHandle.open(pid) as process_handle:
+            if _bridge_pid_is_ours(pid, recorded_start):
+                try:
+                    process_handle.send_signal(signal.SIGTERM)
+                    logger.info(
+                        "[whatsapp] Killed stale bridge PID %d from pidfile", pid
+                    )
+                except (ProcessLookupError, PermissionError, OSError) as exc:
+                    remove_pidfile = isinstance(exc, ProcessLookupError)
+                    logger.warning(
+                        "[whatsapp] Could not signal verified bridge PID %d: %s",
+                        pid,
+                        exc,
+                    )
+            elif process_handle.is_alive():
+                logger.warning(
+                    "[whatsapp] Not killing pidfile PID %d: it is no longer the "
+                    "bridge (recycled onto an unrelated process); skipping to avoid "
+                    "killing a stranger.",
+                    pid,
+                )
+    except ProcessLookupError:
         pass
+    except (StableProcessHandleUnavailable, PermissionError, OSError) as exc:
+        # On a platform where identity cannot be pinned, preserve both the
+        # process and pidfile. The following port preflight will fail closed.
+        remove_pidfile = False
+        logger.warning(
+            "[whatsapp] Not signalling stale bridge PID %d without a stable "
+            "process handle: %s",
+            pid,
+            exc,
+        )
+
+    if remove_pidfile:
+        try:
+            pid_file.unlink()
+        except OSError:
+            pass
 
 
 def _write_bridge_pidfile(session_path: Path, pid: int) -> None:
@@ -664,8 +640,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             
             # Kill any orphaned bridge from a previous gateway run
             _kill_stale_bridge_by_pidfile(self._session_path)
-            _kill_port_process(self._bridge_port)
             await asyncio.sleep(1)
+            _ensure_bridge_port_available(self._bridge_port)
             
             # Start the bridge process in its own process group.
             # Route output to a log file so QR codes, errors, and reconnection

--- a/tests/gateway/test_whatsapp_bridge_pidfile.py
+++ b/tests/gateway/test_whatsapp_bridge_pidfile.py
@@ -20,15 +20,16 @@ import time
 import pytest
 
 import os
+import signal
 import socket
+from unittest.mock import patch
 
 from plugins.platforms.whatsapp.adapter import (
     _bridge_pid_is_ours,
-    _kill_port_process,
     _kill_stale_bridge_by_pidfile,
-    _listener_pids_on_port,
     _write_bridge_pidfile,
 )
+from plugins.platforms.whatsapp import adapter as whatsapp_adapter
 from gateway.status import get_process_start_time, _pid_exists
 
 
@@ -68,7 +69,9 @@ class TestIdentityGuard:
         proc = _spawn_sleeper()
         try:
             _write_bridge_pidfile(tmp_path, proc.pid)
-            _kill_stale_bridge_by_pidfile(tmp_path)
+            with patch("plugins.platforms.whatsapp.adapter.os.kill") as raw_kill:
+                _kill_stale_bridge_by_pidfile(tmp_path)
+                assert all(call.args[1] == 0 for call in raw_kill.call_args_list)
             assert _wait_dead(proc), "the real bridge process should be killed"
             assert not (tmp_path / "bridge.pid").exists()
         finally:
@@ -77,52 +80,50 @@ class TestIdentityGuard:
                 proc.wait()
 
 
-    def test_legacy_pidfile_kills_matching_bridge_cmdline(self, tmp_path):
-        """Legacy pidfile: a PID whose cmdline names node + session IS reaped."""
-        # Shape the cmdline to look like the node bridge for this session.
+    def test_legacy_pidfile_never_authorizes_a_signal(self, tmp_path):
+        """A PID-only legacy file cannot prove identity, even with matching argv."""
         proc = _spawn_sleeper("node", str(tmp_path))
         try:
             (tmp_path / "bridge.pid").write_text(str(proc.pid))  # legacy: pid only
             _kill_stale_bridge_by_pidfile(tmp_path)
-            assert _wait_dead(proc), "a cmdline-confirmed bridge should be killed"
+            assert proc.poll() is None, "an unproven legacy PID must be preserved"
         finally:
             if proc.poll() is None:
                 proc.kill()
                 proc.wait()
 
 
-class TestKillPortProcess:
-    """Freeing the bridge port must target only LISTENers, never clients.
+class TestEnsureBridgePortAvailable:
+    """Port cleanup never infers process ownership or signals by listener PID."""
 
-    Root cause of the live Firefox kills: ``lsof -ti :PORT`` (and ``fuser
-    PORT/tcp``) also returned *client* sockets whose connection merely involved
-    the port number. The WhatsApp bridge uses port 3000 by default — a common
-    local dev-server port — so a browser tab on ``localhost:3000`` was matched
-    and SIGTERMed every time the (crash-looping) bridge restarted.
-    """
-
-    def test_listener_lookup_excludes_client_process(self):
-        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        srv.bind(("127.0.0.1", 0))
-        port = srv.getsockname()[1]
-        srv.listen(5)
-        # A separate process holding a *client* connection to that port.
-        client = subprocess.Popen([
-            sys.executable, "-c",
-            "import socket,time; c=socket.create_connection(('127.0.0.1',%d)); time.sleep(0.2)" % port,
-        ])
+    def test_occupied_port_is_reported_without_signalling_any_process(self):
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+        listener.listen(1)
         try:
-            conn, _ = srv.accept()  # establish the client connection
-            pids = _listener_pids_on_port(port)
-            if os.getpid() not in pids:
-                pytest.skip("neither lsof nor ss detected the listener here")
-            # The listener (this process) is found; the client process is NOT —
-            # the LISTEN filter is what spares unrelated clients like a browser.
-            assert client.pid not in pids
-            conn.close()
+            with patch("plugins.platforms.whatsapp.adapter.os.kill") as kill, patch(
+                "plugins.platforms.whatsapp.adapter.subprocess.run"
+            ) as run:
+                with pytest.raises(RuntimeError, match="still in use"):
+                    whatsapp_adapter._ensure_bridge_port_available(port)
+
+            kill.assert_not_called()
+            run.assert_not_called()
         finally:
-            client.kill()
-            client.wait()
-            srv.close()
+            listener.close()
+
+    def test_free_port_needs_no_process_discovery(self):
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+        probe.close()
+
+        with patch("plugins.platforms.whatsapp.adapter.os.kill") as kill, patch(
+            "plugins.platforms.whatsapp.adapter.subprocess.run"
+        ) as run:
+            whatsapp_adapter._ensure_bridge_port_available(port)
+
+        kill.assert_not_called()
+        run.assert_not_called()
 

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -13,7 +13,6 @@ Regression tests for two bugs in WhatsAppAdapter.connect():
 """
 
 import asyncio
-import signal
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -99,6 +98,7 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
         patch("builtins.open", return_value=mock_fh),
         patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock),
         patch("plugins.platforms.whatsapp.adapter.asyncio.create_task"),
+        patch("plugins.platforms.whatsapp.adapter._ensure_bridge_port_available"),
     ]
     if mock_client_cls is not None:
         base.append(patch("aiohttp.ClientSession", mock_client_cls))
@@ -158,7 +158,7 @@ class TestDataInitialized:
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8], \
+             patches[5], patches[6], patches[7], patches[8], patches[9], \
              patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
             # Must NOT raise NameError
             result = await adapter.connect()
@@ -188,7 +188,7 @@ class TestFileHandleClosedOnError:
         patches = _connect_patches(mock_proc, mock_fh)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7]:
+             patches[5], patches[6], patches[7], patches[8]:
             result = await adapter.connect()
 
         assert result is False
@@ -297,80 +297,12 @@ class TestBridgeRuntimeFailure:
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8]:
+             patches[5], patches[6], patches[7], patches[8], patches[9]:
             result = await adapter.connect()
 
         assert result is False
         mock_fh.close.assert_called_once()
         assert adapter._bridge_log_fh is None
-
-
-# ---------------------------------------------------------------------------
-# _kill_port_process() cross-platform tests
-# ---------------------------------------------------------------------------
-
-class TestKillPortProcess:
-    """Verify _kill_port_process uses platform-appropriate commands."""
-
-    @pytest.mark.windows_only
-    def test_uses_netstat_and_taskkill_on_windows(self):
-        """``windows_only``: netstat/taskkill are Windows binaries. The old
-        ``_IS_WINDOWS`` patch selected this branch on Linux, where neither
-        exists, so the mocked argv was the only thing under test."""
-        from plugins.platforms.whatsapp.adapter import _kill_port_process
-
-        netstat_output = (
-            "  Proto  Local Address          Foreign Address        State           PID\n"
-            "  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       12345\n"
-            "  TCP    0.0.0.0:3001           0.0.0.0:0              LISTENING       99999\n"
-        )
-        mock_netstat = MagicMock(stdout=netstat_output)
-        mock_taskkill = MagicMock()
-
-        def run_side_effect(cmd, **kwargs):
-            if cmd[0] == "netstat":
-                return mock_netstat
-            if cmd[0] == "taskkill":
-                return mock_taskkill
-            return MagicMock()
-
-        with patch("plugins.platforms.whatsapp.adapter.subprocess.run", side_effect=run_side_effect) as mock_run:
-            _kill_port_process(3000)
-
-        # netstat called
-        assert any(
-            call.args[0][0] == "netstat" for call in mock_run.call_args_list
-        )
-        # taskkill called with correct PID
-        assert any(
-            call.args[0] == ["taskkill", "/PID", "12345", "/F"]
-            for call in mock_run.call_args_list
-        )
-
-
-    @pytest.mark.linux_only
-    def test_kills_only_listeners_on_linux(self):
-        """POSIX path SIGTERMs only LISTENer PIDs (never clients) — the #43846 fix.
-
-        Replaces the old fuser-based test: ``fuser``/bare ``lsof -i`` also
-        matched client sockets sharing the port number, which closed unrelated
-        processes (a browser tab on the same port). The implementation now
-        resolves listeners via ``_listener_pids_on_port`` and signals only those.
-
-        ``linux_only``: asserts the POSIX ``os.kill``/SIGTERM path, which is
-        genuinely selected here without patching ``_IS_WINDOWS``.
-        """
-        from plugins.platforms.whatsapp import adapter as wa
-
-        kills = []
-        with patch("plugins.platforms.whatsapp.adapter._listener_pids_on_port",
-                   return_value=[55555]) as mock_listeners, \
-             patch("plugins.platforms.whatsapp.adapter.os.kill",
-                   side_effect=lambda pid, sig: kills.append((pid, sig))):
-            wa._kill_port_process(3000)
-
-        mock_listeners.assert_called_once_with(3000)
-        assert kills == [(55555, signal.SIGTERM)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -116,6 +116,36 @@ class TestFileContentHash:
 
 class TestStaleBridgeHandshake:
 
+    @pytest.mark.asyncio
+    async def test_port_preflight_failure_never_spawns_bridge(self, tmp_path):
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+
+        with patch(
+            "plugins.platforms.whatsapp.adapter.check_whatsapp_requirements",
+            return_value=True,
+        ), patch(
+            "aiohttp.ClientSession",
+            _mock_health({"status": "disconnected"}),
+        ), patch(
+            "plugins.platforms.whatsapp.adapter.asyncio.sleep",
+            new_callable=AsyncMock,
+        ), patch(
+            "plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"
+        ), patch(
+            "plugins.platforms.whatsapp.adapter._ensure_bridge_port_available",
+            side_effect=RuntimeError("port still in use"),
+        ), patch("subprocess.Popen") as mock_popen, patch.object(
+            adapter, "_acquire_platform_lock", return_value=True, create=True
+        ):
+            assert await adapter.connect() is False
+
+        mock_popen.assert_not_called()
+
 
     @pytest.mark.asyncio
     async def test_restarts_bridge_when_read_receipt_config_changed(self, tmp_path):
@@ -144,7 +174,7 @@ class TestStaleBridgeHandshake:
              patch("aiohttp.ClientSession", mock_client), \
              patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
              patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
-             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("plugins.platforms.whatsapp.adapter._ensure_bridge_port_available"), \
              patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
              patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
             await adapter.connect()
@@ -169,7 +199,7 @@ class TestDepRefreshStamp:
              patch("aiohttp.ClientSession", _mock_health({"status": "disconnected"})), \
              patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
              patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
-             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("plugins.platforms.whatsapp.adapter._ensure_bridge_port_available"), \
              patch("subprocess.run") as mock_run, \
              patch("subprocess.Popen", return_value=mock_proc), \
              patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
@@ -196,7 +226,7 @@ class TestCacheDirEnvPassthrough:
              patch("aiohttp.ClientSession", _mock_health({"status": "disconnected"})), \
              patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
              patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
-             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("plugins.platforms.whatsapp.adapter._ensure_bridge_port_available"), \
              patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
              patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
             await adapter.connect()

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -51,6 +51,94 @@ class TestProviderEnvDetection:
         assert not _has_provider_env_config(content)
 
 
+def test_empty_env_does_not_require_api_key_when_codex_oauth_is_logged_in(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True)
+    (home / ".env").write_text("", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "model:\n  provider: openai-codex\n  default: gpt-5.6-sol\n"
+        "memory: {}\n",
+        encoding="utf-8",
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setitem(
+        sys.modules,
+        "model_tools",
+        types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        ),
+    )
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status_local", lambda: {})
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {})
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "OpenAI Codex auth" in out and "logged in" in out
+    assert "No API key found" not in out
+    assert "Run 'hermes setup' to configure API keys" not in out
+
+
+def test_auth_provider_failures_are_isolated_and_reported(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True)
+    (home / ".env").write_text("", encoding="utf-8")
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir()
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setitem(
+        sys.modules,
+        "model_tools",
+        types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        ),
+    )
+    from hermes_cli import auth as auth_mod
+
+    def _fail_nous():
+        raise RuntimeError("nous probe failed")
+
+    def _fail_xai():
+        raise RuntimeError("xai probe failed")
+
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status_local", _fail_nous)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(
+        auth_mod,
+        "get_minimax_oauth_auth_status",
+        lambda: {"logged_in": True, "region": "global"},
+    )
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", _fail_xai)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "Nous Portal auth" in out and "nous probe failed" in out
+    assert "OpenAI Codex auth" in out and "logged in" in out
+    assert "MiniMax OAuth" in out and "region=global" in out
+    assert "xAI OAuth" in out and "xai probe failed" in out
+
+
 class TestDoctorToolAvailabilitySummary:
     def test_missing_api_key_summary_ignores_disabled_toolsets(self, monkeypatch):
         unavailable = [

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -6,11 +6,50 @@ import signal
 import subprocess
 import sys
 import textwrap
+from io import BytesIO
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
 
 import hermes_cli.gateway as gateway
+
+
+def test_find_gateway_pids_only_includes_service_units_for_all_profiles(monkeypatch):
+    """A service owned by another profile is not a current-profile process."""
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda: {31415})
+    monkeypatch.setattr(gateway, "_scan_gateway_pids", lambda *a, **k: [])
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+
+    assert gateway.find_gateway_pids() == []
+    assert gateway.find_gateway_pids(all_profiles=True) == [31415]
+
+
+@pytest.mark.parametrize(
+    ("profile_arg", "command"),
+    [
+        ("", "python -m hermes_cli.main --profile=work gateway run"),
+        (
+            "--profile work",
+            "python -m hermes_cli.main --profile worker gateway run",
+        ),
+    ],
+)
+def test_scan_gateway_pids_requires_exact_profile(monkeypatch, profile_arg, command):
+    """Process discovery never attributes another profile by substring."""
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: Path("/tmp/hermes"))
+    monkeypatch.setattr(gateway, "_profile_arg", lambda _home: profile_arg)
+    monkeypatch.setattr(gateway.os.path, "isdir", lambda path: path == "/proc")
+    monkeypatch.setattr(gateway.os, "listdir", lambda _path: ["12345"])
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *_args, **_kwargs: BytesIO(command.replace(" ", "\0").encode()),
+    )
+
+    assert gateway._scan_gateway_pids(set()) == []
 
 
 def _install_fake_gateway_run(monkeypatch, start_gateway):

--- a/tests/hermes_cli/test_process_safety.py
+++ b/tests/hermes_cli/test_process_safety.py
@@ -1,0 +1,72 @@
+"""Stable process handles must signal identity, never a recyclable PID."""
+
+from __future__ import annotations
+
+import ctypes
+import signal
+import subprocess
+import sys
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def test_pidfd_handle_signals_the_opened_process_without_os_kill():
+    from hermes_cli.process_safety import StableProcessHandle
+
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        with patch("os.kill") as raw_kill:
+            with StableProcessHandle.open(proc.pid) as handle:
+                assert handle.is_alive() is True
+                handle.send_signal(signal.SIGTERM)
+            raw_kill.assert_not_called()
+
+        proc.wait(timeout=5)
+        assert proc.returncode is not None
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+
+def test_closed_handle_cannot_signal():
+    from hermes_cli.process_safety import StableProcessHandle
+
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        handle = StableProcessHandle.open(proc.pid)
+        handle.close()
+        with pytest.raises(RuntimeError, match="closed"):
+            handle.send_signal(signal.SIGTERM)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+
+def test_windows_handle_lifecycle_uses_openprocess_and_closehandle():
+    from unittest.mock import MagicMock
+
+    from hermes_cli.process_safety import StableProcessHandle
+
+    kernel32 = SimpleNamespace(
+        OpenProcess=MagicMock(return_value=1234),
+        TerminateProcess=MagicMock(return_value=1),
+        WaitForSingleObject=MagicMock(return_value=0x102),
+        CloseHandle=MagicMock(return_value=1),
+    )
+
+    with patch("hermes_cli.process_safety.sys.platform", "win32"), patch.object(
+        ctypes, "WinDLL", return_value=kernel32, create=True
+    ):
+        handle = StableProcessHandle.open(4321)
+        assert handle.is_alive() is True
+        handle.send_signal(signal.SIGTERM)
+        handle.close()
+
+    kernel32.OpenProcess.assert_called_once_with(0x00101001, False, 4321)
+    kernel32.TerminateProcess.assert_called_once_with(1234, 1)
+    kernel32.CloseHandle.assert_called_once_with(1234)

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -1,9 +1,9 @@
 """Tests for the stale-dashboard handling run at the end of ``hermes update``.
 
 ``hermes update`` detects ``hermes dashboard`` processes left over from the
-previous version and kills them (SIGTERM + SIGKILL grace, or ``taskkill /F``
-on Windows).  Without this, the running backend silently serves stale Python
-against a freshly-updated JS bundle, producing 401s / empty data.
+previous version and stops them through stable kernel process handles. Without
+this, the running backend silently serves stale Python against a freshly-updated
+JS bundle, producing 401s / empty data.
 
 History:
 - #16872 introduced the warn-only helper (``_warn_stale_dashboard_processes``).
@@ -86,6 +86,23 @@ def _ps_runner(stdout: str):
     return _side_effect
 
 
+class _FakeStableHandle:
+    def __init__(self, pid: int):
+        self.pid = pid
+        self.signals: list[int] = []
+        self.alive = True
+
+    def send_signal(self, sig: int) -> None:
+        self.signals.append(sig)
+        self.alive = False
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+    def close(self) -> None:
+        pass
+
+
 class TestFindStaleDashboardPids:
     """Unit tests for the ps/wmic-based detection step."""
 
@@ -105,6 +122,57 @@ class TestFindStaleDashboardPids:
         assert os.getpid() not in pids
         assert 12345 in pids
 
+    def test_ancestor_launcher_pid_excluded(self):
+        ancestor = MagicMock(pid=54321)
+        with patch("psutil.Process") as mock_process, patch("subprocess.run") as mock_run:
+            mock_process.return_value.parents.return_value = [ancestor]
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(54321, "hermes dashboard --status"),
+                    _ps_line(12345, "hermes dashboard --port 9119"),
+                ]) + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+
+        assert 54321 not in pids
+        assert 12345 in pids
+
+    def test_ancestor_lookup_failure_fails_closed(self):
+        with patch("psutil.Process", side_effect=RuntimeError("access denied")), patch(
+            "subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_ps_line(12345, "hermes dashboard --port 9119") + "\n",
+                stderr="",
+            )
+            assert _find_stale_dashboard_pids() == []
+
+    @pytest.mark.parametrize(
+        "flag", ["--status", "--stop", '\"--status\"', "'--stop'"]
+    )
+    def test_management_command_is_not_a_dashboard_runtime(self, flag):
+        with patch("psutil.Process") as mock_process, patch(
+            "subprocess.run"
+        ) as mock_run:
+            mock_process.return_value.parents.return_value = []
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join(
+                    [
+                        _ps_line(54321, f"bash -c hermes dashboard {flag}"),
+                        _ps_line(12345, "hermes dashboard --port 9119"),
+                    ]
+                )
+                + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+
+        assert pids == [12345]
+
 
     def test_ps_timeout_returns_empty(self):
         import subprocess as sp
@@ -120,30 +188,23 @@ class TestKillStaleDashboardPosix:
 
 
     def test_sigterm_graceful_exit(self, capsys):
-        """Processes that exit on SIGTERM (the probe gets ProcessLookupError)
-        are reported as stopped and SIGKILL is never sent."""
+        """Stable handles receive SIGTERM; raw PID signalling is never used."""
         import signal as _signal
 
-        killed_signals: list[tuple[int, int]] = []
-
-        def fake_kill(pid, sig):
-            killed_signals.append((pid, sig))
-            if sig == 0:
-                # Probe after SIGTERM → "process gone".
-                raise ProcessLookupError
-            # SIGTERM itself: succeed silently.
+        handles = {pid: _FakeStableHandle(pid) for pid in (12345, 12346)}
 
         with patch("hermes_cli.main._find_stale_dashboard_pids",
                    return_value=[12345, 12346]), \
-             patch("os.kill", side_effect=fake_kill), \
+             patch("hermes_cli.dashboard_procs._open_verified_dashboard_handle",
+                   side_effect=lambda pid: handles[pid]), \
+             patch("os.kill") as raw_kill, \
+             patch("subprocess.run") as raw_taskkill, \
              patch("time.sleep"):
             result = _kill_stale_dashboard_processes()
 
-        # Both got SIGTERM.
-        sigterms = [pid for pid, sig in killed_signals if sig == _signal.SIGTERM]
-        assert sorted(sigterms) == [12345, 12346]
-        # No SIGKILL was needed.
-        assert not any(sig == _signal.SIGKILL for _, sig in killed_signals)
+        assert all(handle.signals == [_signal.SIGTERM] for handle in handles.values())
+        raw_kill.assert_not_called()
+        raw_taskkill.assert_not_called()
         assert result["matched"] == [12345, 12346]
         assert result["killed"] == [12345, 12346]
         assert result["failed"] == []
@@ -194,32 +255,22 @@ class TestKillStaleDashboardPosix:
 
 
 class TestKillStaleDashboardWindows:
-    """Kill path on Windows: taskkill /F."""
+    """Windows also terminates stable handles, never recyclable PIDs."""
 
-    @pytest.mark.windows_only
-    def test_taskkill_invoked_for_each_pid(self, capsys):
-        """``windows_only``: ``taskkill.exe`` only exists on Windows, and the
-        faked platform also silently skipped the POSIX-only cgroup/argv
-        snapshot the real Windows path must not take.
-        """
-
-        def fake_run(args, *a, **kw):
-            # taskkill returns 0 on success
-            return MagicMock(returncode=0, stdout="", stderr="")
+    def test_stable_handle_invoked_for_each_pid(self, capsys):
+        handles = {pid: _FakeStableHandle(pid) for pid in (12345, 12346)}
 
         with patch("hermes_cli.main._find_stale_dashboard_pids",
                    return_value=[12345, 12346]), \
-             patch("subprocess.run", side_effect=fake_run) as mock_run:
+             patch("hermes_cli.dashboard_procs._open_verified_dashboard_handle",
+                   side_effect=lambda pid: handles[pid]), \
+             patch("subprocess.run") as raw_taskkill:
             _kill_stale_dashboard_processes()
 
-        # Each PID triggered a taskkill /PID <n> /F invocation.
-        taskkill_calls = [
-            c for c in mock_run.call_args_list
-            if c.args and isinstance(c.args[0], list) and c.args[0][:1] == ["taskkill"]
-        ]
-        assert len(taskkill_calls) == 2
-        assert ["taskkill", "/PID", "12345", "/F"] in [c.args[0] for c in taskkill_calls]
-        assert ["taskkill", "/PID", "12346", "/F"] in [c.args[0] for c in taskkill_calls]
+        import signal as _signal
+
+        assert all(handle.signals == [_signal.SIGTERM] for handle in handles.values())
+        raw_taskkill.assert_not_called()
 
         out = capsys.readouterr().out
         assert "✓ stopped PID 12345" in out
@@ -288,6 +339,19 @@ class TestWindowsWmicEncoding:
             "down the reader thread (#17049)."
         )
 
+    def test_malformed_process_id_is_ignored(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=(
+                    "CommandLine=python -m hermes_cli.main dashboard\n"
+                    "ProcessId=not-a-pid\n"
+                ),
+                stderr="",
+            )
+            assert _find_stale_dashboard_pids() == []
+
 
 class TestSupervisedBackendRestart:
     """After the kill, systemd-supervised PIDs get their owning unit
@@ -301,18 +365,17 @@ class TestSupervisedBackendRestart:
         """A killed PID whose cgroup names a custom unit → systemctl restart."""
         live = self._live()
 
-        def fake_kill(pid, sig):
-            if sig == 0:
-                raise ProcessLookupError
+        handle = _FakeStableHandle(4321)
 
         with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
              patch.object(live, "_find_stale_dashboard_pids", return_value=[4321]), \
+             patch("hermes_cli.dashboard_procs._open_verified_dashboard_handle",
+                   return_value=handle), \
              patch.object(live, "_get_pid_cgroup_path",
                           return_value="/system.slice/hermes-serve.service"), \
              patch.object(live, "_get_systemd_service_for_pid",
                           return_value="hermes-serve.service"), \
              patch.object(live, "_try_restart_systemd_service", return_value=True) as restart, \
-             patch("os.kill", side_effect=fake_kill), \
              patch("time.sleep"):
             _kill_stale_dashboard_processes(restart_managed=True)
 


### PR DESCRIPTION
## Summary

- introduce a cross-platform `StableProcessHandle` abstraction (`pidfd` on Linux, process handles on Windows) so stale-process cleanup cannot signal a recycled PID
- use verified stable handles for dashboard cleanup and fail closed on unsupported platforms
- make WhatsApp bridge startup clean up only a verified pidfile owner and refuse to kill an unrelated listener on port 3000
- tighten gateway stale-PID matching to the exact Hermes profile via `--profile` / `HERMES_HOME`
- make `hermes doctor` OAuth-aware and isolate each auth provider probe

## Why

The prior cleanup paths identified a process by numeric PID and later signalled that PID. If the process exited and the kernel reused the PID between those operations, Hermes could terminate an unrelated process. The WhatsApp startup path also used to kill whatever occupied port 3000. This change pins the process identity before verification and signals only through that stable handle.

## Testing

- `scripts/run_tests.sh tests/gateway/test_whatsapp_bridge_pidfile.py tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_stale_bridge.py tests/hermes_cli/test_doctor.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_process_safety.py tests/hermes_cli/test_update_stale_dashboard.py -q`
  - 111 passed, 0 failed, 3 platform-specific skipped after rebasing onto current `main`
- `scripts/run_tests.sh tests/gateway/ tests/hermes_cli/ -q`
  - 9,854 passed, 0 failed, 91 platform-specific skipped
- independent security/correctness review: PASS, no critical findings

Windows-only behavior is covered by mocked unit tests here and the repository's `tests-os` Windows CI lane.
