### PR TITLE
feat(approval): explain silently auto-approved dangerous commands (port kilocode#12728/#12995)

### DIFF
--- a/tests/tools/test_approval_provenance.py
+++ b/tests/tools/test_approval_provenance.py
@@ -1,0 +1,176 @@
+"""Provenance for silently auto-approved dangerous commands.
+
+Port of the approval-provenance surfaced in Kilo-Org/kilocode#12728/#12995:
+when a flagged command runs without a prompt because of a prior user decision
+(session approval, permanent 'always' entry, or a command_allowlist glob),
+the guard result must say WHY, so the tool result can explain the
+auto-approval instead of looking like a silent bypass.
+"""
+
+
+
+import pytest
+
+from tools import approval as mod
+from tools.approval import (
+    _approval_scope,
+    _matching_permanent_allowlist_entry,
+    approve_permanent,
+    approve_session,
+    check_all_command_guards,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    mod._session_approved.clear()
+    mod._permanent_approved.clear()
+    monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(mod, "is_current_session_yolo_enabled", lambda: False)
+    monkeypatch.setattr(mod, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(mod, "get_current_session_key", lambda default=None: "prov-sess")
+    yield
+    mod._session_approved.clear()
+    mod._permanent_approved.clear()
+
+
+def _tirith_allow(monkeypatch):
+    monkeypatch.setattr(
+        "tools.tirith_security.check_command_security",
+        lambda _c: {"action": "allow", "findings": [], "summary": ""},
+        raising=False,
+    )
+
+
+class TestApprovalScope:
+    def test_none_when_unapproved(self):
+        assert _approval_scope("prov-sess", "recursive delete") is None
+
+    def test_session_scope(self):
+        approve_session("prov-sess", "recursive delete")
+        assert _approval_scope("prov-sess", "recursive delete") == "session"
+
+    def test_permanent_scope_wins(self):
+        approve_session("prov-sess", "recursive delete")
+        approve_permanent("recursive delete")
+        assert _approval_scope("prov-sess", "recursive delete") == "permanent"
+
+
+class TestAllowlistEntryLookup:
+    def test_exact_match_returns_entry(self):
+        mod.load_permanent({"podman ps"})
+        assert _matching_permanent_allowlist_entry("podman ps") == "podman ps"
+
+    def test_glob_match_returns_pattern(self):
+        mod.load_permanent({"podman *"})
+        assert _matching_permanent_allowlist_entry("podman rm x") == "podman *"
+
+    def test_compound_command_never_matches(self):
+        mod.load_permanent({"podman *"})
+        assert _matching_permanent_allowlist_entry("podman ps && rm -rf /x") is None
+
+
+class TestGuardProvenance:
+    def test_session_preapproval_reports_provenance(self, monkeypatch):
+        _tirith_allow(monkeypatch)
+        monkeypatch.setattr(mod, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(mod, "_is_gateway_approval_context", lambda: False)
+        is_dangerous, pattern_key, _desc = mod.detect_dangerous_command(
+            "rm -rf /tmp/stuff"
+        )
+        assert is_dangerous
+        approve_session("prov-sess", pattern_key)
+
+        result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+
+        assert result["approved"] is True
+        assert result.get("pre_approved") == "session"
+        assert result.get("description")
+
+    def test_permanent_preapproval_reports_provenance(self, monkeypatch):
+        _tirith_allow(monkeypatch)
+        monkeypatch.setattr(mod, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(mod, "_is_gateway_approval_context", lambda: False)
+        _d, pattern_key, _desc = mod.detect_dangerous_command("rm -rf /tmp/stuff")
+        approve_session("prov-sess", pattern_key)
+        approve_permanent(pattern_key)
+
+        result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+
+        assert result["approved"] is True
+        assert result.get("pre_approved") == "permanent"
+
+    def test_allowlist_match_reports_rule(self, monkeypatch):
+        mod.load_permanent({"rm -rf /tmp/scratch"})
+
+        result = check_all_command_guards("rm -rf /tmp/scratch", "local")
+
+        assert result["approved"] is True
+        assert result.get("pre_approved") == "allowlist"
+        assert result.get("pre_approved_rule") == "rm -rf /tmp/scratch"
+
+    def test_unflagged_command_has_no_provenance(self, monkeypatch):
+        _tirith_allow(monkeypatch)
+        monkeypatch.setattr(mod, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(mod, "_is_gateway_approval_context", lambda: False)
+
+        result = check_all_command_guards("echo hello", "local")
+
+        assert result["approved"] is True
+        assert "pre_approved" not in result
+
+
+class TestTerminalToolNote:
+    """End-to-end: the terminal tool result carries an 'approval' note
+    explaining a silent pre-approval."""
+
+    def _run(self, monkeypatch, approval):
+        import json
+
+        from tools import terminal_tool as tt
+
+        monkeypatch.setattr(tt, "_check_all_guards", lambda *a, **k: approval)
+        return json.loads(tt.terminal_tool(command="echo prov-ok"))
+
+    def test_session_preapproval_note_in_result(self, monkeypatch):
+        result = self._run(
+            monkeypatch,
+            {
+                "approved": True,
+                "message": None,
+                "pre_approved": "session",
+                "description": "recursive file deletion",
+            },
+        )
+        assert result["exit_code"] == 0
+        assert "approve for session" in result.get("approval", "")
+        assert "recursive file deletion" in result["approval"]
+
+    def test_permanent_preapproval_note_in_result(self, monkeypatch):
+        result = self._run(
+            monkeypatch,
+            {
+                "approved": True,
+                "message": None,
+                "pre_approved": "permanent",
+                "description": "recursive file deletion",
+            },
+        )
+        assert "'always' approval" in result.get("approval", "")
+
+    def test_allowlist_note_names_matched_rule(self, monkeypatch):
+        result = self._run(
+            monkeypatch,
+            {
+                "approved": True,
+                "message": None,
+                "pre_approved": "allowlist",
+                "pre_approved_rule": "podman *",
+            },
+        )
+        assert "command_allowlist" in result.get("approval", "")
+        assert "podman *" in result["approval"]
+
+    def test_plain_approval_has_no_note(self, monkeypatch):
+        result = self._run(monkeypatch, {"approved": True, "message": None})
+        assert "approval" not in result

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -21,6 +21,9 @@ def _isolate_approval_state(monkeypatch):
     )
     # Empty session + permanent approval stores so nothing pre-approves.
     monkeypatch.setattr(approval, "is_approved", lambda sk, pk: False)
+    # _approval_scope reads the stores directly — make sure they are clean.
+    approval._session_approved.pop("test-session", None)
+    approval._permanent_approved.discard("plugin_rule:ssh")
     # Not a yolo session (the shared gate checks this first).
     monkeypatch.setattr(approval, "is_current_session_yolo_enabled", lambda: False)
     monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False, raising=False)
@@ -33,14 +36,22 @@ def _isolate_approval_state(monkeypatch):
 
 class TestRequestToolApproval:
     def test_session_cached_approval_short_circuits(self, monkeypatch):
-        monkeypatch.setattr(approval, "is_approved", lambda sk, pk: True)
-        # Should NOT prompt at all.
-        monkeypatch.setattr(
-            approval, "prompt_dangerous_approval",
-            lambda *a, **k: pytest.fail("should not prompt when already approved"),
-        )
-        res = request_tool_approval("write_file", "sensitive path", rule_key="ssh")
-        assert res == {"approved": True, "message": None}
+        # Pre-approve for real (provenance now reads the approval stores
+        # directly via _approval_scope, not through is_approved).
+        approval.approve_session("test-session", "plugin_rule:ssh")
+        try:
+            # Should NOT prompt at all.
+            monkeypatch.setattr(
+                approval, "prompt_dangerous_approval",
+                lambda *a, **k: pytest.fail("should not prompt when already approved"),
+            )
+            res = request_tool_approval("write_file", "sensitive path", rule_key="ssh")
+            assert res["approved"] is True
+            assert res["message"] is None
+            # Provenance: the result explains WHY no prompt fired.
+            assert res.get("pre_approved") == "session"
+        finally:
+            approval._session_approved.pop("test-session", None)
 
     def test_cli_approve_once(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2639,8 +2639,8 @@ def _has_allowlist_shell_operator(command: str) -> bool:
     return bool(_ALLOWLIST_SHELL_OPERATOR_RE.search(command or ""))
 
 
-def _command_matches_permanent_allowlist(command: str) -> bool:
-    """Return True when command_allowlist contains this command or a glob.
+def _matching_permanent_allowlist_entry(command: str) -> str | None:
+    """Return the command_allowlist entry matching *command*, or None.
 
     Permanent approvals historically store dangerous-pattern keys such as
     ``recursive delete``. Manual entries in ``command_allowlist`` are command
@@ -2648,9 +2648,9 @@ def _command_matches_permanent_allowlist(command: str) -> bool:
     """
     command = (command or "").strip()
     if not command:
-        return False
+        return None
     if _has_allowlist_shell_operator(command):
-        return False
+        return None
 
     with _lock:
         patterns = tuple(_permanent_approved)
@@ -2662,10 +2662,32 @@ def _command_matches_permanent_allowlist(command: str) -> bool:
         if not pattern:
             continue
         if command == pattern:
-            return True
+            return pattern
         if any(ch in pattern for ch in "*?[") and fnmatch.fnmatchcase(command, pattern):
-            return True
-    return False
+            return pattern
+    return None
+
+
+def _command_matches_permanent_allowlist(command: str) -> bool:
+    """Return True when command_allowlist contains this command or a glob."""
+    return _matching_permanent_allowlist_entry(command) is not None
+
+
+def _approval_scope(session_key: str, pattern_key: str) -> str | None:
+    """Return how *pattern_key* was pre-approved: 'permanent', 'session', or None.
+
+    Provenance companion to :func:`is_approved` — used to tell the agent and
+    the user WHY a flagged action ran without a prompt (port of the approval
+    provenance surfaced in Kilo-Org/kilocode#12728 / #12995).
+    """
+    aliases = _approval_key_aliases(pattern_key)
+    with _lock:
+        if any(alias in _permanent_approved for alias in aliases):
+            return "permanent"
+        session_approvals = _session_approved.get(session_key, set())
+        if any(alias in session_approvals for alias in aliases):
+            return "session"
+    return None
 
 
 
@@ -3202,8 +3224,10 @@ def _run_approval_gate(
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
-    if is_approved(session_key, pattern_key):
-        return {"approved": True, "message": None}
+    _scope = _approval_scope(session_key, pattern_key)
+    if _scope is not None:
+        return {"approved": True, "message": None,
+                "pre_approved": _scope, "description": description}
 
     if approval_callback is None:
         try:
@@ -3458,8 +3482,11 @@ def check_dangerous_command(command: str, env_type: str,
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
         return {"approved": True, "message": None}
 
-    if _command_matches_permanent_allowlist(command):
-        return {"approved": True, "message": None}
+    _allowlist_entry = _matching_permanent_allowlist_entry(command)
+    if _allowlist_entry is not None:
+        return {"approved": True, "message": None,
+                "pre_approved": "allowlist",
+                "pre_approved_rule": _allowlist_entry}
 
     is_dangerous, pattern_key, description = detect_dangerous_command(command)
     if not is_dangerous:
@@ -3785,8 +3812,11 @@ def check_all_command_guards(command: str, env_type: str,
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
         return {"approved": True, "message": None}
 
-    if _command_matches_permanent_allowlist(command):
-        return {"approved": True, "message": None}
+    _allowlist_entry = _matching_permanent_allowlist_entry(command)
+    if _allowlist_entry is not None:
+        return {"approved": True, "message": None,
+                "pre_approved": "allowlist",
+                "pre_approved_rule": _allowlist_entry}
 
     is_cli = _is_interactive_cli()
     is_gateway = _is_gateway_approval_context()
@@ -3911,6 +3941,9 @@ def check_all_command_guards(command: str, env_type: str,
 
     # Collect warnings that need approval
     warnings = []  # list of (pattern_key, description, is_tirith)
+    # Provenance for warnings suppressed by an earlier approval:
+    # (description, scope) where scope is 'session' or 'permanent'.
+    pre_approved_hits: list[tuple[str, str]] = []
 
     session_key = get_current_session_key()
 
@@ -3923,15 +3956,32 @@ def check_all_command_guards(command: str, env_type: str,
         rule_id = findings[0].get("rule_id", "unknown") if findings else "unknown"
         tirith_key = f"tirith:{rule_id}"
         tirith_desc = _format_tirith_description(tirith_result)
-        if not is_approved(session_key, tirith_key):
+        _tirith_scope = _approval_scope(session_key, tirith_key)
+        if _tirith_scope is None:
             warnings.append((tirith_key, tirith_desc, True))
+        else:
+            pre_approved_hits.append((tirith_desc, _tirith_scope))
 
     if is_dangerous:
-        if not is_approved(session_key, pattern_key):
+        _pattern_scope = _approval_scope(session_key, pattern_key)
+        if _pattern_scope is None:
             warnings.append((pattern_key, description, False))
+        else:
+            pre_approved_hits.append((description, _pattern_scope))
 
     # Nothing to warn about
     if not warnings:
+        if pre_approved_hits:
+            # Flagged, but a prior user decision covers every finding —
+            # surface WHY it ran without a prompt (Kilo #12728/#12995 port).
+            _scopes = {scope for _, scope in pre_approved_hits}
+            _scope = "permanent" if "permanent" in _scopes else "session"
+            return {
+                "approved": True,
+                "message": None,
+                "pre_approved": _scope,
+                "description": "; ".join(desc for desc, _ in pre_approved_hits),
+            }
         return {"approved": True, "message": None}
 
     # --- Phase 2.5: Smart approval (auxiliary LLM risk assessment) ---
@@ -4301,8 +4351,10 @@ def check_execute_code_guard(code: str, env_type: str,
     # Check session/permanent approval — same gate as check_all_command_guards.
     # Without this, "Approve session" / "Always" choices are stored but never
     # consulted, so every execute_code call re-prompts the user (#39275).
-    if is_approved(session_key, pattern_key):
-        return {"approved": True, "message": None}
+    _scope = _approval_scope(session_key, pattern_key)
+    if _scope is not None:
+        return {"approved": True, "message": None,
+                "pre_approved": _scope, "description": description}
 
     # Smart mode: ask the aux LLM about the whole script. An APPROVE here only
     # suppresses the redundant whole-script prompt; the per-call terminal()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2959,6 +2959,31 @@ def terminal_tool(
             elif approval.get("smart_approved"):
                 desc = approval.get("description", "flagged as dangerous")
                 approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
+            elif approval.get("pre_approved"):
+                # Provenance for silent auto-approvals (port of Kilo
+                # #12728/#12995): say WHY a flagged command ran without a
+                # prompt so an auto-approved run is explained instead of
+                # looking like a bypass.
+                _scope = approval.get("pre_approved")
+                desc = approval.get("description", "flagged as dangerous")
+                if _scope == "allowlist":
+                    _rule = approval.get("pre_approved_rule", "")
+                    _rule_part = f" (matched `{_rule}`)" if _rule else ""
+                    approval_note = (
+                        "Command was auto-approved by the command_allowlist "
+                        f"in config.yaml{_rule_part}."
+                    )
+                elif _scope == "permanent":
+                    approval_note = (
+                        f"Command was flagged ({desc}) and auto-approved by a "
+                        "permanent allowlist entry the user saved earlier "
+                        "('always' approval)."
+                    )
+                elif _scope == "session":
+                    approval_note = (
+                        f"Command was flagged ({desc}) and auto-approved by an "
+                        "earlier 'approve for session' decision in this session."
+                    )
 
         # Prepare command for execution
         pty_disabled_reason = None


### PR DESCRIPTION
## Summary
Flagged commands that run **without a prompt** because of a prior user decision now say why — "approved earlier for this session", "permanent 'always' entry", or "matched command_allowlist entry `podman *`" — instead of executing indistinguishably from a never-flagged command.

Today only two of the auto-approval paths explain themselves (`user_approved`, `smart_approved`). The three silent ones — session approvals, permanent 'always' entries, and `command_allowlist` globs — return a bare `{"approved": True}`, so neither the model nor the user reviewing a transcript can tell an allowlisted dangerous command from a benign one. Port of the approval-provenance work in [Kilo-Org/kilocode#12728](https://github.com/Kilo-Org/kilocode/pull/12728) + [#12995](https://github.com/Kilo-Org/kilocode/pull/12995), adapted to Hermes' guard-result contract (they attach `metadata.approval` to tool parts; we extend the existing `approval` note on the terminal tool result).

## Changes
- `tools/approval.py`:
  - `_approval_scope(session_key, pattern_key)` → `'permanent'` / `'session'` / `None` (provenance companion to `is_approved`, same alias handling).
  - `_matching_permanent_allowlist_entry()` returns the exact allowlist entry that matched (the boolean wrapper is kept).
  - All pre-approval fast paths now attach `pre_approved` (+ `pre_approved_rule` for allowlist hits) to their approved results: `check_all_command_guards` (both the allowlist shortcut and the per-warning suppression, including tirith keys), `check_dangerous_command`'s `_run_approval_gate`, and `check_execute_code_guard`.
- `tools/terminal_tool.py`: renders the provenance as the existing `approval` field on the tool result, alongside the current user-approved / smart-approved notes.
- `tests/tools/test_approval_provenance.py`: 14 tests covering scope resolution, allowlist entry lookup, guard-level provenance (session/permanent/allowlist/unflagged), and the end-to-end terminal note.

No approval decision changes — provenance is metadata on results that were already approved.

## Validation
| Path | Before | After |
|---|---|---|
| session-approved `rm -rf /tmp/x` | bare approved | `pre_approved: session` + note in tool result |
| 'always' entry | bare approved | `pre_approved: permanent` + note |
| `command_allowlist: podman *` | bare approved | `pre_approved: allowlist`, rule named |
| unflagged command | bare approved | unchanged (no note) |

`tests/tools/test_approval_provenance.py` 14/14; sibling approval suites (169 tests across 7 files) pass with the same 2 pre-existing cross-file-pollution failures as unmodified main (`TestApprovalPromptRedaction`, passes in isolation on both). Sabotage-verified: removing the scope lookup fails 4 of the new tests.

## Infographic

![Approval provenance](https://v3b.fal.media/files/b/0aa5d7ec/y8vw71l5er2AORhNxI-Nm_oCsy7MCT.png)
