### PR TITLE
fix(agent): repair skills search tool calls

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3123,6 +3123,15 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     if normalized in agent.valid_tool_names:
         return normalized
 
+    # Tool-calling models sometimes ask to search skills even though the
+    # available operation is the skills catalog.  Only repair the observed
+    # names, and only when the catalog tool is available in this session.
+    if (
+        normalized in {"skill_search", "skills_search"}
+        and "skills_list" in agent.valid_tool_names
+    ):
+        return "skills_list"
+
     # Build the full candidate set for class-like emissions.
     cands: set[str] = {tool_name, lowered, normalized, _camel_snake(tool_name)}
     # Strip trailing tool-suffix up to twice — TodoTool_tool needs it.

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -22,6 +22,7 @@ VALID = {
     "browser_click",
     "browser_navigate",
     "web_search",
+    "skills_list",
     "read_file",
     "write_file",
     "terminal",
@@ -63,7 +64,19 @@ class TestClassLikeEmissions:
         assert repair("BrowserClick") == "browser_click"
 
 
+class TestSkillsSearchHallucinations:
+    """The skills catalog is the safe fallback for observed pseudo-tools."""
 
+    @pytest.mark.parametrize("tool_name", ("skill_search", "skills_search"))
+    def test_repairs_to_skills_catalog(self, repair, tool_name):
+        assert repair(tool_name) == "skills_list"
+
+    def test_does_not_enable_skills_catalog_when_unavailable(self):
+        from run_agent import AIAgent
+
+        stub = SimpleNamespace(valid_tool_names=VALID - {"skills_list"})
+        repair = AIAgent._repair_tool_call.__get__(stub, AIAgent)
+        assert repair("skills_search") is None
 
 
 


### PR DESCRIPTION
## What changed and why

Per the reporter's 2026-08-10 clarification, the missing-skills flow also occurs with Qwen via Ollama, so this is not Gemma-specific. Repair the observed `skill_search` and `skills_search` pseudo-tool names to `skills_list`, but only when `skills_list` is present in the session's resolved toolset.

The change is deliberately limited to the tool-name repair path and its regression tests; it adds no tool, configuration, or provider-specific behavior.

Fixes #15985

## How to test

- `pytest tests/run_agent/test_repair_tool_call_name.py -q`
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`

## What platforms tested on

- macOS (automated test suite)
- The repair is pure Python and has no platform-specific code paths.

<!-- autocontrib:worker-id=issue-followup-877570a1 kind=pr-open -->