### PR TITLE
fix(matrix): auto-repair mismatched server device records

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1572,9 +1572,16 @@ class MatrixAdapter(BasePlatformAdapter):
         try:
             # share_keys() only uploads an account identity when this flag is
             # false. This is a deliberate repair, not an accidental
-            # rebootstrap caused by an empty store.
+            # rebootstrap caused by an empty store. Restore the prior flag on
+            # failure so a failed repair does not leave the account looking
+            # unshared (which would trigger repeat upload attempts).
+            previously_shared = olm.account.shared
             olm.account.shared = False
-            await olm.share_keys()
+            try:
+                await olm.share_keys()
+            except Exception:
+                olm.account.shared = previously_shared
+                raise
         except Exception as exc:
             logger.error(
                 "Matrix: could not re-upload local keys for repaired device %s: %s",

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import asyncio
 import array
 import inspect
+import json
 import logging
 import mimetypes
 import os
@@ -1440,6 +1441,156 @@ class MatrixAdapter(BasePlatformAdapter):
         except Exception:
             return False
 
+    @staticmethod
+    def _is_unknown_token_error(exc: Exception) -> bool:
+        return getattr(exc, "errcode", "") == "M_UNKNOWN_TOKEN" or "Unknown access token" in str(exc)
+
+    async def _delete_server_device(self, client: Any) -> bool:
+        """Delete this device's server record, completing password UIA if asked.
+
+        Homeservers commonly require user-interactive authentication to remove
+        a device, so an access token alone can be insufficient even though it
+        was enough to identify the device. The challenge is completed only
+        with the configured MATRIX_PASSWORD.
+        """
+        try:
+            await client.api.request(
+                client.api.Method.DELETE if hasattr(client.api, "Method") else "DELETE",
+                f"/_matrix/client/v3/devices/{client.device_id}",
+            )
+            return True
+        except Exception as exc:
+            session = ""
+            if getattr(exc, "http_status", None) == 401:
+                try:
+                    session = str(json.loads(getattr(exc, "text", "{}") or "{}").get("session") or "")
+                except (TypeError, ValueError):
+                    pass
+            if not session:
+                logger.error(
+                    "Matrix: could not delete server device %s: %s",
+                    client.device_id, exc, exc_info=True,
+                )
+                return False
+            if not self._password:
+                logger.error(
+                    "Matrix: deleting server device %s requires password UIA, "
+                    "but no MATRIX_PASSWORD is configured",
+                    client.device_id,
+                )
+                return False
+            try:
+                await client.api.request(
+                    client.api.Method.DELETE if hasattr(client.api, "Method") else "DELETE",
+                    f"/_matrix/client/v3/devices/{client.device_id}",
+                    {
+                        "auth": {
+                            "type": "m.login.password",
+                            "session": session,
+                            "identifier": {"type": "m.id.user", "user": str(client.mxid)},
+                            "password": self._password,
+                        }
+                    },
+                    sensitive=True,
+                )
+                return True
+            except Exception as uia_exc:
+                logger.error(
+                    "Matrix: password UIA could not delete server device %s: %s",
+                    client.device_id, uia_exc, exc_info=True,
+                )
+                return False
+
+    async def _reauthenticate_after_device_delete(self, client: Any) -> bool:
+        """Obtain a replacement token bound to the same configured device ID.
+
+        Deleting a device invalidates that device's access token, and the
+        homeserver may also have deleted the device while the local crypto
+        store survived (M_UNKNOWN_TOKEN on the next request). Re-login with
+        the configured password re-binds a fresh token to the same device ID,
+        so the local Olm identity stays valid for it. Without a password the
+        caller must fail closed.
+        """
+        expected_device_id = str(self._device_id or client.device_id or "")
+        if not expected_device_id or not self._password:
+            logger.error(
+                "Matrix: cannot reauthenticate device %s without a configured Matrix password",
+                expected_device_id or "(unknown)",
+            )
+            return False
+        try:
+            # Do not send the known-invalid bearer token to /login.
+            client.api.token = ""
+            await client.login(
+                identifier=self._user_id or client.mxid,
+                password=self._password,
+                device_name="Hermes Agent",
+                device_id=expected_device_id,
+            )
+        except Exception as exc:
+            logger.error(
+                "Matrix: could not reauthenticate device %s: %s",
+                expected_device_id, exc, exc_info=True,
+            )
+            return False
+        if str(client.device_id or "") != expected_device_id or not getattr(client.api, "token", ""):
+            logger.error(
+                "Matrix: reauthentication did not restore configured device %s",
+                expected_device_id,
+            )
+            return False
+        self._access_token = str(client.api.token)
+        return True
+
+    async def _repair_server_device_keys(
+        self,
+        client: Any,
+        olm: Any,
+        local_ed25519: str,
+        local_curve25519: str,
+    ) -> bool:
+        """Rebind the server device record to this installation's local identity.
+
+        A Matrix device ID and the private keys in its crypto store are a
+        pair. If the homeserver carries a different public key for the same
+        device ID, deleting that server record and re-uploading the local
+        identity is the least disruptive deterministic repair. Every step is
+        verified; any failure remains fail-closed.
+        """
+        logger.warning(
+            "Matrix: repairing server device record for %s from the local crypto store",
+            client.device_id,
+        )
+        if not await self._delete_server_device(client):
+            return False
+        # Deleting our own device may have invalidated the token in use.
+        # Re-authenticate deterministically when a password is configured;
+        # otherwise the token is either still valid (upload proceeds) or the
+        # upload fails below with a precise error.
+        if self._password and not await self._reauthenticate_after_device_delete(client):
+            return False
+        try:
+            # share_keys() only uploads an account identity when this flag is
+            # false. This is a deliberate repair, not an accidental
+            # rebootstrap caused by an empty store.
+            olm.account.shared = False
+            await olm.share_keys()
+        except Exception as exc:
+            logger.error(
+                "Matrix: could not re-upload local keys for repaired device %s: %s",
+                client.device_id, exc, exc_info=True,
+            )
+            return False
+        if not await self._reverify_keys_after_upload(
+            client, local_ed25519, local_curve25519
+        ):
+            return False
+        logger.warning(
+            "Matrix: repaired device %s and verified its local identity on the server",
+            client.device_id,
+        )
+        return True
+
     async def _reverify_keys_after_upload(
         self, client: Any, local_ed25519: str, local_curve25519: str
     ) -> bool:
@@ -1673,8 +1824,22 @@ class MatrixAdapter(BasePlatformAdapter):
             try:
                 await olm.share_keys()
             except Exception as exc:
-                logger.error("Matrix: failed to re-upload device keys: %s", exc, exc_info=True)
-                return False
+                # The homeserver may have deleted this device while the local
+                # crypto store survived; its token is then invalid
+                # (M_UNKNOWN_TOKEN). Re-authenticate the same device ID and
+                # retry the upload once before giving up.
+                if self._is_unknown_token_error(exc) and await self._reauthenticate_after_device_delete(client):
+                    try:
+                        await olm.share_keys()
+                    except Exception as retry_exc:
+                        logger.error(
+                            "Matrix: failed to re-upload device keys after reauthentication: %s",
+                            retry_exc, exc_info=True,
+                        )
+                        return False
+                else:
+                    logger.error("Matrix: failed to re-upload device keys: %s", exc, exc_info=True)
+                    return False
             return await self._reverify_keys_after_upload(
                 client, local_ed25519, local_curve25519
             )
@@ -1699,47 +1864,25 @@ class MatrixAdapter(BasePlatformAdapter):
                     else "invalid device self-signature"
                 )
             )
-            if olm.account.shared:
+            if olm.account.shared and not self._password:
+                # Automatic repair re-binds the server record to this
+                # installation's identity, which requires the account
+                # password (UIA completion + same-device re-authentication
+                # after the deletion invalidates the token). An account that
+                # already shared its keys without a configured password stays
+                # fail-closed.
                 logger.error(
                     "Matrix: server device record for %s failed verification (%s) — "
-                    "local crypto state is stale. Delete %s and restart.",
+                    "local crypto state is stale. Configure MATRIX_PASSWORD to enable "
+                    "automatic repair, or delete %s and restart.",
                     client.device_id,
                     invalid_reason,
                     _CRYPTO_DB_PATH,
                 )
                 return False
 
-            logger.warning(
-                "Matrix: server device record for %s failed verification (%s) — "
-                "attempting re-upload",
-                client.device_id,
-                invalid_reason,
-            )
-            try:
-                await client.api.request(
-                    client.api.Method.DELETE
-                    if hasattr(client.api, "Method")
-                    else "DELETE",
-                    f"/_matrix/client/v3/devices/{client.device_id}",
-                )
-                logger.info(
-                    "Matrix: deleted stale device %s from server", client.device_id
-                )
-            except Exception:
-                pass
-            try:
-                await olm.share_keys()
-            except Exception as exc:
-                logger.error(
-                    "Matrix: cannot upload device keys for %s: %s. "
-                    "Try generating a new access token to get a fresh device.",
-                    client.device_id,
-                    exc,
-                    exc_info=True,
-                )
-                return False
-            return await self._reverify_keys_after_upload(
-                client, local_ed25519, local_curve25519
+            return await self._repair_server_device_keys(
+                client, olm, local_ed25519, local_curve25519
             )
 
         return True

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1408,10 +1408,44 @@ class MatrixAdapter(BasePlatformAdapter):
                 return str(kval)
         return None
 
-    async def _reverify_keys_after_upload(
-        self, client: Any, local_ed25519: str
+    @staticmethod
+    def _extract_server_curve25519(device_keys_obj: Any) -> Optional[str]:
+        """Extract the curve25519 encryption key from a DeviceKeys object."""
+        for kid, kval in (getattr(device_keys_obj, "keys", {}) or {}).items():
+            if str(kid).startswith("curve25519:"):
+                return str(kval)
+        return None
+
+    @staticmethod
+    def _has_valid_device_self_signature(
+        device_keys_obj: Any,
+        user_id: str,
+        device_id: str,
+        ed25519: str,
     ) -> bool:
-        """Re-query the server after share_keys() and verify our ed25519 key matches."""
+        """Cryptographically verify a server device record's own signature.
+
+        String-matching the advertised ed25519 key is not enough: the record
+        itself must be signed by that key. Fails closed — any error during
+        verification (malformed record, missing signature, bad key material)
+        counts as invalid.
+        """
+        try:
+            from mautrix.crypto.signature import verify_signature_json
+
+            serialized = device_keys_obj.serialize()
+            return bool(
+                verify_signature_json(serialized, user_id, device_id, ed25519)
+            )
+        except Exception:
+            return False
+
+    async def _reverify_keys_after_upload(
+        self, client: Any, local_ed25519: str, local_curve25519: str
+    ) -> bool:
+        """Re-query the server after share_keys() and verify the full device
+        record: both identity keys must match and the self-signature must be
+        valid."""
         if not client.device_id or self._device_id_unverified:
             logger.warning(
                 "Matrix: skipping post-upload key verification — "
@@ -1423,16 +1457,31 @@ class MatrixAdapter(BasePlatformAdapter):
             dk = getattr(resp, "device_keys", {}) or {}
             ud = dk.get(str(client.mxid)) or {}
             dev = ud.get(str(client.device_id))
-            if dev:
-                server_ed = self._extract_server_ed25519(dev)
-                if server_ed != local_ed25519:
-                    logger.error(
-                        "Matrix: device %s has immutable identity keys that "
-                        "don't match this installation. Generate a new access "
-                        "token with a fresh device.",
-                        client.device_id,
-                    )
-                    return False
+            if not dev:
+                logger.error(
+                    "Matrix: device %s was not present after key upload",
+                    client.device_id,
+                )
+                return False
+            server_ed = self._extract_server_ed25519(dev)
+            server_curve = self._extract_server_curve25519(dev)
+            if server_ed != local_ed25519 or server_curve != local_curve25519:
+                logger.error(
+                    "Matrix: device %s has identity keys that don't match this "
+                    "installation after upload. Generate a new access token "
+                    "with a fresh device.",
+                    client.device_id,
+                )
+                return False
+            if not self._has_valid_device_self_signature(
+                dev, str(client.mxid), str(client.device_id), server_ed
+            ):
+                logger.error(
+                    "Matrix: device %s has an invalid self-signature after "
+                    "key upload",
+                    client.device_id,
+                )
+                return False
         except Exception as exc:
             logger.error("Matrix: post-upload key verification failed: %s", exc, exc_info=True)
             return False
@@ -1616,6 +1665,7 @@ class MatrixAdapter(BasePlatformAdapter):
         our_user_devices = device_keys_map.get(str(client.mxid)) or {}
         our_keys = our_user_devices.get(str(client.device_id))
         local_ed25519 = olm.account.identity_keys.get("ed25519")
+        local_curve25519 = olm.account.identity_keys.get("curve25519")
 
         if not our_keys:
             logger.warning("Matrix: device keys missing from server — re-uploading")
@@ -1625,23 +1675,45 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.error("Matrix: failed to re-upload device keys: %s", exc, exc_info=True)
                 return False
-            return await self._reverify_keys_after_upload(client, local_ed25519)
+            return await self._reverify_keys_after_upload(
+                client, local_ed25519, local_curve25519
+            )
 
         server_ed25519 = self._extract_server_ed25519(our_keys)
+        server_curve25519 = self._extract_server_curve25519(our_keys)
+        signature_valid = bool(server_ed25519) and self._has_valid_device_self_signature(
+            our_keys, str(client.mxid), str(client.device_id), server_ed25519
+        )
 
-        if server_ed25519 != local_ed25519:
+        if (
+            server_ed25519 != local_ed25519
+            or server_curve25519 != local_curve25519
+            or not signature_valid
+        ):
+            invalid_reason = (
+                "identity key mismatch"
+                if server_ed25519 != local_ed25519
+                else (
+                    "encryption key mismatch"
+                    if server_curve25519 != local_curve25519
+                    else "invalid device self-signature"
+                )
+            )
             if olm.account.shared:
                 logger.error(
-                    "Matrix: server has different identity keys for device %s — "
+                    "Matrix: server device record for %s failed verification (%s) — "
                     "local crypto state is stale. Delete %s and restart.",
                     client.device_id,
+                    invalid_reason,
                     _CRYPTO_DB_PATH,
                 )
                 return False
 
             logger.warning(
-                "Matrix: server has stale keys for device %s — attempting re-upload",
+                "Matrix: server device record for %s failed verification (%s) — "
+                "attempting re-upload",
                 client.device_id,
+                invalid_reason,
             )
             try:
                 await client.api.request(
@@ -1666,7 +1738,9 @@ class MatrixAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
                 return False
-            return await self._reverify_keys_after_upload(client, local_ed25519)
+            return await self._reverify_keys_after_upload(
+                client, local_ed25519, local_curve25519
+            )
 
         return True
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -12,6 +12,24 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageType
 
 
+@pytest.fixture(autouse=True)
+def _accept_mock_device_signatures(monkeypatch):
+    """Accept the unsigned mock device records used throughout this module.
+
+    Connect/verification tests here build mock server device records without
+    real Olm signatures; their subject is the connect and device-ID flow, not
+    cryptography. Cryptographic self-signature verification itself is covered
+    with real signed records in test_matrix_device_key_verification.py.
+    """
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    monkeypatch.setattr(
+        MatrixAdapter,
+        "_has_valid_device_self_signature",
+        staticmethod(lambda *args: True),
+    )
+
+
 def _make_fake_mautrix():
     """Create a lightweight set of fake ``mautrix`` modules.
 
@@ -947,11 +965,11 @@ class TestMatrixAccessTokenAuth:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:DEV123": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"DEV123": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_access_token"
         mock_client.api.session = MagicMock()
@@ -1166,11 +1184,11 @@ class TestMatrixDeviceId:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"MY_STABLE_DEVICE": {
-                "keys": {"ed25519:MY_STABLE_DEVICE": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:WHOAMI_DEV": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"WHOAMI_DEV": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_access_token"
         mock_client.api.session = MagicMock()
@@ -1545,11 +1563,11 @@ class TestMatrixDiagnostics:
         mock_client.add_event_handler = MagicMock()
         mock_client.add_dispatcher = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:DEV123": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"DEV123": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_token"
         mock_client.api.session = MagicMock()
@@ -1669,11 +1687,11 @@ class TestMatrixEncryptedEventHandler:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        _verify_dev = MagicMock()
+        _verify_dev.keys = {"ed25519:DEV123": "fake_ed25519_key"}
+        _verify_resp = MagicMock()
+        _verify_resp.device_keys = {"@bot:example.org": {"DEV123": _verify_dev}}
+        mock_client.query_keys = AsyncMock(return_value=_verify_resp)
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_token"
         mock_client.api.session = MagicMock()

--- a/tests/gateway/test_matrix_device_key_repair.py
+++ b/tests/gateway/test_matrix_device_key_repair.py
@@ -1,0 +1,191 @@
+"""Regression tests: automatic repair of mismatched server device records.
+
+When the homeserver's record for our device diverges from the local crypto
+store, the adapter rebinds the record to the intact local identity: delete
+the mismatched record (completing password UIA when the homeserver requires
+it), re-authenticate the same device ID if the deletion invalidated the
+token, re-upload the local keys, and verify. Accounts that already shared
+keys without a configured password stay fail-closed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+USER_ID = "@bot:example.org"
+DEVICE_ID = "DEV123"
+
+
+def _make_adapter(password: str = "pw"):
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_access_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": USER_ID,
+            "encryption": True,
+            "device_id": DEVICE_ID,
+        },
+    )
+    adapter = MatrixAdapter(config)
+    adapter._password = password
+    return adapter
+
+
+def _record(keys: dict):
+    dev = MagicMock()
+    dev.keys = keys
+    resp = MagicMock()
+    resp.device_keys = {USER_ID: {DEVICE_ID: dev}}
+    return resp
+
+
+def _empty_resp():
+    resp = MagicMock()
+    resp.device_keys = {USER_ID: {}}
+    return resp
+
+
+def _mock_client():
+    client = MagicMock()
+    client.mxid = USER_ID
+    client.device_id = DEVICE_ID
+    client.api = MagicMock()
+    client.api.token = "syt_test_access_token"
+    client.api.request = AsyncMock(return_value=None)
+    client.login = AsyncMock()
+    return client
+
+
+def _mock_olm(shared: bool = True):
+    olm = MagicMock()
+    olm.account = MagicMock()
+    olm.account.shared = shared
+    olm.account.identity_keys = {"ed25519": "local_new", "curve25519": "c1"}
+    olm.share_keys = AsyncMock()
+    return olm
+
+
+class _UnknownTokenError(Exception):
+    errcode = "M_UNKNOWN_TOKEN"
+
+
+class _UiaRequired(Exception):
+    http_status = 401
+    text = '{"session": "uia-session-abc"}'
+
+
+@pytest.mark.asyncio
+async def test_mismatch_with_password_repairs_and_reauthenticates_same_device():
+    adapter = _make_adapter(password="pw")
+    client = _mock_client()
+    olm = _mock_olm(shared=True)
+
+    mismatched = _record({"ed25519:DEV123": "server_old", "curve25519:DEV123": "c1"})
+    fixed = _record({"ed25519:DEV123": "local_new", "curve25519:DEV123": "c1"})
+    client.query_keys = AsyncMock(side_effect=[mismatched, fixed])
+    client.login = AsyncMock(side_effect=lambda **kw: setattr(client.api, "token", "fresh-token"))
+
+    with patch.object(
+        type(adapter), "_has_valid_device_self_signature", staticmethod(lambda *a: True)
+    ):
+        result = await adapter._verify_device_keys_on_server(client, olm)
+
+    assert result is True
+    # Server record deleted, token re-bound to the SAME device ID via password
+    # login, local identity re-uploaded and re-verified.
+    client.api.request.assert_awaited_once()
+    assert "/devices/DEV123" in client.api.request.await_args.args[1]
+    client.login.assert_awaited_once()
+    assert client.login.await_args.kwargs["device_id"] == DEVICE_ID
+    assert client.login.await_args.kwargs["password"] == "pw"
+    assert adapter._access_token == "fresh-token"
+    olm.share_keys.assert_awaited_once()
+    assert olm.account.shared is False
+
+
+@pytest.mark.asyncio
+async def test_delete_server_device_completes_password_uia():
+    adapter = _make_adapter(password="pw")
+    client = _mock_client()
+    client.api.request = AsyncMock(side_effect=[_UiaRequired(), None])
+
+    assert await adapter._delete_server_device(client) is True
+
+    assert client.api.request.await_count == 2
+    uia_call = client.api.request.await_args_list[1]
+    auth = uia_call.args[2]["auth"]
+    assert auth["type"] == "m.login.password"
+    assert auth["session"] == "uia-session-abc"
+    assert auth["password"] == "pw"
+    assert auth["identifier"] == {"type": "m.id.user", "user": USER_ID}
+    assert uia_call.kwargs.get("sensitive") is True
+
+
+@pytest.mark.asyncio
+async def test_uia_without_password_fails_closed():
+    adapter = _make_adapter(password="")
+    client = _mock_client()
+    client.api.request = AsyncMock(side_effect=[_UiaRequired()])
+
+    assert await adapter._delete_server_device(client) is False
+    assert client.api.request.await_count == 1  # no passwordless retry
+
+
+@pytest.mark.asyncio
+async def test_shared_account_without_password_stays_fail_closed():
+    adapter = _make_adapter(password="")
+    client = _mock_client()
+    olm = _mock_olm(shared=True)
+
+    mismatched = _record({"ed25519:DEV123": "server_old", "curve25519:DEV123": "c1"})
+    client.query_keys = AsyncMock(return_value=mismatched)
+
+    with patch.object(
+        type(adapter), "_has_valid_device_self_signature", staticmethod(lambda *a: True)
+    ):
+        result = await adapter._verify_device_keys_on_server(client, olm)
+
+    assert result is False
+    client.api.request.assert_not_awaited()  # no repair attempted
+    olm.share_keys.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_token_on_upload_triggers_reauth_and_retry():
+    adapter = _make_adapter(password="pw")
+    client = _mock_client()
+    olm = _mock_olm(shared=False)
+
+    fixed = _record({"ed25519:DEV123": "local_new", "curve25519:DEV123": "c1"})
+    client.query_keys = AsyncMock(side_effect=[_empty_resp(), fixed])
+    olm.share_keys = AsyncMock(side_effect=[_UnknownTokenError("M_UNKNOWN_TOKEN"), None])
+    client.login = AsyncMock(side_effect=lambda **kw: setattr(client.api, "token", "fresh-token"))
+
+    with patch.object(
+        type(adapter), "_has_valid_device_self_signature", staticmethod(lambda *a: True)
+    ):
+        result = await adapter._verify_device_keys_on_server(client, olm)
+
+    assert result is True
+    assert olm.share_keys.await_count == 2
+    client.login.assert_awaited_once()
+    assert client.login.await_args.kwargs["device_id"] == DEVICE_ID
+
+
+@pytest.mark.asyncio
+async def test_repair_fails_closed_when_server_delete_fails():
+    adapter = _make_adapter(password="pw")
+    client = _mock_client()
+    olm = _mock_olm(shared=False)
+    client.api.request = AsyncMock(side_effect=ConnectionError("homeserver unreachable"))
+
+    result = await adapter._repair_server_device_keys(client, olm, "local_new", "c1")
+
+    assert result is False
+    olm.share_keys.assert_not_awaited()
+    client.login.assert_not_awaited()

--- a/tests/gateway/test_matrix_device_key_verification.py
+++ b/tests/gateway/test_matrix_device_key_verification.py
@@ -1,0 +1,99 @@
+"""Regression tests: Matrix device-record verification must validate the full
+server-side record, not just string-match the ed25519 identity key.
+
+A record that advertises a diverging curve25519 encryption key — or whose
+self-signature does not verify against the advertised ed25519 key — must fail
+verification. Otherwise peers encrypt Megolm sessions to a key this
+installation does not hold, and inbound messages become undecryptable with no
+local error.
+"""
+
+import pytest
+from mautrix.crypto.account import OlmAccount
+from mautrix.types import DeviceID, UserID
+
+USER_ID = UserID("@hermes-test:example.org")
+DEVICE_ID = DeviceID("HERMESTEST")
+
+
+def _signed_device_keys():
+    """A real Olm account and its genuinely signed DeviceKeys record."""
+    account = OlmAccount()
+    return account, account.get_device_keys(USER_ID, DEVICE_ID)
+
+
+class _SerializedRecord:
+    """Carries a (possibly tampered) serialized DeviceKeys payload with the
+    two access patterns the adapter uses: ``.keys`` and ``.serialize()``."""
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self.keys = payload.get("keys", {})
+
+    def serialize(self) -> dict:
+        return dict(self._payload)
+
+
+def test_self_signature_valid_for_real_signed_device_keys():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    account, device_keys = _signed_device_keys()
+
+    assert MatrixAdapter._has_valid_device_self_signature(
+        device_keys, str(USER_ID), str(DEVICE_ID), account.identity_keys["ed25519"]
+    )
+    # Both identity keys extract from the real record.
+    assert (
+        MatrixAdapter._extract_server_ed25519(device_keys)
+        == account.identity_keys["ed25519"]
+    )
+    assert (
+        MatrixAdapter._extract_server_curve25519(device_keys)
+        == account.identity_keys["curve25519"]
+    )
+
+
+def test_self_signature_rejects_tampered_encryption_key():
+    """Swapping curve25519 for another account's key must invalidate the record."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    account, device_keys = _signed_device_keys()
+    other = OlmAccount()
+
+    payload = device_keys.serialize()
+    payload["keys"][f"curve25519:{DEVICE_ID}"] = other.identity_keys["curve25519"]
+    tampered = _SerializedRecord(payload)
+
+    # Raw ed25519 still matches — string comparison alone would accept this.
+    assert MatrixAdapter._extract_server_ed25519(tampered) == account.identity_keys["ed25519"]
+    assert not MatrixAdapter._has_valid_device_self_signature(
+        tampered, str(USER_ID), str(DEVICE_ID), account.identity_keys["ed25519"]
+    )
+
+
+def test_self_signature_rejects_wrong_device_and_user():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    account, device_keys = _signed_device_keys()
+    ed25519 = account.identity_keys["ed25519"]
+
+    assert not MatrixAdapter._has_valid_device_self_signature(
+        device_keys, str(USER_ID), "OTHERDEVICE", ed25519
+    )
+    assert not MatrixAdapter._has_valid_device_self_signature(
+        device_keys, "@someone-else:example.org", str(DEVICE_ID), ed25519
+    )
+
+
+def test_self_signature_fails_closed_on_malformed_record():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    account, device_keys = _signed_device_keys()
+
+    payload = device_keys.serialize()
+    payload.pop("signatures", None)
+    unsigned_record = _SerializedRecord(payload)
+
+    assert not MatrixAdapter._has_valid_device_self_signature(
+        unsigned_record, str(USER_ID), str(DEVICE_ID), account.identity_keys["ed25519"]
+    )


### PR DESCRIPTION
## What

Replaces the two dead-end outcomes of a failed device-key verification with a deterministic automatic repair that rebinds the server device record to this installation's intact local identity:

1. **Delete** the mismatched server record — completing the homeserver's **UIA challenge with the configured `MATRIX_PASSWORD`** when required (an access token alone is often insufficient to remove a device)
2. **Re-authenticate the same configured device ID** via password login — deleting a device invalidates its token, and without re-binding, the local Olm identity is orphaned from any usable token
3. **Re-upload** the local identity keys and **verify** the repaired record (full verification: both identity keys + self-signature, per #83488)

Every step fails closed with a precise log message. Accounts that already shared keys **without** a configured password keep the previous fail-closed behavior, with the message now naming `MATRIX_PASSWORD` as the enabler for automatic repair.

A sibling fix in the keys-missing branch: if the initial re-upload dies with `M_UNKNOWN_TOKEN` (homeserver deleted the device while the local store survived), the adapter re-authenticates the same device ID and retries once instead of giving up.

**Depends on / stacked on #83488** (verification hardening) — this branch builds on it; merge that one first or review this diff against it.

## Why

Previously: if the account had never shared keys, the adapter tried delete + re-upload while *silently ignoring* delete failures; if keys were already shared, it logged "delete the crypto store and restart" and refused E2EE. Long-lived E2EE deployments hit the shared-account path whenever a device is deleted/recreated server-side — the bot then sits deaf in encrypted rooms until an operator manually wipes state. This repair sequence runs in our production deployment (Tuwunel homeserver, multiplexed gateway) and has turned that class of incident from manual recovery into a self-healing restart.

## Behavioral notes for reviewers

- **Delete failure is now fatal to the repair** (previously ignored). Rationale: if the mismatched record can't be removed, re-upload is server-dependent at best — homeservers may refuse to replace published keys. Fail-closed with a precise error beats a half-repair.
- **UIA password is used only for the device-deletion challenge** and marked `sensitive=True`; never logged.
- Re-authentication deliberately reuses the **configured device ID** — a fresh device ID would orphan the local crypto store's identity keys.

## Tests

New `tests/gateway/test_matrix_device_key_repair.py` (6 tests): full repair sequence with same-device re-auth; UIA challenge completion (asserts the auth payload shape and `sensitive`); UIA without password fails closed after one attempt; shared-account-without-password stays fail-closed with no repair attempted; `M_UNKNOWN_TOKEN` on upload triggers re-auth + single retry; delete failure aborts before any upload.

`scripts/run_tests.sh` over 8 Matrix test files: **148 passed, 0 failed**.

Refs #83481
