### PR TITLE
docs(image-gen-provider): list hermes-agent-poe-image-gen as third-party reference

### DIFF
--- a/website/docs/developer-guide/image-gen-provider-plugin.md
+++ b/website/docs/developer-guide/image-gen-provider-plugin.md
@@ -315,7 +315,7 @@ These ship as standalone pip packages / repos, not under this tree. They're list
 
 | Plugin | Source | Notes |
 |---|---|---|
-| [hermes-agent-poe-image-gen](https://github.com/dzoey/hermes-agent-poe-image-gen) | [PyPI](https://pypi.org/project/hermes-agent-poe-image-gen/) / pip | Poe.com backend via `fastapi_poe` SDK. 27-bot catalog (Nano-Banana, GPT-Image, Flux-2, Grok-Imagine-Image, Ideogram, DALL-E-4, …) loaded from a `models.json` sidecar so users can add/remove bots without editing Python. Any arbitrary Poe bot name is also accepted at call time. Requires `POE_API_KEY`. |
+| [hermes-agent-poe-image-gen](https://github.com/dzoey/hermes-agent-poe-image-gen) | [PyPI](https://pypi.org/project/hermes-agent-poe-image-gen/) / pip | Poe.com backend via `fastapi_poe` SDK. Model catalog loaded from a `models.json` sidecar (see plugin README for current list). Requires `POE_API_KEY`. |
 
 Want to add yours? Open a PR against this page with a one-line entry following the same format.
 

--- a/website/docs/developer-guide/image-gen-provider-plugin.md
+++ b/website/docs/developer-guide/image-gen-provider-plugin.md
@@ -309,6 +309,16 @@ my-backend-imggen = "my_backend_imggen_package"
 
 `my_backend_imggen_package` must expose a top-level `register` function. See [Distribute via pip](/developer-guide/plugins#distribute-via-pip) in the general plugin guide for the full setup.
 
+## Third-party image-gen plugins
+
+These ship as standalone pip packages / repos, not under this tree. They're listed here for discoverability — install via `pip install <name>` (or clone into `~/.hermes/plugins/image_gen/<name>/`) and select them in `image_gen.provider` like any other backend. See [Build a Hermes Plugin](/developer-guide/plugins#distribute-via-pip) for the entry-point convention.
+
+| Plugin | Source | Notes |
+|---|---|---|
+| [hermes-agent-poe-image-gen](https://github.com/dzoey/hermes-agent-poe-image-gen) | [PyPI](https://pypi.org/project/hermes-agent-poe-image-gen/) / pip | Poe.com backend via `fastapi_poe` SDK. 27-bot catalog (Nano-Banana, GPT-Image, Flux-2, Grok-Imagine-Image, Ideogram, DALL-E-4, …) loaded from a `models.json` sidecar so users can add/remove bots without editing Python. Any arbitrary Poe bot name is also accepted at call time. Requires `POE_API_KEY`. |
+
+Want to add yours? Open a PR against this page with a one-line entry following the same format.
+
 ## Related pages
 
 - [Image Generation](/user-guide/features/image-generation) — user-facing feature documentation


### PR DESCRIPTION
## Summary

Adds a **Third-party image-gen plugins** section to the image-gen provider plugin doc (`website/docs/developer-guide/image-gen-provider-plugin.md`) listing [hermes-agent-poe-image-gen](https://github.com/dzoey/hermes-agent-poe-image-gen) as a discoverable third-party implementation.

No code change. 10-line doc-only PR.

## Why

The doc currently lists reference implementations under the `plugins/image_gen/<name>/` tree, but doesn't surface external plugins that follow the documented pip / user-install convention. The maintainer comment on the closed PR #41463 explicitly suggested this path:

> consider publishing Poe as a standalone Hermes plugin repository or pip entry point, then promote it in `#plugins-skills-and-skins`

This PR surfaces the plugin in the equivalent in-repo location — the canonical plugin-authoring doc — without violating the `in-tree-provider-integration` policy, because:

- The plugin code lives at `dzoey/hermes-agent-poe-image-gen`, **not** under this repo's tree.
- The doc edit is purely a one-line table entry pointing at the external repo.
- It uses the existing `pip` install path documented in the same file's "Distribute via pip" section.

## What's added

A new section after "Distribute via pip" and before "Related pages":

```markdown
## Third-party image-gen plugins

These ship as standalone pip packages / repos, not under this tree. They're listed here for discoverability — install via `pip install <name>` (or clone into `~/.hermes/plugins/image_gen/<name>/`) and select them in `image_gen.provider` like any other backend.

| Plugin | Source | Notes |
|---|---|---|
| hermes-agent-poe-image-gen | PyPI / pip | Poe.com backend via `fastapi_poe` SDK. 27-bot catalog (Nano-Banana, GPT-Image, Flux-2, Grok-Imagine-Image, Ideogram, DALL-E-4, …) loaded from a `models.json` sidecar so users can add/remove bots without editing Python. Any arbitrary Poe bot name is also accepted at call time. Requires `POE_API_KEY`. |

Want to add yours? Open a PR against this page with a one-line entry following the same format.
```

## Note on the PyPI link

The table currently links `PyPI` to `https://pypi.org/project/hermes-agent-poe-image-gen/`, but I haven't published the package yet (the GitHub repo at `dzoey/hermes-agent-poe-image-gen` exists with the code, just no PyPI release). The link is currently a 404. Happy to either:

- (a) Remove the PyPI link from this PR until the package is actually published, or
- (b) Land this as-is and publish to PyPI in a follow-up before merge.

Will defer to maintainer preference.

## Alternatives considered

- Adding the plugin to a new `plugins/` directory in this repo — explicitly out of policy per PR #41463.
- Editing `built-in-plugins.md` — that page is scoped to plugins shipped with the repo; external plugins would be off-topic there.
- Cross-linking from `README.md` — would conflict with the existing third-party/built-in separation; better suited to a dedicated community-plugins doc if one is created later.
