### PR TITLE
docs(kanban): document workflow configuration preflight

### DIFF
--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -20,6 +20,92 @@ GitHub PR      =  upstreamable artifact (optional, for code lanes)
 
 Hermes Kanban owns lifecycle truth — `ready` → `running` → `review` / `blocked` / `done` / `archived`. Worker lanes execute work but never own that truth; everything they do flows back through the kanban kernel via the `kanban_*` tools (or, for non-Hermes external workers, via the API). Reviewers gate the transition from "code change written" to "task done."
 
+## Workflow-configuration preflight
+
+Tasks that change durable workflow configuration use the `workflow_configuration`
+intake contract. Preflight is a read-only validation and normalization step that
+runs before the task is written; it is not a second dispatcher and it does not
+force a coding CLI.
+
+The specialist resolution order is **Forge, then DEV, then Chip, then Quill**.
+An explicit implementation assignee is honored only when that profile exists and
+is one of those validated implementation profiles. `default` and `halo` are
+control profiles, not owners of mutable workflow configuration. If no valid
+implementation profile is available, preflight rejects the request before any
+task or dependency row is written.
+
+Accepted requests receive canonical metadata. A normal routed task has the
+following shape (an explicitly requested `cursor` replaces the default agent):
+
+```json
+{
+  "canonical": true,
+  "task_type": "workflow_configuration",
+  "lane": "FORGE",
+  "implementation_lane": true,
+  "route": "coding_cli_router",
+  "use_coding_router": true,
+  "coding_agent": "codex",
+  "coding_agent_resolution": "default"
+}
+```
+
+Direct DEV execution is represented explicitly rather than by inventing a
+coding-agent name:
+
+```json
+{
+  "canonical": true,
+  "task_type": "workflow_configuration",
+  "lane": "DEV",
+  "implementation_lane": true,
+  "route": "dev_direct",
+  "use_coding_router": false,
+  "coding_agent": null,
+  "coding_agent_resolution": "dev_direct",
+  "execution_fallback": "dev_direct"
+}
+```
+
+`coding_agent=codex` is the default; `coding_agent=cursor` is valid only when
+explicitly requested. No coding CLI is forced by this contract: the route and
+the normalized metadata describe what the owning lane may use. Human approval,
+review, deployment, and other gates remain in force.
+
+Use the dry-run command to inspect the decision without touching the board:
+
+```bash
+hermes kanban preflight --task-type workflow_configuration \
+  --assignee forge --json
+hermes kanban preflight --task-type workflow_configuration \
+  --metadata '{"route":"dev_direct","use_coding_router":false}' --json
+```
+
+Both successful responses report `writes: 0` and `duplicates_created: 0`.
+Representative rejections include:
+
+```text
+--metadata '{"route":"dev_direct","use_coding_router":true}'
+# rejected: dev_direct requires use_coding_router=false
+
+--metadata '{"use_coding_router":false,"coding_agent":"codex"}'
+# rejected: direct execution must omit coding_agent
+
+--coding-agent claude
+# rejected: choose codex or cursor
+```
+
+Rejected input is fail-closed: it returns an actionable error and performs no
+task, parent-link, or duplicate write. Preflight does not replace create-time
+idempotency; automation should still provide an idempotency key when creating a
+task.
+
+When a workflow-configuration task depends on another task, pass real parent
+IDs through `parents=[...]` (or the CLI's repeated `--parent` option) when
+creating it. A child remains dependency-gated in `todo` until every parent is
+`done`; prose such as “depends on X” is not a dependency edge. The normal
+worker/reviewer lifecycle still applies after promotion.
+
 ## What a lane provides
 
 To be a kanban worker lane, an integration must provide three things:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -69,6 +69,67 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
 - **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims, spawns assigned profiles. Runs **inside the gateway** by default (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task (default: 2) the dispatcher auto-blocks it with the last error as the reason — prevents thrashing on tasks whose profile doesn't exist, workspace can't mount, etc.
 - **Tenant** — optional string namespace *within* a board. One specialist fleet can serve multiple businesses (`--tenant business-a`) with data isolation by workspace path and memory key prefix. Tenants are a soft filter; boards are the hard isolation boundary.
 
+### Workflow-configuration intake contract
+
+Use `task_type: "workflow_configuration"` for durable workflow/configuration
+changes. The create path performs a **read-only preflight before the first
+database write**. It resolves implementation ownership in this order:
+**Forge → DEV → Chip → Quill**. An explicit `--assignee` is accepted only if
+it names an installed profile in that implementation set; `default` and `halo`
+cannot own mutable configuration. If no implementation profile resolves, the
+request is rejected before creating a task, parent link, or duplicate.
+
+The same decision can be inspected without writing anything:
+
+```bash
+hermes kanban preflight --task-type workflow_configuration \
+  --assignee forge --json
+```
+
+The JSON result includes `accepted`, `resolved_assignee`, normalized `metadata`,
+`writes: 0`, and `duplicates_created: 0`. A normal result contains canonical
+routing metadata like this:
+
+```json
+{
+  "canonical": true,
+  "task_type": "workflow_configuration",
+  "lane": "FORGE",
+  "implementation_lane": true,
+  "route": "coding_cli_router",
+  "use_coding_router": true,
+  "coding_agent": "codex",
+  "coding_agent_resolution": "default"
+}
+```
+
+The default coding agent is `codex`; `cursor` is recorded only when explicitly
+requested. Direct implementation is represented without a fake agent:
+
+```json
+{
+  "route": "dev_direct",
+  "use_coding_router": false,
+  "coding_agent": null,
+  "coding_agent_resolution": "dev_direct",
+  "execution_fallback": "dev_direct"
+}
+```
+
+`dev_direct` requires `use_coding_router: false` and omission of
+`coding_agent`. For example, `coding_agent: "claude"`,
+`{"route":"dev_direct","use_coding_router":true}`, and
+`{"use_coding_router":false,"coding_agent":"codex"}` are invalid and fail
+closed. These are routing descriptions, not mandates to launch a CLI; human
+approval, review, deployment, and other gates remain in effect.
+
+For parent-child work, create the dependency edge with `--parent <task-id>`
+(repeat it for multiple parents) or `parents=[...]` in `kanban_create`. The
+child stays in `todo` until all parents are `done`, then is promoted to `ready`.
+Putting a dependency only in the title/body does not gate dispatch. Preflight is
+read-only and never creates duplicates; actual automation should additionally
+use `--idempotency-key` so a retried create returns the existing task.
+
 ## Boards (multi-project)
 
 Boards let you separate unrelated streams of work — one per project, repo,


### PR DESCRIPTION
## Summary
- Document the workflow_configuration preflight and Forge → DEV → Chip → Quill resolution order.
- Specify canonical routing metadata, direct DEV representation, fail-closed rejection, dependency edges, and read-only/no-duplicate guarantees.
- Explicitly preserve human gates and clarify that no coding CLI is forced.

## Verification
- `uv run pytest tests/hermes_cli/test_kanban_workflow_configuration_intake.py -q` (12 passed)
- `git diff --check`
- Docusaurus build not run: `npm ci` is blocked by repository engine requirement npm >=11.17.0; installed npm is 10.9.7.

Kanban task: t_7ffdf06b