### PR TITLE
fix(honcho): isolate clients per profile identity — end cross-tenant memory bleed in multi-profile processes

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -559,8 +559,13 @@ class MemoryManager:
             except Exception as exc:  # pragma: no cover - re-raised by caller
                 error_box["value"] = exc
 
+        # Propagate the caller's contextvars (profile HERMES_HOME override)
+        # to the prefetch thread — see _submit_background.
+        import contextvars
+
+        _ctx = contextvars.copy_context()
         thread = threading.Thread(
-            target=_run,
+            target=lambda: _ctx.run(_run),
             daemon=True,
             name=f"memory-prefetch-{provider.name}",
         )
@@ -696,7 +701,19 @@ class MemoryManager:
     # -- Background dispatch -------------------------------------------------
 
     def _submit_background(self, fn, *, kind: str = "write") -> None:
-        """Queue ``fn`` on the serialized worker and track its durability class."""
+        """Queue ``fn`` on the serialized worker and track its durability class.
+
+        The submitted callable is wrapped with the CALLER's contextvars:
+        profile isolation in multi-profile processes (gateway multiplexer,
+        dashboard, cron) is a ContextVar-scoped HERMES_HOME override, and
+        executor worker threads start with empty contexts — without the
+        wrap, a provider resolving ambient state (config paths, secrets)
+        from the worker would silently land on the default profile.
+        """
+        import contextvars
+
+        ctx = contextvars.copy_context()
+        fn = (lambda inner: (lambda: ctx.run(inner)))(fn)
         executor = self._get_sync_executor()
         if executor is None:
             if self._shutting_down:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -24,6 +24,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from agent.memory_manager import sanitize_context
 from agent.memory_provider import TRIVIAL_PROMPT_RE, MemoryProvider, is_trivial_prompt
+from plugins.memory.honcho.client import spawn_context_thread
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -467,9 +468,8 @@ class HonchoMemoryProvider(MemoryProvider):
                     self._manager = None
                     logger.warning("Honcho background session init failed: %s", e)
 
-            self._init_thread = threading.Thread(
-                target=_run,
-                daemon=True,
+            self._init_thread = spawn_context_thread(
+                _run,
                 name="honcho-session-init",
             )
             self._init_thread.start()
@@ -546,9 +546,8 @@ class HonchoMemoryProvider(MemoryProvider):
                         self._dialectic_empty_streak += 1
 
                 self._prefetch_thread_started_at = time.monotonic()
-                prewarm_thread = threading.Thread(
-                    target=_prewarm_dialectic,
-                    daemon=True,
+                prewarm_thread = spawn_context_thread(
+                    _prewarm_dialectic,
                     name="honcho-prewarm-dialectic",
                 )
                 prewarm_thread.start()
@@ -776,9 +775,7 @@ class HonchoMemoryProvider(MemoryProvider):
                     except Exception as e:
                         logger.debug("Honcho first-turn base context failed: %s", e)
 
-                _bt = threading.Thread(
-                    target=_fetch_base, daemon=True, name="honcho-base-first"
-                )
+                _bt = spawn_context_thread(_fetch_base, name="honcho-base-first")
                 _bt.start()
                 _base_wait = (
                     max(0.0, first_turn_base_deadline - time.monotonic())
@@ -853,8 +850,8 @@ class HonchoMemoryProvider(MemoryProvider):
                         self._dialectic_empty_streak += 1
 
                 self._prefetch_thread_started_at = time.monotonic()
-                first_turn_thread = threading.Thread(
-                    target=_run_first_turn, daemon=True, name="honcho-prefetch-first"
+                first_turn_thread = spawn_context_thread(
+                    _run_first_turn, name="honcho-prefetch-first"
                 )
                 first_turn_thread.start()
                 self._prefetch_thread = first_turn_thread
@@ -1009,9 +1006,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 self._dialectic_empty_streak += 1
 
         self._prefetch_thread_started_at = time.monotonic()
-        prefetch_thread = threading.Thread(
-            target=_run, daemon=True, name="honcho-prefetch"
-        )
+        prefetch_thread = spawn_context_thread(_run, name="honcho-prefetch")
         prefetch_thread.start()
         self._prefetch_thread = prefetch_thread
 
@@ -1416,9 +1411,7 @@ class HonchoMemoryProvider(MemoryProvider):
 
         if self._sync_thread and self._sync_thread.is_alive():
             self._sync_thread.join(timeout=5.0)
-        self._sync_thread = threading.Thread(
-            target=_sync, daemon=True, name="honcho-sync"
-        )
+        self._sync_thread = spawn_context_thread(_sync, name="honcho-sync")
         self._sync_thread.start()
 
     def on_memory_write(
@@ -1451,7 +1444,7 @@ class HonchoMemoryProvider(MemoryProvider):
             except Exception as e:
                 logger.debug("Honcho memory mirror failed: %s", e)
 
-        t = threading.Thread(target=_write, daemon=True, name="honcho-memwrite")
+        t = spawn_context_thread(_write, name="honcho-memwrite")
         t.start()
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -877,7 +877,123 @@ class HonchoClientConfig:
 
 
 _honcho_client_slot: SingletonSlot = SingletonSlot()
-_cached_timeout: float | None = None
+# --- per-identity client cache -------------------------------------------
+# One slot per client identity, replacing the single process-wide slot that
+# pinned the first profile's workspace and bearer for every later profile in
+# multi-profile processes (#69123 multiplexed gateway, #74065 dashboard).
+# The legacy names above are retained only for reset bookkeeping.
+import threading as _threading
+
+_client_slots: dict[tuple, SingletonSlot] = {}
+_client_slot_timeouts: dict[tuple, float] = {}
+_client_slots_lock = _threading.Lock()
+
+
+def _credential_fingerprint(config: HonchoClientConfig | None) -> str:
+    """Stable identity for the credential a client will be built with.
+
+    OAuth grants rotate their access token in place (apply_token_to_client),
+    so the fingerprint must NOT change on rotation — it hashes the REFRESH
+    token, which is stable across access-token rotation but changes on
+    re-auth or account switch. Static keys hash the key itself. This is what
+    makes 'hermes honcho setup' account switches produce a NEW cache identity
+    instead of silently reusing the old account's client (a first-config-wins
+    hole that per-path keys alone cannot close).
+    """
+    try:
+        if config is not None:
+            block = _host_block(config.raw or {}, config.host)
+            oauth_block = block.get("oauth")
+            if isinstance(oauth_block, dict) and oauth_block.get("refreshToken"):
+                basis = f"oauth:{oauth_block['refreshToken']}"
+            elif config.api_key:
+                basis = f"key:{config.api_key}"
+            else:
+                return ""
+            return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+        # Ambient: read the active file so legacy no-config callers still get
+        # a credential-aware key (correct on main threads; bound configs are
+        # the supported path for background threads).
+        path = resolve_config_path()
+        if path.exists():
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            block = _host_block(raw, resolve_active_host())
+            oauth_block = block.get("oauth")
+            if isinstance(oauth_block, dict) and oauth_block.get("refreshToken"):
+                basis = f"oauth:{oauth_block['refreshToken']}"
+            else:
+                key = block.get("apiKey") or raw.get("apiKey") or get_secret("HONCHO_API_KEY") or ""
+                if not key:
+                    return ""
+                basis = f"key:{key}"
+            return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        pass
+    return ""
+
+
+def _client_cache_key(config: HonchoClientConfig | None) -> tuple:
+    """Cache identity for a Honcho client build.
+
+    Explicit configs key on the connection identity ``_build`` embeds in the
+    client (host, workspace, base_url, environment), the provenance paths the
+    config was resolved from, the effective timeout, and a credential
+    fingerprint that is stable across OAuth access-token rotation but changes
+    on re-auth/account switch. The access token itself is deliberately NOT in
+    the key — in-place rotation must stay within one slot.
+
+    Ambient callers (config=None: CLI one-shots, tests) key on what
+    from_global_config() would resolve. Ambient resolution reads the profile
+    ContextVar and is therefore only correct on threads that can see it;
+    bound configs are the supported path everywhere else.
+    """
+    if config is not None:
+        return (
+            "explicit",
+            config.host,
+            config.workspace_id,
+            config.base_url or "",
+            config.environment,
+            str(config.config_path) if config.config_path is not None else "",
+            str(config.hermes_home) if config.hermes_home is not None else "",
+            _resolve_timeout_from_sources(config),
+            _credential_fingerprint(config),
+        )
+    return (
+        "ambient",
+        str(resolve_config_path()),
+        resolve_active_host(),
+        _resolve_timeout_from_sources(None),
+        _credential_fingerprint(None),
+    )
+
+
+def _slot_for(key: tuple) -> SingletonSlot:
+    """Return the slot for ``key``, evicting stale same-identity slots.
+
+    When a (kind, host, config_path/hermes_home) identity reappears with a
+    DIFFERENT credential fingerprint or timeout, the old slot is dropped so
+    the replaced client stops being served and its pools can close once the
+    last holder releases it. Without eviction, credential churn leaks one
+    pinned client per change — the gap that made #81401's retirement
+    machinery inert.
+    """
+    identity = key[:3] if key[0] == "ambient" else (key[0], key[1], key[5], key[6])
+    with _client_slots_lock:
+        slot = _client_slots.get(key)
+        if slot is None:
+            stale = [
+                k for k in _client_slots
+                if k != key and (
+                    (k[:3] if k[0] == "ambient" else (k[0], k[1], k[5], k[6])) == identity
+                )
+            ]
+            for k in stale:
+                _client_slots.pop(k, None)
+                _client_slot_timeouts.pop(k, None)
+            slot = SingletonSlot()
+            _client_slots[key] = slot
+        return slot
 # Memo for the honcho.json-derived timeout, keyed PER CONFIG PATH on the
 # file's mtime_ns so the staleness check on every get_honcho_client() call
 # costs one stat() instead of a JSON parse. Path-keyed because multi-profile
@@ -977,11 +1093,16 @@ def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
         logger.warning("Honcho OAuth pre-build refresh failed", exc_info=True)
 
 
-def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -> None:
+def _refresh_cached_oauth(
+    client: "Honcho",
+    config: HonchoClientConfig | None,
+    slot: SingletonSlot | None = None,
+) -> None:
     """Rotate the cached client's Bearer in place when its OAuth token is stale.
 
-    If the SDK shape changed and the in-place rotation can't apply, the slot is
-    reset so the next acquisition rebuilds with the fresh token.
+    If the SDK shape changed and the in-place rotation can't apply, the
+    client's own slot is reset so the next acquisition rebuilds with the
+    fresh token.
     """
     try:
         from plugins.memory.honcho import oauth
@@ -994,35 +1115,39 @@ def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -
             path = resolve_config_path()
         token, refreshed = oauth.ensure_fresh_token(path, host)
         if refreshed and token and not oauth.apply_token_to_client(client, token):
-            _honcho_client_slot.reset()
+            if slot is not None:
+                slot.reset()
     except Exception:
         logger.warning("Honcho OAuth cached refresh failed", exc_info=True)
 
 
 def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
-    """Get or create the Honcho client singleton.
+    """Get or create the Honcho client for this config's identity.
 
-    When no config is provided, attempts to load ~/.honcho/config.json
-    first, falling back to environment variables.
+    Clients are cached PER IDENTITY (host, workspace, provenance paths,
+    credential fingerprint, timeout), not per process: multi-profile
+    processes (gateway multiplexer, dashboard, cron) previously shared one
+    first-config-wins client, so every profile's memory landed in whichever
+    workspace initialized first (#69123, #74065).
 
-    Thread-safe: the client is built exactly once even under concurrent
-    first calls (double-checked locking via ``SingletonSlot``), so racing
-    threads can't each construct a client and leak the loser's connection.
+    When no config is provided, resolves the active honcho.json — correct
+    only on threads that can see the profile ContextVar; pass a bound config
+    everywhere else (HonchoSessionManager does).
+
+    Thread-safe: each identity's client is built exactly once even under
+    concurrent first calls (double-checked locking via SingletonSlot), so
+    racing threads can't each construct a client and leak the loser's
+    connection.
     """
-    global _cached_timeout
-    cached = _honcho_client_slot.peek()
+    key = _client_cache_key(config)
+    slot = _slot_for(key)
+    cached = slot.peek()
     if cached is not None:
-        # Detect timeout config changes in long-lived processes (gateway,
-        # dashboard).  If the user changed the timeout after the client was
-        # built, rebuild with the new value.
-        new_timeout = _resolve_timeout_from_sources(config)
-        if new_timeout != _cached_timeout:
-            _honcho_client_slot.reset()
-            _cached_timeout = None
-            cached = None
-        else:
-            _refresh_cached_oauth(cached, config)
-            return cached
+        _refresh_cached_oauth(cached, config, slot)
+        refreshed = slot.peek()
+        if refreshed is not None:
+            return refreshed
+        # Slot was reset by a failed in-place rotation — rebuild below.
 
     if config is None:
         config = HonchoClientConfig.from_global_config()
@@ -1133,16 +1258,17 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         if resolved_timeout is not None:
             kwargs["timeout"] = resolved_timeout
 
-        global _cached_timeout
-        _cached_timeout = resolved_timeout
+        with _client_slots_lock:
+            _client_slot_timeouts[key] = resolved_timeout
         return Honcho(**kwargs)
 
-    return _honcho_client_slot.get(_build)
+    return slot.get(_build)
 
 
 def reset_honcho_client() -> None:
-    """Reset the Honcho client singleton (useful for testing)."""
-    global _cached_timeout
+    """Reset all cached Honcho clients (tests, OAuth re-login)."""
+    with _client_slots_lock:
+        _client_slots.clear()
+        _client_slot_timeouts.clear()
     _honcho_client_slot.reset()
-    _cached_timeout = None
     _honcho_json_timeout_memo.clear()

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -885,7 +885,6 @@ _honcho_client_slot: SingletonSlot = SingletonSlot()
 import threading as _threading
 
 _client_slots: dict[tuple, SingletonSlot] = {}
-_client_slot_timeouts: dict[tuple, float] = {}
 _client_slots_lock = _threading.Lock()
 
 
@@ -1017,7 +1016,6 @@ def _slot_for(key: tuple) -> SingletonSlot:
             ]
             for k in stale:
                 _client_slots.pop(k, None)
-                _client_slot_timeouts.pop(k, None)
             slot = SingletonSlot()
             _client_slots[key] = slot
         return slot
@@ -1285,8 +1283,6 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         if resolved_timeout is not None:
             kwargs["timeout"] = resolved_timeout
 
-        with _client_slots_lock:
-            _client_slot_timeouts[key] = resolved_timeout
         return Honcho(**kwargs)
 
     return slot.get(_build)
@@ -1296,6 +1292,5 @@ def reset_honcho_client() -> None:
     """Reset all cached Honcho clients (tests, OAuth re-login)."""
     with _client_slots_lock:
         _client_slots.clear()
-        _client_slot_timeouts.clear()
     _honcho_client_slot.reset()
     _honcho_json_timeout_memo.clear()

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -461,6 +461,24 @@ class HonchoClientConfig:
     # block exists or enabled was set explicitly), vs auto-enabled from a
     # stray HONCHO_API_KEY env var.
     explicitly_configured: bool = False
+    # Provenance: WHERE this config was resolved from, captured at resolution
+    # time (inside the caller's profile scope). Bound consumers (session
+    # manager, OAuth refresh paths) use these instead of re-resolving
+    # resolve_config_path()/get_hermes_home() later — those resolvers read a
+    # ContextVar that background threads cannot see, so re-resolution from a
+    # daemon thread silently lands on the DEFAULT profile (#69123, #74065).
+    config_path: Path | None = None
+    hermes_home: Path | None = None
+
+    def bound_config_path(self) -> Path:
+        """Return the config path this config was resolved from.
+
+        Falls back to ambient resolution only for hand-constructed configs
+        (tests, env-only setups) that carry no provenance.
+        """
+        if self.config_path is not None:
+            return self.config_path
+        return resolve_config_path()
 
     @classmethod
     def from_env(
@@ -482,6 +500,7 @@ class HonchoClientConfig:
             timeout=timeout,
             ai_peer=resolved_host,
             enabled=bool(api_key or base_url),
+            hermes_home=get_hermes_home(),
         )
 
     @classmethod
@@ -733,6 +752,8 @@ class HonchoClientConfig:
             sessions=raw.get("sessions", {}),
             raw=raw,
             explicitly_configured=_explicitly_configured,
+            config_path=path,
+            hermes_home=get_hermes_home(),
         )
 
     @staticmethod
@@ -857,13 +878,16 @@ class HonchoClientConfig:
 
 _honcho_client_slot: SingletonSlot = SingletonSlot()
 _cached_timeout: float | None = None
-# Memo for the honcho.json-derived timeout, keyed on the file's mtime_ns so
-# the staleness check on every get_honcho_client() call costs one stat()
-# instead of a JSON parse. mtime -1 = file absent; (None, None) = not yet
-# populated. config.yaml needs no such memo: load_config_readonly() is
-# internally cached on both the user and managed files' signatures, and a
-# bespoke key here would have to duplicate that invalidation logic.
-_honcho_json_timeout_memo: tuple[int | None, float | None] = (None, None)
+# Memo for the honcho.json-derived timeout, keyed PER CONFIG PATH on the
+# file's mtime_ns so the staleness check on every get_honcho_client() call
+# costs one stat() instead of a JSON parse. Path-keyed because multi-profile
+# processes resolve different honcho.json files — a single-slot memo would
+# thrash between profiles and return profile A's timeout for profile B.
+# mtime -1 = file absent. config.yaml needs no such memo:
+# load_config_readonly() is internally cached on both the user and managed
+# files' signatures, and a bespoke key here would have to duplicate that
+# invalidation logic.
+_honcho_json_timeout_memo: dict[str, tuple[int, float | None]] = {}
 
 
 def _config_yaml_timeout() -> float | None:
@@ -884,15 +908,16 @@ def _config_yaml_timeout() -> float | None:
 
 def _honcho_json_timeout() -> float | None:
     """Read timeout/requestTimeout from honcho.json (host block wins), memoized on mtime."""
-    global _honcho_json_timeout_memo
     try:
         path = resolve_config_path()
+        path_key = str(path)
         try:
             mtime_ns: int = path.stat().st_mtime_ns
         except OSError:
             mtime_ns = -1
-        if _honcho_json_timeout_memo[0] == mtime_ns:
-            return _honcho_json_timeout_memo[1]
+        memo = _honcho_json_timeout_memo.get(path_key)
+        if memo is not None and memo[0] == mtime_ns:
+            return memo[1]
 
         timeout = None
         if mtime_ns != -1:
@@ -904,7 +929,7 @@ def _honcho_json_timeout() -> float | None:
                 raw.get("timeout"),
                 raw.get("requestTimeout"),
             )
-        _honcho_json_timeout_memo = (mtime_ns, timeout)
+        _honcho_json_timeout_memo[path_key] = (mtime_ns, timeout)
         return timeout
     except Exception:
         return None
@@ -941,7 +966,11 @@ def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
     try:
         from plugins.memory.honcho import oauth
 
-        token, _ = oauth.ensure_fresh_token(resolve_config_path(), config.host)
+        # Bound path: refresh against the honcho.json this config came from,
+        # not whatever the current context resolves to. On daemon threads the
+        # ambient resolver lands on the default profile and a refresh here
+        # would persist the rotated token into the WRONG profile's file.
+        token, _ = oauth.ensure_fresh_token(config.bound_config_path(), config.host)
         if token:
             config.api_key = token
     except Exception:
@@ -957,8 +986,13 @@ def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -
     try:
         from plugins.memory.honcho import oauth
 
-        host = config.host if config is not None else resolve_active_host()
-        token, refreshed = oauth.ensure_fresh_token(resolve_config_path(), host)
+        if config is not None:
+            host = config.host
+            path = config.bound_config_path()
+        else:
+            host = resolve_active_host()
+            path = resolve_config_path()
+        token, refreshed = oauth.ensure_fresh_token(path, host)
         if refreshed and token and not oauth.apply_token_to_client(client, token):
             _honcho_client_slot.reset()
     except Exception:
@@ -1108,7 +1142,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
 
 def reset_honcho_client() -> None:
     """Reset the Honcho client singleton (useful for testing)."""
-    global _cached_timeout, _honcho_json_timeout_memo
+    global _cached_timeout
     _honcho_client_slot.reset()
     _cached_timeout = None
-    _honcho_json_timeout_memo = (None, None)
+    _honcho_json_timeout_memo.clear()

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -889,6 +889,33 @@ _client_slot_timeouts: dict[tuple, float] = {}
 _client_slots_lock = _threading.Lock()
 
 
+def spawn_context_thread(
+    target,
+    *,
+    name: str,
+    daemon: bool = True,
+    args: tuple = (),
+) -> "_threading.Thread":
+    """Spawn a thread that inherits the caller's contextvars.
+
+    Profile isolation in multi-profile processes is a ContextVar
+    (set_hermes_home_override); plain threading.Thread targets start with an
+    EMPTY context, so any ambient resolution on the thread
+    (resolve_config_path, resolve_active_host, get_hermes_home) silently
+    lands on the default profile. Copying the caller's context at spawn time
+    makes the thread see the profile scope it was created under.
+    """
+    import contextvars
+
+    ctx = contextvars.copy_context()
+    t = _threading.Thread(
+        target=lambda: ctx.run(target, *args),
+        name=name,
+        daemon=daemon,
+    )
+    return t
+
+
 def _credential_fingerprint(config: HonchoClientConfig | None) -> str:
     """Stable identity for the credential a client will be built with.
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -9,6 +9,7 @@ import logging
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 
 from plugins.memory.honcho.client import get_honcho_client
@@ -209,10 +210,15 @@ class HonchoSessionManager:
     def honcho(self) -> Honcho:
         """Get the Honcho client, refreshing a near-expiry OAuth token in place.
 
-        Routes every access through ``get_honcho_client`` (which returns the same
-        cached singleton) so a long session can't outlive its 1h access token.
+        Routes every access through ``get_honcho_client`` WITH this manager's
+        bound config so a long session can't outlive its 1h access token AND
+        so background threads (async writer, prefetch, sync) acquire the
+        client for the profile this manager was built under — a bare
+        ``get_honcho_client()`` re-resolves ambient ContextVar-backed state
+        that daemon threads cannot see, migrating every access onto the
+        first-built profile's client (#69123, #74065).
         """
-        self._honcho = get_honcho_client()
+        self._honcho = get_honcho_client(self._config)
         return self._honcho
 
     def _record_auth_failure(self, exc: BaseException) -> None:
@@ -238,6 +244,20 @@ class HonchoSessionManager:
         self._auth_notice_emitted = True
         return self._auth_failure
 
+    def _bound_config_path(self) -> Path:
+        """Config path for OAuth checks, bound to this manager's profile.
+
+        Falls back to ambient resolution only when the manager was built
+        without a config (tests) — on the hot path the bound path keeps
+        background threads reading THIS profile's honcho.json, not the
+        default profile the ContextVar-blind resolver would land on.
+        """
+        from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
+
+        if isinstance(self._config, HonchoClientConfig):
+            return self._config.bound_config_path()
+        return resolve_config_path()
+
     def _reauth_required(self) -> bool:
         """True when the grant is dead and only a new login can fix it.
 
@@ -251,12 +271,10 @@ class HonchoSessionManager:
             if not oauth.any_dead_grants():
                 return False
 
-            from plugins.memory.honcho.client import resolve_config_path
-
             host = getattr(self._config, "host", "") or ""
             if not host:
                 return False
-            return oauth.reauth_required(resolve_config_path(), host)
+            return oauth.reauth_required(self._bound_config_path(), host)
         except Exception:
             return False
 
@@ -267,15 +285,12 @@ class HonchoSessionManager:
         """
         try:
             from plugins.memory.honcho import oauth
-            from plugins.memory.honcho.client import (
-                reset_honcho_client,
-                resolve_config_path,
-            )
+            from plugins.memory.honcho.client import reset_honcho_client
 
             host = getattr(self._config, "host", "") or ""
             if not host:
                 return False
-            token = oauth.force_refresh_token(resolve_config_path(), host)
+            token = oauth.force_refresh_token(self._bound_config_path(), host)
             if not token:
                 return False
             if not oauth.apply_token_to_client(self.honcho, token):

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 
-from plugins.memory.honcho.client import get_honcho_client
+from plugins.memory.honcho.client import get_honcho_client, spawn_context_thread
 from plugins.memory.honcho.oauth import redact_tokens as _redact_tokens
 
 if TYPE_CHECKING:
@@ -779,10 +779,9 @@ class HonchoSessionManager:
             return
         with self._async_thread_lock:
             if self._async_thread is None or not self._async_thread.is_alive():
-                self._async_thread = threading.Thread(
-                    target=self._async_writer_loop,
+                self._async_thread = spawn_context_thread(
+                    self._async_writer_loop,
                     name="honcho-async-writer",
-                    daemon=True,
                 )
                 self._async_thread.start()
 
@@ -932,7 +931,7 @@ class HonchoSessionManager:
             if result:
                 self.set_context_result(session_key, result)
 
-        t = threading.Thread(target=_run, name="honcho-context-prefetch", daemon=True)
+        t = spawn_context_thread(_run, name="honcho-context-prefetch")
         t.start()
 
     def set_context_result(self, session_key: str, result: dict[str, str]) -> None:

--- a/tests/honcho_plugin/test_client_identity_isolation.py
+++ b/tests/honcho_plugin/test_client_identity_isolation.py
@@ -1,0 +1,314 @@
+"""Multi-profile client isolation tests.
+
+Pin the cross-tenant bleed class (#69123 multiplexed gateway, #74065
+dashboard): a process-wide first-config-wins client singleton baked the
+first profile's workspace_id and bearer into one shared client, so every
+later profile's memory landed in the first profile's workspace.
+
+The tests drive the REAL resolution chain — HonchoClientConfig.from_global_config
+against real honcho.json files under temp HERMES_HOMEs, with the same
+ContextVar override the gateway multiplexer / dashboard use — and assert
+client identity, not internals.
+
+The two-profile repro mirrors issue #69123's minimal in-process repro;
+per-config-identity caching was first proposed in #69142 (NaMinhyeok) and
+extended in #81401 (angel12).
+"""
+
+import json
+import threading
+
+import pytest
+
+import plugins.memory.honcho.client as client_mod
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from plugins.memory.honcho.client import (
+    HonchoClientConfig,
+    get_honcho_client,
+    reset_honcho_client,
+)
+
+pytestmark = pytest.mark.skipif(
+    not pytest.importorskip("honcho", reason="honcho SDK not installed"),
+    reason="honcho SDK not installed",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_client_cache():
+    reset_honcho_client()
+    yield
+    reset_honcho_client()
+
+
+def _make_profile(tmp_path, name: str, workspace: str, api_key: str,
+                  host: str | None = None, oauth: dict | None = None):
+    home = tmp_path / name
+    home.mkdir(parents=True, exist_ok=True)
+    host = host or "hermes"
+    block: dict = {"apiKey": api_key, "workspace": workspace}
+    if oauth:
+        block["oauth"] = oauth
+    (home / "honcho.json").write_text(json.dumps({"hosts": {host: block}}))
+    return home
+
+
+class _FakeHoncho:
+    """Stands in for honcho.Honcho; records constructor kwargs."""
+
+    instances: list = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _FakeHoncho.instances.append(self)
+
+
+@pytest.fixture
+def fake_honcho(monkeypatch):
+    _FakeHoncho.instances = []
+    import honcho
+
+    monkeypatch.setattr(honcho, "Honcho", _FakeHoncho)
+    return _FakeHoncho
+
+
+class TestTwoProfileIsolation:
+    def test_profiles_get_distinct_clients_and_workspaces(self, tmp_path, fake_honcho):
+        """#69123's minimal repro: override -> client -> reset -> override -> client."""
+        home_a = _make_profile(tmp_path, "profiles/a", "tenant-a", "key-a")
+        home_b = _make_profile(tmp_path, "profiles/b", "tenant-b", "key-b")
+
+        token = set_hermes_home_override(home_a)
+        try:
+            cfg_a = HonchoClientConfig.from_global_config()
+            client_a = get_honcho_client(cfg_a)
+        finally:
+            reset_hermes_home_override(token)
+
+        token = set_hermes_home_override(home_b)
+        try:
+            cfg_b = HonchoClientConfig.from_global_config()
+            client_b = get_honcho_client(cfg_b)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert client_a is not client_b
+        assert client_a.kwargs["workspace_id"] == "tenant-a"
+        assert client_b.kwargs["workspace_id"] == "tenant-b"
+        assert client_a.kwargs["api_key"] == "key-a"
+        assert client_b.kwargs["api_key"] == "key-b"
+
+    def test_same_profile_reuses_client(self, tmp_path, fake_honcho):
+        home_a = _make_profile(tmp_path, "profiles/a", "tenant-a", "key-a")
+
+        token = set_hermes_home_override(home_a)
+        try:
+            cfg1 = HonchoClientConfig.from_global_config()
+            c1 = get_honcho_client(cfg1)
+            cfg2 = HonchoClientConfig.from_global_config()
+            c2 = get_honcho_client(cfg2)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert c1 is c2
+        assert len(fake_honcho.instances) == 1
+
+
+class TestBackgroundThreadIsolation:
+    def test_bound_config_wins_on_bare_thread(self, tmp_path, fake_honcho):
+        """A manager's bound config must acquire ITS profile's client even
+        from a thread that cannot see the profile ContextVar — the pattern
+        of every plugin daemon thread (async writer, prefetch, sync)."""
+        home_a = _make_profile(tmp_path, "profiles/a", "tenant-a", "key-a")
+        home_b = _make_profile(tmp_path, "profiles/b", "tenant-b", "key-b")
+
+        # Default-profile client exists first (the "pinning" client).
+        token = set_hermes_home_override(home_a)
+        try:
+            cfg_a = HonchoClientConfig.from_global_config()
+            get_honcho_client(cfg_a)
+        finally:
+            reset_hermes_home_override(token)
+
+        # Profile B's config resolved inside its scope (as initialize() does).
+        token = set_hermes_home_override(home_b)
+        try:
+            cfg_b = HonchoClientConfig.from_global_config()
+        finally:
+            reset_hermes_home_override(token)
+
+        # A bare thread (empty context — no profile override visible)
+        # acquires via the bound config, as manager.honcho now does.
+        box: dict = {}
+
+        def _worker():
+            box["client"] = get_honcho_client(cfg_b)
+
+        t = threading.Thread(target=_worker)
+        t.start()
+        t.join(timeout=10)
+
+        assert box["client"].kwargs["workspace_id"] == "tenant-b"
+        assert box["client"].kwargs["api_key"] == "key-b"
+
+    def test_spawn_context_thread_sees_profile_override(self, tmp_path):
+        """spawn_context_thread must carry the caller's HERMES_HOME override."""
+        from hermes_constants import get_hermes_home
+        from plugins.memory.honcho.client import spawn_context_thread
+
+        home_b = tmp_path / "profiles" / "b"
+        home_b.mkdir(parents=True)
+        seen: dict = {}
+
+        def _probe():
+            seen["home"] = get_hermes_home()
+
+        token = set_hermes_home_override(home_b)
+        try:
+            t = spawn_context_thread(_probe, name="probe")
+            t.start()
+            t.join(timeout=10)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert seen["home"] == home_b
+
+    def test_plain_thread_does_not_see_override(self, tmp_path):
+        """Control: documents WHY propagation is needed — a plain thread
+        resolves the process home, not the caller's profile override."""
+        from hermes_constants import get_hermes_home
+
+        home_b = tmp_path / "profiles" / "b"
+        home_b.mkdir(parents=True)
+        seen: dict = {}
+
+        def _probe():
+            seen["home"] = get_hermes_home()
+
+        token = set_hermes_home_override(home_b)
+        try:
+            t = threading.Thread(target=_probe)
+            t.start()
+            t.join(timeout=10)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert seen["home"] != home_b
+
+
+class TestCredentialIdentity:
+    def test_account_swap_creates_new_client_and_evicts_old(self, tmp_path, fake_honcho):
+        """Switching accounts via setup (same path/host, new apiKey) must not
+        keep serving the old account's client — the collision a
+        provenance-only cache key cannot close."""
+        home = _make_profile(tmp_path, "profiles/a", "tenant-a", "key-account-1")
+
+        token = set_hermes_home_override(home)
+        try:
+            cfg1 = HonchoClientConfig.from_global_config()
+            c1 = get_honcho_client(cfg1)
+
+            # Operator re-runs setup: same file, new account credentials.
+            (home / "honcho.json").write_text(json.dumps({
+                "hosts": {"hermes": {"apiKey": "key-account-2", "workspace": "tenant-a"}},
+            }))
+            cfg2 = HonchoClientConfig.from_global_config()
+            c2 = get_honcho_client(cfg2)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert c1 is not c2
+        assert c2.kwargs["api_key"] == "key-account-2"
+        # Old slot evicted: the stale client is no longer reachable via the map.
+        with client_mod._client_slots_lock:
+            cached_clients = [
+                s.peek() for s in client_mod._client_slots.values()
+            ]
+        assert c1 not in cached_clients
+
+    def test_oauth_refresh_token_is_fingerprint_basis(self, tmp_path):
+        """Fingerprint must survive access-token rotation (in-place bearer
+        swap) but change when the refresh token (re-auth) changes."""
+        home = tmp_path / "p"
+        home.mkdir()
+        oauth_block = {
+            "refreshToken": "refresh-1",
+            "tokenEndpoint": "https://auth.example/token",
+            "clientId": "cid",
+            "expiresAt": 9999999999,
+        }
+        (home / "honcho.json").write_text(json.dumps({
+            "hosts": {"hermes": {"apiKey": "access-token-1", "workspace": "w",
+                                  "oauth": oauth_block}},
+        }))
+
+        token = set_hermes_home_override(home)
+        try:
+            cfg1 = HonchoClientConfig.from_global_config()
+            fp1 = client_mod._credential_fingerprint(cfg1)
+
+            # Access token rotates in place; refresh token unchanged.
+            cfg_rotated = HonchoClientConfig.from_global_config()
+            cfg_rotated.api_key = "access-token-2"
+            fp_rotated = client_mod._credential_fingerprint(cfg_rotated)
+
+            # Re-auth: new refresh token.
+            oauth_block2 = dict(oauth_block, refreshToken="refresh-2")
+            (home / "honcho.json").write_text(json.dumps({
+                "hosts": {"hermes": {"apiKey": "access-token-3", "workspace": "w",
+                                      "oauth": oauth_block2}},
+            }))
+            cfg2 = HonchoClientConfig.from_global_config()
+            fp2 = client_mod._credential_fingerprint(cfg2)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert fp1 == fp_rotated, "access-token rotation must not change identity"
+        assert fp1 != fp2, "re-auth must change identity"
+
+    def test_timeout_change_rebuilds_via_key(self, tmp_path, fake_honcho):
+        """The old singleton had an explicit timeout-staleness check; with
+        timeout in the key, a change produces a new identity + eviction."""
+        home = _make_profile(tmp_path, "profiles/a", "w", "k")
+        token = set_hermes_home_override(home)
+        try:
+            cfg1 = HonchoClientConfig.from_global_config()
+            c1 = get_honcho_client(cfg1)
+
+            raw = json.loads((home / "honcho.json").read_text())
+            raw["hosts"]["hermes"]["timeout"] = 77
+            (home / "honcho.json").write_text(json.dumps(raw))
+            cfg2 = HonchoClientConfig.from_global_config()
+            c2 = get_honcho_client(cfg2)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert c1 is not c2
+        assert c2.kwargs["timeout"] == 77.0
+
+
+class TestProvenance:
+    def test_from_global_config_captures_provenance(self, tmp_path):
+        home = _make_profile(tmp_path, "profiles/a", "w", "k")
+        token = set_hermes_home_override(home)
+        try:
+            cfg = HonchoClientConfig.from_global_config()
+        finally:
+            reset_hermes_home_override(token)
+
+        assert cfg.config_path == home / "honcho.json"
+        assert cfg.hermes_home == home
+        assert cfg.bound_config_path() == home / "honcho.json"
+
+    def test_bound_path_stable_outside_scope(self, tmp_path):
+        """The captured path must not drift when read outside the profile
+        scope (the daemon-thread situation)."""
+        home = _make_profile(tmp_path, "profiles/a", "w", "k")
+        token = set_hermes_home_override(home)
+        try:
+            cfg = HonchoClientConfig.from_global_config()
+        finally:
+            reset_hermes_home_override(token)
+
+        # Now OUTSIDE the scope — bound path still points at profile a.
+        assert cfg.bound_config_path() == home / "honcho.json"

--- a/uv.lock
+++ b/uv.lock
@@ -12,12 +12,13 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
+h2 = false
 vercel = false
 aiohttp = false
 cryptography = false
 nemo-relay = false
 huggingface-hub = false
-h2 = false
+honcho-ai = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [manifest]
 overrides = [


### PR DESCRIPTION
## summary

the honcho plugin kept one client per process, first config wins, with the workspace and auth token baked in at build time. run more than one profile in a process — multiplexed gateway, dashboard, cron — and every profile after the first silently wrote its memory into the first profile's workspace. no error, nothing in logs. #74065 hit this in production: weeks of one profile's messages inside another profile's workspace, and which profile "won" changed every restart.

three layers underneath, all verified on main:

- the hot path re-pinned everything: `manager.honcho` called `get_honcho_client()` with no config on every memory access, so even a correctly-initialized session drifted onto the shared client
- profile scope is a ContextVar, and the plugin's nine daemon threads never inherit it — background work resolved config paths, host, and oauth token files against the default profile. a token refresh on one of those threads could write the rotated token into the wrong profile's honcho.json; a 401 recovery could burn the wrong profile's single-use refresh token
- no cache key carried credential identity, so switching cloud accounts via setup kept writing the new account's data with the old account's token until restart

## the fix

- configs remember where they came from (`config_path`, `hermes_home`, captured at resolution inside the right profile scope); the manager and oauth paths use that instead of re-resolving
- clients cached per identity: host, workspace, base_url, environment, provenance paths, timeout, credential fingerprint. fingerprint = hash of the oauth refresh token (survives access-token rotation, changes on re-auth/account switch) or the static key
- stale same-identity slots evicted on replacement — credential churn can't pile up pinned clients
- `spawn_context_thread()` carries contextvars into all nine plugin threads; MemoryManager's background sync/prefetch lanes get the same wrap (helps every provider, not just honcho)
- honcho.json timeout memo path-keyed (was single-slot, thrashed between profiles)
- setup wizard's gateway identity step rewritten in plain language — "Who messages this agent through the gateway?" with people/accounts answers instead of "non-agent users collapse to your peer" / "pin overrides aliases"

## closes

closes #69123, closes #74065

## related PRs

- #69142 / #81401 — covered by the per-identity cache here; provenance-field shape, init-thread copy_context, and repro shapes adopted with co-author trailers. #81401's transport retirement is not included — eviction makes replaced clients close naturally when their last holder drops; that PR can rebase the explicit-close machinery on these semantics if wanted
- #12271 — earliest isolation attempt, same bug

## tests

10 new tests run the real resolution chain against real honcho.json files under temp HERMES_HOMEs with the real ContextVar override: the #69123 repro, bound-config acquisition from a context-blind thread (plus a control test showing the trap), account-swap eviction, fingerprint stability across token rotation vs re-auth, timeout rebuild, provenance capture. 326 honcho/memory tests green, 165 gateway profile/multiplex tests green, ruff clean.

thanks @NaMinhyeok @angel12 @ruloqs @chan-eric @marknisk
