### PR TITLE
feat(skills): render localized labeled source links in chat

### DIFF
--- a/skills/research/grounded-citations/SKILL.md
+++ b/skills/research/grounded-citations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: grounded-citations
 description: "Ground answers and documents in cited, verifiable sources."
-version: 1.1.0
+version: 1.2.0
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]
@@ -15,7 +15,7 @@ metadata:
 # Grounded Citations
 
 Every claim taken from an outside source gets an inline numbered citation and a
-`Sources:` list, Perplexity-style. A ledger script owns the `url → [n]` mapping
+labeled `Sources:` list. A ledger script owns the `url → [n]` mapping
 so the numbers and URLs come from retrieval, never from memory — the model only
 ever emits small integers it was handed.
 
@@ -61,8 +61,9 @@ S=~/.hermes/skills/research/grounded-citations/scripts/sources.py
 python3 "$S" reset                                  # start a clean ledger
 python3 "$S" add https://example.com/a --title "A"  # prints: [1]
 python3 "$S" add https://example.com/b --title "B"  # prints: [2]
+python3 "$S" annotate 1 --label "Localized label" --description "Why it matters."
 python3 "$S" list                                   # ledger table
-python3 "$S" render                                 # Sources: block
+python3 "$S" render --heading "Localized Sources"  # labeled chat block
 python3 "$S" verify draft.md                        # catch bad citations
 ```
 
@@ -77,9 +78,10 @@ id within a ledger, so ids stay stable across many search/extract rounds.
 | Register a source, get its id | `sources.py add <url> [--title T]` |
 | Register several at once | `sources.py add <url1> <url2> ...` |
 | Register from JSON tool output | `sources.py ingest results.json` |
+| Add localized chat metadata | `sources.py annotate <id> --label L [--description D]` |
 | Attach verbatim evidence to a source | `sources.py quote <id> --text "exact wording" --from page.txt` |
 | Show ledger | `sources.py list [--json]` |
-| Render the Sources block | `sources.py render [--style markdown\|plain\|footnotes\|bibtex\|evidence] [--only 1,3]` |
+| Render the Sources block | `sources.py render [--style chat\|markdown\|plain\|footnotes\|bibtex\|evidence] [--heading H] [--only 1,3]` |
 | Render only what a draft cites | `sources.py render --cited-in draft.md` |
 | Rewrite a draft's Sources block in place | `sources.py render --replace-in draft.md` |
 | Check a draft's citations | `sources.py verify draft.md [--strict] [--min-coverage 0.6] [--evidence]` |
@@ -96,7 +98,14 @@ in a draft — reusing the ledger keeps the numbering stable.
 prose. Registering later, from memory, is the failure mode this skill exists to
 prevent.
 
-③ **Write cite-while-drafting.** Place the bracketed id(s) immediately after
+③ **Annotate sources for chat.** After reading the retrieved content, use
+`annotate` to supply a concise visible label and, when useful, a one-line
+description in the active conversation locale. Summarize what the source
+supports; do not mechanically translate a noisy HTML title. If extraction did
+not provide enough context, skip annotation — `render` will use a conservative
+host/path label and will not invent a description.
+
+④ **Write cite-while-drafting.** Place the bracketed id(s) immediately after
 each sentence the source supports:
 
 ```
@@ -111,20 +120,25 @@ Ice floats because it is less dense than liquid water.[1][2]
 - Quote exact figures, dates, and names as the source states them; flag gaps
   explicitly ("no source found for X") instead of smoothing them over.
 
-④ **Append the Sources block** with `sources.py render --cited-in <draft>` so
+⑤ **Append the Sources block** with `sources.py render --cited-in <draft>` so
 the id → URL mapping is generated mechanically from the ledger, not retyped.
-For non-markdown targets pick the matching `--style` and follow
+The default `chat` style emits compact labeled Markdown links; localize its
+heading with `--heading`. Use `--style markdown` for the previous raw URL form
+needed by scripts and technical exports. For non-markdown targets pick the
+matching `--style` and follow
 `references/citation-formats.md` for placement (footnotes in docx, endnotes in
 PDF/LaTeX, a Sources slide in decks, per-page source lists in wiki output).
 
-⑤ **Verify before delivering** — `sources.py verify <draft>` exits non-zero on
+⑥ **Verify before delivering** — `sources.py verify <draft>` exits non-zero on
 unknown ids, on a Sources block that disagrees with the ledger, or (with
 `--min-coverage`) on prose that is too thinly cited. Fix and re-run.
 
-⑥ **Chat answers** follow the same steps with the draft in your reply: register
-sources, cite inline, end with the rendered `Sources:` list. For a short answer
-you may render the block from `sources.py render --only <ids>` instead of
-writing to a file.
+⑦ **Chat answers** follow the same steps with the draft in your reply: register
+and annotate sources, cite inline, then end with
+`sources.py render --heading "<localized heading>" --only <ids>`. The authored
+Markdown links stay compact on CLI, messaging, Web, and Desktop while retaining
+the ledger URL as their target. For a longer answer, use `--replace-in` and run
+`verify` on the resulting draft.
 
 ## Fact-Checking Mode
 
@@ -198,6 +212,10 @@ and read the `info: stats:` line to see the counts before picking a number.
   only between tasks.
 - **Retyping URLs into the Sources block.** Always `render`. A hand-typed URL
   is an unverified claim.
+- **Using page titles as localized labels.** Titles may be noisy or in a
+  different language. Derive labels and descriptions from retrieved content;
+  when that content is unavailable, leave the source unannotated for the safe
+  host/path fallback.
 - **Citing a search snippet as if you read the page.** A `web_search`
   description supports only what it literally says. Cite the extracted page
   when the claim needs the body — `web_extract` it first.

--- a/skills/research/grounded-citations/references/citation-formats.md
+++ b/skills/research/grounded-citations/references/citation-formats.md
@@ -8,14 +8,18 @@ this file says where it goes and what the inline marker looks like.
 Inline `[n]` immediately after the sentence. Block at the end:
 
 ```
-## Sources
+## Fuentes <!-- hermes-sources -->
 
-[1] https://example.com/a — Page title
-[2] https://example.com/b
+[1] [Resumen de resultados](https://example.com/a) — Cifras y conclusiones citadas en la respuesta.
+[2] [example.com / b](https://example.com/b)
 ```
 
-`--style plain` gives a bare `Sources:` header for chat replies where a
-markdown heading would be noise.
+`chat` is the default style. Populate localized labels/descriptions with
+`annotate`, and localize the heading with `--heading`; the hidden
+`hermes-sources` marker lets `verify` recognize any language. Missing metadata
+falls back to a readable host/path label with no description. Use
+`--style markdown` for the legacy raw URL list, or `--style plain` for a bare
+technical `Sources:` block.
 
 ## PDF via LaTeX (`latex-pdf-report` skill)
 

--- a/skills/research/grounded-citations/scripts/sources.py
+++ b/skills/research/grounded-citations/scripts/sources.py
@@ -365,7 +365,8 @@ def render_sources(
             lines.append(f"[^{s['id']}]: {s['url']}{suffix}")
         return "\n".join(lines)
     if style == "chat":
-        lines.append(f"## {heading} <!-- hermes-sources -->")
+        normalized_heading = " ".join(heading.split()) or "Sources"
+        lines.append(f"## {normalized_heading} <!-- hermes-sources -->")
         lines.append("")
         for s in picked:
             label = _markdown_label(s.get("label") or _fallback_label(s["url"]))
@@ -393,6 +394,19 @@ def render_sources(
 # ---------------------------------------------------------------------------
 
 
+def _sources_header_index(lines: list[str]) -> int:
+    """Return the last Sources header outside fenced code, or -1."""
+    header_idx = -1
+    in_fence = False
+    for i, line in enumerate(lines):
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence and _SOURCES_HEADER_RE.match(line):
+            header_idx = i
+    return header_idx
+
+
 def _split_draft(text: str) -> tuple[str, dict[int, str]]:
     """Split a draft into (prose, sources_block_map).
 
@@ -401,10 +415,7 @@ def _split_draft(text: str) -> tuple[str, dict[int, str]]:
     Fenced code blocks are dropped from prose.
     """
     lines = text.splitlines()
-    header_idx = -1
-    for i, line in enumerate(lines):
-        if _SOURCES_HEADER_RE.match(line):
-            header_idx = i
+    header_idx = _sources_header_index(lines)
     listed: dict[int, str] = {}
     if header_idx >= 0:
         for line in lines[header_idx + 1:]:
@@ -433,10 +444,7 @@ def _strip_sources_block(text: str) -> str:
     idempotent instead of stacking duplicate blocks.
     """
     lines = text.splitlines()
-    header_idx = -1
-    for i, line in enumerate(lines):
-        if _SOURCES_HEADER_RE.match(line):
-            header_idx = i
+    header_idx = _sources_header_index(lines)
     if header_idx < 0:
         return text
     return "\n".join(lines[:header_idx])

--- a/skills/research/grounded-citations/scripts/sources.py
+++ b/skills/research/grounded-citations/scripts/sources.py
@@ -11,9 +11,10 @@ Subcommands
   reset                            start a clean ledger
   add URL [URL ...]                register source(s), print their ids
   ingest FILE|-                    register every url found in JSON tool output
+  annotate ID --label L [...]      attach localized chat metadata
   quote ID --text T --from FILE|-  attach verbatim supporting evidence to a source
   list                             show the ledger
-  render                           render a Sources block
+  render                           render a labeled chat Sources block
   verify DRAFT                     check a draft's citations against the ledger
 
 Fact-checking is evidence-backed citation: ``quote`` only accepts text that
@@ -39,6 +40,7 @@ import sys
 import time
 from pathlib import Path
 from typing import Any, Iterable
+from urllib.parse import unquote, urlsplit
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _hermes_home import get_hermes_home  # noqa: E402
@@ -49,9 +51,14 @@ SCHEMA_VERSION = 1
 # reference-style labels are excluded by requiring digits only and no
 # following "(" or ":".
 _CITE_RE = re.compile(r"\[(\d{1,4})\](?![(:])")
-_SOURCES_HEADER_RE = re.compile(r"^\s*(?:#{1,6}\s*)?(?:\*\*)?sources:?(?:\*\*)?\s*$", re.IGNORECASE)
+_SOURCES_HEADER_RE = re.compile(
+    r"^(?:\s*(?:#{1,6}\s*)?(?:\*\*)?sources:?(?:\*\*)?\s*|"
+    r".*<!--\s*hermes-sources\s*-->.*)$",
+    re.IGNORECASE,
+)
 _SOURCE_LINE_RE = re.compile(r"^\s*\[(\d{1,4})\]\s*[-–:]?\s*(\S+)")
 _URL_IN_TEXT_RE = re.compile(r"https?://[^\s\"'<>)\]}]+")
+_URL_IN_ANGLE_TARGET_RE = re.compile(r"\]\(<(https?://[^>]+)>\)")
 _FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
 # Explicit declaration that a claim comes from model knowledge, not a source.
 _UNVERIFIED_RE = re.compile(r"\[unverified\]", re.IGNORECASE)
@@ -196,6 +203,48 @@ def add_sources(
     return out
 
 
+def annotate_source(
+    path: Path,
+    source_id: int,
+    label: str,
+    description: str | None = None,
+) -> dict[str, Any]:
+    """Attach human-facing chat metadata to an existing ledger source."""
+    with _LedgerLock(path):
+        data = load_ledger(path)
+        entry = next((s for s in data["sources"] if s["id"] == source_id), None)
+        if entry is None:
+            raise SystemExit(f"error: no source [{source_id}] in the ledger")
+        entry["label"] = " ".join(label.split())
+        entry["description"] = " ".join((description or "").split())
+        save_ledger(path, data)
+    return entry
+
+
+def _fallback_label(url: str) -> str:
+    """Build a conservative human-readable label from URL components."""
+    parsed = urlsplit(url)
+    host = (parsed.hostname or parsed.netloc or url).removeprefix("www.")
+    segments = [unquote(segment).replace("-", " ") for segment in parsed.path.split("/") if segment]
+    return " / ".join([host, *segments])
+
+
+def _markdown_label(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+
+
+def _markdown_target(url: str) -> str:
+    return f"<{url}>" if any(char in url for char in "() ") else url
+
+
+def _source_url_from_line(line: str) -> str | None:
+    angle_target = _URL_IN_ANGLE_TARGET_RE.search(line)
+    if angle_target:
+        return angle_target.group(1)
+    url = _URL_IN_TEXT_RE.search(line)
+    return url.group(0) if url else None
+
+
 def urls_from_json(payload: Any) -> list[tuple[str, str]]:
     """Walk arbitrary JSON tool output collecting (url, title) pairs.
 
@@ -293,6 +342,7 @@ def render_sources(
     sources: list[dict[str, Any]],
     style: str = "markdown",
     only: set[int] | None = None,
+    heading: str = "Sources",
 ) -> str:
     picked = [s for s in sources if only is None or s["id"] in only]
     picked.sort(key=lambda s: s["id"])
@@ -313,6 +363,16 @@ def render_sources(
             title = s.get("title")
             suffix = f" — {title}" if title else ""
             lines.append(f"[^{s['id']}]: {s['url']}{suffix}")
+        return "\n".join(lines)
+    if style == "chat":
+        lines.append(f"## {heading} <!-- hermes-sources -->")
+        lines.append("")
+        for s in picked:
+            label = _markdown_label(s.get("label") or _fallback_label(s["url"]))
+            target = _markdown_target(s["url"])
+            lines.append(f"[{s['id']}] [{label}]({target})")
+            if s.get("description"):
+                lines[-1] += f" — {_markdown_label(s['description'])}"
         return "\n".join(lines)
     header = "Sources:" if style == "plain" else "## Sources"
     lines.append(header)
@@ -350,8 +410,7 @@ def _split_draft(text: str) -> tuple[str, dict[int, str]]:
         for line in lines[header_idx + 1:]:
             m = _SOURCE_LINE_RE.match(line)
             if m:
-                url_match = _URL_IN_TEXT_RE.search(line)
-                listed[int(m.group(1))] = url_match.group(0) if url_match else m.group(2)
+                listed[int(m.group(1))] = _source_url_from_line(line) or m.group(2)
         body_lines = lines[:header_idx]
     else:
         body_lines = lines
@@ -535,6 +594,11 @@ def main(argv: list[str] | None = None) -> int:
     p_ing = sub.add_parser("ingest", help="register every url in JSON tool output")
     p_ing.add_argument("file", help="JSON file, or - for stdin")
 
+    p_ann = sub.add_parser("annotate", help="attach localized chat label and description")
+    p_ann.add_argument("id", type=int, help="ledger id of the source to annotate")
+    p_ann.add_argument("--label", required=True, help="localized visible link label")
+    p_ann.add_argument("--description", help="optional localized one-line description")
+
     p_q = sub.add_parser("quote", help="attach verbatim supporting evidence to a source")
     p_q.add_argument("id", type=int, help="ledger id of the source the quote supports")
     p_q.add_argument("--text", required=True, help="the exact quote, copied from the page")
@@ -550,8 +614,11 @@ def main(argv: list[str] | None = None) -> int:
 
     p_render = sub.add_parser("render", help="render a Sources block")
     p_render.add_argument(
-        "--style", default="markdown", choices=["markdown", "plain", "footnotes", "bibtex", "evidence"]
+        "--style",
+        default="chat",
+        choices=["chat", "markdown", "plain", "footnotes", "bibtex", "evidence"],
     )
+    p_render.add_argument("--heading", default="Sources", help="localized heading for chat style")
     p_render.add_argument("--only", help="ids to include, e.g. 1,3,5-7")
     p_render.add_argument("--cited-in", help="include only ids cited in this draft file")
     p_render.add_argument(
@@ -604,6 +671,11 @@ def main(argv: list[str] | None = None) -> int:
             print(f"[{entry['id']}] {entry['url']}")
         return 0
 
+    if args.cmd == "annotate":
+        entry = annotate_source(path, args.id, args.label, args.description)
+        print(f"[{entry['id']}] chat metadata attached")
+        return 0
+
     if args.cmd == "quote":
         raw = (
             sys.stdin.read()
@@ -638,7 +710,7 @@ def main(argv: list[str] | None = None) -> int:
             prose, _ = _split_draft(draft)
             cited = {int(m) for m in _CITE_RE.findall(prose)}
             only = cited if only is None else (only & cited)
-        block = render_sources(sources, style=args.style, only=only)
+        block = render_sources(sources, style=args.style, only=only, heading=args.heading)
         if not block:
             print("no sources to render", file=sys.stderr)
             return 1

--- a/tests/skills/test_grounded_citations_skill.py
+++ b/tests/skills/test_grounded_citations_skill.py
@@ -696,6 +696,56 @@ def test_render_replace_in_appends_when_no_block_exists(sources_mod, tmp_path: P
     capsys.readouterr()
 
 
+def test_render_replace_in_ignores_localized_marker_inside_fence(
+    sources_mod, tmp_path: Path, capsys
+) -> None:
+    ledger = tmp_path / "fenced.json"
+    args = ["--ledger", str(ledger)]
+    sources_mod.main(args + ["add", "https://a.example"])
+    capsys.readouterr()
+    draft = tmp_path / "d.md"
+    draft.write_text(
+        "Example output:\n\n"
+        "```md\n## Fuentes <!-- hermes-sources -->\n"
+        "[1] [example](https://example.invalid)\n```\n\n"
+        "A real claim after the example cites the ledger.[1]\n",
+        encoding="utf-8",
+    )
+
+    assert sources_mod.main(args + ["render", "--replace-in", str(draft)]) == 0
+    rendered = draft.read_text(encoding="utf-8")
+
+    assert "example.invalid" in rendered
+    assert "A real claim after the example cites the ledger.[1]" in rendered
+    assert rendered.endswith(
+        "## Sources <!-- hermes-sources -->\n\n[1] [a.example](https://a.example)\n"
+    )
+
+
+def test_render_replace_in_normalizes_multiline_heading_idempotently(
+    sources_mod, tmp_path: Path, capsys
+) -> None:
+    ledger = tmp_path / "heading.json"
+    args = ["--ledger", str(ledger)]
+    sources_mod.main(args + ["add", "https://a.example"])
+    capsys.readouterr()
+    draft = tmp_path / "d.md"
+    draft.write_text("A claim resting on the first source.[1]\n", encoding="utf-8")
+    command = args + [
+        "render",
+        "--heading",
+        "Fuentes\nconsultadas",
+        "--replace-in",
+        str(draft),
+    ]
+
+    assert sources_mod.main(command) == 0
+    first = draft.read_text(encoding="utf-8")
+    assert "## Fuentes consultadas <!-- hermes-sources -->" in first
+    assert sources_mod.main(command) == 0
+    assert draft.read_text(encoding="utf-8") == first
+
+
 # ---------------------------------------------------------------------------
 # Output legibility
 # ---------------------------------------------------------------------------

--- a/tests/skills/test_grounded_citations_skill.py
+++ b/tests/skills/test_grounded_citations_skill.py
@@ -150,6 +150,60 @@ def test_render_markdown_lists_ids_and_urls(sources_mod, ledger: Path) -> None:
     assert "[2] https://b.example" in block
 
 
+def test_render_chat_uses_localized_labeled_links(sources_mod) -> None:
+    sources = [
+        {
+            "id": 1,
+            "url": "https://jetson.com/jetson-one",
+            "label": "Jetson ONE: характеристики персонального eVTOL",
+            "description": "Официальная страница с ключевыми характеристиками.",
+        }
+    ]
+
+    block = sources_mod.render_sources(sources, style="chat", heading="Источники")
+
+    assert block == (
+        "## Источники <!-- hermes-sources -->\n\n"
+        "[1] [Jetson ONE: характеристики персонального eVTOL]"
+        "(https://jetson.com/jetson-one) — "
+        "Официальная страница с ключевыми характеристиками."
+    )
+
+
+def test_annotate_source_persists_localized_chat_metadata(sources_mod, ledger: Path) -> None:
+    sources_mod.add_sources(ledger, ["https://example.com/report"], title="Original page title")
+
+    entry = sources_mod.annotate_source(
+        ledger,
+        1,
+        label="Résumé localisé du rapport",
+        description="Synthèse des résultats cités dans la réponse.",
+    )
+
+    assert entry["title"] == "Original page title"
+    assert entry["label"] == "Résumé localisé du rapport"
+    assert entry["description"] == "Synthèse des résultats cités dans la réponse."
+    persisted = json.loads(ledger.read_text(encoding="utf-8"))["sources"][0]
+    assert persisted == entry
+
+
+def test_render_chat_falls_back_to_readable_host_path_without_description(sources_mod) -> None:
+    sources = [
+        {
+            "id": 2,
+            "url": "https://www.example.com/reports/annual%20review?utm=chat",
+            "title": "Untrusted HTML title",
+        }
+    ]
+
+    block = sources_mod.render_sources(sources, style="chat")
+
+    assert "[2] [example.com / reports / annual review]" in block
+    assert "(https://www.example.com/reports/annual%20review?utm=chat)" in block
+    assert "Untrusted HTML title" not in block
+    assert " — " not in block
+
+
 def test_render_only_subset_and_ordering(sources_mod, ledger: Path) -> None:
     block = sources_mod.render_sources(_seed(sources_mod, ledger), style="plain", only={3, 1})
     lines = [ln for ln in block.splitlines() if ln.startswith("[")]
@@ -240,6 +294,43 @@ def test_markdown_links_are_not_citations(sources_mod, ledger: Path, tmp_path: P
     assert (code, errors) == (0, [])
 
 
+def test_localized_chat_sources_block_verifies_against_ledger(
+    sources_mod, ledger: Path, tmp_path: Path
+) -> None:
+    sources_mod.add_sources(ledger, ["https://a.example/report"])
+    sources_mod.annotate_source(ledger, 1, label="Rapport localisé")
+    sources = json.loads(ledger.read_text(encoding="utf-8"))["sources"]
+    block = sources_mod.render_sources(sources, style="chat", heading="Sources consultées")
+
+    code, errors, _ = _verify(
+        sources_mod,
+        ledger,
+        tmp_path,
+        "La réponse contient une affirmation vérifiable.[1]\n\n" + block + "\n",
+    )
+
+    assert (code, errors) == (0, [])
+
+
+def test_chat_renderer_escapes_labels_and_verifies_parenthesized_urls(
+    sources_mod, ledger: Path, tmp_path: Path
+) -> None:
+    url = "https://en.wikipedia.org/wiki/Source_(journal)"
+    sources_mod.add_sources(ledger, [url])
+    sources_mod.annotate_source(ledger, 1, label="Source [journal]")
+    sources = json.loads(ledger.read_text(encoding="utf-8"))["sources"]
+    block = sources_mod.render_sources(sources, style="chat")
+
+    assert r"[Source \[journal\]](<https://en.wikipedia.org/wiki/Source_(journal)>)" in block
+    code, errors, _ = _verify(
+        sources_mod,
+        ledger,
+        tmp_path,
+        "This sentence cites a parenthesized URL safely.[1]\n\n" + block + "\n",
+    )
+    assert (code, errors) == (0, [])
+
+
 def test_min_coverage_gate(sources_mod, ledger: Path, tmp_path: Path) -> None:
     _seed(sources_mod, ledger)
     text = (
@@ -290,10 +381,43 @@ def test_cli_add_render_verify_roundtrip(sources_mod, tmp_path: Path, capsys) ->
 
     draft = tmp_path / "d.md"
     draft.write_text("Only the first source is used here.[1]\n", encoding="utf-8")
-    assert sources_mod.main(args + ["render", "--cited-in", str(draft)]) == 0
+    assert sources_mod.main(args + ["render", "--style", "markdown", "--cited-in", str(draft)]) == 0
     block = capsys.readouterr().out
     assert "[1] https://a.example" in block and "[2]" not in block
 
+    with draft.open("a", encoding="utf-8") as fh:
+        fh.write("\n" + block)
+    assert sources_mod.main(args + ["verify", str(draft)]) == 0
+
+
+def test_cli_defaults_to_localized_chat_rendering(sources_mod, tmp_path: Path, capsys) -> None:
+    ledger = tmp_path / "chat.json"
+    args = ["--ledger", str(ledger)]
+    assert sources_mod.main(args + ["add", "https://example.com/report"]) == 0
+    capsys.readouterr()
+    assert (
+        sources_mod.main(
+            args
+            + [
+                "annotate",
+                "1",
+                "--label",
+                "Informe de resultados",
+                "--description",
+                "Resumen de las cifras citadas.",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    draft = tmp_path / "chat.md"
+    draft.write_text("La respuesta presenta una cifra comprobable.[1]\n", encoding="utf-8")
+    assert sources_mod.main(args + ["render", "--heading", "Fuentes", "--cited-in", str(draft)]) == 0
+    block = capsys.readouterr().out
+
+    assert "## Fuentes <!-- hermes-sources -->" in block
+    assert "[1] [Informe de resultados](https://example.com/report)" in block
     with draft.open("a", encoding="utf-8") as fh:
         fh.write("\n" + block)
     assert sources_mod.main(args + ["verify", str(draft)]) == 0
@@ -565,7 +689,10 @@ def test_render_replace_in_appends_when_no_block_exists(sources_mod, tmp_path: P
     assert sources_mod.main(args + ["render", "--replace-in", str(draft)]) == 0
     body = draft.read_text(encoding="utf-8")
     assert body.startswith("A claim resting on the first source.[1]")
-    assert "## Sources" in body and "[1] https://a.example" in body
+    assert "## Sources <!-- hermes-sources -->" in body
+    assert "[1] [a.example](https://a.example)" in body
+    capsys.readouterr()
+    assert sources_mod.main(args + ["verify", str(draft)]) == 0
     capsys.readouterr()
 
 


### PR DESCRIPTION
## What does this PR do?

Grounded chat answers can now end with compact, localized source links instead of bare URLs. The citation ledger keeps stable numeric ids and exact URL targets for mechanical verification, while existing raw Markdown, plain, footnote, BibTeX, and evidence formats remain available for technical workflows.

### Motivation

Bare source URLs are difficult to scan in chat and can produce oversized link previews on rich clients. Retrieved sources already have stable ledger ids and URL targets, so the skill can present readable labels across CLI, messaging, Web, and Desktop without moving citation rendering into any one client.

### Behavior

- `sources.py render` now defaults to a `chat` style with a localized heading, labeled Markdown links, and optional one-line descriptions.
- `sources.py annotate` stores a localized label and optional description derived from retrieved content.
- Sources without annotations receive a conservative host/path label and no invented description.
- Stable `[n]` ids and ledger URL targets remain verifiable, including URLs with parentheses.
- `--style markdown`, `plain`, `footnotes`, `bibtex`, and `evidence` preserve raw and technical output modes.
- Localized source blocks carry a hidden marker so replacement and verification remain language-independent and idempotent.

### Implementation

The stdlib ledger script adds structured chat metadata, safe Markdown label and URL serialization, localized heading recognition, and fence-aware source-block replacement. The bundled skill and citation-format reference document the cross-surface workflow and technical-format compatibility. Focused tests cover localized rendering, safe fallbacks, verification, CLI round trips, fenced examples, and repeated replacement.

## Related Issue

Closes #83466

## Type of Change

- [x] New feature

## Changes Made

- `skills/research/grounded-citations/scripts/sources.py` - add localized chat annotation, rendering, verification, and replacement support.
- `skills/research/grounded-citations/SKILL.md` - document the localized chat workflow and raw-format compatibility.
- `skills/research/grounded-citations/references/citation-formats.md` - describe labeled chat output across supported surfaces.
- `tests/skills/test_grounded_citations_skill.py` - cover rendering, fallback, verification, escaping, and idempotence contracts.

## How to Test

1. Add and annotate a ledger source, render it with a localized heading, append it to a cited draft, and run `verify` on that draft.
2. Automated (already run locally, 55 passed):

```bash
scripts/run_tests.sh tests/skills/test_grounded_citations_skill.py
```

3. Lint the changed Python files:

```bash
uv run ruff check skills/research/grounded-citations/scripts/sources.py tests/skills/test_grounded_citations_skill.py
```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for the new behavior
- [x] I've tested on Windows 10
