### PR TITLE
fix(cli): skill commands with instructions get queue feedback while agent is busy (#83209)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4078,6 +4078,20 @@ def _looks_like_slash_command(text: str) -> bool:
     return "/" not in first_word[1:]
 
 
+def _command_base(text: str) -> str:
+    """Return the lowercased command name of a slash command, slash stripped.
+
+    ``/My-Skill foo`` -> ``my-skill``. Shared by the busy-time
+    ``_should_handle_*_inline`` detectors and skill-command detection; each
+    used to re-parse this verbatim, which drifted (one stripped the slash
+    before checking the slash-keyed skill map, silently disabling its
+    branch).
+    """
+    if not text:
+        return ""
+    return text.split(None, 1)[0].lower().lstrip("/")
+
+
 # ============================================================================
 # Skill Slash Commands — dynamic commands generated from installed skills
 # ============================================================================
@@ -9933,7 +9947,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return False
         try:
             from hermes_cli.commands import resolve_command
-            base = text.split(None, 1)[0].lower().lstrip('/')
+            base = _command_base(text)
             cmd = resolve_command(base)
             return bool(cmd and cmd.name == "model")
         except Exception:
@@ -9957,7 +9971,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return False
         try:
             from hermes_cli.commands import resolve_command
-            base = text.split(None, 1)[0].lower().lstrip('/')
+            base = _command_base(text)
             cmd = resolve_command(base)
             return bool(cmd and cmd.name == "steer")
         except Exception:
@@ -9988,11 +10002,44 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return False
         try:
             from hermes_cli.commands import resolve_command
-            base = text.split(None, 1)[0].lower().lstrip('/')
+            base = _command_base(text)
             cmd = resolve_command(base)
             return bool(cmd and cmd.name == "background")
         except Exception:
             return False
+
+    def _skill_command_instruction(self, text: str) -> str:
+        """Return the user payload of a skill invocation, or "" if not one.
+
+        A skill command is a slash command whose base name resolves to an
+        installed skill (not a built-in). When it carries a payload (e.g.
+        ``/my-skill review this PR``), the payload is a real user
+        instruction that deserves feedback instead of silent queueing while
+        the agent is busy (#83209). Returns just the instruction text so
+        callers can preview it.
+        """
+        if not text or not _looks_like_slash_command(text):
+            return ""
+        base = _command_base(text)
+        if not base:
+            return ""
+        try:
+            from hermes_cli.commands import resolve_command
+            if resolve_command(base):
+                return ""  # built-in command, not a skill
+        except Exception:
+            return ""
+        try:
+            skills = _ensure_skill_commands()
+        except Exception:
+            return ""
+        # scan_skill_commands() keys are slash-prefixed ("/my-skill") — the
+        # same form production dispatch checks (cli.py `base_cmd in
+        # skill_commands`). Strip the leading slash before comparing.
+        if f"/{base}" not in skills:
+            return ""
+        parts = text.split(None, 1)
+        return parts[1].strip() if len(parts) > 1 else ""
 
     def _output_console(self):
         """Use prompt_toolkit-safe Rich rendering once the TUI is live."""
@@ -15829,6 +15876,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         pass
                 else:
                     self._pending_input.put(payload)
+                    # A skill command with an instruction payload must not
+                    # queue silently while the agent is busy: the user sees
+                    # nothing happen, re-sends, and every send queues another
+                    # full skill-expanded message that replays after the turn
+                    # (#83209). Print explicit feedback naming their
+                    # instruction so they know it is registered for the next
+                    # turn. (Skills still need a full turn — the expanded
+                    # skill content must load into context, so mid-run steer
+                    # is the wrong channel for them.)
+                    if getattr(self, "_agent_running", False):
+                        skill_instruction = self._skill_command_instruction(text)
+                        if skill_instruction:
+                            preview = skill_instruction[:80] + ("..." if len(skill_instruction) > 80 else "")
+                            _cprint(f"  {_DIM}Queued for the next turn (skill): {preview}{_RST}")
                 # History stores real pasted content, not the placeholder, so
                 # up-arrow recall restores the actual text.
                 self._inline_pastes(event.app.current_buffer)

--- a/tests/cli/test_skill_queued_feedback.py
+++ b/tests/cli/test_skill_queued_feedback.py
@@ -1,0 +1,132 @@
+"""Regression tests for skill-command queue feedback while the agent is busy (#83209).
+
+A skill command carrying a user instruction (e.g. ``/my-skill review this
+PR``) submitted while the agent is running used to be queued silently into
+``_pending_input``: the user saw only "⚡ Loading skill", got no feedback
+that their instruction was registered, and re-sending replayed N copies of
+the same expanded turn. The fix prints explicit "Queued for the next turn
+(skill): <instruction>" feedback when the agent is busy.
+
+These tests exercise the detector without starting a prompt_toolkit app.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+from cli import _command_base
+
+
+def _make_cli():
+    """Create a HermesCLI instance with prompt_toolkit stubbed out.
+
+    Returns ``(cli, module)``. The module is returned so tests can
+    ``patch.object(module, ...)``: the instance's methods close over THIS
+    module object's globals, and ``patch.dict(sys.modules, ...)`` (used to
+    stub prompt_toolkit) removes ``cli`` from ``sys.modules`` on exit, so a
+    string-target ``patch("cli.X")`` would re-import a *fresh* module the
+    instance never references.
+    """
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
+        "os.environ", clean_env, clear=False
+    ):
+        import cli as _cli_mod
+
+        _cli_mod = importlib.reload(_cli_mod)
+        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), patch.dict(
+            _cli_mod.__dict__, {"CLI_CONFIG": _clean_config}
+        ):
+            return _cli_mod.HermesCLI(), _cli_mod
+
+
+class TestSkillCommandInstructionDetector:
+    """_skill_command_instruction recognizes skill commands with payloads.
+
+    NOTE: scan_skill_commands() keys are slash-prefixed (``"/my-skill"``),
+    matching the production dispatch check (cli.py ``base_cmd in
+    skill_commands``). Tests must use that format — a slash-less stub once
+    masked a membership bug that disabled the feedback in production.
+    """
+
+    def test_returns_payload_for_skill_command_with_instruction(self):
+        cli, mod = _make_cli()
+        with patch.object(
+            mod, "_ensure_skill_commands",
+            return_value={"/my-skill": {"name": "my-skill"}},
+        ), patch("hermes_cli.commands.resolve_command", return_value=None):
+            assert cli._skill_command_instruction("/my-skill review this PR") == "review this PR"
+
+    def test_matches_slash_prefixed_skill_keys_like_production(self):
+        """Regression: slash-less comparison made the feedback dead code."""
+        cli, mod = _make_cli()
+        with patch.object(
+            mod, "_ensure_skill_commands",
+            return_value={"/gif-search": {"name": "gif-search"}},
+        ), patch("hermes_cli.commands.resolve_command", return_value=None):
+            assert cli._skill_command_instruction("/gif-search find a cat gif") == "find a cat gif"
+
+    def test_returns_empty_for_skill_command_without_payload(self):
+        cli, mod = _make_cli()
+        with patch.object(
+            mod, "_ensure_skill_commands",
+            return_value={"/my-skill": {"name": "my-skill"}},
+        ), patch("hermes_cli.commands.resolve_command", return_value=None):
+            assert cli._skill_command_instruction("/my-skill") == ""
+
+    def test_returns_empty_for_builtin_command(self):
+        cli, mod = _make_cli()
+        # resolve_command returns a truthy CommandDef for built-ins.
+        with patch.object(
+            mod, "_ensure_skill_commands",
+            return_value={"/steer": {"name": "steer"}},
+        ), patch(
+            "hermes_cli.commands.resolve_command",
+            return_value=MagicMock(name="steer"),
+        ):
+            assert cli._skill_command_instruction("/steer focus on errors") == ""
+
+    def test_returns_empty_for_plain_text(self):
+        cli, _mod = _make_cli()
+        assert cli._skill_command_instruction("review this PR") == ""
+
+    def test_returns_empty_for_unknown_slash_command(self):
+        cli, mod = _make_cli()
+        with patch.object(mod, "_ensure_skill_commands", return_value={}), patch(
+            "hermes_cli.commands.resolve_command", return_value=None
+        ):
+            assert cli._skill_command_instruction("/no-such-skill do something") == ""
+
+    def test_command_base_strips_slash_and_lowercases(self):
+        assert _command_base("/My-Skill foo") == "my-skill"
+        assert _command_base("/steer focus") == "steer"
+        assert _command_base("") == ""


### PR DESCRIPTION
## Summary

Fixes #83209 — a skill command with an instruction (e.g. `/my-skill review this PR`) typed while the agent is running was **silently queued** into `_pending_input`. The user saw only "⚡ Loading skill", got no confirmation their instruction registered, and re-sending replayed N copies of the same expanded turn.

### Fix

When the agent is running and the submitted text is a skill command carrying a payload, `handle_enter` now prints explicit feedback:

```
  Queued for the next turn (skill): review this PR
```

**Why feedback, not steer:** skills need a full turn — the expanded skill content must load into context before the instruction makes sense. Mid-run steer (`agent.steer()`) would inject the raw instruction without the skill's procedures, so it is the wrong channel here. The bug was the *silence* (no confirmation → re-send → replay loop), and the fix is the confirmation. This mirrors the existing busy-path idioms: `/steer` and `/background` got inline dispatch (#34569, #75221); skill commands with payloads now at least confirm they are queued.

### Implementation notes

- New `_skill_command_instruction(text)` on `HermesCLI`: returns the user payload iff the base resolves to an installed skill (not a built-in) and text follows the name.
- Skill detection matches `scan_skill_commands()`'s **slash-prefixed keys** (`"/my-skill"`), the same form the production dispatch path checks (`cli.py` `base_cmd in skill_commands`). An early draft compared slash-less, which would have silently disabled the feedback in production — caught in the two-axis review and covered by a regression test.
- Extracted the verbatim command-base parse shared by all four busy-time `_should_handle_*_inline` detectors into a `_command_base(text)` helper (was duplicated 4×).

## Tests

7 new tests in `tests/cli/test_skill_queued_feedback.py`:
- payload extracted for a real skill command
- **slash-prefixed key matching (regression for the production-disabling bug)**
- no-payload → empty; built-in rejected; plain text rejected; unknown skill rejected
- `_command_base` unit cases

All 14 tests across the skill + steer-busy-path files pass; RED verified (pre-fix code fails the new assertions).
