### PR TITLE
fix(matrix): verify curve25519 and self-signature in device-key checks

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1408,10 +1408,44 @@ class MatrixAdapter(BasePlatformAdapter):
                 return str(kval)
         return None
 
-    async def _reverify_keys_after_upload(
-        self, client: Any, local_ed25519: str
+    @staticmethod
+    def _extract_server_curve25519(device_keys_obj: Any) -> Optional[str]:
+        """Extract the curve25519 encryption key from a DeviceKeys object."""
+        for kid, kval in (getattr(device_keys_obj, "keys", {}) or {}).items():
+            if str(kid).startswith("curve25519:"):
+                return str(kval)
+        return None
+
+    @staticmethod
+    def _has_valid_device_self_signature(
+        device_keys_obj: Any,
+        user_id: str,
+        device_id: str,
+        ed25519: str,
     ) -> bool:
-        """Re-query the server after share_keys() and verify our ed25519 key matches."""
+        """Cryptographically verify a server device record's own signature.
+
+        String-matching the advertised ed25519 key is not enough: the record
+        itself must be signed by that key. Fails closed — any error during
+        verification (malformed record, missing signature, bad key material)
+        counts as invalid.
+        """
+        try:
+            from mautrix.crypto.signature import verify_signature_json
+
+            serialized = device_keys_obj.serialize()
+            return bool(
+                verify_signature_json(serialized, user_id, device_id, ed25519)
+            )
+        except Exception:
+            return False
+
+    async def _reverify_keys_after_upload(
+        self, client: Any, local_ed25519: str, local_curve25519: str
+    ) -> bool:
+        """Re-query the server after share_keys() and verify the full device
+        record: both identity keys must match and the self-signature must be
+        valid."""
         if not client.device_id or self._device_id_unverified:
             logger.warning(
                 "Matrix: skipping post-upload key verification — "
@@ -1423,16 +1457,31 @@ class MatrixAdapter(BasePlatformAdapter):
             dk = getattr(resp, "device_keys", {}) or {}
             ud = dk.get(str(client.mxid)) or {}
             dev = ud.get(str(client.device_id))
-            if dev:
-                server_ed = self._extract_server_ed25519(dev)
-                if server_ed != local_ed25519:
-                    logger.error(
-                        "Matrix: device %s has immutable identity keys that "
-                        "don't match this installation. Generate a new access "
-                        "token with a fresh device.",
-                        client.device_id,
-                    )
-                    return False
+            if not dev:
+                logger.error(
+                    "Matrix: device %s was not present after key upload",
+                    client.device_id,
+                )
+                return False
+            server_ed = self._extract_server_ed25519(dev)
+            server_curve = self._extract_server_curve25519(dev)
+            if server_ed != local_ed25519 or server_curve != local_curve25519:
+                logger.error(
+                    "Matrix: device %s has identity keys that don't match this "
+                    "installation after upload. Generate a new access token "
+                    "with a fresh device.",
+                    client.device_id,
+                )
+                return False
+            if not self._has_valid_device_self_signature(
+                dev, str(client.mxid), str(client.device_id), server_ed
+            ):
+                logger.error(
+                    "Matrix: device %s has an invalid self-signature after "
+                    "key upload",
+                    client.device_id,
+                )
+                return False
         except Exception as exc:
             logger.error("Matrix: post-upload key verification failed: %s", exc, exc_info=True)
             return False
@@ -1616,6 +1665,7 @@ class MatrixAdapter(BasePlatformAdapter):
         our_user_devices = device_keys_map.get(str(client.mxid)) or {}
         our_keys = our_user_devices.get(str(client.device_id))
         local_ed25519 = olm.account.identity_keys.get("ed25519")
+        local_curve25519 = olm.account.identity_keys.get("curve25519")
 
         if not our_keys:
             logger.warning("Matrix: device keys missing from server — re-uploading")
@@ -1625,23 +1675,45 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.error("Matrix: failed to re-upload device keys: %s", exc, exc_info=True)
                 return False
-            return await self._reverify_keys_after_upload(client, local_ed25519)
+            return await self._reverify_keys_after_upload(
+                client, local_ed25519, local_curve25519
+            )
 
         server_ed25519 = self._extract_server_ed25519(our_keys)
+        server_curve25519 = self._extract_server_curve25519(our_keys)
+        signature_valid = bool(server_ed25519) and self._has_valid_device_self_signature(
+            our_keys, str(client.mxid), str(client.device_id), server_ed25519
+        )
 
-        if server_ed25519 != local_ed25519:
+        if (
+            server_ed25519 != local_ed25519
+            or server_curve25519 != local_curve25519
+            or not signature_valid
+        ):
+            invalid_reason = (
+                "identity key mismatch"
+                if server_ed25519 != local_ed25519
+                else (
+                    "encryption key mismatch"
+                    if server_curve25519 != local_curve25519
+                    else "invalid device self-signature"
+                )
+            )
             if olm.account.shared:
                 logger.error(
-                    "Matrix: server has different identity keys for device %s — "
+                    "Matrix: server device record for %s failed verification (%s) — "
                     "local crypto state is stale. Delete %s and restart.",
                     client.device_id,
+                    invalid_reason,
                     _CRYPTO_DB_PATH,
                 )
                 return False
 
             logger.warning(
-                "Matrix: server has stale keys for device %s — attempting re-upload",
+                "Matrix: server device record for %s failed verification (%s) — "
+                "attempting re-upload",
                 client.device_id,
+                invalid_reason,
             )
             try:
                 await client.api.request(
@@ -1666,7 +1738,9 @@ class MatrixAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
                 return False
-            return await self._reverify_keys_after_upload(client, local_ed25519)
+            return await self._reverify_keys_after_upload(
+                client, local_ed25519, local_curve25519
+            )
 
         return True
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -953,23 +953,81 @@ class MatrixAdapter(BasePlatformAdapter):
         return None
 
     @staticmethod
+    def _extract_server_curve25519(device_keys_obj: Any) -> Optional[str]:
+        """Extract the curve25519 encryption key from a DeviceKeys object."""
+        for kid, kval in (getattr(device_keys_obj, "keys", {}) or {}).items():
+            if str(kid).startswith("curve25519:"):
+                return str(kval)
+        return None
+
+    @staticmethod
+    def _has_valid_device_self_signature(
+        device_keys_obj: Any,
+        user_id: str,
+        device_id: str,
+        ed25519: str,
+    ) -> bool:
+        """Cryptographically verify a server device record's own signature.
+
+        String-matching the advertised ed25519 key is not enough: the record
+        itself must be signed by that key. Fails closed — any error during
+        verification (malformed record, missing signature, bad key material)
+        counts as invalid.
+        """
+        try:
+            from mautrix.crypto.signature import verify_signature_json
+
+            serialized = device_keys_obj.serialize()
+            return bool(
+                verify_signature_json(serialized, user_id, device_id, ed25519)
+            )
+        except Exception as exc:
+            # Fail closed stays deliberate: any error means "not verifiably
+            # valid". Log at debug so a broken install (e.g. ImportError) or
+            # a malformed record is diagnosable instead of indistinguishable
+            # from a genuine signature failure.
+            logger.debug(
+                "Matrix: device self-signature verification raised: %s",
+                exc,
+                exc_info=True,
+            )
+            return False
+
+    @staticmethod
     async def _query_own_device_keys(client: Any):
         """query_keys for our own device; the DeviceKeys entry or None."""
         resp = await client.query_keys({client.mxid: [client.device_id]})
         our_user_devices = (getattr(resp, "device_keys", {}) or {}).get(str(client.mxid)) or {}
         return our_user_devices.get(str(client.device_id))
 
-    async def _reverify_keys_after_upload(self, client: Any, local_ed25519: str) -> bool:
-        """Re-query the server after share_keys() and verify our ed25519 key matches."""
+    async def _reverify_keys_after_upload(
+        self, client: Any, local_ed25519: str, local_curve25519: Optional[str]
+    ) -> bool:
+        """Re-query the server after share_keys() and verify the full device
+        record: both identity keys must match and the self-signature must be
+        valid."""
         if not client.device_id or self._device_id_unverified:
             logger.warning("Matrix: skipping post-upload key verification — device_id not yet established")
             return True
         try:
             dev = await self._query_own_device_keys(client)
-            if dev and self._extract_server_ed25519(dev) != local_ed25519:
+            if not dev:
+                logger.error("Matrix: device %s was not present after key upload", client.device_id)
+                return False
+            server_ed = self._extract_server_ed25519(dev)
+            server_curve = self._extract_server_curve25519(dev)
+            if server_ed != local_ed25519 or server_curve != local_curve25519:
                 logger.error(
-                    "Matrix: device %s has immutable identity keys that don't match this "
-                    "installation. Generate a new access token with a fresh device.", client.device_id)
+                    "Matrix: device %s has identity keys that don't match this "
+                    "installation after upload. Generate a new access token "
+                    "with a fresh device.", client.device_id)
+                return False
+            if not self._has_valid_device_self_signature(
+                dev, str(client.mxid), str(client.device_id), server_ed
+            ):
+                logger.error(
+                    "Matrix: device %s has an invalid self-signature after key upload",
+                    client.device_id)
                 return False
         except Exception as exc:
             logger.error("Matrix: post-upload key verification failed: %s", exc, exc_info=True)
@@ -1071,6 +1129,7 @@ class MatrixAdapter(BasePlatformAdapter):
             logger.error("Matrix: cannot verify device keys on server: %s — refusing E2EE", exc, exc_info=True)
             return False
         local_ed25519 = olm.account.identity_keys.get("ed25519")
+        local_curve25519 = olm.account.identity_keys.get("curve25519")
 
         async def _reupload(error_fmt: str, *error_args) -> bool:
             try:
@@ -1078,19 +1137,47 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.error(error_fmt, *error_args, exc, exc_info=True)
                 return False
-            return await self._reverify_keys_after_upload(client, local_ed25519)
+            return await self._reverify_keys_after_upload(client, local_ed25519, local_curve25519)
         if not our_keys:
             logger.warning("Matrix: device keys missing from server — re-uploading")
             olm.account.shared = False
             return await _reupload("Matrix: failed to re-upload device keys: %s")
-        if self._extract_server_ed25519(our_keys) == local_ed25519:
+        server_ed25519 = self._extract_server_ed25519(our_keys)
+        server_curve25519 = self._extract_server_curve25519(our_keys)
+        signature_valid = bool(server_ed25519) and self._has_valid_device_self_signature(
+            our_keys, str(client.mxid), str(client.device_id), server_ed25519
+        )
+        if (
+            server_ed25519 == local_ed25519
+            and server_curve25519 == local_curve25519
+            and signature_valid
+        ):
             return True
+        invalid_reason = (
+            "identity key missing from server record"
+            if not server_ed25519
+            else (
+                "identity key mismatch"
+                if server_ed25519 != local_ed25519
+                else (
+                    "encryption key missing from server record"
+                    if not server_curve25519
+                    else (
+                        "encryption key mismatch"
+                        if server_curve25519 != local_curve25519
+                        else "invalid device self-signature"
+                    )
+                )
+            )
+        )
         if olm.account.shared:
             logger.error(
-                "Matrix: server has different identity keys for device %s — local crypto state is "
-                "stale. Delete %s and restart.", client.device_id, str(self._crypto_db_path))
+                "Matrix: server device record for %s failed verification (%s) — local crypto state is "
+                "stale. Delete %s and restart.", client.device_id, invalid_reason, str(self._crypto_db_path))
             return False
-        logger.warning("Matrix: server has stale keys for device %s — attempting re-upload", client.device_id)
+        logger.warning(
+            "Matrix: server device record for %s failed verification (%s) — attempting re-upload",
+            client.device_id, invalid_reason)
         with suppress(Exception):
             await client.api.request(
                 client.api.Method.DELETE if hasattr(client.api, "Method") else "DELETE",

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -12,6 +12,24 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageType
 
 
+@pytest.fixture(autouse=True)
+def _accept_mock_device_signatures(monkeypatch):
+    """Accept the unsigned mock device records used throughout this module.
+
+    Connect/verification tests here build mock server device records without
+    real Olm signatures; their subject is the connect and device-ID flow, not
+    cryptography. Cryptographic self-signature verification itself is covered
+    with real signed records in test_matrix_device_key_verification.py.
+    """
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    monkeypatch.setattr(
+        MatrixAdapter,
+        "_has_valid_device_self_signature",
+        staticmethod(lambda *args: True),
+    )
+
+
 def _make_fake_mautrix():
     """Create a lightweight set of fake ``mautrix`` modules.
 
@@ -947,11 +965,11 @@ class TestMatrixAccessTokenAuth:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:DEV123": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"DEV123": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_access_token"
         mock_client.api.session = MagicMock()
@@ -1166,11 +1184,11 @@ class TestMatrixDeviceId:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"MY_STABLE_DEVICE": {
-                "keys": {"ed25519:MY_STABLE_DEVICE": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:WHOAMI_DEV": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"WHOAMI_DEV": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_access_token"
         mock_client.api.session = MagicMock()
@@ -1545,11 +1563,11 @@ class TestMatrixDiagnostics:
         mock_client.add_event_handler = MagicMock()
         mock_client.add_dispatcher = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:DEV123": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"DEV123": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_token"
         mock_client.api.session = MagicMock()
@@ -1669,11 +1687,11 @@ class TestMatrixEncryptedEventHandler:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:DEV123": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"DEV123": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_token"
         mock_client.api.session = MagicMock()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -12,6 +12,24 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.event import MessageType
 
 
+@pytest.fixture(autouse=True)
+def _accept_mock_device_signatures(monkeypatch):
+    """Accept the unsigned mock device records used throughout this module.
+
+    Connect/verification tests here build mock server device records without
+    real Olm signatures; their subject is the connect and device-ID flow, not
+    cryptography. Cryptographic self-signature verification itself is covered
+    with real signed records in test_matrix_device_key_verification.py.
+    """
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    monkeypatch.setattr(
+        MatrixAdapter,
+        "_has_valid_device_self_signature",
+        staticmethod(lambda *args: True),
+    )
+
+
 def _make_fake_mautrix():
     """Create a lightweight set of fake ``mautrix`` modules.
 
@@ -947,11 +965,11 @@ class TestMatrixAccessTokenAuth:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:DEV123": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"DEV123": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_access_token"
         mock_client.api.session = MagicMock()
@@ -1166,11 +1184,11 @@ class TestMatrixDeviceId:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"MY_STABLE_DEVICE": {
-                "keys": {"ed25519:MY_STABLE_DEVICE": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:WHOAMI_DEV": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"WHOAMI_DEV": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_access_token"
         mock_client.api.session = MagicMock()
@@ -1545,11 +1563,11 @@ class TestMatrixDiagnostics:
         mock_client.add_event_handler = MagicMock()
         mock_client.add_dispatcher = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:DEV123": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"DEV123": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_token"
         mock_client.api.session = MagicMock()
@@ -1669,11 +1687,11 @@ class TestMatrixEncryptedEventHandler:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:DEV123": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"DEV123": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_token"
         mock_client.api.session = MagicMock()

--- a/tests/gateway/test_matrix_device_key_verification.py
+++ b/tests/gateway/test_matrix_device_key_verification.py
@@ -1,0 +1,99 @@
+"""Regression tests: Matrix device-record verification must validate the full
+server-side record, not just string-match the ed25519 identity key.
+
+A record that advertises a diverging curve25519 encryption key — or whose
+self-signature does not verify against the advertised ed25519 key — must fail
+verification. Otherwise peers encrypt Megolm sessions to a key this
+installation does not hold, and inbound messages become undecryptable with no
+local error.
+"""
+
+import pytest
+from mautrix.crypto.account import OlmAccount
+from mautrix.types import DeviceID, UserID
+
+USER_ID = UserID("@hermes-test:example.org")
+DEVICE_ID = DeviceID("HERMESTEST")
+
+
+def _signed_device_keys():
+    """A real Olm account and its genuinely signed DeviceKeys record."""
+    account = OlmAccount()
+    return account, account.get_device_keys(USER_ID, DEVICE_ID)
+
+
+class _SerializedRecord:
+    """Carries a (possibly tampered) serialized DeviceKeys payload with the
+    two access patterns the adapter uses: ``.keys`` and ``.serialize()``."""
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self.keys = payload.get("keys", {})
+
+    def serialize(self) -> dict:
+        return dict(self._payload)
+
+
+def test_self_signature_valid_for_real_signed_device_keys():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    account, device_keys = _signed_device_keys()
+
+    assert MatrixAdapter._has_valid_device_self_signature(
+        device_keys, str(USER_ID), str(DEVICE_ID), account.identity_keys["ed25519"]
+    )
+    # Both identity keys extract from the real record.
+    assert (
+        MatrixAdapter._extract_server_ed25519(device_keys)
+        == account.identity_keys["ed25519"]
+    )
+    assert (
+        MatrixAdapter._extract_server_curve25519(device_keys)
+        == account.identity_keys["curve25519"]
+    )
+
+
+def test_self_signature_rejects_tampered_encryption_key():
+    """Swapping curve25519 for another account's key must invalidate the record."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    account, device_keys = _signed_device_keys()
+    other = OlmAccount()
+
+    payload = device_keys.serialize()
+    payload["keys"][f"curve25519:{DEVICE_ID}"] = other.identity_keys["curve25519"]
+    tampered = _SerializedRecord(payload)
+
+    # Raw ed25519 still matches — string comparison alone would accept this.
+    assert MatrixAdapter._extract_server_ed25519(tampered) == account.identity_keys["ed25519"]
+    assert not MatrixAdapter._has_valid_device_self_signature(
+        tampered, str(USER_ID), str(DEVICE_ID), account.identity_keys["ed25519"]
+    )
+
+
+def test_self_signature_rejects_wrong_device_and_user():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    account, device_keys = _signed_device_keys()
+    ed25519 = account.identity_keys["ed25519"]
+
+    assert not MatrixAdapter._has_valid_device_self_signature(
+        device_keys, str(USER_ID), "OTHERDEVICE", ed25519
+    )
+    assert not MatrixAdapter._has_valid_device_self_signature(
+        device_keys, "@someone-else:example.org", str(DEVICE_ID), ed25519
+    )
+
+
+def test_self_signature_fails_closed_on_malformed_record():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    account, device_keys = _signed_device_keys()
+
+    payload = device_keys.serialize()
+    payload.pop("signatures", None)
+    unsigned_record = _SerializedRecord(payload)
+
+    assert not MatrixAdapter._has_valid_device_self_signature(
+        unsigned_record, str(USER_ID), str(DEVICE_ID), account.identity_keys["ed25519"]
+    )


### PR DESCRIPTION
## What

Device-key verification in the Matrix adapter now validates the **full** server-side device record instead of string-matching only the ed25519 identity key:

- compares the **curve25519** encryption key as well (new `_extract_server_curve25519`)
- cryptographically validates the record's **self-signature** via mautrix's `verify_signature_json` (new `_has_valid_device_self_signature`, fails closed)
- treats a device **missing from the post-upload re-query** as a verification failure instead of a vacuous pass
- mismatch log messages now name the reason: identity key mismatch / encryption key mismatch / invalid self-signature

The repair behavior is deliberately unchanged (delete + re-upload when the account was never shared; refuse E2EE with operator instructions otherwise). This PR is detection-only; a follow-up proposal will address automating repair.

## Why

Previously, a server record whose advertised curve25519 diverged from the local store passed verification whenever ed25519 matched — leaving peers to encrypt Megolm sessions to a key this installation does not hold (undecryptable inbound, no local error). And a corrupted/tampered record with an invalid self-signature was accepted on a raw string match. Both gaps matter in long-lived E2EE deployments where devices get deleted/recreated server-side; observed operating a production multiplexed gateway with Matrix + E2EE.

No new dependencies: `verify_signature_json` ships with the already-pinned mautrix.

## Tests

- New `tests/gateway/test_matrix_device_key_verification.py`: real `OlmAccount`-signed device records — valid signature accepted; tampered curve25519 rejected (raw ed25519 still matches, proving the signature check is what catches it); wrong device/user rejected; unsigned record rejected.
- `tests/gateway/test_matrix.py`: four connect-flow tests used dict-shaped `query_keys` mocks that the old code vacuously accepted (`getattr(dict, "device_keys")` → `{}` → skip). They now return response-shaped mocks keyed by the device ID the flow actually queries — including `test_connect_keeps_configured_device_id_on_adapter`, where the record must live under the token's own device (`WHOAMI_DEV`), not the configured one. An autouse fixture accepts these unsigned mock records and points at the real crypto coverage.
- `scripts/run_tests.sh` over 6 Matrix test files: **141 passed, 0 failed**.

Refs #83481
