### PR TITLE
fix(cron): stop jobs from retrying undeliverable API-server sessions

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1579,7 +1579,7 @@ def _validate_delivery_target(deliver: Any, origin: Optional[Dict[str, Any]]) ->
         raw_parts = [str(part).strip() for part in deliver]
     else:
         raw_parts = str(deliver or "").split(",")
-    targets = [part.lower() for part in raw_parts if part.strip()]
+    targets = [part.strip().lower() for part in raw_parts if part.strip()]
 
     explicit_api_target = any(
         target == "api_server" or target.startswith("api_server:")

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1566,6 +1566,37 @@ def _validate_job_mode_invariants(
         )
 
 
+def _validate_delivery_target(deliver: Any, origin: Optional[Dict[str, Any]]) -> None:
+    """Reject cron targets that can never receive an asynchronous delivery.
+
+    The API server is an HTTP request/response surface, not a persistent chat
+    transport. Its adapter therefore cannot push a later cron result back to
+    the request session. Reject both an API-server ``origin`` and an explicit
+    ``api_server:*`` target before the job is persisted; ``local`` and real
+    gateway targets remain valid for jobs created from API requests.
+    """
+    if isinstance(deliver, (list, tuple)):
+        raw_parts = [str(part).strip() for part in deliver]
+    else:
+        raw_parts = str(deliver or "").split(",")
+    targets = [part.lower() for part in raw_parts if part.strip()]
+
+    explicit_api_target = any(
+        target == "api_server" or target.startswith("api_server:")
+        for target in targets
+    )
+    origin_is_api = (
+        isinstance(origin, dict)
+        and str(origin.get("platform") or "").strip().lower() == "api_server"
+    )
+    if explicit_api_target or (origin_is_api and "origin" in targets):
+        raise ValueError(
+            "API-server sessions use HTTP request/response and cannot receive "
+            "scheduled push delivery. Set deliver='local' to save output only, "
+            "or choose a gateway-connected platform."
+        )
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1660,6 +1691,7 @@ def create_job(
     # Default delivery to origin if available, otherwise local
     if deliver is None:
         deliver = "origin" if origin else "local"
+    _validate_delivery_target(deliver, origin)
 
     job_id = uuid.uuid4().hex[:12]
     now = _hermes_now().isoformat()
@@ -1891,6 +1923,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
+
+            if {"deliver", "origin"}.intersection(updates):
+                _validate_delivery_target(updated.get("deliver"), updated.get("origin"))
 
             # Re-check execution-mode invariants on the MERGED record when
             # any participating field changes, so create-time invariants

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5634,6 +5634,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"job": job})
         except _CronSchedulerRegistrationError as e:
             return web.json_response(e.to_dict(), status=424)
+        except ValueError as e:
+            return web.json_response({"error": _redact_api_error_text(e)}, status=400)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -5691,6 +5693,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             _notify_cron_provider_jobs_changed()
             return web.json_response({"job": job})
+        except ValueError as e:
+            return web.json_response({"error": _redact_api_error_text(e)}, status=400)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1,5 +1,6 @@
 """Tests for cron/jobs.py — schedule parsing, job CRUD, and due-job detection."""
 
+import json
 import threading
 import pytest
 from datetime import datetime, timedelta, timezone
@@ -285,6 +286,28 @@ class TestJobCRUD:
         )
 
         assert job["deliver"] == deliver
+
+    def test_cronjob_tool_surfaces_api_server_delivery_validation(self, tmp_cron_dir, monkeypatch):
+        from tools.cronjob_tools import cronjob
+
+        monkeypatch.setattr(
+            "tools.cronjob_tools._origin_from_env",
+            lambda: {"platform": "api_server", "chat_id": "session-1"},
+        )
+        monkeypatch.setattr(
+            "cron.scheduler.create_job_with_scheduler_registration",
+            lambda **kwargs: create_job(**kwargs),
+        )
+
+        result = json.loads(cronjob(
+            action="create",
+            prompt="Follow up later",
+            schedule="30m",
+        ))
+
+        assert result["success"] is False
+        assert "Set deliver='local'" in result["error"]
+        assert load_jobs() == []
 
 
 class TestUpdateJob:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -261,7 +261,18 @@ class TestJobCRUD:
         )
         assert job["deliver"] == "origin"
 
-    @pytest.mark.parametrize("deliver", [None, "origin", "origin,all", "api_server:session-1"])
+    @pytest.mark.parametrize(
+        "deliver",
+        [
+            None,
+            "origin",
+            " origin ",
+            "origin,all",
+            "origin , all",
+            "api_server:session-1",
+            " api_server:session-1 ",
+        ],
+    )
     def test_rejects_api_server_push_delivery(self, tmp_cron_dir, deliver):
         kwargs = {
             "prompt": "Follow up later",
@@ -326,7 +337,8 @@ class TestUpdateJob:
         fetched = get_job(job["id"])
         assert fetched["name"] == "New Name"
 
-    def test_update_rejects_api_server_origin_delivery(self, tmp_cron_dir):
+    @pytest.mark.parametrize("deliver", ["origin", " origin ", "origin , all"])
+    def test_update_rejects_api_server_origin_delivery(self, tmp_cron_dir, deliver):
         job = create_job(
             prompt="Follow up later",
             schedule="every 1h",
@@ -335,7 +347,7 @@ class TestUpdateJob:
         )
 
         with pytest.raises(ValueError, match="cannot receive scheduled push delivery"):
-            update_job(job["id"], {"deliver": "origin"})
+            update_job(job["id"], {"deliver": deliver})
 
         assert get_job(job["id"])["deliver"] == "local"
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -260,6 +260,32 @@ class TestJobCRUD:
         )
         assert job["deliver"] == "origin"
 
+    @pytest.mark.parametrize("deliver", [None, "origin", "origin,all", "api_server:session-1"])
+    def test_rejects_api_server_push_delivery(self, tmp_cron_dir, deliver):
+        kwargs = {
+            "prompt": "Follow up later",
+            "schedule": "30m",
+            "origin": {"platform": "api_server", "chat_id": "session-1"},
+        }
+        if deliver is not None:
+            kwargs["deliver"] = deliver
+
+        with pytest.raises(ValueError, match="cannot receive scheduled push delivery"):
+            create_job(**kwargs)
+
+        assert load_jobs() == []
+
+    @pytest.mark.parametrize("deliver", ["local", "telegram:123"])
+    def test_api_server_origin_allows_non_api_delivery(self, tmp_cron_dir, deliver):
+        job = create_job(
+            prompt="Follow up later",
+            schedule="30m",
+            deliver=deliver,
+            origin={"platform": "api_server", "chat_id": "session-1"},
+        )
+
+        assert job["deliver"] == deliver
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
@@ -276,6 +302,19 @@ class TestUpdateJob:
         # Verify persisted to disk
         fetched = get_job(job["id"])
         assert fetched["name"] == "New Name"
+
+    def test_update_rejects_api_server_origin_delivery(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Follow up later",
+            schedule="every 1h",
+            deliver="local",
+            origin={"platform": "api_server", "chat_id": "session-1"},
+        )
+
+        with pytest.raises(ValueError, match="cannot receive scheduled push delivery"):
+            update_job(job["id"], {"deliver": "origin"})
+
+        assert get_job(job["id"])["deliver"] == "local"
 
 
 class TestPauseResumeJob:

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -168,6 +168,26 @@ class TestCreateJob:
                 assert data["retry_create"] is False
                 assert "private callback URL and token" not in data["error"]
 
+    @pytest.mark.asyncio
+    async def test_create_job_reports_validation_error_as_bad_request(self, adapter):
+        app = _create_app(adapter)
+        message = (
+            "API-server sessions use HTTP request/response and cannot receive "
+            "scheduled push delivery. Set deliver='local' to save output only."
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", side_effect=ValueError(message)
+            ):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                })
+
+                assert resp.status == 400
+                assert (await resp.json())["error"] == message
+
 
     @pytest.mark.asyncio
     async def test_create_job_prompt_too_long(self, adapter):
@@ -213,6 +233,24 @@ class TestGetJob:
 # ---------------------------------------------------------------------------
 
 class TestUpdateJob:
+
+    @pytest.mark.asyncio
+    async def test_update_job_reports_validation_error_as_bad_request(self, adapter):
+        app = _create_app(adapter)
+        message = (
+            "API-server sessions use HTTP request/response and cannot receive "
+            "scheduled push delivery. Set deliver='local' to save output only."
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_update", side_effect=ValueError(message)
+            ):
+                resp = await cli.patch(
+                    f"/api/jobs/{VALID_JOB_ID}", json={"deliver": "origin"}
+                )
+
+                assert resp.status == 400
+                assert (await resp.json())["error"] == message
 
     @pytest.mark.asyncio
     async def test_update_job_rejects_unknown_fields(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Cron jobs created from API-server request/response sessions can default to an origin target that cannot receive asynchronous pushes. Recurring jobs then attempt the same structurally impossible delivery on every run, producing repeated warnings and errors. This change rejects API-server push targets before persistence while preserving local output and delivery to gateway-connected platforms.

### Symptom

An API-server request schedules a job without overriding delivery, so the job inherits `deliver="origin"`. When the job runs later, delivery fails with `API server uses HTTP request/response, not send()` and recurring jobs repeat that permanent failure.

### Impact

Operators see recurring delivery failures and sustained log noise for jobs that can never reach their target. Production evidence for the reported environment showed repeated failures across multiple jobs and API-server sessions over consecutive days.

### Bug Cause

**Trigger:** `cron/jobs.py:1691` in `create_job`, when an API-server origin defaults to `deliver="origin"`.

**Causal chain:**
1. An API-server request creates a scheduled job and supplies its session as the origin.
2. Job creation accepts the origin delivery target without checking whether that platform supports asynchronous push delivery.
3. The scheduler later calls the API-server adapter, which deterministically rejects `send()`, and recurring jobs encounter the same permanent failure again.

**Why it is wrong:** The API server is an HTTP request/response surface, not a persistent chat transport, so an API-server session is never a valid target for a later push.

**Working sibling / contrast:** API-origin jobs remain valid when `deliver="local"` or when delivery targets a gateway-connected platform such as Telegram.

**Ruled out:** This is not a transient transport failure. The adapter structurally does not implement asynchronous sends for API-server sessions, and current one-shot dispatch accounting already prevents completed one-shots from firing indefinitely.

### Fix

Validate delivery targets at both create and update boundaries. Reject `origin` when the origin platform is `api_server`, reject explicit `api_server` targets, and provide guidance to use local output or a gateway-connected platform. Tests verify rejection happens before persistence and that supported targets remain accepted.

## Related Issue

Closes #83484

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py` - validate create and update delivery targets before persistence.
- `tests/cron/test_jobs.py` - cover API-server origin defaults, explicit targets, updates, persistence, and supported alternatives.

## How to Test

1. Create a cron job with `origin.platform="api_server"` and omitted delivery, `deliver="origin"`, or an explicit `api_server` target. Confirm creation raises an actionable `ValueError` and persists no job.
2. Create the same API-origin job with `deliver="local"` or a gateway platform target. Confirm the job is accepted.
3. Run the focused cron job tests:

```bash
scripts/run_tests.sh tests/cron/test_jobs.py
```

The related test run completed with 161 passing tests. The seven targeted API-server delivery cases were also verified red against the base commit and green at this tip.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation update: N/A - validation behavior is described by the existing delivery parameter guidance and the new error
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - validation is platform-independent Python logic
- [x] Tool descriptions or schemas update: N/A - existing delivery guidance already directs API users to `local` or gateway targets
