### PR TITLE
fix(kanban): forward concurrency caps from dashboard /dispatch endpoint

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2265,11 +2265,53 @@ def dispatch(
     max_n: int = Query(8, alias="max"),
     board: Optional[str] = Query(None),
 ):
+    # Read kanban concurrency caps from config so the dashboard's
+    # /dispatch endpoint honours the same limits as the gateway tick
+    # (kanban_watchers.py) and CLI (kanban.py _cmd_dispatch). Without
+    # this, the dashboard bypasses max_in_progress_per_profile and
+    # max_in_progress entirely — the Desktop app's auto-nudge after
+    # every board write then spawns unlimited concurrent workers per
+    # profile, circumventing the cap the gateway tick enforces.
+    try:
+        from hermes_cli.config import load_config
+        _cfg = load_config()
+        _kanban_cfg = _cfg.get("kanban", {}) if isinstance(_cfg, dict) else {}
+        default_assignee = (_kanban_cfg.get("default_assignee") or "").strip() or None
+
+        def _coerce_positive_int(value):
+            if value is None:
+                return None
+            try:
+                ival = int(value)
+            except (TypeError, ValueError):
+                return None
+            return ival if ival >= 1 else None
+
+        max_in_progress_per_profile = _coerce_positive_int(
+            _kanban_cfg.get("max_in_progress_per_profile")
+        )
+        max_in_progress = _coerce_positive_int(_kanban_cfg.get("max_in_progress"))
+        failure_limit = _coerce_positive_int(_kanban_cfg.get("failure_limit"))
+        if failure_limit is None:
+            failure_limit = kanban_db.DEFAULT_SPAWN_FAILURE_LIMIT
+    except Exception:
+        default_assignee = None
+        max_in_progress_per_profile = None
+        max_in_progress = None
+        failure_limit = kanban_db.DEFAULT_SPAWN_FAILURE_LIMIT
+
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
         result = kanban_db.dispatch_once(
-            conn, dry_run=dry_run, max_spawn=max_n, board=board,
+            conn,
+            dry_run=dry_run,
+            max_spawn=max_n,
+            board=board,
+            max_in_progress=max_in_progress,
+            failure_limit=failure_limit,
+            default_assignee=default_assignee,
+            max_in_progress_per_profile=max_in_progress_per_profile,
         )
         # DispatchResult is a dataclass.
         try:


### PR DESCRIPTION
## Problem

The dashboard's `POST /dispatch` endpoint (`plugins/kanban/dashboard/plugin_api.py`) calls `dispatch_once()` **without forwarding** `max_in_progress_per_profile`, `max_in_progress`, `default_assignee`, or `failure_limit` from the kanban config. When these parameters are `None`, the enforcement logic in `_dispatch_once_locked` skips the cap checks entirely.

This means the dashboard bypasses per-profile and global concurrency caps that the gateway tick and CLI correctly enforce.

### Impact

The Desktop app's Kanban plugin auto-nudges the dispatcher after **every board write** (`autoNudge` in `apps/desktop/src/plugins/kanban/api.ts` — debounced 400ms, fire-and-forget). Every `patchTask`, `createTask`, `deleteTask`, `bulkTasks`, `reassignTask`, and `reclaimTask` call triggers a `POST /dispatch`.

Because the dashboard endpoint doesn't forward `max_in_progress_per_profile`, a user with `kanban.max_in_progress_per_profile: 1` who creates or unblocks multiple tasks for the same profile through the Desktop Kanban plugin sees **all of them spawn simultaneously**, bypassing the cap. The gateway's 60-second tick enforces the cap correctly, but the dashboard's immediate dispatch circumvents it before the tick runs.

The old Dashboard web app does not have this problem — it only calls `/dispatch` when the user explicitly clicks "Nudge dispatcher".

## Root Cause

Three callers invoke `dispatch_once()`:

| Caller | Forwards caps? |
|--------|---------------|
| Gateway watcher (`kanban_watchers.py`) | Yes |
| CLI `_cmd_dispatch` (`kanban.py`) | Yes |
| **Dashboard `/dispatch`** (`plugin_api.py`) | **No** |

## Fix

Read the same config keys using the same `_coerce_positive_int` helper already used by the CLI path (`kanban.py:_cmd_dispatch`), then forward all four parameters to `dispatch_once()`. The config-reading block is copied verbatim from the CLI path to ensure identical semantics.

### Parameters now forwarded

- `max_in_progress_per_profile` — per-profile concurrency cap (#21582)
- `max_in_progress` — global concurrency cap (#33488)
- `default_assignee` — fallback profile for unassigned ready tasks (#27145)
- `failure_limit` — consecutive spawn failure threshold before auto-block

### Backward compatibility

The `try/except` fallback (matching the CLI path) ensures that if `load_config()` fails, all caps fall back to `None` (disabled) — identical to the current behavior. Users without these config keys set see no change.

## Follow-up (not in this PR)

The config-reading logic is now duplicated across three call sites. A future refactor could extract a shared `dispatch_config_from_config()` helper that returns a dataclass, so all three callers use one implementation.