### PR TITLE
fix(cli): suspend only the CLI process on Ctrl+Z, not the process group (#83006)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3551,6 +3551,22 @@ def _strip_leaked_bracketed_paste_wrappers(text: str) -> str:
     return strip_leaked_bracketed_paste_wrappers(text)
 
 
+def _suspend_cli_process() -> None:
+    """Suspend only the CLI process, not its whole process group (Unix).
+
+    Ctrl+Z used to signal the process group via ``os.kill(0, SIGTSTP)``,
+    which also stopped every background job sharing the group (e.g. a
+    long-running terminal/OCR task spawned from the session) and made a
+    stray 0x1A byte in pasted input look like a crash (#83006). Shell job
+    control stops only the foreground job; mirror that by signaling just
+    this process so ``fg`` resumes the CLI while background tasks keep
+    running.
+    """
+    import signal as _sig
+
+    os.kill(os.getpid(), _sig.SIGTSTP)
+
+
 def _apply_bracketed_paste_timeout_patch() -> None:
     """Patch prompt_toolkit to recover from torn bracketed-paste sequences.
 
@@ -16449,14 +16465,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 _cprint(f"\n{_DIM}Suspend (Ctrl+Z) is not supported on Windows.{_RST}")
                 event.app.invalidate()
                 return
-            import signal as _sig
             from prompt_toolkit.application import run_in_terminal
             from hermes_cli.skin_engine import get_active_skin
             agent_name = get_active_skin().get_branding("agent_name", "Hermes Agent")
             msg = f"\n{agent_name} has been suspended. Run `fg` to bring {agent_name} back."
             def _suspend():
                 os.write(1, msg.encode())
-                os.kill(0, _sig.SIGTSTP)
+                logger.info("Ctrl+Z: suspending Hermes CLI (pid %d)", os.getpid())
+                _suspend_cli_process()
             run_in_terminal(_suspend)
 
         # Voice push-to-talk key: configurable via config.yaml (voice.record_key)

--- a/cli.py
+++ b/cli.py
@@ -3555,11 +3555,19 @@ def _suspend_cli_process() -> None:
     """Suspend only the CLI process, not its whole process group (Unix).
 
     Ctrl+Z used to signal the group via ``os.kill(0, SIGTSTP)``, stopping
-    every background job sharing it (long-running terminal/OCR tasks) and
-    making a stray 0x1A byte in pasted input look like a crash (#83006).
-    Shell job control stops only the foreground job; mirror that by
-    signaling just this process so ``fg`` resumes the CLI while background
-    tasks keep running.
+    every background job sharing it (long-running terminal/OCR tasks) —
+    which made a stray 0x1A byte in pasted input *look* like a crash
+    (#83006). Shell job control stops only the foreground job; mirror that
+    by signaling just this process so ``fg`` resumes the CLI while
+    background tasks keep running.
+
+    Known limit: this narrows, but does not eliminate, the paste-trigger
+    half of #83006. A pasted 0x1A whose bytes reach the key parser (torn
+    paste where the ESC[200~ start marker is lost, or a raw 0x1A keypress)
+    still fires the ``c-z`` binding and suspends the CLI itself — only the
+    collateral group suspension is gone. A raw 0x1A is byte-identical to a
+    real Ctrl+Z, so it is inherently undetectable app-side; leave it as a
+    documented terminal/job-control limit.
     """
     import signal as _sig
 

--- a/cli.py
+++ b/cli.py
@@ -3554,13 +3554,12 @@ def _strip_leaked_bracketed_paste_wrappers(text: str) -> str:
 def _suspend_cli_process() -> None:
     """Suspend only the CLI process, not its whole process group (Unix).
 
-    Ctrl+Z used to signal the process group via ``os.kill(0, SIGTSTP)``,
-    which also stopped every background job sharing the group (e.g. a
-    long-running terminal/OCR task spawned from the session) and made a
-    stray 0x1A byte in pasted input look like a crash (#83006). Shell job
-    control stops only the foreground job; mirror that by signaling just
-    this process so ``fg`` resumes the CLI while background tasks keep
-    running.
+    Ctrl+Z used to signal the group via ``os.kill(0, SIGTSTP)``, stopping
+    every background job sharing it (long-running terminal/OCR tasks) and
+    making a stray 0x1A byte in pasted input look like a crash (#83006).
+    Shell job control stops only the foreground job; mirror that by
+    signaling just this process so ``fg`` resumes the CLI while background
+    tasks keep running.
     """
     import signal as _sig
 

--- a/cli.py
+++ b/cli.py
@@ -4109,6 +4109,22 @@ def _hermes_call_output_screen_diff(
         )
 
 
+def _suspend_cli_process() -> None:
+    """Suspend only the CLI process, not its whole process group (Unix).
+
+    Ctrl+Z used to signal the process group via ``os.kill(0, SIGTSTP)``,
+    which also stopped every background job sharing the group (e.g. a
+    long-running terminal/OCR task spawned from the session) and made a
+    stray 0x1A byte in pasted input look like a crash (#83006). Shell job
+    control stops only the foreground job; mirror that by signaling just
+    this process so ``fg`` resumes the CLI while background tasks keep
+    running.
+    """
+    import signal as _sig
+
+    os.kill(os.getpid(), _sig.SIGTSTP)
+
+
 def _apply_bracketed_paste_timeout_patch() -> None:
     """Patch prompt_toolkit to recover from torn bracketed-paste sequences.
 
@@ -18990,14 +19006,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 _cprint(f"\n{_DIM}Suspend (Ctrl+Z) is not supported on Windows.{_RST}")
                 event.app.invalidate()
                 return
-            import signal as _sig
             from prompt_toolkit.application import run_in_terminal
             from hermes_cli.skin_engine import get_active_skin
             agent_name = get_active_skin().get_branding("agent_name", "Hermes Agent")
             msg = f"\n{agent_name} has been suspended. Run `fg` to bring {agent_name} back."
             def _suspend():
                 os.write(1, msg.encode())
-                os.kill(0, _sig.SIGTSTP)
+                logger.info("Ctrl+Z: suspending Hermes CLI (pid %d)", os.getpid())
+                _suspend_cli_process()
             run_in_terminal(_suspend)
 
         # Voice push-to-talk key: configurable via config.yaml (voice.record_key)

--- a/cli.py
+++ b/cli.py
@@ -4112,13 +4112,12 @@ def _hermes_call_output_screen_diff(
 def _suspend_cli_process() -> None:
     """Suspend only the CLI process, not its whole process group (Unix).
 
-    Ctrl+Z used to signal the process group via ``os.kill(0, SIGTSTP)``,
-    which also stopped every background job sharing the group (e.g. a
-    long-running terminal/OCR task spawned from the session) and made a
-    stray 0x1A byte in pasted input look like a crash (#83006). Shell job
-    control stops only the foreground job; mirror that by signaling just
-    this process so ``fg`` resumes the CLI while background tasks keep
-    running.
+    Ctrl+Z used to signal the group via ``os.kill(0, SIGTSTP)``, stopping
+    every background job sharing it (long-running terminal/OCR tasks) and
+    making a stray 0x1A byte in pasted input look like a crash (#83006).
+    Shell job control stops only the foreground job; mirror that by
+    signaling just this process so ``fg`` resumes the CLI while background
+    tasks keep running.
     """
     import signal as _sig
 

--- a/cli.py
+++ b/cli.py
@@ -4113,11 +4113,19 @@ def _suspend_cli_process() -> None:
     """Suspend only the CLI process, not its whole process group (Unix).
 
     Ctrl+Z used to signal the group via ``os.kill(0, SIGTSTP)``, stopping
-    every background job sharing it (long-running terminal/OCR tasks) and
-    making a stray 0x1A byte in pasted input look like a crash (#83006).
-    Shell job control stops only the foreground job; mirror that by
-    signaling just this process so ``fg`` resumes the CLI while background
-    tasks keep running.
+    every background job sharing it (long-running terminal/OCR tasks) —
+    which made a stray 0x1A byte in pasted input *look* like a crash
+    (#83006). Shell job control stops only the foreground job; mirror that
+    by signaling just this process so ``fg`` resumes the CLI while
+    background tasks keep running.
+
+    Known limit: this narrows, but does not eliminate, the paste-trigger
+    half of #83006. A pasted 0x1A whose bytes reach the key parser (torn
+    paste where the ESC[200~ start marker is lost, or a raw 0x1A keypress)
+    still fires the ``c-z`` binding and suspends the CLI itself — only the
+    collateral group suspension is gone. A raw 0x1A is byte-identical to a
+    real Ctrl+Z, so it is inherently undetectable app-side; leave it as a
+    documented terminal/job-control limit.
     """
     import signal as _sig
 

--- a/tests/cli/test_ctrl_z_suspend_scope.py
+++ b/tests/cli/test_ctrl_z_suspend_scope.py
@@ -6,49 +6,14 @@ the group (long-running terminal/OCR tasks spawned from the session) and
 turned a stray 0x1A byte in pasted input into an apparent crash. The fix
 signals only the current process, matching shell job-control semantics.
 """
-import ast
 import signal
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
-ROOT = Path(__file__).resolve().parents[2]
-CLI_PATH = ROOT / "cli.py"
-
-
-def _load_suspend_helper():
-    """Load cli._suspend_cli_process without importing cli.
-
-    AST-loading the exact helper keeps the test tied to production code
-    while avoiding cli.py's heavy import side effects. If the helper is
-    removed or renamed, this test fails.
-    """
-    source = CLI_PATH.read_text(encoding="utf-8")
-    tree = ast.parse(source)
-    helper_node = next(
-        (
-            node
-            for node in tree.body
-            if isinstance(node, ast.FunctionDef)
-            and node.name == "_suspend_cli_process"
-        ),
-        None,
-    )
-    assert helper_node is not None, "cli.py must define _suspend_cli_process()"
-    helper_source = ast.get_source_segment(source, helper_node)
-    assert helper_source is not None, "failed to extract _suspend_cli_process source"
-    import os as _os
-
-    namespace: dict = {"os": _os}
-    exec(helper_source, namespace)
-    helper = namespace["_suspend_cli_process"]
-    assert callable(helper), "extracted _suspend_cli_process must be callable"
-    return helper
+from cli import _suspend_cli_process
 
 
 def test_suspend_targets_only_current_process():
     """Ctrl+Z must signal the current pid, never the process group (0)."""
-    _suspend_cli_process = _load_suspend_helper()
     with patch("os.kill") as mock_kill, patch("os.getpid", return_value=4242):
         _suspend_cli_process()
     mock_kill.assert_called_once_with(4242, signal.SIGTSTP)
@@ -56,11 +21,3 @@ def test_suspend_targets_only_current_process():
     assert 0 not in called_pids, (
         "Ctrl+Z must not signal the whole process group (os.kill(0, ...))"
     )
-
-
-def test_suspend_skipped_on_windows():
-    """The helper is Unix-only; Windows has no SIGTSTP."""
-    if sys.platform == "win32":
-        import pytest
-
-        pytest.skip("POSIX-only helper")

--- a/tests/cli/test_ctrl_z_suspend_scope.py
+++ b/tests/cli/test_ctrl_z_suspend_scope.py
@@ -1,0 +1,66 @@
+"""Tests for Ctrl+Z suspend scope (#83006).
+
+The CLI's Ctrl+Z binding used to suspend the *entire process group* via
+``os.kill(0, SIGTSTP)``, which also stopped every background job sharing
+the group (long-running terminal/OCR tasks spawned from the session) and
+turned a stray 0x1A byte in pasted input into an apparent crash. The fix
+signals only the current process, matching shell job-control semantics.
+"""
+import ast
+import signal
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+CLI_PATH = ROOT / "cli.py"
+
+
+def _load_suspend_helper():
+    """Load cli._suspend_cli_process without importing cli.
+
+    AST-loading the exact helper keeps the test tied to production code
+    while avoiding cli.py's heavy import side effects. If the helper is
+    removed or renamed, this test fails.
+    """
+    source = CLI_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    helper_node = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_suspend_cli_process"
+        ),
+        None,
+    )
+    assert helper_node is not None, "cli.py must define _suspend_cli_process()"
+    helper_source = ast.get_source_segment(source, helper_node)
+    assert helper_source is not None, "failed to extract _suspend_cli_process source"
+    import os as _os
+
+    namespace: dict = {"os": _os}
+    exec(helper_source, namespace)
+    helper = namespace["_suspend_cli_process"]
+    assert callable(helper), "extracted _suspend_cli_process must be callable"
+    return helper
+
+
+def test_suspend_targets_only_current_process():
+    """Ctrl+Z must signal the current pid, never the process group (0)."""
+    _suspend_cli_process = _load_suspend_helper()
+    with patch("os.kill") as mock_kill, patch("os.getpid", return_value=4242):
+        _suspend_cli_process()
+    mock_kill.assert_called_once_with(4242, signal.SIGTSTP)
+    called_pids = [call.args[0] for call in mock_kill.call_args_list]
+    assert 0 not in called_pids, (
+        "Ctrl+Z must not signal the whole process group (os.kill(0, ...))"
+    )
+
+
+def test_suspend_skipped_on_windows():
+    """The helper is Unix-only; Windows has no SIGTSTP."""
+    if sys.platform == "win32":
+        import pytest
+
+        pytest.skip("POSIX-only helper")


### PR DESCRIPTION
## Summary

Fixes #83006 — Ctrl+Z in the CLI/classic TUI suspended the **entire process group** via `os.kill(0, SIGTSTP)`, not just the CLI itself.

Two compounding symptoms, one root cause:

1. **Background jobs die silently.** Any subprocess sharing the CLI's process group (long-running terminal/OCR tasks spawned from the session) was suspended alongside Hermes when Ctrl+Z was pressed. If the user then killed the stopped group, background work was destroyed mid-run.
2. **A paste can trigger it.** A raw `0x1A` byte (SUB, common in text copied from PDFs/scanned docs) is parsed by prompt_toolkit as the `c-z` key — with no Ctrl+Z ever pressed. Because the handler signaled the whole group, this looked like a random "crash and exit" and stopped unrelated background tasks.

## Fix

- New `_suspend_cli_process()` helper: `os.kill(os.getpid(), SIGTSTP)` instead of `os.kill(0, SIGTSTP)`. This mirrors shell job control — `fg` resumes the CLI, and background tasks in the same group keep running. (Only production SIGTSTP-send site; `gateway/status.py` only reads stopped state.)
- `logger.info` when the binding fires, so accidental triggers are diagnosable from agent logs.

## Known limitation (paste guard)

The issue also suggested ignoring `c-z` while in bracketed-paste mode. Investigation of the installed prompt_toolkit (3.0.52) showed that **properly-marked bracketed pastes already cannot trigger this**: `Vt100Parser.feed()` buffers `\x1b[200~ … \x1b[201~` content and delivers it as a single `BracketedPaste` key, so a `0x1A` inside never becomes a `c-z` keypress. The only residual path is *unmarked* raw bytes (terminals without bracketed-paste support, or bytes injected without the wrapper) — and at that level a `0x1A` byte is byte-identical to a real Ctrl+Z press, so no guard can distinguish them without breaking the feature. With the process-group kill removed, even that residual path is now non-destructive: only the CLI suspends, `fg` recovers.

## Test

`tests/cli/test_ctrl_z_suspend_scope.py` — asserts `_suspend_cli_process()` signals the current pid with `SIGTSTP` and never `0`. Verified via `scripts/run_tests.sh` (11/11 in the cli subset, including neighboring ctrl+binding and bracketed-paste tests).
