### PR TITLE
fix(desktop): reject malformed grid layouts instead of throwing RangeError

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/grid-model.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/grid-model.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+
+import { type GridLayout, initColumns, isGridValid, modelToZones, MULTIPLIER } from './grid-model'
+
+/**
+ * `modelToZones` sizes five scratch arrays from a zone count derived by scanning
+ * `cellChildMap`. `new Array(n)` throws a hard `RangeError: Invalid array
+ * length` for negative / fractional / NaN n, and because the call happens
+ * during render, the throw takes down the whole desktop shell in a remount
+ * loop. Malformed layouts must leave through the documented `null` return that
+ * every caller already handles.
+ */
+describe('modelToZones rejects malformed grids instead of throwing', () => {
+  const cases: Array<{ name: string; model: GridLayout }> = [
+    {
+      name: 'zero rows',
+      model: { rows: 0, columns: 1, rowPercents: [], columnPercents: [MULTIPLIER], cellChildMap: [] }
+    },
+    {
+      name: 'negative rows',
+      model: { rows: -2, columns: 1, rowPercents: [], columnPercents: [MULTIPLIER], cellChildMap: [] }
+    },
+    {
+      name: 'fractional columns',
+      model: { rows: 1, columns: 1.5, rowPercents: [MULTIPLIER], columnPercents: [MULTIPLIER], cellChildMap: [[0]] }
+    },
+    {
+      name: 'NaN rows',
+      model: { rows: NaN, columns: 1, rowPercents: [MULTIPLIER], columnPercents: [MULTIPLIER], cellChildMap: [[0]] }
+    },
+    {
+      name: 'Infinity columns',
+      model: {
+        rows: 1,
+        columns: Number.POSITIVE_INFINITY,
+        rowPercents: [MULTIPLIER],
+        columnPercents: [MULTIPLIER],
+        cellChildMap: [[0]]
+      }
+    },
+    {
+      name: 'a NaN cell index',
+      model: {
+        rows: 1,
+        columns: 2,
+        rowPercents: [MULTIPLIER],
+        columnPercents: [5000, 5000],
+        cellChildMap: [[0, NaN]]
+      }
+    },
+    {
+      name: 'a negative cell index',
+      model: {
+        rows: 1,
+        columns: 2,
+        rowPercents: [MULTIPLIER],
+        columnPercents: [5000, 5000],
+        cellChildMap: [[0, -1]]
+      }
+    },
+    {
+      name: 'a fractional cell index',
+      model: {
+        rows: 1,
+        columns: 2,
+        rowPercents: [MULTIPLIER],
+        columnPercents: [5000, 5000],
+        cellChildMap: [[0, 0.5]]
+      }
+    },
+    {
+      // The regression that produced the shipped crash: a row shorter than
+      // `columns` reads `undefined`, Math.max yields NaN, and every NaN
+      // comparison in the `zoneCount > rows * cols` bound check is false — so
+      // the malformed count flowed straight into `new Array(NaN)`.
+      name: 'a row shorter than columns',
+      model: {
+        rows: 2,
+        columns: 2,
+        rowPercents: [5000, 5000],
+        columnPercents: [5000, 5000],
+        cellChildMap: [[0, 1], [2]]
+      }
+    },
+    {
+      name: 'a missing row',
+      model: {
+        rows: 2,
+        columns: 1,
+        rowPercents: [5000, 5000],
+        columnPercents: [MULTIPLIER],
+        cellChildMap: [[0]]
+      }
+    },
+    {
+      name: 'a non-array row',
+      model: {
+        rows: 1,
+        columns: 1,
+        rowPercents: [MULTIPLIER],
+        columnPercents: [MULTIPLIER],
+        cellChildMap: [null as unknown as number[]]
+      }
+    },
+    {
+      name: 'a non-array cellChildMap',
+      model: {
+        rows: 1,
+        columns: 1,
+        rowPercents: [MULTIPLIER],
+        columnPercents: [MULTIPLIER],
+        cellChildMap: null as unknown as number[][]
+      }
+    }
+  ]
+
+  for (const { name, model } of cases) {
+    it(`returns null for ${name}`, () => {
+      expect(() => modelToZones(model)).not.toThrow()
+      expect(modelToZones(model)).toBeNull()
+    })
+  }
+
+  it('does not throw for any malformed case, including via isGridValid', () => {
+    // isGridValid delegates to modelToZones, so it must stay throw-free too.
+    for (const { model } of cases) {
+      expect(() => isGridValid(model)).not.toThrow()
+      expect(isGridValid(model)).toBe(false)
+    }
+  })
+})
+
+describe('modelToZones still accepts well-formed grids', () => {
+  it('maps a valid single-row grid to one zone per column', () => {
+    const zones = modelToZones(initColumns(3))
+
+    expect(zones).not.toBeNull()
+    expect(zones).toHaveLength(3)
+  })
+
+  it('accepts a zone spanning multiple cells', () => {
+    const model: GridLayout = {
+      rows: 2,
+      columns: 2,
+      rowPercents: [5000, 5000],
+      columnPercents: [5000, 5000],
+      // Zone 0 spans the whole top row; zones 1 and 2 sit below it.
+      cellChildMap: [
+        [0, 0],
+        [1, 2]
+      ]
+    }
+
+    expect(modelToZones(model)).toHaveLength(3)
+    expect(isGridValid(model)).toBe(true)
+  })
+
+  it('validates the templates the shell boots with', () => {
+    for (const count of [1, 2, 3, 4, 5, 6]) {
+      expect(isGridValid(initColumns(count))).toBe(true)
+    }
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/grid-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/grid-model.ts
@@ -49,6 +49,14 @@ export interface GridResizer {
 // GridData helpers (verbatim)
 // ---------------------------------------------------------------------------
 
+/**
+ * True for a safe, positive, whole array length. Rejects NaN, Infinity,
+ * fractions and negatives — every value `new Array(n)` throws on.
+ */
+function isPositiveInt(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0
+}
+
 /** result[k] is the sum of the first k elements of the given list. */
 export function prefixSum(list: number[]): number[] {
   const result: number[] = [0]
@@ -105,11 +113,37 @@ function unique(list: number[]): number[] {
 export function modelToZones(model: GridLayout): GridZone[] | null {
   const { rows, columns: cols, cellChildMap } = model
 
+  // Untrusted input reaches this function from persisted layouts, older schema
+  // versions, and template generators, and `new Array(n)` below throws a hard
+  // `RangeError: Invalid array length` for n that is negative, fractional, NaN
+  // or > 2^32-1. A throw here happens during render and takes the whole shell
+  // down (the error boundary remounts, refetches, and throws again — a crash
+  // loop that reads as "the desktop is frozen"). Every malformed shape must
+  // therefore leave through the `null` return that callers already handle.
+  if (!isPositiveInt(rows) || !isPositiveInt(cols) || !Array.isArray(cellChildMap)) {
+    return null
+  }
+
   let zoneCount = 0
 
   for (let row = 0; row < rows; row++) {
+    const cells = cellChildMap[row]
+
+    // A row shorter than `columns` yields `undefined` -> NaN, which silently
+    // defeats the `zoneCount > rows * cols` bound check below (every NaN
+    // comparison is false) and reaches `new Array(NaN)`.
+    if (!Array.isArray(cells) || cells.length < cols) {
+      return null
+    }
+
     for (let col = 0; col < cols; col++) {
-      zoneCount = Math.max(zoneCount, cellChildMap[row][col])
+      const cell = cells[col]
+
+      if (!Number.isInteger(cell) || cell < 0) {
+        return null
+      }
+
+      zoneCount = Math.max(zoneCount, cell)
     }
   }
 
@@ -590,7 +624,7 @@ export function isGridValid(model: unknown): model is GridLayout {
 
   const m = model as GridLayout
 
-  if (typeof m.rows !== 'number' || typeof m.columns !== 'number' || m.rows <= 0 || m.columns <= 0) {
+  if (!isPositiveInt(m.rows) || !isPositiveInt(m.columns)) {
     return false
   }
 
@@ -599,8 +633,8 @@ export function isGridValid(model: unknown): model is GridLayout {
     !Array.isArray(m.columnPercents) ||
     m.rowPercents.length !== m.rows ||
     m.columnPercents.length !== m.columns ||
-    m.rowPercents.some(x => typeof x !== 'number' || x < 1) ||
-    m.columnPercents.some(x => typeof x !== 'number' || x < 1)
+    m.rowPercents.some(x => !Number.isFinite(x) || x < 1) ||
+    m.columnPercents.some(x => !Number.isFinite(x) || x < 1)
   ) {
     return false
   }
@@ -608,7 +642,11 @@ export function isGridValid(model: unknown): model is GridLayout {
   if (
     !Array.isArray(m.cellChildMap) ||
     m.cellChildMap.length !== m.rows ||
-    m.cellChildMap.some(r => !Array.isArray(r) || r.length !== m.columns || r.some(c => typeof c !== 'number'))
+    // `typeof NaN === 'number'`, so a bare typeof check lets NaN through into
+    // modelToZones. Require a whole, non-negative cell index instead.
+    m.cellChildMap.some(
+      r => !Array.isArray(r) || r.length !== m.columns || r.some(c => !Number.isInteger(c) || c < 0)
+    )
   ) {
     return false
   }


### PR DESCRIPTION
## Problem

Hermes Desktop hangs shortly after "Finalizing desktop startup": the shell stops
responding, sessions can't be opened, and the log fills with

```
Uncaught RangeError: Invalid array length
Minified React error #520
[renderer] webContents became unresponsive
[renderer] render-process-gone reason=killed exitCode=9
```

It reproduced on every launch, in both packaged and `--source` builds, and
survived clean rebuilds.

## Root cause

`modelToZones()` in `apps/desktop/src/components/pane-shell/tree/grid-model.ts`
sizes five scratch arrays from a zone count it derives by scanning
`cellChildMap`. Its only bound check is an upper one:

```ts
zoneCount = Math.max(zoneCount, cellChildMap[row][col])
zoneCount++
if (zoneCount > rows * cols) return null   // upper bound only
const indexCount = new Array<number>(zoneCount).fill(0)
```

**Every comparison with `NaN` is false**, so that check cannot catch a `NaN`
count. A `cellChildMap` row shorter than `columns` reads `undefined`,
`Math.max` yields `NaN`, the guard passes, and `new Array(NaN)` throws.

Reproduced against the pre-fix function in isolation:

```
row shorter than columns   -> THREW RangeError: Invalid array length
NaN cell                   -> THREW RangeError: Invalid array length
fractional cell            -> THREW RangeError: Invalid array length
negative cell              -> returned 1          (silent wrong answer)
missing row                -> THREW TypeError
```

Because the throw happens during render, only the top-level error boundary
catches it — and it then remounts, refetches, and hits the same input again.
That loop is what surfaces as a frozen app. Worth noting for anyone reading the
logs: the `sessions.changed` / `session.reclaimed` burst is a **consequence** of
the remount loop, not its cause. The misleading part of the stack is that the
visible frames (`i18n`, `TooltipProvider`, `useQuery`, `error-boundary`) are just
the enclosing tree; grepping the bundle they point at finds no array allocation
at all.

## Fix

Validate at the boundary that owns the invariant, and leave through the `null`
return that callers already handle:

- `rows` / `columns` must be positive integers.
- each `cellChildMap` row must be an array of at least `columns` length.
- each cell index must be a non-negative integer.

All three callers handle `null` today: `gridToTree` returns `null`,
`gridIsTreeExpressible` returns `false`, and `zone-editor` falls back to `[]`.

Also hardened `isGridValid`, which delegates to `modelToZones` and could
therefore throw instead of returning `false`. Its cell check used
`typeof c !== 'number'` — and `typeof NaN === 'number'`, so `NaN` passed
validation. The percent checks had the same hole. Both now use
`Number.isInteger` / `Number.isFinite`.

## Testing

- Reproduced the crash against the original logic in isolation (above), so the
  new tests fail without this fix rather than merely asserting current behavior.
- 16 new tests in `grid-model.test.ts` covering `rows: 0`, negative rows,
  fractional columns, `NaN` rows, `Infinity` columns, `NaN` / negative /
  fractional cell, short row, missing row, non-array row, non-array
  `cellChildMap` — each asserting both `not.toThrow()` and the documented `null`.
  Happy-path cases (multi-cell zone spans, `initColumns` templates 1–6) are
  included so the guard cannot over-reject.
- `npm run typecheck` clean across `tsconfig.json`, `tsconfig.electron.json`,
  `tsconfig.e2e.json`.
- `eslint` clean on both changed files.
- `npm run check` green end to end: 406 UI test files / 3636 tests, plus the
  electron suites and the `dist:mac:dmg` packaging build.
- Relaunched the packaged app and confirmed the new log segment contains no
  `RangeError`, `unresponsive`, or `render-process-gone`, with the renderer
  settling to a steady idle instead of pegging a core.

## Relationship to #82128

#82128 clamped the two `useVirtualizer` call sites
(`virtual-session-list.tsx`, `file-tree.tsx`). That fix is applied here and is
correct as far as it goes, but the crash persisted with it in place: this is a
**third, distinct call site that is not a virtualizer**, so the clamps never
covered it. The two changes are complementary.

## Scope note

This addresses the throw at the site that allocates the array. I verified the
log is clean after the fix, but I can't claim from the test suite alone that no
other unguarded `new Array(n)` exists elsewhere in the app — only that this one
is closed and that the reported crash no longer reproduces.
