### PR TITLE
fix(gateway): stop a resuming viewer stealing a running session's stream

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -228,3 +228,47 @@ def test_ws_transport_preserves_cross_batch_order():
     asyncio.run(scenario())
 
 
+
+
+def _rebind_session(running, current_transport):
+    return {"running": running, "transport": current_transport}
+
+
+def test_resume_does_not_steal_a_running_sessions_transport():
+    """A second viewer resuming a session must not take over its live stream.
+
+    Resume is also how another window / tile / client PEEKS at a session. When
+    it rebound unconditionally, a turn already streaming to viewer A suddenly
+    emitted to viewer B, and A watched its own answer stop mid-sentence.
+    """
+    viewer_a = object()
+    viewer_b = object()
+
+    assert not server._resume_may_rebind_transport(_rebind_session(True, viewer_a), viewer_b)
+
+
+def test_resume_rebinds_an_idle_session():
+    """With no turn in flight there is nothing to interrupt."""
+    viewer_a = object()
+    viewer_b = object()
+
+    assert server._resume_may_rebind_transport(_rebind_session(False, viewer_a), viewer_b)
+
+
+def test_resume_rebinds_a_running_session_whose_viewer_disconnected():
+    """A detached session has no live reader, so the resuming client wins."""
+    viewer_b = object()
+
+    detached = _rebind_session(True, server._detached_ws_transport)
+    assert server._resume_may_rebind_transport(detached, viewer_b)
+
+    on_stdio = _rebind_session(True, server._stdio_transport)
+    assert server._resume_may_rebind_transport(on_stdio, viewer_b)
+
+
+def test_resume_is_idempotent_for_the_same_viewer():
+    """The viewer that already owns the stream may always re-assert it."""
+    viewer_a = object()
+
+    assert server._resume_may_rebind_transport(_rebind_session(True, viewer_a), viewer_a)
+    assert server._resume_may_rebind_transport(_rebind_session(True, None), viewer_a)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8163,6 +8163,33 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     return in_memory_fallback
 
 
+def _resume_may_rebind_transport(session: dict, transport: Transport) -> bool:
+    """Whether a ``session.resume`` may point this session at *transport*.
+
+    Resume is also how a second viewer PEEKS at a session (another window, a
+    tile, a mobile client). Rebinding unconditionally meant that peek stole the
+    stream: a turn already running for viewer A suddenly emitted to viewer B,
+    and A watched its own answer stop mid-sentence.
+
+    So a RUNNING session keeps the transport it is streaming to, unless that
+    transport is gone — a disconnect points detached sessions at
+    ``_detached_ws_transport`` (see ``_reap_or_detach_sessions_for_transport``),
+    and a session parked there has no live reader, so the resuming client is
+    strictly better than nothing. An idle session always rebinds: with no turn
+    in flight there is nothing to interrupt, and the next prompt would rebind
+    anyway.
+    """
+    current = session.get("transport")
+
+    if current is transport or current is None:
+        return True
+
+    if not session.get("running"):
+        return True
+
+    return current is _detached_ws_transport or current is _stdio_transport
+
+
 def _live_session_payload(
     sid: str,
     session: dict,
@@ -8175,7 +8202,7 @@ def _live_session_payload(
     with session["history_lock"]:
         if cols is not None:
             session["cols"] = cols
-        if transport is not None:
+        if transport is not None and _resume_may_rebind_transport(session, transport):
             session["transport"] = transport
         if touch:
             session["last_active"] = time.time()


### PR DESCRIPTION
## The bug

`session.resume` is not only "reattach me" — it is also how a **second viewer peeks** at a session from another window, tile, or client.

`_live_session_payload` rebinds the session's transport unconditionally:

```python
if transport is not None:
    session["transport"] = transport
```

So the peek **takes over the live stream**. A turn already running for viewer A suddenly emits to viewer B, and A watches its own answer stop mid-sentence — no error, no indication, and no way to get the stream back short of another resume (which then steals it from B).

The window is exactly "a turn is in flight and someone else opens the same session", which is the normal case as soon as a client supports more than one view of a conversation.

## The fix

A **running** session keeps the transport it is streaming to. Three cases still rebind, because none of them can interrupt anyone:

- **an idle session** — nothing is in flight, and the next prompt would rebind anyway;
- **a session parked on `_detached_ws_transport` or `_stdio_transport`** — a disconnect points detached sessions at the former (`_reap_or_detach_sessions_for_transport`), so there is no live reader and the resuming client is strictly better than nothing;
- **the viewer that already owns the stream**, re-asserting it (also covers `current is None`).

The predicate is a pure function on `(session, transport)`, so it is directly testable without standing up a gateway.

## Scope

`tui_gateway/server.py` only — one new helper plus one condition on an existing assignment. No API, wire-format, or config change; a client that only ever has one viewer sees no difference.

## Tests

Four regression tests in `tests/test_tui_gateway_ws.py`, one per branch above.

- With the patch: `10 passed`.
- Reverting `server.py` and keeping the tests: **`4 failed, 6 passed`**.

## Provenance

This has been running in a downstream fork for some time, where the multi-viewer case (extra windows, tiles, a phone client on the same session) is common enough that the stolen-stream symptom showed up immediately. Sending it upstream because the root cause is in the shared gateway, not in anything fork-specific — the guard is worth having wherever more than one viewer can resume a session.

Confirmed still present on `main` at `37e46c774c`.