### PR TITLE
fix(tui_gateway): let completed Desktop sessions run refine

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8101,6 +8101,62 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_refine_uses_live_agent_and_persisted_history_without_spawning_worker(monkeypatch):
+    captured = {}
+
+    class _Agent:
+        valid_tool_names = {"memory", "skill_manage"}
+
+        def _spawn_background_review(self, **kwargs):
+            captured.update(kwargs)
+
+    class _DB:
+        def get_messages_as_conversation(self, key, include_ancestors=True, **_kwargs):
+            assert key == "session-key"
+            assert include_ancestors is True
+            return [
+                {"role": "user", "content": "persisted question"},
+                {"role": "assistant", "content": "persisted answer"},
+            ]
+
+    class _ExplodingWorker:
+        def __init__(self, *_args, **_kwargs):
+            raise AssertionError("/refine must not run in the isolated slash worker")
+
+    server._sessions["sid"] = _session(
+        agent=_Agent(),
+        history=[{"role": "user", "content": "stale in-memory history"}],
+        slash_worker=None,
+    )
+    monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "refine",
+                "method": "slash.exec",
+                "params": {
+                    "command": "refine save the workflow",
+                    "session_id": "sid",
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert "Reviewing this conversation" in response["result"]["output"]
+    assert captured == {
+        "messages_snapshot": [
+            {"role": "user", "content": "persisted question"},
+            {"role": "assistant", "content": "persisted answer"},
+        ],
+        "review_memory": True,
+        "review_skills": True,
+        "focus": "save the workflow",
+    }
+
+
 def test_prompt_submit_sets_approval_session_key(monkeypatch):
     from tools.approval import get_current_session_key
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8157,6 +8157,52 @@ def test_refine_uses_live_agent_and_persisted_history_without_spawning_worker(mo
     }
 
 
+def test_refine_forwards_to_compute_host_owner_without_spawning_worker(monkeypatch):
+    calls = []
+
+    class _ExplodingWorker:
+        def __init__(self, *_args, **_kwargs):
+            raise AssertionError("/refine must not run in the isolated slash worker")
+
+    session = _session(_compute_host_active=True)
+    session["agent"] = None
+    server._sessions["sid"] = session
+    monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: True)
+
+    def send_control(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"type": "control.ack", "output": "host review started"}
+
+    monkeypatch.setattr(server, "_send_compute_host_control", send_control)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "refine-host",
+                "method": "slash.exec",
+                "params": {
+                    "command": "refine save the workflow",
+                    "session_id": "sid",
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert response["result"]["output"] == "host review started"
+    assert calls == [
+        (
+            ("sid",),
+            {
+                "route_name": "slash.refine",
+                "command": "/refine save the workflow",
+                "wait": True,
+            },
+        )
+    ]
+
+
 def test_prompt_submit_sets_approval_session_key(monkeypatch):
     from tools.approval import get_current_session_key
 

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -60,9 +60,58 @@ def test_mutator_route_table_matches_prd_inventory():
         "slash.personality": "idle-gated",
         "slash.prompt": "idle-gated",
         "slash.compress": "idle-gated",
+        "slash.refine": "idle-gated",
         "session.reset": "idle-gated",
         "session.history.reload": "idle-gated",
         "slash.retry": "idle-gated",
+    }
+
+
+def test_compute_host_refine_control_uses_host_owned_agent(monkeypatch):
+    captured = {}
+
+    class _Agent:
+        valid_tool_names = {"memory", "skill_manage"}
+
+        def _spawn_background_review(self, **kwargs):
+            captured.update(kwargs)
+
+    session = {
+        "agent": _Agent(),
+        "session_key": "host-session",
+        "history": [
+            {"role": "user", "content": "host question"},
+            {"role": "assistant", "content": "host answer"},
+        ],
+        "history_lock": threading.Lock(),
+        "history_version": 2,
+        "running": False,
+    }
+    monkeypatch.setattr(server, "_sessions", {"sid": session})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    stdout = io.StringIO()
+    host = ComputeHost(stdout=stdout, heartbeat_secs=0)
+    try:
+        host._handle_control(
+            {
+                "type": "control",
+                "sid": "sid",
+                "request_id": "refine",
+                "route_name": "slash.refine",
+                "command": "/refine save the workflow",
+            }
+        )
+    finally:
+        host.close()
+
+    ack = _json_lines(stdout)[-1]
+    assert ack["type"] == "control.ack"
+    assert "Reviewing this conversation" in ack["output"]
+    assert captured == {
+        "messages_snapshot": session["history"],
+        "review_memory": True,
+        "review_skills": True,
+        "focus": "save the workflow",
     }
 
 

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -735,7 +735,13 @@ class ComputeHost:
                 return
             command = str(frame.get("command") or "")
             output = ""
-            if command:
+            if route_name == "slash.refine":
+                parts = command.lstrip("/").split(maxsplit=1)
+                focus = parts[1] if len(parts) > 1 else ""
+                output = server._live_slash_command_output(
+                    sid, session, "refine", focus
+                ) or ""
+            elif command:
                 output = server._mirror_slash_side_effects(sid, session, command)
             with session["history_lock"]:
                 messages = server._history_to_messages(list(session.get("history") or []))

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -39,6 +39,7 @@ MUTATOR_ROUTE_TABLE: dict[str, str] = {
     "slash.personality": "idle-gated",
     "slash.prompt": "idle-gated",
     "slash.compress": "idle-gated",
+    "slash.refine": "idle-gated",
     "session.reset": "idle-gated",
     "session.history.reload": "idle-gated",
     "slash.retry": "idle-gated",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12881,6 +12881,21 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
             return "Refine unavailable (no session)."
         if session.get("running"):
             return "Agent is running — wait for the turn to finish, then /refine."
+        if _session_uses_compute_host(session):
+            command = "/refine" + (f" {arg}" if arg.strip() else "")
+            try:
+                ack = _send_compute_host_control(
+                    sid,
+                    route_name="slash.refine",
+                    command=command,
+                    wait=True,
+                )
+            except Exception as exc:
+                return f"compute-host slash.refine failed: {exc}"
+            if ack.get("type") in {"control.error", "error"}:
+                return str(ack.get("message") or "compute-host slash.refine failed")
+            _apply_compute_host_metadata_mirror(session, ack)
+            return str(ack.get("output") or "")
         agent = session.get("agent")
         if agent is None:
             return "Nothing to refine yet — send a message first."

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12658,6 +12658,7 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
         "history",
         "models",
         "prompt",
+        "refine",
         "rename",
         "status",
         "usage",
@@ -12875,6 +12876,47 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
         if session is None:
             return "No active agent -- send a message first."
         return _format_live_prompt_output(session)
+    if name == "refine":
+        if session is None:
+            return "Refine unavailable (no session)."
+        if session.get("running"):
+            return "Agent is running — wait for the turn to finish, then /refine."
+        agent = session.get("agent")
+        if agent is None:
+            return "Nothing to refine yet — send a message first."
+
+        snapshot = []
+        session_key = str(session.get("session_key") or "")
+        if session_key:
+            try:
+                with _session_db(session) as db:
+                    if db is not None:
+                        snapshot = db.get_messages_as_conversation(
+                            session_key, include_ancestors=True
+                        )
+            except Exception:
+                logger.debug("failed to load persisted /refine transcript", exc_info=True)
+        if not snapshot:
+            with session["history_lock"]:
+                snapshot = list(session.get("history", []))
+        if not snapshot:
+            return "Nothing to refine yet — the conversation is empty."
+
+        review_skills = "skill_manage" in getattr(agent, "valid_tool_names", set())
+        try:
+            agent._spawn_background_review(
+                messages_snapshot=list(snapshot),
+                review_memory=True,
+                review_skills=review_skills,
+                focus=arg.strip() or None,
+            )
+        except Exception as exc:
+            return f"/refine failed to start: {exc}"
+        tail = f" (focus: {arg.strip()})" if arg.strip() else ""
+        return (
+            f"⚗ Reviewing this conversation in the background{tail} — "
+            "any memory/skill updates will be reported when done."
+        )
     if name == "status":
         response = _methods["session.status"]("status", {"session_id": sid})
         if response.get("error"):


### PR DESCRIPTION
## What does this PR do?

Desktop and TUI sessions can now run `/refine` against a completed conversation even when the isolated slash-command worker has no cached agent. The command stays with the session owner, reads the canonical persisted transcript, and preserves the review focus instead of incorrectly reporting that there is nothing to refine.

### Symptom

A Desktop session with completed, persisted turns can return `Nothing to refine yet - send a message first.` when the user invokes `/refine` after the agent is idle.

### Impact

Affected Desktop and TUI users cannot refine an existing conversation even though its transcript remains visible and durable. The command ignores usable session history and the requested background review never starts.

### Bug Cause

**Trigger:** `tui_gateway/methods_tools.py` / `slash.exec` dispatch for `/refine`

**Causal chain:**
1. Desktop sends `/refine` through the TUI gateway's `slash.exec` path.
2. Because `refine` was not a live-session command, dispatch selected an isolated `HermesCLI` slash worker that did not own the active session agent or its persisted transcript.
3. The isolated handler saw an empty cache and returned the same response used for a genuinely empty conversation.

**Why it is wrong:** Session ownership and durable conversation state live in the gateway process or its compute host, not in the isolated slash worker. Cache absence in that worker does not mean the conversation is empty.

**Working sibling / contrast:** Other live session commands already execute against the gateway-owned session. The messaging gateway's `/refine` path has its own valid agent cache and is not routed through this isolated Desktop/TUI seam.

**Ruled out:** An actually empty conversation was ruled out because the regression test supplies persisted user and assistant turns and verifies that they are selected over stale in-memory history.

### Fix

Route `/refine` as an idle-gated live-session command. The gateway now snapshots the persisted transcript including ancestor messages, falls back to locked live history when needed, and starts the review on the owning agent. Turn-isolated sessions forward the command to the compute host so the process that owns the live agent performs the same operation.

## Related Issue

Closes #83455

## Type of Change

- [x] Bug fix

## Changes Made

- `tui_gateway/server.py` - handle `/refine` on the live session, load durable history, and forward compute-host-owned sessions.
- `tui_gateway/compute_host.py` - execute forwarded refine requests on the host-owned agent.
- `tui_gateway/host_supervisor.py` - register refine as an idle-gated mutator route.
- `tests/test_tui_gateway_server.py` - cover persisted-history recovery and compute-host forwarding without isolated worker creation.
- `tests/tui_gateway/test_compute_host_phase1.py` - cover host-owned review startup and route classification.

## How to Test

Automated tests already run locally on Windows:

```bash
scripts/run_tests.sh tests/test_tui_gateway_server.py
scripts/run_tests.sh tests/agent/test_refine_focus.py
scripts/run_tests.sh tests/tui_gateway/test_compute_host_phase1.py
```

Results: 534 gateway server tests passed, 3 refine focus tests passed, and 8 compute-host tests passed. One unrelated pre-existing Windows `O_APPEND` test in the compute-host file still fails; the focused refine and route tests passed.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's test entry on relevant tests
- [x] I've added regression tests for this bug fix
- [x] I've tested on Windows
