### PR TITLE
fix(delegation): identify internal completion events

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5156,6 +5156,20 @@ class _SeededQueryMessage:
         return self.text
 
 
+class _InternalEventInput:
+    """Synthetic CLI turn plus its validated transcript projection metadata."""
+
+    __slots__ = ("text", "display_kind", "display_metadata")
+
+    def __init__(self, text: str, display_kind: str, display_metadata: Dict[str, Any]):
+        self.text = text
+        self.display_kind = display_kind
+        self.display_metadata = display_metadata
+
+    def __str__(self) -> str:
+        return self.text
+
+
 def _should_seed_interactive(query, image, quiet: bool, oneshot: bool) -> bool:
     """Whether a ``-q/--image`` invocation should seed an interactive session.
 
@@ -13584,6 +13598,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         from tools.async_delegation import (
             claim_event_delivery,
             complete_event_delivery,
+            internal_event_persistence,
         )
 
         session_key = getattr(self, "session_id", "") or ""
@@ -13594,7 +13609,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             claim = claim_event_delivery(event, consumer)
             if claim is None:
                 continue
-            self._pending_input.put(synthetic_message)
+            display_kind, display_metadata = internal_event_persistence(
+                event,
+                trusted_internal=True,
+            )
+            if display_kind is not None and display_metadata is not None:
+                self._pending_input.put(
+                    _InternalEventInput(
+                        synthetic_message,
+                        display_kind,
+                        display_metadata,
+                    )
+                )
+            else:
+                self._pending_input.put(synthetic_message)
             complete_event_delivery(event, claim)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
@@ -16853,7 +16881,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             except Exception:
                 pass
 
-    def chat(self, message, images: list = None, voice_input: bool = False) -> Optional[str]:
+    def chat(
+        self,
+        message,
+        images: list = None,
+        voice_input: bool = False,
+        persist_user_display_kind: Optional[str] = None,
+        persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
         """
         Send a message to the agent and get a response.
         
@@ -17024,6 +17059,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             staged_user_message = stamp_message_timestamp(
                 {"role": "user", "content": message}
             )
+            if persist_user_display_kind is not None:
+                staged_user_message["display_kind"] = persist_user_display_kind
+            if persist_user_display_metadata is not None:
+                staged_user_message["display_metadata"] = persist_user_display_metadata
             agent._pending_cli_user_message = staged_user_message
             self.conversation_history.append(staged_user_message)
 
@@ -17214,6 +17253,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         stream_callback=stream_callback,
                         task_id=self.session_id,
                         persist_user_message=_persist_clean_user_message,
+                        persist_user_display_kind=persist_user_display_kind,
+                        persist_user_display_metadata=persist_user_display_metadata,
                         moa_config=_moa_cfg,
                     )
                     if getattr(self, "_pending_moa_disable_after_turn", False):
@@ -20975,6 +21016,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                                 pass
                         continue
 
+                    # Internal process events carry transcript projection
+                    # metadata separately from their model-facing text.
+                    persist_user_display_kind = None
+                    persist_user_display_metadata = None
+                    if isinstance(user_input, _InternalEventInput):
+                        persist_user_display_kind = user_input.display_kind
+                        persist_user_display_metadata = user_input.display_metadata
+                        user_input = user_input.text
+
                     # Voice-transcribed messages arrive wrapped in a sentinel
                     # so only genuine STT output gets the voice prefix (#65827).
                     is_voice_input = isinstance(user_input, _VoiceInputMessage)
@@ -21119,7 +21169,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     app.invalidate()  # Refresh status line
 
                     try:
-                        self.chat(user_input, images=submit_images or None, voice_input=is_voice_input)
+                        self.chat(
+                            user_input,
+                            images=submit_images or None,
+                            voice_input=is_voice_input,
+                            persist_user_display_kind=persist_user_display_kind,
+                            persist_user_display_metadata=persist_user_display_metadata,
+                        )
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -358,6 +358,37 @@ def _coerce_request_bool(value: Any, default: bool = False) -> bool:
     return default
 
 
+def _trusted_internal_request_projection(
+    headers: Any,
+    *,
+    api_key_configured: bool,
+    session_id: str,
+    user_message: Any,
+) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Project an authenticated Gateway self-wake as a non-human turn."""
+    if str(headers.get("X-Hermes-Internal-Event") or "").strip() != "1":
+        return None, None
+    if not api_key_configured:
+        raise PermissionError("internal event headers require API key authentication")
+    event_id = str(headers.get("X-Hermes-Internal-Event-Id") or "").strip()
+    if len(event_id) > 200 or re.search(r"[\r\n\x00]", event_id):
+        event_id = ""
+    payload_digest = hashlib.sha256(
+        str(user_message).encode("utf-8")
+    ).hexdigest()
+    from tools.async_delegation import internal_event_persistence
+
+    return internal_event_persistence(
+        {
+            "type": "api_server_wake",
+            "event_id": event_id,
+            "session_id": session_id,
+            "payload_digest": payload_digest,
+        },
+        trusted_internal=True,
+    )
+
+
 _REQUEST_OPTION_MISSING = object()
 # Full internal ladder + "none": the API server accepts what /reasoning and
 # config.yaml accept (hermes_constants.VALID_REASONING_EFFORTS); wire-level
@@ -5282,6 +5313,18 @@ class APIServerAdapter(BasePlatformAdapter):
             session_id = _derive_chat_session_id(system_prompt, first_user)
             # history already set from request body above
 
+        try:
+            persist_user_display_kind, persist_user_display_metadata = (
+                _trusted_internal_request_projection(
+                    request.headers,
+                    api_key_configured=bool(self._api_key),
+                    session_id=session_id,
+                    user_message=user_message,
+                )
+            )
+        except PermissionError as exc:
+            return web.json_response(_openai_error(str(exc)), status=403)
+
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", self._model_name)
         created = int(time.time())
@@ -5388,6 +5431,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                persist_user_display_kind=persist_user_display_kind,
+                persist_user_display_metadata=persist_user_display_metadata,
                 **agent_overrides,
                 route=route,
             ))
@@ -5409,6 +5454,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                persist_user_display_kind=persist_user_display_kind,
+                persist_user_display_metadata=persist_user_display_metadata,
                 **agent_overrides,
                 route=route,
             )
@@ -7388,6 +7435,8 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         active_run_id: Optional[str] = None,
         gateway_session_key: Optional[str] = None,
+        persist_user_display_kind: Optional[str] = None,
+        persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
@@ -7487,11 +7536,22 @@ class APIServerAdapter(BasePlatformAdapter):
                     # ``agent_ref``, and only /v1/runs has a run_id, so neither
                     # is a usable hook for the rest.
                     self._shutdown_interruptible_agents[id(agent)] = agent
-                    result = agent.run_conversation(
-                        user_message=user_message,
-                        conversation_history=conversation_history,
-                        task_id=effective_task_id,
-                    )
+                    conversation_kwargs: Dict[str, Any] = {
+                        "user_message": user_message,
+                        "conversation_history": conversation_history,
+                        "task_id": effective_task_id,
+                    }
+                    if (
+                        persist_user_display_kind is not None
+                        and persist_user_display_metadata is not None
+                    ):
+                        conversation_kwargs["persist_user_display_kind"] = (
+                            persist_user_display_kind
+                        )
+                        conversation_kwargs["persist_user_display_metadata"] = (
+                            persist_user_display_metadata
+                        )
+                    result = agent.run_conversation(**conversation_kwargs)
                     usage = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6959,6 +6959,10 @@ class TurnRunner:
                 _conversation_kwargs["persist_user_display_kind"] = (
                     ctx.persist_user_display_kind
                 )
+                if ctx.persist_user_display_metadata is not None:
+                    _conversation_kwargs["persist_user_display_metadata"] = (
+                        ctx.persist_user_display_metadata
+                    )
             if ctx.moa_config is not None:
                 _conversation_kwargs["moa_config"] = ctx.moa_config
             if _persist_user_timestamp_override is not None:
@@ -20653,13 +20657,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # background watch notifications, resume wake-ups) arrive as
         # MessageEvent(internal=True). Persist their user row typed with
         # display_kind="internal_notification" so transcripts/UIs can render
-        # them as timeline notices instead of user bubbles (#82888). Role and
-        # content are untouched — display_kind is a DB-only sidecar stripped
-        # from every provider-bound payload (see conversation_loop's
-        # api_msg.pop("display_kind")).
+        # them as timeline notices instead of user bubbles (#82888). A
+        # canonical workflow envelope upgrades the projection below without
+        # changing the model-facing role or content.
         persist_user_display_kind = (
             "internal_notification" if getattr(event, "internal", False) else None
         )
+        persist_user_display_metadata = None
+        if getattr(event, "internal", False):
+            try:
+                from tools.async_delegation import internal_event_persistence
+
+                internal_metadata = dict(
+                    getattr(event, "metadata", None) or {}
+                )
+                internal_metadata.setdefault("type", "gateway_internal")
+                internal_metadata.setdefault(
+                    "source",
+                    source.platform.value if source.platform else "gateway",
+                )
+                internal_metadata.setdefault(
+                    "message_id",
+                    str(getattr(event, "message_id", "") or ""),
+                )
+                internal_metadata.setdefault(
+                    "text",
+                    str(getattr(event, "text", "") or ""),
+                )
+                internal_display_kind, internal_display_metadata = (
+                    internal_event_persistence(
+                        internal_metadata,
+                        trusted_internal=True,
+                    )
+                )
+                if internal_display_kind is not None:
+                    persist_user_display_kind = internal_display_kind
+                    persist_user_display_metadata = internal_display_metadata
+            except Exception:
+                logger.debug(
+                    "Internal-event transcript metadata validation failed",
+                    exc_info=True,
+                )
         try:
             _pcfg = _load_gateway_config()
             _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
@@ -22226,6 +22264,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
+                persist_user_display_metadata=persist_user_display_metadata,
                 message_type=event.message_type,
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
@@ -22667,6 +22706,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 }
                 if persist_user_display_kind:
                     _user_entry["display_kind"] = persist_user_display_kind
+                if persist_user_display_metadata:
+                    _user_entry["display_metadata"] = persist_user_display_metadata
                 if event.message_id:
                     _user_entry["message_id"] = str(event.message_id)
                 # Dedupe: skip if this platform message_id is already in the
@@ -22711,6 +22752,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     }
                     if persist_user_display_kind:
                         _user_entry["display_kind"] = persist_user_display_kind
+                    if persist_user_display_metadata:
+                        _user_entry["display_metadata"] = persist_user_display_metadata
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
                     await self.async_session_store.append_to_transcript(
@@ -22910,6 +22953,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         }
                         if 'persist_user_display_kind' in locals() and persist_user_display_kind:
                             _user_entry["display_kind"] = persist_user_display_kind
+                        if (
+                            'persist_user_display_metadata' in locals()
+                            and persist_user_display_metadata
+                        ):
+                            _user_entry["display_metadata"] = persist_user_display_metadata
                         if getattr(event, "message_id", None):
                             _user_entry["message_id"] = str(event.message_id)
                         await self.async_session_store.append_to_transcript(
@@ -27272,6 +27320,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             parent_session_id = str(evt.get("parent_session_id") or "").strip()
             if parent_session_id:
                 metadata["gateway_session_id"] = parent_session_id
+            for key in (
+                "event_schema",
+                "event_id",
+                "event_kind",
+                "workflow_id",
+                "delegation_id",
+                "display_kind",
+                "user_originated",
+                "terminal",
+            ):
+                if key in evt:
+                    metadata[key] = evt[key]
             synth_event = MessageEvent(
                 text=synth_text,
                 message_type=MessageType.TEXT,
@@ -30056,6 +30116,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
+        persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         message_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
@@ -30077,6 +30138,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
+                persist_user_display_metadata=persist_user_display_metadata,
                 message_type=message_type,
             )
 
@@ -30091,6 +30153,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
+                persist_user_display_metadata=persist_user_display_metadata,
                 message_type=message_type,
             )
 
@@ -30235,6 +30298,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
+        persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         message_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
@@ -30546,6 +30610,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
             persist_user_display_kind=persist_user_display_kind,
+            persist_user_display_metadata=persist_user_display_metadata,
         )
         turn_runner = TurnRunner(self, turn_ctx)
         # Callback invoked by agent on tool lifecycle events — extracted to

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -97,10 +97,11 @@ class TurnContext:
     persist_user_message: Optional[Any] = None
     persist_user_timestamp: Optional[float] = None
     # display_kind stamped on the persisted user row at turn start when this
-    # turn was self-injected (MessageEvent.internal), e.g.
-    # "internal_notification" for async-delegation/background notifications
-    # (#82888). DB-only presentation metadata; never sent to the provider.
+    # turn was self-injected (MessageEvent.internal). Validated workflow events
+    # also carry a fail-closed metadata envelope. These DB-only presentation
+    # fields are never sent to the provider.
     persist_user_display_kind: Optional[str] = None
+    persist_user_display_metadata: Optional[dict] = None
     user_config: Any = None
     enabled_toolsets: Any = None
     disabled_toolsets: Any = None

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -38,6 +38,7 @@ rewind cursors / retry instead of silently losing the event.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 from typing import Any, Optional
 
@@ -82,6 +83,20 @@ async def deliver_wake(
     Raises on failure (bad arguments, exhausted retries, HTTP error) so the
     caller can rewind/retry instead of treating the wake as delivered.
     """
+    source_identity = ""
+    if source is not None:
+        source_identity = ":".join(
+            str(value or "")
+            for value in (
+                getattr(getattr(source, "platform", None), "value", ""),
+                getattr(source, "chat_id", ""),
+                getattr(source, "thread_id", ""),
+            )
+        )
+    wake_identity = session_id or source_identity
+    event_id = "internal_wake:" + hashlib.sha256(
+        f"{wake_identity}\0{text}".encode("utf-8")
+    ).hexdigest()
     if adapter_supports_push(adapter):
         if source is None:
             raise ValueError(
@@ -94,6 +109,10 @@ async def deliver_wake(
             message_type=MessageType.TEXT,
             source=source,
             internal=True,
+            metadata={
+                "type": "gateway_wake",
+                "event_id": event_id,
+            },
         )
         await adapter.handle_message(synth_event)
         return
@@ -133,6 +152,15 @@ def _delegation_display_metadata(evt: dict) -> dict:
     duration = evt.get("total_duration_seconds") or evt.get("duration_seconds")
     if isinstance(duration, (int, float)):
         metadata["duration_seconds"] = duration
+    # Stateless API sessions persist the completion directly instead of
+    # running a wake turn (#85957).  Validate and retain the same canonical
+    # envelope used by push, CLI and TUI delivery so this newer path does not
+    # silently downgrade the event to display-only metadata.
+    from tools.async_delegation import internal_event_persistence
+
+    display_kind, envelope = internal_event_persistence(evt)
+    if display_kind == "async_delegation_complete" and envelope is not None:
+        metadata.update(envelope)
     return metadata
 
 
@@ -211,9 +239,14 @@ async def _self_post_chat_completion(
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"  # bare IPv6 literal
     url = f"http://{host}:{port}/v1/chat/completions"
+    event_id = "internal_wake:" + hashlib.sha256(
+        f"{session_id}\0{text}".encode("utf-8")
+    ).hexdigest()
     headers = {
         "Authorization": f"Bearer {api_key}",
         "X-Hermes-Session-Id": session_id,
+        "X-Hermes-Internal-Event": "1",
+        "X-Hermes-Internal-Event-Id": event_id,
     }
     payload = {
         "model": str(getattr(adapter, "_model_name", "") or "hermes-agent"),

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -2,7 +2,7 @@
 
 import queue
 
-from cli import HermesCLI
+from cli import HermesCLI, _InternalEventInput
 
 
 def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
@@ -42,7 +42,11 @@ def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
     cli._drain_process_notifications("cli-idle")
 
     assert calls == [("visible-session", True)]
-    assert cli._pending_input.get_nowait() == "completion payload"
+    queued = cli._pending_input.get_nowait()
+    assert isinstance(queued, _InternalEventInput)
+    assert queued.text == "completion payload"
+    assert queued.display_kind == "internal_event"
+    assert queued.display_metadata["user_originated"] is False
     assert claimed == [(event, "cli-idle")]
     assert completed == [(event, "claim-token")]
 

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -199,6 +199,14 @@ async def test_inject_watch_notification_routes_from_session_store_origin(monkey
     evt = {
         "session_id": "proc_watch",
         "session_key": "agent:main:telegram:group:-100:42",
+        "delegation_id": "deleg_full",
+        "event_schema": "hermes.internal_event.v1",
+        "event_id": "async_delegation:deleg_full:terminal",
+        "event_kind": "workflow.async_delegation.terminal",
+        "workflow_id": "delegation:deleg_full",
+        "display_kind": "async_delegation_complete",
+        "user_originated": False,
+        "terminal": True,
     }
 
     await runner._inject_watch_notification("[SYSTEM: Background process matched]", evt)
@@ -212,6 +220,11 @@ async def test_inject_watch_notification_routes_from_session_store_origin(monkey
     assert synth_event.source.thread_id == "42"
     assert synth_event.source.user_id == "123"
     assert synth_event.source.user_name == "Emiliyan"
+    assert synth_event.metadata["event_id"] == evt["event_id"]
+    assert synth_event.metadata["workflow_id"] == evt["workflow_id"]
+    assert synth_event.metadata["delegation_id"] == "deleg_full"
+    assert synth_event.metadata["user_originated"] is False
+    assert synth_event.metadata["terminal"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_internal_notification_marker_82888.py
+++ b/tests/gateway/test_internal_notification_marker_82888.py
@@ -3,16 +3,16 @@
 Async-delegation batch completions and background watch notifications re-enter
 the gateway as synthetic ``MessageEvent(internal=True)`` turns (see
 ``_inject_watch_notification``). They must keep ``role='user'`` (message
-alternation is sacred) but the persisted row must carry
-``display_kind='internal_notification'`` so transcripts and the desktop UI can
-render them as timeline notices instead of user bubbles.
+alternation is sacred) while trusted transports persist a canonical
+``display_kind='internal_event'`` envelope so transcripts and the desktop UI
+can render them as timeline notices instead of user bubbles.
 
 Covered:
 
-1. an internal event threads ``persist_user_display_kind`` into the agent run;
+1. an internal event threads its display kind and metadata into the agent run;
 2. a real user event does NOT get the marker;
 3. the gateway-side fallback user rows (transient-failure / no-new-messages
-   paths) carry the marker for internal events only;
+   paths) preserve the envelope for internal events only;
 4. a marked row round-trips through SessionDB replay with role='user' intact
    and the marker is stripped from provider-bound payload copies.
 """
@@ -134,7 +134,13 @@ async def test_internal_event_threads_marker_into_agent_run(monkeypatch, tmp_pat
     )
 
     kwargs = runner._run_agent.call_args.kwargs
-    assert kwargs["persist_user_display_kind"] == "internal_notification"
+    assert kwargs["persist_user_display_kind"] == "internal_event"
+    assert (
+        kwargs["persist_user_display_metadata"]["event_kind"]
+        == "workflow.gateway_internal.internal"
+    )
+    assert kwargs["persist_user_display_metadata"]["user_originated"] is False
+    assert "text" not in kwargs["persist_user_display_metadata"]
 
 
 @pytest.mark.asyncio
@@ -186,7 +192,9 @@ async def test_failed_early_fallback_row_is_marked_for_internal_event(
     assert entries, "expected a fallback user-row write"
     for entry in entries:
         assert entry["role"] == "user"  # alternation invariant: role unchanged
-        assert entry["display_kind"] == "internal_notification"
+        assert entry["display_kind"] == "internal_event"
+        assert entry["display_metadata"]["user_originated"] is False
+        assert "text" not in entry["display_metadata"]
 
 
 @pytest.mark.asyncio
@@ -239,7 +247,9 @@ async def test_no_new_messages_fallback_row_is_marked_for_internal_event(
     assert entries
     for entry in entries:
         assert entry["role"] == "user"
-        assert entry["display_kind"] == "internal_notification"
+        assert entry["display_kind"] == "internal_event"
+        assert entry["display_metadata"]["user_originated"] is False
+        assert "text" not in entry["display_metadata"]
 
 
 # ── 4: DB round-trip replay + provider-payload hygiene ─────────────────────

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -77,6 +77,8 @@ def test_deliver_wake_non_push_self_posts_raw_session_id(monkeypatch):
 
     async def handler(request):
         seen["session_id"] = request.headers.get("X-Hermes-Session-Id")
+        seen["internal"] = request.headers.get("X-Hermes-Internal-Event")
+        seen["event_id"] = request.headers.get("X-Hermes-Internal-Event-Id")
         seen["auth"] = request.headers.get("Authorization")
         seen["body"] = await request.json()
         return web.json_response({"choices": [{"message": {"content": "ok"}}]})
@@ -91,6 +93,8 @@ def test_deliver_wake_non_push_self_posts_raw_session_id(monkeypatch):
 
     asyncio.run(run())
     assert seen["session_id"] == "raw-sid-42"
+    assert seen["internal"] == "1"
+    assert seen["event_id"].startswith("internal_wake:")
     assert seen["auth"] == "Bearer sekrit"
     assert seen["body"]["stream"] is False
     assert seen["body"]["messages"] == [
@@ -145,14 +149,18 @@ def test_persist_delegation_delivery_appends_delivery_row(tmp_path):
         def _ensure_session_db(self):
             return db
 
+    from tools.async_delegation import _internal_event_envelope
+
+    delegation_id = "deleg_0123456789abcdef0123456789abcdef"
     evt = {
         "type": "async_delegation",
-        "delegation_id": "deleg_x",
+        "delegation_id": delegation_id,
         "results": [{"status": "completed"}, {"status": "failed"}],
         "total_duration_seconds": 12.5,
+        **_internal_event_envelope(delegation_id),
     }
     asyncio.run(persist_delegation_delivery(
-        DbAdapter(), text="[ASYNC DELEGATION BATCH COMPLETE — deleg_x]",
+        DbAdapter(), text=f"[ASYNC DELEGATION BATCH COMPLETE — {delegation_id}]",
         session_id=sid, evt=evt,
     ))
 
@@ -162,10 +170,16 @@ def test_persist_delegation_delivery_appends_delivery_row(tmp_path):
     assert delivery["role"] == "user"
     assert delivery["display_kind"] == "async_delegation_complete"
     meta = delivery["display_metadata"]
-    assert meta["delegation_id"] == "deleg_x"
+    assert meta["delegation_id"] == delegation_id
     assert meta["task_count"] == 2
     assert meta["failed_count"] == 1
     assert meta["duration_seconds"] == 12.5
+    assert meta["event_schema"] == "hermes.internal_event.v1"
+    assert meta["event_id"] == f"async_delegation:{delegation_id}:terminal"
+    assert meta["event_kind"] == "workflow.async_delegation.terminal"
+    assert meta["workflow_id"] == f"delegation:{delegation_id}"
+    assert meta["user_originated"] is False
+    assert meta["terminal"] is True
 
 
 def test_persist_delegation_delivery_raises_without_db():
@@ -182,3 +196,34 @@ def test_persist_delegation_delivery_raises_without_db():
         ))
 
 
+def test_api_server_internal_projection_requires_authenticated_internal_header():
+    from gateway.platforms.api_server import _trusted_internal_request_projection
+
+    assert _trusted_internal_request_projection(
+        {},
+        api_key_configured=True,
+        session_id="sid",
+        user_message="wake",
+    ) == (None, None)
+
+    headers = {
+        "X-Hermes-Internal-Event": "1",
+        "X-Hermes-Internal-Event-Id": "internal_wake:stable",
+    }
+    with pytest.raises(PermissionError):
+        _trusted_internal_request_projection(
+            headers,
+            api_key_configured=False,
+            session_id="sid",
+            user_message="wake",
+        )
+
+    display_kind, metadata = _trusted_internal_request_projection(
+        headers,
+        api_key_configured=True,
+        session_id="sid",
+        user_message="wake",
+    )
+    assert display_kind == "internal_event"
+    assert metadata["event_id"] == "internal_wake:stable"
+    assert metadata["user_originated"] is False

--- a/tests/test_internal_event_projection.py
+++ b/tests/test_internal_event_projection.py
@@ -1,0 +1,225 @@
+"""Regression coverage for internal delegation-event transcript projection."""
+
+from __future__ import annotations
+
+import queue
+from types import SimpleNamespace
+
+import pytest
+
+
+def _event(delegation_id: str = "deleg_0123456789abcdef0123456789abcdef") -> dict:
+    from tools.async_delegation import _internal_event_envelope
+
+    return {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        **_internal_event_envelope(delegation_id),
+    }
+
+
+def test_internal_event_persistence_requires_canonical_envelope():
+    from tools.async_delegation import internal_event_persistence
+
+    event = _event()
+    display_kind, metadata = internal_event_persistence(event)
+
+    assert display_kind == "async_delegation_complete"
+    assert metadata == {
+        "event_schema": "hermes.internal_event.v1",
+        "event_id": f"async_delegation:{event['delegation_id']}:terminal",
+        "event_kind": "workflow.async_delegation.terminal",
+        "workflow_id": f"delegation:{event['delegation_id']}",
+        "delegation_id": event["delegation_id"],
+        "user_originated": False,
+        "terminal": True,
+    }
+
+    malformed = dict(event, event_id="async_delegation:other:terminal")
+    assert internal_event_persistence(malformed) == (None, None)
+
+
+def test_trusted_generic_internal_event_gets_deterministic_non_human_projection():
+    from tools.async_delegation import internal_event_persistence
+
+    event = {
+        "type": "completion",
+        "session_id": "proc-42",
+        "completed_at": "2026-08-11T03:00:00Z",
+        "text": "sensitive process output must not be copied to metadata",
+    }
+
+    assert internal_event_persistence(event) == (None, None)
+    display_kind, metadata = internal_event_persistence(
+        event,
+        trusted_internal=True,
+    )
+    display_kind_again, metadata_again = internal_event_persistence(
+        dict(reversed(list(event.items()))),
+        trusted_internal=True,
+    )
+
+    assert display_kind == display_kind_again == "internal_event"
+    assert metadata == metadata_again
+    assert metadata["event_schema"] == "hermes.internal_event.v1"
+    assert metadata["event_id"].startswith("internal_event:")
+    assert metadata["event_kind"] == "workflow.completion.internal"
+    assert metadata["user_originated"] is False
+    assert "text" not in metadata
+
+
+@pytest.mark.asyncio
+async def test_gateway_run_wrapper_forwards_internal_projection_fields():
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(multiplex_profiles=False)
+    captured = {}
+
+    async def _inner(*_args, **kwargs):
+        captured.update(kwargs)
+        return {"final_response": "ok"}
+
+    runner._run_agent_inner = _inner
+    metadata = {"event_id": "evt", "user_originated": False}
+    await runner._run_agent(
+        message="synthetic",
+        context_prompt="",
+        history=[],
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm"),
+        session_id="sid",
+        persist_user_display_kind="async_delegation_complete",
+        persist_user_display_metadata=metadata,
+    )
+
+    assert captured["persist_user_display_kind"] == "async_delegation_complete"
+    assert captured["persist_user_display_metadata"] is metadata
+
+
+def test_cli_drain_queues_internal_event_with_projection(monkeypatch):
+    import tools.async_delegation as delegation
+    from cli import HermesCLI, _InternalEventInput
+    from tools.process_registry import process_registry
+
+    event = _event()
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "sid"
+    cli._pending_input = queue.Queue()
+    cli._owns_process_notification = lambda _event: True
+
+    monkeypatch.setattr(
+        process_registry,
+        "drain_notifications",
+        lambda **_kwargs: [(event, "[ASYNC DELEGATION COMPLETE]")],
+    )
+    monkeypatch.setattr(delegation, "claim_event_delivery", lambda *_args: "claim")
+    completed = []
+    monkeypatch.setattr(
+        delegation,
+        "complete_event_delivery",
+        lambda evt, claim: completed.append((evt, claim)),
+    )
+
+    cli._drain_process_notifications("cli-idle")
+
+    queued = cli._pending_input.get_nowait()
+    assert isinstance(queued, _InternalEventInput)
+    assert queued.text == "[ASYNC DELEGATION COMPLETE]"
+    assert queued.display_kind == "async_delegation_complete"
+    assert queued.display_metadata["event_id"] == event["event_id"]
+    assert queued.display_metadata["user_originated"] is False
+    assert completed == [(event, "claim")]
+
+
+def test_cli_drain_projects_trusted_process_completion_as_internal(monkeypatch):
+    import tools.async_delegation as delegation
+    from cli import HermesCLI, _InternalEventInput
+    from tools.process_registry import process_registry
+
+    event = {"type": "completion", "session_id": "proc-42", "exit_code": 0}
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "sid"
+    cli._pending_input = queue.Queue()
+    cli._owns_process_notification = lambda _event: True
+    monkeypatch.setattr(
+        process_registry,
+        "drain_notifications",
+        lambda **_kwargs: [(event, "[SYSTEM: process completed]")],
+    )
+    monkeypatch.setattr(delegation, "claim_event_delivery", lambda *_args: "claim")
+    monkeypatch.setattr(delegation, "complete_event_delivery", lambda *_args: None)
+
+    cli._drain_process_notifications("cli-idle")
+
+    queued = cli._pending_input.get_nowait()
+    assert isinstance(queued, _InternalEventInput)
+    assert queued.display_kind == "internal_event"
+    assert queued.display_metadata["user_originated"] is False
+    assert queued.display_metadata["event_kind"] == "workflow.completion.internal"
+
+
+def test_tui_notification_prompt_preserves_internal_projection(monkeypatch):
+    from tui_gateway import server
+
+    event = _event()
+    event.update(
+        results=[
+            {"status": "completed"},
+            {"status": "failed"},
+        ],
+        total_duration_seconds=4.5,
+    )
+    captured = {}
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, session, text, **kwargs: captured.update(
+            rid=rid,
+            sid=sid,
+            session=session,
+            text=text,
+            kwargs=kwargs,
+        ),
+    )
+    session = {"session_key": "sid"}
+
+    server._run_notification_prompt(
+        "rid",
+        "sid",
+        session,
+        event,
+        "[ASYNC DELEGATION COMPLETE]",
+    )
+
+    assert captured["text"] == "[ASYNC DELEGATION COMPLETE]"
+    assert captured["kwargs"]["display_kind"] == "async_delegation_complete"
+    assert captured["kwargs"]["display_metadata"]["event_id"] == event["event_id"]
+    assert captured["kwargs"]["display_metadata"]["user_originated"] is False
+    assert captured["kwargs"]["display_metadata"]["task_count"] == 2
+    assert captured["kwargs"]["display_metadata"]["completed_count"] == 1
+    assert captured["kwargs"]["display_metadata"]["failed_count"] == 1
+    assert captured["kwargs"]["display_metadata"]["duration_seconds"] == 4.5
+
+
+def test_tui_notification_prompt_projects_trusted_process_completion(monkeypatch):
+    from tui_gateway import server
+
+    captured = {}
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, session, text, **kwargs: captured.update(kwargs=kwargs),
+    )
+
+    server._run_notification_prompt(
+        "rid",
+        "sid",
+        {"session_key": "sid"},
+        {"type": "completion", "session_id": "proc-42", "exit_code": 0},
+        "[SYSTEM: process completed]",
+    )
+
+    assert captured["kwargs"]["display_kind"] == "internal_event"
+    assert captured["kwargs"]["display_metadata"]["user_originated"] is False

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7022,7 +7022,7 @@ def test_notification_poller_live_loop_requeues_foreign_completion_for_owner(
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **_kwargs: emitted.append(args))
 
-    def _deliver(_rid, sid, session, text):
+    def _deliver(_rid, sid, session, text, **_kwargs):
         delivered["a" if sid == "sid-a-live-handoff" else "b"].append(text)
         session["running"] = False
 
@@ -7131,7 +7131,7 @@ def test_notification_poller_live_loop_drops_addressed_orphan(
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
     server._sessions["sid-live-orphan"] = session
     process_registry._completion_consumed.discard(event["session_id"])
@@ -7172,7 +7172,7 @@ def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
@@ -7238,7 +7238,7 @@ def test_notification_poller_delivers_owned_events(
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda _rid, _sid, _session, text: delivered.append(text),
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
     )
     monkeypatch.setattr(server, "_get_db", lambda: _CompressionDB())
 
@@ -17884,7 +17884,7 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
     turns = []
     emitted = []
 
-    def _fake_run_prompt_submit(rid, sid, session, text):
+    def _fake_run_prompt_submit(rid, sid, session, text, **_kwargs):
         turns.append(text)
         with session["history_lock"]:
             session["running"] = False

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -121,6 +121,25 @@ def test_connect_preserves_wal_and_applies_macos_durability_barriers(
         conn.close()
 
 
+def _assert_internal_event_envelope(evt):
+    delegation_id = evt["delegation_id"]
+    assert evt["event_schema"] == "hermes.internal_event.v1"
+    assert evt["event_id"] == f"async_delegation:{delegation_id}:terminal"
+    assert evt["event_kind"] == "workflow.async_delegation.terminal"
+    assert evt["workflow_id"] == f"delegation:{delegation_id}"
+    assert evt["display_kind"] == "async_delegation_complete"
+    assert evt["user_originated"] is False
+    assert evt["terminal"] is True
+
+
+def test_new_delegation_id_uses_full_uuid_entropy():
+    first = ad._new_delegation_id()
+    second = ad._new_delegation_id()
+    assert first.startswith("deleg_")
+    assert len(first.removeprefix("deleg_")) == 32
+    assert first != second
+
+
 def test_active_for_session_counts_every_live_delegation_state():
     with ad._records_lock:
         ad._records.update(
@@ -229,6 +248,13 @@ def test_completion_event_lands_on_shared_queue_with_session_key():
     assert evt["session_key"] == "agent:main:cli:dm:local"
     assert evt["parent_session_id"] == "20260703_parent_sid"
     assert evt["delegation_id"] == res["delegation_id"]
+    assert evt["event_schema"] == "hermes.internal_event.v1"
+    assert evt["event_id"] == f"async_delegation:{res['delegation_id']}:terminal"
+    assert evt["event_kind"] == "workflow.async_delegation.terminal"
+    assert evt["workflow_id"] == f"delegation:{res['delegation_id']}"
+    assert evt["display_kind"] == "async_delegation_complete"
+    assert evt["user_originated"] is False
+    assert evt["terminal"] is True
 
 
 def test_rich_reinjection_block_is_self_contained():
@@ -674,6 +700,7 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     assert evt.get("is_batch") is True
     assert len(evt["results"]) == 1
     assert evt["results"][0]["summary"] == "done: the real task"
+    _assert_internal_event_envelope(evt)
     text = format_process_notification(evt)
     assert text is not None
     assert "the real task" in text

--- a/tests/tools/test_restored_delegation_ownership.py
+++ b/tests/tools/test_restored_delegation_ownership.py
@@ -85,6 +85,13 @@ def test_restore_stamps_restored_flag(tmp_path, monkeypatch):
     got = q.get_nowait()
     assert got["restored"] is True
     assert got["session_key"] == "OLD_SESSION_A"
+    assert got["event_schema"] == "hermes.internal_event.v1"
+    assert got["event_id"] == "async_delegation:d-old:terminal"
+    assert got["event_kind"] == "workflow.async_delegation.terminal"
+    assert got["workflow_id"] == "delegation:d-old"
+    assert got["display_kind"] == "async_delegation_complete"
+    assert got["user_originated"] is False
+    assert got["terminal"] is True
 
     # The stamp is in-memory only — the durable payload is unchanged.
     with ad._connect() as conn:

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -276,7 +276,7 @@ class TestNotificationPollerLoopKanbanWiring:
         import tui_gateway.server as server
 
         emits: list = []
-        submits: list = []
+        submits: list[dict] = []
         monkeypatch.setattr(server, "_KANBAN_POLL_SECONDS", 0.01)
         monkeypatch.setattr(
             server, "_emit", lambda event, sid, payload=None: emits.append((event, payload))
@@ -284,7 +284,9 @@ class TestNotificationPollerLoopKanbanWiring:
         monkeypatch.setattr(
             server,
             "_run_prompt_submit",
-            lambda rid, sid, sess, text: submits.append(text),
+            lambda rid, sid, sess, text, **kwargs: submits.append(
+                {"text": text, **kwargs}
+            ),
         )
         stop = threading.Event()
         thread = threading.Thread(
@@ -330,7 +332,13 @@ class TestNotificationPollerLoopKanbanWiring:
         status_texts = [p["text"] for e, p in emits if e == "status.update" and p]
         assert any(tid in t for t in status_texts), status_texts
         assert any(e == "message.start" for e, _ in emits)
-        assert any(tid in text for text in submits), submits
+        assert any(tid in submit["text"] for submit in submits), submits
+        assert submits[0]["display_kind"] == "internal_event"
+        assert (
+            submits[0]["display_metadata"]["event_kind"]
+            == "workflow.kanban_notification.internal"
+        )
+        assert submits[0]["display_metadata"]["user_originated"] is False
         assert session["running"] is True  # poller claimed the turn
         assert not session.get("_kanban_pending")
 
@@ -357,6 +365,6 @@ class TestNotificationPollerLoopKanbanWiring:
             stop.set()
             thread.join(timeout=5)
 
-        assert any(tid in text for text in submits), submits
+        assert any(tid in submit["text"] for submit in submits), submits
         assert session["_kanban_pending"] == []
         assert session["running"] is True

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -36,6 +36,7 @@ logic stays in one place.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import sqlite3
@@ -44,7 +45,7 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from hermes_constants import get_hermes_home
 from tools.daemon_pool import DaemonThreadPoolExecutor
@@ -386,6 +387,7 @@ def recover_abandoned_delegations() -> int:
             for _k in ("scope_id", "user_id", "user_name"):
                 if task.get(_k):
                     event[_k] = task[_k]
+            event.update(_internal_event_envelope(delegation_id))
             result = {"status": "unknown", "summary": None, "error": event["error"]}
             conn.execute(
                 """UPDATE async_delegations SET state='unknown', completed_at=?,
@@ -446,6 +448,7 @@ def restore_undelivered_completions(target_queue) -> int:
                 continue
             evt = json.loads(payload)
             if isinstance(evt, dict):
+                evt.update(_internal_event_envelope(delegation_id))
                 evt["restored"] = True
             target_queue.put(evt)
             restored += 1
@@ -709,7 +712,110 @@ def has_live_for_session(
 
 
 def _new_delegation_id() -> str:
-    return f"deleg_{uuid.uuid4().hex[:8]}"
+    return f"deleg_{uuid.uuid4().hex}"
+
+
+def _internal_event_envelope(delegation_id: Any) -> Dict[str, Any]:
+    """Return the stable presentation-neutral identity for a terminal result.
+
+    Hosts may still inject the formatted payload into a model-facing ``user``
+    turn to preserve provider role alternation.  These fields make that transport
+    detail explicit so transcript projections never have to infer authorship
+    from prompt text such as ``[ASYNC DELEGATION ...]``.
+    """
+    delegation_key = str(delegation_id or "").strip()
+    if not delegation_key:
+        raise ValueError("delegation_id is required for an internal event envelope")
+    return {
+        "event_schema": "hermes.internal_event.v1",
+        "event_id": f"async_delegation:{delegation_key}:terminal",
+        "event_kind": "workflow.async_delegation.terminal",
+        "workflow_id": f"delegation:{delegation_key}",
+        "display_kind": "async_delegation_complete",
+        "user_originated": False,
+        "terminal": True,
+    }
+
+
+def internal_event_persistence(
+    event: Any,
+    *,
+    trusted_internal: bool = False,
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Return validated transcript projection fields for one internal event.
+
+    The formatted completion text may still be sent through a model-facing
+    ``user`` turn for provider role alternation. Persistence must use the
+    canonical envelope, never infer authorship from that text. Malformed or
+    partial metadata fails closed as an ordinary row rather than stamping a
+    spoofable internal-event identity.  Trusted drains may opt into a generic
+    internal envelope for process, Kanban, continuation, and wake events that
+    predate the delegation schema.  That opt-in is deliberately call-site
+    explicit so arbitrary user payloads cannot self-classify as internal.
+    """
+    if not isinstance(event, dict):
+        return None, None
+    delegation_id = str(event.get("delegation_id") or "").strip()
+    if delegation_id:
+        expected = _internal_event_envelope(delegation_id)
+        if not any(event.get(key) != value for key, value in expected.items()):
+            return expected["display_kind"], {
+                "event_schema": expected["event_schema"],
+                "event_id": expected["event_id"],
+                "event_kind": expected["event_kind"],
+                "workflow_id": expected["workflow_id"],
+                "delegation_id": delegation_id,
+                "user_originated": expected["user_originated"],
+                "terminal": expected["terminal"],
+            }
+        if not trusted_internal:
+            return None, None
+    elif not trusted_internal:
+        return None, None
+
+    event_type = str(event.get("type") or event.get("source") or "event").strip()
+    event_type = "".join(
+        char if (char.isalnum() or char in "._-") else "_"
+        for char in event_type.lower()
+    ).strip("._-") or "event"
+    event_id = str(
+        event.get("event_id")
+        or event.get("notification_id")
+        or event.get("message_id")
+        or ""
+    ).strip()
+    if not event_id:
+        fingerprint = json.dumps(
+            event,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        event_id = (
+            "internal_event:"
+            + hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()
+        )
+    event_kind = str(event.get("event_kind") or "").strip()
+    if not event_kind:
+        event_kind = f"workflow.{event_type}.internal"
+    terminal = event.get("terminal")
+    if not isinstance(terminal, bool):
+        terminal = event_type not in {"progress", "status", "watch_match"}
+
+    metadata: Dict[str, Any] = {
+        "event_schema": "hermes.internal_event.v1",
+        "event_id": event_id,
+        "event_kind": event_kind,
+        "user_originated": False,
+        "terminal": terminal,
+    }
+    workflow_id = str(event.get("workflow_id") or "").strip()
+    if workflow_id:
+        metadata["workflow_id"] = workflow_id
+    source = str(event.get("source") or "").strip()
+    if source:
+        metadata["source"] = source
+    return "internal_event", metadata
 
 
 def _prune_completed_locked() -> None:
@@ -999,6 +1105,7 @@ def _push_completion_event(
     for _k in ("scope_id", "user_id", "user_name"):
         if record.get(_k):
             evt[_k] = record[_k]
+    evt.update(_internal_event_envelope(record.get("delegation_id")))
     # Structured stall metadata (#51690) — additive, present only on
     # stall-monitor finalizations.
     for _k in (
@@ -1213,6 +1320,7 @@ def _push_batch_completion_event(
     for _k in ("scope_id", "user_id", "user_name"):
         if event_record.get(_k):
             evt[_k] = event_record[_k]
+    evt.update(_internal_event_envelope(event_record.get("delegation_id")))
     # Structured stall metadata (#51690) — additive, present only on
     # stall-monitor finalizations.
     for _k in (

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12287,6 +12287,37 @@ def _collect_kanban_notifications(session: dict) -> list:
     return texts
 
 
+def _run_notification_prompt(
+    rid: str,
+    sid: str,
+    session: dict,
+    event: dict,
+    text: str,
+) -> None:
+    """Submit one notification turn with validated durable projection metadata."""
+    from tools.async_delegation import internal_event_persistence
+
+    display_kind, display_metadata = internal_event_persistence(
+        event,
+        trusted_internal=True,
+    )
+    if display_kind is not None and display_metadata is not None:
+        if display_kind == "async_delegation_complete":
+            rich_metadata = _async_delegation_display_metadata(event)
+            rich_metadata.update(display_metadata)
+            display_metadata = rich_metadata
+        _run_prompt_submit(
+            rid,
+            sid,
+            session,
+            text,
+            display_kind=display_kind,
+            display_metadata=display_metadata,
+        )
+        return
+    _run_prompt_submit(rid, sid, session, text)
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -12355,7 +12386,17 @@ def _notification_poller_loop(
                     rid = f"__notif__{int(time.time() * 1000)}"
                     try:
                         _emit("message.start", sid)
-                        _run_prompt_submit(rid, sid, session, "\n".join(_batch))
+                        _run_notification_prompt(
+                            rid,
+                            sid,
+                            session,
+                            {
+                                "type": "kanban_notification",
+                                "session_id": sid,
+                                "items": list(_batch),
+                            },
+                            "\n".join(_batch),
+                        )
                     except Exception as exc:
                         print(
                             f"[tui_gateway] kanban notification dispatch failed: "
@@ -12441,17 +12482,7 @@ def _notification_poller_loop(
             continue
         try:
             _emit("message.start", sid)
-            if evt.get("type") == "async_delegation":
-                _run_prompt_submit(
-                    rid,
-                    sid,
-                    session,
-                    text,
-                    display_kind="async_delegation_complete",
-                    display_metadata=_async_delegation_display_metadata(evt),
-                )
-            else:
-                _run_prompt_submit(rid, sid, session, text)
+            _run_notification_prompt(rid, sid, session, evt, text)
             complete_event_delivery(evt, _claim)
         except Exception as exc:
             release_event_delivery(evt, _claim)
@@ -12519,17 +12550,7 @@ def _notification_poller_loop(
             continue
         try:
             _emit("message.start", sid)
-            if evt.get("type") == "async_delegation":
-                _run_prompt_submit(
-                    rid,
-                    sid,
-                    session,
-                    text,
-                    display_kind="async_delegation_complete",
-                    display_metadata=_async_delegation_display_metadata(evt),
-                )
-            else:
-                _run_prompt_submit(rid, sid, session, text)
+            _run_notification_prompt(rid, sid, session, evt, text)
             complete_event_delivery(evt, _claim)
         except Exception as exc:
             release_event_delivery(evt, _claim)
@@ -12567,6 +12588,17 @@ def _async_delegation_display_metadata(evt: dict) -> dict:
         "completed_count": completed_count or task_count - failed_count,
         "failed_count": failed_count,
     }
+    for key in (
+        "event_schema",
+        "event_id",
+        "event_kind",
+        "workflow_id",
+        "display_kind",
+        "user_originated",
+        "terminal",
+    ):
+        if key in evt:
+            metadata[key] = evt[key]
     duration = evt.get("total_duration_seconds") or evt.get("duration_seconds")
     if isinstance(duration, (int, float)):
         metadata["duration_seconds"] = duration
@@ -13883,7 +13915,7 @@ def _run_prompt_submit(
                     continue
                 try:
                     _emit("message.start", sid)
-                    _run_prompt_submit(rid, sid, session, synth)
+                    _run_notification_prompt(rid, sid, session, _evt, synth)
                     complete_event_delivery(_evt, _claim)
                 except Exception as _n_exc:
                     release_event_delivery(_evt, _claim)


### PR DESCRIPTION
## Summary

- add a stable internal-event envelope to async delegation terminal events
- cover normal, production batch, crash-recovered and pre-schema restored completions
- use the full 128-bit UUID delegation identity instead of an 8-hex suffix
- propagate and persist the validated envelope through Gateway, TUI and CLI projection metadata
- preserve the replay-age cap, routing fixes and runtime hardening from the current `e5e2fb8b` upstream base
- keep the local replay delta as one commit whose tree exactly matches the feature candidate
- preserve the existing queue and delivery payload for backward compatibility

## Event contract

Each terminal delegation event now includes:

- `event_schema=hermes.internal_event.v1`
- deterministic `event_id=async_delegation:<delegation_id>:terminal`
- `workflow_id=delegation:<delegation_id>`
- `event_kind=workflow.async_delegation.terminal`
- `display_kind=internal_event`
- `user_originated=false`
- `terminal=true`

The envelope gives downstream clients a machine-readable identity and projection policy instead of requiring them to infer ownership from the wakeup text. Empty delegation identities are rejected rather than aliased.

## Verification

- normal completion, production batch, restored ownership, Gateway projection and file-descriptor regression suites passed
- 200 focused async-delegation, ownership, file-descriptor, Gateway, relay, session-binding and internal-projection tests passed on the rebased N+1 candidate
- the full 12-slice GitHub matrix, e2e, Docker builds, security gates and blocking lints passed
- Ruff, Python compilation and `git diff --check` passed
