### PR TITLE
Canonical form in login page

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -420,7 +420,7 @@ _PASSWORD_FORM_SCRIPT = """\
       if (err) { err.hidden = true; err.textContent = ''; }
       if (btn) { btn.disabled = true; }
       var body = {
-        provider: form.getAttribute('data-provider') || '',
+        provider: (form.querySelector('input[name=provider]') || {}).value || '',
         username: (form.querySelector('input[name=username]') || {}).value || '',
         password: (form.querySelector('input[name=password]') || {}).value || '',
         next: (form.querySelector('input[name=next]') || {}).value || ''
@@ -516,6 +516,7 @@ def _render_password_form(provider, next_path: str) -> str:
         f'      <form class="provider-form" data-provider="{pname}" '
         f'autocomplete="on">\n'
         f'        <div class="form-title">Sign in with {plabel}</div>\n'
+        f'        <input type="hidden" name="provider" value="{pname}">\n'
         f'        <input type="hidden" name="next" value="{safe_next}">\n'
         f'        <label class="field">\n'
         f'          <span class="field-label">Username</span>\n'


### PR DESCRIPTION
## What does this PR do?
Current form in login page uses a non-standard way to store provider info: attribute data-provider in the HTML form element. But HTML sanitizers removes silently "unused" attributes, becoming unusable  the javascript.

This PR proposes very light modifications using the canonical way to store data in a form, using input element.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [X] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
Modified hermes_cli/dashboard_auth/login_page.py

### Code

- [X ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [X ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

