### PR TITLE
fix(honcho): enforce saveMessages containment, honor writeFrequency, and clean up write-path shutdown

### DIFF
--- a/contributors/emails/carnie-bot@openclaw.local
+++ b/contributors/emails/carnie-bot@openclaw.local
@@ -1,0 +1,2 @@
+menhguin
+# agent bot from PR #82038

--- a/contributors/emails/daniel21436@hotmail.com
+++ b/contributors/emails/daniel21436@hotmail.com
@@ -1,0 +1,2 @@
+strzhao
+# PR #81214 adoption

--- a/contributors/emails/dillontownsel@gmail.com
+++ b/contributors/emails/dillontownsel@gmail.com
@@ -1,0 +1,2 @@
+dtownsel
+# PR #82130 adoption

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -215,7 +215,7 @@ Pick **[e]** at the prompt to set the three keys directly instead of going throu
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `writeFrequency` | string/int | `"async"` | `"async"` (background), `"turn"` (sync per turn), `"session"` (batch on end), or integer N (every N turns) |
-| `saveMessages` | bool | `true` | Persist messages to Honcho API |
+| `saveMessages` | bool | `true` | Persist messages to Honcho API. When `false`, all automatic writes are skipped — raw turns (`sync_turn`), conclusion mirroring (`on_memory_write`), and session-end/shutdown flushes — while read and tools paths stay fully functional. |
 
 ### Session Resolution
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1437,16 +1437,23 @@ class HonchoMemoryProvider(MemoryProvider):
         msg_limit = self._config.message_max_chars if self._config else 25000
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
-        if not clean_user_content or not clean_assistant_content:
+        # Skip only when the whole turn is empty. An interrupted or tool-only
+        # turn can legitimately have an empty assistant side; the user's
+        # message must still be persisted (the manager already drops
+        # empty-user turns upstream). Empty sides are skipped per-loop below
+        # so we never write empty-string messages either.
+        if not clean_user_content and not clean_assistant_content:
             return
 
         def _sync():
             try:
                 session = self._manager.get_or_create(self._session_key)
-                for chunk in self._chunk_message(clean_user_content, msg_limit):
-                    session.add_message("user", chunk)
-                for chunk in self._chunk_message(clean_assistant_content, msg_limit):
-                    session.add_message("assistant", chunk)
+                if clean_user_content:
+                    for chunk in self._chunk_message(clean_user_content, msg_limit):
+                        session.add_message("user", chunk)
+                if clean_assistant_content:
+                    for chunk in self._chunk_message(clean_assistant_content, msg_limit):
+                        session.add_message("assistant", chunk)
                 self._manager._flush_session(session)
             except Exception as e:
                 logger.debug("Honcho sync_turn failed: %s", e)

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1654,7 +1654,12 @@ class HonchoMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Flush any remaining messages
+        # Flush any remaining messages. Honors saveMessages: false — skip
+        # persistence, but the worker-thread joins above still run (cleanup
+        # is independent of persistence; placing the guard here rather than
+        # at the top avoids leaking _prefetch_thread/_sync_thread).
+        if not getattr(self._config, "save_messages", True):
+            return
         if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
             try:
                 self._manager.flush_all()

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1661,15 +1661,26 @@ class HonchoMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Flush any remaining messages. Honors saveMessages: false — skip
-        # persistence, but the worker-thread joins above still run (cleanup
-        # is independent of persistence; placing the guard here rather than
-        # at the top avoids leaking _prefetch_thread/_sync_thread).
+        manager = self._manager
+        if manager and self._init_thread and self._init_thread.is_alive() and not self._session_initialized:
+            manager = None
+        # Honors saveMessages: false — skip persistence, but thread cleanup
+        # still runs: the session manager's async-writer thread must be
+        # joined either way so daemon threads aren't left blocked in httpx
+        # I/O during interpreter finalization.
         if not getattr(self._config, "save_messages", True):
+            if manager:
+                try:
+                    manager.stop_async_writer()
+                except Exception:
+                    pass
             return
-        if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
+        if manager:
             try:
-                self._manager.flush_all()
+                # manager.shutdown() = flush_all() + join the async-writer
+                # thread. Previously only flush_all() ran here, leaving the
+                # writer thread alive at exit.
+                manager.shutdown()
             except Exception:
                 pass
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1454,7 +1454,10 @@ class HonchoMemoryProvider(MemoryProvider):
                 if clean_assistant_content:
                     for chunk in self._chunk_message(clean_assistant_content, msg_limit):
                         session.add_message("assistant", chunk)
-                self._manager._flush_session(session)
+                # Route through save() so writeFrequency is honored —
+                # _flush_session() directly bypassed "session"/N batching
+                # and flushed every turn regardless of config.
+                self._manager.save(session)
             except Exception as e:
                 logger.debug("Honcho sync_turn failed: %s", e)
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1414,6 +1414,9 @@ class HonchoMemoryProvider(MemoryProvider):
 
         Messages exceeding the Honcho API limit (default 25k chars) are
         split into multiple messages with continuation markers.
+
+        Honors saveMessages: false — the provider then never persists raw
+        turns to Honcho (read/tools paths stay fully functional).
         """
         if self._cron_skipped:
             return
@@ -1496,6 +1499,8 @@ class HonchoMemoryProvider(MemoryProvider):
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
         if self._cron_skipped:
+            return
+        if not getattr(self._config, "save_messages", True):
             return
         if not self._manager:
             return

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -29,6 +29,30 @@ from tools.registry import tool_error
 logger = logging.getLogger(__name__)
 
 
+# Gateway-internal notifications can arrive through the same user-role channel
+# as genuine user messages. They are execution metadata, not conversation, and
+# must never become durable personal memory. Keep this deliberately anchored:
+# a human discussing one of these strings mid-message is still valid input.
+_INTERNAL_GATEWAY_TURN_RE = re.compile(
+    r"^\s*(?:"
+    r"\[ASYNC (?:DELEGATION )?(?:BATCH )?COMPLETE[^\]]*\]|"
+    r"\[CONTEXT COMPACTION[^\]]*\]|"
+    r"\[CONTEXT SUMMARY\]:?|"
+    r"\[PRIOR CONTEXT[^\]]*\]|"
+    r"\[Your active task list was preserved across context compression\]|"
+    r"\[IMPORTANT: Background process \d+ matched watch pattern[^\n]*|"
+    r"A background fan-out of \d+ subagent\(s\) you dispatched earlier has finished\.|"
+    r"A background subagent you dispatched earlier has finished\."
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _is_internal_gateway_turn(text: str) -> bool:
+    """Return True for machine-generated gateway/delegation notifications."""
+    return bool(_INTERNAL_GATEWAY_TURN_RE.match(text or ""))
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
 # ---------------------------------------------------------------------------
@@ -1393,6 +1417,14 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
+        # ``saveMessages`` is the operator's hard write gate. Previously it
+        # was parsed into HonchoClientConfig but never enforced here, so a
+        # cached hybrid provider kept writing even after containment was set.
+        if self._config and not getattr(self._config, "save_messages", True):
+            return
+        if _is_internal_gateway_turn(user_content):
+            logger.debug("Honcho sync skipped machine-generated gateway turn")
+            return
         if self._recall_mode == "tools" and not self._session_ready():
             return
         if not self._session_ready():
@@ -1402,6 +1434,8 @@ class HonchoMemoryProvider(MemoryProvider):
         msg_limit = self._config.message_max_chars if self._config else 25000
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        if not clean_user_content or not clean_assistant_content:
+            return
 
         def _sync():
             try:
@@ -1438,6 +1472,11 @@ class HonchoMemoryProvider(MemoryProvider):
         if action != "add" or target != "user" or not content:
             return
         if self._cron_skipped:
+            return
+        # ``saveMessages`` is the operator's hard write gate; the memory-tool
+        # mirror is an automatic Honcho mutation path and must respect it too,
+        # otherwise containment would only cover conversation turns.
+        if self._config and not getattr(self._config, "save_messages", True):
             return
         if self._recall_mode == "tools" and not self._session_ready():
             return

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -538,6 +538,19 @@ class HonchoSessionManager:
             return f"{sanitized_peer_id}-{digest}"
         return sanitized_peer_id
 
+    def _declared_owner_peer_id(self) -> str | None:
+        """Peer ID of the install owner, or None when no owner is declared.
+
+        The owner is the identity setup writes as ``peerName``. A runtime
+        gateway identity is the owner only when an alias maps it onto that
+        peer — which _resolve_user_peer_id already does, so callers can
+        compare a session's resolved user peer against this value.
+        """
+        peer_name = getattr(self._config, "peer_name", None) if self._config else None
+        if peer_name and str(peer_name).strip():
+            return self._sanitize_id(str(peer_name).strip())
+        return None
+
     def _resolve_user_peer_id(self, key: str) -> str:
         """Resolve the Honcho user peer ID for this manager/session."""
         pin_peer_name = (
@@ -1116,20 +1129,34 @@ class HonchoSessionManager:
             return False
 
         # Only migrate the owner-describing memory files (MEMORY.md / USER.md)
-        # when the session's user peer IS the owner peer. Otherwise a
+        # when the session's user peer IS the install owner. Otherwise a
         # non-owner triggering a new session (e.g. any other human in a shared
         # Slack/Discord channel) gets the owner's full profile files uploaded
         # under the NON-OWNER's peer, and Honcho's deriver attributes the
         # owner's facts to that person. SOUL.md describes the agent, not a
         # human, but skipping it here too keeps the migration owner-scoped.
-        # The owner is resolved through _resolve_user_peer_id (pin/runtime/
-        # alias aware) — config.peer_name alone is optional and None for
-        # most single-user setups.
-        owner_peer_id = self._resolve_user_peer_id(session_key)
-        if session.user_peer_id != owner_peer_id:
+        #
+        # The owner is a CONFIG fact — the declared peerName — never a
+        # re-resolution of the session's own peer: _resolve_user_peer_id
+        # answers "who is this session's user", so comparing its output to
+        # session.user_peer_id compares the triggering user to themselves
+        # and passes for the non-owner too.
+        owner_peer_id = self._declared_owner_peer_id()
+        if owner_peer_id is not None:
+            session_is_owner = session.user_peer_id == owner_peer_id
+        else:
+            # No declared owner. Without a runtime identity this is the
+            # single-operator path (peer id from config defaults or the
+            # session key) and the files describe that operator. With a
+            # runtime identity the session belongs to whoever messaged
+            # through the gateway — nobody can be proven to be the owner.
+            session_is_owner = not self._runtime_user_ids()
+        if not session_is_owner:
             logger.info(
-                "Skipping memory-file migration for non-owner session (user=%s)",
+                "Skipping memory-file migration: session user peer '%s' is not the "
+                "declared owner (peerName=%s)",
                 session.user_peer_id,
+                owner_peer_id or "unset",
             )
             return False
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -771,6 +771,18 @@ class HonchoSessionManager:
                 )
                 self._async_thread.start()
 
+    def stop_async_writer(self) -> None:
+        """Stop the async writer thread WITHOUT flushing pending messages.
+
+        Used on shutdown when persistence is disabled (saveMessages: false):
+        the thread must still be joined so process exit is clean, but nothing
+        may be written.
+        """
+        if self._async_queue is not None:
+            if self._async_thread is not None and self._async_thread.is_alive():
+                self._async_queue.put(_ASYNC_SHUTDOWN)
+                self._async_thread.join(timeout=10)
+
     def shutdown(self) -> None:
         """Gracefully shut down the async writer thread."""
         if self._async_queue is not None:

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1115,6 +1115,20 @@ class HonchoSessionManager:
             logger.warning("No Honcho session cached for '%s', skipping memory migration", session_key)
             return False
 
+        # Only migrate the owner-describing memory files (MEMORY.md / USER.md)
+        # when the session's user peer IS the configured owner peer. Otherwise a
+        # non-owner triggering a new session (e.g. any other human in a shared
+        # Slack/Discord channel) gets the owner's full profile files uploaded
+        # under the NON-OWNER's peer, and Honcho's deriver attributes the
+        # owner's facts to that person. SOUL.md describes the agent, not a
+        # human, but skipping it here too keeps the migration owner-scoped.
+        if session.user_peer_id != self._sanitize_id(self._config.peer_name):
+            logger.info(
+                "Skipping memory-file migration for non-owner session (user=%s)",
+                session.user_peer_id,
+            )
+            return False
+
         uploaded = False
         files = [
             (

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1116,13 +1116,17 @@ class HonchoSessionManager:
             return False
 
         # Only migrate the owner-describing memory files (MEMORY.md / USER.md)
-        # when the session's user peer IS the configured owner peer. Otherwise a
+        # when the session's user peer IS the owner peer. Otherwise a
         # non-owner triggering a new session (e.g. any other human in a shared
         # Slack/Discord channel) gets the owner's full profile files uploaded
         # under the NON-OWNER's peer, and Honcho's deriver attributes the
         # owner's facts to that person. SOUL.md describes the agent, not a
         # human, but skipping it here too keeps the migration owner-scoped.
-        if session.user_peer_id != self._sanitize_id(self._config.peer_name):
+        # The owner is resolved through _resolve_user_peer_id (pin/runtime/
+        # alias aware) — config.peer_name alone is optional and None for
+        # most single-user setups.
+        owner_peer_id = self._resolve_user_peer_id(session_key)
+        if session.user_peer_id != owner_peer_id:
             logger.info(
                 "Skipping memory-file migration for non-owner session (user=%s)",
                 session.user_peer_id,

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -54,13 +54,23 @@ def make_manager(monkeypatch):
     monkeypatch.setattr(session_module, "get_honcho_client", lambda *a, **k: client)
     created = []
 
-    def _make(write_frequency="turn") -> HonchoSessionManager:
+    def _make(
+        write_frequency="turn",
+        *,
+        runtime_user_peer_name=None,
+        **cfg_kwargs,
+    ) -> HonchoSessionManager:
         cfg = HonchoClientConfig(
             write_frequency=write_frequency,
             api_key="test-key",
             enabled=True,
+            **cfg_kwargs,
         )
-        mgr = HonchoSessionManager(honcho=client, config=cfg)
+        mgr = HonchoSessionManager(
+            honcho=client,
+            config=cfg,
+            runtime_user_peer_name=runtime_user_peer_name,
+        )
         created.append(mgr)
         return mgr
 
@@ -420,28 +430,34 @@ class TestAsyncWriterRetry:
         assert call_count[0] == 2
 
 
+def _prime_migration_session(mgr, key, honcho_session_id, ai_peer_id="custom-ai"):
+    """Cache a session whose user peer is what the REAL resolver returns for
+    this manager — exactly what get_or_create stores — so the owner gate is
+    tested against reachable states, not hand-picked peer ids."""
+    session = _make_session(
+        key=key,
+        user_peer_id=mgr._resolve_user_peer_id(key),
+        assistant_peer_id=ai_peer_id,
+        honcho_session_id=honcho_session_id,
+    )
+    mgr._cache[session.key] = session
+    honcho_session = MagicMock()
+    mgr._sessions_cache[session.honcho_session_id] = honcho_session
+    return session, honcho_session
+
+
 class TestMemoryFileMigrationTargets:
     def test_soul_upload_targets_ai_peer(self, tmp_path, make_manager):
-        mgr = make_manager(write_frequency="turn")
-        # Migration is owner-gated: the session's user peer must match what
-        # _resolve_user_peer_id returns. Make the runtime identity match the
-        # crafted session so this reads as the owner's own session.
-        mgr._runtime_user_peer_name = "custom-user"
-        session = _make_session(
-            key="cli:test",
-            user_peer_id="custom-user",
-            assistant_peer_id="custom-ai",
-            honcho_session_id="cli-test",
-        )
-        mgr._cache[session.key] = session
+        # peerName declares the owner; no runtime identity, so the session
+        # resolves to the owner peer and migration proceeds.
+        mgr = make_manager(write_frequency="turn", peer_name="custom-user")
+        session, honcho_session = _prime_migration_session(mgr, "cli:test", "cli-test")
+        assert session.user_peer_id == "custom-user"
 
         user_peer = MagicMock(name="user-peer")
         ai_peer = MagicMock(name="ai-peer")
         mgr._peers_cache[session.user_peer_id] = user_peer
         mgr._peers_cache[session.assistant_peer_id] = ai_peer
-
-        honcho_session = MagicMock()
-        mgr._sessions_cache[session.honcho_session_id] = honcho_session
 
         (tmp_path / "MEMORY.md").write_text("memory facts", encoding="utf-8")
         (tmp_path / "USER.md").write_text("user profile", encoding="utf-8")
@@ -461,26 +477,108 @@ class TestMemoryFileMigrationTargets:
         assert peer_by_upload_name["user_profile.md"] is user_peer
         assert peer_by_upload_name["agent_soul.md"] is ai_peer
 
-    def test_migration_skipped_for_non_owner_session(self, tmp_path, make_manager):
-        """A non-owner user peer in the session must not receive the owner's
-        memory files — see #43752-adjacent shared-channel misattribution."""
-        mgr = make_manager(write_frequency="turn")
-        mgr._runtime_user_peer_name = "owner-user"
-        session = _make_session(
-            key="discord:shared",
-            user_peer_id="some-other-human",
-            assistant_peer_id="custom-ai",
-            honcho_session_id="shared-chan",
+
+class TestMemoryFileMigrationOwnerGate:
+    def test_non_owner_gateway_user_is_skipped(self, tmp_path, make_manager):
+        """The shared-channel scenario: a declared owner exists, but the
+        session was triggered by someone else's platform identity. The old
+        gate (re-resolving the session's own peer) passed here."""
+        mgr = make_manager(
+            write_frequency="turn",
+            peer_name="owner-user",
+            runtime_user_peer_name="some-other-human",
         )
-        mgr._cache[session.key] = session
-        mgr._sessions_cache[session.honcho_session_id] = MagicMock()
+        session, honcho_session = _prime_migration_session(
+            mgr, "discord:shared", "shared-chan"
+        )
+        assert session.user_peer_id == "some-other-human"
 
         (tmp_path / "MEMORY.md").write_text("owner facts", encoding="utf-8")
 
         uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
 
         assert uploaded is False
-        assert mgr._sessions_cache[session.honcho_session_id].upload_file.call_count == 0
+        assert honcho_session.upload_file.call_count == 0
+
+    def test_no_declared_owner_with_gateway_identity_is_skipped(
+            self, tmp_path, make_manager):
+        """Without peerName nobody messaging through a gateway can be proven
+        to be the owner — migration must not run."""
+        mgr = make_manager(
+            write_frequency="turn",
+            runtime_user_peer_name="discord-123",
+        )
+        session, honcho_session = _prime_migration_session(
+            mgr, "discord:shared", "shared-chan"
+        )
+
+        (tmp_path / "MEMORY.md").write_text("owner facts", encoding="utf-8")
+
+        uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
+
+        assert uploaded is False
+        assert honcho_session.upload_file.call_count == 0
+
+    def test_no_declared_owner_single_operator_migrates(self, tmp_path, make_manager):
+        """No peerName and no runtime identity is the plain CLI install —
+        the only person who exists is the operator the files describe."""
+        mgr = make_manager(write_frequency="turn")
+        session, honcho_session = _prime_migration_session(mgr, "cli:test", "cli-test")
+        mgr._peers_cache[session.user_peer_id] = MagicMock()
+        mgr._peers_cache[session.assistant_peer_id] = MagicMock()
+
+        (tmp_path / "MEMORY.md").write_text("memory facts", encoding="utf-8")
+
+        uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
+
+        assert uploaded is True
+        assert honcho_session.upload_file.call_count == 1
+
+    def test_aliased_owner_identity_migrates(self, tmp_path, make_manager):
+        """An alias mapping the owner's platform ID onto peerName makes that
+        gateway identity the owner."""
+        mgr = make_manager(
+            write_frequency="turn",
+            peer_name="owner-user",
+            user_peer_aliases={"discord-999": "owner-user"},
+            runtime_user_peer_name="discord-999",
+        )
+        session, honcho_session = _prime_migration_session(
+            mgr, "discord:dm", "discord-dm"
+        )
+        assert session.user_peer_id == "owner-user"
+        mgr._peers_cache[session.user_peer_id] = MagicMock()
+        mgr._peers_cache[session.assistant_peer_id] = MagicMock()
+
+        (tmp_path / "USER.md").write_text("user profile", encoding="utf-8")
+
+        uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
+
+        assert uploaded is True
+        assert honcho_session.upload_file.call_count == 1
+
+    def test_pinned_peer_name_migrates(self, tmp_path, make_manager):
+        """pinPeerName collapses every identity onto the owner peer by
+        explicit config, so the files land on the peer they describe."""
+        mgr = make_manager(
+            write_frequency="turn",
+            peer_name="owner-user",
+            pin_peer_name=True,
+            runtime_user_peer_name="anyone-at-all",
+        )
+        session, honcho_session = _prime_migration_session(
+            mgr, "discord:shared", "shared-chan"
+        )
+        assert session.user_peer_id == "owner-user"
+        mgr._peers_cache[session.user_peer_id] = MagicMock()
+        mgr._peers_cache[session.assistant_peer_id] = MagicMock()
+
+        (tmp_path / "MEMORY.md").write_text("memory facts", encoding="utf-8")
+
+        uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
+
+        assert uploaded is True
+        assert honcho_session.upload_file.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -423,6 +423,10 @@ class TestAsyncWriterRetry:
 class TestMemoryFileMigrationTargets:
     def test_soul_upload_targets_ai_peer(self, tmp_path, make_manager):
         mgr = make_manager(write_frequency="turn")
+        # Migration is owner-gated: the session's user peer must match what
+        # _resolve_user_peer_id returns. Make the runtime identity match the
+        # crafted session so this reads as the owner's own session.
+        mgr._runtime_user_peer_name = "custom-user"
         session = _make_session(
             key="cli:test",
             user_peer_id="custom-user",
@@ -456,6 +460,27 @@ class TestMemoryFileMigrationTargets:
         assert peer_by_upload_name["consolidated_memory.md"] is user_peer
         assert peer_by_upload_name["user_profile.md"] is user_peer
         assert peer_by_upload_name["agent_soul.md"] is ai_peer
+
+    def test_migration_skipped_for_non_owner_session(self, tmp_path, make_manager):
+        """A non-owner user peer in the session must not receive the owner's
+        memory files — see #43752-adjacent shared-channel misattribution."""
+        mgr = make_manager(write_frequency="turn")
+        mgr._runtime_user_peer_name = "owner-user"
+        session = _make_session(
+            key="discord:shared",
+            user_peer_id="some-other-human",
+            assistant_peer_id="custom-ai",
+            honcho_session_id="shared-chan",
+        )
+        mgr._cache[session.key] = session
+        mgr._sessions_cache[session.honcho_session_id] = MagicMock()
+
+        (tmp_path / "MEMORY.md").write_text("owner facts", encoding="utf-8")
+
+        uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
+
+        assert uploaded is False
+        assert mgr._sessions_cache[session.honcho_session_id].upload_file.call_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -316,6 +316,28 @@ class TestAsyncWriterThread:
         mgr.shutdown()
         assert mgr._async_thread is None
 
+    def test_stop_async_writer_joins_thread_without_flushing(self, make_manager):
+        mgr = make_manager(write_frequency="async")
+        mgr._ensure_async_writer()
+        sess = _make_session()
+        sess.add_message("user", "must not be written")
+        with mgr._cache_lock:
+            mgr._cache[sess.key] = sess
+
+        flushed = []
+        mgr._flush_session = lambda session: flushed.append(session) or True
+
+        thread = mgr._async_thread
+        mgr.stop_async_writer()
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+        assert flushed == []
+
+    def test_stop_async_writer_without_started_thread_is_noop(self, make_manager):
+        mgr = make_manager(write_frequency="async")
+        mgr.stop_async_writer()
+        assert mgr._async_thread is None
+
 
 # ---------------------------------------------------------------------------
 # async retry on failure

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -1,0 +1,65 @@
+"""Tests for the saveMessages knob: when false, the provider never writes to Honcho.
+
+The knob has always been parsed by HonchoClientConfig but was not consumed by
+the write paths (sync_turn / on_memory_write / on_session_end). These tests pin
+the contract: saveMessages=false disables all automatic persistence while read
+and tools paths remain untouched.
+"""
+
+from unittest.mock import MagicMock
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig
+
+
+def _provider(save_messages: bool) -> HonchoMemoryProvider:
+    p = HonchoMemoryProvider()
+    p._config = HonchoClientConfig(save_messages=save_messages)
+    p._manager = MagicMock()
+    p._session_key = 'test-session'
+    p._session_initialized = True
+    return p
+
+
+class TestSyncTurn:
+    def test_disabled_writes_nothing(self):
+        p = _provider(save_messages=False)
+        p.sync_turn('user says', 'assistant says')
+        p._manager.get_or_create.assert_not_called()
+        p._manager._flush_session.assert_not_called()
+
+    def test_enabled_writes(self):
+        p = _provider(save_messages=True)
+        p.sync_turn('user says', 'assistant says')
+        if p._sync_thread is not None:
+            p._sync_thread.join(timeout=5)
+        p._manager.get_or_create.assert_called_once()
+
+
+class TestOnMemoryWrite:
+    def test_disabled_skips_conclusion_mirror(self):
+        p = _provider(save_messages=False)
+        p.on_memory_write('add', 'user', 'user likes coffee')
+        p._manager.create_conclusion.assert_not_called()
+
+    def test_enabled_mirrors(self):
+        import time
+
+        p = _provider(save_messages=True)
+        p.on_memory_write('add', 'user', 'user likes coffee')
+        deadline = time.time() + 5
+        while time.time() < deadline and not p._manager.create_conclusion.called:
+            time.sleep(0.05)
+        p._manager.create_conclusion.assert_called_once()
+
+
+class TestOnSessionEnd:
+    def test_disabled_skips_flush(self):
+        p = _provider(save_messages=False)
+        p.on_session_end([])
+        p._manager.flush_all.assert_not_called()
+
+    def test_enabled_flushes(self):
+        p = _provider(save_messages=True)
+        p.on_session_end([])
+        p._manager.flush_all.assert_called_once()

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -26,7 +26,16 @@ class TestSyncTurn:
         p = _provider(save_messages=False)
         p.sync_turn('user says', 'assistant says')
         p._manager.get_or_create.assert_not_called()
-        p._manager._flush_session.assert_not_called()
+        p._manager.save.assert_not_called()
+
+    def test_enabled_routes_through_save(self):
+        p = _provider(save_messages=True)
+        p.sync_turn('user says', 'assistant says')
+        if p._sync_thread is not None:
+            p._sync_thread.join(timeout=5)
+        p._manager.get_or_create.assert_called_once()
+        # save() (not _flush_session) so writeFrequency batching is honored
+        p._manager.save.assert_called_once()
 
     def test_enabled_writes(self):
         p = _provider(save_messages=True)

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -66,8 +66,10 @@ class TestOnSessionEnd:
 
 
 class TestShutdown:
-    """shutdown() joins worker threads then flushes; saveMessages=false must
-    skip the flush (persistence) while still running the joins (cleanup)."""
+    """shutdown() joins worker threads then delegates to the session manager:
+    manager.shutdown() (flush + join async writer) when persistence is on,
+    manager.stop_async_writer() (join only, no flush) when saveMessages=false.
+    Cleanup runs in both cases; only persistence is gated."""
 
     def _provider_for_shutdown(self, save_messages: bool) -> HonchoMemoryProvider:
         p = _provider(save_messages=save_messages)
@@ -78,12 +80,16 @@ class TestShutdown:
         p._sync_thread = None
         return p
 
-    def test_disabled_skips_flush(self):
+    def test_disabled_skips_flush_but_stops_writer(self):
         p = self._provider_for_shutdown(save_messages=False)
         p.shutdown()
         p._manager.flush_all.assert_not_called()
+        p._manager.shutdown.assert_not_called()
+        p._manager.stop_async_writer.assert_called_once()
 
-    def test_enabled_flushes(self):
+    def test_enabled_shuts_down_manager(self):
         p = self._provider_for_shutdown(save_messages=True)
         p.shutdown()
-        p._manager.flush_all.assert_called_once()
+        # manager.shutdown() flushes AND joins the async-writer thread;
+        # calling flush_all() alone left the writer thread alive at exit.
+        p._manager.shutdown.assert_called_once()

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -63,3 +63,27 @@ class TestOnSessionEnd:
         p = _provider(save_messages=True)
         p.on_session_end([])
         p._manager.flush_all.assert_called_once()
+
+
+class TestShutdown:
+    """shutdown() joins worker threads then flushes; saveMessages=false must
+    skip the flush (persistence) while still running the joins (cleanup)."""
+
+    def _provider_for_shutdown(self, save_messages: bool) -> HonchoMemoryProvider:
+        p = _provider(save_messages=save_messages)
+        # shutdown() iterates these thread handles; if no turn/session-end ran
+        # they may be unset, so default to None (= "no thread started").
+        p._init_thread = None
+        p._prefetch_thread = None
+        p._sync_thread = None
+        return p
+
+    def test_disabled_skips_flush(self):
+        p = self._provider_for_shutdown(save_messages=False)
+        p.shutdown()
+        p._manager.flush_all.assert_not_called()
+
+    def test_enabled_flushes(self):
+        p = self._provider_for_shutdown(save_messages=True)
+        p.shutdown()
+        p._manager.flush_all.assert_called_once()

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -324,3 +324,227 @@ def test_honcho_tools_lazy_hooks_do_not_prestart_background_init(monkeypatch):
     assert result == {"result": ["ready"]}
     assert init_calls == ["session-1"]
     assert not background_started.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Write-containment regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_honcho_sync_turn_skips_write_when_save_messages_is_disabled():
+    """The resolved write-disable switch must gate an initialized provider."""
+    provider = HonchoMemoryProvider()
+    cfg = _configured_tools_config(init_on_session_start=True)
+    cfg.save_messages = False
+    manager_calls = []
+
+    class Manager:
+        def get_or_create(self, session_key):
+            manager_calls.append(session_key)
+            return SimpleNamespace()
+
+    provider._config = cfg
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.sync_turn("a genuine user turn", "a genuine assistant reply")
+
+    assert provider._sync_thread is None
+    assert manager_calls == []
+
+
+def test_honcho_sync_turn_skips_anchored_gateway_notifications():
+    """Known bracketed gateway wrappers must not become durable messages."""
+    wrappers = (
+        "[ASYNC DELEGATION BATCH COMPLETE — deleg_1]\nworker results follow",
+        "[ASYNC DELEGATION COMPLETE — deleg_2]",
+        "[CONTEXT COMPACTION — REFERENCE ONLY]\nsummary follows",
+        "[CONTEXT COMPACTION - REFERENCE ONLY]",
+        "[CONTEXT COMPACTION]",
+        "[PRIOR CONTEXT — for reference only; not a new message]",
+        "[Your active task list was preserved across context compression]",
+        "[CONTEXT SUMMARY]: previous context",
+        "[IMPORTANT: Background process 12 matched watch pattern \"foo\"\nCommand: x",
+    )
+
+    for wrapper in wrappers:
+        provider = HonchoMemoryProvider()
+        manager_calls = []
+
+        class Manager:
+            def get_or_create(self, session_key):
+                manager_calls.append(session_key)
+                return SimpleNamespace()
+
+        provider._config = _configured_tools_config(init_on_session_start=True)
+        provider._manager = Manager()
+        provider._session_key = "test-session"
+        provider._session_initialized = True
+
+        provider.sync_turn(wrapper, "assistant reply")
+
+        assert provider._sync_thread is None, f"wrapper not suppressed: {wrapper[:60]!r}"
+        assert manager_calls == [], f"wrapper not suppressed: {wrapper[:60]!r}"
+
+
+def test_honcho_sync_turn_skips_prose_gateway_notifications():
+    """Prose-form gateway notifications must not become durable messages."""
+    prose_wrappers = (
+        "A background fan-out of 3 subagent(s) you dispatched earlier has finished.",
+        "A background subagent you dispatched earlier has finished. You may have moved on.",
+    )
+
+    for wrapper in prose_wrappers:
+        provider = HonchoMemoryProvider()
+        manager_calls = []
+
+        class Manager:
+            def get_or_create(self, session_key):
+                manager_calls.append(session_key)
+                return SimpleNamespace()
+
+        provider._config = _configured_tools_config(init_on_session_start=True)
+        provider._manager = Manager()
+        provider._session_key = "test-session"
+        provider._session_initialized = True
+
+        provider.sync_turn(wrapper, "assistant reply")
+
+        assert provider._sync_thread is None, f"prose wrapper not suppressed: {wrapper[:60]!r}"
+        assert manager_calls == [], f"prose wrapper not suppressed: {wrapper[:60]!r}"
+
+
+def test_honcho_sync_turn_does_not_suppress_genuine_user_messages():
+    """Genuine user messages that mention gateway terms must still be stored."""
+    genuine = (
+        "A background process I ran has finished — can you check the output?",
+        "A background subagent you dispatched earlier has finished? no wait, I was asking about the report",
+        "the async delegation batch complete marker disappeared from my log",
+        "CONTEXT COMPACTION happened mid-message and I want to see it",
+        "When you see PRIOR CONTEXT, treat it carefully",
+        "I want to know about your task list",
+        "IMPORTANT: Background process — can you explain what that means?",
+        "[IMPORTANT: Background process — what does that mean?]",
+    )
+
+    for msg in genuine:
+        provider = HonchoMemoryProvider()
+        manager_calls = []
+
+        class Manager:
+            def get_or_create(self, session_key):
+                manager_calls.append(session_key)
+                return SimpleNamespace()
+
+        provider._config = _configured_tools_config(init_on_session_start=True)
+        provider._manager = Manager()
+        provider._session_key = "test-session"
+        provider._session_initialized = True
+
+        provider.sync_turn(msg, "assistant reply")
+
+        assert provider._sync_thread is not None, f"genuine message suppressed: {msg[:60]!r}"
+        assert manager_calls != [], f"genuine message suppressed: {msg[:60]!r}"
+
+
+def test_honcho_sync_turn_skips_empty_content():
+    """Empty or whitespace-only turns must not be stored."""
+    provider = HonchoMemoryProvider()
+    manager_calls = []
+
+    class Manager:
+        def get_or_create(self, session_key):
+            manager_calls.append(session_key)
+            return SimpleNamespace()
+
+    provider._config = _configured_tools_config(init_on_session_start=True)
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.sync_turn("   ", "  ")
+
+    assert provider._sync_thread is None
+    assert manager_calls == []
+
+
+def test_honcho_sync_turn_same_instance_config_flip_gates_writes():
+    """The cached-provider regression: flipping save_messages on the SAME
+    configured instance must stop writes without re-initialization."""
+    provider = HonchoMemoryProvider()
+    cfg = _configured_tools_config(init_on_session_start=True)
+    cfg.save_messages = True
+    manager_calls = []
+    write_done = threading.Event()
+
+    class Manager:
+        def get_or_create(self, session_key):
+            manager_calls.append(session_key)
+            return SimpleNamespace(add_message=lambda role, content: None)
+
+        def _flush_session(self, session):
+            write_done.set()
+
+    provider._config = cfg
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    # enabled -> write happens
+    provider.sync_turn("user turn", "assistant reply")
+    assert write_done.wait(timeout=5), "first write never completed"
+
+    # operator flips containment on the same cached config object
+    cfg.save_messages = False
+    manager_calls.clear()
+    provider.sync_turn("user turn two", "assistant reply two")
+
+    # no new write may occur; the stale _sync_thread from the enabled write is fine
+    assert manager_calls == []
+
+
+def test_honcho_on_memory_write_honors_save_messages_false():
+    """The memory-tool mirror is an automatic write path and must respect the
+    write-disable switch; otherwise containment only covers conversation turns."""
+    provider = HonchoMemoryProvider()
+    cfg = _configured_tools_config(init_on_session_start=True)
+    cfg.save_messages = False
+    conclusion_calls = []
+
+    class Manager:
+        def create_conclusion(self, session_key, content):
+            conclusion_calls.append((session_key, content))
+
+    provider._config = cfg
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.on_memory_write("add", "user", "prefers fail-open memory")
+
+    assert conclusion_calls == []
+
+
+def test_honcho_on_memory_write_still_writes_when_enabled():
+    """With save_messages enabled, the memory-tool mirror still writes."""
+    provider = HonchoMemoryProvider()
+    cfg = _configured_tools_config(init_on_session_start=True)
+    cfg.save_messages = True
+    conclusion_calls = []
+    write_done = threading.Event()
+
+    class Manager:
+        def create_conclusion(self, session_key, content):
+            conclusion_calls.append((session_key, content))
+            write_done.set()
+
+    provider._config = cfg
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.on_memory_write("add", "user", "prefers fail-open memory")
+
+    assert write_done.wait(timeout=5), "memory mirror write never completed"
+    assert conclusion_calls != []

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -483,7 +483,7 @@ def test_honcho_sync_turn_same_instance_config_flip_gates_writes():
             manager_calls.append(session_key)
             return SimpleNamespace(add_message=lambda role, content: None)
 
-        def _flush_session(self, session):
+        def save(self, session):
             write_done.set()
 
     provider._config = cfg


### PR DESCRIPTION
## summary

**the bug, in plain english:** setting `saveMessages: false` was supposed to stop hermes from persisting conversations to Honcho. the knob was parsed but never checked — every automatic write path kept writing. separately, when Honcho activates on an install with existing local memory, hermes uploads MEMORY.md/USER.md (files that describe the install owner) into the new session under the session's user peer. in a shared channel, the first person to message the agent creates that session — so a stranger could trigger the upload and have the owner's profile attributed to *them*.

**the fix:** every automatic write path now checks `saveMessages` before touching Honcho (reads and explicit tools still work). the migration only uploads when the session's user peer is the declared owner — the `peerName` from config, including platform IDs aliased onto it. with no `peerName` declared, it uploads only on the single-operator CLI path, where no gateway identity exists; nobody reachable through a gateway can silently receive the owner's files.

- gates all four automatic write paths (`sync_turn`, `on_memory_write`, `on_session_end`, `shutdown` flush) on `saveMessages`; read/tools paths untouched
- rejects machine-generated gateway notifications (delegation-complete, context-compaction wrappers, etc.) from being persisted as user turns — anchored regex, genuine user messages mentioning those phrases still store
- routes `sync_turn` through `manager.save()` so `writeFrequency` batching modes actually apply
- provider shutdown now calls `manager.shutdown()` (flush + join writer thread) when persistence is on, or a new `manager.stop_async_writer()` (join only, no flush) when `saveMessages` is false — containment and clean teardown compose
- owner-gates the one-time memory-file migration so a non-owner user triggering a session in a shared channel doesn't get the owner's MEMORY.md/USER.md uploaded under their peer; the owner is the declared `peerName` (aliases onto it still count), and with no `peerName` the migration only runs when no runtime gateway identity is present

## commits

adopted with original authorship, follow-ups separate:

- #82130 (@dtownsel) — saveMessages gates on sync_turn/on_memory_write + gateway-internal-turn rejection + regression tests
- #81214 (@strzhao, salvaging #67559 by @Matroskin86) — saveMessages gates on session-end + shutdown flush
- #82038 (@menhguin) — non-owner migration skip
- follow-ups: one-sided-turn persistence fix (the adopted guard dropped a real user message when the assistant side was empty), writeFrequency routing (also reported in #19650 by @starship-s and #72708 by @Diaspar4u), async-writer join, and the migration owner gate anchored on the declared `peerName` (an earlier revision re-resolved the session's own peer id, which compares the triggering user to themselves and passes for non-owners)

## closes / supersedes

- closes #35209 (saveMessages ignored)
- supersedes #73935, #67559, #35210 on the saveMessages axis
- covers the sync_turn scope of #19650 / #72708 (their broader lifecycle refactors not adopted)

## verification

- 333 tests green: `tests/honcho_plugin/` (12 files), `tests/test_honcho_*`, `tests/agent/test_memory_manager.py`, including 9 new saveMessages tests, 15 containment/startup tests, non-owner migration test, stop-without-flush writer test
- ruff clean, `git diff --check` clean, linear history on main

thanks @dtownsel, @strzhao, @Matroskin86, @Yahome, @menhguin, @starship-s, @Diaspar4u for finding and working these.

