### PR TITLE
fix(dashboard): preserve nested plugin routes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -101,6 +101,7 @@ import { useI18n } from "@/i18n";
 import type { Translations } from "@/i18n/types";
 import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
 import type { PluginManifest } from "@/plugins";
+import { pluginRoutePaths } from "@/plugins/pluginRoutes";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
 import { latchChatActivation } from "@/lib/chat-activation";
@@ -345,22 +346,26 @@ function buildRoutes(
     if (m.tab.hidden) continue;
     if (m.tab.path === "/plugins") continue;
     if (builtinRoutes[m.tab.path]) continue;
-    routes.push({
-      key: `plugin:${m.name}`,
-      path: m.tab.path,
-      element: <PluginPage name={m.name} />,
-    });
+    for (const [index, path] of pluginRoutePaths(m.tab.path).entries()) {
+      routes.push({
+        key: `plugin:${m.name}:${index}`,
+        path,
+        element: <PluginPage name={m.name} />,
+      });
+    }
   }
 
   for (const m of manifests) {
     if (!m.tab.hidden) continue;
     if (m.tab.path === "/plugins") continue;
     if (builtinRoutes[m.tab.path] || m.tab.override) continue;
-    routes.push({
-      key: `plugin:hidden:${m.name}`,
-      path: m.tab.path,
-      element: <PluginPage name={m.name} />,
-    });
+    for (const [index, path] of pluginRoutePaths(m.tab.path).entries()) {
+      routes.push({
+        key: `plugin:hidden:${m.name}:${index}`,
+        path,
+        element: <PluginPage name={m.name} />,
+      });
+    }
   }
 
   return routes;

--- a/web/src/plugins/pluginRoutes.test.ts
+++ b/web/src/plugins/pluginRoutes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { pluginRoutePaths } from "./pluginRoutes";
+
+describe("pluginRoutePaths", () => {
+  it("mounts a plugin at its base path and all descendant paths", () => {
+    expect(pluginRoutePaths("/eng-runs")).toEqual([
+      "/eng-runs",
+      "/eng-runs/*",
+    ]);
+  });
+
+  it("does not create a double slash for paths with a trailing slash", () => {
+    expect(pluginRoutePaths("/eng-runs/")).toEqual([
+      "/eng-runs/",
+      "/eng-runs/*",
+    ]);
+  });
+});

--- a/web/src/plugins/pluginRoutes.ts
+++ b/web/src/plugins/pluginRoutes.ts
@@ -1,0 +1,3 @@
+export function pluginRoutePaths(path: string): [string, string] {
+  return [path, `${path.replace(/\/$/, "")}/*`];
+}


### PR DESCRIPTION
## Problem
Dashboard plugins are mounted only at their exact `tab.path`. A plugin that navigates to a nested permalink such as `/eng-runs/<run-id>` falls through `UnknownRouteFallback` and redirects to `/sessions`.

## Fix
Register both the exact plugin path and a descendant wildcard for visible and hidden plugin tabs.

## Verification
- Added focused route-path regression tests (RED before implementation)
- `npm test`: 199 tests passed in the live checkout
- `npm run typecheck`: passed
- Production SPA build: passed
- Live authenticated click and direct deep-link verification at `/eng-runs/<run-id>`: passed