### PR TITLE
feat(gateway): persist the session /reasoning override across restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8377,6 +8377,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 resolved_session_key = None
 
         if resolved_session_key:
+            self._rehydrate_session_reasoning_override(resolved_session_key)
             _r_state = self._peek_session_state(resolved_session_key)
             if _r_state is not None and _r_state.conversation.reasoning_override is not None:
                 return _r_state.conversation.reasoning_override
@@ -8396,6 +8397,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._session_state(session_key).conversation.reasoning_override = (
             None if reasoning_config is None else dict(reasoning_config)
         )
+        # Write through so the override survives a gateway restart, mirroring
+        # the /model leg.  Clearing (reasoning_config=None) nulls the
+        # persisted field too, so a conversation boundary can't be undone by
+        # a later rehydrate.
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return
+        try:
+            store.set_reasoning_override(session_key, reasoning_config)
+        except Exception:
+            logger.debug(
+                "Failed to persist session reasoning override", exc_info=True
+            )
 
     def _resolve_session_service_tier(
         self,
@@ -23342,6 +23356,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         logger.info(
             "Rehydrated persisted /model override for session=%s: model=%s provider=%s",
             session_key, override.get("model"), provider or "",
+        )
+
+    def _rehydrate_session_reasoning_override(self, session_key: str) -> None:
+        """Lazily restore a persisted /reasoning override after a restart.
+
+        Mirrors :meth:`_rehydrate_session_model_override`.  The runner's
+        per-session reasoning override is in-memory, so before persistence a
+        gateway restart silently reverted ``/reasoning high`` to the config
+        default while a ``/model`` switch in the same session survived.
+
+        The override carries no credential ({"enabled": bool, "effort": str}),
+        so there is nothing to re-resolve — the persisted value is restored
+        verbatim.
+
+        No-op when an in-memory override already exists (live state wins) or
+        when the store has nothing persisted (e.g. the user ran /new, which
+        clears both the in-memory field and the persisted one).
+        """
+        _rehydrate_state = self._peek_session_state(session_key)
+        if (
+            _rehydrate_state is not None
+            and _rehydrate_state.conversation.reasoning_override is not None
+        ):
+            return
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return
+        try:
+            persisted = store.get_reasoning_override(session_key)
+            if not isinstance(persisted, dict) or not persisted:
+                return
+            restored = dict(persisted)
+        except Exception:
+            logger.debug(
+                "Failed to read persisted session reasoning override", exc_info=True
+            )
+            return
+        self._session_state(session_key).conversation.reasoning_override = restored
+        logger.info(
+            "Rehydrated persisted /reasoning override for session=%s: %s",
+            session_key, restored,
         )
 
     def _apply_session_model_override(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -770,6 +770,33 @@ def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict
     return cleaned or None
 
 
+def sanitize_reasoning_override(
+    override: Optional[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """Return a copy of *override* containing only persistable keys.
+
+    The override is a plain ``{"enabled": bool, "effort": str}`` shape and
+    carries no credential today; restricting the persisted keys to that pair
+    is the structural guarantee that a future shape change cannot start
+    smuggling one into sessions.json.
+
+    Returns ``None`` when the input is empty/not a dict or no persistable
+    values remain, so callers can store the result directly on
+    ``SessionEntry.reasoning_override``.  ``{"enabled": False}`` (reasoning
+    explicitly disabled for the session) is a real override and is kept —
+    presence of the key, not truthiness of its value, decides.
+    """
+    if not isinstance(override, dict):
+        return None
+    cleaned: Dict[str, Any] = {}
+    if "enabled" in override:
+        cleaned["enabled"] = bool(override["enabled"])
+    effort = override.get("effort")
+    if isinstance(effort, str) and effort.strip():
+        cleaned["effort"] = effort.strip()
+    return cleaned or None
+
+
 @dataclass
 class SessionEntry:
     """
@@ -868,6 +895,15 @@ class SessionEntry:
     # (see sanitize_model_override / SessionStore.set_model_override).
     model_override: Optional[Dict[str, str]] = None
 
+    # Session-scoped /reasoning override ({"enabled": bool, "effort": str}).
+    # The runner's per-session override is in-memory, so before this field a
+    # gateway restart silently reverted /reasoning to the config default while
+    # a /model switch in the same session survived.  Unlike the model
+    # override this carries no credential, so nothing has to be re-resolved
+    # on rehydration (see sanitize_reasoning_override /
+    # SessionStore.set_reasoning_override).
+    reasoning_override: Optional[Dict[str, Any]] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "session_key": self.session_key,
@@ -911,6 +947,11 @@ class SessionEntry:
             # Defence-in-depth: strip credentials even if a caller stored an
             # unsanitized dict directly on the entry.
             result["model_override"] = sanitize_model_override(self.model_override)
+        if self.reasoning_override:
+            # Same defence-in-depth: only the known-safe keys reach disk.
+            result["reasoning_override"] = sanitize_reasoning_override(
+                self.reasoning_override
+            )
         if self.origin:
             result["origin"] = self.origin.to_dict()
         return result
@@ -1000,6 +1041,9 @@ class SessionEntry:
             reset_had_activity=data.get("reset_had_activity", False),
             prev_session_id=data.get("prev_session_id"),
             model_override=sanitize_model_override(data.get("model_override")),
+            reasoning_override=sanitize_reasoning_override(
+                data.get("reasoning_override")
+            ),
         )
 
 
@@ -2182,9 +2226,11 @@ class SessionStore:
             entry.expiry_finalized = True
             if clear_model_override:
                 # Session finalization is a conversation boundary — drop the
-                # persisted /model override too so a later message doesn't
-                # rehydrate it after the in-memory override was popped.
+                # persisted /model and /reasoning overrides too so a later
+                # message doesn't rehydrate them after the in-memory
+                # overrides were cleared.
                 entry.model_override = None
+                entry.reasoning_override = None
             self._save()
         if self._db:
             setter = getattr(self._db, "set_expiry_finalized", None)
@@ -2909,6 +2955,36 @@ class SessionStore:
             if entry is None:
                 return None
             return dict(entry.model_override) if entry.model_override else None
+
+    def set_reasoning_override(
+        self, session_key: str, override: Optional[Dict[str, Any]]
+    ) -> None:
+        """Persist (or clear) the session-scoped /reasoning override.
+
+        Only the known-safe keys (enabled/effort — see
+        ``sanitize_reasoning_override``) are written.  Pass ``None`` (or a
+        dict with no persistable values) to clear the persisted override,
+        e.g. on /new.
+        """
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return
+            cleaned = sanitize_reasoning_override(override)
+            if entry.reasoning_override == cleaned:
+                return
+            entry.reasoning_override = cleaned
+            self._save()
+
+    def get_reasoning_override(self, session_key: str) -> Optional[Dict[str, Any]]:
+        """Return the persisted /reasoning override for *session_key*, if any."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            return dict(entry.reasoning_override) if entry.reasoning_override else None
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/tests/gateway/test_session_reasoning_override_persistence.py
+++ b/tests/gateway/test_session_reasoning_override_persistence.py
@@ -1,0 +1,255 @@
+"""Per-session /reasoning overrides must survive gateway restarts.
+
+The gateway persists the *model* half of the session-override pair
+(``SessionEntry.model_override``) but not the *reasoning* half, so a restart
+silently reverted ``/reasoning high`` to the config default while a ``/model``
+switch in the same session survived — asymmetric and surprising.
+
+``SessionEntry.reasoning_override`` closes that gap: the runner writes the
+override through on every set/clear and lazily rehydrates it on first use.
+Unlike the model override it carries no credential, so nothing is re-resolved.
+
+Covers:
+  - the override survives a simulated restart (a second SessionStore instance
+    reading the same sessions dir, and a fresh runner rehydrating from it)
+  - clearing the override (the /new, /reset and ``/reasoning reset`` path)
+    nulls BOTH the in-memory field and the persisted one
+  - live in-memory state wins over the persisted value
+  - a sessions.json written before this field existed loads without error
+  - only the known-safe keys are ever serialized
+"""
+import json
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.session import (
+    SessionSource,
+    SessionStore,
+    sanitize_reasoning_override,
+)
+
+OVERRIDE = {"enabled": True, "effort": "high"}
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+@pytest.fixture
+def store_factory(tmp_path, monkeypatch):
+    """Build SessionStores over a shared sessions dir, without SQLite."""
+
+    def _raise():
+        raise RuntimeError("SQLite disabled in test")
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _raise)
+
+    def _make() -> SessionStore:
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        assert store._db is None
+        return store
+
+    return _make
+
+
+def _sessions_json(tmp_path) -> dict:
+    return json.loads((tmp_path / "sessions.json").read_text(encoding="utf-8"))
+
+
+def _make_runner(store):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._session_reasoning_overrides = {}
+    runner.session_store = store
+    return runner
+
+
+def test_override_persists_and_survives_restart(store_factory):
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+
+    store.set_reasoning_override(session_key, OVERRIDE)
+
+    # Simulated restart: a brand-new store instance reads the same dir.
+    store2 = store_factory()
+    assert store2.get_reasoning_override(session_key) == OVERRIDE
+
+
+def test_runner_write_through_survives_restart(store_factory):
+    """The runner's set/read pair round-trips through disk end to end."""
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+
+    _make_runner(store)._set_session_reasoning_override(session_key, OVERRIDE)
+
+    # Simulated restart: fresh store + fresh runner with no in-memory state.
+    runner = _make_runner(store_factory())
+    runner._rehydrate_session_reasoning_override(session_key)
+
+    assert runner._session_reasoning_overrides[session_key] == OVERRIDE
+
+
+def test_clearing_nulls_memory_and_disk(store_factory, tmp_path):
+    """The clear path (/new, /reset, /reasoning reset) must drop both copies."""
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+
+    runner = _make_runner(store)
+    runner._set_session_reasoning_override(session_key, OVERRIDE)
+    assert store.get_reasoning_override(session_key) == OVERRIDE
+
+    runner._set_session_reasoning_override(session_key, None)
+
+    assert session_key not in runner._session_reasoning_overrides
+    assert store.get_reasoning_override(session_key) is None
+    # And a post-restart rehydrate cannot resurrect it.
+    assert store_factory().get_reasoning_override(session_key) is None
+    assert "reasoning_override" not in _sessions_json(tmp_path)[session_key]
+
+
+def test_expiry_finalization_drops_the_persisted_override(store_factory):
+    """Session finalization is a conversation boundary — drop the override."""
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    store.set_reasoning_override(entry.session_key, OVERRIDE)
+
+    store.set_expiry_finalized(entry)
+
+    assert store.get_reasoning_override(entry.session_key) is None
+
+
+def test_live_in_memory_override_wins_over_persisted(store_factory):
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    store.set_reasoning_override(session_key, {"enabled": True, "effort": "low"})
+
+    runner = _make_runner(store)
+    runner._session_reasoning_overrides[session_key] = OVERRIDE
+    runner._rehydrate_session_reasoning_override(session_key)
+
+    assert runner._session_reasoning_overrides[session_key] == OVERRIDE
+
+
+def test_rehydrate_is_a_noop_with_nothing_persisted(store_factory):
+    store = store_factory()
+    session_key = store.get_or_create_session(_make_source()).session_key
+
+    runner = _make_runner(store)
+    runner._rehydrate_session_reasoning_override(session_key)
+
+    assert session_key not in runner._session_reasoning_overrides
+
+
+def test_resolve_reads_the_persisted_override_after_restart(
+    store_factory, tmp_path, monkeypatch
+):
+    """The real read path — not just the rehydrate helper — must see disk.
+
+    ``_resolve_session_reasoning_config`` is what every turn calls to decide
+    the effort actually sent to the model. Wiring persistence into the store
+    but not into this resolver would leave the restart bug fully intact while
+    the round-trip tests stayed green.
+    """
+    import gateway.run as gateway_run
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: low\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    store = store_factory()
+    source = _make_source()
+    session_key = store.get_or_create_session(source).session_key
+    _make_runner(store)._set_session_reasoning_override(session_key, OVERRIDE)
+
+    # Simulated restart: fresh store + fresh runner, no in-memory override.
+    runner = _make_runner(store_factory())
+    resolved = runner._resolve_session_reasoning_config(session_key=session_key)
+
+    # The config default is "low"; the persisted session override must win.
+    assert resolved == OVERRIDE
+
+
+def test_resolve_falls_back_to_config_when_nothing_persisted(
+    store_factory, tmp_path, monkeypatch
+):
+    """The mirror of the test above — no persisted override, no interference."""
+    import gateway.run as gateway_run
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: low\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    store = store_factory()
+    session_key = store.get_or_create_session(_make_source()).session_key
+
+    runner = _make_runner(store)
+    assert runner._resolve_session_reasoning_config(session_key=session_key) == {
+        "enabled": True,
+        "effort": "low",
+    }
+
+
+def test_legacy_sessions_json_without_the_key_loads(store_factory, tmp_path):
+    """A sessions.json written before this field existed must load clean."""
+    store = store_factory()
+    session_key = store.get_or_create_session(_make_source()).session_key
+
+    raw = _sessions_json(tmp_path)
+    assert "reasoning_override" not in raw[session_key]
+    # Belt and braces: strip it even if a future default starts emitting one.
+    raw[session_key].pop("reasoning_override", None)
+    (tmp_path / "sessions.json").write_text(json.dumps(raw), encoding="utf-8")
+
+    reloaded = store_factory()
+    assert reloaded.get_reasoning_override(session_key) is None
+    assert reloaded.get_or_create_session(_make_source()).session_key == session_key
+
+
+def test_only_safe_keys_are_serialized(store_factory, tmp_path):
+    """Nothing outside {enabled, effort} may reach sessions.json."""
+    store = store_factory()
+    session_key = store.get_or_create_session(_make_source()).session_key
+
+    store.set_reasoning_override(
+        session_key,
+        {"enabled": True, "effort": "high", "api_key": "sk-should-never-persist"},
+    )
+
+    persisted = _sessions_json(tmp_path)[session_key]["reasoning_override"]
+    assert persisted == OVERRIDE
+    assert "sk-should-never-persist" not in (tmp_path / "sessions.json").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_sanitize_reasoning_override():
+    assert sanitize_reasoning_override(None) is None
+    assert sanitize_reasoning_override({}) is None
+    assert sanitize_reasoning_override("high") is None  # type: ignore[arg-type]
+    assert sanitize_reasoning_override({"api_key": "sk-x"}) is None
+    assert sanitize_reasoning_override(OVERRIDE) == OVERRIDE
+    # "reasoning disabled for this session" is a real override, not an absence.
+    assert sanitize_reasoning_override({"enabled": False}) == {"enabled": False}
+    assert sanitize_reasoning_override({"enabled": True, "effort": ""}) == {
+        "enabled": True
+    }


### PR DESCRIPTION
## What does this PR do?

The gateway persists the **model** half of the session-override pair and not the **reasoning** half.

`SessionEntry` carries `model_override` (`gateway/session.py`), written through at both `/model` apply sites and lazily rehydrated by `GatewayRunner._rehydrate_session_model_override`. There is no counterpart for `/reasoning`, whose override lives only in `ConversationState` — in memory, for the life of the process.

Measured on `main`:

```
$ python -c "import dataclasses; from gateway.session import SessionEntry; \
    print([f.name for f in dataclasses.fields(SessionEntry) if 'override' in f.name])"
['model_override']
```

So: restart the gateway, and a session that ran `/reasoning high` silently drops back to the config default, while a `/model` switch made in that same session survives. The user set two deliberate session-scoped preferences and exactly one of them comes back — asymmetric, silent, and hard to notice (the effort is not echoed on every turn).

This adds the missing half, modelled on the existing model-override path rather than inventing a second mechanism.

Why this approach: the model leg already solved the same problem carefully — additive-optional field, sanitizer, store accessors, lazy per-session rehydrate — so the reasoning leg reuses that shape. It is also strictly simpler, because the reasoning override is `{"enabled": bool, "effort": str}` and carries no credential: no `api_key` to strip, nothing to re-resolve on rehydration.

## Related Issue

<!-- No existing issue; found while reading the session-override code. -->

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/session.py`
  - `sanitize_reasoning_override()` — restricts the persisted shape to `{enabled, effort}`. Nothing today can smuggle a secret into `sessions.json`; this makes that a property of the code rather than of the current shape. `{"enabled": False}` is kept, since "reasoning disabled for this session" is a real override — presence of the key decides, not truthiness.
  - `SessionEntry.reasoning_override` — additive-optional, serialized in `to_dict` only when set. `from_dict` reads it with `data.get`, so a `sessions.json` written before this field loads clean, and an older gateway ignores a newer file.
  - `SessionStore.set_reasoning_override()` / `get_reasoning_override()` — mirroring the model accessors, including the no-op-when-unchanged guard that avoids a needless index rewrite.
  - `set_expiry_finalized()` now drops the persisted reasoning override alongside the model one, since finalization is a conversation boundary.
- `gateway/run.py`
  - `GatewayRunner._set_session_reasoning_override()` writes through. This is the single door `/reasoning <level>`, `/reasoning reset` and the interactive picker all call, so clearing nulls the persisted field too.
  - `GatewayRunner._rehydrate_session_reasoning_override()` — lazy per-session restore mirroring `_rehydrate_session_model_override`. Live in-memory state wins; nothing persisted is a no-op.
  - The rehydrate is wired into `_resolve_session_reasoning_config()` — the resolver every turn actually calls — not just exposed as a helper.
- `tests/gateway/test_session_reasoning_override_persistence.py` — new, 11 tests.

**Scope note:** this is durability, not scope. A conversation boundary (`/new`, `/reset`, `/reasoning reset`, auto-reset, expiry finalization) still clears the override; it just now clears the persisted copy too, so a boundary cannot be undone by a later rehydrate.

## How to Test

1. Set a session-scoped effort in a gateway chat: `/reasoning high`.
2. Restart the gateway.
3. Send a message in the same chat, then run `/reasoning`. Before this change the status reads the config default (scope: global); after it reads `high` (scope: session) — matching how a `/model` switch already behaves.
4. `/new`, restart again, `/reasoning` → back to the config default, i.e. the boundary still wins.

Driving that same sequence through the resolver a real turn calls (`_resolve_session_reasoning_config`) plus the exact membership test the `/reasoning` status line renders its scope from, with `agent.reasoning_effort: low` in config and a second `SessionStore` over the same sessions dir standing in for the restart:

```
########## BEFORE (base fafbdd25ad) ##########
pre-restart  resolved: {'enabled': True, 'effort': 'high'}
post-restart resolved: {'enabled': True, 'effort': 'low'} | /reasoning scope: global
after /new + restart: {'enabled': True, 'effort': 'low'}

########## AFTER (this branch) ##########
pre-restart  resolved: {'enabled': True, 'effort': 'high'}
post-restart resolved: {'enabled': True, 'effort': 'high'} | /reasoning scope: session
after /new + restart: {'enabled': True, 'effort': 'low'}
```

The middle line is the bug and the fix. The last line is the scope guarantee: `/new` still clears the override, before and after.

Automated:

```
$ scripts/run_tests.sh tests/gateway/test_session_reasoning_override_persistence.py
=== Summary: 1 files, 11 tests passed, 0 failed (100% complete) ===
```

Full gateway suite:

```
$ scripts/run_tests.sh tests/gateway/
=== Summary: 612 files, 5141 tests passed, 2 failed, 13 skipped (100% complete) in 155.7s ===
```

Both failures — `test_systemd_notify.py::test_notify_supports_systemd_abstract_socket` (`FileNotFoundError` binding an abstract socket; Linux-only primitive on macOS) and `test_session_store_prune.py::test_session_store_default_db_uses_runtime_hermes_home` — reproduce identically on a clean detached worktree at this branch's base commit, so they are pre-existing on `main` and unrelated to this change.

Because "the tests pass" and "the tests would catch this breaking" are different claims, each load-bearing line was driven out one at a time and the suite required to go RED. 8/8 mutants killed:

| Mutant | Result |
|---|---|
| write-through removed from `_set_session_reasoning_override` | KILLED |
| rehydrate call removed from `_resolve_session_reasoning_config` | KILLED |
| rehydrate restores an empty dict | KILLED |
| `to_dict` drops the field | KILLED |
| `from_dict` ignores the persisted key | KILLED |
| clearing preserves the stored value | KILLED |
| expiry finalization keeps the override | KILLED |
| sanitizer passes unknown keys through | KILLED |

Control (unmutated) and post-restore runs are both green, so the score is not an artifact of a suite that never passes. The "rehydrate call removed" mutant initially **survived** — the first round of tests exercised the helper directly but never the resolver every turn goes through, which is exactly the gap that would have shipped the bug intact behind a green suite. `test_resolve_reads_the_persisted_override_after_restart` was added to close it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the test suite and all tests pass (2 pre-existing failures, reproduced on the base commit — see above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on every new symbol) — no user-facing doc change needed, `/reasoning` behaviour is unchanged apart from surviving a restart
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform impact considered — pure Python, no platform primitives; the field rides the existing `sessions.json` / `gateway_routing` write path
