### PR TITLE
fix(accounts): stop stale Anthropic connections and false removal success

### DIFF
--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -9,6 +9,8 @@ const disconnectOAuthProvider = vi.fn()
 const getEnvVars = vi.fn()
 const startManualProviderOAuth = vi.fn()
 const startManualLocalEndpoint = vi.fn()
+const runInTerminal = vi.fn()
+const notify = vi.fn()
 const onboarding = atom({ manual: false })
 
 vi.mock('@/hermes', () => ({
@@ -21,6 +23,15 @@ vi.mock('@/store/onboarding', () => ({
   $desktopOnboarding: onboarding,
   startManualProviderOAuth: (providerId: string) => startManualProviderOAuth(providerId),
   startManualLocalEndpoint: (reason: null | string) => startManualLocalEndpoint(reason)
+}))
+
+vi.mock('@/app/right-sidebar/store', () => ({
+  runInTerminal: (command: string) => runInTerminal(command)
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: (notification: unknown) => notify(notification),
+  notifyError: vi.fn()
 }))
 
 function provider(id: string, loggedIn: boolean, patch: Partial<OAuthProvider> = {}): OAuthProvider {
@@ -65,6 +76,10 @@ beforeEach(() => {
     providers: [provider('nous', true), provider('minimax-oauth', false)]
   })
   vi.spyOn(window, 'confirm').mockReturnValue(true)
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { terminal: {} }
+  })
 })
 
 afterEach(() => {
@@ -125,6 +140,32 @@ describe('ProvidersSettings', () => {
     expect(await screen.findByText('Qwen Code')).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Remove Qwen Code' })).toBeNull()
     expect(screen.getByText(/managed by its own CLI/)).toBeTruthy()
+  })
+
+  it('runs a connected external provider terminal affordance without reopening sign-in', async () => {
+    const command = 'Remove-Item -Force "$HOME/.claude/.credentials.json"'
+    listOAuthProviders.mockResolvedValue({
+      providers: [
+        provider('claude-code', true, {
+          disconnect_command: command,
+          disconnectable: false,
+          flow: 'external',
+          name: 'Anthropic OAuth'
+        })
+      ]
+    })
+
+    await renderProvidersSettings()
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: /Disconnect Anthropic OAuth: Required Extra Usage Credits to Use Subscription in terminal/
+      })
+    )
+
+    expect(runInTerminal).toHaveBeenCalledWith(command)
+    expect(startManualProviderOAuth).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ kind: 'info', title: 'Disconnect' }))
   })
 
   it('renders a Keys card for a backend-tagged provider with no PROVIDER_GROUPS prefix', async () => {

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -260,7 +260,20 @@ function ConnectedProviderRow({
         )}
       </RowButton>
       <div className="flex items-center gap-1 pr-2">
-        <Trail className="size-4 text-muted-foreground transition group-hover:text-foreground" />
+        {terminalDisconnect ? (
+          <Button
+            aria-label={`${copy.disconnect} ${title} in terminal`}
+            onClick={() => onTerminalDisconnect(provider)}
+            size="icon-xs"
+            title={copy.disconnectInTerminal}
+            type="button"
+            variant="ghost"
+          >
+            <Terminal className="size-4" />
+          </Button>
+        ) : (
+          <Trail className="size-4 text-muted-foreground transition group-hover:text-foreground" />
+        )}
         {canDisconnect && (
           <Button
             aria-label={`${t.common.remove} ${title}`}
@@ -400,7 +413,7 @@ export function ProvidersSettings({
     runInTerminal(command)
     notify({
       kind: 'info',
-      title: t.settings.providers.removedTitle,
+      title: t.settings.providers.disconnect,
       message: t.settings.providers.removeTerminalRunning(name)
     })
   }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9948,8 +9948,9 @@ def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str
         rm_file = "rm -f ~/.claude/.credentials.json"
         if sys.platform == "win32":
             return (
+                'if (Test-Path -LiteralPath "$HOME/.claude/.credentials.json") { '
                 'Remove-Item -LiteralPath "$HOME/.claude/.credentials.json" '
-                "-Force -ErrorAction SilentlyContinue"
+                "-Force -ErrorAction Stop }"
             )
         if sys.platform == "darwin":
             return f'security delete-generic-password -s "Claude Code-credentials" 2>/dev/null; {rm_file}'
@@ -10114,14 +10115,20 @@ async def disconnect_oauth_provider(
                         cleared = True
                 except Exception as e:
                     _log.exception("disconnect %s OAuth file failed", provider_id)
-                    raise HTTPException(status_code=500, detail=str(e))
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"Failed to remove stored credentials for {provider['name']}.",
+                    )
                 # Also clear the credential pool entry if present.
                 try:
                     from hermes_cli.auth import clear_provider_auth
                     cleared = clear_provider_auth("anthropic") or cleared
                 except Exception as e:
                     _log.exception("disconnect %s auth store failed", provider_id)
-                    raise HTTPException(status_code=500, detail=str(e))
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"Failed to remove stored credentials for {provider['name']}.",
+                    )
                 if not cleared:
                     raise HTTPException(
                         status_code=409,
@@ -10146,7 +10153,10 @@ async def disconnect_oauth_provider(
                 raise
             except Exception as e:
                 _log.exception("disconnect %s failed", provider_id)
-                raise HTTPException(status_code=500, detail=str(e))
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Failed to remove stored credentials for {provider['name']}.",
+                )
 
     return await asyncio.to_thread(_run)
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9703,11 +9703,14 @@ def _claude_code_only_status() -> Dict[str, Any]:
     when they also have a separate Hermes-managed PKCE login.
     """
     try:
-        from agent.anthropic_adapter import read_claude_code_credentials
+        from agent.anthropic_adapter import (
+            is_claude_code_token_valid,
+            read_claude_code_credentials,
+        )
         creds = read_claude_code_credentials()
     except Exception:
         creds = None
-    if creds and creds.get("accessToken"):
+    if creds and is_claude_code_token_valid(creds):
         return {
             "logged_in": True,
             "source": "claude_code_cli",
@@ -9943,6 +9946,11 @@ def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str
         return None
     if provider.get("id") == "claude-code":
         rm_file = "rm -f ~/.claude/.credentials.json"
+        if sys.platform == "win32":
+            return (
+                'Remove-Item -LiteralPath "$HOME/.claude/.credentials.json" '
+                "-Force -ErrorAction SilentlyContinue"
+            )
         if sys.platform == "darwin":
             return f'security delete-generic-password -s "Claude Code-credentials" 2>/dev/null; {rm_file}'
         return rm_file
@@ -10104,24 +10112,38 @@ async def disconnect_oauth_provider(
                     if oauth_file.exists():
                         oauth_file.unlink()
                         cleared = True
-                except Exception:
-                    pass
+                except Exception as e:
+                    _log.exception("disconnect %s OAuth file failed", provider_id)
+                    raise HTTPException(status_code=500, detail=str(e))
                 # Also clear the credential pool entry if present.
                 try:
                     from hermes_cli.auth import clear_provider_auth
                     cleared = clear_provider_auth("anthropic") or cleared
-                except Exception:
-                    pass
+                except Exception as e:
+                    _log.exception("disconnect %s auth store failed", provider_id)
+                    raise HTTPException(status_code=500, detail=str(e))
+                if not cleared:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=f"No stored credentials were removed for {provider['name']}.",
+                    )
                 _log.info("oauth/disconnect: %s", provider_id)
-                return {"ok": bool(cleared), "provider": provider_id}
+                return {"ok": True, "provider": provider_id}
 
             try:
                 from hermes_cli.auth import clear_provider_auth, invalidate_nous_auth_status_cache
                 cleared = clear_provider_auth(provider_id)
                 if provider_id == "nous":
                     invalidate_nous_auth_status_cache()
+                if not cleared:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=f"No stored credentials were removed for {provider['name']}.",
+                    )
                 _log.info("oauth/disconnect: %s (cleared=%s)", provider_id, cleared)
-                return {"ok": bool(cleared), "provider": provider_id}
+                return {"ok": True, "provider": provider_id}
+            except HTTPException:
+                raise
             except Exception as e:
                 _log.exception("disconnect %s failed", provider_id)
                 raise HTTPException(status_code=500, detail=str(e))

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -562,9 +562,11 @@ def test_claude_code_disconnect_command_is_native_powershell_on_windows():
     command = web_server._oauth_provider_disconnect_command(provider)
 
     assert command is not None
+    assert "Test-Path" in command
     assert "Remove-Item" in command
     assert "-Force" in command
-    assert "-ErrorAction SilentlyContinue" in command
+    assert "-ErrorAction Stop" in command
+    assert "SilentlyContinue" not in command
     assert "rm -f" not in command
 
 
@@ -628,15 +630,18 @@ def test_anthropic_disconnect_surfaces_auth_store_failure(tmp_path, monkeypatch)
         lambda: tmp_path / "missing-oauth.json",
     )
 
+    sensitive_detail = f"auth store is read-only: {tmp_path}"
+
     def fail_clear(_provider):
-        raise OSError("auth store is read-only")
+        raise OSError(sensitive_detail)
 
     monkeypatch.setattr(auth_mod, "clear_provider_auth", fail_clear)
 
     resp = client.delete("/api/providers/oauth/anthropic", headers=HEADERS)
 
     assert resp.status_code == 500, resp.text
-    assert "auth store is read-only" in resp.text
+    assert "Failed to remove stored credentials for Anthropic API Key" in resp.text
+    assert sensitive_detail not in resp.text
 
 
 def test_xai_dashboard_poller_seeds_single_entry_and_clears_suppression(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -534,6 +534,40 @@ def test_oauth_catalog_marks_external_providers_not_disconnectable():
     assert cmd and ".claude/.credentials.json" in cmd
 
 
+def test_expired_claude_code_credentials_are_not_connected(monkeypatch):
+    """Accounts must use the same local validity gate as Anthropic resolution."""
+    from agent import anthropic_adapter
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "read_claude_code_credentials",
+        lambda: {"accessToken": "expired-token", "expiresAt": 1},
+    )
+
+    resp = client.get("/api/providers/oauth", headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    providers = {p["id"]: p for p in resp.json()["providers"]}
+
+    assert providers["claude-code"]["status"]["logged_in"] is False
+
+
+@pytest.mark.windows_only
+def test_claude_code_disconnect_command_is_native_powershell_on_windows():
+    from hermes_cli import web_server
+
+    provider = next(
+        p for p in web_server._build_oauth_catalog() if p["id"] == "claude-code"
+    )
+
+    command = web_server._oauth_provider_disconnect_command(provider)
+
+    assert command is not None
+    assert "Remove-Item" in command
+    assert "-Force" in command
+    assert "-ErrorAction SilentlyContinue" in command
+    assert "rm -f" not in command
+
+
 def test_external_oauth_disconnect_rejected_before_auth_mutation(monkeypatch):
     """DELETE must not pretend to remove credentials owned by another CLI."""
     from hermes_cli import auth as auth_mod
@@ -564,6 +598,45 @@ def test_env_sourced_oauth_status_is_not_disconnectable(monkeypatch):
     delete_resp = client.delete("/api/providers/oauth/anthropic", headers=HEADERS)
     assert delete_resp.status_code == 400, delete_resp.text
     assert "Settings" in delete_resp.text
+
+
+def test_disconnect_returns_error_when_no_credentials_were_removed(monkeypatch):
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": True})
+    monkeypatch.setattr(auth_mod, "clear_provider_auth", lambda _provider: False)
+
+    resp = client.delete("/api/providers/oauth/nous", headers=HEADERS)
+
+    assert resp.status_code == 409, resp.text
+    assert "No stored credentials were removed" in resp.text
+
+
+def test_anthropic_disconnect_surfaces_auth_store_failure(tmp_path, monkeypatch):
+    from agent import anthropic_adapter
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(
+        web_server,
+        "_resolve_provider_status",
+        lambda _provider_id, _status_fn: {"logged_in": True, "source": "hermes_pkce"},
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_get_hermes_oauth_file",
+        lambda: tmp_path / "missing-oauth.json",
+    )
+
+    def fail_clear(_provider):
+        raise OSError("auth store is read-only")
+
+    monkeypatch.setattr(auth_mod, "clear_provider_auth", fail_clear)
+
+    resp = client.delete("/api/providers/oauth/anthropic", headers=HEADERS)
+
+    assert resp.status_code == 500, resp.text
+    assert "auth store is read-only" in resp.text
 
 
 def test_xai_dashboard_poller_seeds_single_entry_and_clears_suppression(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes the Accounts page reporting expired Anthropic OAuth credentials as connected while the model picker correctly rejects them. It also makes disconnect behavior honest on Windows: external Claude Code credentials use native PowerShell syntax and an explicit terminal action, while API-managed removals now return an error instead of a false success when nothing was cleared.

### Symptom

On Windows 11, an expired Claude Code credential file can leave Anthropic OAuth marked Connected even though no authenticated models are available. Running the offered removal command fails because PowerShell interprets `rm -f` as an ambiguous `Remove-Item` invocation, yet the UI can report that the account was removed; the connected-row terminal affordance also reopens setup instead of disconnecting.

### Impact

Affected users cannot trust the Accounts page to reflect usable Anthropic authentication and can receive a success indication after a no-op or failed credential removal. Persisted external credentials can survive reinstall and keep the misleading state visible.

### Bug Cause

**Trigger:** `hermes_cli/web_server.py` / `_claude_code_only_status`, `_oauth_provider_disconnect_command`, and `disconnect_oauth_provider`

**Causal chain:**
1. A persisted Claude Code credential file contains an access token that is expired, or a Windows user invokes the external-provider disconnect action.
2. The Accounts status path checks only for token presence, while provider resolution applies the canonical expiration check; the removal path emits POSIX `rm -f` into PowerShell and API removal can return HTTP 200 with `ok: false`.
3. Accounts shows Connected without a usable provider, PowerShell rejects the command, and clients can present removal as successful even though credentials remain.

**Why it is wrong:** Authentication status diverges between the Accounts catalog and model resolution, the generated command does not match the host shell, and unsuccessful state mutation is encoded as a successful HTTP response.

**Working sibling / contrast:** Anthropic model resolution already uses `is_claude_code_token_valid`, and successful API-managed disconnects already have a definite credential-store mutation to report.

**Ruled out:** Missing Anthropic environment variables are not the cause of the Connected badge; the stale state comes from the separately persisted Claude Code credential source, as confirmed by exercising the external credential file path with the environment keys unset.

### Fix

- Reuse the canonical Claude Code token-validity predicate when building Accounts status.
- Generate `Remove-Item -LiteralPath ... -Force -ErrorAction SilentlyContinue` on Windows while retaining native commands for macOS and POSIX hosts.
- Turn the connected external-provider terminal glyph into a real disconnect action and label terminal execution as in progress instead of removed.
- Return HTTP 409 when no managed credentials were removed and surface credential-store failures as HTTP 500, allowing Desktop and dashboard clients to show errors instead of success.

## Related Issue

Closes #83459

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` - align Claude Code status with token validity, emit host-native disconnect commands, and fail unsuccessful API removals.
- `tests/hermes_cli/test_web_oauth_dispatch.py` - cover expired credentials, native Windows PowerShell syntax, no-op removal, and auth-store failures.
- `apps/desktop/src/app/settings/providers-settings.tsx` - make the terminal affordance disconnect and avoid false removal success messaging.
- `apps/desktop/src/app/settings/providers-settings.test.tsx` - verify the connected external-provider terminal action does not reopen sign-in.

## How to Test

1. On Windows 11, place an expired Claude Code access token in the external credentials file and open Providers > Accounts; verify Anthropic OAuth is not marked Connected.
2. With a connected external Anthropic entry, invoke its terminal disconnect action; verify the command uses unambiguous native PowerShell syntax, removes the file, and does not reopen setup.
3. Force an API-managed credential clear to remove nothing or raise an error; verify the endpoint returns HTTP 409 or 500 and the client does not show a success notification.
4. Run the focused automated suites:

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_oauth_dispatch.py
cd apps/desktop && npx vitest run src/app/settings/providers-settings.test.tsx
```

Focused results: 19 Python tests passed and 7 Desktop tests passed. Targeted ESLint and `tsc --noEmit` also passed. The Windows PowerShell command, expired-token status, API failure signaling, and both client error surfaces were verified end to end on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A, no user-facing documentation changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool behavior changed
