### PR TITLE
feat(slack): let channel members initiate work without DM access

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -504,6 +504,26 @@ class GatewayAuthorizationMixin:
         if not user_id:
             return False
 
+        # Slack can grant ordinary message initiation to every human in an
+        # exact channel without also granting DM or interactive-action access.
+        # Resolve the live adapter rather than process-global config/env so
+        # multiplexed profiles keep independent policies.  Deliberately do not
+        # special-case "*": this capability is exact-channel-only.
+        if (
+            source.platform == Platform.SLACK
+            and source.chat_type in {"group", "channel"}
+            and source.chat_id
+            and getattr(source, "is_bot", False) is not True
+        ):
+            adapter = self._adapter_for_source(source)
+            extra = getattr(getattr(adapter, "config", None), "extra", None)
+            if isinstance(extra, dict):
+                open_user_channels = _coerce_allow_set(
+                    extra.get("open_user_channels")
+                )
+                if source.chat_id in open_user_channels:
+                    return True
+
         platform_env_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
             Platform.DISCORD: "DISCORD_ALLOWED_USERS",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1957,6 +1957,7 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        "open_user_channels": "",      # Exact channels where non-allowlisted humans may initiate ordinary work
         # Channel IDs where @mention is ALWAYS required, even when
         # require_mention is false globally (per-channel force-mention override).
         "require_mention_channels": "",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6676,10 +6676,7 @@ class SlackAdapter(BasePlatformAdapter):
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:
-                from gateway.session import SessionSource
-
-                source = SessionSource(
-                    platform=Platform.SLACK,
+                source = self.build_source(
                     chat_id=str(channel_id or normalized_user_id),
                     # Interactive approval/confirmation authority must remain
                     # distinct from ordinary channel-message initiation.
@@ -7034,6 +7031,7 @@ class SlackAdapter(BasePlatformAdapter):
         """Handle a clarify button click (a choice or "Other") from Block Kit."""
         await ack()
 
+        team_id = self._event_team_id({}, body)
         action_id = action.get("action_id", "")
         value = action.get("value", "")
         message = body.get("message", {})
@@ -7046,6 +7044,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_id,
             channel_id=channel_id,
             user_name=user_name,
+            team_id=team_id,
         ):
             logger.warning(
                 "[Slack] Unauthorized clarify click by %s (%s) - ignoring",
@@ -7745,6 +7744,14 @@ class SlackAdapter(BasePlatformAdapter):
                 user_id,
             )
             return
+        if not is_dm:
+            allowed_channels = self._slack_allowed_channels()
+            if allowed_channels and channel_id not in allowed_channels:
+                logger.info(
+                    "[Slack] Ignoring slash command from non-allowed channel: %s",
+                    channel_id,
+                )
+                return
         source = self.build_source(
             chat_id=channel_id,
             chat_type="dm" if is_dm else "group",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -9052,7 +9052,17 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ic, list):
             ic = ",".join(str(v) for v in ic)
         os.environ["SLACK_IGNORED_CHANNELS"] = str(ic)
-    return None  # all settings flow through env; nothing to merge into extras
+
+    # Keep channel-scoped user authorization in PlatformConfig.extra. Unlike
+    # legacy presentation/routing toggles above, this security boundary must
+    # never flow through process-global env in a multiplex gateway.
+    open_user_channels = slack_cfg.get("open_user_channels")
+    nested_extra = slack_cfg.get("extra")
+    if open_user_channels is None and isinstance(nested_extra, dict):
+        open_user_channels = nested_extra.get("open_user_channels")
+    if open_user_channels is not None:
+        return {"open_user_channels": open_user_channels}
+    return None
 
 
 def _is_connected(config) -> bool:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5550,6 +5550,7 @@ class SlackAdapter(BasePlatformAdapter):
                 chat_type="dm" if is_dm else "group",
                 user_id=user_id,
                 user_name="",
+                is_bot=sender_is_bot,
             )
             if not _auth_fn(_source):
                 logger.warning(
@@ -6680,7 +6681,9 @@ class SlackAdapter(BasePlatformAdapter):
                 source = SessionSource(
                     platform=Platform.SLACK,
                     chat_id=str(channel_id or normalized_user_id),
-                    chat_type="dm" if str(channel_id or "").startswith("D") else "group",
+                    # Interactive approval/confirmation authority must remain
+                    # distinct from ordinary channel-message initiation.
+                    chat_type="interaction",
                     user_id=normalized_user_id,
                     user_name=str(user_name).strip() if user_name else None,
                     scope_id=str(team_id) if team_id else None,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -8993,14 +8993,12 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     legacy ``slack_cfg`` block that used to live in
     ``gateway/config.py::load_gateway_config()`` before this migration.
 
-    The SlackAdapter reads its runtime configuration via ``os.getenv()``
-    throughout the connect / handle code paths, so rather than rewrite those
-    call sites to read from ``PlatformConfig.extra``, this hook keeps the
-    existing env-driven model and owns the YAML→env translation here, next to
-    the adapter that consumes it. Env vars take precedence over YAML — every
-    assignment is guarded by ``not os.getenv(...)`` so explicit env vars
-    survive a config.yaml update. Returns ``None`` because no extras are
-    seeded into ``PlatformConfig.extra`` directly (everything flows through env).
+    Most SlackAdapter runtime settings remain env-driven, so this hook owns
+    their YAML→env translation next to the adapter that consumes them. Env vars
+    take precedence over YAML — every env assignment is guarded by
+    ``not os.getenv(...)`` so explicit env vars survive a config.yaml update.
+    Security policy that must stay adapter/profile scoped is returned for
+    seeding into ``PlatformConfig.extra`` instead of process-global env.
     """
     if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
@@ -9101,8 +9099,8 @@ def register(ctx) -> None:
         # keys (require_mention, strict_mention, ignore_other_user_mentions,
         # thread_require_mention, allow_bots, free_response_channels,
         # reactions, disable_dms, allowed_channels, ignored_channels) into
-        # SLACK_* env vars that
-        # the adapter reads via os.getenv(). Replaces the
+        # SLACK_* env vars that the adapter reads via os.getenv(), while
+        # open_user_channels is returned as adapter-scoped extra config. Replaces the
         # hardcoded block in gateway/config.py. Hook contract: #24849.
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -259,6 +259,19 @@ class TestSlashCommandSessionIsolation:
         assert event.source.user_id == "U123"
         assert event.source.scope_id == "T123"
 
+    @pytest.mark.asyncio
+    async def test_channel_slash_command_obeys_allowed_channels(self, adapter):
+        adapter.config.extra["allowed_channels"] = ["C_ALLOWED"]
+
+        await adapter._handle_slash_command({
+            "text": "hello",
+            "user_id": "U123",
+            "channel_id": "C_BLOCKED",
+            "team_id": "T123",
+        })
+
+        adapter.handle_message.assert_not_awaited()
+
 
 class TestSlackWorkspaceCollisionIsolation:
     @pytest.mark.asyncio

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -210,11 +210,14 @@ class TestSlackInteractiveAuth:
     def test_delegates_to_gateway_runner_auth(self):
         adapter = _make_adapter()
         runner = _attach_auth_runner(adapter, auth_fn=lambda source: source.user_id == "U_OK")
+        runner._profile_name_for_source = MagicMock(return_value="coder")
+        adapter.gateway_runner = runner
 
         assert adapter._is_interactive_user_authorized(
             "U_OK",
             channel_id="C1",
             user_name="operator",
+            team_id="T1",
         ) is True
         assert adapter._is_interactive_user_authorized(
             "U_BAD",
@@ -226,6 +229,29 @@ class TestSlackInteractiveAuth:
         assert runner.seen_sources[0].platform == Platform.SLACK
         assert runner.seen_sources[0].chat_id == "C1"
         assert runner.seen_sources[0].chat_type == "interaction"
+        assert runner.seen_sources[0].scope_id == "T1"
+        assert runner.seen_sources[0].profile == "coder"
+        assert runner.seen_sources[0]._transport_adapter_ref() is adapter
+
+    @pytest.mark.asyncio
+    async def test_clarify_action_forwards_workspace_to_authorization(self):
+        adapter = _make_adapter()
+        adapter._is_interactive_user_authorized = MagicMock(return_value=False)
+
+        await adapter._handle_clarify_action(
+            AsyncMock(),
+            {
+                "team": {"id": "T1"},
+                "channel": {"id": "C1"},
+                "user": {"id": "U1", "name": "operator"},
+                "message": {"ts": "1.2"},
+            },
+            {"action_id": "hermes_clarify_0", "value": "clarify-1|0"},
+        )
+
+        adapter._is_interactive_user_authorized.assert_called_once_with(
+            "U1", channel_id="C1", user_name="operator", team_id="T1"
+        )
 
 
 class TestSlackSlashConfirmAction:

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -225,7 +225,7 @@ class TestSlackInteractiveAuth:
         assert len(runner.seen_sources) == 2
         assert runner.seen_sources[0].platform == Platform.SLACK
         assert runner.seen_sources[0].chat_id == "C1"
-        assert runner.seen_sources[0].chat_type == "group"
+        assert runner.seen_sources[0].chat_type == "interaction"
 
 
 class TestSlackSlashConfirmAction:

--- a/tests/gateway/test_slack_channel_initiator_auth.py
+++ b/tests/gateway/test_slack_channel_initiator_auth.py
@@ -82,7 +82,7 @@ def test_channel_grant_does_not_authorize_bot_senders(runner):
 
 def test_multiplex_profile_uses_selected_adapter_policy(runner):
     runner._profile_adapters = {
-        "coder": {Platform.SLACK: _adapter("C_CODER")},
+        "coder": {Platform.SLACK: _adapter("C_CODER,C_SECOND")},
     }
 
     assert runner._is_user_authorized(
@@ -91,6 +91,9 @@ def test_multiplex_profile_uses_selected_adapter_policy(runner):
     assert runner._is_user_authorized(
         _source(chat_id="C_TEAM", profile="coder")
     ) is False
+    assert runner._is_user_authorized(
+        _source(chat_id="C_SECOND", profile="coder")
+    ) is True
 
 
 def test_missing_multiplex_adapter_fails_closed(runner):

--- a/tests/gateway/test_slack_channel_initiator_auth.py
+++ b/tests/gateway/test_slack_channel_initiator_auth.py
@@ -1,0 +1,99 @@
+"""Security-boundary tests for Slack channel-scoped initiator grants."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.config import Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+class _Runner(GatewayAuthorizationMixin):
+    pass
+
+
+def _adapter(open_user_channels):
+    return SimpleNamespace(
+        config=PlatformConfig(
+            enabled=True,
+            extra={"open_user_channels": open_user_channels},
+        )
+    )
+
+
+@pytest.fixture
+def runner(monkeypatch):
+    for key in (
+        "SLACK_ALLOWED_USERS",
+        "SLACK_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "SLACK_ALLOW_BOTS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    instance = _Runner()
+    instance.adapters = {Platform.SLACK: _adapter(["C_TEAM"])}
+    instance._profile_adapters = {}
+    instance.pairing_store = None
+    return instance
+
+
+def _source(*, chat_id="C_TEAM", chat_type="group", user_id="U_MEMBER", profile=None, is_bot=False):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        profile=profile,
+        is_bot=is_bot,
+    )
+
+
+def test_exact_channel_grant_unions_with_owner_allowlist(runner, monkeypatch):
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_OWNER")
+
+    assert runner._is_user_authorized(_source()) is True
+    assert runner._is_user_authorized(_source(chat_id="C_OTHER")) is False
+    assert runner._is_user_authorized(
+        _source(chat_id="C_OTHER", user_id="U_OWNER")
+    ) is True
+
+
+@pytest.mark.parametrize("chat_type", ["dm", "interaction"])
+def test_channel_grant_does_not_widen_dm_or_interactive_access(runner, chat_type):
+    assert runner._is_user_authorized(_source(chat_type=chat_type)) is False
+
+
+def test_channel_chat_type_is_an_ordinary_initiator_surface(runner):
+    assert runner._is_user_authorized(_source(chat_type="channel")) is True
+
+
+def test_wildcard_is_not_interpreted_as_all_channels(runner):
+    runner.adapters[Platform.SLACK] = _adapter("*")
+
+    assert runner._is_user_authorized(_source(chat_id="C_TEAM")) is False
+
+
+def test_channel_grant_does_not_authorize_bot_senders(runner):
+    assert runner._is_user_authorized(_source(is_bot=True)) is False
+
+
+def test_multiplex_profile_uses_selected_adapter_policy(runner):
+    runner._profile_adapters = {
+        "coder": {Platform.SLACK: _adapter("C_CODER")},
+    }
+
+    assert runner._is_user_authorized(
+        _source(chat_id="C_CODER", profile="coder")
+    ) is True
+    assert runner._is_user_authorized(
+        _source(chat_id="C_TEAM", profile="coder")
+    ) is False
+
+
+def test_missing_multiplex_adapter_fails_closed(runner):
+    assert runner._is_user_authorized(
+        _source(chat_id="C_TEAM", profile="missing")
+    ) is False

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -358,6 +358,30 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     _os.environ.pop("SLACK_FREE_RESPONSE_CHANNELS", None)
 
 
+def test_config_preserves_nested_slack_open_user_channels(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n"
+        "  slack:\n"
+        "    enabled: true\n"
+        "    extra:\n"
+        "      open_user_channels:\n"
+        "        - C0AQWDLHY9M\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.SLACK].extra["open_user_channels"] == [
+        "C0AQWDLHY9M"
+    ]
+
+
 def test_top_level_slack_settings_do_not_disable_env_token_setup(monkeypatch, tmp_path):
     from gateway.config import load_gateway_config
 

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -331,6 +331,8 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     (hermes_home / "config.yaml").write_text(
         "slack:\n"
         "  require_mention: false\n"
+        "  open_user_channels:\n"
+        "    - C0AQWDLHY9M\n"
         "  free_response_channels:\n"
         "    - C0AQWDLHY9M\n"
         "    - C9999999999\n",
@@ -346,6 +348,7 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     assert config is not None
     slack_extra = config.platforms[Platform.SLACK].extra
     assert slack_extra.get("require_mention") is False
+    assert slack_extra.get("open_user_channels") == ["C0AQWDLHY9M"]
     assert slack_extra.get("free_response_channels") == ["C0AQWDLHY9M", "C9999999999"]
     # Verify env vars were set by config bridging
     import os as _os

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -738,6 +738,33 @@ Behavior:
 
 See also: [admin/user slash command split](../../reference/slash-commands.md#permissions-and-adminuser-split).
 
+### Channel-scoped initiator authorization (`open_user_channels`)
+
+Allow any human in specific channels to start ordinary Hermes work without
+adding them to the global `SLACK_ALLOWED_USERS` list:
+
+```yaml
+slack:
+  open_user_channels:
+    - "C0123456789"   # #team-assistant
+```
+
+This is an exact-channel initiator grant, not an administrator grant:
+
+- The listed channel's human participants may send ordinary messages, subject
+  to the existing `allowed_channels`, mention, strict-mention, and bot-sender
+  gates.
+- Their 1:1 DMs and group DMs remain governed by `SLACK_ALLOWED_USERS` and
+  pairing.
+- Approval and confirmation buttons remain governed by the global user
+  allowlists; channel-scoped initiators cannot approve privileged actions.
+- `"*"` is not a wildcard. List each Slack channel ID explicitly.
+- Each multiplexed profile uses its selected Slack adapter's own list.
+
+`allowed_channels` and `open_user_channels` solve different problems: the
+former restricts where the bot may run, while the latter grants ordinary
+message initiation to humans in an exact channel.
+
 ### Unauthorized User Handling
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

Adds exact-channel Slack initiator authorization so teams can let human members start ordinary Hermes work in selected shared channels without granting those members DM access or authority over interactive approvals and confirmations. The policy is resolved from the selected live Slack adapter, keeping multiplexed profiles isolated, while existing mention, channel-routing, and bot-sender gates remain in force.

## Related Issue

Closes #83460

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/authz_mixin.py` - authorize ordinary human Slack messages only when their exact channel is listed by the selected adapter.
- `plugins/platforms/slack/adapter.py` - preserve adapter-scoped configuration, identify bot senders, and keep interactive callbacks outside the ordinary-message grant.
- `hermes_cli/config_defaults.py` - add the default `slack.open_user_channels` setting.
- `website/docs/user-guide/messaging/slack.md` - document setup, exact-match behavior, and security boundaries.
- `tests/gateway/` - cover owner access, exact and unlisted channels, DMs, interactions, bots, wildcard rejection, mention routing, and multiplexed profile isolation.

## How to Test

1. Configure `slack.open_user_channels` with an exact Slack channel ID.
2. Verify a non-allowlisted human can initiate ordinary work in that channel but remains denied in another channel, a DM, and an interactive approval callback.
3. Run the focused authorization and routing suites:

```bash
scripts/run_tests.sh tests/gateway/test_slack_mention.py tests/gateway/test_slack_channel_initiator_auth.py tests/gateway/test_slack_approval_buttons.py
```

The final reviewed tip passed all 56 focused tests. The broader Slack adapter and plugin validation completed earlier with 238 passing tests.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I ran the repository test entry on the relevant suites and all tests pass
- [x] I added tests for my changes
- [x] I tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I updated relevant documentation - `website/docs/user-guide/messaging/slack.md`
- [x] I updated `cli-config.yaml.example` if I added or changed config keys - N/A; the key is provided through runtime defaults and the Slack guide
- [x] I updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I considered cross-platform impact per the compatibility guide - the authorization logic is platform-independent Python
- [x] I updated tool descriptions or schemas if I changed tool behavior - N/A
