### PR TITLE
fix(cron): run named jobs without unnecessary list scans

### DIFF
--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -19,3 +19,27 @@ def test_cronjob_schema_action_description_flags_create_requirements():
     assert "REQUIRED" in action_desc
 
 
+def test_cronjob_schema_directs_non_destructive_actions_to_exact_name_lookup():
+    """Run/pause/resume should use deterministic name resolution without listing."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    description = CRONJOB_SCHEMA["description"].lower()
+
+    assert "exact name" in description
+    assert "case-insensitive" in description
+    assert "run/pause/resume" in description
+    assert "do not call action='list' first" in description
+
+
+def test_cronjob_schema_keeps_list_first_safety_for_remove():
+    """Removing a job must still verify its ID before the destructive action."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    description = CRONJOB_SCHEMA["description"].lower()
+    remove_guidance = description[description.index("for action='remove'"):]
+
+    assert "action='list'" in remove_guidance
+    assert "action='remove'" in remove_guidance
+    assert "never guess" in remove_guidance
+
+

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1449,7 +1449,9 @@ Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing
 
 action='run' fires the job immediately in the BACKGROUND (like delegate_task): the call returns at once with a handle and the job's outcome re-enters the conversation as a new message when it finishes. Do not wait or poll after triggering a run — just continue. Optionally pass 'prompt' with action='run' to inject transient per-run context (appended to the job's stored prompt for that single fire only, never persisted).
 
-To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
+For run/pause/resume, job_id accepts either the job's ID or its exact name (case-insensitive). Pass the exact name directly and let the server resolve it. Do not call action='list' first just to check; if the name is not found or is ambiguous, the tool reports that and you can list jobs then.
+
+For action='remove', first call action='list' to find and verify the job ID, then call action='remove' with that ID. Never guess an ID when deleting a job.
 
 Jobs run in a fresh session with no current-chat context, so prompts must be self-contained.
 If skills are provided on create, the future cron run loads those skills in order, then follows the prompt as the task instruction.
@@ -1469,7 +1471,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "job_id": {
                 "type": "string",
-                "description": "Required for update/pause/resume/remove/run"
+                "description": "Required for update/pause/resume/remove/run. Accepts a job ID or exact name (case-insensitive)."
             },
             "prompt": {
                 "type": "string",


### PR DESCRIPTION
## What does this PR do?

When a user asks Hermes to run, pause, or resume a scheduled job by its exact name, the tool guidance currently tells the model to list every job first. That unnecessary visual scan can make the model miss a job that the server could resolve deterministically. This change directs non-destructive actions to the existing exact-name resolver while preserving list-first ID verification for removal.

### Symptom

A request to trigger a job by its exact name can produce an unnecessary `action='list'` call followed by a false claim that the job does not exist, even when the target is present in the returned list.

### Impact

Users can fail to run, pause, or resume existing scheduled jobs by name. The extra list response also adds avoidable context and latency.

### Bug Cause

**Trigger:** `tools/cronjob_tools.py:1452` / the `cronjob` schema description for job-management actions

**Causal chain:**
1. A user requests `run`, `pause`, or `resume` using an exact job name.
2. The schema's unconditional "always list first" wording routes the model through a full job listing and visual name scan instead of the deterministic resolver.
3. The model can miss the target and report that it does not exist rather than execute the requested action.

**Why it is wrong:** The server already accepts a job ID or exact case-insensitive name for these non-destructive actions and reports missing or ambiguous names explicitly.

**Working sibling / contrast:** Removal is destructive, so listing jobs and verifying the concrete ID remains the appropriate safe path.

**Ruled out:** The runtime resolver is not missing or nondeterministic; existing tool tests verify exact-name resolution, ambiguity handling, and not-found behavior. The defect is the broader schema guidance that discourages using that resolver.

### Fix

The schema now tells `run`, `pause`, and `resume` callers to pass an exact job name directly and list only after a not-found or ambiguity response. Separate removal guidance still requires listing first and using a verified job ID. Runtime schema-contract tests cover both requirements.

## Related Issue

Closes #83470

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/cronjob_tools.py` - scope list-first safety guidance to removal and document exact-name resolution for non-destructive actions.
- `tests/cron/test_cronjob_schema.py` - add runtime schema-contract coverage for direct name lookup and destructive removal safety.

## How to Test

1. Import `CRONJOB_SCHEMA` and verify its description directs `run`, `pause`, and `resume` to exact case-insensitive name resolution without a preliminary list call.
2. Verify the removal-specific guidance still requires `action='list'`, a verified ID, and no guessed deletion target.
3. Run the focused tool and schema suites:

```bash
scripts/run_tests.sh tests/tools/test_cronjob_tools.py
scripts/run_tests.sh tests/cron/test_cronjob_schema.py
```

Expected result: 68 tool tests and 3 schema tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A because the agent-facing schema is the documented behavior changed here
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; this schema-only guidance behaves identically across platforms
- [x] I've updated tool descriptions/schemas for the changed tool guidance

## Screenshots / Logs

N/A - focused automated tests exercise the imported runtime schema contract.
