### PR TITLE
fix(unbroker): enforce disclosure boundaries

### DIFF
--- a/optional-skills/security/unbroker/references/brokers/usphonebook.json
+++ b/optional-skills/security/unbroker/references/brokers/usphonebook.json
@@ -25,29 +25,38 @@
     "method": "web_form",
     "url": "https://www.usphonebook.com/opt-out",
     "requires": {
-      "profile_url": true,
+      "profile_url": false,
       "email_verification": true,
-      "captcha": false,
+      "captcha": true,
       "gov_id": false,
       "account": false,
       "phone_callback": false,
-      "payment": false
+      "payment": false,
+      "address_or_dob": true
     },
     "inputs": [
       "full_name",
-      "contact_email",
-      "profile_url"
+      "contact_email"
     ],
-    "notes": "Reverse-phone + people-search. Opt-out: paste the listing URL, provide an email, confirm via the emailed link.",
+    "playbook": [
+      "The live /opt-out route redirects to /removal. Stage 1 asks legal first/last name + contact email + Google reCAPTCHA, then emails a 24-hour verification link.",
+      "Open the fresh verification link in the same browser session. Stage 2 requires first/last name, city, state, ZIP, email, and at least one of date of birth or street address. Middle name and phone are optional. A second Google reCAPTCHA checkbox is required before the final POST.",
+      "If DOB or street address is outside the active case's disclosure boundary, queue one consolidated human decision. After explicit authorization of one field, keep the other plus middle name and phone withheld unless separately approved.",
+      "Do not send the request to support@usphonebook.com: its official auto-reply says that mailbox does not process privacy requests and routes opt-outs back to /removal.",
+      "After the confirmation says the request was received, record awaiting_processing, allow 72 hours, clear browser cache/start a fresh search, and record confirmed_removed only if that new search proves the listing absent."
+    ],
+    "notes": "Field-verified 2026-08-10. The former profile-URL + email recipe is stale. Current flow: legal name/email/reCAPTCHA -> emailed 24-hour link -> city/state/ZIP plus either DOB or street address -> second reCAPTCHA -> 72-hour processing confirmation. Both reCAPTCHAs were standard Google checkboxes and cleared without solver/bypass in the operator CDP browser. Official support email refuses privacy requests.",
     "quirks": [
-      "Opt-out URL is the documented public endpoint; datacenter IPs get 403 (anti-bot), so confirm the live flow via the operator's residential browser before the first submission, then set last_verified.",
-      "Needs the confirmed profile_url.",
-      "Email verification required."
+      "The public /opt-out route redirects to /removal and uses Google reCAPTCHA on the initial name/email request.",
+      "The emailed second-stage form marks city, state, and ZIP as required; client-side validation also requires either date of birth or street address even though neither is individually marked with an asterisk. Middle name and phone remain optional and should be withheld by default.",
+      "The second-stage form also requires its own Google reCAPTCHA checkbox. A POST without that checkbox returns the same form with 'Captcha is required'.",
+      "Use a fresh verification email/link when a prior ticket returns generic validation errors for every populated field; stale/consumed ticket context can make valid values look invalid.",
+      "The Privacy Rights page routes public-record visibility requests back to the opt-out form; Right to Delete does not supply an alternate email lane for a consumer with no direct relationship.",
+      "support@usphonebook.com is not a privacy-request lane; its verified auto-reply refuses such requests."
     ],
     "est_processing_days": 3,
     "reappearance_risk": "medium"
   },
-  "last_verified": null,
-  "source": "curated",
-  "confidence": "documented"
+  "last_verified": "2026-08-10",
+  "source": "curated"
 }

--- a/optional-skills/security/unbroker/scripts/autopilot.py
+++ b/optional-skills/security/unbroker/scripts/autopilot.py
@@ -180,6 +180,8 @@ def _optout_action(row: dict, playbook: dict[str, dict], subject_id: str, dossie
         "confirm_first": confirm_first,
         "optout_url": row.get("optout_url"),
         "clears_children": row.get("clears_children") or [],
+        "disclosure_fields": row.get("disclosure_fields") or [],
+        "needs_operator_input": row.get("needs_operator_input") or [],
         "steps": steps,
         "after": f"python3 scripts/pdd.py record {subject_id} {bid} submitted "
                  f"--disclosed <field>... --channel web_form",
@@ -198,6 +200,11 @@ def _optout_action(row: dict, playbook: dict[str, dict], subject_id: str, dossie
     if req.get("captcha"):
         action["note"] = ("CAPTCHA-gated: attempt with the configured browser backend once; if it "
                           "does not clear, record blocked (do NOT retry-loop or bypass)")
+    if action["needs_operator_input"]:
+        action["operator_boundary"] = (
+            "Begin only with disclosure_fields; stop before disclosing unplanned fields and queue "
+            "one consolidated human decision unless explicit owner approval is already recorded."
+        )
     return action, None
 
 

--- a/optional-skills/security/unbroker/scripts/ledger.py
+++ b/optional-skills/security/unbroker/scripts/ledger.py
@@ -100,6 +100,11 @@ def transition(subject_id: str, broker_id: str, new_state: str, **fields) -> dic
         case["state"] = new_state
         for key, value in fields.items():
             case[key] = value
+        # human_task_reason describes the active parked state, not permanent case history.
+        # Do not surface caller-supplied or stale human-only metadata after the case enters
+        # any operational/non-human state.
+        if new_state != "human_task_queued":
+            case.pop("human_task_reason", None)
         stamp = now()
         case.setdefault("history", []).append({"at": stamp, "from": old, "to": new_state})
         ledger[broker_id] = case

--- a/optional-skills/security/unbroker/scripts/tiers.py
+++ b/optional-skills/security/unbroker/scripts/tiers.py
@@ -47,7 +47,8 @@ def plan(subject_dossier: dict, brokers_list: list[dict], cfg: dict,
         search = b.get("search") or {}
         # Defensive shape coercion: a subagent may have written a malformed record (requires as a
         # list, quirks as a string). Normalize here so nothing downstream crashes on a bad broker file.
-        req = opt.get("requires") if isinstance(opt.get("requires"), dict) else {}
+        raw_req = opt.get("requires")
+        req = raw_req if isinstance(raw_req, dict) else {}
         q = opt.get("quirks")
         quirks = q if isinstance(q, list) else ([q] if isinstance(q, str) and q else [])
         tier = select_tier(b, email_mode, browser_clears_captcha)
@@ -59,6 +60,12 @@ def plan(subject_dossier: dict, brokers_list: list[dict], cfg: dict,
         if req.get("dob") and not (subject_dossier.get("identity") or {}).get("date_of_birth"):
             prewarn.append("date_of_birth: this broker's identity gate requires DOB to match records; "
                            "collect it up front (intake --dob) or expect a mid-flow human pause")
+        if req.get("address_or_dob"):
+            prewarn.append(
+                "city/state/postal plus explicit approval of date_of_birth or street: this broker's "
+                "verified second stage requires location and one sensitive matching field; those "
+                "fields are not added to disclosure_fields automatically, so expect a human pause"
+            )
         actions.append({
             "broker_id": b.get("id"),
             "broker_name": b.get("name"),
@@ -162,6 +169,8 @@ def batch_plan(subject_dossier: dict, brokers_list: list[dict], cfg: dict,
                "clears_children": a.get("owns") or [],
                "optout_requires": a.get("optout_requires") or {},
                "optout_quirks": a.get("optout_quirks") or [],
+               "disclosure_fields": a.get("disclosure_fields") or [],
+               "needs_operator_input": a.get("needs_operator_input") or [],
                "deletion": a.get("deletion") or {},
                "optout_playbook": a.get("optout_playbook") or [],
                "notes": a.get("notes", "")}

--- a/tests/skills/test_unbroker_skill.py
+++ b/tests/skills/test_unbroker_skill.py
@@ -171,6 +171,44 @@ def test_plan_excludes_disallowed_fields():
         assert "profile_url" not in a["disclosure_fields"]
 
 
+def test_usphonebook_plan_prewarns_about_location_plus_dob_or_street_gate():
+    d = _consenting()
+    action = next(
+        a for a in tiers.plan(d, brokers.load_all(), config.DEFAULT_CONFIG)
+        if a["broker_id"] == "usphonebook"
+    )
+
+    assert action["optout_requires"]["address_or_dob"] is True
+    assert action["disclosure_fields"] == ["contact_email", "full_name"]
+    assert any("city/state/postal" in warning for warning in action["needs_operator_input"])
+    assert any("date_of_birth or street" in warning for warning in action["needs_operator_input"])
+
+
+def test_usphonebook_next_action_preserves_operator_disclosure_boundary():
+    with temp_env():
+        d = _consenting()
+        b = brokers.get("usphonebook")
+        cfg = {
+            **config.DEFAULT_CONFIG,
+            "autonomy": "full",
+            "email_mode": "browser",
+            "browser_backend": "browserbase",
+        }
+        queue = autopilot.next_actions(
+            d,
+            [b],
+            cfg,
+            ledger={"usphonebook": {"state": "found"}},
+            env={"BROWSERBASE_API_KEY": "configured"},
+        )
+        action = next(a for a in queue["actions"] if a.get("broker_id") == "usphonebook")
+
+        assert action["type"] == "optout_web_form"
+        assert action["disclosure_fields"] == ["contact_email", "full_name"]
+        assert any("city/state/postal" in warning for warning in action["needs_operator_input"])
+        assert "stop before disclosing unplanned fields" in action["operator_boundary"]
+
+
 
 
 def _mini_broker(bid, owns=None, requires=None, notes="", quirks=None):
@@ -222,6 +260,61 @@ def test_ledger_valid_transition_and_audit():
         audit = storage.read_jsonl(__import__("paths").audit_path(sid))
         assert any(e["to"] == "found" for e in audit)
 
+
+def test_transition_clears_stale_human_task_reason_when_case_resumes():
+    with temp_env():
+        sid = "sub_test01"
+        ledger.transition(sid, "usphonebook", "found", found=True)
+        ledger.transition(
+            sid,
+            "usphonebook",
+            "human_task_queued",
+            human_task_reason="extra disclosure requires owner approval",
+        )
+
+        case = ledger.transition(sid, "usphonebook", "awaiting_processing")
+
+        assert case["state"] == "awaiting_processing"
+        assert "human_task_reason" not in case
+
+
+def test_transition_clears_stale_human_task_reason_from_blocked_case():
+    with temp_env():
+        sid = "sub_test01"
+        ledger.transition(
+            sid,
+            "propertyrecs",
+            "blocked",
+            human_task_reason="operator browser required",
+        )
+
+        case = ledger.transition(sid, "propertyrecs", "not_found")
+
+        assert case["state"] == "not_found"
+        assert "human_task_reason" not in case
+
+
+def test_transition_rejects_human_task_reason_metadata_on_nonhuman_target():
+    with temp_env():
+        sid = "sub_test01"
+        case = ledger.transition(
+            sid,
+            "propertyrecs",
+            "blocked",
+            human_task_reason="must not survive",
+        )
+        assert case["state"] == "blocked"
+        assert "human_task_reason" not in case
+
+        case = ledger.transition(
+            sid,
+            "propertyrecs",
+            "not_found",
+            human_task_reason="must not survive",
+        )
+
+        assert case["state"] == "not_found"
+        assert "human_task_reason" not in case
 
 
 


### PR DESCRIPTION
## Summary

- clear stale `human_task_reason` metadata whenever a case enters a non-human state
- preserve disclosure fields and operator warnings through batch planning into actual web-form actions
- field-verify the current two-stage USPhoneBook flow and its least-disclosure boundary
- add regressions for stale metadata, planner prewarning, and autopilot boundary propagation

## Why

A resumed case could continue showing an obsolete human-task reason, and USPhoneBook's verified location plus DOB-or-street matching gate could be lost between planning and the emitted web-form action. The latter risks either a mid-flow dead end or unplanned disclosure.

## Validation

- `python3 tests/skills/test_unbroker_skill.py` — 35/35 passed
- `python3 -m py_compile optional-skills/security/unbroker/scripts/autopilot.py optional-skills/security/unbroker/scripts/ledger.py optional-skills/security/unbroker/scripts/tiers.py`
- `python3 -m json.tool optional-skills/security/unbroker/references/brokers/usphonebook.json`
- `git diff --check`
- added-line security scan: no hardcoded secrets, shell injection, eval/exec, unsafe pickle, or SQL-formatting findings

## Privacy boundary

USPhoneBook's automated action retains only `full_name` and `contact_email` in `disclosure_fields`. Its required city/state/postal plus DOB-or-street gate is emitted as `needs_operator_input`, and the action explicitly says to stop before any unplanned disclosure unless owner approval is already recorded.
