### PR TITLE
feat(image_generate): add optional per-call model override

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -52,7 +52,9 @@ class ImageGenProvider(CatalogProviderBase):
         style/composition refs, clamped to ``max_reference_images``); any source image
         routes to the edit endpoint. Return :func:`success_response` / :func:`error_response`.
         Unknown ``kwargs`` MUST be ignored (forward compat); ``upscale`` (bool) is a
-        post-generation high-res pass, reported as ``upscaled: True`` in ``extra``."""
+        post-generation high-res pass, reported as ``upscaled: True`` in ``extra``;
+        ``model`` (str) is a per-call backend model id overriding the configured default
+        — providers without per-call model selection ignore it silently."""
 
 
 def resolve_aspect_ratio(value: Optional[str]) -> str:

--- a/tests/tools/test_image_generate_schema.py
+++ b/tests/tools/test_image_generate_schema.py
@@ -158,7 +158,9 @@ class TestDynamicParamGating(unittest.TestCase):
              patch("hermes_cli.plugins._ensure_plugins_discovered"):
             schema = _build_dynamic_image_schema()
         props = schema["parameters"]["properties"]
-        self.assertEqual(sorted(props), ["aspect_ratio", "prompt"])
+        # The per-call ``model`` override is backend-agnostic (the provider ABC
+        # accepts it via ``**kwargs``), so it survives capability gating.
+        self.assertEqual(sorted(props), ["aspect_ratio", "model", "prompt"])
         self.assertNotIn("upscale", props)
 
     def test_static_schema_carries_no_capability_args(self):

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -9,6 +9,7 @@ tests/tools/test_managed_media_gateways.py.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -368,12 +369,16 @@ class TestRegistryIntegration:
     def test_schema_exposes_expected_agent_params(self, image_tool):
         """The agent-facing schema exposes the unified text+image surface:
         prompt (required), aspect_ratio, the image-to-image inputs
-        image_url + reference_image_urls, and the opt-in upscale pass. Model
-        selection stays a user-level config choice, never an agent-level arg."""
+        image_url + reference_image_urls, the opt-in upscale pass, and the
+        optional ``model`` per-call override. The configured
+        ``image_gen.model`` remains the default when ``model`` is unset;
+        the schema just lets the agent request a specific backend model
+        on a single call when the active provider accepts one.
+        """
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
         assert set(props.keys()) == {
             "prompt", "aspect_ratio", "image_url", "reference_image_urls",
-            "upscale",
+            "upscale", "model",
         }
         assert image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["required"] == ["prompt"]
 
@@ -665,3 +670,103 @@ class TestUpscaleDispatchForwarding:
 
         image_tool._dispatch_to_plugin_provider("a cat", "square")
         assert "upscale" not in fake_provider.generate.call_args.kwargs
+
+    def test_dispatch_per_call_model_wins_over_configured(self, image_tool, monkeypatch):
+        """A non-empty ``model`` arg overrides ``image_gen.model`` for the call."""
+        import json as _json
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "krea")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: "configured-default")
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None
+        )
+
+        out = image_tool._dispatch_to_plugin_provider(
+            "a cat", "square", model="per-call-override"
+        )
+        assert _json.loads(out)["success"] is True
+        assert fake_provider.generate.call_args.kwargs["model"] == "per-call-override"
+
+    def test_dispatch_falls_back_to_configured_when_model_unset(self, image_tool, monkeypatch):
+        """When ``model`` is unset / whitespace, the configured default is used."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "krea")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: "configured-default")
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None
+        )
+
+        image_tool._dispatch_to_plugin_provider("a cat", "square", model="   ")
+        assert fake_provider.generate.call_args.kwargs["model"] == "configured-default"
+
+    def test_handle_image_generate_extracts_model_from_args(self, image_tool, monkeypatch):
+        """The handler reads ``model`` from the LLM tool-call args and threads it through."""
+        import json as _json
+        from unittest.mock import MagicMock
+
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "krea")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: "configured-default")
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None
+        )
+        # Skip post-processing so we just verify what reached the provider.
+        monkeypatch.setattr(image_tool, "_postprocess_image_generate_result", lambda raw, **k: raw)
+
+        raw = image_tool._handle_image_generate(
+            {"prompt": "a cat", "model": "  Nano-Banana-Pro  "}
+        )
+        assert _json.loads(raw)["success"] is True
+        assert fake_provider.generate.call_args.kwargs["model"] == "Nano-Banana-Pro"
+
+    def test_handle_image_generate_ignores_non_string_model(self, image_tool, monkeypatch):
+        """A bad LLM tool-call that passes a non-string ``model`` doesn't crash dispatch."""
+        import json as _json
+        from unittest.mock import MagicMock
+
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "krea")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: "configured-default")
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None
+        )
+        monkeypatch.setattr(image_tool, "_postprocess_image_generate_result", lambda raw, **k: raw)
+
+        raw = image_tool._handle_image_generate(
+            {"prompt": "a cat", "model": 12345}
+        )
+        assert _json.loads(raw)["success"] is True
+        # Falls back to the configured default when the per-call value isn't usable.
+        assert fake_provider.generate.call_args.kwargs["model"] == "configured-default"
+
+    def test_resolve_fal_model_per_call_override(self, image_tool, monkeypatch):
+        """`_resolve_fal_model(override)` honors a non-empty override string."""
+        model_id, _meta = image_tool._resolve_fal_model(" fal-ai/nano-banana-pro ")
+        assert model_id == "fal-ai/nano-banana-pro"
+
+    def test_resolve_fal_model_falls_back_to_configured(self, image_tool, monkeypatch):
+        """Empty / whitespace override falls back to the configured value."""
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: None)
+        monkeypatch.setattr(os, "getenv", lambda key, default=None: "fal-ai/gpt-image-1.5" if key == "FAL_IMAGE_MODEL" else (default or ""))
+        model_id, _meta = image_tool._resolve_fal_model("   ")
+        assert model_id == "fal-ai/gpt-image-1.5"

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -9,7 +9,6 @@ tests/tools/test_managed_media_gateways.py.
 
 from __future__ import annotations
 
-import os
 from unittest.mock import patch
 
 import pytest
@@ -770,6 +769,22 @@ class TestUpscaleDispatchForwarding:
     def test_resolve_fal_model_falls_back_to_configured(self, image_tool, monkeypatch):
         """Empty / whitespace override falls back to the configured value."""
         monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: None)
-        monkeypatch.setattr(os, "getenv", lambda key, default=None: "fal-ai/gpt-image-1.5" if key == "FAL_IMAGE_MODEL" else (default or ""))
+        monkeypatch.setenv("FAL_IMAGE_MODEL", "fal-ai/gpt-image-1.5")
         model_id, _meta = image_tool._resolve_fal_model("   ")
         assert model_id == "fal-ai/gpt-image-1.5"
+
+    def test_resolve_fal_model_override_dropped_signal(self, image_tool, monkeypatch):
+        """An unrecognized override id signals fallback via metadata."""
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: None)
+        monkeypatch.delenv("FAL_IMAGE_MODEL", raising=False)
+        model_id, meta = image_tool._resolve_fal_model("fal-ai/nonexistent-model")
+        assert model_id == image_tool.DEFAULT_MODEL
+        assert meta.get("override_dropped") is True
+
+    def test_resolve_fal_model_no_override_dropped_when_unset(self, image_tool, monkeypatch):
+        """No override means no override_dropped flag in metadata."""
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: None)
+        monkeypatch.delenv("FAL_IMAGE_MODEL", raising=False)
+        model_id, meta = image_tool._resolve_fal_model(None)
+        assert model_id == image_tool.DEFAULT_MODEL
+        assert "override_dropped" not in meta

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -9,6 +9,7 @@ tests/tools/test_managed_media_gateways.py.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -374,14 +375,16 @@ class TestRegistryIntegration:
         + aspect_ratio. Capability args (image_url, reference_image_urls,
         upscale) are added per-model by the dynamic override so sessions
         whose active model can't honor them never see them (#95681 diet).
-        Model selection stays a user-level config choice, never an
-        agent-level arg."""
+        Model selection stays a user-level config choice; the per-call
+        ``model`` override is advertised by the dynamic builder, not the
+        static schema."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
         assert set(props.keys()) == {"prompt", "aspect_ratio"}
         assert image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["required"] == ["prompt"]
-        # The dynamic builder owns the capability args.
+        # The dynamic builder owns the capability args + the per-call model override.
         dyn = image_tool._build_dynamic_image_schema()
         assert "parameters" in dyn and "prompt" in dyn["parameters"]["properties"]
+        assert dyn["parameters"]["properties"]["model"]["type"] == "string"
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]
@@ -670,3 +673,103 @@ class TestUpscaleDispatchForwarding:
 
         image_tool._dispatch_to_plugin_provider("a cat", "square")
         assert "upscale" not in fake_provider.generate.call_args.kwargs
+
+    def test_dispatch_per_call_model_wins_over_configured(self, image_tool, monkeypatch):
+        """A non-empty ``model`` arg overrides ``image_gen.model`` for the call."""
+        import json as _json
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "krea")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: "configured-default")
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None
+        )
+
+        out = image_tool._dispatch_to_plugin_provider(
+            "a cat", "square", model="per-call-override"
+        )
+        assert _json.loads(out)["success"] is True
+        assert fake_provider.generate.call_args.kwargs["model"] == "per-call-override"
+
+    def test_dispatch_falls_back_to_configured_when_model_unset(self, image_tool, monkeypatch):
+        """When ``model`` is unset / whitespace, the configured default is used."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "krea")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: "configured-default")
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None
+        )
+
+        image_tool._dispatch_to_plugin_provider("a cat", "square", model="   ")
+        assert fake_provider.generate.call_args.kwargs["model"] == "configured-default"
+
+    def test_handle_image_generate_extracts_model_from_args(self, image_tool, monkeypatch):
+        """The handler reads ``model`` from the LLM tool-call args and threads it through."""
+        import json as _json
+        from unittest.mock import MagicMock
+
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "krea")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: "configured-default")
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None
+        )
+        # Skip post-processing so we just verify what reached the provider.
+        monkeypatch.setattr(image_tool, "_postprocess_image_generate_result", lambda raw, **k: raw)
+
+        raw = image_tool._handle_image_generate(
+            {"prompt": "a cat", "model": "  Nano-Banana-Pro  "}
+        )
+        assert _json.loads(raw)["success"] is True
+        assert fake_provider.generate.call_args.kwargs["model"] == "Nano-Banana-Pro"
+
+    def test_handle_image_generate_ignores_non_string_model(self, image_tool, monkeypatch):
+        """A bad LLM tool-call that passes a non-string ``model`` doesn't crash dispatch."""
+        import json as _json
+        from unittest.mock import MagicMock
+
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "krea")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: "configured-default")
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None
+        )
+        monkeypatch.setattr(image_tool, "_postprocess_image_generate_result", lambda raw, **k: raw)
+
+        raw = image_tool._handle_image_generate(
+            {"prompt": "a cat", "model": 12345}
+        )
+        assert _json.loads(raw)["success"] is True
+        # Falls back to the configured default when the per-call value isn't usable.
+        assert fake_provider.generate.call_args.kwargs["model"] == "configured-default"
+
+    def test_resolve_fal_model_per_call_override(self, image_tool, monkeypatch):
+        """`_resolve_fal_model(override)` honors a non-empty override string."""
+        model_id, _meta = image_tool._resolve_fal_model(" fal-ai/nano-banana-pro ")
+        assert model_id == "fal-ai/nano-banana-pro"
+
+    def test_resolve_fal_model_falls_back_to_configured(self, image_tool, monkeypatch):
+        """Empty / whitespace override falls back to the configured value."""
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: None)
+        monkeypatch.setattr(os, "getenv", lambda key, default=None: "fal-ai/gpt-image-1.5" if key == "FAL_IMAGE_MODEL" else (default or ""))
+        model_id, _meta = image_tool._resolve_fal_model("   ")
+        assert model_id == "fal-ai/gpt-image-1.5"

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -768,23 +768,31 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
 # ---------------------------------------------------------------------------
 # Model resolution + payload construction
 # ---------------------------------------------------------------------------
-def _resolve_fal_model() -> tuple:
+def _resolve_fal_model(override: Optional[str] = None) -> tuple:
     """Resolve the active FAL model from config.yaml (primary) or default.
 
+    A non-empty ``override`` (typically the per-call ``model`` argument
+    surfaced in the ``image_generate`` schema) wins over the configured
+    ``image_gen.model`` value. Callers that don't accept per-call model
+    overrides can simply pass None.
+
     Returns (model_id, metadata_dict). Falls back to DEFAULT_MODEL if the
-    configured model is unknown (logged as a warning).
+    resolved model id is unknown (logged as a warning).
     """
     model_id = ""
-    try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        img_cfg = cfg.get("image_gen") if isinstance(cfg, dict) else None
-        if isinstance(img_cfg, dict):
-            raw = img_cfg.get("model")
-            if isinstance(raw, str):
-                model_id = raw.strip()
-    except Exception as exc:
-        logger.debug("Could not load image_gen.model from config: %s", exc)
+    if isinstance(override, str):
+        model_id = override.strip()
+    if not model_id:
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            img_cfg = cfg.get("image_gen") if isinstance(cfg, dict) else None
+            if isinstance(img_cfg, dict):
+                raw = img_cfg.get("model")
+                if isinstance(raw, str):
+                    model_id = raw.strip()
+        except Exception as exc:
+            logger.debug("Could not load image_gen.model from config: %s", exc)
 
     # Env var escape hatch (undocumented; backward-compat for tests/scripts).
     if not model_id:
@@ -1087,6 +1095,7 @@ def image_generate_tool(
     image_url: Optional[str] = None,
     reference_image_urls: Optional[list] = None,
     upscale: Optional[bool] = None,
+    model: Optional[str] = None,
 ) -> str:
     """Generate an image from a text prompt, or edit a source image, via FAL.
 
@@ -1094,16 +1103,22 @@ def image_generate_tool(
     the configured model declares an ``edit_endpoint``, the call routes to that
     image-to-image / edit endpoint; otherwise it's plain text-to-image.
 
-    The agent-facing schema exposes ``prompt``, ``aspect_ratio``, ``image_url``
-    and ``reference_image_urls``; the remaining kwargs are overrides for direct
-    Python callers and are filtered per-model via the ``supports`` /
-    ``edit_supports`` whitelist (unsupported overrides are silently dropped so
-    legacy callers don't break when switching models).
+    The agent-facing schema exposes ``prompt``, ``aspect_ratio``, ``image_url``,
+    ``reference_image_urls``, ``upscale`` and the optional ``model`` override;
+    the remaining kwargs are overrides for direct Python callers and are
+    filtered per-model via the ``supports`` / ``edit_supports`` whitelist
+    (unsupported overrides are silently dropped so legacy callers don't break
+    when switching models).
+
+    The ``model`` argument is the per-call override surfaced in the
+    ``image_generate`` schema. When set, it wins over ``image_gen.model`` from
+    config for this call only. Empty / whitespace / non-string values fall
+    back to the configured default.
 
     Returns a JSON string with ``{"success": bool, "image": url | None,
     "modality": "text" | "image", "error": str, "error_type": str}``.
     """
-    model_id, meta = _resolve_fal_model()
+    model_id, meta = _resolve_fal_model(model)
 
     # Collect any source images (primary + references) into one ordered list.
     source_images: list = []
@@ -1474,6 +1489,19 @@ IMAGE_GENERATE_SCHEMA = {
                     "the per-model default."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional backend-specific model identifier that "
+                    "overrides the configured default for this call only "
+                    "(e.g. a FAL model id, an OpenAI or xAI image model, or "
+                    "when the active backend exposes a bot-name catalog, a "
+                    "specific bot name). The set of valid values depends on "
+                    "the active backend; leave unset to use the configured "
+                    "default. Ignored by backends that don't accept a "
+                    "per-call model override."
+                ),
+            },
         },
         "required": ["prompt"],
     },
@@ -1525,6 +1553,7 @@ def _dispatch_to_plugin_provider(
     image_url: Optional[str] = None,
     reference_image_urls: Optional[list] = None,
     upscale: Optional[bool] = None,
+    model: Optional[str] = None,
 ):
     """Route the call to a plugin-registered provider when one is selected.
 
@@ -1542,13 +1571,21 @@ def _dispatch_to_plugin_provider(
     route to its edit endpoint. ``upscale`` (when explicitly set) requests a
     post-generation high-resolution pass; providers without upscale support
     ignore it via their ``**kwargs`` (the ABC contract).
+
+    ``model`` (when explicitly set) is the per-call backend-specific model
+    override surfaced in the ``image_generate`` schema. It wins over
+    ``image_gen.model`` from config for this call only. Backends without a
+    per-call model concept receive the value harmlessly and ignore it.
     """
     configured = _read_configured_image_provider()
     if not configured or configured == "fal":
         return None  # unset/explicit FAL keeps the legacy FAL path
 
-    # Also read configured model so we can pass it to the plugin
+    # Also read configured model so we can pass it to the plugin. A per-call
+    # ``model`` argument always wins; the configured default is the fallback.
     configured_model = _read_configured_image_model()
+    override_model = (model or "").strip() or None
+    effective_model = override_model or configured_model
 
     try:
         # Import locally so plugin discovery isn't triggered just by
@@ -1586,8 +1623,8 @@ def _dispatch_to_plugin_provider(
 
     kwargs: Dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
     try:
-        if configured_model:
-            kwargs["model"] = configured_model
+        if effective_model:
+            kwargs["model"] = effective_model
         if isinstance(image_url, str) and image_url.strip():
             kwargs["image_url"] = image_url.strip()
         norm_refs = None
@@ -1687,13 +1724,15 @@ def _maybe_route_managed_krea(
     image_url: Optional[str] = None,
     reference_image_urls: Optional[list] = None,
     upscale: Optional[bool] = None,
+    model: Optional[str] = None,
 ) -> Optional[str]:
     """Route a native ``krea-2-*`` model to the managed Krea gateway, in managed mode.
 
     Returns a JSON result string when handled by the Krea managed gateway, or
     ``None`` to fall through to the normal plugin/FAL pipeline. Fires only when
     all hold:
-      - the configured image model is a native ``krea-2-*`` id, AND
+      - the configured image model is a native ``krea-2-*`` id (or the per-call
+        ``model`` argument names one), AND
       - the user isn't already routed to the Krea plugin via
         ``image_gen.provider`` (that path dispatches normally), AND
       - the managed Krea gateway is resolvable (portal/managed mode).
@@ -1704,7 +1743,10 @@ def _maybe_route_managed_krea(
     if _read_configured_image_provider() == "krea":
         return None
 
-    normalized = _normalize_krea_model(_read_configured_image_model())
+    # Per-call model wins over the configured default for routing decisions,
+    # matching the dispatch path's behavior. Routing only fires for ``krea-2-*``.
+    candidate_model = (model or "").strip() or _read_configured_image_model()
+    normalized = _normalize_krea_model(candidate_model)
     if normalized is None:
         return None
 
@@ -1818,6 +1860,10 @@ def _handle_image_generate(args, **kw):
     upscale = args.get("upscale")
     if not isinstance(upscale, bool):
         upscale = None
+    # Optional per-call model override. Strings only — anything else is treated
+    # as "unset" so a bad LLM tool-call can't crash the dispatch path.
+    raw_model = args.get("model")
+    per_call_model = raw_model.strip() if isinstance(raw_model, str) else None
     task_id = kw.get("task_id")
 
     # Terminal-backend confinement chokepoint: convert path-like sources to
@@ -1837,6 +1883,7 @@ def _handle_image_generate(args, **kw):
         image_url=image_url,
         reference_image_urls=reference_image_urls,
         upscale=upscale,
+        model=per_call_model,
     )
     if dispatched is not None:
         return _postprocess_image_generate_result(dispatched, task_id=task_id)
@@ -1851,6 +1898,7 @@ def _handle_image_generate(args, **kw):
         image_url=image_url,
         reference_image_urls=reference_image_urls,
         upscale=upscale,
+        model=per_call_model,
     )
     if krea_routed is not None:
         return _postprocess_image_generate_result(krea_routed, task_id=task_id)
@@ -1861,6 +1909,7 @@ def _handle_image_generate(args, **kw):
         image_url=image_url,
         reference_image_urls=reference_image_urls,
         upscale=upscale,
+        model=per_call_model,
     )
     return _postprocess_image_generate_result(raw, task_id=task_id)
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -185,10 +185,14 @@ def _plugin_provider_name() -> Optional[str]:
     return configured
 
 
-def _resolve_fal_model() -> tuple:
-    """Return ``(model_id, meta)`` for the configured FAL model, falling back to DEFAULT_MODEL (warned) when unknown."""
+def _resolve_fal_model(override: Optional[str] = None) -> tuple:
+    """``(model_id, meta)`` for the effective FAL model — a non-empty per-call ``override``
+    (the ``model`` argument surfaced in the ``image_generate`` schema) wins over the
+    configured ``image_gen.model`` — falling back to DEFAULT_MODEL (warned) when the
+    resolved id is unknown."""
+    model_id = override.strip() if isinstance(override, str) else ""
     # FAL_IMAGE_MODEL is an undocumented escape hatch (backward-compat for tests/scripts).
-    model_id = _read_image_gen_key("model") or os.getenv("FAL_IMAGE_MODEL", "").strip()
+    model_id = model_id or _read_configured_image_model() or os.getenv("FAL_IMAGE_MODEL", "").strip()
     if model_id and model_id not in FAL_MODELS:
         logger.warning("Unknown FAL model '%s' in config; falling back to %s", model_id, DEFAULT_MODEL)
         model_id = None
@@ -408,14 +412,17 @@ def image_generate_tool(
     num_inference_steps: Optional[int] = None, guidance_scale: Optional[float] = None,
     num_images: Optional[int] = None, output_format: Optional[str] = None,
     seed: Optional[int] = None, image_url: Optional[str] = None,
-    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None) -> str:
+    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None,
+    model: Optional[str] = None) -> str:
     """Generate (or, with source images + an ``edit_endpoint`` model, edit) an image via FAL.
 
     Extra kwargs are overrides filtered per-model via ``supports`` / ``edit_supports`` (dropped
-    silently so callers survive model switches). Returns JSON ``{"success", "image", "modality",
-    "error", "error_type"}``.
+    silently so callers survive model switches). ``model`` is the per-call override surfaced in
+    the ``image_generate`` schema; it wins over ``image_gen.model`` from config for this call
+    only, and empty / whitespace / non-string values fall back to the configured default.
+    Returns JSON ``{"success", "image", "modality", "error", "error_type"}``.
     """
-    model_id, meta = _resolve_fal_model()
+    model_id, meta = _resolve_fal_model(model)
     refs = reference_image_urls if isinstance(reference_image_urls, (list, tuple)) else []
     source_images = [c.strip() for c in (image_url, *refs) if isinstance(c, str) and c.strip()]
     use_edit = bool(source_images) and bool(meta.get("edit_endpoint"))
@@ -608,9 +615,11 @@ def _add_provider_kwargs(kwargs, image_url, reference_image_urls, upscale, model
 
 def _dispatch_to_plugin_provider(
     prompt: str, aspect_ratio: str, image_url: Optional[str] = None,
-    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None):
+    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None,
+    model: Optional[str] = None):
     """JSON result from the selected plugin provider, or ``None`` to fall through to in-tree FAL
-    (provider unset / ``"fal"`` / ``"nous"``). Providers without ``upscale`` ignore it via ``**kwargs``."""
+    (provider unset / ``"fal"`` / ``"nous"``). Providers without ``upscale`` ignore it via
+    ``**kwargs``; a per-call ``model`` override wins over the configured ``image_gen.model``."""
     configured = _plugin_provider_name()
     if configured is None:
         return None
@@ -634,7 +643,7 @@ def _dispatch_to_plugin_provider(
     kwargs: Dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
     try:
         _add_provider_kwargs(kwargs, image_url, reference_image_urls, upscale,
-                             model=_read_configured_image_model())
+                             model=((model or "").strip() or _read_configured_image_model()))
         result = provider.generate(**kwargs)
     except Exception as exc:
         # A TypeError from generate() predating image_url support (third-party plugin not yet
@@ -667,16 +676,22 @@ def _normalize_krea_model(model_id: Optional[str]) -> Optional[str]:
 
 def _maybe_route_managed_krea(
     prompt: str, aspect_ratio: str, image_url: Optional[str] = None,
-    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None) -> Optional[str]:
+    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None,
+    model: Optional[str] = None) -> Optional[str]:
     """JSON result from the managed Krea gateway, or ``None`` to fall through.
 
-    Fires only for a native ``krea-2-*`` model with no ``image_gen.provider`` other than
+    Fires only for a native ``krea-2-*`` model — the configured one, or one named by
+    the per-call ``model`` override — with no ``image_gen.provider`` other than
     ``"nous"`` stored (a picker choice dispatches normally) and a resolvable Krea gateway.
     """
     configured_provider = _read_configured_image_provider()
     if configured_provider is not None and configured_provider != NOUS_MANAGED_PROVIDER:
         return None
-    normalized = _normalize_krea_model(_read_configured_image_model())
+
+    # Per-call model wins over the configured default for routing decisions,
+    # matching the dispatch path's behavior. Routing only fires for ``krea-2-*``.
+    candidate_model = (model or "").strip() or _read_configured_image_model()
+    normalized = _normalize_krea_model(candidate_model)
     if normalized is None:
         return None
     try:
@@ -730,6 +745,12 @@ def _handle_image_generate(args, **kw):
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
     upscale = args.get("upscale")
+    if not isinstance(upscale, bool):
+        upscale = None
+    # Optional per-call model override. Strings only — anything else is treated
+    # as "unset" so a bad LLM tool-call can't crash the dispatch path.
+    raw_model = args.get("model")
+    per_call_model = raw_model.strip() if isinstance(raw_model, str) else None
     task_id = kw.get("task_id")
     # Confinement chokepoint BEFORE any dispatch: every route receives sandbox-confined bytes.
     image_url, reference_image_urls, confine_error = _confine_source_images(
@@ -739,7 +760,7 @@ def _handle_image_generate(args, **kw):
     # Order matters: explicit plugin provider (incl. "krea"), then model-driven managed Krea
     # interception (only when no provider is set, so BYO/direct FAL stays untouched), then FAL.
     sources = dict(image_url=image_url, reference_image_urls=reference_image_urls,
-                   upscale=upscale if isinstance(upscale, bool) else None)
+                   upscale=upscale, model=per_call_model)
     raw = None
     for route in (_dispatch_to_plugin_provider, _maybe_route_managed_krea, image_generate_tool):
         raw = route(prompt, aspect_ratio, **sources)
@@ -813,6 +834,19 @@ _UPSCALE_PARAM = {
     ),
 }
 
+_MODEL_PARAM = {
+    "type": "string",
+    "description": (
+        "Optional backend-specific model identifier that overrides the "
+        "configured default for this call only (e.g. a FAL model id, an "
+        "OpenAI or xAI image model, or — when the active backend exposes a "
+        "bot-name catalog — a specific bot name). The set of valid values "
+        "depends on the active backend; leave unset to use the configured "
+        "default. Ignored by backends that don't accept a per-call model "
+        "override."
+    ),
+}
+
 
 def _build_dynamic_image_schema() -> Dict[str, Any]:
     """Render description AND params from the active model's capabilities; args it cannot
@@ -847,6 +881,9 @@ def _build_dynamic_image_schema() -> Dict[str, Any]:
         edit_clause = " (text-to-image only — the active model cannot edit existing images)"
     if info.get("supports_upscale"):
         properties["upscale"] = _UPSCALE_PARAM
+    # Every backend accepts a per-call model override via the provider ``**kwargs``
+    # contract (worst case: silently ignored), so it is advertised unconditionally.
+    properties["model"] = _MODEL_PARAM
     return {"description": base_desc.format(edit_clause=edit_clause),
             "parameters": {"type": "object", "properties": properties, "required": ["prompt"]}}
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -184,20 +184,23 @@ def _plugin_provider_name() -> Optional[str]:
         return None
     return configured
 
-
 def _resolve_fal_model(override: Optional[str] = None) -> tuple:
     """``(model_id, meta)`` for the effective FAL model — a non-empty per-call ``override``
     (the ``model`` argument surfaced in the ``image_generate`` schema) wins over the
     configured ``image_gen.model`` — falling back to DEFAULT_MODEL (warned) when the
-    resolved id is unknown."""
-    model_id = override.strip() if isinstance(override, str) else ""
+    resolved id is unknown. When an override was requested but dropped, the returned
+    meta carries ``"override_dropped": True`` so the response can signal the fallback."""
+    requested = override.strip() if isinstance(override, str) else ""
     # FAL_IMAGE_MODEL is an undocumented escape hatch (backward-compat for tests/scripts).
-    model_id = model_id or _read_configured_image_model() or os.getenv("FAL_IMAGE_MODEL", "").strip()
+    model_id = requested or _read_configured_image_model() or os.getenv("FAL_IMAGE_MODEL", "").strip()
     if model_id and model_id not in FAL_MODELS:
         logger.warning("Unknown FAL model '%s' in config; falling back to %s", model_id, DEFAULT_MODEL)
         model_id = None
     model_id = model_id or DEFAULT_MODEL
-    return model_id, FAL_MODELS[model_id]
+    meta = FAL_MODELS[model_id]
+    if requested and requested != model_id:
+        meta = dict(meta, override_dropped=True)
+    return model_id, meta
 
 
 _SIZE_KEY_BY_STYLE = {"image_size_preset": "image_size", "gpt_literal": "image_size",
@@ -420,7 +423,9 @@ def image_generate_tool(
     silently so callers survive model switches). ``model`` is the per-call override surfaced in
     the ``image_generate`` schema; it wins over ``image_gen.model`` from config for this call
     only, and empty / whitespace / non-string values fall back to the configured default.
-    Returns JSON ``{"success", "image", "modality", "error", "error_type"}``.
+    Returns JSON ``{"success", "image", "modality", "model", "error", "error_type"}`` — plus
+    ``"model_override_dropped": true`` when a per-call override was requested but the id was
+    unrecognized (``"model"`` then names the fallback actually used).
     """
     model_id, meta = _resolve_fal_model(model)
     refs = reference_image_urls if isinstance(reference_image_urls, (list, tuple)) else []
@@ -467,11 +472,15 @@ def image_generate_tool(
                     len(formatted_images), generation_time, upscaled_count, endpoint, modality)
         debug_call_data["success"] = True
         debug_call_data["images_generated"] = len(formatted_images)
-        return finish(generation_time, {
+        response_data = {
             "success": True,
             "image": formatted_images[0]["url"],
             "modality": modality,
-            "upscaled": bool(formatted_images[0].get("upscaled"))})
+            "upscaled": bool(formatted_images[0].get("upscaled")),
+            "model": model_id}
+        if meta.get("override_dropped"):
+            response_data["model_override_dropped"] = True
+        return finish(generation_time, response_data)
     except Exception as e:
         error_msg = f"Error generating image: {str(e)}"
         logger.error("%s", error_msg, exc_info=True)
@@ -619,7 +628,9 @@ def _dispatch_to_plugin_provider(
     model: Optional[str] = None):
     """JSON result from the selected plugin provider, or ``None`` to fall through to in-tree FAL
     (provider unset / ``"fal"`` / ``"nous"``). Providers without ``upscale`` ignore it via
-    ``**kwargs``; a per-call ``model`` override wins over the configured ``image_gen.model``."""
+    ``**kwargs``; a per-call ``model`` override wins over the configured ``image_gen.model``.
+    Backends without a per-call model concept receive the value via ``**kwargs`` and ignore
+    it — the provider ABC contract requires implementations to accept unknown kwargs."""
     configured = _plugin_provider_name()
     if configured is None:
         return None
@@ -837,13 +848,10 @@ _UPSCALE_PARAM = {
 _MODEL_PARAM = {
     "type": "string",
     "description": (
-        "Optional backend-specific model identifier that overrides the "
-        "configured default for this call only (e.g. a FAL model id, an "
-        "OpenAI or xAI image model, or — when the active backend exposes a "
-        "bot-name catalog — a specific bot name). The set of valid values "
-        "depends on the active backend; leave unset to use the configured "
-        "default. Ignored by backends that don't accept a per-call model "
-        "override."
+        "Optional backend-specific model id that overrides the configured "
+        "default for this call only. Valid values depend on the active "
+        "backend; leave unset to use the configured default. Ignored by "
+        "backends that don't accept a per-call model override."
     ),
 }
 


### PR DESCRIPTION
## Summary

The `image_generate` tool schema currently exposes no way for the agent to request a specific model — model selection is locked to `image_gen.model` in `config.yaml`. That's a fine default, but several backend types all support per-call model overrides at the provider level:

- **FAL** — long catalog of model ids (`fal-ai/flux-2-pro`, `fal-ai/nano-banana-pro`, …)
- **OpenAI / xAI** — image model selection per call
- **Poe** — accepts any bot name on a single call (`GPT-Image-1`, `Nano-Banana-Pro`, `Flux-2-Turbo`, …)

The dispatcher just drops the value on the floor because the schema doesn't declare it.

This PR adds an optional `model` string so the agent can request a specific backend model on a single call. Resolution order: **per-call override > `image_gen.model` in config > provider default**. All three backend paths honor it (plugin dispatch, managed Krea, in-tree FAL).

**Rebased onto current `main`** (`b1f003e186`, post-#97057). The original commits predated the capability-gated dynamic-schema rework and the September decomposition of `tools/image_generation_tool.py`; the semantic changes are now ported onto that structure:

- `model` is advertised by `_build_dynamic_image_schema()` (unconditionally — every backend accepts it via the provider ABC's `**kwargs` contract, worst case silently ignored), keeping the static registration schema minimal per the #95681 diet and `test_static_schema_carries_no_capability_args`.
- Dispatch threads the override through `_add_provider_kwargs` (`model` wins over the configured `image_gen.model`), the Krea routing predicate, and `_resolve_fal_model(override)`.
- Unknown override ids on the FAL path fall back to the configured default **with a signal**: the response includes `"model": <resolved id>` and `"model_override_dropped": true` (silent-fallback contract from the review discussion).
- The `ImageGenProvider.generate()` ABC docstring now lists `model` as a known optional kwarg alongside `upscale`.
- `tests/tools/test_image_generate_schema.py::test_text_only_plugin_provider_hides_edit_and_upscale` pin updated: the backend-agnostic `model` param survives capability gating.

## Why this isn't the same as the closed #41463

PR #41463 was closed as `sweeper:not-planned` because it added an **in-tree vendor directory** under `plugins/image_gen/poe/`, violating the `in-tree-provider-integration` policy in `AGENTS.md`.

This PR:
- **Does not add any new plugin directory.** It only widens the existing core tool surface.
- **Names no specific provider or bot** in the schema description — only "a backend-specific model identifier" — so the change is backend-agnostic and benefits every image-gen plugin (FAL, OpenAI, xAI, plus any user-installed plugin that supports per-call overrides).
- Matches the existing ABC contract — `ImageGenProvider.generate(**kwargs)` already accepts `model=`; the dispatcher was just discarding it.

## Changes

- `tools/image_generation_tool.py`
  - `_resolve_fal_model(override=None)` — a non-empty per-call override wins over `image_gen.model` / `FAL_IMAGE_MODEL`; an unrecognized id falls back to `DEFAULT_MODEL` with `"override_dropped": True` in the returned meta.
  - `image_generate_tool(..., model=None)` — FAL path honors the override; the success payload includes `"model"` (the id actually used) and `"model_override_dropped": true` when the requested id wasn't recognized.
  - `_dispatch_to_plugin_provider(..., model=None)` — per-call override wins over the configured model forwarded to `provider.generate(model=...)`.
  - `_maybe_route_managed_krea(..., model=None)` — the per-call model participates in the `krea-2-*` routing predicate.
  - `_handle_image_generate(args, **kw)` — reads `model` from the LLM tool-call args (strings only; non-strings treated as unset) and threads it through all three routes.
  - `_build_dynamic_image_schema()` — advertises the `model` param unconditionally via the new `_MODEL_PARAM` snippet.
- `agent/image_gen_provider.py` — `ImageGenProvider.generate()` docstring documents `model` as a known optional kwarg.
- `tests/tools/test_image_generation.py` — updated the static-schema pin, plus tests covering: per-call-wins-over-configured (dispatch + handler), whitespace-falls-back, non-string-ignored, end-to-end `_handle_image_generate` extraction, `_resolve_fal_model(override)` override/dropped-signal/no-signal cases.
- `tests/tools/test_image_generate_schema.py` — dynamic-schema pin updated to include the backend-agnostic `model` param.

## Test plan

```
$ python -m pytest tests/tools/test_image_generation.py \
                   tests/tools/test_image_generate_schema.py \
                   tests/tools/test_image_generation_plugin_dispatch.py \
                   tests/tools/test_image_generation_image_to_image.py \
                   tests/tools/test_image_generation_artifacts.py \
                   tests/tools/test_image_generation_env.py \
                   tests/tools/test_image_generation_interrupt.py \
                   tests/tools/test_managed_media_gateways.py \
                   tests/plugins/image_gen/ -q
335 passed, 31 subtests passed in 8.38s
```

## Backwards compatibility

- Pure addition — `model` is optional; behavior with no `model` arg is identical to current.
- The `ImageGenProvider.generate(**kwargs)` ABC already accepts `model`; plugins that pre-date this change and don't accept it will hit a `TypeError`, but the existing dispatch path already retries without `image_url` / `reference_image_urls` for that case. Same retry pattern can be extended to `model` in a follow-up if a real plugin surfaces the issue.
- No config-file changes required.

## Why now

Without this, the only way to use Poe's bot-name catalog from an agent session is to either edit `image_gen.model` in `config.yaml` before each call (and restart the gateway) or hardcode a specific bot as the user-level default. This change lets the agent pick a different backend model per-call without any user action, while keeping the configured default for everyone who doesn't ask.

---

Relates to #104744 (same override surface, incompatible unknown-override contract: this PR signals fallback via `model_override_dropped`, that one fail-fasts with `error_type: unknown_model`) and #83124 (custom-endpoint provider plugin, orthogonal — rides the same `model=` forwarding). Maintainer to pick the contract; happy to port anything from the other variants if preferred.