### PR TITLE
fix(config): preserve default-profile safety settings

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4945,8 +4945,11 @@ def set_config_value(key: str, value: str, force: bool = False):
     user_config = {}
     if config_path.exists():
         try:
+            from ruamel.yaml import YAML
+
+            yaml_rt = YAML(typ="rt")
             with open(config_path, encoding="utf-8") as f:
-                user_config = fast_safe_load(f) or {}
+                user_config = yaml_rt.load(f) or {}
         except Exception as exc:
             print(
                 f"✗ Cannot parse {config_path}: {exc}\n"
@@ -4966,7 +4969,15 @@ def set_config_value(key: str, value: str, force: bool = False):
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
     coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
+    # ``agent.verify_on_stop`` is tri-state: the default string sentinel
+    # ``auto`` plus explicit boolean overrides.  Treating every value as a
+    # string because the default is ``auto`` writes ``"true"``/``"false"``
+    # instead of the documented YAML booleans.
+    if key == "agent.verify_on_stop" and value.lower() in {
+        "true", "yes", "on", "false", "no", "off"
+    }:
+        coerced_value = value.lower() in {"true", "yes", "on"}
+    elif not isinstance(_default_value_for_key(key), str):
         if value.lower() in {'true', 'yes', 'on'}:
             coerced_value = True
         elif value.lower() in {'false', 'no', 'off'}:
@@ -4977,6 +4988,13 @@ def set_config_value(key: str, value: str, force: bool = False):
             coerced_value = float(value)
 
     value = coerced_value
+    # Simple mapping paths can use the surgical round-trip writer below. Paths
+    # that navigate a list, or require a structural normalization, must persist
+    # the reconciled full document instead.
+    _requires_full_document_write = any(
+        segment.isdigit() for segment in key.split(".")
+    )
+
     # Normalize a scalar ``model`` key before writing sub-keys so that
     # ``hermes config set model.provider openai`` doesn't silently
     # destroy the model id when ``model`` is a bare string shorthand
@@ -4987,6 +5005,7 @@ def set_config_value(key: str, value: str, force: bool = False):
         _model_val = user_config.get("model")
         if isinstance(_model_val, str) and _model_val:
             user_config["model"] = {"default": _model_val}
+            _requires_full_document_write = True
     # Guard against #74995: a single-segment key that names an existing
     # mapping would silently overwrite the entire section with a scalar
     # (e.g. ``hermes config set model gpt-5.6-sol`` when model already
@@ -5053,11 +5072,19 @@ def set_config_value(key: str, value: str, force: bool = False):
     if _alias_norm in ("model.api_base", "api_base"):
         user_config = _normalize_root_model_keys(user_config)
         key = "model.base_url"
+        _requires_full_document_write = True
         print("  (note: 'api_base' is an alias — saved as model.base_url)")
-    # Write only user config back (not the full merged defaults)
+    # Write only user config back (not the full merged defaults), while
+    # preserving comments, ordering, quoting, and unrelated user-edited bytes.
     ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    if _requires_full_document_write:
+        from utils import atomic_roundtrip_yaml_save
+
+        atomic_roundtrip_yaml_save(config_path, user_config)
+    else:
+        from utils import atomic_roundtrip_yaml_update
+
+        atomic_roundtrip_yaml_update(config_path, key, value)
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -579,23 +579,18 @@ _TEST_PATTERNS = ("test_", "tmp_")
 _TEST_SUFFIXES = (".test.py", ".test.js", ".test.ts", ".test.md")
 
 
-def _is_inside_git_checkout(path: Path, boundary: Path) -> bool:
-    """Return True when *path* belongs to a Git checkout under *boundary*.
+def _is_inside_git_checkout(path: Path) -> bool:
+    """Return True when *path* belongs to a Git checkout.
 
     Ordinary repositories use a ``.git/`` directory; linked worktrees use a
     ``.git`` file. Both are durable source and must never be auto-cleaned.
     """
     current = path if path.is_dir() else path.parent
-    boundary = boundary.resolve()
-    try:
-        current.resolve().relative_to(boundary)
-    except (ValueError, OSError):
-        return False
 
     while True:
         if (current / ".git").exists():
             return True
-        if current == boundary or current.parent == current:
+        if current.parent == current:
             return False
         current = current.parent
 
@@ -606,6 +601,8 @@ def guess_category(path: Path) -> Optional[str]:
     Used by the ``post_tool_call`` hook to auto-track ephemeral files.
     """
     if not is_safe_path(path):
+        return None
+    if _is_inside_git_checkout(path.resolve()):
         return None
 
     # Skip the state dir itself, logs, memory files, sessions, config.
@@ -635,8 +632,6 @@ def guess_category(path: Path) -> Optional[str]:
             return None
         if top == "cache":
             return "temp"
-        if _is_inside_git_checkout(path.resolve(), hermes_home):
-            return None
     except ValueError:
         # Path isn't under HERMES_HOME (e.g. /tmp/hermes-*) — fall through.
         pass

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -158,6 +158,11 @@ _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
     "site-packages", "__pycache__",
 })
 
+_AUTO_TRACK_PROTECTED_TOP_LEVEL = frozenset({
+    ".worktrees", "backups", "hermes-agent", "mcp-servers",
+    "optional-skills", "profiles",
+})
+
 
 # Paths under $HERMES_HOME that must NEVER be deleted by quick(),
 # regardless of what the stored category says.  This is a defense-in-depth
@@ -272,6 +277,10 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
         cat = item["category"]
         size = item["size"]
 
+        # Re-validate stale test entries before presenting them as disposable.
+        if cat == "test" and guess_category(p) != "test":
+            continue
+
         # Re-validate stale "cron-output" entries (fixes #37721).
         if cat == "cron-output":
             re_cat = guess_category(p)
@@ -322,6 +331,12 @@ def quick() -> Dict[str, Any]:
             continue
 
         age = (now - datetime.fromisoformat(item["timestamp"])).days
+
+        # A path may have been tracked before it became durable source (or
+        # before a newer classifier learned to protect its source tree).
+        if cat == "test" and guess_category(p) != "test":
+            _log(f"SKIP stale test entry: {p} (now protected source)")
+            continue
 
         # ---- stale-state migration (fixes #37721) ----
         # Old tracked.json entries may carry a "cron-output" category for
@@ -564,6 +579,27 @@ _TEST_PATTERNS = ("test_", "tmp_")
 _TEST_SUFFIXES = (".test.py", ".test.js", ".test.ts", ".test.md")
 
 
+def _is_inside_git_checkout(path: Path, boundary: Path) -> bool:
+    """Return True when *path* belongs to a Git checkout under *boundary*.
+
+    Ordinary repositories use a ``.git/`` directory; linked worktrees use a
+    ``.git`` file. Both are durable source and must never be auto-cleaned.
+    """
+    current = path if path.is_dir() else path.parent
+    boundary = boundary.resolve()
+    try:
+        current.resolve().relative_to(boundary)
+    except (ValueError, OSError):
+        return False
+
+    while True:
+        if (current / ".git").exists():
+            return True
+        if current == boundary or current.parent == current:
+            return False
+        current = current.parent
+
+
 def guess_category(path: Path) -> Optional[str]:
     """Return a category label for *path*, or None if we shouldn't track it.
 
@@ -586,7 +622,7 @@ def guess_category(path: Path) -> Optional[str]:
             # tmp_* (#75403, also #32164, #37721).
             "patches", "projects", "skins", "themes", "contributors",
             "profiles", "backups", "optional-skills",
-        }:
+        } or top in _AUTO_TRACK_PROTECTED_TOP_LEVEL:
             return None
         if top == "cron" or top == "cronjobs":
             # Only files under the disposable ``output/`` subtree are
@@ -599,6 +635,8 @@ def guess_category(path: Path) -> Optional[str]:
             return None
         if top == "cache":
             return "temp"
+        if _is_inside_git_checkout(path.resolve(), hermes_home):
+            return None
     except ValueError:
         # Path isn't under HERMES_HOME (e.g. /tmp/hermes-*) — fall through.
         pass

--- a/tests/hermes_cli/test_default_profile_safety_transition.py
+++ b/tests/hermes_cli/test_default_profile_safety_transition.py
@@ -1,0 +1,664 @@
+"""Behavior contract for the reversible default-profile safety transition.
+
+All state is synthetic and isolated under a temporary ``HERMES_HOME``.  The
+fixture intentionally exercises the same config, verification, and memory
+control seams that a later live cutover will use without touching live state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+import utils
+from hermes_cli.config import set_config_value
+
+
+_INITIAL_CONFIG = (
+    "# synthetic safety fixture; preserve this header byte-for-byte\n"
+    "approvals:\n"
+    "  mode: \"manual\"\n"
+    "  timeout: 321  # unrelated approval setting\n"
+    "  cron_mode: \"deny\"\n"
+    "memory:\n"
+    "  write_approval: false\n"
+    "  provider: \"\"  # unrelated memory setting\n"
+    "agent:\n"
+    "  verify_on_stop: auto\n"
+    "unrelated:\n"
+    "  quoted: \"keep:exact\"\n"
+    "  flow: [one, \"two\"]\n"
+    "# synthetic tail sentinel\n"
+)
+
+
+def _mask_transition_values(raw: bytes) -> bytes:
+    """Mask only the three authorized scalar values for byte comparison."""
+    patterns = (
+        (rb"(?m)^(  mode:)[^\r\n]*(\r?)$", rb"\1 <TARGET>\2"),
+        (
+            rb"(?m)^(  write_approval:)[^\r\n]*(\r?)$",
+            rb"\1 <TARGET>\2",
+        ),
+        (
+            rb"(?m)^(  verify_on_stop:)[^\r\n]*(\r?)$",
+            rb"\1 <TARGET>\2",
+        ),
+    )
+    for pattern, replacement in patterns:
+        raw = re.sub(pattern, replacement, raw, count=1)
+    return raw
+
+
+@pytest.fixture
+def synthetic_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    config_path.write_text(_INITIAL_CONFIG, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _apply_safety_transition() -> None:
+    set_config_value("approvals.mode", "smart")
+    set_config_value("memory.write_approval", "true")
+    set_config_value("agent.verify_on_stop", "true")
+
+
+def test_safety_transition_round_trip_preserves_unrelated_bytes(synthetic_home):
+    config_path = synthetic_home / "config.yaml"
+    original = config_path.read_bytes()
+
+    _apply_safety_transition()
+
+    transitioned = config_path.read_bytes()
+    loaded = yaml.safe_load(transitioned)
+    assert loaded["approvals"]["mode"] == "smart"
+    assert loaded["memory"]["write_approval"] is True
+    assert loaded["agent"]["verify_on_stop"] is True
+    assert loaded["approvals"]["cron_mode"] == "deny"
+    assert _mask_transition_values(transitioned) == _mask_transition_values(original)
+
+    set_config_value("approvals.mode", "manual")
+    set_config_value("memory.write_approval", "false")
+    set_config_value("agent.verify_on_stop", "auto")
+
+    assert config_path.read_bytes() == original
+
+
+def test_verify_on_stop_exit_without_acceptance_stays_incomplete(synthetic_home):
+    from run_agent import AIAgent
+
+    _apply_safety_transition()
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            session_id="synthetic-safety-transition",
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            provider="openai-compat",
+            model="test/model",
+            max_iterations=1,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "stable synthetic prompt"
+    agent._session_db = None
+    agent._session_json_enabled = False
+    agent.save_trajectories = False
+    agent.compression_enabled = False
+    agent._cleanup_task_resources = lambda *_a, **_kw: None
+    agent._save_trajectory = lambda *_a, **_kw: None
+
+    def model_call(_api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        message = SimpleNamespace(content="exit-only candidate", tool_calls=None)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=message, finish_reason="stop")],
+            model="test/model",
+            usage=None,
+        )
+
+    agent._interruptible_api_call = model_call
+    agent._handle_max_iterations = MagicMock(return_value="replacement summary")
+
+    with (
+        patch("agent.verification_stop.build_verify_on_stop_nudge", return_value="verify it"),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("edit changed.py")
+
+    assert result["final_response"] == "exit-only candidate"
+    assert result["turn_exit_reason"] == "max_iterations_reached(1/1)"
+    assert result["completed"] is False
+    agent._handle_max_iterations.assert_not_called()
+
+
+def test_durable_memory_promotion_stops_at_approval_with_zero_writes(synthetic_home):
+    from tools import write_approval as wa
+    from tools.memory_tool import MemoryStore, memory_tool
+    from tools.terminal_tool import set_approval_callback
+
+    _apply_safety_transition()
+    approval_requests = []
+
+    def deny(command, description, **_kwargs):
+        approval_requests.append((command, description))
+        return "deny"
+
+    set_approval_callback(deny)
+    try:
+        store = MemoryStore()
+        store.load_from_disk()
+        result = json.loads(
+            memory_tool("add", "memory", "synthetic durable fact", store=store)
+        )
+    finally:
+        set_approval_callback(None)
+
+    assert result["success"] is False
+    assert "denied" in result["error"].lower()
+    assert len(approval_requests) == 1
+    assert store.memory_entries == []
+    assert wa.pending_count("memory") == 0
+    assert not (synthetic_home / "MEMORY.md").exists()
+    assert not (synthetic_home / "USER.md").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode contract")
+@pytest.mark.parametrize("writer", ["update", "save"])
+def test_roundtrip_writer_applies_original_mode_before_atomic_replace(
+    tmp_path, monkeypatch, writer
+):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("setting: old\n", encoding="utf-8")
+    config_path.chmod(0o640)
+    observed_modes = []
+    real_atomic_replace = utils.atomic_replace
+
+    def record_mode_before_replace(tmp_file, target):
+        observed_modes.append(stat.S_IMODE(Path(tmp_file).stat().st_mode))
+        return real_atomic_replace(tmp_file, target)
+
+    monkeypatch.setattr(utils, "atomic_replace", record_mode_before_replace)
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(config_path, "setting", "new")
+    else:
+        utils.atomic_roundtrip_yaml_save(config_path, {"setting": "new"})
+
+    assert observed_modes == [0o640]
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o640
+
+
+def test_numeric_config_update_preserves_yaml11_ambiguous_list_strings(
+    synthetic_home,
+):
+    config_path = synthetic_home / "config.yaml"
+    config_path.write_text(
+        "custom_providers:\n"
+        "- name: provider-a\n"
+        "  api_key: old-key\n"
+        "unrelated:\n"
+        '  tokens: ["off", "yes", "null", "~"]\n'
+        "  items:\n"
+        '  - duration: "1:20"\n',
+        encoding="utf-8",
+    )
+
+    set_config_value("custom_providers.0.api_key", "new-key")
+
+    loaded = yaml.safe_load(config_path.read_bytes())
+    assert loaded["custom_providers"][0]["api_key"] == "new-key"
+    assert loaded["unrelated"]["tokens"] == ["off", "yes", "null", "~"]
+    assert all(isinstance(value, str) for value in loaded["unrelated"]["tokens"])
+    assert loaded["unrelated"]["items"][0]["duration"] == "1:20"
+    assert type(loaded["unrelated"]["items"][0]["duration"]) is str
+
+
+def test_safety_transition_round_trip_preserves_crlf_bytes(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    original = _INITIAL_CONFIG.replace("\n", "\r\n").encode("utf-8")
+    config_path.write_bytes(original)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    _apply_safety_transition()
+
+    transitioned = config_path.read_bytes()
+    loaded = yaml.safe_load(transitioned)
+    assert loaded["approvals"]["mode"] == "smart"
+    assert loaded["memory"]["write_approval"] is True
+    assert loaded["agent"]["verify_on_stop"] is True
+    assert loaded["approvals"]["cron_mode"] == "deny"
+    assert _mask_transition_values(transitioned) == _mask_transition_values(original)
+
+    set_config_value("approvals.mode", "manual")
+    set_config_value("memory.write_approval", "false")
+    set_config_value("agent.verify_on_stop", "auto")
+
+    assert config_path.read_bytes() == original
+
+
+def _mask_setting_value(raw: bytes) -> bytes:
+    return re.sub(
+        rb"(?m)^(setting:)[^\r\n]*(\r?)$",
+        rb"\1 <TARGET>\2",
+        raw,
+        count=1,
+    )
+
+
+@pytest.mark.parametrize("writer", ["update", "save"])
+def test_roundtrip_writer_preserves_mixed_line_endings(tmp_path, writer):
+    config_path = tmp_path / "config.yaml"
+    original = (
+        b"# unrelated bare-LF header\n"
+        b"setting: old\r\n"
+        b"# unrelated CRLF comment\r\n"
+        b"unrelated: keep\n"
+    )
+    config_path.write_bytes(original)
+
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(config_path, "setting", "new")
+    else:
+        utils.atomic_roundtrip_yaml_save(
+            config_path,
+            {"setting": "new", "unrelated": "keep"},
+        )
+
+    assert _mask_setting_value(config_path.read_bytes()) == _mask_setting_value(
+        original
+    )
+
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(config_path, "setting", "old")
+    else:
+        utils.atomic_roundtrip_yaml_save(
+            config_path,
+            {"setting": "old", "unrelated": "keep"},
+        )
+    assert config_path.read_bytes() == original
+
+
+@pytest.mark.parametrize("writer", ["update", "save"])
+def test_roundtrip_writer_avoids_windows_crlf_double_translation(
+    tmp_path, monkeypatch, writer
+):
+    config_path = tmp_path / "config.yaml"
+    original = b"# header\r\nsetting: old\r\nunrelated: keep\r\n"
+    config_path.write_bytes(original)
+    real_fdopen = utils.os.fdopen
+
+    def simulate_windows_fdopen(fd, mode, *args, **kwargs):
+        if "b" not in mode and "newline" not in kwargs:
+            kwargs["newline"] = "\r\n"
+        return real_fdopen(fd, mode, *args, **kwargs)
+
+    monkeypatch.setattr(utils.os, "fdopen", simulate_windows_fdopen)
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(config_path, "setting", "new")
+    else:
+        utils.atomic_roundtrip_yaml_save(
+            config_path,
+            {"setting": "new", "unrelated": "keep"},
+        )
+
+    transitioned = config_path.read_bytes()
+    assert b"\r\r\n" not in transitioned
+    assert re.search(rb"(?<!\r)\n", transitioned) is None
+    assert _mask_setting_value(transitioned) == _mask_setting_value(original)
+
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(config_path, "setting", "old")
+    else:
+        utils.atomic_roundtrip_yaml_save(
+            config_path,
+            {"setting": "old", "unrelated": "keep"},
+        )
+    assert config_path.read_bytes() == original
+
+
+@pytest.mark.parametrize("bom", [b"", b"\xef\xbb\xbf"])
+def test_safety_transition_round_trip_preserves_mixed_line_endings(
+    tmp_path, monkeypatch, bom
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    original = bom + b"".join(
+        line.encode("utf-8") + (b"\n" if line.startswith("#") else b"\r\n")
+        for line in _INITIAL_CONFIG.splitlines()
+    )
+    config_path.write_bytes(original)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    _apply_safety_transition()
+    transitioned = config_path.read_bytes()
+    assert _mask_transition_values(transitioned) == _mask_transition_values(original)
+
+    set_config_value("approvals.mode", "manual")
+    set_config_value("memory.write_approval", "false")
+    set_config_value("agent.verify_on_stop", "auto")
+    assert config_path.read_bytes() == original
+
+
+@pytest.mark.parametrize("writer", ["update", "save"])
+@pytest.mark.parametrize("key", ["off", "yes", "null", "~", "1:20"])
+def test_roundtrip_writer_quotes_yaml11_mapping_keys(tmp_path, writer, key):
+    path = tmp_path / "config.yaml"
+    path.write_text("{}\n", encoding="utf-8")
+    state = {"providers": {key: {"command": "run"}}}
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(path, f"providers.{key}.command", "run")
+    else:
+        utils.atomic_roundtrip_yaml_save(path, state)
+    loaded = yaml.safe_load(path.read_bytes())
+    actual_key = next(iter(loaded["providers"]))
+    assert actual_key == key
+    assert type(actual_key) is str
+
+
+@pytest.mark.parametrize("writer", ["update", "save"])
+def test_roundtrip_writer_preserves_bom_and_indentless_sequence(tmp_path, writer):
+    path = tmp_path / "config.yaml"
+    original = (
+        b"\xef\xbb\xbf# header\nsetting: old\r\nunrelated:\n"
+        b"- one\r\n- two\n"
+    )
+    path.write_bytes(original)
+    state = {"setting": "new", "unrelated": ["one", "two"]}
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(path, "setting", "new")
+    else:
+        utils.atomic_roundtrip_yaml_save(path, state)
+    assert _mask_setting_value(path.read_bytes()) == _mask_setting_value(original)
+    state["setting"] = "old"
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(path, "setting", "old")
+    else:
+        utils.atomic_roundtrip_yaml_save(path, state)
+    assert path.read_bytes() == original
+
+
+def test_safety_transition_preserves_indentless_sequence(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    path = home / "config.yaml"
+    original = _INITIAL_CONFIG.replace(
+        "# synthetic tail sentinel\n",
+        "unrelated_list:\n- one\r\n- two\n# synthetic tail sentinel\n",
+    ).encode("utf-8")
+    path.write_bytes(original)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _apply_safety_transition()
+    assert _mask_transition_values(path.read_bytes()) == _mask_transition_values(original)
+    set_config_value("approvals.mode", "manual")
+    set_config_value("memory.write_approval", "false")
+    set_config_value("agent.verify_on_stop", "auto")
+    assert path.read_bytes() == original
+
+
+@pytest.mark.skipif(not hasattr(os, "fchown"), reason="requires POSIX fchown")
+@pytest.mark.parametrize("writer", ["update", "save"])
+def test_roundtrip_writer_applies_owner_before_replace(tmp_path, monkeypatch, writer):
+    path = tmp_path / "config.yaml"
+    path.write_text("setting: old\n", encoding="utf-8")
+    calls = []
+    real_replace = utils.atomic_replace
+    monkeypatch.setattr(utils, "_preserve_file_owner", lambda _path: (123, 456))
+    monkeypatch.setattr(utils, "_restore_file_owner", lambda *_args: None)
+    monkeypatch.setattr(utils.os, "fchown", lambda _fd, uid, gid: calls.append((uid, gid)))
+
+    def assert_owned_before_replace(source, target):
+        assert calls == [(123, 456)]
+        return real_replace(source, target)
+    monkeypatch.setattr(utils, "atomic_replace", assert_owned_before_replace)
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(path, "setting", "new")
+    else:
+        utils.atomic_roundtrip_yaml_save(path, {"setting": "new"})
+
+
+@pytest.mark.skipif(not hasattr(os, "fchown"), reason="requires POSIX fchown")
+@pytest.mark.parametrize("writer", ["update", "save"])
+def test_roundtrip_writer_accepts_rejected_redundant_fchown(tmp_path, monkeypatch, writer):
+    path = tmp_path / "config.yaml"
+    path.write_text("setting: old\n", encoding="utf-8")
+    owner = (path.stat().st_uid, path.stat().st_gid)
+
+    def reject_redundant(fd, uid, gid):
+        temp_stat = os.fstat(fd)
+        assert (temp_stat.st_uid, temp_stat.st_gid) == (uid, gid) == owner
+        raise PermissionError("redundant fchown rejected")
+    monkeypatch.setattr(utils.os, "fchown", reject_redundant)
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(path, "setting", "new")
+    else:
+        utils.atomic_roundtrip_yaml_save(path, {"setting": "new"})
+    assert yaml.safe_load(path.read_bytes())["setting"] == "new"
+
+
+@pytest.mark.skipif(not hasattr(os, "fchown"), reason="requires POSIX fchown")
+@pytest.mark.parametrize("writer", ["update", "save"])
+def test_roundtrip_writer_fails_closed_when_fchown_fails_and_target_owner_changes(
+    tmp_path, monkeypatch, writer
+):
+    path = tmp_path / "config.yaml"
+    original = b"setting: old\nunrelated: keep\n"
+    path.write_bytes(original)
+    owner_a = (123, 456)
+    owner_b = SimpleNamespace(st_uid=234, st_gid=567)
+    owner_c = SimpleNamespace(
+        st_uid=345, st_gid=678, st_mode=path.stat().st_mode
+    )
+    real_stat = Path.stat
+    replace_mock = MagicMock()
+    monkeypatch.setattr(utils, "_preserve_file_owner", lambda _path: owner_a)
+    monkeypatch.setattr(utils.os, "fstat", lambda _fd: owner_b)
+    monkeypatch.setattr(utils.os, "fchown", MagicMock(side_effect=PermissionError("denied")))
+
+    def changed_target_stat(self, *args, **kwargs):
+        if self == path:
+            return owner_c
+        return real_stat(self, *args, **kwargs)
+    monkeypatch.setattr(utils.Path, "stat", changed_target_stat)
+    monkeypatch.setattr(utils, "atomic_replace", replace_mock)
+    with pytest.raises(PermissionError, match="denied"):
+        if writer == "update":
+            utils.atomic_roundtrip_yaml_update(path, "setting", "new")
+        else:
+            utils.atomic_roundtrip_yaml_save(path, {"setting": "new", "unrelated": "keep"})
+    replace_mock.assert_not_called()
+    assert path.read_bytes() == original
+
+
+def test_numeric_list_update_preserves_distinct_yaml12_ambiguous_keys(synthetic_home):
+    from ruamel.yaml import YAML
+
+    path = synthetic_home / "config.yaml"
+    path.write_text(
+        "custom_providers:\n"
+        "- name: provider-a\n"
+        "  api_key: old-key\n"
+        "unrelated:\n"
+        "  off: string-key\n"
+        "  false: boolean-key\n",
+        encoding="utf-8",
+    )
+
+    set_config_value("custom_providers.0.api_key", "new-key")
+
+    rendered = path.read_text(encoding="utf-8")
+    yaml12 = YAML(typ="safe")
+    yaml12.version = (1, 2)
+    loaded12 = yaml12.load(rendered)
+    assert loaded12["custom_providers"][0]["api_key"] == "new-key"
+    assert loaded12["unrelated"] == {"off": "string-key", False: "boolean-key"}
+    loaded11 = yaml.safe_load(rendered)
+    assert loaded11["unrelated"] == {"off": "string-key", False: "boolean-key"}
+
+
+@pytest.mark.skipif(not hasattr(os, "fchown"), reason="requires POSIX fchown")
+@pytest.mark.parametrize("writer", ["update", "save"])
+def test_roundtrip_writer_reapplies_mode_after_fchown_before_replace(
+    tmp_path, monkeypatch, writer
+):
+    path = tmp_path / "config.yaml"
+    path.write_text("setting: old\n", encoding="utf-8")
+    os.chown(path, -1, os.getgid())
+    os.chmod(path, 0o2750)
+    monkeypatch.setattr(utils, "_preserve_file_owner", lambda _path: (123, 456))
+    real_fchown = os.fchown
+
+    def fchown_that_clears_setid(fd, _uid, _gid):
+        real_fchown(fd, -1, os.getgid())
+        mode = stat.S_IMODE(os.fstat(fd).st_mode)
+        os.fchmod(fd, mode & ~(stat.S_ISUID | stat.S_ISGID))
+
+    monkeypatch.setattr(utils.os, "fchown", fchown_that_clears_setid)
+    real_replace = utils.atomic_replace
+
+    def assert_complete_metadata_before_replace(source, target):
+        assert stat.S_IMODE(Path(source).stat().st_mode) == 0o2750
+        return real_replace(source, target)
+
+    monkeypatch.setattr(utils, "atomic_replace", assert_complete_metadata_before_replace)
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(path, "setting", "new")
+    else:
+        utils.atomic_roundtrip_yaml_save(path, {"setting": "new"})
+
+
+def test_roundtrip_update_quotes_equal_existing_yaml11_mapping_key(tmp_path):
+    from ruamel.yaml import YAML
+
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        "providers:\n"
+        "  off:  # preserve-key-comment\n"
+        "    command: old\n"
+        "  false:\n"
+        "    command: boolean\n",
+        encoding="utf-8",
+    )
+
+    utils.atomic_roundtrip_yaml_update(path, "providers.off.command", "new")
+
+    rendered = path.read_text(encoding="utf-8")
+    assert "# preserve-key-comment" in rendered
+    yaml12 = YAML(typ="safe")
+    yaml12.version = (1, 2)
+    loaded12 = yaml12.load(rendered)
+    assert loaded12["providers"]["off"]["command"] == "new"
+    assert loaded12["providers"][False]["command"] == "boolean"
+    loaded11 = yaml.safe_load(rendered)
+    assert loaded11["providers"]["off"]["command"] == "new"
+    assert loaded11["providers"][False]["command"] == "boolean"
+
+
+def test_numeric_list_update_preserves_unrelated_plain_yaml11_boolean(synthetic_home):
+    path = synthetic_home / "config.yaml"
+    path.write_text(
+        "custom_providers:\n"
+        "- name: provider-a\n"
+        "  api_key: old-key\n"
+        "cron:\n"
+        "  model_drift_guard: off\n",
+        encoding="utf-8",
+    )
+
+    set_config_value("custom_providers.0.api_key", "new-key")
+
+    rendered = path.read_text(encoding="utf-8")
+    assert "model_drift_guard: off" in rendered
+    loaded = yaml.safe_load(rendered)
+    assert loaded["cron"]["model_drift_guard"] is False
+
+
+def test_numeric_list_update_preserves_list_item_comments(synthetic_home):
+    path = synthetic_home / "config.yaml"
+    path.write_text(
+        "custom_providers:\n"
+        "- name: provider-a  # preserve-item-comment\n"
+        "  api_key: old-key  # preserve-api-comment\n"
+        "unrelated: keep\n",
+        encoding="utf-8",
+    )
+
+    set_config_value("custom_providers.0.api_key", "new-key")
+
+    rendered = path.read_text(encoding="utf-8")
+    assert "# preserve-item-comment" in rendered
+    assert "# preserve-api-comment" in rendered
+    loaded = yaml.safe_load(rendered)
+    assert loaded["custom_providers"][0]["api_key"] == "new-key"
+
+
+def test_numeric_list_update_applies_equal_but_type_distinct_value(synthetic_home):
+    path = synthetic_home / "config.yaml"
+    path.write_text(
+        "custom_providers:\n"
+        "- name: provider-a\n"
+        "  enabled: false\n",
+        encoding="utf-8",
+    )
+
+    set_config_value("custom_providers.0.enabled", "0")
+
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert type(loaded["custom_providers"][0]["enabled"]) is int
+    assert loaded["custom_providers"][0]["enabled"] == 0
+
+
+@pytest.mark.parametrize("writer", ["update", "save"])
+def test_roundtrip_writer_does_not_mutate_metadata_after_replace(
+    tmp_path, monkeypatch, writer
+):
+    path = tmp_path / "config.yaml"
+    path.write_text("setting: old\n", encoding="utf-8")
+    os.chown(path, -1, os.getgid())
+    os.chmod(path, 0o2750)
+    published = False
+    post_publish_calls = []
+
+    def publish(tmp_name, target):
+        nonlocal published
+        os.replace(tmp_name, target)
+        published = True
+        return str(target)
+
+    def record_chown(*_args):
+        if published:
+            post_publish_calls.append("chown")
+
+    def record_chmod(*_args):
+        if published:
+            post_publish_calls.append("chmod")
+
+    monkeypatch.setattr(utils, "atomic_replace", publish)
+    monkeypatch.setattr(utils.os, "chown", record_chown)
+    monkeypatch.setattr(utils.os, "chmod", record_chmod)
+
+    if writer == "update":
+        utils.atomic_roundtrip_yaml_update(path, "setting", "new")
+    else:
+        utils.atomic_roundtrip_yaml_save(path, {"setting": "new"})
+
+    assert post_publish_calls == []
+    assert stat.S_IMODE(path.stat().st_mode) == 0o2750
+    assert yaml.safe_load(path.read_text(encoding="utf-8"))["setting"] == "new"

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -115,6 +115,29 @@ class TestGuessCategory:
         # Even though it matches test_* pattern, logs/ is excluded.
         assert dg.guess_category(p) is None
 
+    def test_mcp_server_tests_are_durable_source(self, _isolate_env):
+        dg = _load_lib()
+        p = _isolate_env / "mcp-servers" / "cmux" / "test_cmux_mcp.py"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+        assert dg.guess_category(p) is None
+
+    def test_profile_tests_are_durable_source(self, _isolate_env):
+        dg = _load_lib()
+        p = _isolate_env / "profiles" / "bot" / "src" / "test_router.py"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+        assert dg.guess_category(p) is None
+
+    def test_tests_inside_git_checkout_are_durable_source(self, _isolate_env):
+        dg = _load_lib()
+        repo = _isolate_env / "workspace" / "project"
+        (repo / ".git").mkdir(parents=True)
+        p = repo / "tests" / "test_feature.py"
+        p.parent.mkdir()
+        p.write_text("x")
+        assert dg.guess_category(p) is None
+
     def test_cron_subtree_categorised(self, _isolate_env):
         dg = _load_lib()
         # Only files under ``cron/output/`` are disposable run artifacts.
@@ -223,6 +246,28 @@ class TestStaleCronEntryMigration:
         summary = dg.quick()
         assert summary["deleted"] == 1, "valid old cron-output should be deleted"
         assert not run_md.exists()
+
+
+class TestStaleDurableTestMigration:
+    def test_quick_preserves_stale_mcp_server_test_entry(self, _isolate_env):
+        dg = _load_lib()
+        test_file = _isolate_env / "mcp-servers" / "cmux" / "test_cmux_mcp.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text("durable")
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(test_file),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": test_file.stat().st_size,
+        }]))
+
+        summary = dg.quick()
+        assert summary["deleted"] == 0
+        assert test_file.read_text() == "durable"
+        assert json.loads(tracked_file.read_text()) == []
 
 
 class TestTrackForgetQuick:

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -15,6 +15,7 @@ Covers the bundled plugin at ``plugins/disk-cleanup/``:
 import importlib
 import json
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -137,6 +138,17 @@ class TestGuessCategory:
         p.parent.mkdir()
         p.write_text("x")
         assert dg.guess_category(p) is None
+
+    def test_tests_inside_tmp_hermes_git_checkout_are_durable_source(self, _isolate_env):
+        dg = _load_lib()
+        with tempfile.TemporaryDirectory(prefix="hermes-cleanup-git-", dir="/tmp") as root:
+            repo = Path(root) / "repo"
+            (repo / ".git").mkdir(parents=True)
+            p = repo / "tests" / "test_feature.py"
+            p.parent.mkdir()
+            p.write_text("x")
+            assert dg.is_safe_path(p) is True
+            assert dg.guess_category(p) is None
 
     def test_cron_subtree_categorised(self, _isolate_env):
         dg = _load_lib()
@@ -268,6 +280,31 @@ class TestStaleDurableTestMigration:
         assert summary["deleted"] == 0
         assert test_file.read_text() == "durable"
         assert json.loads(tracked_file.read_text()) == []
+
+    def test_quick_preserves_stale_tmp_git_test_entry(self, _isolate_env):
+        dg = _load_lib()
+        with tempfile.TemporaryDirectory(prefix="hermes-cleanup-git-", dir="/tmp") as root:
+            repo = Path(root) / "repo"
+            (repo / ".git").mkdir(parents=True)
+            test_file = repo / "tests" / "test_feature.py"
+            test_file.parent.mkdir()
+            test_file.write_text("durable")
+
+            tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+            tracked_file.parent.mkdir(parents=True)
+            tracked_file.write_text(json.dumps([{
+                "path": str(test_file),
+                "category": "test",
+                "timestamp": "2025-01-01T00:00:00+00:00",
+                "size": test_file.stat().st_size,
+            }]))
+
+            _, auto = dg.dry_run()
+            assert auto == []
+            summary = dg.quick()
+            assert summary["deleted"] == 0
+            assert test_file.read_text() == "durable"
+            assert json.loads(tracked_file.read_text()) == []
 
 
 class TestTrackForgetQuick:

--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -293,6 +293,10 @@ class TestCamofoxVisionConfig:
 
         with (
             patch("tools.browser_camofox.open", create=True) as mock_open,
+            patch(
+                "tools.vision_tools._bounded_browser_screenshot_data_url",
+                return_value="data:image/png;base64,dmFsaWQ=",
+            ),
             patch("agent.auxiliary_client.call_llm", return_value=mock_response) as mock_llm,
             patch("tools.browser_camofox.load_config", return_value={"auxiliary": {"vision": {"temperature": 1, "timeout": 45}}}),
         ):
@@ -325,6 +329,10 @@ class TestCamofoxVisionConfig:
 
         with (
             patch("tools.browser_camofox.open", create=True) as mock_open,
+            patch(
+                "tools.vision_tools._bounded_browser_screenshot_data_url",
+                return_value="data:image/png;base64,dmFsaWQ=",
+            ),
             patch("agent.auxiliary_client.call_llm", return_value=mock_response) as mock_llm,
             patch("tools.browser_camofox.load_config", return_value={"auxiliary": {"vision": {}}}),
         ):

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -6,6 +6,7 @@ import sys
 from unittest.mock import patch, MagicMock
 
 import pytest
+from PIL import Image
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
@@ -248,7 +249,7 @@ class TestBrowserVisionConfig:
         shots_dir = tmp_path / "browser_screenshots"
         shots_dir.mkdir()
         screenshot = shots_dir / "shot.png"
-        screenshot.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        Image.new("RGB", (16, 16), color="white").save(screenshot, format="PNG")
         return shots_dir, screenshot
 
     def test_browser_vision_uses_configured_temperature_and_timeout(self, tmp_path):

--- a/tests/tools/test_browser_lightpanda.py
+++ b/tests/tools/test_browser_lightpanda.py
@@ -5,6 +5,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from PIL import Image
 
 
 # ---------------------------------------------------------------------------
@@ -248,13 +249,113 @@ class TestLightpandaFallbackWarning:
         assert response["browser_engine_fallback"]["to"] == "chrome"
         bt._last_active_session_key.pop("warn-test", None)
 
+    def test_browser_navigate_surfaces_auto_snapshot_fallback_warning(self):
+        import json
+        import tools.browser_tool as bt
+
+        snapshot_result = bt._annotate_lightpanda_fallback(
+            {"success": True, "data": {"snapshot": "- heading \"Fallback OK\" [ref=e1]", "refs": {"e1": {}}}},
+            "Lightpanda returned an empty/too-short snapshot; retried with Chrome.",
+        )
+
+        with patch("tools.browser_tool._is_local_backend", return_value=True), \
+             patch("tools.browser_tool._get_cloud_provider", return_value=None), \
+             patch("tools.browser_tool._get_session_info", return_value={
+                 "session_name": "test", "_first_nav": False, "features": {"local": True, "proxies": True}
+             }), \
+             patch("tools.browser_tool._run_browser_command", side_effect=[
+                 {"success": True, "data": {"title": "Fallback OK", "url": "https://example.com/"}},
+                 snapshot_result,
+             ]):
+            response = json.loads(bt.browser_navigate("https://example.com", task_id="warn-test2"))
+
+        assert response["success"] is True
+        assert response["browser_engine"] == "chrome"
+        assert "Lightpanda fallback" in response["fallback_warning"]
+        assert response["element_count"] == 1
+        bt._last_active_session_key.pop("warn-test2", None)
+
+    def test_failed_fallback_warning_is_preserved_on_click_error(self):
+        import json
+        import tools.browser_tool as bt
+
+        result = bt._annotate_lightpanda_fallback(
+            {"success": False, "error": "Chrome fallback failed"},
+            "Lightpanda 'click' failed (timeout); retried with Chrome.",
+        )
+        bt._last_active_session_key["warn-test3"] = "warn-test3"
+        with patch("tools.browser_tool._run_browser_command", return_value=result):
+            response = json.loads(bt.browser_click("@e1", task_id="warn-test3"))
+
+        assert response["success"] is False
+        assert "Lightpanda fallback" in response["fallback_warning"]
+        assert response["browser_engine"] == "chrome"
+        bt._last_active_session_key.pop("warn-test3", None)
+
+
+    def test_browser_vision_lightpanda_uses_chrome_capture_and_normal_call_llm_shape(self, tmp_path):
+        import json
+        import tools.browser_tool as bt
+
+        chrome_shot = tmp_path / "chrome.png"
+        Image.new("RGB", (16, 16), color="white").save(chrome_shot, format="PNG")
+
+        class _Msg:
+            content = "Example Domain screenshot"
+
+        class _Choice:
+            message = _Msg()
+
+        class _Response:
+            choices = [_Choice()]
+
+        captured_kwargs = {}
+
+        def fake_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _Response()
+
+        with patch("tools.browser_tool._get_browser_engine", return_value="lightpanda"), \
+             patch("tools.browser_tool._should_inject_engine", return_value=True), \
+             patch("tools.browser_tool._chrome_fallback_screenshot", return_value={
+                 "success": True, "data": {"path": str(chrome_shot)}
+             }), \
+             patch("hermes_constants.get_hermes_dir", return_value=tmp_path), \
+             patch("tools.browser_tool.call_llm", side_effect=fake_call_llm):
+            response = json.loads(bt.browser_vision("what is this?", task_id="vision-test"))
+
+        assert response["success"] is True
+        assert response["analysis"] == "Example Domain screenshot"
+        assert response["browser_engine"] == "chrome"
+        assert "Lightpanda fallback" in response["fallback_warning"]
+        assert "messages" in captured_kwargs
+        assert "images" not in captured_kwargs
+        assert captured_kwargs["task"] == "vision"
+
+
+    def test_browser_get_images_preserves_fallback_warning(self):
+        import json
+        import tools.browser_tool as bt
+
+        result = bt._annotate_lightpanda_fallback(
+            {"success": True, "data": {"result": "[]"}},
+            "Lightpanda 'eval' failed (timeout); retried with Chrome.",
+        )
+        bt._last_active_session_key["warn-images"] = "warn-images"
+        with patch("tools.browser_tool._run_browser_command", return_value=result):
+            response = json.loads(bt.browser_get_images(task_id="warn-images"))
+
+        assert response["success"] is True
+        assert response["browser_engine"] == "chrome"
+        assert "Lightpanda fallback" in response["fallback_warning"]
+        bt._last_active_session_key.pop("warn-images", None)
 
     def test_browser_vision_lightpanda_response_has_structured_fallback(self, tmp_path):
         import json
         import tools.browser_tool as bt
 
         chrome_shot = tmp_path / "chrome-structured.png"
-        chrome_shot.write_bytes(b"\x89PNG" + b"0" * 128)
+        Image.new("RGB", (16, 16), color="white").save(chrome_shot, format="PNG")
 
         class _Msg:
             content = "Example Domain screenshot"

--- a/tests/tools/test_browser_vision_bounded_capture.py
+++ b/tests/tools/test_browser_vision_bounded_capture.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import base64
+import io
+import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
-from tools import browser_tool
+from PIL import Image
+
+from tools import browser_camofox, browser_tool
+
+
+def _png_bytes(size: tuple[int, int] = (16, 16)) -> bytes:
+    output = io.BytesIO()
+    Image.new("RGB", size, color="white").save(output, format="PNG")
+    return output.getvalue()
 
 
 def _capture_runner(payload: bytes, calls: list[list[str]]):
@@ -41,7 +53,7 @@ def _browser_patches(runner):
 def test_browser_vision_captures_viewport_by_default_and_full_page_only_on_request(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
     calls: list[list[str]] = []
-    patches = _browser_patches(_capture_runner(b"small-png", calls))
+    patches = _browser_patches(_capture_runner(_png_bytes(), calls))
     with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
         browser_tool.browser_vision("inspect", task_id="bounded-default")
         browser_tool.browser_vision("inspect", full_page=True, task_id="bounded-full")
@@ -55,7 +67,7 @@ def test_browser_vision_captures_viewport_by_default_and_full_page_only_on_reque
 def test_browser_vision_forwards_full_page_to_lightpanda_chrome_fallback(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
     source = tmp_path / "fallback.png"
-    source.write_bytes(b"small-png")
+    source.write_bytes(_png_bytes())
     fallback_args: list[str] = []
 
     def fallback(_task_id, args, _timeout):
@@ -86,12 +98,82 @@ def test_browser_vision_downscales_large_native_attachment_before_returning(tmp_
 
     oversized = b"x" * (4 * 1024 * 1024 + 64)
     patches = _browser_patches(_capture_runner(oversized, calls))
+    small_data_url = "data:image/png;base64," + base64.b64encode(_png_bytes()).decode("ascii")
     with patches[0], patches[1], patches[2], patches[3], patches[4], \
             patch("tools.vision_tools._build_native_vision_tool_result", side_effect=native_result), \
-            patch("tools.vision_tools._resize_image_for_vision", return_value="data:image/jpeg;base64,U01BTEw=") as resize:
+            patch("tools.vision_tools._resize_image_for_vision", return_value=small_data_url) as resize:
         result = browser_tool.browser_vision("inspect", task_id="bounded-large")
 
     assert isinstance(result, dict)
     resize.assert_called_once()
-    assert attached["image_data_url"] == "data:image/jpeg;base64,U01BTEw="
+    assert attached["image_data_url"] == small_data_url
     assert len(str(attached["image_data_url"])) < len(oversized)
+
+
+def test_browser_vision_fails_closed_when_resize_cannot_bound_attachment(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    calls: list[list[str]] = []
+    oversized = b"x" * (4 * 1024 * 1024 + 64)
+    oversized_url = "data:image/png;base64," + base64.b64encode(oversized).decode("ascii")
+    patches = _browser_patches(_capture_runner(oversized, calls))
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+            patch("tools.vision_tools._build_native_vision_tool_result") as native_result, \
+            patch("tools.vision_tools._resize_image_for_vision", return_value=oversized_url) as resize:
+        result = browser_tool.browser_vision("inspect", task_id="bounded-failure")
+
+    assert isinstance(result, str)
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert payload["code"] == "browser_vision_attachment_unbounded"
+    assert payload["screenshot_path"]
+    native_result.assert_not_called()
+    assert resize.call_args.kwargs["max_base64_bytes"] == 2 * 1024 * 1024
+    assert resize.call_args.kwargs["max_dimension"] == 4096
+
+
+def test_camofox_vision_forwards_full_page_to_screenshot_endpoint(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    seen: dict[str, object] = {}
+
+    def get_raw(path, params):
+        seen["path"] = path
+        seen["params"] = params
+        return SimpleNamespace(content=_png_bytes())
+
+    llm_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="looks good"))]
+    )
+    with patch.object(browser_camofox, "_get_session", return_value={
+            "tab_id": "tab-1", "user_id": "user-1"}), \
+            patch.object(browser_camofox, "_camofox_private_page_block", return_value=None), \
+            patch.object(browser_camofox, "_get_raw", side_effect=get_raw), \
+            patch.object(browser_camofox, "load_config", return_value={}), \
+            patch("agent.auxiliary_client.call_llm", return_value=llm_response):
+        result = browser_camofox.camofox_vision(
+            "inspect", full_page=True, task_id="camofox-full-page")
+
+    assert json.loads(result)["success"] is True
+    assert seen["params"] == {"userId": "user-1", "fullPage": "true"}
+
+
+def test_camofox_vision_fails_closed_before_aux_call_when_resize_is_still_oversized(
+        tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    oversized = b"x" * (4 * 1024 * 1024 + 64)
+    oversized_url = "data:image/png;base64," + base64.b64encode(oversized).decode("ascii")
+
+    with patch.object(browser_camofox, "_get_session", return_value={
+            "tab_id": "tab-1", "user_id": "user-1"}), \
+            patch.object(browser_camofox, "_camofox_private_page_block", return_value=None), \
+            patch.object(browser_camofox, "_get_raw", return_value=SimpleNamespace(content=oversized)), \
+            patch("tools.vision_tools._resize_image_for_vision", return_value=oversized_url), \
+            patch("agent.auxiliary_client.call_llm") as call_llm:
+        result = browser_camofox.camofox_vision(
+            "inspect", full_page=True, task_id="camofox-bounded-failure")
+
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert payload["code"] == "browser_vision_attachment_unbounded"
+    assert payload["screenshot_path"]
+    call_llm.assert_not_called()

--- a/tests/tools/test_browser_vision_bounded_capture.py
+++ b/tests/tools/test_browser_vision_bounded_capture.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from tools import browser_tool
+
+
+def _capture_runner(payload: bytes, calls: list[list[str]]):
+    def run(_task_id, command, args, **_kwargs):
+        calls.append([command, *args])
+        if command == "screenshot":
+            output = Path(args[-1])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_bytes(payload)
+            return {"success": True, "data": {"path": str(output)}}
+        raise AssertionError(f"unexpected browser command: {command}")
+
+    return run
+
+
+def _native_result(**kwargs):
+    return {
+        "content": [],
+        "meta": {"attached_data_url": kwargs["image_data_url"]},
+        "text_summary": "captured",
+    }
+
+
+def _browser_patches(runner):
+    return (
+        patch.object(browser_tool, "_is_camofox_mode", return_value=False),
+        patch.object(browser_tool, "_is_local_backend", return_value=True),
+        patch.object(browser_tool, "_get_browser_engine", return_value="chrome"),
+        patch.object(browser_tool, "_run_browser_command", side_effect=runner),
+        patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=True),
+        patch("tools.vision_tools._build_native_vision_tool_result", side_effect=_native_result),
+    )
+
+
+def test_browser_vision_captures_viewport_by_default_and_full_page_only_on_request(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    calls: list[list[str]] = []
+    patches = _browser_patches(_capture_runner(b"small-png", calls))
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        browser_tool.browser_vision("inspect", task_id="bounded-default")
+        browser_tool.browser_vision("inspect", full_page=True, task_id="bounded-full")
+
+    screenshot_calls = [call for call in calls if call[0] == "screenshot"]
+    assert len(screenshot_calls) == 2
+    assert "--full" not in screenshot_calls[0]
+    assert "--full" in screenshot_calls[1]
+
+
+def test_browser_vision_forwards_full_page_to_lightpanda_chrome_fallback(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    source = tmp_path / "fallback.png"
+    source.write_bytes(b"small-png")
+    fallback_args: list[str] = []
+
+    def fallback(_task_id, args, _timeout):
+        fallback_args.extend(args)
+        return {"success": True, "data": {"path": str(source)}}
+
+    with patch.object(browser_tool, "_is_camofox_mode", return_value=False), \
+            patch.object(browser_tool, "_is_local_backend", return_value=True), \
+            patch.object(browser_tool, "_get_browser_engine", return_value="lightpanda"), \
+            patch.object(browser_tool, "_should_inject_engine", return_value=True), \
+            patch.object(browser_tool, "_chrome_fallback_screenshot", side_effect=fallback), \
+            patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=True), \
+            patch("tools.vision_tools._build_native_vision_tool_result", side_effect=_native_result):
+        result = browser_tool.browser_vision("inspect", full_page=True, task_id="bounded-lightpanda")
+
+    assert isinstance(result, dict), result
+    assert "--full" in fallback_args, result
+
+
+def test_browser_vision_downscales_large_native_attachment_before_returning(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    calls: list[list[str]] = []
+    attached: dict[str, object] = {}
+
+    def native_result(**kwargs):
+        attached.update(kwargs)
+        return {"content": [], "meta": {}, "text_summary": "captured"}
+
+    oversized = b"x" * (4 * 1024 * 1024 + 64)
+    patches = _browser_patches(_capture_runner(oversized, calls))
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+            patch("tools.vision_tools._build_native_vision_tool_result", side_effect=native_result), \
+            patch("tools.vision_tools._resize_image_for_vision", return_value="data:image/jpeg;base64,U01BTEw=") as resize:
+        result = browser_tool.browser_vision("inspect", task_id="bounded-large")
+
+    assert isinstance(result, dict)
+    resize.assert_called_once()
+    assert attached["image_data_url"] == "data:image/jpeg;base64,U01BTEw="
+    assert len(str(attached["image_data_url"])) < len(oversized)

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -31,6 +31,7 @@ import logging
 import os
 import threading
 import uuid
+from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import SplitResult, urlsplit, urlunsplit
 
@@ -837,6 +838,7 @@ def camofox_get_images(task_id: Optional[str] = None) -> str:
 
 
 def camofox_vision(question: str, annotate: bool = False,
+                   full_page: bool = False,
                    task_id: Optional[str] = None) -> str:
     """Take a screenshot and analyze it with vision AI via Camofox."""
     try:
@@ -851,7 +853,10 @@ def camofox_vision(question: str, annotate: bool = False,
         # Get screenshot as binary PNG
         resp = _get_raw(
             f"/tabs/{session['tab_id']}/screenshot",
-            params={"userId": session["user_id"]},
+            params={
+                "userId": session["user_id"],
+                "fullPage": "true" if full_page else "false",
+            },
         )
 
         # Save screenshot to cache
@@ -863,8 +868,24 @@ def camofox_vision(question: str, annotate: bool = False,
         with open(screenshot_path, "wb") as f:
             f.write(resp.content)
 
-        # Encode for vision LLM
-        img_b64 = base64.b64encode(resp.content).decode("utf-8")
+        # Bound and independently validate the model-bound image. The original
+        # screenshot remains on disk even if safe attachment is impossible.
+        from tools.vision_tools import _bounded_browser_screenshot_data_url
+
+        image_data_url = _bounded_browser_screenshot_data_url(
+            Path(screenshot_path), mime_type="image/png"
+        )
+        if image_data_url is None:
+            return json.dumps({
+                "success": False,
+                "code": "browser_vision_attachment_unbounded",
+                "error": (
+                    "Screenshot was retained locally but could not be bounded "
+                    "safely for model context. Use the screenshot_path locally "
+                    "or capture a smaller viewport."
+                ),
+                "screenshot_path": screenshot_path,
+            })
 
         # Also get annotated snapshot if requested
         annotation_context = ""
@@ -909,7 +930,7 @@ def camofox_vision(question: str, annotate: bool = False,
                     {
                         "type": "image_url",
                         "image_url": {
-                            "url": f"data:image/png;base64,{img_b64}",
+                            "url": image_data_url,
                         },
                     },
                 ],

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4205,7 +4205,12 @@ def browser_vision(
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_vision
-        return camofox_vision(question, annotate, task_id)
+        return camofox_vision(
+            question,
+            annotate=annotate,
+            full_page=full_page,
+            task_id=task_id,
+        )
 
     import base64
     import uuid as uuid_mod
@@ -4360,23 +4365,22 @@ def browser_vision(
         # is too late for native-vision routes: a multi-megabyte full-page PNG
         # would already be retained in the next request and every retry.
         _screenshot_bytes = screenshot_path.read_bytes()
-        _screenshot_b64 = base64.b64encode(_screenshot_bytes).decode("ascii")
-        data_url = f"data:image/png;base64,{_screenshot_b64}"
+        from tools.vision_tools import _bounded_browser_screenshot_data_url
 
-        from tools.vision_tools import _RESIZE_TARGET_BYTES, _resize_image_for_vision
-
-        if len(data_url) > _RESIZE_TARGET_BYTES:
-            logger.info(
-                "browser_vision: bounding screenshot attachment (%.1f MB) to ~%.0f MB",
-                len(data_url) / (1024 * 1024),
-                _RESIZE_TARGET_BYTES / (1024 * 1024),
-            )
-            resized_data_url = _resize_image_for_vision(
-                screenshot_path,
-                mime_type="image/png",
-            )
-            if resized_data_url:
-                data_url = resized_data_url
+        data_url = _bounded_browser_screenshot_data_url(
+            screenshot_path, mime_type="image/png"
+        )
+        if data_url is None:
+            return json.dumps({
+                "success": False,
+                "code": "browser_vision_attachment_unbounded",
+                "error": (
+                    "Screenshot was retained locally but could not be bounded "
+                    "safely for model context. Use the screenshot_path locally "
+                    "or capture a smaller viewport."
+                ),
+                "screenshot_path": str(screenshot_path),
+            }, ensure_ascii=False)
 
         # Fast path: when native image routing is in effect for the active main
         # model, attach the screenshot directly instead of describing it through

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2089,7 +2089,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_vision",
-        "description": "Take a screenshot of the current page so you can inspect it visually. Use this when you need to understand what the page looks like - especially for CAPTCHAs, visual verification challenges, complex layouts, or cases where the text snapshot misses important visual information. When your active model has native vision, the screenshot is attached to your context directly and you inspect it on the next turn; otherwise Hermes falls back to an auxiliary vision model and returns a text analysis. Includes a screenshot_path that you can share with the user by including MEDIA:<screenshot_path> in your response. Requires browser_navigate to be called first.",
+        "description": "Take a bounded viewport screenshot of the current page so you can inspect it visually. Use full_page only when the entire document is essential; full-page captures can be large. When your active model has native vision, a size-bounded attachment is added to the next turn; otherwise Hermes uses the auxiliary vision model. Includes a screenshot_path for sharing via MEDIA:<screenshot_path>. Requires browser_navigate first.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -2101,6 +2101,11 @@ BROWSER_TOOL_SCHEMAS = [
                     "type": "boolean",
                     "default": False,
                     "description": "If true, overlay numbered [N] labels on interactive elements. Each [N] maps to ref @eN for subsequent browser commands. Useful for QA and spatial reasoning about page layout."
+                },
+                "full_page": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "If true, capture the full document instead of the visible viewport. Large captures are downscaled before attachment."
                 }
             },
             "required": ["question"]
@@ -4167,7 +4172,12 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> Union[str, Dict[str, Any]]:
+def browser_vision(
+    question: str,
+    annotate: bool = False,
+    full_page: bool = False,
+    task_id: Optional[str] = None,
+) -> Union[str, Dict[str, Any]]:
     """
     Take a screenshot of the current page for visual inspection.
 
@@ -4184,6 +4194,9 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     Args:
         question: What you want to know about the page visually
         annotate: If True, overlay numbered [N] labels on interactive elements
+        full_page: If True, capture the full document; otherwise capture only
+            the visible viewport. Oversized captures are downscaled before they
+            are attached to model context.
         task_id: Task identifier for session isolation
 
     Returns:
@@ -4245,6 +4258,8 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         screenshot_args = []
         if annotate:
             screenshot_args.append("--annotate")
+        if full_page:
+            screenshot_args.append("--full")
         fb_result = _chrome_fallback_screenshot(
             effective_task_id, screenshot_args, _get_command_timeout(),
         )
@@ -4300,7 +4315,8 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
             screenshot_args = []
             if annotate:
                 screenshot_args.append("--annotate")
-            screenshot_args.append("--full")
+            if full_page:
+                screenshot_args.append("--full")
             screenshot_args.append(str(screenshot_path))
             result = _run_browser_command(
                 effective_task_id,
@@ -4339,10 +4355,28 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
                 ),
             }, ensure_ascii=False)
 
-        # Convert screenshot to base64 at full resolution.
+        # Keep the original screenshot on disk for user sharing, but bound the
+        # model attachment proactively. Waiting for a provider size rejection
+        # is too late for native-vision routes: a multi-megabyte full-page PNG
+        # would already be retained in the next request and every retry.
         _screenshot_bytes = screenshot_path.read_bytes()
         _screenshot_b64 = base64.b64encode(_screenshot_bytes).decode("ascii")
         data_url = f"data:image/png;base64,{_screenshot_b64}"
+
+        from tools.vision_tools import _RESIZE_TARGET_BYTES, _resize_image_for_vision
+
+        if len(data_url) > _RESIZE_TARGET_BYTES:
+            logger.info(
+                "browser_vision: bounding screenshot attachment (%.1f MB) to ~%.0f MB",
+                len(data_url) / (1024 * 1024),
+                _RESIZE_TARGET_BYTES / (1024 * 1024),
+            )
+            resized_data_url = _resize_image_for_vision(
+                screenshot_path,
+                mime_type="image/png",
+            )
+            if resized_data_url:
+                data_url = resized_data_url
 
         # Fast path: when native image routing is in effect for the active main
         # model, attach the screenshot directly instead of describing it through
@@ -5084,7 +5118,12 @@ registry.register(
     name="browser_vision",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_vision"],
-    handler=lambda args, **kw: browser_vision(question=args.get("question", ""), annotate=args.get("annotate", False), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_vision(
+        question=args.get("question", ""),
+        annotate=args.get("annotate", False),
+        full_page=args.get("full_page", False),
+        task_id=kw.get("task_id"),
+    ),
     check_fn=check_browser_vision_requirements,
     emoji="👁️",
 )

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -649,6 +649,11 @@ _EMBED_MAX_DIMENSION = 7900
 # rejects an image, we downscale to this target and retry once.
 _RESIZE_TARGET_BYTES = 5 * 1024 * 1024
 
+# Browser screenshots are retained in conversation tool results, so their
+# context budget must be substantially lower than the provider's upload cap.
+_BROWSER_SCREENSHOT_DATA_URL_LIMIT = 2 * 1024 * 1024
+_BROWSER_SCREENSHOT_MAX_DIMENSION = 4096
+
 
 def _is_image_size_error(error: Exception) -> bool:
     """Detect if an API error is related to image or payload size."""
@@ -887,6 +892,50 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
 
     # Shouldn't reach here, but fall back to full encode
     return data_url or _image_to_base64_data_url(image_path, mime_type=mime_type)
+
+
+def _bounded_browser_screenshot_data_url(
+    image_path: Path, mime_type: str = "image/png"
+) -> Optional[str]:
+    """Return a validated bounded screenshot data URL, or ``None``.
+
+    Resizing is best-effort, so callers must not trust its return value. This
+    helper independently verifies both the encoded byte budget and decoded
+    pixel dimensions and fails closed when decoding or validation is not
+    possible.
+    """
+    data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
+    if (
+        len(data_url) > _BROWSER_SCREENSHOT_DATA_URL_LIMIT
+        or _image_exceeds_dimension(image_path, _BROWSER_SCREENSHOT_MAX_DIMENSION)
+    ):
+        data_url = _resize_image_for_vision(
+            image_path,
+            mime_type=mime_type,
+            max_base64_bytes=_BROWSER_SCREENSHOT_DATA_URL_LIMIT,
+            max_dimension=_BROWSER_SCREENSHOT_MAX_DIMENSION,
+        )
+
+    if not isinstance(data_url, str) or len(data_url) > _BROWSER_SCREENSHOT_DATA_URL_LIMIT:
+        return None
+
+    try:
+        import io as _io
+        from PIL import Image as _PILImage
+
+        _header, encoded = data_url.split(",", 1)
+        if ";base64" not in _header:
+            return None
+        decoded = base64.b64decode(encoded, validate=True)
+        with _PILImage.open(_io.BytesIO(decoded)) as image:
+            if max(image.size) > _BROWSER_SCREENSHOT_MAX_DIMENSION:
+                return None
+            image.verify()
+    except Exception as exc:
+        logger.warning("Browser screenshot bound validation failed: %s", exc)
+        return None
+
+    return data_url
 
 
 # ---------------------------------------------------------------------------

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 """Shared utility functions for hermes-agent."""
 
+import difflib
 import errno
 import json
 import logging
@@ -7,6 +8,7 @@ import os
 import shutil
 import stat
 import tempfile
+from io import StringIO
 from pathlib import Path
 from typing import Any, Union
 from urllib.parse import urlparse
@@ -43,8 +45,8 @@ def _preserve_file_mode(path: Path) -> "int | None":
         return None
 
 
-def _preserve_file_owner(path: Path) -> "tuple[int, int] | None":
-    """Capture the owning uid/gid of *path* if the platform supports it."""
+def _current_file_owner(path: Path) -> "tuple[int, int] | None":
+    """Read the owning uid/gid of *path* if the platform supports it."""
     if os.name != "posix":
         return None
     try:
@@ -52,6 +54,36 @@ def _preserve_file_owner(path: Path) -> "tuple[int, int] | None":
     except OSError:
         return None
     return st.st_uid, st.st_gid
+
+
+def _preserve_file_owner(path: Path) -> "tuple[int, int] | None":
+    """Capture the owner that a completed atomic write must restore."""
+    return _current_file_owner(path)
+
+
+def _preown_file(
+    fd: int,
+    owner: "tuple[int, int] | None",
+    fallback_owner: "tuple[int, int] | None" = None,
+) -> bool:
+    if owner is None:
+        return True
+    if not hasattr(os, "fchown"):
+        return False
+    temp_stat = os.fstat(fd)
+    if (temp_stat.st_uid, temp_stat.st_gid) == owner:
+        return True
+    try:
+        os.fchown(fd, *owner)
+    except OSError:
+        temp_stat = os.fstat(fd)
+        temp_owner = (temp_stat.st_uid, temp_stat.st_gid)
+        if temp_owner == owner:
+            return True
+        if temp_owner != fallback_owner:
+            raise
+        return False
+    return True
 
 
 def _restore_file_owner(path: Path, owner: "tuple[int, int] | None") -> None:
@@ -413,6 +445,131 @@ def atomic_yaml_write(
         raise
 
 
+def _quote_yaml11_ambiguous_scalar(value: Any) -> Any:
+    """Keep ruamel YAML 1.2 output type-stable for PyYAML 1.1 readers."""
+    if isinstance(value, str):
+        try:
+            loaded = yaml.safe_load(value)
+        except yaml.YAMLError:
+            loaded = None
+        if isinstance(loaded, str) and loaded == value:
+            return value
+        from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+
+        return DoubleQuotedScalarString(value)
+    return value
+
+
+def _safe_mapping_key(dst: Any, key: Any) -> Any:
+    """Replace an equal plain YAML key with its YAML-1.1-safe scalar object."""
+    safe_key = _quote_yaml11_ambiguous_scalar(key)
+    for index, existing_key in enumerate(dst):
+        if existing_key != safe_key:
+            continue
+        if type(existing_key) is type(safe_key):
+            return existing_key
+        existing_value = dst[existing_key]
+        comment = dst.ca.items.pop(existing_key, None)
+        del dst[existing_key]
+        dst.insert(index, safe_key, existing_value)
+        if comment is not None:
+            dst.ca.items[safe_key] = comment
+        return safe_key
+    return safe_key
+
+
+def _split_text_lines(text: str) -> list[tuple[str, str]]:
+    """Return each physical line with its exact line-ending bytes as text."""
+    result: list[tuple[str, str]] = []
+    for line in text.splitlines(keepends=True):
+        if line.endswith("\r\n"):
+            result.append((line[:-2], "\r\n"))
+        elif line.endswith(("\n", "\r")):
+            result.append((line[:-1], line[-1:]))
+        else:
+            result.append((line, ""))
+    return result
+
+
+def _render_roundtrip_yaml_bytes(
+    yaml_rt: Any,
+    data: Any,
+    source_text: str | None,
+) -> bytes:
+    """Render YAML while retaining each unchanged source line's terminator."""
+    rendered_stream = StringIO()
+    yaml_rt.dump(data, rendered_stream)
+    rendered = rendered_stream.getvalue()
+    if source_text is None:
+        return rendered.encode("utf-8")
+
+    has_bom = source_text.startswith("\ufeff")
+    if has_bom:
+        source_text = source_text[1:]
+    source_lines = _split_text_lines(source_text)
+    rendered_lines = _split_text_lines(rendered)
+    endings = [ending for _content, ending in source_lines if ending]
+    dominant = max(dict.fromkeys(endings), key=endings.count) if endings else "\n"
+    selected: list[str | None] = [None] * len(rendered_lines)
+    original_content: list[str | None] = [None] * len(rendered_lines)
+
+    def _identity(content: str) -> str:
+        stripped = content.lstrip(" ")
+        return stripped if stripped.startswith("- ") else content
+
+    def _head(content: str) -> str | None:
+        stripped = content.lstrip(" ").removeprefix("- ")
+        return stripped.split(":", 1)[0] if ":" in stripped else None
+
+    def _with_source_indent(source: str, rendered: str) -> str | None:
+        if _head(source) is None or _head(source) != _head(rendered):
+            return None
+        indent = source[: len(source) - len(source.lstrip(" "))]
+        return indent + rendered.lstrip(" ")
+
+    matcher = difflib.SequenceMatcher(
+        a=[_identity(content) for content, _ending in source_lines],
+        b=[_identity(content) for content, _ending in rendered_lines],
+        autojunk=False,
+    )
+    for tag, source_start, source_end, rendered_start, rendered_end in matcher.get_opcodes():
+        source_span = source_lines[source_start:source_end]
+        if tag == "equal":
+            for offset in range(rendered_end - rendered_start):
+                selected[rendered_start + offset] = source_span[offset][1]
+                original_content[rendered_start + offset] = source_span[offset][0]
+            continue
+        for offset in range(rendered_end - rendered_start):
+            rendered_index = rendered_start + offset
+            if source_span:
+                source_line = source_span[min(offset, len(source_span) - 1)]
+                ending = source_line[1]
+                original_content[rendered_index] = _with_source_indent(
+                    source_line[0], rendered_lines[rendered_index][0]
+                )
+            elif source_start > 0:
+                ending = source_lines[source_start - 1][1]
+            elif source_start < len(source_lines):
+                ending = source_lines[source_start][1]
+            else:
+                ending = dominant
+            selected[rendered_index] = ending
+
+    output: list[str] = []
+    for index, (content, _rendered_ending) in enumerate(rendered_lines):
+        ending = selected[index]
+        if ending is None:
+            ending = dominant
+        if not ending and index < len(rendered_lines) - 1:
+            ending = dominant
+        preserved_content = original_content[index]
+        if preserved_content is not None:
+            content = preserved_content
+        output.append(content + ending)
+    encoded = "".join(output).encode("utf-8")
+    return (b"\xef\xbb\xbf" + encoded) if has_bom else encoded
+
+
 def atomic_roundtrip_yaml_update(
     path: Union[str, Path],
     key_path: str,
@@ -437,9 +594,11 @@ def atomic_roundtrip_yaml_update(
     yaml_rt.default_flow_style = False
     yaml_rt.indent(mapping=2, sequence=4, offset=2)
 
+    source_text: str | None = None
     if path.exists():
-        with path.open("r", encoding="utf-8") as f:
-            config = yaml_rt.load(f) or CommentedMap()
+        source_text = path.read_bytes().decode("utf-8")
+        normalized_source = source_text.replace("\r\n", "\n").replace("\r", "\n")
+        config = yaml_rt.load(normalized_source) or CommentedMap()
     else:
         config = CommentedMap()
 
@@ -449,29 +608,42 @@ def atomic_roundtrip_yaml_update(
     current = config
     keys = key_path.split(".")
     for key in keys[:-1]:
-        next_value = current.get(key)
+        safe_key = _safe_mapping_key(current, key)
+        next_value = current.get(safe_key)
         if not isinstance(next_value, CommentedMap):
             next_value = CommentedMap()
-            current[key] = next_value
+            current[safe_key] = next_value
         current = next_value
-    current[keys[-1]] = value
+    final_key = _safe_mapping_key(current, keys[-1])
+    current[final_key] = _quote_yaml11_ambiguous_scalar(value)
 
     original_mode = _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)
+    fallback_owner = _current_file_owner(path)
     fd, tmp_path = tempfile.mkstemp(
         dir=str(path.parent),
         prefix=f".{path.stem}_",
         suffix=".tmp",
     )
+    owner_prepared = original_owner is None
+    mode_prepared = original_mode is None
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            yaml_rt.dump(config, f)
+        with os.fdopen(fd, "wb") as f:
+            owner_prepared = _preown_file(
+                f.fileno(), original_owner, fallback_owner
+            )
+            f.write(_render_roundtrip_yaml_bytes(yaml_rt, config, source_text))
             f.flush()
+            if original_mode is not None and hasattr(os, "fchmod"):
+                os.fchmod(f.fileno(), original_mode)
+                mode_prepared = True
             os.fsync(f.fileno())
         real_path = atomic_replace(tmp_path, path)
         real_path_obj = Path(real_path)
-        _restore_file_owner(real_path_obj, original_owner)
-        _restore_file_mode(real_path_obj, original_mode)
+        if not owner_prepared:
+            _restore_file_owner(real_path_obj, original_owner)
+        if not mode_prepared:
+            _restore_file_mode(real_path_obj, original_mode)
     except BaseException:
         try:
             os.unlink(tmp_path)
@@ -515,8 +687,6 @@ def atomic_roundtrip_yaml_save(
     """
     from ruamel.yaml import YAML
     from ruamel.yaml.comments import CommentedMap
-    from ruamel.yaml.scalarstring import DoubleQuotedScalarString
-
     from hermes_cli.config import require_readable_config_before_write
 
     path = Path(path)
@@ -529,9 +699,11 @@ def atomic_roundtrip_yaml_save(
     yaml_rt.default_flow_style = False
     yaml_rt.indent(mapping=2, sequence=4, offset=2)
 
+    source_text: str | None = None
     if path.exists():
-        with path.open("r", encoding="utf-8") as f:
-            existing = yaml_rt.load(f)
+        source_text = path.read_bytes().decode("utf-8")
+        normalized_source = source_text.replace("\r\n", "\n").replace("\r", "\n")
+        existing = yaml_rt.load(normalized_source)
         if not isinstance(existing, CommentedMap):
             existing = CommentedMap(existing or {})
     else:
@@ -546,26 +718,57 @@ def atomic_roundtrip_yaml_save(
     # `approvals.mode: off` silently round-trips back as `False` under
     # yaml.safe_load. Force-quote any new string value that YAML 1.1 would
     # otherwise misparse as bool/null.
-    _YAML11_AMBIGUOUS_WORDS = {
-        "y", "n", "yes", "no", "true", "false", "on", "off", "null", "~",
-    }
+    def _yaml11_safe_value(value: Any) -> Any:
+        if isinstance(value, list):
+            return [_yaml11_safe_value(item) for item in value]
+        if isinstance(value, dict):
+            return {
+                _quote_yaml11_ambiguous_scalar(key): _yaml11_safe_value(item)
+                for key, item in value.items()
+            }
+        return _quote_yaml11_ambiguous_scalar(value)
 
-    def _quote_if_yaml11_ambiguous(value):
-        if isinstance(value, str) and value.lower() in _YAML11_AMBIGUOUS_WORDS:
-            return DoubleQuotedScalarString(value)
-        return value
+    def _same_yaml_value(left: Any, right: Any) -> bool:
+        if isinstance(left, bool) or isinstance(right, bool):
+            return isinstance(left, bool) and isinstance(right, bool) and left == right
+        if isinstance(left, str) and isinstance(right, str):
+            return left == right
+        if isinstance(left, int) and isinstance(right, int):
+            return left == right
+        if isinstance(left, float) and isinstance(right, float):
+            return left == right
+        return type(left) is type(right) and left == right
+
+    def _merge_sequence(dst: list, src: list) -> None:
+        for index, value in enumerate(src):
+            if index >= len(dst):
+                dst.append(_yaml11_safe_value(value))
+                continue
+            current = dst[index]
+            if isinstance(value, dict) and isinstance(current, CommentedMap):
+                _merge(current, value)
+            elif isinstance(value, list) and isinstance(current, list):
+                _merge_sequence(current, value)
+            elif not _same_yaml_value(current, value):
+                dst[index] = _yaml11_safe_value(value)
+        del dst[len(src) :]
 
     def _merge(dst: CommentedMap, src: dict) -> None:
         # Update / recurse into keys present in src.
         for key, value in src.items():
+            safe_key = _safe_mapping_key(dst, key)
+            current = dst.get(safe_key)
             if isinstance(value, dict):
-                current = dst.get(key)
                 if not isinstance(current, CommentedMap):
                     current = CommentedMap()
-                    dst[key] = current
+                    dst[safe_key] = current
                 _merge(current, value)
+            elif isinstance(value, list) and isinstance(current, list):
+                _merge_sequence(current, value)
             else:
-                dst[key] = _quote_if_yaml11_ambiguous(value)
+                if safe_key in dst and _same_yaml_value(current, value):
+                    continue
+                dst[safe_key] = _yaml11_safe_value(value)
         # Delete keys missing from src — preserves "explicit absence" semantics
         # of the old _save_cfg(cfg) pattern (e.g. cfg.pop("custom_prompt", None)
         # then _save_cfg must actually remove the key from disk).
@@ -576,20 +779,31 @@ def atomic_roundtrip_yaml_save(
 
     original_mode = _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)
+    fallback_owner = _current_file_owner(path)
     fd, tmp_path = tempfile.mkstemp(
         dir=str(path.parent),
         prefix=f".{path.stem}_",
         suffix=".tmp",
     )
+    owner_prepared = original_owner is None
+    mode_prepared = original_mode is None
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            yaml_rt.dump(existing, f)
+        with os.fdopen(fd, "wb") as f:
+            owner_prepared = _preown_file(
+                f.fileno(), original_owner, fallback_owner
+            )
+            f.write(_render_roundtrip_yaml_bytes(yaml_rt, existing, source_text))
             f.flush()
+            if original_mode is not None and hasattr(os, "fchmod"):
+                os.fchmod(f.fileno(), original_mode)
+                mode_prepared = True
             os.fsync(f.fileno())
         real_path = atomic_replace(tmp_path, path)
         real_path_obj = Path(real_path)
-        _restore_file_owner(real_path_obj, original_owner)
-        _restore_file_mode(real_path_obj, original_mode)
+        if not owner_prepared:
+            _restore_file_owner(real_path_obj, original_owner)
+        if not mode_prepared:
+            _restore_file_mode(real_path_obj, original_mode)
     except BaseException:
         try:
             os.unlink(tmp_path)


### PR DESCRIPTION
## Summary
- add atomic round-trip YAML update/save paths that preserve comments, BOM/newline form, YAML scalar/key semantics, and file metadata
- preserve fail-closed temporary-inode ownership handling across concurrent target changes
- add synthetic default-profile safety-transition coverage without touching live profile state

## Test plan
- focused/adjacent: 134 passed
- adjacent agent/approval/verification: 45 passed, 1 skipped
- counted full suite: 29,335 passed, 19 failed, 260 skipped; the failed-node and collection-error sets are exactly immutable-base-equivalent
- compileall, Ruff, diff checks, and staged gitleaks: passed

## Safety boundary
This PR packages the already-reviewed local candidate only. It does not mutate a live Hermes profile, gateway, sessions, memory, cron, services, plugins, private fixtures, or remote nodes.