### PR TITLE
fix(cron): send classifier contract as a system prompt

### DIFF
--- a/cron/scripts/classify_items.py
+++ b/cron/scripts/classify_items.py
@@ -165,7 +165,10 @@ def main() -> int:
     try:
         resp = call_llm(
             task="monitor",
-            messages=[{"role": "user", "content": prompt}],
+            messages=[
+                {"role": "system", "content": _CLASSIFY_INSTRUCTIONS},
+                {"role": "user", "content": prompt},
+            ],
             max_tokens=1024,
             temperature=0,
         )

--- a/tests/cron/test_classify_items.py
+++ b/tests/cron/test_classify_items.py
@@ -1,0 +1,58 @@
+import io
+import json
+import sys
+from types import SimpleNamespace
+
+from cron.scripts import classify_items
+
+
+def test_main_sends_classifier_contract_as_system_prompt(monkeypatch, capsys):
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        message = SimpleNamespace(
+            content='[{"index": 0, "score": 9, "reason": "production incident"}]'
+        )
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                [
+                    {
+                        "id": "incident-1",
+                        "subject": "Production unavailable",
+                        "summary": "HTTP 500; respond today",
+                    }
+                ]
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "classify_items.py",
+            "--criteria",
+            "Surface production incidents",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert classify_items.main() == 0
+    assert captured["task"] == "monitor"
+    assert captured["messages"][0] == {
+        "role": "system",
+        "content": classify_items._CLASSIFY_INSTRUCTIONS,
+    }
+    assert captured["messages"][1]["role"] == "user"
+    assert "Production unavailable" in captured["messages"][1]["content"]
+
+    output = json.loads(capsys.readouterr().out)
+    assert output[0]["id"] == "incident-1"
+    assert output[0]["score"] == 9


### PR DESCRIPTION
## Summary

- send the fixed classification contract as a system message
- keep feed-specific criteria and item data in the user message
- add a regression test covering message roles and output preservation

## Why

The classifier currently embeds its behavioral contract in the user prompt. Passing the invariant contract as a system message gives it the intended instruction priority and keeps untrusted feed content confined to the user role.

## Test

- `python -m pytest tests/cron/test_classify_items.py -v` (1 passed)