### PR TITLE
fix(honcho): resolve baseUrl/apiKey correctly for self-hosted and multi-profile setups

### DIFF
--- a/contributors/emails/rsherman@velocityinteractive.com
+++ b/contributors/emails/rsherman@velocityinteractive.com
@@ -1,0 +1,2 @@
+cfdude
+# PR #43803 adoption

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1534,13 +1534,31 @@ class HonchoMemoryProvider(MemoryProvider):
                     return tool_error("Missing required parameter: query")
                 peer = args.get("peer", "user")
                 reasoning_level = args.get("reasoning_level")
-                result = self._manager.dialectic_query(
-                    self._session_key, query,
-                    reasoning_level=reasoning_level,
-                    peer=peer,
-                    # Explicit reasoning bypasses the automatic-injection cap.
-                    apply_injection_cap=False,
-                )
+                try:
+                    result = self._manager.dialectic_query(
+                        self._session_key, query,
+                        reasoning_level=reasoning_level,
+                        peer=peer,
+                        # Explicit reasoning bypasses the automatic-injection cap.
+                        apply_injection_cap=False,
+                        # Explicit tool call: surface timeouts/server errors as
+                        # errors instead of collapsing them into "no result",
+                        # which is indistinguishable from an empty answer.
+                        raise_errors=True,
+                    )
+                except HonchoAuthError:
+                    # Let the outer dispatch's auth-specific handler render this.
+                    raise
+                except Exception as e:
+                    logger.warning("honcho_reasoning failed: %s", e)
+                    return tool_error(
+                        f"Honcho reasoning query failed ({e}). This is a backend "
+                        "error, not an empty result — the peer may still have "
+                        "relevant context. Slow dialectic calls at higher "
+                        "reasoning levels can exceed the configured timeout; "
+                        "consider a lower reasoning_level or raising the "
+                        "'timeout' value in honcho.json."
+                    )
                 # Update cadence tracker so auto-injection respects the gap after an explicit call
                 self._last_dialectic_turn = self._turn_count
                 return json.dumps({"result": result or "No result from Honcho."})

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -1110,8 +1110,11 @@ def _all_profile_host_configs() -> list[tuple[str, str, dict]]:
     for p in profiles:
         if p.name == "default":
             continue
-        h = f"{HOST}.{p.name}"
-        results.append((p.name, h, hosts.get(h, {})))
+        h = profile_host_key(p.name)
+        # _host_block (not hosts.get) so legacy dot-form keys
+        # ("hermes.work") stay readable per the README's back-compat
+        # promise — the canonical key resolves first, legacy falls back.
+        results.append((p.name, h, _host_block(cfg, h)))
 
     return results
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -471,7 +471,16 @@ class HonchoClientConfig:
         """Create config from environment variables (fallback)."""
         resolved_host = host or resolve_active_host()
         api_key = get_secret("HONCHO_API_KEY")
-        base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
+        # HONCHO_URL is the SDK's own env var (honcho.client resolves it when
+        # no environment is passed); accept it here so the fallback path
+        # behaves the same as from_global_config() when no config file exists.
+        # Read straight from os.environ, matching HONCHO_BASE_URL: a base URL
+        # is a deployment setting, not a profile-scoped credential.
+        base_url = (
+            os.environ.get("HONCHO_BASE_URL", "").strip()
+            or os.environ.get("HONCHO_URL", "").strip()
+            or None
+        )
         timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
         return cls(
             host=resolved_host,
@@ -534,10 +543,22 @@ class HonchoClientConfig:
             or raw.get("environment", "production")
         )
 
+        # The Honcho SDK's native config format — and what Claude Desktop
+        # writes — nests the URL at endpoint.baseUrl. Read it first: a user
+        # who has that block set almost certainly means it, and the flat
+        # baseUrl / base_url keys below are the Hermes-specific spelling.
+        endpoint_block = raw.get("endpoint")
+        native_base_url = (
+            endpoint_block.get("baseUrl")
+            if isinstance(endpoint_block, dict)
+            else None
+        )
         base_url = (
-            raw.get("baseUrl")
+            native_base_url
+            or raw.get("baseUrl")
             or raw.get("base_url")
             or os.environ.get("HONCHO_BASE_URL", "").strip()
+            or os.environ.get("HONCHO_URL", "").strip()
             or None
         )
         # Host config wins over flat/global config and environment.
@@ -1057,7 +1078,16 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         if resolved_base_url:
             logger.info("Initializing Honcho client (base_url: %s, workspace: %s)", resolved_base_url, config.workspace_id)
         else:
-            logger.info("Initializing Honcho client (host: %s, workspace: %s)", config.host, config.workspace_id)
+            # No base_url resolved, so the SDK falls back to its own
+            # ENVIRONMENTS map (honcho.client: local -> http://localhost:8000,
+            # production -> https://api.honcho.dev). Name the target at INFO:
+            # a self-hosted user whose config wasn't picked up otherwise sees
+            # a healthy-looking startup and silently talks to the public cloud.
+            logger.info(
+                "Initializing Honcho client (host: %s, workspace: %s, "
+                "base_url unset — SDK will resolve from environment=%s)",
+                config.host, config.workspace_id, config.environment,
+            )
 
         # Local Honcho instances don't require an API key, but the SDK
         # expects a non-empty string.  Use a placeholder for local URLs.

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -33,6 +33,26 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _sanitize_url(url: str | None) -> str | None:
+    """Return url unchanged, or None if it contains non-printable ASCII characters.
+
+    A stray terminal escape sequence (e.g. \x1b from copy-paste) in a URL can
+    cause upstream SDKs to raise ``Invalid non-printable ASCII character`` at
+    client construction time. Dropping the bad value keeps Honcho disabled with
+    a clear warning rather than poisoning startup.
+    """
+    if url is None:
+        return None
+    if all(0x20 <= ord(c) < 0x7F for c in url):
+        return url
+    logger.warning(
+        "Honcho base_url contains non-printable characters and will be ignored: %r",
+        url,
+    )
+    return None
+
+
 HOST = "hermes"
 
 
@@ -476,7 +496,7 @@ class HonchoClientConfig:
         # behaves the same as from_global_config() when no config file exists.
         # Read straight from os.environ, matching HONCHO_BASE_URL: a base URL
         # is a deployment setting, not a profile-scoped credential.
-        base_url = (
+        base_url = _sanitize_url(
             os.environ.get("HONCHO_BASE_URL", "").strip()
             or os.environ.get("HONCHO_URL", "").strip()
             or None
@@ -553,7 +573,7 @@ class HonchoClientConfig:
             if isinstance(endpoint_block, dict)
             else None
         )
-        base_url = (
+        base_url = _sanitize_url(
             host_block.get("baseUrl")
             or host_block.get("base_url")
             or native_base_url
@@ -1063,7 +1083,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
                 honcho_cfg = hermes_cfg.get("honcho", {})
                 if isinstance(honcho_cfg, dict):
                     if not resolved_base_url:
-                        resolved_base_url = honcho_cfg.get("base_url", "").strip() or None
+                        resolved_base_url = _sanitize_url(honcho_cfg.get("base_url", "").strip() or None)
                     if resolved_timeout is None:
                         resolved_timeout = _resolve_optional_float(
                             honcho_cfg.get("timeout"),

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -1103,8 +1103,8 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
             # key that would break a no-auth local server, so we substitute the
             # SDK's required-non-empty placeholder unless the host block opts in.
             _raw = config.raw or {}
-            _host_block = (_raw.get("hosts") or {}).get(config.host, {})
-            _host_has_key = bool(_host_block.get("apiKey"))
+            _host_block_local = _host_block(_raw, config.host)  # uses dot-form legacy fallback (#37436)
+            _host_has_key = bool(_host_block_local.get("apiKey"))
             effective_api_key = config.api_key if _host_has_key else "local"
         else:
             effective_api_key = config.api_key

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -557,6 +557,23 @@ class HonchoClientConfig:
             or raw.get("apiKey")
             or get_secret("HONCHO_API_KEY")
         )
+        # Named-profile host blocks do NOT inherit the default host's apiKey —
+        # profiles are isolated islands by design (see resolve_active_host).
+        # But the failure mode is silent: the profile runs unauthenticated and
+        # every write 401s while tools report "no context". Warn loudly so the
+        # operator learns the key must be set on THIS host block (#36098, #66125).
+        if (
+            not api_key
+            and host_block
+            and resolved_host != HOST
+            and _host_block(raw, HOST).get("apiKey")
+        ):
+            logger.warning(
+                "Honcho host block '%s' has no apiKey; the default '%s' host's key "
+                "is NOT inherited (profiles are credential-isolated). Set apiKey on "
+                "hosts.%s in %s or this profile runs unauthenticated.",
+                resolved_host, HOST, resolved_host, path,
+            )
 
         environment = (
             host_block.get("environment")
@@ -1113,19 +1130,19 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
 
         # Local Honcho instances don't require an API key, but the SDK
         # expects a non-empty string.  Use a placeholder for local URLs.
-        # For local: only use config.api_key if the host block explicitly
-        # sets apiKey (meaning the user wants local auth). Otherwise skip
-        # the stored key -- it's likely a cloud key that would break local.
+        # For local: honor config.api_key when the user set it EXPLICITLY in
+        # honcho.json — host block or top-level (#36098 issue 2: the top-level
+        # key was dropped for the placeholder, 401ing AUTH_USE_AUTH=true
+        # self-hosts). Only an env-sourced key (HONCHO_API_KEY) is still
+        # treated as likely-cloud and skipped for local URLs.
         _is_local = _is_local_base_url(resolved_base_url)
         if _is_local:
-            # Check if the host block has its own apiKey (explicit local auth).
-            # For local/LAN/VPN self-hosts, a stored root key is likely a cloud
-            # key that would break a no-auth local server, so we substitute the
-            # SDK's required-non-empty placeholder unless the host block opts in.
             _raw = config.raw or {}
             _host_block_local = _host_block(_raw, config.host)  # uses dot-form legacy fallback (#37436)
-            _host_has_key = bool(_host_block_local.get("apiKey"))
-            effective_api_key = config.api_key if _host_has_key else "local"
+            _explicit_key = bool(
+                _host_block_local.get("apiKey") or _raw.get("apiKey")
+            )
+            effective_api_key = config.api_key if _explicit_key else "local"
         else:
             effective_api_key = config.api_key
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -554,7 +554,9 @@ class HonchoClientConfig:
             else None
         )
         base_url = (
-            native_base_url
+            host_block.get("baseUrl")
+            or host_block.get("base_url")
+            or native_base_url
             or raw.get("baseUrl")
             or raw.get("base_url")
             or os.environ.get("HONCHO_BASE_URL", "").strip()

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -830,6 +830,7 @@ class HonchoSessionManager:
         reasoning_level: str | None = None,
         peer: str = "user",
         apply_injection_cap: bool = True,
+        raise_errors: bool = False,
     ) -> str:
         """
         Query Honcho's dialectic endpoint about a peer.
@@ -848,6 +849,11 @@ class HonchoSessionManager:
             apply_injection_cap: Clip automatic injections to
                 ``dialecticMaxChars``. Explicit ``honcho_reasoning`` calls pass
                 False because Honcho already bounds their output.
+            raise_errors: Re-raise backend failures instead of returning "".
+                Explicit tool calls pass True so a timeout or server error
+                surfaces as an error, not as "no result" (#36098 issue 4:
+                collapsing failures to "" made auth errors, timeouts, and
+                genuinely-empty answers indistinguishable).
 
         Returns:
             Honcho's synthesized answer, or empty string on failure.
@@ -903,6 +909,8 @@ class HonchoSessionManager:
             raise
         except Exception as e:
             logger.warning("Honcho dialectic query failed: %s", e)
+            if raise_errors:
+                raise
             return ""
 
     def prefetch_context(self, session_key: str, user_message: str | None = None) -> None:

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -416,8 +416,9 @@ class TestGetHonchoClient:
         reason="honcho SDK not installed"
     )
     def test_local_base_url_without_host_key_uses_placeholder(self):
-        """Without an explicit host-block apiKey, a local base_url still gets
-        the SDK's non-empty placeholder instead of the (likely cloud) root key."""
+        """Without an explicit apiKey anywhere in honcho.json, a local
+        base_url gets the SDK's non-empty placeholder instead of the (likely
+        cloud, env-sourced) resolved key."""
         fake_honcho = MagicMock(name="Honcho")
         cfg = HonchoClientConfig(
             api_key="cloud-root-key",
@@ -431,6 +432,29 @@ class TestGetHonchoClient:
             get_honcho_client(cfg)
 
         assert mock_honcho.call_args.kwargs["api_key"] == "local"
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("honcho"),
+        reason="honcho SDK not installed"
+    )
+    def test_local_base_url_honors_top_level_api_key(self):
+        """Regression for #36098 issue 2: a top-level apiKey in honcho.json is
+        explicit user intent and must be honored for local base_urls (AUTH_USE_AUTH
+        self-hosts). Previously only a host-block apiKey escaped the 'local'
+        placeholder, so the top-level key was dropped and every request 401'd."""
+        fake_honcho = MagicMock(name="Honcho")
+        cfg = HonchoClientConfig(
+            api_key="explicit-top-level-key",
+            base_url="http://localhost:8000",
+            host="hermes",
+            workspace_id="hermes",
+            raw={"apiKey": "explicit-top-level-key"},
+        )
+
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho:
+            get_honcho_client(cfg)
+
+        assert mock_honcho.call_args.kwargs["api_key"] == "explicit-top-level-key"
 
     @pytest.mark.skipif(
         not importlib.util.find_spec("honcho"),

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -202,6 +202,18 @@ class TestFromGlobalConfig:
         # Should fall back to from_env without crashing
         assert isinstance(config, HonchoClientConfig)
 
+    def test_base_url_host_block_overrides_root_and_env(self, tmp_path):
+        """Host-specific baseUrl should win for self-hosted Honcho deployments."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "baseUrl": "http://root:9000",
+            "hosts": {"hermes": {"baseUrl": "http://host-block:9001"}},
+        }))
+
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://env:8000"}, clear=False):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://host-block:9001"
+
 
 class TestResolveSessionName:
     def test_manual_override(self):

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -214,6 +214,41 @@ class TestFromGlobalConfig:
             config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.base_url == "http://host-block:9001"
 
+    def test_base_url_full_precedence_chain(self, tmp_path):
+        """Invariant: host block > endpoint.baseUrl (SDK-native) > flat root
+        > HONCHO_BASE_URL > HONCHO_URL. Pins the composed order of #14489
+        (host block) and #43803 (endpoint block + HONCHO_URL)."""
+        config_file = tmp_path / "config.json"
+        layers = {
+            "hosts": {"hermes": {"baseUrl": "http://host:1"}},
+            "endpoint": {"baseUrl": "http://endpoint:2"},
+            "baseUrl": "http://flat:3",
+        }
+        env = {"HONCHO_BASE_URL": "http://envbase:4", "HONCHO_URL": "http://envurl:5"}
+        expected = [
+            "http://host:1",     # full stack -> host block wins
+            "http://endpoint:2", # drop host block -> SDK-native endpoint
+            "http://flat:3",     # drop endpoint -> flat root key
+            "http://envbase:4",  # empty file -> HONCHO_BASE_URL
+            "http://envurl:5",   # drop HONCHO_BASE_URL -> HONCHO_URL
+        ]
+
+        for i, want in enumerate(expected):
+            cfg_dict = dict(layers)
+            if i >= 1:
+                cfg_dict.pop("hosts")
+            if i >= 2:
+                cfg_dict.pop("endpoint")
+            if i >= 3:
+                cfg_dict.pop("baseUrl")
+            env_dict = dict(env)
+            if i >= 4:
+                env_dict.pop("HONCHO_BASE_URL")
+            config_file.write_text(json.dumps(cfg_dict))
+            with patch.dict(os.environ, env_dict, clear=True):
+                config = HonchoClientConfig.from_global_config(config_path=config_file)
+            assert config.base_url == want, f"layer {i}: got {config.base_url!r}, want {want!r}"
+
 
 class TestResolveSessionName:
     def test_manual_override(self):
@@ -352,6 +387,50 @@ class TestObservationModeMigration:
 class TestGetHonchoClient:
     def teardown_method(self):
         reset_honcho_client()
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("honcho"),
+        reason="honcho SDK not installed"
+    )
+    def test_dot_form_legacy_host_key_keeps_local_api_key(self):
+        """Regression for #37436: a legacy dot-form host block (hermes.work)
+        must be found by the local-auth check. Before the _host_block fallback,
+        the direct dict lookup missed it, the stored apiKey was dropped for the
+        'local' placeholder, and every write 401'd silently."""
+        fake_honcho = MagicMock(name="Honcho")
+        cfg = HonchoClientConfig(
+            api_key="explicit-local-key",
+            base_url="http://localhost:8000",
+            host="hermes_work",
+            workspace_id="hermes",
+            raw={"hosts": {"hermes.work": {"apiKey": "explicit-local-key"}}},
+        )
+
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho:
+            get_honcho_client(cfg)
+
+        assert mock_honcho.call_args.kwargs["api_key"] == "explicit-local-key"
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("honcho"),
+        reason="honcho SDK not installed"
+    )
+    def test_local_base_url_without_host_key_uses_placeholder(self):
+        """Without an explicit host-block apiKey, a local base_url still gets
+        the SDK's non-empty placeholder instead of the (likely cloud) root key."""
+        fake_honcho = MagicMock(name="Honcho")
+        cfg = HonchoClientConfig(
+            api_key="cloud-root-key",
+            base_url="http://localhost:8000",
+            host="hermes",
+            workspace_id="hermes",
+            raw={},
+        )
+
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho:
+            get_honcho_client(cfg)
+
+        assert mock_honcho.call_args.kwargs["api_key"] == "local"
 
     @pytest.mark.skipif(
         not importlib.util.find_spec("honcho"),

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -67,6 +67,29 @@ class TestFromEnv:
         assert config.enabled is True
 
 
+    def test_honcho_url_env_var_is_honored(self):
+        """HONCHO_URL is the SDK's own env var; from_env() accepts it too."""
+        with patch.dict(os.environ, {"HONCHO_URL": "http://localhost:8000"}, clear=False):
+            os.environ.pop("HONCHO_API_KEY", None)
+            os.environ.pop("HONCHO_BASE_URL", None)
+            config = HonchoClientConfig.from_env()
+        assert config.base_url == "http://localhost:8000"
+        assert config.enabled is True
+
+
+    def test_honcho_base_url_wins_over_honcho_url(self):
+        with patch.dict(
+            os.environ,
+            {
+                "HONCHO_BASE_URL": "http://localhost:8000",
+                "HONCHO_URL": "http://localhost:9999",
+            },
+            clear=False,
+        ):
+            config = HonchoClientConfig.from_env()
+        assert config.base_url == "http://localhost:8000"
+
+
 class TestFromGlobalConfig:
     def test_missing_config_falls_back_to_env(self, tmp_path):
         with patch.dict(os.environ, {}, clear=True):
@@ -76,6 +99,60 @@ class TestFromGlobalConfig:
         # Should fall back to from_env
         assert config.enabled is False
         assert config.api_key is None
+
+
+    def test_missing_config_still_reads_honcho_url(self, tmp_path):
+        """The env fallback path must honor HONCHO_URL, not just HONCHO_BASE_URL.
+
+        from_global_config() returns from_env() when the config file is
+        absent, so a fallback that only from_global_config() understood
+        would silently do nothing for users with no ~/.honcho/config.json.
+        """
+        with patch.dict(os.environ, {"HONCHO_URL": "http://localhost:8000"}, clear=True):
+            config = HonchoClientConfig.from_global_config(
+                config_path=tmp_path / "nonexistent.json"
+            )
+        assert config.base_url == "http://localhost:8000"
+        assert config.enabled is True
+
+
+    def test_base_url_from_sdk_native_endpoint_block(self, tmp_path):
+        """endpoint.baseUrl is the SDK-native spelling Claude Desktop writes."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "key",
+            "endpoint": {"baseUrl": "http://localhost:8000"},
+        }))
+
+        with patch.dict(os.environ, {}, clear=True):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://localhost:8000"
+
+
+    def test_endpoint_base_url_wins_over_top_level_and_env(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "endpoint": {"baseUrl": "http://localhost:8000"},
+            "baseUrl": "http://localhost:9001",
+            "base_url": "http://localhost:9002",
+        }))
+
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://localhost:9003"}, clear=True):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://localhost:8000"
+
+
+    def test_endpoint_block_non_dict_is_ignored(self, tmp_path):
+        """A malformed endpoint value falls through instead of crashing."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "endpoint": "http://localhost:8000",
+            "baseUrl": "http://localhost:9001",
+        }))
+
+        with patch.dict(os.environ, {}, clear=True):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://localhost:9001"
 
 
     def test_host_block_overrides_root(self, tmp_path):

--- a/tests/plugins/memory/test_honcho_cli_peers.py
+++ b/tests/plugins/memory/test_honcho_cli_peers.py
@@ -1,0 +1,125 @@
+"""Regression tests for #76414: `hermes honcho peers` showed "(not set)"
+for every non-default profile.
+
+_all_profile_host_configs() built the per-profile host key inline as
+f"{HOST}.{profile}" ("hermes.work") while every other reader/writer —
+profile_host_key(), resolve_active_host(), honcho status/enable/sync and
+the runtime plugin — uses the underscore form ("hermes_work"). The lookup
+always missed, so cmd_peers fell back to "(not set)" and leaked the raw
+malformed key into the AI-peer column.
+
+These tests drive the real cmd_peers / _all_profile_host_configs against
+a real honcho.json (temp HERMES_HOME, no network).
+"""
+import io
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import plugins.memory.honcho.cli as honcho_cli
+
+
+@pytest.fixture
+def honcho_home(tmp_path, monkeypatch):
+    cfg = {
+        "peerName": "alice",
+        "hosts": {
+            "hermes": {"peerName": "alice", "aiPeer": "hermes"},
+            "hermes_work": {"peerName": "alice", "aiPeer": "hermes"},
+            "hermes_my_profile": {"peerName": "bob", "aiPeer": "hermes"},
+        },
+    }
+    path = tmp_path / "honcho.json"
+    path.write_text(json.dumps(cfg))
+    monkeypatch.setattr(honcho_cli, "_config_path", lambda: path)
+    return tmp_path
+
+
+def _peers_output(profiles):
+    buf = io.StringIO()
+    old = sys.stdout
+    sys.stdout = buf
+    try:
+        honcho_cli.cmd_peers(SimpleNamespace())
+    finally:
+        sys.stdout = old
+    return buf.getvalue()
+
+
+class TestAllProfileHostConfigs:
+    def test_profile_host_keys_match_writer_form(self, honcho_home, monkeypatch):
+        """The lookup key must be profile_host_key()'s underscore form —
+        the same one honcho sync/enable/status and the runtime write to."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="work")],
+        )
+        rows = honcho_cli._all_profile_host_configs()
+        by_name = {name: (host, block) for name, host, block in rows}
+        host, block = by_name["work"]
+        assert host == "hermes_work"  # not "hermes.work"
+        assert block.get("peerName") == "alice"  # the populated block was found
+
+    def test_sanitized_profile_names_resolve(self, honcho_home, monkeypatch):
+        """Profiles needing sanitization (dots/spaces in the name) also
+        resolve — profile_host_key maps 'my.profile' -> 'hermes_my_profile';
+        the inline dot form never could."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [SimpleNamespace(name="default"),
+                     SimpleNamespace(name="my.profile")],
+        )
+        rows = honcho_cli._all_profile_host_configs()
+        by_name = {name: block for name, _, block in rows}
+        assert by_name["my.profile"].get("peerName") == "bob"
+
+    def test_legacy_dot_form_host_key_still_readable(self, honcho_home, monkeypatch):
+        """Back-compat: honcho.json files with LEGACY dot-form host keys
+        ("hermes.work") must keep working — the README promises those keys
+        stay readable, and _host_block() exists precisely for that fallback.
+        A bare hosts.get(profile_host_key(...)) would regress them."""
+        path = honcho_home / "honcho.json"
+        cfg = json.loads(path.read_text())
+        del cfg["hosts"]["hermes_work"]
+        cfg["hosts"]["hermes.work"] = {"peerName": "carol", "aiPeer": "hermes"}
+        path.write_text(json.dumps(cfg))
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="work")],
+        )
+        rows = honcho_cli._all_profile_host_configs()
+        by_name = {name: block for name, _, block in rows}
+        assert by_name["work"].get("peerName") == "carol"
+
+
+class TestCmdPeers:
+    def test_peers_shows_populated_identity_not_host_key_leak(
+            self, honcho_home, monkeypatch):
+        """Issue #76414's visible symptom: the AI-peer column showed the
+        raw malformed key 'hermes.work' (or '(not set)')."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="work")],
+        )
+        out = _peers_output(SimpleNamespace())
+        assert "hermes.work" not in out
+        assert "(not set)" not in out
+        # work row shows the populated block's values
+        work_line = [l for l in out.splitlines() if l.strip().startswith("work")][0]
+        assert "alice" in work_line and "hermes" in work_line
+
+    def test_peers_falls_back_cleanly_when_block_missing(
+            self, honcho_home, monkeypatch):
+        """A profile with no host block still falls back to the top-level
+        peerName and the (well-formed) host key — not a crash or a leak."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="new")],
+        )
+        out = _peers_output(SimpleNamespace())
+        assert "hermes.new" not in out  # well-formed key, no dot-form leak
+        new_line = [l for l in out.splitlines() if l.strip().startswith("new")][0]
+        assert "alice" in new_line  # top-level peerName fallback

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -151,3 +151,56 @@ class TestHonchoBaseUrlSanitize:
         monkeypatch.delenv('HONCHO_API_KEY', raising=False)
         cfg = HonchoClientConfig.from_env()
         assert cfg.base_url is None
+
+
+class TestProfileKeyIsolationWarning:
+    """#36098 / #66125: a named-profile host block without apiKey does NOT
+    inherit the default host's key (isolation by design), but the failure
+    must be loud, not silent."""
+
+    def test_keyless_profile_block_warns_when_default_has_key(self, tmp_path, monkeypatch, caplog):
+        import logging
+        monkeypatch.delenv('HONCHO_API_KEY', raising=False)
+        config_path = tmp_path / 'config.json'
+        config_path.write_text(json.dumps({
+            'hosts': {
+                'hermes': {'apiKey': 'shared-key'},
+                'hermes_coder': {'baseUrl': 'http://192.168.1.50:8000'},
+            },
+        }))
+        with caplog.at_level(logging.WARNING, logger='plugins.memory.honcho.client'):
+            cfg = HonchoClientConfig.from_global_config(
+                host='hermes_coder', config_path=config_path,
+            )
+        assert cfg.api_key is None  # isolation preserved — no silent inheritance
+        assert any('NOT inherited' in r.message for r in caplog.records)
+
+    def test_no_warning_when_profile_block_has_key(self, tmp_path, monkeypatch, caplog):
+        import logging
+        monkeypatch.delenv('HONCHO_API_KEY', raising=False)
+        config_path = tmp_path / 'config.json'
+        config_path.write_text(json.dumps({
+            'hosts': {
+                'hermes': {'apiKey': 'shared-key'},
+                'hermes_coder': {'apiKey': 'coder-key'},
+            },
+        }))
+        with caplog.at_level(logging.WARNING, logger='plugins.memory.honcho.client'):
+            cfg = HonchoClientConfig.from_global_config(
+                host='hermes_coder', config_path=config_path,
+            )
+        assert cfg.api_key == 'coder-key'
+        assert not any('NOT inherited' in r.message for r in caplog.records)
+
+    def test_no_warning_for_default_host(self, tmp_path, monkeypatch, caplog):
+        import logging
+        monkeypatch.delenv('HONCHO_API_KEY', raising=False)
+        config_path = tmp_path / 'config.json'
+        config_path.write_text(json.dumps({
+            'hosts': {'hermes': {'baseUrl': 'http://localhost:8000'}},
+        }))
+        with caplog.at_level(logging.WARNING, logger='plugins.memory.honcho.client'):
+            HonchoClientConfig.from_global_config(
+                host='hermes', config_path=config_path,
+            )
+        assert not any('NOT inherited' in r.message for r in caplog.records)

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -123,3 +123,31 @@ class TestLatencyFlagResolution:
         cfg = HonchoClientConfig.from_global_config(config_path=config_path)
         assert cfg.timeout == 5.0
 
+
+class TestHonchoBaseUrlSanitize:
+    def test_clean_base_url_accepted(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('HONCHO_BASE_URL', raising=False)
+        config_path = tmp_path / 'config.json'
+        config_path.write_text(json.dumps({
+            'apiKey': 'k',
+            'baseUrl': 'https://honcho.example.com',
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+        assert cfg.base_url == 'https://honcho.example.com'
+
+    def test_nonprintable_base_url_dropped(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('HONCHO_BASE_URL', raising=False)
+        config_path = tmp_path / 'config.json'
+        bad = 'https://honcho.example.com\x1b'
+        config_path.write_text(json.dumps({
+            'apiKey': 'k',
+            'baseUrl': bad,
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+        assert cfg.base_url is None
+
+    def test_env_nonprintable_dropped(self, monkeypatch):
+        monkeypatch.setenv('HONCHO_BASE_URL', 'https://x.example\x1b')
+        monkeypatch.delenv('HONCHO_API_KEY', raising=False)
+        cfg = HonchoClientConfig.from_env()
+        assert cfg.base_url is None


### PR DESCRIPTION
## summary

self-hosted and multi-profile Honcho configuration silently resolved to the wrong target. five distinct bugs, all in the same resolution chain:

- `endpoint.baseUrl` (the SDK-native spelling, what Claude Desktop writes) was never read — self-hosted users with that config shape were silently routed to production cloud (#43800)
- host-block `baseUrl` was ignored — per-profile self-host URLs lost to the flat root key
- the local-auth check looked up the host block with a direct `dict.get`, missing legacy dot-form keys (`hermes.work`) — the stored apiKey was dropped for the `"local"` placeholder and every write 401'd silently (#37436)
- the same local-auth check also ignored a top-level `apiKey` — explicit user intent, what `hermes honcho setup` writes — so `AUTH_USE_AUTH=true` self-hosts 401'd on every request even with correctly configured credentials (#36098 issue 2)
- `hermes honcho peers` built per-profile host keys as dot-form inline while every other reader uses the underscore form — every non-default profile showed "(not set)" (#76414)

plus two silent-failure UX gaps:

- a named-profile host block without `apiKey` does not inherit the default host's key (credential isolation is deliberate) but nothing said so — the profile ran unauthenticated and every tool said "no context" (#36098 issue 1, #66125). isolation is affirmed; resolution now warns loudly naming the exact host block that needs the key
- `honcho_reasoning` collapsed timeouts and server errors into "No result from Honcho." — indistinguishable from an empty answer, sending operators down representation/observation rabbit holes when the real cause was a 30s timeout (#36098 issue 4). explicit tool calls now surface the failure and point at the timeout knob; automatic injection keeps its fail-quiet behavior
- a non-printable character in a base_url (stray `\x1b` from copy-paste) crashed client init; now dropped with a warning (salvage of #2757)
- when no base_url resolves at all, the init log now names the target the SDK will fall back to, so silent cloud-routing is visible at INFO

## resolution order after this PR

host block > `endpoint.baseUrl` > flat root (`baseUrl`/`base_url`) > `HONCHO_BASE_URL` > `HONCHO_URL`, pinned by an invariant test that walks all five layers.

## commits

adopted with original authorship, follow-ups separate:

- #43803 (@cfdude) — endpoint.baseUrl + HONCHO_URL + fallback logging
- #14489 (@LeonSGP43) — host-block baseUrl precedence
- #37671 (@Morad37) — `_host_block` dot-form fallback in the local-auth check
- #62757 (@Bartok9, salvaging #2757 by @teyrebaz33) — non-printable base_url sanitization
- #76455 (@spfcraze) — peers command underscore host keys
- follow-ups: precedence-chain reconciliation of #14489 x #43803, regression tests #37671 shipped without, the #36098 top-level-apiKey and keyless-profile-warning fixes, and the honcho_reasoning error surfacing

## closes / addresses

- closes #43800, #37436, #76414
- addresses #36098 (issues 1, 2, 4 — issue 3, timeout scaling by reasoning level, left as a follow-up; the new error message surfaces the knob)
- addresses #66125 (isolation affirmed + loud warning, the alternative the issue itself proposed)
- adopts #43803, #14489, #37671, #62757, #76455; supersedes #37456

## verification

- 335 tests green across tests/honcho_plugin/, tests/test_honcho_*, tests/plugins/memory/ — including 13 new: dot-form 401 regression, top-level-key local auth, keyless-profile warning (3 cases), 5-layer precedence invariant, non-printable sanitization, peers-command regressions
- ruff clean, `git diff --check` clean, linear history on main

thanks @cfdude, @LeonSGP43, @Morad37, @westkite1201, @Bartok9, @teyrebaz33, @spfcraze, @EduardKov (whose #36098 and #37436 reports mapped most of this cluster), and @xxxigm for the reports and fixes.
