### PR TITLE
fix(auth): re-resolve stale kimi pool base_url on load (#5908)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1585,6 +1585,11 @@ def _normalize_loaded_kimi_entry(provider_id: str, entry: Dict[str, Any]) -> Dic
 
     Read-only repair, applied on load only (never written back):
 
+    * Because ``KIMI_BASE_URL`` always wins (matching ``_resolve_kimi_base_url``
+      semantics), a read result is a function of the current environment: the
+      same persisted entry can report different URLs across processes when the
+      env differs. Nothing is written back, so a session-scoped env override is
+      never baked into ``auth.json``.
     * ``base_url`` missing, or equal to the provider's registry default, or
       equal to the legacy ``KIMI_CODE_BASE_URL + "/v1"`` variant → re-resolve
       from the key prefix (``KIMI_BASE_URL`` env always wins).
@@ -1609,6 +1614,9 @@ def _normalize_loaded_kimi_entry(provider_id: str, entry: Dict[str, Any]) -> Dic
         or entry.get("api_key")
         or ""
     ).strip()
+    if not api_key:
+        # No credential to infer an endpoint from — leave the entry untouched.
+        return entry
     if stored and not env_url:
         stale = {(pconfig.inference_base_url or "").rstrip("/")}
         if api_key.startswith("sk-kimi-"):

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -78,7 +78,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple, cast
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from hermes_cli.config import (
@@ -1571,6 +1571,76 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
     return True
 
 
+def _normalize_loaded_kimi_entry(provider_id: str, entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Re-resolve a persisted kimi pool entry's ``base_url`` when missing/stale.
+
+    Creation-time seeding and credential registration already resolve Kimi
+    base URLs from the key prefix, so entries written by current code are
+    correct. Entries persisted by older versions — or written during a setup
+    race before the key was loaded — can carry the registry default
+    (``https://api.moonshot.ai/v1``), which ``sk-kimi-`` keys reject with
+    HTTP 401. The legacy documented workaround (``/coding/v1``) is also stale:
+    the Anthropic SDK appends ``/v1/messages`` to the ``/coding`` endpoint, so
+    the suffixed value double-appends and 404s.
+
+    Read-only repair, applied on load only (never written back):
+
+    * ``base_url`` missing, or equal to the provider's registry default, or
+      equal to the legacy ``KIMI_CODE_BASE_URL + "/v1"`` variant → re-resolve
+      from the key prefix (``KIMI_BASE_URL`` env always wins).
+    * Any other non-default stored URL (custom proxy/endpoint) is the user's
+      explicit choice → preserved, unless ``KIMI_BASE_URL`` is set, which
+      overrides it (matching ``_resolve_kimi_base_url`` semantics).
+    """
+    if provider_id not in {"kimi-coding", "kimi-coding-cn"}:
+        return entry
+    pconfig = PROVIDER_REGISTRY.get(provider_id)
+    if not pconfig:
+        return entry
+
+    env_url = ""
+    if pconfig.base_url_env_var:
+        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+
+    stored = str(entry.get("base_url") or "").strip().rstrip("/")
+    api_key = str(
+        entry.get("access_token")
+        or entry.get("runtime_api_key")
+        or entry.get("api_key")
+        or ""
+    ).strip()
+    if stored and not env_url:
+        stale = {(pconfig.inference_base_url or "").rstrip("/")}
+        if api_key.startswith("sk-kimi-"):
+            # The legacy documented workaround (/coding/v1) double-appends /v1
+            # in the Anthropic SDK; only Kimi Code keys are guaranteed to use
+            # the Anthropic protocol. A non-kimi key stored with /coding/v1 is
+            # treated as an explicit custom endpoint and preserved.
+            stale.add((KIMI_CODE_BASE_URL + "/v1").rstrip("/"))
+        if stored not in stale:
+            # Non-default stored URL: explicit user choice (custom proxy/endpoint).
+            return entry
+
+    resolved = _resolve_kimi_base_url(
+        api_key, pconfig.inference_base_url, env_url
+    ).rstrip("/")
+    if resolved == stored:
+        return entry
+    normalized = dict(entry)
+    normalized["base_url"] = resolved
+    return normalized
+
+
+def _normalize_pool_entries(provider_id: str, entries: Any) -> Any:
+    """Read-time normalization for persisted credential pool entries."""
+    if not isinstance(entries, list):
+        return entries
+    return [
+        _normalize_loaded_kimi_entry(provider_id, e) if isinstance(e, dict) else e
+        for e in entries
+    ]
+
+
 def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice.
 
@@ -1608,14 +1678,25 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
             if isinstance(existing, list) and existing:
                 continue
             merged[gp_key] = list(gp_entries)
-        return merged
+        # Normalize after the profile/global merge so each provider's final
+        # slice (profile entries or the read-only global fallback) is repaired
+        # exactly once, without mutating the underlying loaded store dicts.
+        return {
+            pid: _normalize_pool_entries(pid, entries)
+            for pid, entries in merged.items()
+        }
 
     provider_entries = pool.get(provider_id)
     if isinstance(provider_entries, list) and provider_entries:
-        return list(provider_entries)
+        return _normalize_pool_entries(provider_id, provider_entries)
     # Profile has no entries for this provider — fall back to global.
     global_entries = global_pool.get(provider_id)
-    return list(global_entries) if isinstance(global_entries, list) else []
+    return cast(
+        Any,
+        _normalize_pool_entries(provider_id, global_entries)
+        if isinstance(global_entries, list)
+        else [],
+    )
 
 
 _POOL_STATUS_FIELDS = (

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -474,6 +474,24 @@ def test_runtime_api_key_field_drives_normalization(profile_env):
     assert entries[0]["base_url"] == KIMI_CODE_URL
 
 
+def test_fully_empty_credential_entry_left_untouched(profile_env):
+    """An entry with no credential at all has nothing to infer a URL from;
+    the load-time repair must not even fill a missing base_url for it."""
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(
+            access_token="",
+            runtime_api_key=None,
+            api_key=None,
+            base_url=None,
+        )],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0].get("base_url") is None
+
+
 def test_non_kimi_provider_entries_untouched(profile_env):
     _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
         "zai": [{

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -288,3 +288,257 @@ def test_write_pool_never_merges_cooldown_onto_reauthed_entry(classic_env):
     assert persisted["access_token"] == "sk-new"
     assert persisted.get("last_status") != "exhausted"
     assert persisted.get("last_error_code") is None
+
+
+# ---------------------------------------------------------------------------
+# read_credential_pool — read-time kimi base_url normalization (#5908)
+# ---------------------------------------------------------------------------
+
+KIMI_STALE_DEFAULT_URL = "https://api.moonshot.ai/v1"
+KIMI_CODE_URL = "https://api.kimi.com/coding"
+KIMI_LEGACY_V1_URL = "https://api.kimi.com/coding/v1"
+
+
+def _kimi_entry(**overrides) -> dict:
+    entry = {
+        "id": "kimi-1",
+        "label": "old Kimi key",
+        "auth_type": "api_key",
+        "priority": 0,
+        "source": "manual",
+        "access_token": "sk-kimi-test-key",
+        "base_url": KIMI_STALE_DEFAULT_URL,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_stale_moonshot_default_url_is_repaired_on_load(profile_env):
+    """#5908: entries persisted before prefix resolution keep the Moonshot
+    default; loading a kimi entry must re-resolve from the key prefix."""
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry()],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_CODE_URL
+
+
+def test_legacy_coding_v1_url_is_repaired_on_load(profile_env):
+    """The old documented workaround ('/coding/v1') double-appends /v1 in the
+    Anthropic SDK; loading must repair it to the canonical /coding URL."""
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(base_url=KIMI_LEGACY_V1_URL)],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_CODE_URL
+
+
+def test_legacy_coding_v1_url_preserved_for_non_kimi_key(profile_env):
+    """A non-kimi key stored with /coding/v1 is treated as an explicit custom
+    endpoint (possible OpenAI-compat use) and must not be rewritten."""
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(
+            access_token="sk-legacy-moonshot-key",
+            base_url=KIMI_LEGACY_V1_URL,
+        )],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_LEGACY_V1_URL
+
+
+def test_stale_default_with_trailing_slash_is_repaired(profile_env):
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(base_url="https://api.moonshot.ai/v1/")],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_CODE_URL
+
+
+def test_empty_env_override_treated_as_unset(profile_env, monkeypatch):
+    monkeypatch.setenv("KIMI_BASE_URL", "")
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry()],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_CODE_URL
+
+
+def test_missing_base_url_is_filled_on_load(profile_env):
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(base_url=None)],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_CODE_URL
+
+
+def test_empty_base_url_string_is_filled_on_load(profile_env):
+    """An empty-string base_url is treated like a missing one and filled."""
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(base_url="")],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_CODE_URL
+
+
+def test_whitespace_only_base_url_is_filled_on_load(profile_env):
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(base_url="   ")],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_CODE_URL
+
+
+def test_custom_nondefault_url_is_preserved_on_load(profile_env):
+    """A stored proxy/custom endpoint is the user's explicit choice — the
+    load-time repair must never clobber it (the #18694 rejection reason)."""
+    custom = "https://kimi-proxy.example.com/v1"
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(base_url=custom)],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == custom
+
+
+def test_env_override_wins_over_stale_url_on_load(profile_env, monkeypatch):
+    monkeypatch.setenv("KIMI_BASE_URL", "https://env-override.example/v1")
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry()],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == "https://env-override.example/v1"
+
+
+def test_env_override_wins_over_custom_url_on_load(profile_env, monkeypatch):
+    monkeypatch.setenv("KIMI_BASE_URL", "https://env-override.example/v1")
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(base_url="https://kimi-proxy.example.com/v1")],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == "https://env-override.example/v1"
+
+
+def test_legacy_moonshot_key_keeps_moonshot_default_on_load(profile_env):
+    """Keys without the sk-kimi- prefix belong on the Moonshot default; the
+    repair must not move them to api.kimi.com."""
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(access_token="sk-legacy-moonshot-key")],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_STALE_DEFAULT_URL
+
+
+def test_runtime_api_key_field_drives_normalization(profile_env):
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry(access_token="", runtime_api_key="sk-kimi-runtime-key")],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_CODE_URL
+
+
+def test_non_kimi_provider_entries_untouched(profile_env):
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "zai": [{
+            "id": "zai-1",
+            "auth_type": "api_key",
+            "access_token": "sk-zai-key",
+            "base_url": "https://api.z.ai/api/paas/v4",
+        }],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("zai")
+    assert entries[0]["base_url"] == "https://api.z.ai/api/paas/v4"
+
+
+def test_global_fallback_entries_normalized_on_load(profile_env):
+    """The read-only global fallback slice must be repaired the same way."""
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry()],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [{
+            "id": "prof-1",
+            "auth_type": "api_key",
+            "access_token": "sk-profile",
+        }],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("kimi-coding")
+    assert entries[0]["base_url"] == KIMI_CODE_URL
+
+
+def test_whole_pool_read_normalizes_kimi_entries(profile_env):
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry()],
+        "openrouter": [{
+            "id": "prof-1",
+            "auth_type": "api_key",
+            "access_token": "sk-profile",
+        }],
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    pool = read_credential_pool()
+    assert pool["kimi-coding"][0]["base_url"] == KIMI_CODE_URL
+    assert pool["openrouter"][0]["id"] == "prof-1"
+
+
+def test_pool_to_runtime_uses_normalized_url(profile_env, monkeypatch):
+    """Regression: the runtime entry constructed from the persisted pool must
+    carry the repaired URL (read_credential_pool → PooledCredential)."""
+    # Hermetic: no ambient kimi env vars that load_pool's seeding could pick up.
+    for var in ("KIMI_API_KEY", "KIMI_CODING_API_KEY", "KIMI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "kimi-coding": [_kimi_entry()],
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("kimi-coding")
+    entry = pool.select()
+    assert entry is not None
+    assert entry.base_url == KIMI_CODE_URL


### PR DESCRIPTION
## What

Fixes #5908 — persisted `kimi-coding` / `kimi-coding-cn` credential pool entries that were written before prefix-based URL resolution (or during a setup race) keep the Moonshot default `base_url` (`https://api.moonshot.ai/v1`), which `sk-kimi-` keys reject with HTTP 401. The runtime consumes the persisted URL verbatim (`read_credential_pool` → `load_pool` → `PooledCredential`), so once the wrong URL is on disk it never self-corrects.

## Approach

Normalize on read inside `read_credential_pool()` — the profile slice, the global-fallback slice, and the whole-pool read — repairing only:

- missing `base_url`,
- the provider registry default (`https://api.moonshot.ai/v1`),
- the legacy `https://api.kimi.com/coding/v1` value from the old documented workaround, **only for `sk-kimi-` keys** (the Anthropic SDK appends `/v1/messages` to the `/coding` endpoint, so the suffixed value double-appends and 404s).

Custom non-default URLs (proxies/endpoints) are preserved as the user's explicit choice unless `KIMI_BASE_URL` is set, which always wins — matching `_resolve_kimi_base_url()` semantics. Read-only: nothing is written back to `auth.json`; `write_credential_pool` is untouched.

## Tests

17 new tests in `tests/hermes_cli/test_auth_profile_fallback.py` (temp-`HERMES_HOME` E2E pattern): stale Moonshot default repaired, legacy `/coding/v1` repaired for `sk-kimi-` keys (and preserved for non-kimi keys), missing `base_url` filled, trailing-slash variant, custom URL preserved, `KIMI_BASE_URL` override wins over both stale and custom stored URLs, empty-string env treated as unset, legacy Moonshot key keeps its default, `runtime_api_key` drives normalization, non-kimi providers untouched, global-fallback slice normalized, whole-pool read normalized, and a pool-to-runtime regression (`load_pool().select().base_url`).

Verified locally: 202 tests pass across `test_auth_profile_fallback.py`, `test_api_key_providers.py`, `test_credential_pool.py`, `test_copilot_catalog_oauth_fallback.py`, `test_custom_provider_model_switch.py`; the new tests fail without the fix and pass with it.

Supersedes #18694 (same target, open since May with failing CI and an unanswered keep_open review; this PR implements the requested changes: custom-URL preservation, current profile/global fallback integration, and the regression tests).
