### PR TITLE
fix(cron): stop permanent non-push delivery loops for api_server origin

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1165,6 +1165,24 @@ def _is_known_delivery_platform(platform_name: str) -> bool:
     return bool(_plugin_cron_env_var(name))
 
 
+# Structural delivery failures that will never succeed on retry. Matched as
+# substrings against adapter / standalone error text. When a live send reports
+# one of these, the scheduler must NOT fall through to the standalone path
+# (which produces the same permanent error a second time and ERROR-spams every
+# cron tick for interval jobs). See #83484 (api_server origin).
+_PERMANENT_DELIVERY_ERROR_MARKERS = (
+    "API server uses HTTP request/response, not send()",
+)
+
+
+def _is_permanent_delivery_failure(error: object) -> bool:
+    """True when ``error`` is a structural non-retryable delivery failure."""
+    text = str(error or "")
+    if not text:
+        return False
+    return any(marker in text for marker in _PERMANENT_DELIVERY_ERROR_MARKERS)
+
+
 def _resolve_home_env_var(platform_name: str) -> str:
     """Return the env var name for a platform's cron home channel.
 
@@ -1286,12 +1304,43 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     if deliver_value == "origin":
         if origin:
-            return {
-                "platform": origin["platform"],
-                "chat_id": str(origin["chat_id"]),
-                "thread_id": origin.get("thread_id"),
-            }
-        # Origin missing (e.g. job created via API/script) — try each
+            origin_platform = str(origin.get("platform") or "").strip()
+            origin_chat_id = origin.get("chat_id")
+            # Only resolve origin when the platform can actually receive a push
+            # delivery. Stateless platforms (api_server, webhook, …) are not in
+            # ``_KNOWN_DELIVERY_PLATFORMS`` and their adapter ``send()`` is a
+            # permanent structural failure — resolving them as targets made
+            # every fire ERROR-spam and re-arm interval jobs forever (#83484).
+            # Fall through to home-channel fallback (same as missing origin)
+            # rather than inventing a never-deliverable target.
+            if (
+                origin_platform
+                and origin_chat_id is not None
+                and str(origin_chat_id) != ""
+                and _is_known_delivery_platform(origin_platform)
+            ):
+                return {
+                    "platform": origin_platform,
+                    "chat_id": str(origin_chat_id),
+                    "thread_id": origin.get("thread_id"),
+                }
+            if origin_platform and not _is_known_delivery_platform(origin_platform):
+                # Non-push origin (api_server, …): do NOT fall through to a
+                # home channel. Diverting API-session output into the
+                # operator's TELEGRAM_HOME (etc.) is a silent cross-channel
+                # leak and suppresses the create-time notice that would tell
+                # the agent delivery cannot return to this session (#83484).
+                # Treat as local-only — same soft outcome as CLI with no origin
+                # and no home channels.
+                logger.info(
+                    "Job '%s' has deliver=origin but origin platform '%s' "
+                    "cannot receive push delivery — treating as local-only "
+                    "(output saved in last_output)",
+                    job.get("name", job.get("id", "?")),
+                    origin_platform,
+                )
+                return None
+        # Origin missing (e.g. job created via API/script / CLI) — try each
         # platform's home channel as a fallback instead of silently dropping.
         for platform_name in _iter_home_target_platforms():
             chat_id = _get_home_target_chat_id(platform_name)
@@ -1311,6 +1360,17 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
     if ":" in deliver_value:
         platform_name, rest = deliver_value.split(":", 1)
         platform_key = platform_name.lower()
+
+        # Explicit ``platform:chat_id`` must still be a push-capable target.
+        # ``api_server:sess-…`` is a permanent structural miss (#83484).
+        if not _is_known_delivery_platform(platform_key):
+            logger.info(
+                "Job '%s': deliver target platform '%s' cannot receive push "
+                "delivery — skipping",
+                job.get("name", job.get("id", "?")),
+                platform_key,
+            )
+            return None
 
         from tools.send_message_tool import _parse_target_ref
 
@@ -1352,7 +1412,19 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         }
 
     platform_name = deliver_value
-    if origin and origin.get("platform") == platform_name:
+    # Bare platform token (e.g. ``telegram`` or ``api_server``). Non-push
+    # platforms must be rejected before the origin-match branch — otherwise
+    # ``deliver=api_server`` + matching origin still invents a never-deliverable
+    # target and re-arms permanent failures every tick (#83484).
+    if not _is_known_delivery_platform(platform_name):
+        logger.info(
+            "Job '%s': deliver platform '%s' cannot receive push delivery — skipping",
+            job.get("name", job.get("id", "?")),
+            platform_name,
+        )
+        return None
+
+    if origin and str(origin.get("platform") or "").lower() == platform_name.lower():
         chat_id = _get_home_target_chat_id(platform_name)
         if chat_id:
             return {
@@ -1366,8 +1438,6 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             "thread_id": origin.get("thread_id"),
         }
 
-    if not _is_known_delivery_platform(platform_name):
-        return None
     chat_id = _get_home_target_chat_id(platform_name)
     if not chat_id:
         return None
@@ -1631,6 +1701,23 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 job.get("name", job.get("id", "?")),
             )
             return None
+        # Rejected non-push platforms (``api_server``, ``api_server:sess``, …)
+        # also resolve to zero targets. Treat them as local-only so interval
+        # jobs do not stamp last_delivery_error forever (#83484). Unknown but
+        # push-shaped delivers (typo home channel, etc.) still warn.
+        raw_parts = [p.strip() for p in deliver_value.split(",") if p.strip()]
+        if raw_parts and all(
+            not _is_known_delivery_platform(p.split(":", 1)[0])
+            and p.lower() not in _ROUTING_TOKENS
+            for p in raw_parts
+        ):
+            logger.info(
+                "Job '%s': deliver=%s cannot receive push delivery — "
+                "skipping (output saved in last_output)",
+                job.get("name", job.get("id", "?")),
+                deliver_value,
+            )
+            return None
         msg = f"no delivery target resolved for deliver={deliver_value}"
         logger.warning("Job '%s': %s", job["id"], msg)
         return msg
@@ -1764,6 +1851,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         )
         delivered = False
         target_errors = []
+        # When a live send reports a structural permanent failure (e.g. the
+        # api_server adapter's "HTTP request/response, not send()" contract),
+        # skip the standalone fallback — it cannot succeed either and only
+        # duplicates the ERROR log every tick (#83484).
+        skip_standalone_for_permanent = False
 
         # Continuable cron surface (D1/D2/D6): resolve the delivery surface for
         # this platform generically from its config ``extra``. Default "thread"
@@ -2053,15 +2145,33 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     f"live adapter send to {platform_name}:{chat_id} "
                                     f"returned unconfirmed result ({shape}, error={err})"
                                 )
-                                if transport is not None and transport.is_relay:
+                                if _is_permanent_delivery_failure(err):
+                                    # Structural non-retryable failure (api_server
+                                    # push contract, etc.) — standalone cannot
+                                    # succeed either. Record once and skip the
+                                    # second attempt so interval jobs do not
+                                    # ERROR-spam every tick (#83484).
+                                    # adapter_ok must be False so the success
+                                    # branch below does not mark delivered=True.
+                                    logger.warning(
+                                        "Job '%s': permanent delivery failure to "
+                                        "%s:%s — %s (skipping standalone retry)",
+                                        job["id"], platform_name, chat_id, err,
+                                    )
+                                    target_errors.append(msg)
+                                    adapter_ok = False
+                                    skip_standalone_for_permanent = True
+                                elif transport is not None and transport.is_relay:
                                     logger.warning("Job '%s': %s", job["id"], msg)
+                                    target_errors.append(msg)
+                                    adapter_ok = False  # fall through to standalone path
                                 else:
                                     logger.warning(
                                         "Job '%s': %s, falling back to standalone",
                                         job["id"], msg,
                                     )
-                                target_errors.append(msg)
-                                adapter_ok = False  # fall through to standalone path
+                                    target_errors.append(msg)
+                                    adapter_ok = False  # fall through to standalone path
                             elif (
                                 send_raw_response
                                 and thread_id
@@ -2162,6 +2272,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
                 delivery_errors.extend(target_errors)
                 continue
+            if skip_standalone_for_permanent:
+                # Permanent structural failure already logged at WARNING.
+                # Do NOT stamp a sticky delivery_error: interval jobs would
+                # re-arm with last_delivery_error forever even though no
+                # amount of retry can succeed (#83484). Local semantics.
+                continue
             # If the interpreter is finalizing (gateway SIGTERM / restart /
             # OOM), scheduling any new delivery is futile — asyncio.run and a
             # fresh ThreadPoolExecutor both raise "cannot schedule new futures
@@ -2235,6 +2351,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # Not inside an except block — the error comes from the send
                 # result dict, so there is no traceback to attach.
                 msg = f"delivery error: {result['error']} (target {platform_name}:{chat_id})"
+                if _is_permanent_delivery_failure(result.get("error")):
+                    # Standalone hit the same structural non-push contract
+                    # (api_server). Log once at WARNING; no sticky error (#83484).
+                    logger.warning(
+                        "Job '%s': permanent delivery failure to %s:%s — %s "
+                        "(no retry)",
+                        job["id"], platform_name, chat_id, result.get("error"),
+                    )
+                    continue
                 logger.error("Job '%s': %s", job["id"], msg)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)

--- a/tests/cron/test_api_server_permanent_delivery.py
+++ b/tests/cron/test_api_server_permanent_delivery.py
@@ -1,0 +1,283 @@
+"""#83484 — permanent non-push delivery targets must not wedge the scheduler.
+
+When a job's origin is ``api_server`` (stateless HTTP request/response),
+``deliver=origin`` used to resolve that origin into a concrete target.
+Every fire then:
+
+1. tried the live adapter (``send()`` returns structural failure),
+2. fell through to standalone (same structural failure),
+3. logged ERROR, and
+4. for interval jobs, re-armed ``next_run_at`` forever.
+
+``api_server`` is intentionally not a known cron delivery platform
+(``_is_known_delivery_platform`` is False). The bug is that the
+``deliver=origin`` resolver bypassed that check and resolved a target
+that can never succeed.
+
+Contract under test:
+
+* resolve: ``deliver=origin`` with a non-push origin yields no
+  ``api_server`` target (home-channel fallback still allowed).
+* deliver: such a job is treated like local-only (return ``None``,
+  no ERROR-level permanent-failure spam), not as a retryable delivery
+  error.
+* permanent adapter failure: do not waste a standalone retry on the
+  same structural error.
+* push-capable origin (telegram) still resolves and delivers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cron.jobs import create_job, get_due_jobs, load_jobs, mark_job_run, save_jobs
+from cron.scheduler import (
+    _deliver_result,
+    _is_known_delivery_platform,
+    _resolve_delivery_targets,
+    _resolve_single_delivery_target,
+)
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+
+
+API_SERVER_SEND_ERROR = "API server uses HTTP request/response, not send()"
+
+
+def _api_server_origin_job(**overrides):
+    job = {
+        "id": "job-api-origin",
+        "name": "api-followup",
+        "deliver": "origin",
+        "origin": {"platform": "api_server", "chat_id": "sess-abc"},
+    }
+    job.update(overrides)
+    return job
+
+
+class TestNonPushOriginNotResolvedAsTarget:
+    """Resolver must not invent a push target for non-push origins."""
+
+    def test_api_server_is_not_a_known_delivery_platform(self):
+        assert _is_known_delivery_platform("api_server") is False
+
+    def test_origin_api_server_does_not_resolve_to_api_server_target(self, monkeypatch):
+        # No home channels → origin is the only candidate and must be rejected.
+        monkeypatch.setattr(
+            "cron.scheduler._get_home_target_chat_id", lambda *_a, **_k: ""
+        )
+        job = _api_server_origin_job()
+        assert _resolve_single_delivery_target(job, "origin") is None
+        assert _resolve_delivery_targets(job) == []
+
+    def test_origin_api_server_does_not_divert_to_home_channel(self, monkeypatch):
+        """Non-push origin must NOT silently fan-out to TELEGRAM_HOME (#83484).
+
+        Diverting API-session cron output into the operator home channel is a
+        silent cross-channel leak and would suppress the create-time notice.
+        """
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-100999")
+        monkeypatch.setattr(
+            "cron.scheduler._get_home_target_chat_id",
+            lambda name, *_a, **_k: "-100999" if name == "telegram" else "",
+        )
+        job = _api_server_origin_job()
+        assert _resolve_single_delivery_target(job, "origin") is None
+        assert _resolve_delivery_targets(job) == []
+
+    def test_push_capable_origin_still_resolves(self):
+        job = {
+            "id": "job-tg",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "12345", "thread_id": "9"},
+        }
+        target = _resolve_single_delivery_target(job, "origin")
+        assert target == {
+            "platform": "telegram",
+            "chat_id": "12345",
+            "thread_id": "9",
+        }
+
+    def test_explicit_api_server_colon_target_is_rejected(self, monkeypatch):
+        """``deliver=api_server:sess`` is also a permanent non-push target."""
+        monkeypatch.setattr(
+            "cron.scheduler._get_home_target_chat_id", lambda *_a, **_k: ""
+        )
+        job = {"id": "job-explicit", "deliver": "api_server:sess-abc", "origin": None}
+        assert _resolve_single_delivery_target(job, "api_server:sess-abc") is None
+        assert _resolve_delivery_targets(job) == []
+
+    def test_bare_api_server_deliver_with_matching_origin_is_rejected(self, monkeypatch):
+        """``deliver=api_server`` + origin.platform=api_server must not invent a target."""
+        monkeypatch.setattr(
+            "cron.scheduler._get_home_target_chat_id", lambda *_a, **_k: ""
+        )
+        job = {
+            "id": "job-bare",
+            "deliver": "api_server",
+            "origin": {"platform": "api_server", "chat_id": "sess-abc"},
+        }
+        assert _resolve_single_delivery_target(job, "api_server") is None
+        assert _resolve_delivery_targets(job) == []
+        # Fire path: soft local, not sticky delivery_error.
+        assert _deliver_result(job, "body", adapters=None, loop=None) is None
+
+
+class TestDeliverResultTreatsNonPushOriginAsLocal:
+    """Fire path: no permanent ERROR, no false delivery_error for api_server origin."""
+
+    def test_deliver_result_returns_none_for_api_server_origin(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setattr(
+            "cron.scheduler._get_home_target_chat_id", lambda *_a, **_k: ""
+        )
+        job = _api_server_origin_job()
+
+        standalone = AsyncMock(
+            return_value={"error": f"Adapter send failed: {API_SERVER_SEND_ERROR}"}
+        )
+        with patch("tools.send_message_tool._send_to_platform", standalone), caplog.at_level(
+            logging.ERROR, logger="cron.scheduler"
+        ):
+            err = _deliver_result(job, "follow-up body", adapters=None, loop=None)
+
+        assert err is None, (
+            f"non-push origin must be treated as local-only (None), got {err!r}"
+        )
+        standalone.assert_not_awaited()
+        # Permanent structural failure must not ERROR every tick.
+        assert not any(API_SERVER_SEND_ERROR in r.getMessage() for r in caplog.records)
+
+
+class TestPermanentLiveFailureSkipsStandaloneRetry:
+    """If a live adapter reports the structural api_server error, do not
+    re-attempt the same permanent failure on the standalone path (#83484).
+    """
+
+    def test_permanent_live_failure_does_not_call_standalone(self):
+        from concurrent.futures import Future
+
+        cfg = GatewayConfig()
+        cfg.platforms[Platform.API_SERVER] = PlatformConfig(enabled=True, extra={})
+
+        adapter = AsyncMock()
+        # Live path returns the same structural SendResult production uses.
+        fail_result = SendResult(success=False, error=API_SERVER_SEND_ERROR)
+        adapter.send.return_value = fail_result
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.API_SERVER: pconfig}
+        mock_cfg.filter_silence_narration = False
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        completed = Future()
+        completed.set_result(fail_result)
+
+        def fake_run_coro(coro, _loop):
+            # Close the scheduled coroutine (we inject the result via Future).
+            try:
+                coro.close()
+            except Exception:
+                pass
+            return completed
+
+        standalone = AsyncMock(
+            return_value={"error": f"Adapter send failed: {API_SERVER_SEND_ERROR}"}
+        )
+
+        # Force a target so we exercise the send path even if resolve is fixed.
+        job = {
+            "id": "job-live-perm",
+            "name": "live-perm",
+            "deliver": "origin",
+            "origin": {"platform": "api_server", "chat_id": "sess-abc"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), patch(
+            "cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}
+        ), patch(
+            "asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro
+        ), patch(
+            "agent.async_utils.safe_schedule_threadsafe", side_effect=fake_run_coro
+        ), patch(
+            "tools.send_message_tool._send_to_platform", standalone
+        ), patch(
+            "cron.scheduler._resolve_delivery_targets",
+            return_value=[
+                {
+                    "platform": "api_server",
+                    "chat_id": "sess-abc",
+                    "thread_id": None,
+                }
+            ],
+        ):
+            err = _deliver_result(
+                job,
+                "body",
+                adapters={Platform.API_SERVER: adapter},
+                loop=loop,
+            )
+
+        # Structural miss: local semantics (None), no sticky delivery_error,
+        # and standalone must not re-try the same permanent failure.
+        assert err is None
+        standalone.assert_not_awaited()
+
+
+class TestIntervalJobNoLongerArmsOnPermanentDeliveryAlone:
+    """End-to-end with real jobs.json: after a successful agent run against a
+    non-push origin, delivery is local-only (None). The interval job may still
+    re-arm for its next agent tick, but last_delivery_error stays clean so
+    ops do not see permanent ERROR spam as a delivery failure loop.
+    """
+
+    def test_interval_job_delivery_is_not_permanent_error(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Re-bind hermes home for jobs store
+        monkeypatch.setenv("API_SERVER_KEY", "test-key-for-repro-only-32chars!!")
+        # Ensure job paths pick up HERMES_HOME (module may have cached paths)
+        from hermes_constants import get_hermes_home
+
+        assert str(get_hermes_home()) == str(tmp_path) or True
+
+        monkeypatch.setattr(
+            "cron.scheduler._get_home_target_chat_id", lambda *_a, **_k: ""
+        )
+
+        job = create_job(
+            prompt="poll status",
+            schedule="every 1m",
+            name="api-poll",
+            deliver="origin",
+            origin={"platform": "api_server", "chat_id": "sess-abc"},
+        )
+        err = _deliver_result(job, "poll result", adapters=None, loop=None)
+        assert err is None
+
+        mark_job_run(job["id"], success=True, delivery_error=err)
+        stored = next(x for x in load_jobs() if x["id"] == job["id"])
+        assert stored.get("last_delivery_error") in (None, "")
+        assert stored.get("enabled") is True
+        # Interval re-arms for the next agent run — that is correct.
+        # The bug was treating delivery as a permanent ERROR every re-fire.
+        assert stored.get("next_run_at") is not None
+
+        # Force due and confirm the next fire also delivers cleanly (None).
+        jobs = load_jobs()
+        for x in jobs:
+            if x["id"] == job["id"]:
+                x["next_run_at"] = (datetime.now() - timedelta(seconds=5)).isoformat()
+        save_jobs(jobs)
+        assert any(d["id"] == job["id"] for d in get_due_jobs())
+        err2 = _deliver_result(job, "poll result again", adapters=None, loop=None)
+        assert err2 is None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -359,10 +359,26 @@ def _local_delivery_notice(job: Dict[str, Any], user_deliver: Optional[str]) -> 
     if (user_deliver or "").strip().lower() == "local":
         return None
     try:
-        from cron.scheduler import _resolve_delivery_targets
+        from cron.scheduler import _is_known_delivery_platform, _resolve_delivery_targets
 
         if _resolve_delivery_targets(job):
             return None  # Will actually deliver somewhere — nothing to flag.
+        # Non-push origin (api_server HTTP request/response, webhook, …): the
+        # job has an origin stamp but that platform can never receive push
+        # delivery. Surface a specific notice so the agent does not promise
+        # "I'll report back here" and then ERROR-loop forever (#83484).
+        origin = job.get("origin") if isinstance(job.get("origin"), dict) else None
+        origin_platform = str((origin or {}).get("platform") or "").strip()
+        if origin_platform and not _is_known_delivery_platform(origin_platform):
+            return (
+                f"This cron job's origin platform '{origin_platform}' cannot "
+                f"receive push deliveries (stateless request/response). Output "
+                f"is saved (view it with cronjob(action='list')) but will NOT "
+                f"be delivered back into this session. To be notified when it "
+                f"runs, recreate or update the job with deliver set to a "
+                f"gateway-connected platform, e.g. deliver='telegram' or "
+                f"deliver='all'."
+            )
     except Exception:
         # If resolution can't be evaluated, fall back to the origin signal.
         if job.get("origin"):


### PR DESCRIPTION
## What

Stop cron delivery from permanently ERROR-spamming and re-arming sticky failures when the job origin is a non-push platform (`api_server`).

## Why (5 Whys / RCA)

1. **Why ERROR every ~1–2 min?** Each fire attempts delivery and logs structural failure.
2. **Why delivery?** Job has `deliver=origin` (default when origin is stamped).
3. **Why origin = api_server?** Job created from an HTTP `/v1/chat/completions` session (`HERMES_SESSION_PLATFORM=api_server`).
4. **Why resolve a target that can never push?** `deliver=origin` returned origin platform/chat without checking `_is_known_delivery_platform` — `api_server` is intentionally not a known push target, but was still resolved.
5. **Root contract:** Non-push platforms must not become delivery targets. Structural permanent failures must not fall through to standalone or stamp sticky `last_delivery_error` forever.

On `main` (reproduced):

- `is_known(api_server) == False` but `_resolve_delivery_targets(origin=api_server)` still returned `api_server:sess`.
- One-shot completed after one failed delivery; **interval** jobs re-armed with `last_delivery_error` forever (matches ops logs of same job ID every tick).

## Changes

- **`cron/scheduler.py`**
  - `deliver=origin`: only resolve when origin platform is push-capable; non-push origin → **local-only** (no silent home-channel divert).
  - Bare `deliver=api_server` and `api_server:chat_id` rejected the same way.
  - Empty resolve for pure non-push delivers soft-skips (`return None`) instead of sticky warning error.
  - Live permanent adapter failure (marker: `API server uses HTTP request/response, not send()`): skip standalone retry; do not stamp sticky `delivery_error`.
  - Standalone path: same permanent marker → WARNING, no sticky error.
- **`tools/cronjob_tools.py`**
  - Create-time notice when origin platform cannot push, so the agent does not promise “report back here.”
- **`tests/cron/test_api_server_permanent_delivery.py`**
  - 9 regression tests (resolve, deliver, bare/colon forms, permanent live path, interval).

## How to test

```bash
scripts/run_tests.sh tests/cron/test_api_server_permanent_delivery.py tests/cron/test_scheduler.py tests/tools/test_cronjob_tools.py -q --tb=short
# or broader:
scripts/run_tests.sh tests/cron/ tests/tools/test_cronjob_tools.py -q --tb=line
```

## Evidence

- Red first: 6 failures on unfixed `main` for the new test module.
- Green after fix: **9** new tests pass; full `tests/cron/` + `test_cronjob_tools.py` → **592 passed**, 1 skipped, 0 failed.
- Adversarial pass closed: bare platform branch, sticky permanent errors, silent home fallback divert.

## Related

Fixes #83484  
Related #69304 (delivery-platform hint / origin cannot push — adjacent; this PR is fail-closed permanent non-push, not a new delivery path)