### PR TITLE
fix(conversation-loop): recover when a leaked "(empty)" sentinel ends a turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -161,6 +161,57 @@ _HANDOFF_SKIP_FINAL_RESPONSE = (
     "awaiting your next message."
 )
 
+# Sentinel Hermes injects as assistant content when a model returns nothing
+# usable after tool calls (see the post-tool nudge and the empty terminal in
+# run_conversation). A model echoing it back into its own final answer has
+# leaked scratchpad shorthand instead of answering. Named so the guard and its
+# tests cannot drift from the injection sites.
+EMPTY_RESPONSE_SENTINEL = "(empty)"
+
+# Content part types that are NOT visible assistant prose.
+# ``flatten_message_text`` deliberately keeps reasoning parts (callers use it to
+# recover text from any shape) and its key list includes the generic ``content``
+# key, so a block like {"type": "thinking", "content": "..."} flattens into the
+# visible string. For deciding whether the VISIBLE answer leaked a sentinel that
+# is wrong: it judges a turn by its scratchpad instead of its answer.
+_NON_VISIBLE_CONTENT_PART_TYPES = frozenset({
+    "thinking",
+    "reasoning",
+    "redacted_thinking",
+    "reasoning_content",
+})
+
+
+def _visible_text_for_sentinel_check(content: Any) -> str:
+    """Return only the visible assistant prose from any assistant-content shape.
+
+    Type-tolerant by design: assistant ``content`` may be a str, a list of
+    blocks (Anthropic via OpenRouter returns
+    ``[{"type":"text"},{"type":"thinking"}]``), or a single mapping. Reasoning
+    blocks are dropped so a scratchpad note is never mistaken for the visible
+    answer. Never raises — a bad shape yields ``""`` and the caller's guard
+    simply does not fire, which is the safe direction (terminate as before
+    rather than crash the turn).
+    """
+    from agent.message_content import flatten_message_text
+
+    def _is_non_visible(part: Any) -> bool:
+        if not isinstance(part, dict):
+            return False
+        part_type = str(part.get("type") or "").strip().lower()
+        return part_type in _NON_VISIBLE_CONTENT_PART_TYPES
+
+    try:
+        if isinstance(content, list):
+            return flatten_message_text(
+                [part for part in content if not _is_non_visible(part)]
+            )
+        if _is_non_visible(content):
+            return ""
+        return flatten_message_text(content)
+    except Exception:
+        logger.debug("visible-text extraction for sentinel check failed", exc_info=True)
+        return ""
 
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
@@ -7002,25 +7053,33 @@ def run_conversation(
                 # contentless: the sentinel is injected by the post-tool nudge below, so
                 # a model echoing it back has leaked scratchpad shorthand into the final
                 # answer instead of answering (observed: "(empty) again risk. Need
-                # progress + tool.").  Such a turn must recover, not terminate.
+                # progress + tool.").  Such a turn is routed into the recovery ladder
+                # below rather than terminating on the shorthand.  NOTE the ladder only
+                # *recovers* it when the post-tool nudge is still available; with the
+                # nudge latch already consumed this turn the leak reaches the empty
+                # terminal and the user sees a bare "(empty)".  That is still preferable
+                # to shipping scratchpad shorthand as a final answer, but it is not a
+                # guaranteed recovery.
                 # Measured on 3,804 real non-trivial stop-messages: exactly 1 match, the
                 # leak itself — so this cannot swallow a legitimate short answer.
                 #
-                # flatten_message_text() is required, NOT a bare .lstrip(): assistant
-                # ``content`` is not always a str.  Anthropic-via-OpenRouter returns a
-                # list of blocks ([{"type":"text"},{"type":"thinking"}]) — the reason
+                # Flattening is required, NOT a bare .lstrip(): assistant ``content`` is
+                # not always a str.  Anthropic-via-OpenRouter returns a list of blocks
+                # ([{"type":"text"},{"type":"thinking"}]) — the reason
                 # strip_think_blocks() coerces its input — and a non-empty list is
                 # truthy, so ``(final_response or "").lstrip()`` would survive the
                 # ``or ""`` and raise AttributeError, killing the whole turn on a
                 # vision/multimodal reply.
-                from agent.message_content import (
-                    flatten_message_text as _flatten_final,
-                )
-
+                #
+                # Only VISIBLE text parts are considered.  flatten_message_text() does
+                # not exclude ``thinking``/``reasoning`` parts and its key list includes
+                # ``content``, so a reasoning block phrased as
+                # {"type":"thinking","content":"(empty) ..."} would otherwise prepend
+                # scratchpad text to the flattened string and fire this guard on a turn
+                # whose visible answer was perfectly good.
+                _visible_final = _visible_text_for_sentinel_check(final_response)
                 _leaked_empty_sentinel = (
-                    _flatten_final(final_response)
-                    .lstrip()
-                    .startswith("(empty)")
+                    _visible_final.lstrip().startswith(EMPTY_RESPONSE_SENTINEL)
                     and agent._has_content_after_think_block(final_response)
                 )
                 if (

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6997,8 +6997,22 @@ def run_conversation(
                 # final response path.
                 agent._mute_post_response = False
                 
-                # Check if response only has think block with no actual content after it
-                if not agent._has_content_after_think_block(final_response):
+                # Check if response only has think block with no actual content after it.
+                # Also treat a response that STARTS WITH our own "(empty)" sentinel as
+                # contentless: the sentinel is injected by the post-tool nudge below, so
+                # a model echoing it back has leaked scratchpad shorthand into the final
+                # answer instead of answering (observed: "(empty) again risk. Need
+                # progress + tool.").  Such a turn must recover, not terminate.
+                # Measured on 3,804 real non-trivial stop-messages: exactly 1 match, the
+                # leak itself — so this cannot swallow a legitimate short answer.
+                _leaked_empty_sentinel = (
+                    (final_response or "").lstrip().startswith("(empty)")
+                    and agent._has_content_after_think_block(final_response)
+                )
+                if (
+                    not agent._has_content_after_think_block(final_response)
+                    or _leaked_empty_sentinel
+                ):
                     # ── Partial stream recovery ─────────────────────
                     # If content was already streamed to the user before
                     # the connection died, use it as the final response
@@ -7007,7 +7021,7 @@ def run_conversation(
                     _partial_streamed = (
                         getattr(agent, "_current_streamed_assistant_text", "") or ""
                     )
-                    if agent._has_content_after_think_block(_partial_streamed):
+                    if not _leaked_empty_sentinel and agent._has_content_after_think_block(_partial_streamed):
                         _turn_exit_reason = "partial_stream_recovery"
                         _recovered = agent._strip_think_blocks(_partial_streamed).strip()
                         logger.info(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7005,8 +7005,22 @@ def run_conversation(
                 # progress + tool.").  Such a turn must recover, not terminate.
                 # Measured on 3,804 real non-trivial stop-messages: exactly 1 match, the
                 # leak itself — so this cannot swallow a legitimate short answer.
+                #
+                # flatten_message_text() is required, NOT a bare .lstrip(): assistant
+                # ``content`` is not always a str.  Anthropic-via-OpenRouter returns a
+                # list of blocks ([{"type":"text"},{"type":"thinking"}]) — the reason
+                # strip_think_blocks() coerces its input — and a non-empty list is
+                # truthy, so ``(final_response or "").lstrip()`` would survive the
+                # ``or ""`` and raise AttributeError, killing the whole turn on a
+                # vision/multimodal reply.
+                from agent.message_content import (
+                    flatten_message_text as _flatten_final,
+                )
+
                 _leaked_empty_sentinel = (
-                    (final_response or "").lstrip().startswith("(empty)")
+                    _flatten_final(final_response)
+                    .lstrip()
+                    .startswith("(empty)")
                     and agent._has_content_after_think_block(final_response)
                 )
                 if (

--- a/tests/test_leaked_empty_sentinel_guard.py
+++ b/tests/test_leaked_empty_sentinel_guard.py
@@ -1,0 +1,101 @@
+"""Regression: a leaked "(empty)" sentinel in a final answer must not end the turn.
+
+Observed live (session 74508b0380e4, msg 126895): the model emitted
+`(empty) again risk. Need progress + tool. Already can. Use execute.` with
+phase=final_answer and finish_reason=stop, ending a 27-minute task mid-flight.
+Content was non-empty, so the post-tool empty-response nudge never fired.
+
+These tests pin the classifier decision, not the whole conversation loop:
+the guard condition is a pure expression over `final_response`.
+"""
+import re
+import unittest
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "agent" / "conversation_loop.py"
+
+
+def _has_content_after_think_block(content: str) -> bool:
+    """Mirror of AIAgent._has_content_after_think_block for the stripped tags."""
+    if not content:
+        return False
+    cleaned = re.sub(
+        r"<(think|thinking|reasoning)>.*?</\1>", "", content, flags=re.S | re.I
+    )
+    return bool(cleaned.strip())
+
+
+def leaked_empty_sentinel(final_response: str) -> bool:
+    """The condition added to conversation_loop.py, kept in sync by test below."""
+    return (final_response or "").lstrip().startswith("(empty)") and (
+        _has_content_after_think_block(final_response)
+    )
+
+
+def enters_recovery(final_response: str) -> bool:
+    """True when the turn routes into the recovery/nudge block instead of ending."""
+    return (
+        not _has_content_after_think_block(final_response)
+        or leaked_empty_sentinel(final_response)
+    )
+
+
+class TestLeakedEmptySentinel(unittest.TestCase):
+    def test_the_real_leak_recovers(self):
+        leak = "(empty) again risk. Need progress + tool. Already can. Use execute."
+        self.assertTrue(leaked_empty_sentinel(leak))
+        self.assertTrue(enters_recovery(leak), "leaked shorthand must not end the turn")
+
+    def test_bare_sentinel_still_recovers(self):
+        self.assertTrue(enters_recovery("(empty)"))
+
+    def test_leading_whitespace_does_not_evade(self):
+        self.assertTrue(enters_recovery("\n  (empty) need tool"))
+
+    # ---- false-positive guards: legitimate answers MUST still end the turn ----
+
+    def test_short_legitimate_answer_still_ends_turn(self):
+        for good in ("Done.", "PASS", "OK", "42", "Yes — verified."):
+            with self.subTest(good=good):
+                self.assertFalse(leaked_empty_sentinel(good))
+                self.assertFalse(enters_recovery(good), f"{good!r} must end the turn")
+
+    def test_answer_merely_mentioning_the_word_empty_ends_turn(self):
+        for good in (
+            "The empty response guard fired once.",
+            "`(empty)` is the sentinel Hermes injects.",
+            "Result: the list was empty.",
+        ):
+            with self.subTest(good=good):
+                self.assertFalse(
+                    enters_recovery(good),
+                    "sentinel must be a PREFIX match, not a substring match",
+                )
+
+    def test_markdown_answer_ends_turn(self):
+        self.assertFalse(enters_recovery("## Triage complete\n\n- 21 tickets\n"))
+
+    def test_thinking_only_still_recovers(self):
+        self.assertTrue(enters_recovery("<think>weighing options</think>"))
+
+
+class TestGuardStaysWiredInSource(unittest.TestCase):
+    """The mirror above is only meaningful if the real file still uses it."""
+
+    def test_source_defines_and_uses_the_guard(self):
+        src = SRC.read_text(encoding="utf-8")
+        self.assertIn("_leaked_empty_sentinel = (", src)
+        self.assertIn('.lstrip().startswith("(empty)")', src)
+        self.assertIn("or _leaked_empty_sentinel", src)
+
+    def test_partial_stream_recovery_cannot_redeliver_the_leak(self):
+        """The streamed text holds the leak verbatim — it must be fenced out."""
+        src = SRC.read_text(encoding="utf-8")
+        self.assertIn(
+            "if not _leaked_empty_sentinel and agent._has_content_after_think_block(_partial_streamed):",
+            src,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_leaked_empty_sentinel_guard.py
+++ b/tests/test_leaked_empty_sentinel_guard.py
@@ -6,77 +6,82 @@ phase=final_answer and finish_reason=stop, ending a 27-minute task mid-flight.
 Content was non-empty, so the post-tool empty-response nudge never fired.
 
 DESIGN NOTE — no mirrored oracle.
-An earlier version of this file defined its own copies of
-``_has_content_after_think_block`` and the guard expression. 7 of its 9 tests
-then passed with the production fix reverted, because they tested the copies.
-This version imports the REAL production helpers and extracts the REAL guard
-expression from source, so reverting the fix fails the behavioural tests.
+Round 1 of this file defined its own copies of `_has_content_after_think_block`
+and of the guard expression; 7 of its 9 tests then passed with the production
+fix reverted, because they tested the copies. Round 2 still inlined the
+production body of `_has_content_after_think_block`.
+
+This version imports every production symbol it exercises:
+  * `_visible_text_for_sentinel_check` and `EMPTY_RESPONSE_SENTINEL`
+    from `agent.conversation_loop`
+  * `AIAgent._has_content_after_think_block` bound to a minimal object
+so a change to any of them fails here rather than silently diverging.
 """
 import ast
-import re
 import unittest
 from pathlib import Path
 
-from agent.agent_runtime_helpers import strip_think_blocks
-from agent.message_content import flatten_message_text
+import run_agent
+from agent.conversation_loop import (
+    EMPTY_RESPONSE_SENTINEL,
+    _visible_text_for_sentinel_check,
+)
 
 SRC = Path(__file__).resolve().parents[1] / "agent" / "conversation_loop.py"
 SOURCE = SRC.read_text(encoding="utf-8")
+OWN_SOURCE = Path(__file__).read_text(encoding="utf-8")
 
 LEAK = "(empty) again risk. Need progress + tool. Already can. Use execute."
 
 
 class _MinimalAgent:
-    """Only what the production helpers actually touch."""
+    """Borrows the REAL predicate off AIAgent — no reimplementation."""
 
-    def _strip_think_blocks(self, content):
-        return strip_think_blocks(self, content)
-
-    def _has_content_after_think_block(self, content):
-        # Production body, verbatim (run_agent.py:1649) — delegates to the
-        # real strip_think_blocks, so tag handling cannot drift.
-        if not content:
-            return False
-        return bool(self._strip_think_blocks(content).strip())
+    _has_content_after_think_block = run_agent.AIAgent._has_content_after_think_block
+    _strip_think_blocks = run_agent.AIAgent._strip_think_blocks
 
 
-def _extract_guard_source():
-    """Pull the real guard expression out of conversation_loop.py.
+def _guard_source() -> str:
+    """The production guard, located by AST (not by brittle text search).
 
-    Fails loudly if the fix is absent, so a revert cannot silently pass.
+    Raises if the fix is absent so a revert cannot pass silently.
     """
-    m = re.search(
-        r"_leaked_empty_sentinel = \(\n(.*?)\n\s*\)\n", SOURCE, re.S
+    tree = ast.parse(SOURCE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "_leaked_empty_sentinel"
+                for t in node.targets
+            )
+        ):
+            return ast.unparse(node.value)
+    raise AssertionError(
+        "`_leaked_empty_sentinel = ...` not found in agent/conversation_loop.py "
+        "— the fix is missing or was renamed"
     )
-    if not m:
-        raise AssertionError(
-            "guard `_leaked_empty_sentinel = (...)` not found in "
-            "agent/conversation_loop.py — the fix is missing or was reworded"
-        )
-    return m.group(1)
 
 
-GUARD_SRC = _extract_guard_source()
+GUARD_EXPR = _guard_source()
 
 
 def leaked_empty_sentinel(agent, final_response):
-    """Evaluate the PRODUCTION guard expression against real helpers."""
-    expr = GUARD_SRC.replace("_flatten_final", "flatten_message_text")
-    # Collapse to a single expression and evaluate with production callables.
+    """Evaluate the PRODUCTION guard expression against PRODUCTION helpers."""
     return bool(
-        eval(  # noqa: S307 - evaluating our own source under test, by design
-            " ".join(expr.split()),
+        eval(  # noqa: S307 - our own source under test, by design
+            GUARD_EXPR,
             {
-                "flatten_message_text": flatten_message_text,
+                "_visible_text_for_sentinel_check": _visible_text_for_sentinel_check,
+                "EMPTY_RESPONSE_SENTINEL": EMPTY_RESPONSE_SENTINEL,
                 "agent": agent,
                 "final_response": final_response,
+                "_visible_final": _visible_text_for_sentinel_check(final_response),
             },
         )
     )
 
 
 def enters_recovery(agent, final_response):
-    """The full `if` condition guarding the empty-recovery block."""
     return (
         not agent._has_content_after_think_block(final_response)
         or leaked_empty_sentinel(agent, final_response)
@@ -91,36 +96,66 @@ class TestLeakedEmptySentinel(unittest.TestCase):
 
     def test_the_real_leak_recovers(self):
         self.assertTrue(leaked_empty_sentinel(self.agent, LEAK))
-        self.assertTrue(
-            enters_recovery(self.agent, LEAK),
-            "leaked shorthand must not end the turn",
-        )
+        self.assertTrue(enters_recovery(self.agent, LEAK))
 
     def test_leading_whitespace_does_not_evade(self):
         self.assertTrue(enters_recovery(self.agent, "\n  (empty) need tool"))
 
+    # ---- BLOCKER from review round 1: crash on non-str content ----
+
     def test_multimodal_list_content_does_not_crash(self):
-        """A non-empty list is truthy: a bare .lstrip() raised AttributeError.
+        self.assertTrue(
+            leaked_empty_sentinel(
+                self.agent,
+                [{"type": "text", "text": "(empty) need tool"}],
+            )
+        )
 
-        Anthropic-via-OpenRouter really returns this shape, which is why
-        strip_think_blocks() coerces its input.
+    def test_multimodal_legitimate_answer_does_not_trip(self):
+        self.assertFalse(
+            leaked_empty_sentinel(
+                self.agent, [{"type": "text", "text": "The chart shows a decline."}]
+            )
+        )
+
+    # ---- FALSE POSITIVE from review round 2: reasoning must not be judged ----
+
+    def test_thinking_block_starting_with_sentinel_does_not_trip(self):
+        """A scratchpad note must never condemn a good visible answer.
+
+        flatten_message_text() keeps reasoning parts and accepts the generic
+        `content` key, so {"type":"thinking","content":"(empty) ..."} used to
+        flatten AHEAD of the real answer and fire the guard.
         """
-        multimodal = [
-            {"type": "text", "text": "(empty) need tool"},
-            {"type": "thinking", "thinking": "scratch"},
-        ]
-        self.assertTrue(leaked_empty_sentinel(self.agent, multimodal))
+        for reasoning_key in ("thinking", "content", "text"):
+            for part_type in ("thinking", "reasoning", "redacted_thinking"):
+                with self.subTest(type=part_type, key=reasoning_key):
+                    content = [
+                        {"type": part_type, reasoning_key: "(empty) scratch note"},
+                        {"type": "text", "text": "Done."},
+                    ]
+                    self.assertFalse(
+                        leaked_empty_sentinel(self.agent, content),
+                        f"{part_type}/{reasoning_key} leaked into the visible check",
+                    )
 
-    def test_multimodal_legitimate_answer_does_not_crash_or_trip(self):
-        multimodal = [{"type": "text", "text": "The chart shows a decline."}]
-        self.assertFalse(leaked_empty_sentinel(self.agent, multimodal))
+    def test_visible_leak_still_caught_alongside_reasoning(self):
+        content = [
+            {"type": "thinking", "thinking": "all good"},
+            {"type": "text", "text": "(empty) need tool"},
+        ]
+        self.assertTrue(leaked_empty_sentinel(self.agent, content))
+
+    def test_helper_never_raises_on_hostile_shapes(self):
+        for junk in (None, 0, object(), [None], [{"type": None}], {"no": "type"}):
+            with self.subTest(junk=junk):
+                self.assertIsInstance(_visible_text_for_sentinel_check(junk), str)
 
     # ---- false-positive guards: legitimate answers MUST still end the turn ----
 
     def test_short_legitimate_answer_still_ends_turn(self):
         for good in ("Done.", "PASS", "OK", "42", "Yes — verified."):
             with self.subTest(good=good):
-                self.assertFalse(leaked_empty_sentinel(self.agent, good))
                 self.assertFalse(enters_recovery(self.agent, good))
 
     def test_answer_merely_mentioning_the_word_empty_ends_turn(self):
@@ -145,41 +180,43 @@ class TestLeakedEmptySentinel(unittest.TestCase):
 
 
 class TestNoMirroredOracle(unittest.TestCase):
-    """Meta-test: this file must not reimplement the logic it tests."""
+    """Meta-tests: this file must not reimplement what it tests."""
 
-    def test_guard_is_extracted_from_production_not_retyped(self):
-        self.assertIn("_leaked_empty_sentinel = (", SOURCE)
-        self.assertIn("re.search", Path(__file__).read_text(encoding="utf-8"))
-
-    def test_helpers_are_imported_not_copied(self):
-        own = Path(__file__).read_text(encoding="utf-8")
-        self.assertIn("from agent.agent_runtime_helpers import strip_think_blocks", own)
-        # A local `def _strip_think_blocks` copy would be the mirror antipattern.
-        self.assertNotIn("re.sub(r\"<(think", own)
-
-    def test_guard_uses_a_type_tolerant_flattener(self):
-        """Pin the BLOCKER fix: a bare .lstrip() on content crashes on lists.
-
-        Comments are stripped first: the explanatory comment above the guard
-        legitimately quotes the old broken expression, and a naive substring
-        assertion would match its own documentation (the
-        'comment-grepping tests self-trip' pitfall).
-        """
-        code_only = "\n".join(
-            line.split("#", 1)[0] for line in SOURCE.splitlines()
+    def test_predicate_is_borrowed_from_production(self):
+        self.assertIs(
+            _MinimalAgent._has_content_after_think_block,
+            run_agent.AIAgent._has_content_after_think_block,
         )
+
+    def test_no_local_copy_of_the_stripper(self):
+        # Compare against code only: the assertions themselves contain these
+        # needles, so scanning raw source would always self-trip.
+        code_only = "\n".join(
+            line for line in OWN_SOURCE.splitlines()
+            if "assertNotIn" not in line and "assertIn" not in line
+        )
+        self.assertNotIn("def _strip_think_blocks(self", code_only)
+        self.assertNotIn("_NON_VISIBLE_CONTENT_PART_TYPES = ", code_only)
+
+    def test_guard_expression_is_extracted_not_retyped(self):
+        self.assertIn("ast.unparse", OWN_SOURCE)
+        # The unparsed guard binds the pre-computed visible text and the shared
+        # constant — proof it came from production, not from this file.
+        self.assertIn("_visible_final", GUARD_EXPR)
+        self.assertIn("EMPTY_RESPONSE_SENTINEL", GUARD_EXPR)
+        self.assertIn("_has_content_after_think_block", GUARD_EXPR)
+
+    def test_sentinel_is_a_shared_constant(self):
+        self.assertEqual(EMPTY_RESPONSE_SENTINEL, "(empty)")
+        code_only = "\n".join(l.split("#", 1)[0] for l in SOURCE.splitlines())
+        self.assertIn("startswith(EMPTY_RESPONSE_SENTINEL)", code_only)
+
+    def test_guard_does_not_use_a_bare_lstrip(self):
+        """Comments are stripped: they legitimately quote the old broken code."""
+        code_only = "\n".join(l.split("#", 1)[0] for l in SOURCE.splitlines())
         self.assertNotIn('(final_response or "").lstrip()', code_only)
-        self.assertIn("_flatten_final(final_response)", code_only)
 
     def test_partial_stream_recovery_cannot_redeliver_the_leak(self):
-        tree = ast.parse(SOURCE)
-        self.assertTrue(
-            any(
-                isinstance(n, ast.Name) and n.id == "_leaked_empty_sentinel"
-                for n in ast.walk(tree)
-            ),
-            "guard variable vanished from production",
-        )
         self.assertIn(
             "if not _leaked_empty_sentinel and agent._has_content_after_think_block("
             "_partial_streamed):",

--- a/tests/test_leaked_empty_sentinel_guard.py
+++ b/tests/test_leaked_empty_sentinel_guard.py
@@ -5,60 +5,123 @@ Observed live (session 74508b0380e4, msg 126895): the model emitted
 phase=final_answer and finish_reason=stop, ending a 27-minute task mid-flight.
 Content was non-empty, so the post-tool empty-response nudge never fired.
 
-These tests pin the classifier decision, not the whole conversation loop:
-the guard condition is a pure expression over `final_response`.
+DESIGN NOTE — no mirrored oracle.
+An earlier version of this file defined its own copies of
+``_has_content_after_think_block`` and the guard expression. 7 of its 9 tests
+then passed with the production fix reverted, because they tested the copies.
+This version imports the REAL production helpers and extracts the REAL guard
+expression from source, so reverting the fix fails the behavioural tests.
 """
+import ast
 import re
 import unittest
 from pathlib import Path
 
+from agent.agent_runtime_helpers import strip_think_blocks
+from agent.message_content import flatten_message_text
+
 SRC = Path(__file__).resolve().parents[1] / "agent" / "conversation_loop.py"
+SOURCE = SRC.read_text(encoding="utf-8")
+
+LEAK = "(empty) again risk. Need progress + tool. Already can. Use execute."
 
 
-def _has_content_after_think_block(content: str) -> bool:
-    """Mirror of AIAgent._has_content_after_think_block for the stripped tags."""
-    if not content:
-        return False
-    cleaned = re.sub(
-        r"<(think|thinking|reasoning)>.*?</\1>", "", content, flags=re.S | re.I
+class _MinimalAgent:
+    """Only what the production helpers actually touch."""
+
+    def _strip_think_blocks(self, content):
+        return strip_think_blocks(self, content)
+
+    def _has_content_after_think_block(self, content):
+        # Production body, verbatim (run_agent.py:1649) — delegates to the
+        # real strip_think_blocks, so tag handling cannot drift.
+        if not content:
+            return False
+        return bool(self._strip_think_blocks(content).strip())
+
+
+def _extract_guard_source():
+    """Pull the real guard expression out of conversation_loop.py.
+
+    Fails loudly if the fix is absent, so a revert cannot silently pass.
+    """
+    m = re.search(
+        r"_leaked_empty_sentinel = \(\n(.*?)\n\s*\)\n", SOURCE, re.S
     )
-    return bool(cleaned.strip())
+    if not m:
+        raise AssertionError(
+            "guard `_leaked_empty_sentinel = (...)` not found in "
+            "agent/conversation_loop.py — the fix is missing or was reworded"
+        )
+    return m.group(1)
 
 
-def leaked_empty_sentinel(final_response: str) -> bool:
-    """The condition added to conversation_loop.py, kept in sync by test below."""
-    return (final_response or "").lstrip().startswith("(empty)") and (
-        _has_content_after_think_block(final_response)
+GUARD_SRC = _extract_guard_source()
+
+
+def leaked_empty_sentinel(agent, final_response):
+    """Evaluate the PRODUCTION guard expression against real helpers."""
+    expr = GUARD_SRC.replace("_flatten_final", "flatten_message_text")
+    # Collapse to a single expression and evaluate with production callables.
+    return bool(
+        eval(  # noqa: S307 - evaluating our own source under test, by design
+            " ".join(expr.split()),
+            {
+                "flatten_message_text": flatten_message_text,
+                "agent": agent,
+                "final_response": final_response,
+            },
+        )
     )
 
 
-def enters_recovery(final_response: str) -> bool:
-    """True when the turn routes into the recovery/nudge block instead of ending."""
+def enters_recovery(agent, final_response):
+    """The full `if` condition guarding the empty-recovery block."""
     return (
-        not _has_content_after_think_block(final_response)
-        or leaked_empty_sentinel(final_response)
+        not agent._has_content_after_think_block(final_response)
+        or leaked_empty_sentinel(agent, final_response)
     )
 
 
 class TestLeakedEmptySentinel(unittest.TestCase):
-    def test_the_real_leak_recovers(self):
-        leak = "(empty) again risk. Need progress + tool. Already can. Use execute."
-        self.assertTrue(leaked_empty_sentinel(leak))
-        self.assertTrue(enters_recovery(leak), "leaked shorthand must not end the turn")
+    def setUp(self):
+        self.agent = _MinimalAgent()
 
-    def test_bare_sentinel_still_recovers(self):
-        self.assertTrue(enters_recovery("(empty)"))
+    # ---- the bug: these FAIL when the production fix is reverted ----
+
+    def test_the_real_leak_recovers(self):
+        self.assertTrue(leaked_empty_sentinel(self.agent, LEAK))
+        self.assertTrue(
+            enters_recovery(self.agent, LEAK),
+            "leaked shorthand must not end the turn",
+        )
 
     def test_leading_whitespace_does_not_evade(self):
-        self.assertTrue(enters_recovery("\n  (empty) need tool"))
+        self.assertTrue(enters_recovery(self.agent, "\n  (empty) need tool"))
+
+    def test_multimodal_list_content_does_not_crash(self):
+        """A non-empty list is truthy: a bare .lstrip() raised AttributeError.
+
+        Anthropic-via-OpenRouter really returns this shape, which is why
+        strip_think_blocks() coerces its input.
+        """
+        multimodal = [
+            {"type": "text", "text": "(empty) need tool"},
+            {"type": "thinking", "thinking": "scratch"},
+        ]
+        self.assertTrue(leaked_empty_sentinel(self.agent, multimodal))
+
+    def test_multimodal_legitimate_answer_does_not_crash_or_trip(self):
+        multimodal = [{"type": "text", "text": "The chart shows a decline."}]
+        self.assertFalse(leaked_empty_sentinel(self.agent, multimodal))
 
     # ---- false-positive guards: legitimate answers MUST still end the turn ----
 
     def test_short_legitimate_answer_still_ends_turn(self):
         for good in ("Done.", "PASS", "OK", "42", "Yes — verified."):
             with self.subTest(good=good):
-                self.assertFalse(leaked_empty_sentinel(good))
-                self.assertFalse(enters_recovery(good), f"{good!r} must end the turn")
+                self.assertFalse(leaked_empty_sentinel(self.agent, good))
+                self.assertFalse(enters_recovery(self.agent, good))
 
     def test_answer_merely_mentioning_the_word_empty_ends_turn(self):
         for good in (
@@ -68,32 +131,59 @@ class TestLeakedEmptySentinel(unittest.TestCase):
         ):
             with self.subTest(good=good):
                 self.assertFalse(
-                    enters_recovery(good),
+                    enters_recovery(self.agent, good),
                     "sentinel must be a PREFIX match, not a substring match",
                 )
 
     def test_markdown_answer_ends_turn(self):
-        self.assertFalse(enters_recovery("## Triage complete\n\n- 21 tickets\n"))
+        self.assertFalse(
+            enters_recovery(self.agent, "## Triage complete\n\n- 21 tickets\n")
+        )
 
     def test_thinking_only_still_recovers(self):
-        self.assertTrue(enters_recovery("<think>weighing options</think>"))
+        self.assertTrue(enters_recovery(self.agent, "<think>weighing</think>"))
 
 
-class TestGuardStaysWiredInSource(unittest.TestCase):
-    """The mirror above is only meaningful if the real file still uses it."""
+class TestNoMirroredOracle(unittest.TestCase):
+    """Meta-test: this file must not reimplement the logic it tests."""
 
-    def test_source_defines_and_uses_the_guard(self):
-        src = SRC.read_text(encoding="utf-8")
-        self.assertIn("_leaked_empty_sentinel = (", src)
-        self.assertIn('.lstrip().startswith("(empty)")', src)
-        self.assertIn("or _leaked_empty_sentinel", src)
+    def test_guard_is_extracted_from_production_not_retyped(self):
+        self.assertIn("_leaked_empty_sentinel = (", SOURCE)
+        self.assertIn("re.search", Path(__file__).read_text(encoding="utf-8"))
+
+    def test_helpers_are_imported_not_copied(self):
+        own = Path(__file__).read_text(encoding="utf-8")
+        self.assertIn("from agent.agent_runtime_helpers import strip_think_blocks", own)
+        # A local `def _strip_think_blocks` copy would be the mirror antipattern.
+        self.assertNotIn("re.sub(r\"<(think", own)
+
+    def test_guard_uses_a_type_tolerant_flattener(self):
+        """Pin the BLOCKER fix: a bare .lstrip() on content crashes on lists.
+
+        Comments are stripped first: the explanatory comment above the guard
+        legitimately quotes the old broken expression, and a naive substring
+        assertion would match its own documentation (the
+        'comment-grepping tests self-trip' pitfall).
+        """
+        code_only = "\n".join(
+            line.split("#", 1)[0] for line in SOURCE.splitlines()
+        )
+        self.assertNotIn('(final_response or "").lstrip()', code_only)
+        self.assertIn("_flatten_final(final_response)", code_only)
 
     def test_partial_stream_recovery_cannot_redeliver_the_leak(self):
-        """The streamed text holds the leak verbatim — it must be fenced out."""
-        src = SRC.read_text(encoding="utf-8")
+        tree = ast.parse(SOURCE)
+        self.assertTrue(
+            any(
+                isinstance(n, ast.Name) and n.id == "_leaked_empty_sentinel"
+                for n in ast.walk(tree)
+            ),
+            "guard variable vanished from production",
+        )
         self.assertIn(
-            "if not _leaked_empty_sentinel and agent._has_content_after_think_block(_partial_streamed):",
-            src,
+            "if not _leaked_empty_sentinel and agent._has_content_after_think_block("
+            "_partial_streamed):",
+            SOURCE,
         )
 
 


### PR DESCRIPTION
## What does this PR do?

A turn could end on a non-answer. When a model emitted a final response that **began with Hermes' own `"(empty)"` sentinel** followed by scratchpad shorthand, `run_conversation` treated it as a completed text turn — `finish_reason=stop`, shorthand persisted as the assistant message, task abandoned mid-flight.

Observed live on a Responses-API provider, one tool round after a `PASS`:

```
finish_reason : stop
content       : (empty) again risk. Need progress + tool. Already can. Use execute.
```

That ended a ~27-minute multi-step task, and the visible "answer" was the model's own planning note.

**The recovery for this class already existed** — the post-tool empty-response nudge. It was unreachable because the whole ladder is gated on the response being contentless:

```python
if not agent._has_content_after_think_block(final_response):
```

The leak carried 67 characters, so it read as content and skipped every branch. A garbage-but-present final answer is strictly worse than an empty one: empty is recoverable, garbage is not.

This PR routes a leaked sentinel into that existing ladder. It adds no new recovery machinery.

**Why the sentinel prefix is a safe signal.** `"(empty)"` is not model text — Hermes injects it (`_nudge_msg["content"]`, and the empty terminal). A model echoing it back has leaked a planning note. Measured against a real session DB of 3,828 non-trivial turn-ending assistant messages: `(empty)` appears as a prefix exactly **once** — this bug. `[Tool loop warning`, `[System:`, `[IMPORTANT:`, the interrupt scaffolding, `[TRANSCRIPT` and `<untrusted_tool_result` appear **zero** times, which is why the guard is deliberately narrow rather than a general shorthand heuristic. (Single-user data — indicative, not a population estimate.)

## Related Issue

Fixes #83505

Adjacent, not duplicated — all three touch the same recovery ladder in `conversation_loop.py`, so whoever merges first will make the others rebase:

- #64733 — `_has_visible_content` guard on the thinking-prefill retry gate
- #65674 — nudge once before the housekeeping empty-follow-up shortcut (issue #65600)
- #70668 — surface prior-turn content as last-resort fallback

Sibling issue #24933 (closed) fixed the *commentary-phase* form of the same scratchpad leak; this is the case where the note arrives stamped `final_answer` instead.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**`agent/conversation_loop.py`**

- `EMPTY_RESPONSE_SENTINEL = "(empty)"` — module-level, shared with the injection sites so the guard cannot drift from them.
- `_visible_text_for_sentinel_check(content)` — returns only visible assistant prose from a str, a list of blocks, or a mapping. Drops `thinking` / `reasoning` / `redacted_thinking` / `reasoning_content` parts. Never raises: a bad shape yields `""` so the guard simply does not fire (fails toward the pre-existing terminate behaviour rather than crashing a turn).
- `_leaked_empty_sentinel` — true when the *visible* text starts with the sentinel and the response is otherwise non-empty; OR-ed into the existing empty-recovery gate.
- The partial-stream recovery branch inside that gate is fenced with `not _leaked_empty_sentinel`. Without this the fix is a no-op with extra steps: the leaked text *was* streamed, so `_current_streamed_assistant_text` holds it and would be re-delivered verbatim.

**`tests/test_leaked_empty_sentinel_guard.py`** (new) — 17 tests / 23 subtests.

Two deliberate design choices, both learned the hard way in review:

- **No mirrored oracle.** The predicate is borrowed off the real class (`_MinimalAgent._has_content_after_think_block = AIAgent._has_content_after_think_block`, pinned with `assertIs`) and the guard expression is extracted from source with `ast.unparse`, then evaluated against the production helpers. An earlier revision defined its own copies and **7 of 9 tests passed with the fix reverted**. A revert now fails at *collection*.
- **Both directions asserted.** The leak must recover; `"Done."`, `"PASS"`, `"OK"`, `"42"`, markdown answers, and substring mentions (`` `(empty)` is the sentinel ``) must still end the turn.

Two behaviours documented in-code rather than changed, to keep this to one concern:

- Recovery is not *guaranteed*. It depends on the post-tool nudge still being available; with the nudge latch already consumed this turn the leak reaches the empty terminal and the user sees a bare `(empty)`. Still better than shipping shorthand as an answer, and the comment now says so instead of claiming "must recover".
- No infinite-loop risk from the terminal's own `"(empty)"`: it assigns and `break`s immediately, so the guard is never re-evaluated.

## How to Test

**1. Reproduce the gate (no provider needed).** The condition is a pure expression over `final_response`:

```python
import re
def has_content(c):   # mirrors _has_content_after_think_block
    return bool(re.sub(r"<(think|thinking|reasoning)>.*?</\1>", "", c or "",
                       flags=re.S | re.I).strip())

leak = "(empty) again risk. Need progress + tool. Already can. Use execute."
print(has_content(leak))   # True -> old gate skipped -> turn terminated
```

**2. Run the new module:**

```bash
python -m pytest tests/test_leaked_empty_sentinel_guard.py -q
# 17 passed, 23 subtests passed
```

**3. Confirm the tests are revert-sensitive** (this is the part worth checking):

```bash
# remove the guard from agent/conversation_loop.py, then:
python -m pytest tests/test_leaked_empty_sentinel_guard.py -q
# ERROR at collection: `_leaked_empty_sentinel = ...` not found — the fix is missing

# or keep the guard but make _visible_text_for_sentinel_check skip the
# reasoning-exclusion, then:
# 6 subtests fail, each naming the (part_type, key) shape that regressed
```

**4. Suite:**

```bash
python -m pytest tests/run_agent/ -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — closest are #64733 / #65674 / #70668, listed above as adjacent
- [x] My PR contains **only** changes related to this fix (2 files, no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Amazon Linux 2 (aarch64), Python 3.11.15

**Note on the test checkbox, stated plainly rather than ticked:** `tests/run_agent/` reports **7 failures on this branch — and the identical 7 on a pristine `origin/main` worktree**. I captured failing test IDs both ways in the same container and diffed them: `0 introduced, 0 fixed`. All 7 are `ModuleNotFoundError: anthropic`, an artifact of my minimal test image installing only the `dev` extra. I have not run the *entire* `tests/` tree, so I can't honestly claim all-green.

Verification ran in Docker against a throwaway clone (`--network none`, repo mounted read-only, `HERMES_HOME` redirected) because this repo is also my live agent install and an in-place run can be rewritten mid-suite.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; rationale lives in code comments beside the guard
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture change
- [x] I've considered cross-platform impact — pure Python string/dict handling, no OS-specific paths or APIs
- [x] I've updated tool descriptions/schemas — N/A, no tool behaviour change

## Screenshots / Logs

The real session row that motivated this, from the local session DB:

```
finish_reason      : stop
content len        : 206        <- an earlier instance: a progress sentence
codex_message_items:
   phase='final_answer' status='completed' text='The queue is broad and includes...'
```

and the one that leaked the sentinel:

```
finish_reason : stop
content       : (empty) again risk. Need progress + tool. Already can. Use execute.
```

Both were mid-task, both had just completed successful tool calls.
