### PR TITLE
fix(slack): ignore metadata-only parent updates

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -554,6 +554,58 @@ def _normalize_slack_text_for_dedupe(text: str) -> str:
     return re.sub(r"\s+", " ", canonical).strip()
 
 
+_SLACK_VISIBLE_MESSAGE_FIELDS = ("text", "blocks", "attachments", "files")
+_SLACK_REPLY_METADATA_FIELDS = (
+    "reply_count",
+    "reply_users_count",
+    "reply_users",
+    "latest_reply",
+    "replies",
+)
+
+
+def _slack_visible_message_value(message: dict, field: str) -> Any:
+    """Normalize absent and empty Slack display fields to the same value."""
+    value = message.get(field)
+    return None if value in (None, "", [], {}) else value
+
+
+def _is_hidden_thread_parent_metadata_update(event: dict, message: dict) -> bool:
+    """Return whether Slack changed only reply bookkeeping on a thread parent.
+
+    Slack emits hidden ``message_changed`` events when a thread receives a
+    reply. Replaying the nested parent as user input is unsafe after restart,
+    when the process-local processed-message cache is empty. Preserve real
+    edits whenever Slack supplies a visible before/after delta. If the prior
+    snapshot is malformed or absent, accept only an explicit edit whose edit
+    timestamp identifies this event; ambiguous hidden parent updates fail
+    closed.
+    """
+    if not event.get("hidden"):
+        return False
+    previous = event.get("previous_message")
+    previous_for_metadata = previous if isinstance(previous, dict) else {}
+    if not any(
+        field in message or field in previous_for_metadata
+        for field in _SLACK_REPLY_METADATA_FIELDS
+    ):
+        return False
+
+    if isinstance(previous, dict) and any(
+        field in previous for field in _SLACK_VISIBLE_MESSAGE_FIELDS
+    ):
+        return not any(
+            _slack_visible_message_value(previous, field)
+            != _slack_visible_message_value(message, field)
+            for field in _SLACK_VISIBLE_MESSAGE_FIELDS
+        )
+
+    edited = message.get("edited")
+    edited_ts = str(edited.get("ts") or "") if isinstance(edited, dict) else ""
+    changed_ts = str(event.get("event_ts") or event.get("ts") or "")
+    return not (edited_ts and changed_ts and edited_ts == changed_ts)
+
+
 def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> str:
     """Return a compact, redacted JSON view of the current message's Block Kit payload."""
     if not blocks:
@@ -5275,6 +5327,16 @@ class SlackAdapter(BasePlatformAdapter):
         if event.get("subtype") == "message_changed":
             updated_message = event.get("message")
             if not isinstance(updated_message, dict):
+                return
+
+            if _is_hidden_thread_parent_metadata_update(event, updated_message):
+                logger.debug(
+                    "[Slack] Ignoring hidden thread-parent reply metadata update "
+                    "channel=%s parent_ts=%s event_ts=%s",
+                    event.get("channel", ""),
+                    updated_message.get("ts", ""),
+                    event.get("event_ts") or event.get("ts", ""),
+                )
                 return
 
             original_message_ts = str(updated_message.get("ts") or "")

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3906,6 +3906,10 @@ class SlackAdapter(BasePlatformAdapter):
         updated_message = event.get("message")
         if not isinstance(updated_message, dict):
             return None
+        from .adapter_events import _is_hidden_thread_parent_metadata_update
+
+        if _is_hidden_thread_parent_metadata_update(event, updated_message):
+            return None
         original_message_ts = str(updated_message.get("ts") or "")
         if original_message_ts and original_message_ts in self._processed_message_ts:
             return None

--- a/plugins/platforms/slack/adapter_events.py
+++ b/plugins/platforms/slack/adapter_events.py
@@ -1,0 +1,58 @@
+"""Slack inbound event classification before nested-message normalization."""
+
+from typing import Any
+
+
+_SLACK_VISIBLE_MESSAGE_FIELDS = ("text", "blocks", "attachments", "files")
+_SLACK_REPLY_METADATA_FIELDS = (
+    "reply_count",
+    "reply_users_count",
+    "reply_users",
+    "latest_reply",
+    "replies",
+)
+
+
+def _slack_visible_message_value(message: dict, field: str) -> Any:
+    """Normalize absent and empty Slack display fields to the same value."""
+    value = message.get(field)
+    return None if value in (None, "", [], {}) else value
+
+
+def _is_hidden_thread_parent_metadata_update(event: dict, message: dict) -> bool:
+    """Return whether Slack changed only reply bookkeeping on a thread parent.
+
+    Slack emits hidden ``message_changed`` events when a thread receives a
+    reply. Replaying the nested parent as user input is unsafe after restart,
+    when the process-local processed-message cache is empty. Preserve real
+    edits whenever Slack supplies a visible before/after delta. If the prior
+    snapshot is malformed or absent, accept only an explicit edit whose edit
+    timestamp identifies this event; ambiguous hidden parent updates fail
+    closed.
+    """
+    if not event.get("hidden"):
+        return False
+    previous = event.get("previous_message")
+    previous_for_metadata = previous if isinstance(previous, dict) else {}
+    if not any(
+        field in message or field in previous_for_metadata
+        for field in _SLACK_REPLY_METADATA_FIELDS
+    ):
+        return False
+
+    # Slack snapshots omit absent display fields; compare their normalized union
+    # so additions and removals both count. Metadata-only partial snapshots do
+    # not establish a visible delta and use the explicit-edit fallback below.
+    if isinstance(previous, dict) and any(
+        field in previous for field in _SLACK_VISIBLE_MESSAGE_FIELDS
+    ):
+        return not any(
+            _slack_visible_message_value(previous, field)
+            != _slack_visible_message_value(message, field)
+            for field in _SLACK_VISIBLE_MESSAGE_FIELDS
+        )
+
+    edited = message.get("edited")
+    edited_ts = str(edited.get("ts") or "") if isinstance(edited, dict) else ""
+    changed_ts = str(event.get("event_ts") or event.get("ts") or "")
+    return not (edited_ts and changed_ts and edited_ts == changed_ts)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1968,6 +1968,148 @@ class TestMessageRouting:
         assert msg_event.message_id == "1234567890.000001"
 
 
+class TestHiddenThreadParentUpdates:
+    @staticmethod
+    def _event(*, current=None, previous=None):
+        parent = {
+            "type": "message",
+            "user": "U_USER",
+            "text": "old thread parent",
+            "ts": "1234567890.000001",
+            "reply_count": 2,
+            "latest_reply": "1234567899.000002",
+            "replies": [
+                {"user": "U_USER", "ts": "1234567899.000001"},
+                {"user": "U_USER", "ts": "1234567899.000002"},
+            ],
+        }
+        if current:
+            parent.update(current)
+        prior = {
+            "type": "message",
+            "user": "U_USER",
+            "text": "old thread parent",
+            "ts": "1234567890.000001",
+            "reply_count": 1,
+            "latest_reply": "1234567899.000001",
+            "replies": [{"user": "U_USER", "ts": "1234567899.000001"}],
+        }
+        if previous is not None:
+            prior = previous
+        return {
+            "type": "message",
+            "subtype": "message_changed",
+            "hidden": True,
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "1234567899.000003",
+            "event_ts": "1234567899.000003",
+            "message": parent,
+            "previous_message": prior,
+        }
+
+    @pytest.mark.asyncio
+    async def test_cold_restart_parent_update_cannot_route_store_or_interrupt(
+        self, adapter
+    ):
+        """A metadata-only parent update must stop before any gateway side effect."""
+        adapter._processed_message_ts.clear()
+        event = self._event(
+            current={
+                "text": "Following up on the thread: please post the test results here."
+            }
+        )
+        event["previous_message"]["text"] = event["message"]["text"]
+
+        session_store = MagicMock()
+        active_agent = MagicMock()
+        busy_ack = AsyncMock()
+
+        async def gateway_boundary(message_event):
+            session_store.append_message("active-slack-thread", "user", message_event.text)
+            active_agent.interrupt(message_event.text)
+            await busy_ack()
+
+        adapter.handle_message = AsyncMock(side_effect=gateway_boundary)
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_awaited()
+        session_store.append_message.assert_not_called()
+        active_agent.interrupt.assert_not_called()
+        busy_ack.assert_not_awaited()
+        assert adapter._processed_message_ts == {}
+
+    @pytest.mark.asyncio
+    async def test_hidden_thread_parent_update_with_text_edit_processed(self, adapter):
+        await adapter._handle_slack_message(
+            self._event(current={"text": "edited thread parent"})
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        assert adapter.handle_message.await_args.args[0].text == "edited thread parent"
+
+    @pytest.mark.asyncio
+    async def test_hidden_thread_parent_update_with_new_mention_processed(self, adapter):
+        adapter.config.extra["require_mention"] = True
+        event = self._event(current={"text": "<@U_BOT> old thread parent"})
+        event["channel"] = "C123"
+        event["channel_type"] = "channel"
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_awaited_once()
+        assert adapter.handle_message.await_args.args[0].text == "old thread parent"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("field", "visible_value"),
+        [
+            ("attachments", [{"text": "visible attachment"}]),
+            ("blocks", [{"type": "section", "text": {"type": "mrkdwn", "text": "visible block"}}]),
+            ("files", [{"id": "F_SANITIZED", "name": "visible.txt"}]),
+        ],
+    )
+    async def test_hidden_thread_parent_update_with_visible_payload_removal_processed(
+        self, adapter, field, visible_value
+    ):
+        event = self._event()
+        event["previous_message"][field] = visible_value
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "previous", ["malformed", {}, {"ts": "1234567890.000001"}]
+    )
+    async def test_hidden_thread_parent_update_with_malformed_snapshot_ignored(
+        self, adapter, previous
+    ):
+        await adapter._handle_slack_message(self._event(previous=previous))
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_hidden_thread_parent_update_with_explicit_edit_and_malformed_snapshot_processed(
+        self, adapter
+    ):
+        await adapter._handle_slack_message(
+            self._event(
+                current={
+                    "text": "edited thread parent",
+                    "edited": {"user": "U_USER", "ts": "1234567899.000003"},
+                },
+                previous="malformed",
+            )
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        assert adapter.handle_message.await_args.args[0].text == "edited thread parent"
+
+
 # ---------------------------------------------------------------------------
 # TestSendTyping — assistant.threads.setStatus
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2283,6 +2283,145 @@ class TestMessageRouting:
         assert msg_event.message_id == "1234567890.000001"
 
 
+class TestHiddenThreadParentUpdates:
+    @staticmethod
+    def _event(*, current=None, previous=None):
+        parent = {
+            "type": "message",
+            "user": "U_USER",
+            "text": "old thread parent",
+            "ts": "1234567890.000001",
+            "reply_count": 2,
+            "latest_reply": "1234567899.000002",
+            "replies": [
+                {"user": "U_USER", "ts": "1234567899.000001"},
+                {"user": "U_USER", "ts": "1234567899.000002"},
+            ],
+        }
+        if current:
+            parent.update(current)
+        prior = {
+            "type": "message",
+            "user": "U_USER",
+            "text": "old thread parent",
+            "ts": "1234567890.000001",
+            "reply_count": 1,
+            "latest_reply": "1234567899.000001",
+            "replies": [{"user": "U_USER", "ts": "1234567899.000001"}],
+        }
+        if previous is not None:
+            prior = previous
+        return {
+            "type": "message",
+            "subtype": "message_changed",
+            "hidden": True,
+            "channel": "D123",
+            "channel_type": "im",
+            "team": "T123",
+            "ts": "1234567899.000003",
+            "event_ts": "1234567899.000003",
+            "message": parent,
+            "previous_message": prior,
+        }
+
+    @pytest.mark.asyncio
+    async def test_cold_restart_parent_update_cannot_route_store_or_interrupt(
+        self, adapter
+    ):
+        """A metadata-only parent update must stop before any gateway side effect."""
+        adapter._processed_message_ts.clear()
+        event = self._event(
+            current={
+                "text": "Following up on the thread: please post the test results here."
+            }
+        )
+        event["previous_message"]["text"] = event["message"]["text"]
+
+        session_store = MagicMock()
+        active_agent = MagicMock()
+        busy_ack = AsyncMock()
+
+        async def gateway_boundary(message_event):
+            session_store.append_message("active-slack-thread", "user", message_event.text)
+            active_agent.interrupt(message_event.text)
+            await busy_ack()
+
+        adapter.handle_message = AsyncMock(side_effect=gateway_boundary)
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_awaited()
+        session_store.append_message.assert_not_called()
+        active_agent.interrupt.assert_not_called()
+        busy_ack.assert_not_awaited()
+        assert adapter._processed_message_ts == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "case, allowed",
+        [("text", True), ("mention", True), ("visible-envelope", True),
+         ("non-parent", True), ("missing", False), ("malformed", False),
+         ("empty", False), ("partial", False), ("explicit-edit", True),
+         ("old-edit", False), ("outer-ts-edit", True), ("empty-fields", False)]
+        + [(f"{field}-{change}", True)
+           for field in ("blocks", "attachments", "files")
+           for change in ("add", "remove", "edit")],
+    )
+    async def test_hidden_parent_visible_edits_and_ambiguous_snapshots(
+        self, adapter, case, allowed
+    ):
+        event = self._event()
+        current, previous = event["message"], event["previous_message"]
+        if case == "text":
+            current["text"] = "edited parent"
+        elif case == "mention":
+            adapter.config.extra["require_mention"] = True
+            event.update(channel="C123", channel_type="channel")
+            current["text"] = "<@U_BOT> old thread parent"
+        elif case == "visible-envelope":
+            event["hidden"] = False
+        elif case == "non-parent":
+            for snapshot in (current, previous):
+                for field in ("reply_count", "latest_reply", "replies"):
+                    snapshot.pop(field)
+        elif case == "missing":
+            event.pop("previous_message")
+        elif case in ("malformed", "empty", "partial"):
+            event["previous_message"] = {
+                "malformed": "bad", "empty": {}, "partial": {"ts": current["ts"]}
+            }[case]
+        elif case in ("explicit-edit", "old-edit", "outer-ts-edit"):
+            event["previous_message"] = None
+            current["edited"] = {
+                "ts": current["ts"] if case == "old-edit" else event["event_ts"]
+            }
+            if case == "outer-ts-edit":
+                event.pop("event_ts")
+        elif case == "empty-fields":
+            current.update(blocks=[], attachments=None, files=[])
+            previous.update(blocks=None, attachments=[], files={})
+        else:
+            field, change = case.split("-")
+            values = {
+                "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "visible"}}],
+                "attachments": [{"text": "visible"}],
+                "files": [{"id": "F_TEST", "name": "visible.txt"}],
+            }
+            if change in ("add", "edit"):
+                current[field] = values[field]
+            if change in ("remove", "edit"):
+                previous[field] = [{"text": "previous visible payload"}]
+
+        assert not adapter._processed_message_ts
+        await adapter._handle_slack_message(event)
+        if allowed:
+            adapter.handle_message.assert_awaited_once()
+            assert adapter.handle_message.await_args.args[0].message_id == current["ts"]
+        else:
+            adapter.handle_message.assert_not_awaited()
+            assert not adapter._processed_message_ts
+
+
 # ---------------------------------------------------------------------------
 # TestSendTyping — assistant.threads.setStatus
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Slack emits hidden `message_changed` events when thread reply metadata changes on an existing parent. The event contains the old parent as a nested `message`. After a gateway restart, the process-local `_processed_message_ts` cache is empty, so normalizing that parent as fresh input can replay an old instruction, persist a phantom user turn, or interrupt the real reply that caused the metadata update.

This PR classifies those events before nested-message normalization:

- drops hidden thread-parent updates when only reply bookkeeping changed
- preserves visible text, Block Kit, attachment, and file additions/removals
- preserves newly-added bot mentions
- fails closed for missing, malformed, empty, or partial prior snapshots
- still accepts a malformed-snapshot event when its explicit edit timestamp matches the outer event
- remains independent of the process-local deduplication cache

This is intentionally narrower than #73450. It addresses metadata-only parent replay without introducing broader answered-parent or bot-address history policy.

## Related Issue

Related to #73450.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - classify hidden metadata-only parent updates before normalization
  - compare visible payload fields separately from Slack reply bookkeeping
  - fail closed when the prior snapshot cannot prove a visible edit
- `tests/gateway/test_slack.py`
  - add a sanitized cold-restart regression proving the event never reaches the gateway boundary and therefore cannot persist or interrupt
  - cover text edits, newly-added mentions, blocks, files, attachments, removals, and malformed or partial snapshots

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_slack.py \
  -k 'hidden_thread_parent or cold_restart_parent_update or message_edit_with_new_mention' -q

scripts/run_tests.sh tests/gateway/test_slack.py -q

ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py
python -m py_compile plugins/platforms/slack/adapter.py tests/gateway/test_slack.py
git diff --check upstream/main...HEAD
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 and Linux production candidates

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; internal Slack ingress filtering only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — platform-independent event classification
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Verification on current `upstream/main`:

- focused regressions: `11 passed`
- complete `tests/gateway/test_slack.py`: `171 passed`
- all 33 Slack-related test files: `391 passed`
- Ruff: passed
- `py_compile`: passed
- `git diff --check`: passed
- independent review: passed with no blocking findings

A sanitized live cold-restart canary produced exactly the two intentional user turns and responses, with zero interruption markers, root replays, redirect acknowledgements, or relevant fatal log lines.

The repository-wide suite was not run for this narrow Slack-only change; upstream Actions remain authoritative for the full cross-platform result.
