### PR TITLE
fix(desktop): artifacts page timestamps render 1970 and local images fail (#83380)

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -1,5 +1,4 @@
-import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
-import { filePathFromMediaPath, isRemoteGateway, mediaExternalUrl } from '@/lib/media'
+import { mediaExternalUrl, resolveMediaDisplaySrc } from '@/lib/media'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
 export type ArtifactKind = 'image' | 'file' | 'link'
@@ -110,16 +109,14 @@ function artifactHref(value: string): string {
   return value
 }
 
-export async function artifactImageSrc(value: string, href = artifactHref(value)): Promise<string> {
-  if (/^(?:https?|data):/i.test(value)) {
-    return href
-  }
-
-  if (typeof window !== 'undefined' && window.hermesDesktop && isRemoteGateway()) {
-    return readDesktopFileDataUrl(filePathFromMediaPath(value))
-  }
-
-  return href
+export async function artifactImageSrc(value: string): Promise<string> {
+  // Delegate the whole local/remote ladder to the shared media resolver:
+  // inline (http/data) stays as-is, remote gateway goes through the
+  // authenticated fs bridge, local desktop through the Electron
+  // readFileDataUrl, and bare non-path link values fall through untouched.
+  // Reimplementing that ladder here would drift from resolveMediaDisplaySrc
+  // and regress one of its legs (#83380).
+  return resolveMediaDisplaySrc(value)
 }
 
 function artifactLabel(value: string): string {
@@ -283,7 +280,15 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         sessionTitle: title,
-        timestamp: message.timestamp || session.last_active || session.started_at || Date.now()
+        // All three sources are epoch SECONDS (message timestamps and
+        // session last_active/started_at are persisted in seconds; the
+        // transcript renderer multiplies by 1000 and session-date-groups
+        // by SECOND). The artifacts page renders with `new Date(timestamp)`
+        // (ms), so normalize once here instead of at each display site.
+        // Date.now() fallback stays ms (#83380).
+        timestamp:
+          (message.timestamp || session.last_active || session.started_at) * 1000 ||
+          Date.now()
       })
     })
   }

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -67,6 +67,61 @@ describe('collectArtifactsForSession', () => {
     })
   })
 
+  it('normalizes second-precision timestamps to ms for the artifacts page', () => {
+    // Message timestamps, session.last_active and session.started_at are all
+    // persisted as epoch SECONDS (see chat-runtime messageCreatedAt * 1000 and
+    // session-date-groups * SECOND). The artifacts page renders with
+    // `new Date(timestamp)` which reads ms, so the collector must convert.
+    // 1781271088s = 2026-06-12; fed to new Date() raw it lands on 1970-01-21
+    // (#83380).
+    const messages: SessionMessage[] = [
+      {
+        content: 'https://example.com/artifact',
+        role: 'assistant',
+        timestamp: 1781271088
+      }
+    ]
+
+    const [artifact] = collectArtifactsForSession(makeSession(), messages)
+
+    expect(artifact.timestamp).toBe(1781271088 * 1000)
+    expect(new Date(artifact.timestamp).getUTCFullYear()).toBe(2026)
+  })
+
+  it('falls back to session last_active (seconds) when the message has no timestamp', () => {
+    const [artifact] = collectArtifactsForSession(
+      makeSession({ last_active: 1781271088 }),
+      [{ content: 'https://example.com/artifact', role: 'assistant', timestamp: 0 }]
+    )
+
+    expect(artifact.timestamp).toBe(1781271088 * 1000)
+  })
+
+  it('keeps Date.now() (ms) as the fallback when no timestamp source exists', () => {
+    const now = 1_720_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+
+    const [artifact] = collectArtifactsForSession(
+      makeSession({ last_active: 0, started_at: 0 }),
+      [{ content: 'https://example.com/artifact', role: 'assistant', timestamp: 0 }]
+    )
+
+    expect(artifact.timestamp).toBe(now)
+  })
+
+  it('resolves local file image artifacts through the desktop fs bridge', async () => {
+    const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,TE9DQUw=')
+    vi.stubGlobal('window', { hermesDesktop: { readFileDataUrl } })
+
+    // Local desktop (connection mode != 'remote'): a local image_generate
+    // output path must be read through the Electron bridge, not left as a
+    // file:// URL the renderer cannot load (#83380).
+    const path = '/home/me/.hermes/cache/image_generate/out.png'
+
+    await expect(artifactImageSrc(path)).resolves.toBe('data:image/png;base64,TE9DQUw=')
+    expect(readFileDataUrl).toHaveBeenCalledWith(path)
+  })
+
   it('resolves remote image artifact thumbnails through the desktop fs bridge', async () => {
     const api = vi.fn(async ({ path }: { path: string }) => {
       if (path.startsWith('/api/fs/read-data-url?')) {
@@ -80,9 +135,8 @@ describe('collectArtifactsForSession', () => {
     $connection.set({ baseUrl: 'https://gw', mode: 'remote', token: 'secret' } as never)
 
     const path = '/Users/me/.hermes/skills/work-esab/references/images/manual-step03.jpeg'
-    const downloadHref = `https://gw/api/files/download?path=${encodeURIComponent(path)}&token=secret`
 
-    await expect(artifactImageSrc(path, downloadHref)).resolves.toBe('data:image/jpeg;base64,cmVtb3Rl')
+    await expect(artifactImageSrc(path)).resolves.toBe('data:image/jpeg;base64,cmVtb3Rl')
 
     expect(api).toHaveBeenCalledWith({
       path: '/api/fs/read-data-url?path=%2FUsers%2Fme%2F.hermes%2Fskills%2Fwork-esab%2Freferences%2Fimages%2Fmanual-step03.jpeg'

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -474,7 +474,7 @@ function ArtifactImageCard({ artifact, failedImage, onImageError, onOpenChat }: 
     let active = true
 
     setSrc('')
-    void artifactImageSrc(artifact.value, artifact.href)
+    void artifactImageSrc(artifact.value)
       .then(nextSrc => {
         if (active) {
           setSrc(nextSrc)


### PR DESCRIPTION
## Summary

Fixes #83380 — two independent bugs on the Desktop **Artifacts** page.

### Bug 1: all artifact timestamps render as January 1970

Every timestamp source feeding the artifacts collector is persisted as epoch **seconds**:
- `message.timestamp` — backend passes it raw (`getAllSessionMessages`), and the transcript renderer multiplies by 1000 (`messageCreatedAt` in chat-runtime.ts)
- `session.last_active` / `session.started_at` — session-date-groups multiplies by `SECOND` (1000)

The collector passed them straight to `new Date(timestamp)` (ms), so e.g. `1781271088` (2026-06-12) rendered as 1970-01-21.

**Fix:** normalize seconds → ms once at the collection site in `artifact-utils.ts` — `(message.timestamp || session.last_active || session.started_at) * 1000 || Date.now()` — keeping the `Date.now()` fallback in ms. One conversion point instead of fixing each display site.

### Bug 2: locally generated images (e.g. ComfyUI outputs) fail to display

`artifactImageSrc` only routed through the desktop fs bridge when `isRemoteGateway()` was true. For a **local** desktop, a file artifact path fell through to `href` = `mediaExternalUrl(value)` → a `file://` URL the renderer cannot load → `onImageError` marked the artifact failed.

**Fix:** `artifactImageSrc` now delegates to the shared `resolveMediaDisplaySrc` (media.ts), which already implements the full ladder — inline stays as-is, remote gateway → authenticated fs bridge read, local desktop → Electron `readFileDataUrl`, non-path link values fall through untouched. This removes a duplicated dispatch ladder (a future fix to one leg would have silently missed the other) and adds the `isFileMediaPath` guard that keeps bare link values like `report.pdf` away from the bridge.

## Tests

4 new regression tests in `apps/desktop/src/app/artifacts/index.test.ts`:
- seconds→ms normalization (asserts `1781271088` → 2026)
- `last_active` fallback (seconds)
- `Date.now()` fallback stays ms
- local-desktop image routing through the Electron bridge

All 8 artifacts tests pass; `tsc --noEmit` and `eslint` clean. RED verified: the 3 timestamp/bridge tests fail on pre-fix code.
