### PR TITLE
fix(ssh): make Windows sandbox routing reliable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -277,6 +277,9 @@ terminal:
 #   ssh_user: "myuser"
 #   ssh_port: 22
 #   ssh_key: "~/.ssh/id_rsa"  # Optional - uses ssh-agent if not specified
+#   # Disable on native Windows or other clients where stale multiplexing
+#   # sockets cause ControlMaster warnings or cross-process interference.
+#   ssh_control_master: true
 
 # -----------------------------------------------------------------------------
 # OPTION 3: Docker container

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3232,6 +3232,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "ssh_user": "TERMINAL_SSH_USER",
     "ssh_port": "TERMINAL_SSH_PORT",
     "ssh_key": "TERMINAL_SSH_KEY",
+    "ssh_control_master": "TERMINAL_SSH_CONTROLMASTER",
     "container_cpu": "TERMINAL_CONTAINER_CPU",
     "container_memory": "TERMINAL_CONTAINER_MEMORY",
     "container_disk": "TERMINAL_CONTAINER_DISK",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -393,6 +393,10 @@ DEFAULT_CONFIG = {
         # When on, SETUID/SETGID caps are omitted from the container since
         # no privilege drop is needed.
         "docker_run_as_host_user": False,
+        # OpenSSH ControlMaster connection reuse. Disable on hosts where the
+        # client leaves stale multiplexing sockets (observed with native
+        # Windows OpenSSH), which can contaminate command/file output.
+        "ssh_control_master": True,
         # Persistent shell — keep a long-lived bash shell across execute() calls
         # so cwd/env vars/shell variables survive between commands.
         # Enabled by default for non-local backends (SSH); local is always opt-in

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -44,7 +44,13 @@ class TestReadFileHandler:
 
 class TestWriteFileHandler:
     @patch("tools.file_tools._get_file_ops")
-    def test_writes_content(self, mock_get):
+    def test_writes_content(self, mock_get, monkeypatch):
+        # This handler-wiring test intentionally uses a POSIX fixture path.
+        # Keep it in the backend namespace when pytest runs on Windows.
+        monkeypatch.setattr(
+            "tools.file_tools._uses_container_paths",
+            lambda task_id="default": True,
+        )
         mock_ops = MagicMock()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/out.txt", "bytes": 13}
@@ -132,7 +138,13 @@ class TestWriteFileHandler:
 
 class TestPatchHandler:
     @patch("tools.file_tools._get_file_ops")
-    def test_replace_mode_calls_patch_replace(self, mock_get):
+    def test_replace_mode_calls_patch_replace(self, mock_get, monkeypatch):
+        # This handler-wiring test intentionally uses a POSIX fixture path.
+        # Keep it in the backend namespace when pytest runs on Windows.
+        monkeypatch.setattr(
+            "tools.file_tools._uses_container_paths",
+            lambda task_id="default": True,
+        )
         mock_ops = MagicMock()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"status": "ok", "replacements": 1}
@@ -225,7 +237,11 @@ class TestPatchSensitivePathExtraction:
     """
 
     @patch("tools.file_tools._get_file_ops")
-    def test_patch_move_to_sensitive_dst_blocked(self, mock_get):
+    def test_patch_move_to_sensitive_dst_blocked(self, mock_get, monkeypatch):
+        monkeypatch.setattr(
+            "tools.file_tools._uses_container_paths",
+            lambda task_id="default": True,
+        )
         from tools.file_tools import patch_tool
         patch_text = (
             "*** Begin Patch\n"
@@ -239,13 +255,17 @@ class TestPatchSensitivePathExtraction:
 
 
     @patch("tools.file_tools._get_file_ops")
-    def test_patch_update_no_space_after_asterisks_blocked(self, mock_get):
+    def test_patch_update_no_space_after_asterisks_blocked(self, mock_get, monkeypatch):
         """``***Update File:`` (no space after asterisks) must also be caught.
 
         patch_parser.py accepts this form (``\\s*`` in its regex), so the
         sensitive path check must be at least as lenient or the check
         is bypassed.
         """
+        monkeypatch.setattr(
+            "tools.file_tools._uses_container_paths",
+            lambda task_id="default": True,
+        )
         from tools.file_tools import patch_tool
         patch_text = (
             "*** Begin Patch\n"
@@ -480,6 +500,10 @@ class TestSensitivePathCheck:
 
 
     def test_system_path_still_blocked(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.file_tools._uses_container_paths",
+            lambda task_id="default": True,
+        )
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved", "/some/other/path")
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
 
@@ -488,9 +512,13 @@ class TestSensitivePathCheck:
         assert "error" in result
         assert "sensitive system path" in result["error"]
 
-    def test_macos_private_var_carveouts(self):
+    def test_macos_private_var_carveouts(self, monkeypatch):
         """macOS temp dirs under /private/var must not be blanket-blocked,
         while the genuinely-sensitive /private/var subtrees still are."""
+        monkeypatch.setattr(
+            "tools.file_tools._uses_container_paths",
+            lambda task_id="default": True,
+        )
         from tools.file_tools import _check_sensitive_path
 
         # $TMPDIR / /tmp / /var/folders realpath into these on macOS.

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -344,6 +344,30 @@ class TestWindowsMsysPathResolution:
         resolved = file_tools._resolve_path_for_task("/home/don/.env")
         assert str(resolved) == "/home/don/.env"
 
+    def test_ssh_uses_remote_posix_paths_on_windows(self, monkeypatch):
+        """SSH bash paths must not be normalized as Windows host paths."""
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(file_tools.sys, "platform", "win32")
+        monkeypatch.setattr(
+            file_tools,
+            "_terminal_env_type_for_task",
+            lambda task_id="default": "ssh",
+        )
+        monkeypatch.setattr(
+            file_tools,
+            "_authoritative_workspace_root",
+            lambda task_id="default": "/home/cua/workspace",
+        )
+
+        resolved = file_tools._resolve_path_for_task(
+            "/home/cua/workspace/canary.txt"
+        )
+        assert str(resolved) == "/home/cua/workspace/canary.txt"
+        assert file_tools._path_resolution_warning(
+            "/home/cua/workspace/canary.txt", resolved
+        ) is None
+
 
 # ---------------------------------------------------------------------------
 # Tool result hint tests (#722)

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -57,6 +57,20 @@ class TestBuildSSHCommand:
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
 
+    def test_controlmaster_can_be_disabled(self, monkeypatch):
+        monkeypatch.delenv("TERMINAL_SSH_CONTROLMASTER", raising=False)
+        env = SSHEnvironment(host="h", user="u", control_master=False)
+        cmd = " ".join(env._build_ssh_command())
+        assert "ControlPath=" not in cmd
+        assert "ControlMaster=" not in cmd
+        assert "ControlPersist=" not in cmd
+
+    def test_controlmaster_env_is_final_authority(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_SSH_CONTROLMASTER", "false")
+        env = SSHEnvironment(host="h", user="u", control_master=True)
+        cmd = " ".join(env._build_ssh_command())
+        assert "ControlMaster=" not in cmd
+
 
 class TestControlSocketPath:
     """Regression tests for issue #11840.
@@ -112,11 +126,18 @@ class TestControlSocketPath:
         )
 
     def test_path_is_deterministic_across_instances(self):
-        """Same (user, host, port) must yield the same control socket so
-        ControlMaster reuse works across reconnects."""
+        """Same target in one process must reuse the same control socket."""
         first = SSHEnvironment(host="example.com", user="alice", port=2222)
         second = SSHEnvironment(host="example.com", user="alice", port=2222)
         assert first.control_socket == second.control_socket
+
+    def test_path_differs_across_processes(self, monkeypatch):
+        """Separate tool workers must not own the same ControlMaster socket."""
+        monkeypatch.setattr("tools.environments.ssh.os.getpid", lambda: 1001)
+        first = SSHEnvironment(host="example.com", user="alice", port=2222)
+        monkeypatch.setattr("tools.environments.ssh.os.getpid", lambda: 1002)
+        second = SSHEnvironment(host="example.com", user="alice", port=2222)
+        assert first.control_socket != second.control_socket
 
     def test_path_differs_for_different_targets(self):
         """Different (user, host, port) triples must produce different paths."""
@@ -127,6 +148,11 @@ class TestControlSocketPath:
 
 
 class TestTerminalToolConfig:
+    def test_ssh_controlmaster_can_be_disabled(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_SSH_CONTROLMASTER", "false")
+        from tools.terminal_tool import _get_env_config
+        assert _get_env_config()["ssh_control_master"] is False
+
     def test_ssh_persistent_default_true(self, monkeypatch):
         """SSH persistent defaults to True (via TERMINAL_PERSISTENT_SHELL)."""
         monkeypatch.delenv("TERMINAL_SSH_PERSISTENT", raising=False)

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -23,6 +23,7 @@ def _reset_bridge_state(monkeypatch):
         "TERMINAL_CWD",
         "TERMINAL_DOCKER_IMAGE",
         "TERMINAL_SSH_HOST",
+        "TERMINAL_SSH_CONTROLMASTER",
     ):
         monkeypatch.delenv(name, raising=False)
     yield
@@ -95,6 +96,20 @@ def test_ssh_config_preserves_remote_tilde_cwd(monkeypatch):
 
     assert os.environ["TERMINAL_CWD"] == "~"
     assert config["cwd"] == "~"
+
+
+def test_explicit_ssh_controlmaster_config_overrides_env(monkeypatch):
+    _write_config(
+        "terminal:\n"
+        "  backend: ssh\n"
+        "  ssh_control_master: false\n"
+    )
+    monkeypatch.setenv("TERMINAL_SSH_CONTROLMASTER", "true")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["ssh_control_master"] is False
+    assert os.environ["TERMINAL_SSH_CONTROLMASTER"] == "False"
 
 
 def test_env_is_preserved_when_config_has_no_terminal_section(monkeypatch):

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -47,15 +47,29 @@ class SSHEnvironment(BaseEnvironment):
     """
 
     def __init__(self, host: str, user: str, cwd: str = "~",
-                 timeout: int = 60, port: int = 22, key_path: str = ""):
+                 timeout: int = 60, port: int = 22, key_path: str = "",
+                 control_master: bool = True):
         super().__init__(cwd=cwd, timeout=timeout)
         self.host = host
         self.user = user
         self.port = port
         self.key_path = key_path
+        # Keep the constructor safe even when a launcher/worker path bypasses
+        # the normal terminal config bridge. SSH host/key already come from
+        # this same environment in those paths, so an explicit operator value
+        # here must remain authoritative.
+        control_master_env = os.getenv("TERMINAL_SSH_CONTROLMASTER")
+        if control_master_env is not None:
+            self.control_master = control_master_env.strip().lower() in {
+                "true", "1", "yes"
+            }
+        else:
+            self.control_master = bool(control_master)
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
-        self.control_dir.mkdir(parents=True, exist_ok=True)
+        self.control_socket: Path | None = None
+        if self.control_master:
+            self.control_dir.mkdir(parents=True, exist_ok=True)
         # Keep the socket filename short and deterministic so the full path
         # stays under the 104-byte sun_path limit that macOS enforces on
         # Unix domain sockets. A raw ``user@host:port`` — especially with an
@@ -63,11 +77,16 @@ class SSHEnvironment(BaseEnvironment):
         # ControlMaster mode easily exceeds the limit under macOS's
         # deeply-nested $TMPDIR (e.g. /var/folders/xx/yy/T/). Hashing the
         # triple keeps the path stable across reconnects so ControlMaster
-        # reuse still works.
-        _socket_id = hashlib.sha256(
-            f"{user}@{host}:{port}".encode()
-        ).hexdigest()[:16]
-        self.control_socket = self.control_dir / f"{_socket_id}.sock"
+        # reuse still works. Include the process id: terminal, file, and
+        # execute_code workers can be separate Hermes processes. A globally
+        # shared socket lets one worker's cleanup close another worker's
+        # master, leaving a stale socket and contaminating command output with
+        # mux warnings. Process scoping preserves reuse inside each worker
+        # without cross-process ownership races.
+            _socket_id = hashlib.sha256(
+                f"{user}@{host}:{port}:{os.getpid()}".encode()
+            ).hexdigest()[:16]
+            self.control_socket = self.control_dir / f"{_socket_id}.sock"
         _ensure_ssh_available()
         self._establish_connection()
         self._remote_home = self._detect_remote_home()
@@ -86,9 +105,10 @@ class SSHEnvironment(BaseEnvironment):
 
     def _build_ssh_command(self, extra_args: list | None = None) -> list:
         cmd = ["ssh"]
-        cmd.extend(["-o", f"ControlPath={self.control_socket}"])
-        cmd.extend(["-o", "ControlMaster=auto"])
-        cmd.extend(["-o", "ControlPersist=300"])
+        if self.control_master:
+            cmd.extend(["-o", f"ControlPath={self.control_socket}"])
+            cmd.extend(["-o", "ControlMaster=auto"])
+            cmd.extend(["-o", "ControlPersist=300"])
         cmd.extend(["-o", "BatchMode=yes"])
         cmd.extend(["-o", "StrictHostKeyChecking=accept-new"])
         cmd.extend(["-o", "ConnectTimeout=10"])
@@ -186,7 +206,9 @@ class SSHEnvironment(BaseEnvironment):
             stdin=subprocess.DEVNULL,
         )
 
-        scp_cmd = ["scp", "-o", f"ControlPath={self.control_socket}"]
+        scp_cmd = ["scp"]
+        if self.control_master:
+            scp_cmd.extend(["-o", f"ControlPath={self.control_socket}"])
         if self.port != 22:
             scp_cmd.extend(["-P", str(self.port)])
         if self.key_path:
@@ -408,7 +430,7 @@ class SSHEnvironment(BaseEnvironment):
             logger.info("SSH: syncing files from sandbox...")
             self._sync_manager.sync_back()
 
-        if self.control_socket.exists():
+        if self.control_master and self.control_socket and self.control_socket.exists():
             try:
                 cmd = ["ssh", "-o", f"ControlPath={self.control_socket}",
                        "-O", "exit", f"{self.user}@{self.host}"]

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -166,6 +166,7 @@ def _resolve_path(filepath: str, task_id: str = "default") -> Path | PurePosixPa
 # sessions get the same protection. See references/worktree-cwd-discipline.md.
 _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
 _CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+_REMOTE_POSIX_PATH_BACKENDS = frozenset({"ssh"})
 
 
 def _terminal_env_type_for_task(task_id: str = "default") -> str:
@@ -210,7 +211,8 @@ def _uses_container_paths(task_id: str = "default") -> bool:
         container_backends = _CONTAINER_BACKENDS
     except Exception:
         container_backends = _CONTAINER_PATH_BACKENDS_FALLBACK
-    return _terminal_env_type_for_task(task_id) in container_backends
+    backend = _terminal_env_type_for_task(task_id)
+    return backend in container_backends or backend in _REMOTE_POSIX_PATH_BACKENDS
 
 
 def _normalize_without_host_deref(path: str | Path | PurePosixPath) -> PurePosixPath:
@@ -415,7 +417,11 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
     (no ``cd`` run yet) is warned on the very first write.
     """
     try:
-        if Path(_expand_tilde(filepath)).is_absolute():
+        expanded = _expand_tilde(filepath)
+        if (
+            (_uses_container_paths(task_id) and posixpath.isabs(expanded))
+            or Path(expanded).is_absolute()
+        ):
             return None
         workspace_root = _authoritative_workspace_root(task_id)
         if not workspace_root:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1661,6 +1661,9 @@ def _get_env_config() -> Dict[str, Any]:
         "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
         "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
         "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_control_master": os.getenv(
+            "TERMINAL_SSH_CONTROLMASTER", "true"
+        ).lower() in {"true", "1", "yes"},
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
@@ -1721,6 +1724,7 @@ def _ssh_config_from_config(config: Dict[str, Any]) -> dict:
         "user": config.get("ssh_user", ""),
         "port": config.get("ssh_port", 22),
         "key": config.get("ssh_key", ""),
+        "control_master": config.get("ssh_control_master", True),
         "persistent": config.get("ssh_persistent", False),
     }
 
@@ -1932,6 +1936,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             user=ssh_config["user"],
             port=ssh_config.get("port", 22),
             key_path=ssh_config.get("key", ""),
+            control_master=ssh_config.get("control_master", True),
             cwd=cwd,
             timeout=timeout,
         )


### PR DESCRIPTION
## What does this PR do?

Makes the SSH terminal backend reliable when Hermes runs natively on Windows against a POSIX sandbox/host.

The fix keeps SSH-backed file paths in the remote POSIX namespace instead of applying Windows host normalization. It also makes OpenSSH ControlMaster configurable and scopes multiplexing sockets per Hermes process, preventing separate terminal/file workers from closing or contaminating one another's shared socket.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Treat the `ssh` backend as a remote POSIX path namespace in `tools/file_tools.py`.
- Add `terminal.ssh_control_master` / `TERMINAL_SSH_CONTROLMASTER` configuration.
- Scope SSH control sockets to the current Hermes process and omit ControlMaster/ControlPath options when disabled.
- Document the setting in `cli-config.yaml.example`.
- Add Windows/SSH routing, config-bridge, ControlMaster, and platform-neutral fixture coverage.

## How to Test

1. Run:
   `python -m pytest -o addopts= -q tests/tools/test_file_tools.py tests/tools/test_ssh_environment.py tests/tools/test_terminal_env_bridge.py`
2. On native Windows, configure the terminal backend as SSH with a POSIX remote `cwd`.
3. Verify terminal and file tools read/write the same remote paths without MSYS/Windows rewriting or multiplexing warnings.

Local result on Windows 10 / Python 3.11.15: **71 passed, 5 skipped**.

## Checklist

### Code

- [ ] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the repository-wide `pytest tests/ -q` suite locally; focused tests passed and CI is requested for the full suite
- [x] I've added tests for my changes
- [x] I've tested on Windows 10

### Documentation & Housekeeping

- [x] Relevant configuration documentation was updated in `cli-config.yaml.example`
- [x] `cli-config.yaml.example` was updated for the new config key
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact was considered; default behavior remains enabled and POSIX path handling is limited to the SSH backend
- [x] Tool description/schema changes are N/A
