### PR TITLE
fix(deps): bump firecrawl-anydoc to 0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -386,7 +386,9 @@ exclude-newer = "14 days"
 # request-smuggling) fix in 4.4.1, published 2026-08-03. Remove after 2026-08-17.
 # aiohttp, cryptography: same shape — the advisory fixes are newer than the
 # 14-day window, so the resolver cannot see them without an exception.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false }
+# firecrawl-anydoc: temporary exception for malformed-document parser hardening
+# in 0.1.8. Remove after 2026-08-24.
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, firecrawl-anydoc = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -295,7 +295,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # NOTE: lazy-only for now — no pyproject `doc-extract` extra until the
     # package clears the uv exclude-newer 14-day quarantine (first release
     # 2026-08-04); add the mirrored extra then.
-    "tool.doc_extract": ("firecrawl-anydoc==0.1.6",),
+    "tool.doc_extract": ("firecrawl-anydoc==0.1.8",),
     # Computer Use (cua-driver) — the MCP client SDK used to spawn and talk
     # to the cua-driver process over stdio. Matches the `mcp` / `computer-use`
     # extras in pyproject.toml. The one-liner installer pulls this in via


### PR DESCRIPTION
## Summary

Bumps the lazy `firecrawl-anydoc` dependency from 0.1.6 to 0.1.8. This picks up malformed-document parser hardening, including checked offset arithmetic across legacy document and OfficeArt parsing, plus more efficient duplicate-anchor allocation that avoids quadratic CPU growth on documents with many identical headings.

Because 0.1.8 is still within the repository's 14-day dependency quarantine, this also adds a temporary package-specific `uv` exception. The exception can be removed after 2026-08-24.
