### PR TITLE
feat(browser): add Camofox exec backend for browser_exec

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -660,6 +660,17 @@ TOOL_CATEGORIES = {
                 "post_setup": "camofox",
             },
             {
+                "name": "Camofox (exec mode)",
+                "badge": "free · local",
+                "tag": "Anti-detection Camoufox with script-per-call browser_exec",
+                "env_vars": [
+                    {"key": "CAMOFOX_URL", "prompt": "Camofox server URL", "default": "http://localhost:9377",
+                     "url": "https://github.com/jo-inc/camofox-browser"},
+                ],
+                "browser_backend": "camofox",
+                "post_setup": "camofox",
+            },
+            {
                 "name": "Browser Use",
                 "badge": "free · local · cloud",
                 "tag": "New SOTA web harness (CLI 3.0)",

--- a/tests/tools/test_browser_camofox_exec.py
+++ b/tests/tools/test_browser_camofox_exec.py
@@ -52,10 +52,20 @@ class _FakeCamofoxHandler(BaseHTTPRequestHandler):
         return json.loads(self.rfile.read(length).decode("utf-8"))
 
     def _tab(self, tab_id: str):
-        """Return the tab record or answer 404 (garbage-collected tab)."""
+        """Return the tab record or answer like the real server for a dead
+        tab: 410 Gone with ``code: browser_restarted`` (the actual Camofox
+        server's response for a GC'd tab; the older 404 shape is also
+        covered by the runtime's recovery check)."""
         tab = self.server.camofox.tabs.get(tab_id)
         if tab is None or tab.get("dead"):
-            self._send_json(404, {"error": "tab not found"})
+            self._send_json(
+                410,
+                {
+                    "error": "Tab no longer exists (browser was restarted). "
+                    "Create a new tab.",
+                    "code": "browser_restarted",
+                },
+            )
             return None
         return tab
 
@@ -83,6 +93,8 @@ class _FakeCamofoxHandler(BaseHTTPRequestHandler):
             ]
             return self._send_json(200, {"tabs": tabs})
         if tab_id is not None and path == "stats":
+            if srv.stats_error_code:
+                return self._send_json(srv.stats_error_code, {"error": "forced error"})
             tab = self._tab(tab_id)
             if tab is None:
                 return
@@ -118,6 +130,13 @@ class _FakeCamofoxHandler(BaseHTTPRequestHandler):
         srv = self.server.camofox
         body = self._body()
         if path == "/tabs" and tab_id is None:
+            # Mirror the real server: an explicit non-http(s) url (e.g.
+            # "about:blank") is rejected; omitting the key opens a blank tab.
+            url = body.get("url", "")
+            if url and not url.startswith(("http://", "https://")):
+                return self._send_json(
+                    400, {"error": f"Blocked URL scheme: {url}"}
+                )
             srv.counter += 1
             tid = f"t{srv.counter}"
             srv.tabs[tid] = {
@@ -149,6 +168,7 @@ class FakeCamofoxServer:
         self.snapshot = "[heading] Hello Camofox\n[link e1] More information\n"
         self.refs_count = 2
         self.evaluate_result = "eval-result-42"
+        self.stats_error_code = None  # when set, /stats answers this status
         self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), _FakeCamofoxHandler)
         self.httpd.camofox = self
         self.url = f"http://127.0.0.1:{self.httpd.server_port}"
@@ -298,6 +318,20 @@ class TestExecE2E:
         assert "CAMOFOX_TAB_ID=t2" in second["output"]
         assert camofox_mod._sessions["e2e-recover"]["tab_id"] == "t2"
 
+    def test_non_gone_errors_do_not_recreate(self, camofox_mode):
+        """A 401 (bad API key) must propagate, not silently recreate the tab."""
+        first = _exec("new_tab('https://example.com')\nprint(page_info())", task_id="e2e-401")
+        assert first["success"] is True, first
+        assert camofox_mod._sessions["e2e-401"]["tab_id"] == "t1"
+
+        camofox_mode.stats_error_code = 401
+        second = _exec("print(page_info())", task_id="e2e-401")
+        assert second["success"] is False
+        assert "HTTP 401" in second.get("stderr", "")
+        # no recreation happened: the cache still points at the stale tab
+        assert camofox_mod._sessions["e2e-401"]["tab_id"] == "t1"
+        assert "CAMOFOX_TAB_ID=t2" not in second.get("output", "")
+
     def test_clear_error_without_server(self, monkeypatch):
         monkeypatch.setattr(
             "hermes_cli.config.read_raw_config",
@@ -311,6 +345,38 @@ class TestExecE2E:
     def test_blocked_url_rejected(self, camofox_mode):
         result = _exec("new_tab('http://169.254.169.254/latest/meta-data')", task_id="e2e-blocked")
         assert result.get("success") is not True
+
+    def test_last_tab_id_wins(self, camofox_mode):
+        """Two new_tab() calls in one script: the cache must follow the LAST."""
+        result = _exec(
+            "new_tab('https://example.com')\nnew_tab('https://example.org')",
+            task_id="e2e-two-tabs",
+        )
+        assert result["success"] is True, result
+        assert "CAMOFOX_TAB_ID=t1" in result["output"]
+        assert "CAMOFOX_TAB_ID=t2" in result["output"]
+        assert camofox_mod._sessions["e2e-two-tabs"]["tab_id"] == "t2"
+
+    def test_provider_credentials_are_scrubbed(self, camofox_mode, monkeypatch):
+        """The model's code runs here — it must not inherit provider keys."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-not-leak")
+        result = _exec(
+            "import os\nprint('KEY=' + os.environ.get('ANTHROPIC_API_KEY', 'absent'))",
+            task_id="e2e-scrub",
+        )
+        assert result["success"] is True, result
+        assert "KEY=absent" in result["output"]
+        assert "sk-should-not-leak" not in result["output"]
+
+    def test_agent_helpers_auto_imported(self, camofox_mode, monkeypatch, tmp_path):
+        """The description promises agent_helpers.py is auto-imported."""
+        monkeypatch.setenv("BH_AGENT_WORKSPACE", str(tmp_path))
+        (tmp_path / "agent_helpers.py").write_text(
+            "def my_helper():\n    return 'helper-ran'\n", encoding="utf-8"
+        )
+        result = _exec("print(my_helper())", task_id="e2e-helpers")
+        assert result["success"] is True, result
+        assert "helper-ran" in result["output"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_camofox_exec.py
+++ b/tests/tools/test_browser_camofox_exec.py
@@ -1,0 +1,337 @@
+"""Tests for the Camofox exec backend (tools/browser_camofox_exec.py).
+
+Covers the Camofox side of the ``browser_exec`` surface:
+
+* Mode detection — ``browser.backend: camofox`` activates ``browser_exec``
+  even when the browser-use CLI is NOT installed; Camofox setups keep the
+  built-in tools under every other backend.
+* E2E execution — the model's code runs in a real subprocess (Hermes
+  interpreter) against a real HTTP fake of the Camofox server: navigation,
+  snapshot, evaluate, click/type, screenshot attachment, tab recovery on
+  404, and the ``CAMOFOX_TAB_ID`` bookkeeping back into the session cache.
+"""
+
+import json
+import os
+import re
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+import tools.browser_camofox as camofox_mod
+import tools.browser_use_cli as bu_cli
+
+
+# ---------------------------------------------------------------------------
+# Fake Camofox server (stdlib http.server, real sockets)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCamofoxHandler(BaseHTTPRequestHandler):
+    server_version = "FakeCamofox/1.0"
+
+    def log_message(self, *args):  # silence test output
+        pass
+
+    # -- helpers ------------------------------------------------------------
+
+    def _send_json(self, code: int, payload: dict):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self) -> dict:
+        length = int(self.headers.get("Content-Length") or 0)
+        if not length:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def _tab(self, tab_id: str):
+        """Return the tab record or answer 404 (garbage-collected tab)."""
+        tab = self.server.camofox.tabs.get(tab_id)
+        if tab is None or tab.get("dead"):
+            self._send_json(404, {"error": "tab not found"})
+            return None
+        return tab
+
+    def _route(self) -> tuple:
+        parsed = urlparse(self.path)
+        match = re.match(r"^/tabs/([^/]+)/(\w+)$", parsed.path)
+        params = parse_qs(parsed.query)
+        if match:
+            return match.group(1), match.group(2), params
+        return None, parsed.path, params
+
+    # -- verbs --------------------------------------------------------------
+
+    def do_GET(self):
+        tab_id, path, params = self._route()
+        srv = self.server.camofox
+        if path == "/health":
+            return self._send_json(200, {"ok": True})
+        if path == "/tabs" and tab_id is None:
+            user_id = (params.get("userId") or [""])[0]
+            tabs = [
+                {"tabId": tid, "listItemId": t["listItemId"], "userId": t["userId"]}
+                for tid, t in srv.tabs.items()
+                if not t.get("dead") and t["userId"] == user_id
+            ]
+            return self._send_json(200, {"tabs": tabs})
+        if tab_id is not None and path == "stats":
+            tab = self._tab(tab_id)
+            if tab is None:
+                return
+            return self._send_json(200, {"ok": True, "url": "https://example.com/"})
+        if tab_id is not None and path == "snapshot":
+            tab = self._tab(tab_id)
+            if tab is None:
+                return
+            return self._send_json(
+                200, {"snapshot": srv.snapshot, "refsCount": srv.refs_count}
+            )
+        if tab_id is not None and path == "screenshot":
+            tab = self._tab(tab_id)
+            if tab is None:
+                return
+            png = b"\x89PNG\r\n\x1a\n" + b"fakepng"
+            self.send_response(200)
+            self.send_header("Content-Type", "image/png")
+            self.send_header("Content-Length", str(len(png)))
+            self.end_headers()
+            self.wfile.write(png)
+            return
+        if tab_id is not None and path == "links":
+            tab = self._tab(tab_id)
+            if tab is None:
+                return
+            links = [{"text": "Example", "href": "https://example.com/"}]
+            return self._send_json(200, {"links": links, "count": len(links)})
+        self._send_json(404, {"error": f"unknown GET {self.path}"})
+
+    def do_POST(self):
+        tab_id, path, _ = self._route()
+        srv = self.server.camofox
+        body = self._body()
+        if path == "/tabs" and tab_id is None:
+            srv.counter += 1
+            tid = f"t{srv.counter}"
+            srv.tabs[tid] = {
+                "userId": body.get("userId", ""),
+                "listItemId": body.get("listItemId", ""),
+                "dead": False,
+            }
+            return self._send_json(
+                200,
+                {"ok": True, "tabId": tid, "url": body.get("url", ""), "title": "Fake"},
+            )
+        if tab_id is not None and path in ("navigate", "wait", "click", "type", "press", "scroll", "evaluate"):
+            tab = self._tab(tab_id)
+            if tab is None:
+                return
+            if path == "evaluate":
+                return self._send_json(200, {"ok": True, "result": srv.evaluate_result})
+            return self._send_json(200, {"ok": True, "url": "https://example.com/"})
+        self._send_json(404, {"error": f"unknown POST {self.path}"})
+
+    def do_DELETE(self):
+        self._send_json(200, {"ok": True})
+
+
+class FakeCamofoxServer:
+    def __init__(self):
+        self.tabs: dict = {}
+        self.counter = 0
+        self.snapshot = "[heading] Hello Camofox\n[link e1] More information\n"
+        self.refs_count = 2
+        self.evaluate_result = "eval-result-42"
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), _FakeCamofoxHandler)
+        self.httpd.camofox = self
+        self.url = f"http://127.0.0.1:{self.httpd.server_port}"
+
+    def start(self):
+        threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
+
+    def stop(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+    def kill_tab(self, tab_id: str):
+        self.tabs[tab_id]["dead"] = True
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    monkeypatch.delenv("BU_NAME", raising=False)
+    monkeypatch.delenv("CAMOFOX_URL", raising=False)
+    camofox_mod._sessions.clear()
+    yield
+    camofox_mod._sessions.clear()
+
+
+@pytest.fixture()
+def camofox_server():
+    srv = FakeCamofoxServer()
+    srv.start()
+    yield srv
+    srv.stop()
+
+
+@pytest.fixture()
+def camofox_mode(monkeypatch, camofox_server):
+    """backend=camofox + a reachable Camofox server (no browser-use CLI)."""
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {"browser": {"backend": "camofox"}},
+    )
+    monkeypatch.setattr("tools.browser_camofox.get_camofox_url", lambda: camofox_server.url)
+    return camofox_server
+
+
+def _exec(code: str, task_id: str = "task-e2e-1") -> dict:
+    return json.loads(bu_cli.browser_exec(code, task_id=task_id))
+
+
+# ---------------------------------------------------------------------------
+# Mode detection
+# ---------------------------------------------------------------------------
+
+
+class TestModeDetection:
+    def test_camofox_backend_enables_exec_without_cli(self, monkeypatch, camofox_server):
+        """backend=camofox activates browser_exec even with no browser-use CLI."""
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"backend": "camofox"}},
+        )
+        monkeypatch.setattr("tools.browser_camofox.get_camofox_url", lambda: camofox_server.url)
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: None)
+        assert bu_cli.is_browser_use_cli_mode() is True
+
+    def test_camofox_backend_without_server_falls_back(self, monkeypatch):
+        """backend=camofox but no CAMOFOX_URL: keep the built-in tools."""
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"backend": "camofox"}},
+        )
+        monkeypatch.setattr("tools.browser_camofox.get_camofox_url", lambda: "")
+        assert bu_cli.is_browser_use_cli_mode() is False
+
+    def test_browser_use_backend_with_camofox_stays_builtin(self, monkeypatch, camofox_server):
+        """Explicit browser-use backend cannot drive Camoufox (no CDP)."""
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"backend": "browser-use"}},
+        )
+        monkeypatch.setattr("tools.browser_camofox.get_camofox_url", lambda: camofox_server.url)
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: ["/usr/bin/browser-use"])
+        assert bu_cli.is_browser_use_cli_mode() is False
+
+    def test_default_with_camofox_keeps_builtin(self, monkeypatch, camofox_server):
+        """Backend unset + Camofox configured: built-in tools stay (old default)."""
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {})
+        monkeypatch.setattr("tools.browser_camofox.get_camofox_url", lambda: camofox_server.url)
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: ["/usr/bin/browser-use"])
+        assert bu_cli.is_browser_use_cli_mode() is False
+
+
+# ---------------------------------------------------------------------------
+# E2E execution against the fake server
+# ---------------------------------------------------------------------------
+
+
+class TestExecE2E:
+    def test_navigate_and_snapshot(self, camofox_mode):
+        result = _exec(
+            "new_tab('https://example.com')\nprint(page_info())", task_id="e2e-nav"
+        )
+        assert result["success"] is True, result
+        assert "Hello Camofox" in result["output"]
+        assert "CAMOFOX_TAB_ID=t1" in result["output"]
+        # Tab id bookkept back into the in-memory session cache.
+        assert camofox_mod._sessions["e2e-nav"]["tab_id"] == "t1"
+
+    def test_js_evaluate(self, camofox_mode):
+        result = _exec("print(js('1+1'))", task_id="e2e-js")
+        assert result["success"] is True, result
+        assert "eval-result-42" in result["output"]
+
+    def test_interaction_helpers(self, camofox_mode):
+        result = _exec(
+            "new_tab('https://example.com')\n"
+            "click_ref('e1')\n"
+            "fill_input('#search', 'camofox')\n"
+            "press_key('Enter')\n"
+            "print('done')",
+            task_id="e2e-interact",
+        )
+        assert result["success"] is True, result
+        assert "done" in result["output"]
+
+    def test_screenshot_attached(self, camofox_mode):
+        result = _exec("capture_screenshot()", task_id="e2e-shot")
+        assert result["success"] is True, result
+        path = result.get("screenshot_path")
+        assert path, result
+        assert os.path.isfile(path)
+        with open(path, "rb") as fh:
+            assert fh.read(8) == b"\x89PNG\r\n\x1a\n"
+
+    def test_tab_recovery_on_404(self, camofox_mode):
+        """A garbage-collected tab is recreated; the cache follows."""
+        first = _exec("new_tab('https://example.com')\nprint(page_info())", task_id="e2e-recover")
+        assert first["success"] is True, first
+        assert camofox_mod._sessions["e2e-recover"]["tab_id"] == "t1"
+
+        camofox_mode.kill_tab("t1")
+        second = _exec("print(page_info())", task_id="e2e-recover")
+        assert second["success"] is True, second
+        assert "CAMOFOX_TAB_ID=t2" in second["output"]
+        assert camofox_mod._sessions["e2e-recover"]["tab_id"] == "t2"
+
+    def test_clear_error_without_server(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"backend": "camofox"}},
+        )
+        monkeypatch.setattr("tools.browser_camofox.get_camofox_url", lambda: "")
+        result = _exec("print('x')", task_id="e2e-nosrv")
+        assert result.get("success") is not True
+        assert "CAMOFOX_URL" in result.get("error", "")
+
+    def test_blocked_url_rejected(self, camofox_mode):
+        result = _exec("new_tab('http://169.254.169.254/latest/meta-data')", task_id="e2e-blocked")
+        assert result.get("success") is not True
+
+
+# ---------------------------------------------------------------------------
+# Schema/description
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_camofox_description_when_backend_camofox(self, monkeypatch, camofox_server):
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"backend": "camofox"}},
+        )
+        overrides = bu_cli._dynamic_schema_overrides()
+        assert "Camofox backend" in overrides["description"]
+        assert "click_ref" in overrides["description"]
+
+    def test_cli_description_when_backend_browser_use(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"backend": "browser-use"}},
+        )
+        overrides = bu_cli._dynamic_schema_overrides()
+        assert "Camofox backend" not in overrides["description"]

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -282,7 +282,9 @@ class TestLegacyCloudMigration:
         from hermes_cli.tools_config import TOOL_CATEGORIES, _is_provider_active
 
         cli_row = next(
-            r for r in TOOL_CATEGORIES["browser"]["providers"] if r.get("browser_backend")
+            r
+            for r in TOOL_CATEGORIES["browser"]["providers"]
+            if r.get("browser_backend") == "browser-use"
         )
         monkeypatch.setenv("BROWSER_USE_API_KEY", "bu-key")
         assert _is_provider_active(cli_row, dict(self._LEGACY)) is True
@@ -386,10 +388,17 @@ class TestProviderPickerIntegration:
 
         return TOOL_CATEGORIES["browser"]["providers"]
 
+    def _backend_row(self, backend):
+        return next(r for r in self._rows() if r.get("browser_backend") == backend)
+
     def test_picker_has_browser_use_cli_row(self):
-        row = next(r for r in self._rows() if r.get("browser_backend"))
-        assert row["browser_backend"] == "browser-use"
+        row = self._backend_row("browser-use")
         assert row["name"] == "Browser Use"
+
+    def test_picker_has_camofox_exec_row(self):
+        row = self._backend_row("camofox")
+        assert row["name"] == "Camofox (exec mode)"
+        assert any(v.get("key") == "CAMOFOX_URL" for v in row.get("env_vars", []))
 
     def test_picker_row_names_stay_unique(self):
         """The CLI row is named "Browser Use"; the legacy plugin API row must
@@ -403,11 +412,20 @@ class TestProviderPickerIntegration:
     def test_selecting_cli_row_writes_backend_and_keeps_cloud_provider(self):
         from hermes_cli.tools_config import _write_provider_config
 
-        row = next(r for r in self._rows() if r.get("browser_backend"))
+        row = self._backend_row("browser-use")
         config = {"browser": {"cloud_provider": "browserbase"}}
         assert row["name"] == "Browser Use"
         _write_provider_config(row, config, managed_feature=None)
         assert config["browser"]["backend"] == "browser-use"
+        assert config["browser"]["cloud_provider"] == "browserbase"
+
+    def test_selecting_camofox_exec_row_writes_backend(self):
+        from hermes_cli.tools_config import _write_provider_config
+
+        row = self._backend_row("camofox")
+        config = {"browser": {"cloud_provider": "browserbase"}}
+        _write_provider_config(row, config, managed_feature=None)
+        assert config["browser"]["backend"] == "camofox"
         assert config["browser"]["cloud_provider"] == "browserbase"
 
     def test_selecting_provider_row_keeps_cli_mode(self):
@@ -426,7 +444,7 @@ class TestProviderPickerIntegration:
     def test_provider_row_stays_active_alongside_cli_mode(self, monkeypatch):
         from hermes_cli.tools_config import _is_provider_active
 
-        cli_row = next(r for r in self._rows() if r.get("browser_backend"))
+        cli_row = self._backend_row("browser-use")
         local_row = next(
             r for r in self._rows() if r.get("browser_provider") == "local"
         )

--- a/tools/browser_camofox_exec.py
+++ b/tools/browser_camofox_exec.py
@@ -40,6 +40,7 @@ from tools.browser_use_cli import (  # noqa: E402
     _DEFAULT_TIMEOUT_S,
     _MAX_TIMEOUT_S,
     _MIN_TIMEOUT_S,
+    _base_subprocess_env,
     _find_screenshot,
     _native_screenshot_result,
     _workspace_dir,
@@ -48,6 +49,7 @@ from tools.registry import tool_error, tool_result  # noqa: E402
 
 _STDERR_CAP_CHARS = 4000
 _TAB_ID_RE = None  # compiled lazily below
+_SCREENSHOT_RE = None  # compiled lazily below
 
 
 def _tab_id_re():
@@ -59,11 +61,38 @@ def _tab_id_re():
     return _TAB_ID_RE
 
 
+def _screenshot_re():
+    global _SCREENSHOT_RE
+    if _SCREENSHOT_RE is None:
+        import re
+
+        _SCREENSHOT_RE = re.compile(r"^CAMOFOX_SCREENSHOT=(.+?)\s*$", re.MULTILINE)
+    return _SCREENSHOT_RE
+
+
+def _marked_screenshot(stdout: str, since: float) -> Optional[str]:
+    """Last ``CAMOFOX_SCREENSHOT=`` path written during this exec, or None.
+
+    The runtime emits this marker with the *native* path so Windows drive
+    letters survive: ``_find_screenshot``'s regex requires a leading "/",
+    so a bare ``C:/…/x.png`` print only matches from ``/…`` onward — which
+    resolves against the process's current drive and silently misses the
+    file whenever the workspace lives on another drive.
+    """
+    for path in reversed(_screenshot_re().findall(stdout or "")):
+        try:
+            if os.path.isfile(path) and os.path.getmtime(path) >= since - 1:
+                return path
+        except OSError:
+            continue
+    return None
+
+
 def _runtime_wrapper() -> str:
     """Python -c wrapper that imports the runtime helpers and execs stdin."""
     runtime_dir = Path(__file__).resolve().parent.as_posix()
     return (
-        "import sys, pathlib\n"
+        "import sys\n"
         f"sys.path.insert(0, {runtime_dir!r})\n"
         "from browser_camofox_runtime import *\n"
         "exec(compile(sys.stdin.read(), '<browser-exec>', 'exec'))\n"
@@ -154,6 +183,12 @@ def browser_exec(
         except Exception as e:
             logger.debug("Windows hide-flags unavailable: %s", e)
 
+    # Credential-scrubbed env, exactly like the CLI backend: the model's code
+    # runs inside this subprocess, so inheriting os.environ wholesale would
+    # hand it every provider key / gateway token in the parent process.
+    proc_env = _base_subprocess_env()
+    proc_env.update(env)
+
     started = time.time()
     try:
         proc = subprocess.run(
@@ -162,7 +197,7 @@ def browser_exec(
             capture_output=True,
             text=True,
             timeout=timeout,
-            env={**os.environ, **env},
+            env=proc_env,
             **popen_extra,
         )
     except subprocess.TimeoutExpired:
@@ -190,12 +225,17 @@ def browser_exec(
             stderr = stderr[:_STDERR_CAP_CHARS] + "\n… (stderr truncated)"
         result["stderr"] = stderr
 
-    # Persist the tab id the runtime resolved (fresh tab on 404, etc.).
-    tab_match = _tab_id_re().search(proc.stdout or "")
-    if tab_match:
-        _update_session_tab(task_id, tab_match.group(1))
+    # Persist the tab id the runtime resolved (fresh tab on 404, a second
+    # new_tab() in the same script, …). The LAST marker is the live tab: the
+    # runtime prints one every time it resolves a tab, so taking the first
+    # would pin the cache to a tab the script has already navigated away from.
+    tab_ids = _tab_id_re().findall(proc.stdout or "")
+    if tab_ids:
+        _update_session_tab(task_id, tab_ids[-1])
 
-    screenshot = _find_screenshot(proc.stdout or "", started)
+    screenshot = _marked_screenshot(proc.stdout or "", started) or _find_screenshot(
+        proc.stdout or "", started
+    )
     if screenshot:
         result["screenshot_path"] = screenshot
         native = _native_screenshot_result(result, screenshot)
@@ -262,5 +302,7 @@ CAMOFOX_DESCRIPTION_HEADER = (
     "— do not spend a call per action — but for long extractions prefer "
     "several medium calls that append to workspace files over one giant "
     "call, so progress survives timeouts. Tabs opened by this backend share "
-    "the Camofox profile (cookies persist per configured identity)."
+    "the Camofox profile (cookies persist per configured identity). The "
+    "`session` argument is accepted for schema parity and ignored in "
+    "Camofox mode — tabs are keyed to the task identity."
 )

--- a/tools/browser_camofox_exec.py
+++ b/tools/browser_camofox_exec.py
@@ -1,0 +1,266 @@
+"""Camofox exec backend for ``browser_exec`` (script-per-call mode).
+
+When ``browser.backend`` is ``"camofox"``, the ``browser_exec`` tool runs
+the model's Python through the Camofox REST API instead of the Browser Use
+CLI 3.0 harness. The surface is the same — one script per call, pre-imported
+helpers — but every helper maps 1:1 onto the Camofox server
+(``tools/browser_camofox_runtime.py`` runs in a fresh subprocess and speaks
+plain HTTP to the Camofox server, keeping the anti-detection Camoufox engine,
+profile persistence and VNC live view that the CDP-only browser-use harness
+cannot drive).
+
+Key differences vs the CLI backend:
+
+* No browser-use CLI install needed — the subprocess is the Hermes Python
+  interpreter (``sys.executable``) running a stdlib-only runtime.
+* Sessions are resolved in-process via ``tools.browser_camofox._get_session``
+  so managed persistence, identity overrides and tab adoption behave exactly
+  like the built-in Camofox tools.
+* Tabs survive across calls on the server; the runtime prints
+  ``CAMOFOX_TAB_ID=<id>`` lines that we parse back into the in-memory
+  session cache so the next call starts from the live tab.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Imported lazily to avoid a circular import (browser_use_cli imports this
+# module's browser_exec only at call time).
+from tools.browser_use_cli import (  # noqa: E402
+    _DEFAULT_TIMEOUT_S,
+    _MAX_TIMEOUT_S,
+    _MIN_TIMEOUT_S,
+    _find_screenshot,
+    _native_screenshot_result,
+    _workspace_dir,
+)
+from tools.registry import tool_error, tool_result  # noqa: E402
+
+_STDERR_CAP_CHARS = 4000
+_TAB_ID_RE = None  # compiled lazily below
+
+
+def _tab_id_re():
+    global _TAB_ID_RE
+    if _TAB_ID_RE is None:
+        import re
+
+        _TAB_ID_RE = re.compile(r"^CAMOFOX_TAB_ID=(\S+)$", re.MULTILINE)
+    return _TAB_ID_RE
+
+
+def _runtime_wrapper() -> str:
+    """Python -c wrapper that imports the runtime helpers and execs stdin."""
+    runtime_dir = Path(__file__).resolve().parent.as_posix()
+    return (
+        "import sys, pathlib\n"
+        f"sys.path.insert(0, {runtime_dir!r})\n"
+        "from browser_camofox_runtime import *\n"
+        "exec(compile(sys.stdin.read(), '<browser-exec>', 'exec'))\n"
+    )
+
+
+def _resolve_session_env(task_id: Optional[str]) -> Optional[Dict[str, str]]:
+    """Resolve the Camofox session in-process and build the subprocess env."""
+    from agent.secret_scope import get_secret
+    from tools.browser_camofox import _get_session, get_camofox_url
+
+    base_url = get_camofox_url()
+    if not base_url:
+        return None
+    session = _get_session(task_id)
+    return {
+        "CAMOFOX_URL": base_url,
+        "CAMOFOX_API_KEY": (get_secret("CAMOFOX_API_KEY", "") or ""),
+        "BH_USER_ID": str(session.get("user_id") or ""),
+        "BH_SESSION_KEY": str(session.get("session_key") or ""),
+        "BH_TAB_ID": str(session.get("tab_id") or ""),
+    }
+
+
+def _update_session_tab(task_id: Optional[str], tab_id: str) -> None:
+    """Write the tab id the runtime resolved back into the session cache."""
+    try:
+        from tools.browser_camofox import _get_session
+
+        session = _get_session(task_id)
+        if session:
+            session["tab_id"] = tab_id
+    except Exception as exc:  # pragma: no cover — best-effort bookkeeping
+        logger.debug("Could not persist Camofox tab id %s: %s", tab_id, exc)
+
+
+def browser_exec(
+    code: str,
+    session: str = "",
+    timeout_s: int = _DEFAULT_TIMEOUT_S,
+    task_id: Optional[str] = None,
+):
+    """Run Python code through the Camofox exec runtime, return its output.
+
+    Mirrors ``tools.browser_use_cli.browser_exec`` — same result shape, same
+    screenshot detection, same workspace semantics. The ``session`` argument
+    is accepted for schema parity; Camofox sessions are keyed by the resolved
+    task identity, not by a daemon name.
+    """
+    if not code or not code.strip():
+        return tool_error(
+            "No code provided. Pass Python that uses the pre-imported helpers, "
+            "e.g. new_tab(\"https://example.com\") then print(page_info())."
+        )
+
+    from tools.browser_use_cli import _blocked_url_in_code
+
+    blocked = _blocked_url_in_code(code)
+    if blocked:
+        return tool_error(blocked)
+
+    env = _resolve_session_env(task_id)
+    if env is None:
+        return tool_error(
+            "Camofox exec mode requires a configured Camofox server. Set "
+            "CAMOFOX_URL (e.g. http://localhost:9377) in ~/.hermes/.env and "
+            "start the server, or switch browser backends via `hermes tools`."
+        )
+
+    workspace = _workspace_dir(task_id)
+    if workspace:
+        env["BH_AGENT_WORKSPACE"] = workspace
+
+    try:
+        timeout = max(_MIN_TIMEOUT_S, min(int(timeout_s), _MAX_TIMEOUT_S))
+    except (TypeError, ValueError):
+        timeout = _DEFAULT_TIMEOUT_S
+
+    popen_extra: dict = {}
+    if os.name == "nt":
+        try:
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
+            popen_extra["creationflags"] = windows_hide_flags()
+            _si = subprocess.STARTUPINFO()
+            _si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            popen_extra["startupinfo"] = _si
+        except Exception as e:
+            logger.debug("Windows hide-flags unavailable: %s", e)
+
+    started = time.time()
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _runtime_wrapper()],
+            input=code,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env={**os.environ, **env},
+            **popen_extra,
+        )
+    except subprocess.TimeoutExpired:
+        return tool_error(
+            f"Camofox exec timed out after {timeout}s. The browser may still "
+            "be working; retry with a larger timeout_s (max "
+            f"{_MAX_TIMEOUT_S}), or split the work into several calls that "
+            "append to workspace files — anything already written to the "
+            "workspace is preserved."
+        )
+    except OSError as e:
+        return tool_error(f"Failed to launch Camofox exec runtime: {e}")
+
+    result: Dict[str, Any] = {
+        "success": proc.returncode == 0,
+        "exit_code": proc.returncode,
+        "output": proc.stdout,
+    }
+    if workspace:
+        result["workspace"] = workspace
+
+    stderr = (proc.stderr or "").strip()
+    if stderr:
+        if len(stderr) > _STDERR_CAP_CHARS:
+            stderr = stderr[:_STDERR_CAP_CHARS] + "\n… (stderr truncated)"
+        result["stderr"] = stderr
+
+    # Persist the tab id the runtime resolved (fresh tab on 404, etc.).
+    tab_match = _tab_id_re().search(proc.stdout or "")
+    if tab_match:
+        _update_session_tab(task_id, tab_match.group(1))
+
+    screenshot = _find_screenshot(proc.stdout or "", started)
+    if screenshot:
+        result["screenshot_path"] = screenshot
+        native = _native_screenshot_result(result, screenshot)
+        if native is not None:
+            return native
+    return tool_result(result)
+
+
+def is_camofox_exec_mode() -> bool:
+    """True when ``browser.backend: camofox`` is configured."""
+    from tools.browser_use_cli import get_browser_backend
+
+    return get_browser_backend() == "camofox"
+
+
+# ---------------------------------------------------------------------------
+# Helpers reused by browser_use_cli for schema/description building
+# ---------------------------------------------------------------------------
+
+CAMOFOX_HELPERS_DIGEST = (
+    "\n\nHELPERS (pre-imported, Camofox backend): new_tab(url) opens a URL in "
+    "a fresh tab (use for the FIRST navigation), goto_url(url) navigates the "
+    "current tab, wait_for_load() after navigation, page_info() returns the "
+    "page URL plus the accessibility snapshot with element refs "
+    "(e1, e2, …), js(expr) evaluates JavaScript and returns its value "
+    "(js('document.title'); wrap function bodies as js('(() => {...})()') — "
+    "a bare '() => {...}' returns the function itself, uncalled), "
+    "fill_input(selector, text) types into inputs by CSS selector, "
+    "type_into_ref(ref, text) types into a snapshot ref, click_ref(ref) "
+    "clicks a snapshot ref (PREFERRED over coordinates — refs are stable), "
+    "click_selector(selector) clicks by CSS selector, click_at_xy(x, y) "
+    "clicks viewport coordinates (fallback), press_key(key) sends a "
+    "keyboard key, scroll_page(direction, amount) scrolls, "
+    "capture_screenshot() saves a PNG and prints its path (the image is "
+    "attached to the tool result for vision models), get_links(limit) lists "
+    "page links, cdp(method, **kwargs) is a limited compatibility shim "
+    "(Page.navigate, Runtime.evaluate, Accessibility.getFullAXTree, "
+    "DOM.getBoxModel — prefer the typed helpers). ensure_real_tab() "
+    "recovers from a stale tab. Login walls: stop and ask the user; never "
+    "guess credentials."
+)
+
+CAMOFOX_DESCRIPTION_HEADER = (
+    "Drive a real web browser (Camoufox anti-detection engine via the "
+    "Camofox server) using pre-imported Python helpers. The `code` argument "
+    "is piped verbatim to a fresh Python runtime and executed with the "
+    "helpers pre-imported; stdout comes back in the result. Start `code` "
+    "with a one-line comment describing the step for the user in plain, "
+    "non-technical language, max 60 chars (e.g. `# Searching Amazon for "
+    "paper towels`) — the UI displays it as the step label.\n\n"
+    "STATE: the browser tab and the workspace persist across calls; Python "
+    "variables do NOT (each call is a fresh interpreter). The workspace is a "
+    "stable directory — path in $BH_AGENT_WORKSPACE and returned as "
+    "`workspace` in every result. For multi-item tasks ('collect all N "
+    "products / every entry / the full table'), append each batch to a "
+    "JSON/CSV file in the workspace as you go, then read it back to assemble "
+    "the final answer; define reusable functions in agent_helpers.py there — "
+    "the harness auto-imports it into every call. Do aggregation in code, "
+    "not in your head: dedupe, count, sort, and format with Python inside "
+    "the exec. Before giving a final answer on a multi-item task, verify the "
+    "collected count against what was asked and go back for anything "
+    "missing.\n\n"
+    "Batch each sub-procedure (navigate, wait, extract, act) into one call "
+    "— do not spend a call per action — but for long extractions prefer "
+    "several medium calls that append to workspace files over one giant "
+    "call, so progress survives timeouts. Tabs opened by this backend share "
+    "the Camofox profile (cookies persist per configured identity)."
+)

--- a/tools/browser_camofox_runtime.py
+++ b/tools/browser_camofox_runtime.py
@@ -1,0 +1,387 @@
+"""Camofox exec-mode runtime — pre-imported helpers for browser_exec.
+
+This module is NOT imported by the Hermes process. It is executed in a
+fresh Python subprocess (``sys.executable -c <wrapper>``) with the model's
+``code`` piped on stdin, mirroring how the Browser Use CLI 3.0 harness
+runs. Keeping it stdlib-only (urllib, json) means the subprocess has no
+dependency on the Hermes venv, config, or secret store.
+
+The parent (``tools/browser_camofox_exec.py``) resolves the Camofox
+session in-process — honoring managed persistence, identity overrides and
+tab adoption — and hands it to us through environment variables:
+
+    CAMOFOX_URL           Camofox server base URL (required)
+    CAMOFOX_API_KEY       optional Bearer token (CAMOFOX_API_KEY secret)
+    BH_USER_ID            stable userId the server maps to a profile
+    BH_SESSION_KEY        listItemId grouping tabs for the task
+    BH_TAB_ID             last known tab id, when the parent has one
+    BH_AGENT_WORKSPACE    scratch dir (screenshots land here when set)
+
+Tab lifecycle across calls: each call is a fresh interpreter, but the tab
+lives on the server. On entry we reuse ``BH_TAB_ID``; if the server says
+404 (tab garbage-collected), we create a fresh tab under the same
+userId/sessionKey, so cookies and profile state survive. Every time the
+tab is resolved we print ``CAMOFOX_TAB_ID=<id>`` on its own line; the
+parent parses it and updates its in-memory session cache so the next call
+starts from the new tab.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+_BASE_URL = os.environ.get("CAMOFOX_URL", "").rstrip("/")
+_API_KEY = os.environ.get("CAMOFOX_API_KEY", "") or ""
+_USER_ID = os.environ.get("BH_USER_ID", "") or ""
+_SESSION_KEY = os.environ.get("BH_SESSION_KEY", "") or ""
+_TAB_ID = os.environ.get("BH_TAB_ID", "") or ""
+_WORKSPACE = os.environ.get("BH_AGENT_WORKSPACE", "") or ""
+
+if not _BASE_URL:
+    raise RuntimeError(
+        "CAMOFOX_URL is not set. The Camofox exec backend requires a running "
+        "Camofox server (CAMOFOX_URL in ~/.hermes/.env)."
+    )
+if not _USER_ID:
+    raise RuntimeError("BH_USER_ID is not set — Camofox session not resolved.")
+
+
+def _request(
+    method: str,
+    path: str,
+    body: dict | None = None,
+    params: dict | None = None,
+    timeout: float = 30.0,
+    raw: bool = False,
+):
+    """HTTP helper against the Camofox REST API."""
+    url = _BASE_URL + path
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    headers = {}
+    if _API_KEY:
+        headers["Authorization"] = f"Bearer {_API_KEY}"
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if raw:
+                return resp.read()
+            payload = resp.read()
+            return json.loads(payload.decode("utf-8")) if payload else {}
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8", "replace")[:300]
+        except Exception:
+            pass
+        raise RuntimeError(
+            f"Camofox {method} {path} failed: HTTP {exc.code} {detail}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"Cannot connect to Camofox at {_BASE_URL}: {exc.reason}"
+        ) from exc
+
+
+def _tab() -> str:
+    """Return a live tab id, creating one when needed (or on 404)."""
+    global _TAB_ID
+    if _TAB_ID:
+        try:
+            _request("GET", f"/tabs/{_TAB_ID}/stats", params={"userId": _USER_ID}, timeout=10)
+            print(f"CAMOFOX_TAB_ID={_TAB_ID}")
+            return _TAB_ID
+        except RuntimeError:
+            pass  # stale tab — fall through and create a fresh one
+    data = _request(
+        "POST",
+        "/tabs",
+        body={"userId": _USER_ID, "listItemId": _SESSION_KEY, "url": "about:blank"},
+    )
+    tab_id = str(data.get("tabId") or "")
+    if not tab_id:
+        raise RuntimeError(f"Camofox /tabs returned no tabId: {data!r}")
+    _TAB_ID = tab_id
+    print(f"CAMOFOX_TAB_ID={tab_id}")
+    return tab_id
+
+
+def ensure_real_tab() -> dict:
+    """Recover from a stale/internal tab; returns the active tab id."""
+    return {"ok": True, "tab_id": _tab()}
+
+
+def new_tab(url: str) -> dict:
+    """Open a URL in a fresh tab (first navigation of a session)."""
+    data = _request(
+        "POST",
+        "/tabs",
+        body={"userId": _USER_ID, "listItemId": _SESSION_KEY, "url": url},
+        timeout=60,
+    )
+    global _TAB_ID
+    _TAB_ID = str(data.get("tabId") or _TAB_ID)
+    print(f"CAMOFOX_TAB_ID={_TAB_ID}")
+    return {"url": data.get("url", url), "title": data.get("title", "")}
+
+
+def goto_url(url: str) -> dict:
+    """Navigate the current tab to a URL."""
+    data = _request(
+        "POST",
+        f"/tabs/{_tab()}/navigate",
+        body={"userId": _USER_ID, "url": url},
+        timeout=60,
+    )
+    return {"url": data.get("url", url), "title": data.get("title", "")}
+
+
+def wait_for_load(timeout: int = 10000, wait_for_network: bool = True) -> dict:
+    """Wait for the page to be ready (default 10s, network quiet)."""
+    data = _request(
+        "POST",
+        f"/tabs/{_tab()}/wait",
+        body={"userId": _USER_ID, "timeout": timeout, "waitForNetwork": wait_for_network},
+        timeout=max(timeout / 1000 + 10, 30),
+    )
+    return {"ok": True, "ready": bool(data.get("ready"))}
+
+
+def page_info() -> str:
+    """Summarize the current page: URL plus the accessibility snapshot."""
+    tab = _tab()
+    try:
+        snap = _request(
+            "GET", f"/tabs/{tab}/snapshot", params={"userId": _USER_ID}, timeout=30
+        )
+        snapshot_text = str(snap.get("snapshot") or "")
+        refs = snap.get("refsCount", 0)
+    except RuntimeError:
+        snapshot_text, refs = "", 0
+    try:
+        url = js("location.href")
+    except RuntimeError:
+        url = ""
+    return (
+        f"URL: {url}\n"
+        f"Element refs: {refs}\n"
+        + (snapshot_text if snapshot_text else "(no snapshot available)")
+    )
+
+
+def js(expr: str):
+    """Evaluate a JavaScript expression in the page and return its value."""
+    data = _request(
+        "POST",
+        f"/tabs/{_tab()}/evaluate",
+        body={"userId": _USER_ID, "expression": expr},
+        timeout=60,
+    )
+    return data.get("result")
+
+
+def fill_input(selector: str, text: str, press_enter: bool = False) -> dict:
+    """Type text into an input selected by CSS selector (fill mode)."""
+    _request(
+        "POST",
+        f"/tabs/{_tab()}/type",
+        body={
+            "userId": _USER_ID,
+            "selector": selector,
+            "text": text,
+            "pressEnter": press_enter,
+        },
+        timeout=60,
+    )
+    return {"ok": True, "selector": selector}
+
+
+def type_into_ref(ref: str, text: str, press_enter: bool = False) -> dict:
+    """Type text into a snapshot element ref (e.g. 'e3')."""
+    _request(
+        "POST",
+        f"/tabs/{_tab()}/type",
+        body={
+            "userId": _USER_ID,
+            "ref": ref.lstrip("@"),
+            "text": text,
+            "pressEnter": press_enter,
+        },
+        timeout=60,
+    )
+    return {"ok": True, "ref": ref.lstrip("@")}
+
+
+def click_ref(ref: str) -> dict:
+    """Click a snapshot element ref (e.g. 'e3')."""
+    data = _request(
+        "POST",
+        f"/tabs/{_tab()}/click",
+        body={"userId": _USER_ID, "ref": ref.lstrip("@")},
+        timeout=60,
+    )
+    return {"ok": True, "clicked": ref.lstrip("@"), "url": data.get("url", "")}
+
+
+def click_selector(selector: str) -> dict:
+    """Click the first element matching a CSS selector."""
+    data = _request(
+        "POST",
+        f"/tabs/{_tab()}/click",
+        body={"userId": _USER_ID, "selector": selector},
+        timeout=60,
+    )
+    return {"ok": True, "clicked": selector, "url": data.get("url", "")}
+
+
+def click_at_xy(x: int, y: int) -> dict:
+    """Click viewport coordinates via elementFromPoint (fallback path)."""
+    expr = (
+        f"(() => {{ const el = document.elementFromPoint({int(x)}, {int(y)}); "
+        "if (!el) return {clicked: false, reason: 'no element at point'}; "
+        "el.click(); return {clicked: true, tag: el.tagName}; })()"
+    )
+    result = js(expr)
+    return {"ok": True, "result": result}
+
+
+def press_key(key: str) -> dict:
+    """Press a keyboard key (e.g. 'Enter', 'Tab', 'Escape')."""
+    _request(
+        "POST",
+        f"/tabs/{_tab()}/press",
+        body={"userId": _USER_ID, "key": key},
+        timeout=30,
+    )
+    return {"ok": True, "pressed": key}
+
+
+def scroll_page(direction: str = "down", amount: int = 500) -> dict:
+    """Scroll the page (direction: up/down/left/right)."""
+    _request(
+        "POST",
+        f"/tabs/{_tab()}/scroll",
+        body={"userId": _USER_ID, "direction": direction, "amount": int(amount)},
+        timeout=30,
+    )
+    return {"ok": True, "direction": direction}
+
+
+def get_links(limit: int = 50) -> dict:
+    """Return page links from the Camofox links endpoint."""
+    data = _request(
+        "GET",
+        f"/tabs/{_tab()}/links",
+        params={"userId": _USER_ID, "limit": int(limit)},
+        timeout=30,
+    )
+    links = data.get("links", []) if isinstance(data, dict) else []
+    return {"links": links, "count": len(links)}
+
+
+def capture_screenshot(full_page: bool = False) -> str:
+    """Save a screenshot PNG and return (and print) its absolute path.
+
+    The path is printed with forward slashes so the Hermes parent can
+    detect it (the screenshot detector regex expects POSIX-style paths)
+    and attach the image for vision-capable models.
+    """
+    png = _request(
+        "GET",
+        f"/tabs/{_tab()}/screenshot",
+        params={"userId": _USER_ID, "fullPage": "true" if full_page else "false"},
+        timeout=60,
+        raw=True,
+    )
+    out_dir = Path(_WORKSPACE) if _WORKSPACE else Path(tempdir())
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"camofox_{int(time.time() * 1000)}.png"
+    path.write_bytes(png)
+    posix = path.as_posix()
+    print(posix)
+    return posix
+
+
+def tempdir() -> str:
+    """Fallback scratch dir when no workspace env is present."""
+    import tempfile
+
+    return tempfile.gettempdir()
+
+
+def cdp(method: str, **kwargs):
+    """Raw-CDP shim for the Browser Use helper surface (limited).
+
+    Camofox is a REST API, not a CDP endpoint, so only a small mapping is
+    supported:
+
+    * ``cdp('Page.navigate', url=...)``            -> goto_url
+    * ``cdp('Runtime.evaluate', expression=...)``  -> js
+    * ``cdp('Accessibility.getFullAXTree')``       -> page_info() text
+    * ``cdp('DOM.getBoxModel', selector=...)``     -> bounding rect
+
+    Prefer the typed helpers (click_ref, fill_input, js, …) — the snapshot
+    already exposes stable element refs, so coordinate hacking is rarely
+    needed.
+    """
+    if method == "Page.navigate":
+        url = kwargs.get("url") or kwargs.get("url_")
+        if not url:
+            raise ValueError("cdp('Page.navigate') requires url=...")
+        return goto_url(url)
+    if method == "Runtime.evaluate":
+        expr = kwargs.get("expression") or kwargs.get("expr")
+        if not expr:
+            raise ValueError("cdp('Runtime.evaluate') requires expression=...")
+        return js(expr)
+    if method == "Accessibility.getFullAXTree":
+        return page_info()
+    if method == "DOM.getBoxModel":
+        selector = kwargs.get("selector")
+        if not selector:
+            raise ValueError(
+                "cdp('DOM.getBoxModel') requires selector=...; refs are not "
+                "resolvable over raw CDP in Camofox mode — use click_ref(ref)"
+            )
+        rect = js(
+            f"(() => {{ const el = document.querySelector({json.dumps(selector)}); "
+            "if (!el) return null; const r = el.getBoundingClientRect(); "
+            "return {x: r.x, y: r.y, width: r.width, height: r.height}; })()"
+        )
+        return rect
+    raise NotImplementedError(
+        f"cdp({method!r}) is not available in Camofox exec mode. Use the typed "
+        "helpers: new_tab, goto_url, page_info, js, fill_input, click_ref, "
+        "click_selector, press_key, scroll_page, capture_screenshot."
+    )
+
+
+__all__ = [
+    "ensure_real_tab",
+    "new_tab",
+    "goto_url",
+    "wait_for_load",
+    "page_info",
+    "js",
+    "fill_input",
+    "type_into_ref",
+    "click_ref",
+    "click_selector",
+    "click_at_xy",
+    "press_key",
+    "scroll_page",
+    "get_links",
+    "capture_screenshot",
+    "cdp",
+]

--- a/tools/browser_camofox_runtime.py
+++ b/tools/browser_camofox_runtime.py
@@ -53,6 +53,14 @@ if not _USER_ID:
     raise RuntimeError("BH_USER_ID is not set — Camofox session not resolved.")
 
 
+class CamofoxHTTPError(RuntimeError):
+    """A non-2xx response from the Camofox server (carries the status code)."""
+
+    def __init__(self, message: str, code: int):
+        super().__init__(message)
+        self.code = code
+
+
 def _request(
     method: str,
     path: str,
@@ -85,8 +93,8 @@ def _request(
             detail = exc.read().decode("utf-8", "replace")[:300]
         except Exception:
             pass
-        raise RuntimeError(
-            f"Camofox {method} {path} failed: HTTP {exc.code} {detail}"
+        raise CamofoxHTTPError(
+            f"Camofox {method} {path} failed: HTTP {exc.code} {detail}", exc.code
         ) from exc
     except urllib.error.URLError as exc:
         raise RuntimeError(
@@ -102,12 +110,21 @@ def _tab() -> str:
             _request("GET", f"/tabs/{_TAB_ID}/stats", params={"userId": _USER_ID}, timeout=10)
             print(f"CAMOFOX_TAB_ID={_TAB_ID}")
             return _TAB_ID
-        except RuntimeError:
-            pass  # stale tab — fall through and create a fresh one
+        except CamofoxHTTPError as exc:
+            # A 404 (tab gone) or 410 (the real Camofox server's response
+            # for a GC'd/restarted tab: "Tab no longer exists (browser was
+            # restarted)") means "recreate". Anything else — 401, 5xx, or a
+            # connection error — must surface: silently opening a fresh tab
+            # would throw away the live page and hide the real failure.
+            if exc.code not in (404, 410):
+                raise
     data = _request(
         "POST",
         "/tabs",
-        body={"userId": _USER_ID, "listItemId": _SESSION_KEY, "url": "about:blank"},
+        # No explicit url: the real server rejects the "about:" scheme
+        # (HTTP 400 "Blocked URL scheme"), while omitting the key opens a
+        # native blank page. new_tab() always passes a real http(s) URL.
+        body={"userId": _USER_ID, "listItemId": _SESSION_KEY},
     )
     tab_id = str(data.get("tabId") or "")
     if not tab_id:
@@ -124,15 +141,18 @@ def ensure_real_tab() -> dict:
 
 def new_tab(url: str) -> dict:
     """Open a URL in a fresh tab (first navigation of a session)."""
+    global _TAB_ID
     data = _request(
         "POST",
         "/tabs",
         body={"userId": _USER_ID, "listItemId": _SESSION_KEY, "url": url},
         timeout=60,
     )
-    global _TAB_ID
-    _TAB_ID = str(data.get("tabId") or _TAB_ID)
-    print(f"CAMOFOX_TAB_ID={_TAB_ID}")
+    tab_id = str(data.get("tabId") or "")
+    if not tab_id:
+        raise RuntimeError(f"Camofox /tabs returned no tabId: {data!r}")
+    _TAB_ID = tab_id
+    print(f"CAMOFOX_TAB_ID={tab_id}")
     return {"url": data.get("url", url), "title": data.get("title", "")}
 
 
@@ -308,6 +328,11 @@ def capture_screenshot(full_page: bool = False) -> str:
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"camofox_{int(time.time() * 1000)}.png"
     path.write_bytes(png)
+    # Native path marker first (the parent prefers it: the screenshot
+    # detector regex for the CLI backend requires a leading "/", which
+    # resolves wrong for Windows drive letters), then the POSIX-style
+    # print as a fallback for the model and the CLI-style detector.
+    print(f"CAMOFOX_SCREENSHOT={path}")
     posix = path.as_posix()
     print(posix)
     return posix
@@ -385,3 +410,38 @@ __all__ = [
     "capture_screenshot",
     "cdp",
 ]
+
+
+def _load_agent_helpers() -> None:
+    """Auto-import ``agent_helpers.py`` from the workspace, as promised.
+
+    The tool description tells the model it can "define reusable functions in
+    agent_helpers.py there — the harness auto-imports it into every call"
+    (the Browser Use CLI harness does). Without this, the model writes the
+    file and every helper silently vanishes on the next call. Names are
+    appended to ``__all__`` so the wrapper's ``import *`` re-exports them.
+    """
+    if not _WORKSPACE:
+        return
+    helpers = Path(_WORKSPACE) / "agent_helpers.py"
+    if not helpers.is_file():
+        return
+    if _WORKSPACE not in sys.path:
+        sys.path.insert(0, _WORKSPACE)
+    try:
+        import agent_helpers
+    except Exception as exc:  # a broken helper file must not kill the call
+        print(f"agent_helpers.py failed to import: {exc}", file=sys.stderr)
+        return
+    exported = getattr(agent_helpers, "__all__", None) or [
+        name for name in vars(agent_helpers) if not name.startswith("_")
+    ]
+    for name in exported:
+        if not hasattr(agent_helpers, name):
+            continue
+        globals()[name] = getattr(agent_helpers, name)
+        if name not in __all__:
+            __all__.append(name)
+
+
+_load_agent_helpers()

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -18,6 +18,7 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 _BACKEND_KEY = "browser-use"
+CAMOFOX_BACKEND_KEY = "camofox"
 BACKEND_DISABLED = "off"
 
 # Cloud daemon names become the BU_NAME env var
@@ -106,31 +107,50 @@ def is_legacy_browser_use_cloud_config(browser_cfg: dict) -> bool:
 
 
 def is_browser_use_cli_mode() -> bool:
-    """True when the Browser Use CLI replaces the built-in browser stack.
+    """True when ``browser_exec`` replaces the built-in browser stack.
 
-    Browser Use mode is the DEFAULT: an unset ``browser.backend`` ("") enables
-    it whenever the browser-use CLI is runnable (installed binary or uvx).
-    Set ``browser.backend: off`` (or ``/browser use off``) for the built-in
-    browser_* tools.
+    Two backends activate the script-per-call surface:
 
-    Camofox always falls back to the built-in tools regardless of
-    ``browser.backend`` — it is Firefox-based with a custom HTTP API and no
-    CDP surface, so the CDP-only browser-use harness cannot drive it.
+    * ``browser.backend: "browser-use"`` — the Browser Use CLI 3.0 harness
+      (the default when the CLI is runnable and Camofox is not configured).
+    * ``browser.backend: "camofox"`` — the Camofox exec backend, which runs
+      the same script-per-call surface against the Camofox REST API. No
+      browser-use CLI install is needed (the runtime is the Hermes Python
+      interpreter); see ``tools/browser_camofox_exec.py``.
+
+    Camofox setups keep the built-in tools when the backend is unset or
+    explicitly ``browser-use`` — Camoufox is Firefox-based with a custom
+    HTTP API and no CDP surface, so the CDP-only browser-use harness cannot
+    drive it.
     """
     try:
         from tools.browser_camofox import is_camofox_mode
-
-        if is_camofox_mode():
-            return False
     except Exception as e:
         logger.debug("Camofox activity check failed: %s", e)
+        is_camofox_mode = lambda: False  # noqa: E731
+
     backend = get_browser_backend()
+    if backend == CAMOFOX_BACKEND_KEY:
+        # Camofox exec mode: only meaningful when a Camofox server is
+        # configured; otherwise fall through to the built-in tools.
+        return is_camofox_mode()
+    if backend == _BACKEND_KEY:
+        # Explicit Browser Use CLI mode — Camofox still falls back to the
+        # built-in tools (the CDP-only harness cannot drive Camoufox). A
+        # missing CLI is reported at execution time, not here: explicit
+        # opt-in means the user asked for the surface.
+        if is_camofox_mode():
+            return False
+        return True
     if backend:
-        return backend == _BACKEND_KEY
+        return False
     if is_legacy_browser_use_cloud_config(_read_browser_cfg()):
         return True
     # Default (backend unset): Browser Use mode when the CLI can run at all;
-    # otherwise keep the built-in tools so browsing never silently breaks.
+    # Camofox setups keep the built-in tools; otherwise the built-in stack
+    # stays so browsing never silently breaks.
+    if is_camofox_mode():
+        return False
     return _find_cli() is not None
 
 
@@ -311,6 +331,18 @@ def browser_exec(
     blocked = _blocked_url_in_code(code)
     if blocked:
         return tool_error(blocked)
+
+    # Camofox exec backend: same script-per-call surface, driven by the
+    # Camofox REST API instead of the browser-use CLI.
+    if get_browser_backend() == CAMOFOX_BACKEND_KEY:
+        from tools.browser_camofox_exec import browser_exec as camofox_exec
+
+        return camofox_exec(
+            code=code,
+            session=session,
+            timeout_s=timeout_s,
+            task_id=task_id,
+        )
 
     cmd = _find_cli()
     if not cmd:
@@ -513,6 +545,13 @@ def _cli_skill_text() -> str:
 
 
 def _dynamic_schema_overrides() -> dict:
+    if get_browser_backend() == CAMOFOX_BACKEND_KEY:
+        from tools.browser_camofox_exec import (
+            CAMOFOX_DESCRIPTION_HEADER,
+            CAMOFOX_HELPERS_DIGEST,
+        )
+
+        return {"description": CAMOFOX_DESCRIPTION_HEADER + CAMOFOX_HELPERS_DIGEST}
     return {"description": _description_header() + _HELPERS_DIGEST}
 
 

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -125,21 +125,30 @@ def is_browser_use_cli_mode() -> bool:
     """
     try:
         from tools.browser_camofox import is_camofox_mode
+
+        def _camofox_active() -> bool:
+            try:
+                return bool(is_camofox_mode())
+            except Exception as e:
+                logger.debug("Camofox activity check failed: %s", e)
+                return False
     except Exception as e:
         logger.debug("Camofox activity check failed: %s", e)
-        is_camofox_mode = lambda: False  # noqa: E731
+
+        def _camofox_active() -> bool:
+            return False
 
     backend = get_browser_backend()
     if backend == CAMOFOX_BACKEND_KEY:
         # Camofox exec mode: only meaningful when a Camofox server is
         # configured; otherwise fall through to the built-in tools.
-        return is_camofox_mode()
+        return _camofox_active()
     if backend == _BACKEND_KEY:
         # Explicit Browser Use CLI mode — Camofox still falls back to the
         # built-in tools (the CDP-only harness cannot drive Camoufox). A
         # missing CLI is reported at execution time, not here: explicit
         # opt-in means the user asked for the surface.
-        if is_camofox_mode():
+        if _camofox_active():
             return False
         return True
     if backend:
@@ -149,7 +158,7 @@ def is_browser_use_cli_mode() -> bool:
     # Default (backend unset): Browser Use mode when the CLI can run at all;
     # Camofox setups keep the built-in tools; otherwise the built-in stack
     # stays so browsing never silently breaks.
-    if is_camofox_mode():
+    if _camofox_active():
         return False
     return _find_cli() is not None
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -67,7 +67,7 @@ Browser Use mode uses the [Browser Use CLI 3.0](https://github.com/browser-use/b
 
 **This is the default browser mode**: when `browser.backend` is unset and the `browser-use` CLI is runnable (installed, or available through `uvx`), the agent gets the single `browser_exec` tool. If the CLI can't run, Hermes falls back to the built-in browser tools automatically.
 
-The mode is a **driver** that composes with your configured browser backend: it drives your local Chrome, a Nous-subscription cloud browser, Browserbase, Firecrawl, or Browser Use cloud browsers — whichever browser source is selected in `hermes tools` → Browser Automation. The one exception is Camofox, which has no CDP endpoint for the harness to attach to; Camofox setups automatically keep the built-in browser tools.
+The mode is a **driver** that composes with your configured browser backend: it drives your local Chrome, a Nous-subscription cloud browser, Browserbase, Firecrawl, or Browser Use cloud browsers — whichever browser source is selected in `hermes tools` → Browser Automation. The one exception is Camofox, which has no CDP endpoint for the harness to attach to; Camofox setups automatically keep the built-in browser tools — unless you select **Camofox (exec mode)**, which gives Camofox the same script-per-call surface over its REST API (see below).
 
 To opt out and force the built-in browser tools, use `/browser use off`, or:
 
@@ -87,6 +87,28 @@ Because Browser Use mode executes model-written Python on your machine, the
 access. Platforms configured without the terminal toolset (e.g. a locked-down
 messaging surface) keep the default browser tools instead.
 :::
+
+### Camofox exec mode
+
+The Camofox backend gets the same script-per-call surface as Browser Use mode — one `browser_exec` call per task step instead of one tool call per click — while keeping everything Camofox is for: the Camoufox anti-detection engine, persistent profiles (`browser.camofox.managed_persistence`), macros, and the VNC live view.
+
+The model's code runs in a fresh Python subprocess with pre-imported helpers that map 1:1 onto the Camofox REST API. No browser-use CLI install is needed.
+
+To enable it, pick **Camofox (exec mode)** in `hermes tools` → Browser Automation (this sets `browser.backend: "camofox"`), or configure manually:
+
+```yaml
+# ~/.hermes/config.yaml
+browser:
+  backend: "camofox"
+```
+
+You still need a running Camofox server with `CAMOFOX_URL` set (see [Camofox local mode](#camofox-local-mode) below).
+
+Available helpers: `new_tab(url)`, `goto_url(url)`, `wait_for_load()`, `page_info()` (URL + accessibility snapshot with element refs), `js(expr)`, `fill_input(selector, text)`, `type_into_ref(ref, text)`, `click_ref(ref)` (preferred — refs are stable), `click_selector(selector)`, `click_at_xy(x, y)`, `press_key(key)`, `scroll_page(direction, amount)`, `capture_screenshot()` (PNG attached for vision models), `get_links(limit)`, and a limited `cdp(method, **kwargs)` compatibility shim (`Page.navigate`, `Runtime.evaluate`, `Accessibility.getFullAXTree`, `DOM.getBoxModel`) — prefer the typed helpers over raw CDP.
+
+Tabs live on the Camofox server and survive across calls under the same profile identity; a garbage-collected tab is recreated automatically with cookies intact.
+
+To go back to the built-in per-click Camofox tools, use `/browser use off` or set `browser.backend: "off"`.
 
 ### Firecrawl cloud mode
 


### PR DESCRIPTION
## Summary

Adds a Camofox exec backend for `browser_exec`: setting `browser.backend: "camofox"` activates the script-per-call browser automation surface against the Camofox REST API instead of the browser-use CLI. The model's code runs in a fresh Python subprocess with pre-imported helpers (`new_tab`, `goto_url`, `page_info`, `js`, `fill_input`, `click_ref`, `click_selector`, `press_key`, `scroll_page`, `capture_screenshot`, `get_links`, plus a limited `cdp` shim) that map 1:1 onto the Camofox server endpoints.

Root cause: the Browser Use CLI 3.0 harness is CDP/Chromium-centric (its `Accessibility.getFullAXTree` helper is Chromium-only), while Camoufox is Firefox-based with a custom HTTP API and no CDP surface — so Camofox setups were previously locked out of the script-per-call mode that cuts browser-task tokens 48–66%, and were forced to keep the per-click built-in tools.

## Changes

- `tools/browser_camofox_runtime.py` (new): stdlib-only subprocess runtime executed via `python -c` with the model's code piped on stdin. Reads `CAMOFOX_URL`/`CAMOFOX_API_KEY`/`BH_*` env vars, talks plain HTTP to the Camofox server, reuses a live tab or recreates one when it is gone (server answers 410 `browser_restarted` for GC'd tabs; 404 tolerated), auto-imports `agent_helpers.py` from the workspace, and prints `CAMOFOX_TAB_ID=` / `CAMOFOX_SCREENSHOT=` markers the parent parses back into the session cache.
- `tools/browser_camofox_exec.py` (new): in-process executor mirroring `browser_use_cli.browser_exec` (same result shape, screenshot detection/attachment, workspace semantics, timeouts). Resolves sessions via `tools.browser_camofox._get_session` so managed persistence, identity overrides and tab adoption behave exactly like the built-in Camofox tools. The subprocess env is credential-scrubbed via `_base_subprocess_env()` — model-authored code must not inherit provider keys.
- `tools/browser_use_cli.py`: adds `CAMOFOX_BACKEND_KEY`, routes `browser_exec` to the Camofox executor when `browser.backend == "camofox"`, extends `is_browser_use_cli_mode()` (backend `camofox` → exec mode when a Camofox server is configured; Camofox setups still keep built-in tools under unset/`browser-use` backends), and serves a Camofox-specific helper digest in the dynamic tool description.
- `hermes_cli/tools_config.py`: new **Camofox (exec mode)** row in `hermes tools` → Browser Automation writing `browser.backend: camofox`, next to the existing Camofox row (built-in per-click tools).
- `tests/tools/test_browser_camofox_exec.py` (new): mode-detection tests plus E2E tests running a real subprocess against a real HTTP fake of the Camofox server — navigation, snapshot, evaluate, click/type/press, screenshot attachment, tab recovery (410 `browser_restarted`, mirroring the real server), non-gone errors (401) propagate without recreating the tab, last-tab-wins bookkeeping, credential scrubbing, agent_helpers auto-import, blocked-URL rejection, clear errors without a server.
- `tests/tools/test_browser_use_cli.py`: picker tests now select rows by their `browser_backend` key (two rows now carry it); new coverage for the Camofox exec row.
- `website/docs/user-guide/features/browser.md`: new **Camofox exec mode** section (enable via picker or config, helper list, tab persistence, revert to built-in tools) and updated the Browser Use mode exception note.

## Validation

| Test | Result |
|------|--------|
| `tests/tools/test_browser_camofox_exec.py` (17 tests: mode detection + E2E vs fake server) | 17/17 passed |
| `tests/tools/test_browser_use_cli.py` (mode detection, picker, schema) | passed on Linux CI semantics; on Windows 10 failures are pre-existing (POSIX fake-CLI shim → WinError 193; POSIX-only screenshot path regex) — the same 10 tests fail on clean `main` without this PR (verified by running them on a `main`-detached worktree) |
| `tests/tools/test_browser_camofox*.py` (existing Camofox suite: auth, persistence, ensure-tab, SSRF guards, timeouts) | all passed |
| `ruff check` on all touched files | all checks passed |
| Independent review (Claude Code, 2 sessions) | 3 major findings fixed (env credential leak, first-vs-last tab marker, promised-but-missing agent_helpers auto-import), 2 minor fixed (404-only recovery → 404/410, POSIX-only screenshot regex), gating/toolset/SSRF paths verified correct; baseline claim re-verified against clean `main` |
| Manual E2E vs real Camofox server at `localhost:9377` (2026-08-10) | navigation, `js('document.title')` → "Example Domain", snapshot with refs, press/scroll/links, screenshot PNG attached, tab deleted → next call recovers with a fresh tab (410 `browser_restarted` path) — all green |

Closes #83497
