### PR TITLE
fix: enforce global Kanban worker concurrency cap

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1220,7 +1220,9 @@ class GatewayKanbanWatchersMixin:
                 or "database disk image is malformed" in msg
             )
 
-        def _tick_once_for_board(slug: str) -> "Optional[object]":
+        def _tick_once_for_board(
+            slug: str, sweep_capacity=None,
+        ) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
 
             Runs in a worker thread via `asyncio.to_thread`. `board=slug`
@@ -1271,6 +1273,7 @@ class GatewayKanbanWatchersMixin:
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
                     reconcile_orphans=reconcile_orphans,
+                    sweep_capacity=sweep_capacity,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):
@@ -1321,9 +1324,14 @@ class GatewayKanbanWatchersMixin:
             except Exception:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             out: list[tuple[str, "Optional[object]"]] = []
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
-                out.append((slug, _tick_once_for_board(slug)))
+            slugs = [b.get("slug") or _kb.DEFAULT_BOARD for b in boards]
+            sweep_capacity = _kb.DispatchSweepCapacity(
+                slugs,
+                max_in_progress=max_in_progress,
+                max_in_progress_per_profile=max_in_progress_per_profile,
+            )
+            for slug in slugs:
+                out.append((slug, _tick_once_for_board(slug, sweep_capacity)))
             return out
 
         def _ready_nonempty() -> bool:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7710,6 +7710,190 @@ class DispatchResult:
     actively preventing two dispatchers from racing on ``kanban.db``."""
 
 
+@dataclass
+class _DispatchCapacityReservation:
+    """One provisional cross-board worker slot."""
+
+    capacity: "DispatchSweepCapacity"
+    key: tuple[str, str]
+    profile: str
+    lock_context: Any
+    active: bool = True
+
+    def release(self) -> None:
+        if self.active:
+            self.capacity._finish(self.key, self.lock_context)
+            self.active = False
+
+    def commit(self) -> None:
+        # Once spawn succeeds the running task in its board DB becomes the
+        # durable capacity record, so the provisional reservation can go.
+        self.release()
+
+
+_DISPATCH_CAPACITY_LOCK = threading.Lock()
+_DISPATCH_CAPACITY_RESERVATIONS: dict[tuple[str, str], str] = {}
+_DISPATCH_CAPACITY_SNAPSHOTS: dict[str, list[tuple[str, Optional[str]]]] = {}
+
+
+class DispatchSweepCapacity:
+    """Atomic machine-wide capacity shared by every board and dispatcher.
+
+    Board task state remains in the board databases.  This object only holds
+    short-lived reservations spanning capacity-check -> claim -> spawn, which
+    closes the gap where concurrent ticks on different DBs could both observe
+    the same last free slot.  A non-blocking install-wide file lock extends the
+    existing process-local reservation guard across gateway/orphan processes.
+    The lock is retained until the claim is either abandoned or its running DB
+    row is durable after spawn; process exit releases it automatically.  Live
+    counts are re-read while reserving so reclaim work earlier in a tick is
+    reflected immediately.
+    """
+
+    def __init__(
+        self,
+        boards: Iterable[str],
+        *,
+        max_in_progress: Optional[int] = None,
+        max_in_progress_per_profile: Optional[int] = None,
+    ) -> None:
+        self.max_in_progress = (
+            max_in_progress
+            if isinstance(max_in_progress, int) and max_in_progress > 0
+            else None
+        )
+        self.max_in_progress_per_profile = (
+            max_in_progress_per_profile
+            if isinstance(max_in_progress_per_profile, int)
+            and max_in_progress_per_profile > 0
+            else None
+        )
+        requested_boards = list(boards)
+        try:
+            discovered_boards = [
+                item.get("slug") or DEFAULT_BOARD
+                for item in list_boards(include_archived=True)
+            ]
+        except Exception:
+            discovered_boards = []
+        self._boards: list[tuple[str, str]] = []
+        seen_paths: set[str] = set()
+        for board in [*requested_boards, *discovered_boards]:
+            slug = board or DEFAULT_BOARD
+            path = str(kanban_db_path(board=slug).expanduser().resolve())
+            if path not in seen_paths:
+                seen_paths.add(path)
+                self._boards.append((slug, path))
+        self._board_paths = {path for _, path in self._boards}
+        self._preview_reservations: dict[tuple[str, str], str] = {}
+
+    def _live_counts(self) -> tuple[int, dict[str, int]]:
+        total = 0
+        by_profile: dict[str, int] = {}
+        reserved_running: set[tuple[str, str]] = set()
+        for slug, path in self._boards:
+            try:
+                with connect_closing(board=slug) as conn:
+                    db_rows = conn.execute(
+                        "SELECT id, assignee FROM tasks WHERE status = 'running'"
+                    ).fetchall()
+                rows = [(row["id"], row["assignee"]) for row in db_rows]
+                _DISPATCH_CAPACITY_SNAPSHOTS[path] = rows
+            except Exception as exc:
+                # Capacity accounting must not transfer a broken board's DB
+                # failure to the healthy board currently reserving a slot.
+                # Keep the last successful count rather than optimistically
+                # dropping workers that may still be live.
+                rows = _DISPATCH_CAPACITY_SNAPSHOTS.get(path, [])
+                _log.warning(
+                    "kanban capacity scan failed for board %s; using last known "
+                    "running count (%d): %s",
+                    slug,
+                    len(rows),
+                    exc,
+                )
+            for task_id, profile in rows:
+                key = (path, task_id)
+                total += 1
+                if profile:
+                    by_profile[profile] = by_profile.get(profile, 0) + 1
+                if key in _DISPATCH_CAPACITY_RESERVATIONS:
+                    reserved_running.add(key)
+
+        # A reservation may already have claimed its task. Count every
+        # reservation exactly once, whether or not that board write is visible.
+        reservations = {
+            **{
+                key: profile
+                for key, profile in _DISPATCH_CAPACITY_RESERVATIONS.items()
+                if key[0] in self._board_paths
+            },
+            **self._preview_reservations,
+        }
+        for key, profile in reservations.items():
+            if key in reserved_running:
+                continue
+            total += 1
+            if profile:
+                by_profile[profile] = by_profile.get(profile, 0) + 1
+        return total, by_profile
+
+    def reserve(
+        self, *, board: Optional[str], task_id: str, profile: str,
+        preview: bool = False,
+    ) -> tuple[Optional[_DispatchCapacityReservation], Optional[str], int]:
+        """Reserve one slot, returning ``(token, blocked_cap, count)``."""
+        if self.max_in_progress is None and self.max_in_progress_per_profile is None:
+            return None, None, 0
+        slug = board or get_current_board()
+        path = str(kanban_db_path(board=slug).expanduser().resolve())
+        key = (path, task_id)
+        with _DISPATCH_CAPACITY_LOCK:
+            # Reuse the board dispatch lock's cross-platform, non-blocking
+            # advisory-lock implementation.  A contender defers this tick
+            # instead of blocking the gateway worker thread.
+            lock_context = _dispatch_tick_lock(
+                kanban_home() / "kanban" / ".capacity"
+            )
+            held = lock_context.__enter__()
+            if not held:
+                lock_context.__exit__(None, None, None)
+                return None, "global", 0
+            retain_lock = False
+            try:
+                total, by_profile = self._live_counts()
+                if self.max_in_progress is not None and total >= self.max_in_progress:
+                    return None, "global", total
+                profile_count = by_profile.get(profile, 0)
+                if (
+                    self.max_in_progress_per_profile is not None
+                    and profile_count >= self.max_in_progress_per_profile
+                ):
+                    return None, "profile", profile_count
+                if preview:
+                    self._preview_reservations[key] = profile
+                    return None, None, 0
+                _DISPATCH_CAPACITY_RESERVATIONS[key] = profile
+                retain_lock = True
+                return (
+                    _DispatchCapacityReservation(
+                        self, key, profile, lock_context
+                    ),
+                    None,
+                    0,
+                )
+            finally:
+                if not retain_lock:
+                    lock_context.__exit__(None, None, None)
+
+    def _finish(self, key: tuple[str, str], lock_context: Any) -> None:
+        with _DISPATCH_CAPACITY_LOCK:
+            try:
+                _DISPATCH_CAPACITY_RESERVATIONS.pop(key, None)
+            finally:
+                lock_context.__exit__(None, None, None)
+
+
 # Bounded registry of recently-reaped worker child exits, populated by the
 # reap loop at the top of ``dispatch_once`` and consulted by
 # ``detect_crashed_workers`` to classify a dead-pid task.
@@ -9222,6 +9406,7 @@ def dispatch_once(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    sweep_capacity: Optional[DispatchSweepCapacity] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -9257,6 +9442,7 @@ def dispatch_once(
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
             reconcile_orphans=reconcile_orphans,
+            sweep_capacity=sweep_capacity,
         )
     with _dispatch_tick_lock(db_path) as held:
         if not held:
@@ -9274,6 +9460,7 @@ def dispatch_once(
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
             reconcile_orphans=reconcile_orphans,
+            sweep_capacity=sweep_capacity,
         )
         # Still under the dispatch lock: opportunistically truncate the WAL
         # at a coarse interval so it cannot grow unbounded between restarts.
@@ -9295,6 +9482,7 @@ def _dispatch_once_locked(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    sweep_capacity: Optional[DispatchSweepCapacity] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -9361,8 +9549,11 @@ def _dispatch_once_locked(
     # Both knobs are total in-flight caps. Collapse them before either lane
     # dispatches so ready and review workers consume the same budget without
     # subtracting the already-running count twice.
-    if max_in_progress is not None and (
+    if (
+        (sweep_capacity is None or sweep_capacity.max_in_progress is None)
+        and max_in_progress is not None and (
         max_spawn is None or max_in_progress < max_spawn
+        )
     ):
         max_spawn = max_in_progress
 
@@ -9396,6 +9587,8 @@ def _dispatch_once_locked(
     # skipped_unassigned — the operator-actionable signal is different:
     # "this profile is busy, try again later" not "this needs routing").
     _per_profile_cap = max_in_progress_per_profile if (
+        (sweep_capacity is None or sweep_capacity.max_in_progress_per_profile is None)
+        and
         isinstance(max_in_progress_per_profile, int)
         and max_in_progress_per_profile > 0
     ) else None
@@ -9527,79 +9720,99 @@ def _dispatch_once_locked(
                         {"reason": guard_reason},
                     )
             continue
+        reservation = None
+        if sweep_capacity is not None:
+            reservation, blocked_cap, capacity_count = sweep_capacity.reserve(
+                board=board,
+                task_id=row["id"],
+                profile=row_assignee,
+                preview=dry_run,
+            )
+            if blocked_cap == "global":
+                break
+            if blocked_cap == "profile":
+                result.skipped_per_profile_capped.append(
+                    (row["id"], row_assignee, capacity_count)
+                )
+                continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
             spawned += 1
-            # Increment per-profile counter even in dry_run so the cap
-            # check sees the would-be spawn on subsequent iterations.
-            # Without this, dry_run reports every task as spawnable and
-            # under-reports the capped subset (#21582).
+            # Increment per-profile counter even in dry_run so the local cap
+            # check sees the would-be spawn on subsequent iterations. Sweep
+            # capacity keeps its own preview reservations for cross-board caps.
             if _per_profile_cap is not None and row_assignee:
                 _per_profile_running[row_assignee] = (
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
-        if claimed is None:
-            continue
         try:
-            resolved_branch_name = None
-            if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
-            else:
-                workspace = resolve_workspace(claimed, board=board)
-        except Exception as exc:
-            auto = _record_spawn_failure(
-                conn, claimed.id, f"workspace: {exc}",
-                failure_limit=failure_limit,
-            )
-            if auto:
-                result.auto_blocked.append(claimed.id)
-            continue
-        # Persist the resolved workspace path so the worker can cd there.
-        set_workspace_path(conn, claimed.id, str(workspace))
-        if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
-        _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        _spawn = spawn_fn if spawn_fn is not None else _default_spawn
-        try:
-            # Back-compat: older spawn_fn signatures accept only
-            # (task, workspace). Test stubs in the suite rely on that.
-            # Introspect the callable and pass `board` only when supported.
-            import inspect
+            claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
+            if claimed is None:
+                continue
             try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
+                resolved_branch_name = None
+                if claimed.workspace_kind == "worktree":
+                    workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
                 else:
-                    pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
-            # NOTE: we intentionally do NOT reset consecutive_failures
-            # here. A successful spawn proves the worker can start but
-            # doesn't prove the run will succeed. Under unified
-            # failure counting, resetting on spawn would let a task
-            # that keeps timing out after spawn loop forever. The
-            # counter is cleared only on successful completion (see
-            # complete_task).
-            result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
-            spawned += 1
-            # Track the new in-flight count for this profile so later
-            # iterations in this same tick respect the per-profile cap
-            # (#21582). Subsequent ticks re-query from the DB.
-            if _per_profile_cap is not None and claimed.assignee:
-                _per_profile_running[claimed.assignee] = (
-                    _per_profile_running.get(claimed.assignee, 0) + 1
+                    workspace = resolve_workspace(claimed, board=board)
+            except Exception as exc:
+                auto = _record_spawn_failure(
+                    conn, claimed.id, f"workspace: {exc}",
+                    failure_limit=failure_limit,
                 )
-        except Exception as exc:
-            auto = _record_spawn_failure(
-                conn, claimed.id, str(exc),
-                failure_limit=failure_limit,
-            )
-            if auto:
-                result.auto_blocked.append(claimed.id)
+                if auto:
+                    result.auto_blocked.append(claimed.id)
+                continue
+            # Persist the resolved workspace path so the worker can cd there.
+            set_workspace_path(conn, claimed.id, str(workspace))
+            if claimed.workspace_kind == "worktree":
+                set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+            _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
+            _spawn = spawn_fn if spawn_fn is not None else _default_spawn
+            try:
+                # Back-compat: older spawn_fn signatures accept only
+                # (task, workspace). Test stubs in the suite rely on that.
+                # Introspect the callable and pass `board` only when supported.
+                import inspect
+                try:
+                    sig = inspect.signature(_spawn)
+                    if "board" in sig.parameters:
+                        pid = _spawn(claimed, str(workspace), board=board)
+                    else:
+                        pid = _spawn(claimed, str(workspace))
+                except (TypeError, ValueError):
+                    pid = _spawn(claimed, str(workspace))
+                if pid:
+                    _set_worker_pid(conn, claimed.id, int(pid))
+                # NOTE: we intentionally do NOT reset consecutive_failures
+                # here. A successful spawn proves the worker can start but
+                # doesn't prove the run will succeed. Under unified
+                # failure counting, resetting on spawn would let a task
+                # that keeps timing out after spawn loop forever. The
+                # counter is cleared only on successful completion (see
+                # complete_task).
+                result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
+                spawned += 1
+                if reservation is not None:
+                    reservation.commit()
+                # Track the new in-flight count for this profile so later
+                # iterations in this same tick respect the per-profile cap
+                # (#21582). Subsequent ticks re-query from the DB.
+                if _per_profile_cap is not None and claimed.assignee:
+                    _per_profile_running[claimed.assignee] = (
+                        _per_profile_running.get(claimed.assignee, 0) + 1
+                    )
+            except Exception as exc:
+                auto = _record_spawn_failure(
+                    conn, claimed.id, str(exc),
+                    failure_limit=failure_limit,
+                )
+                if auto:
+                    result.auto_blocked.append(claimed.id)
+        finally:
+            if reservation is not None:
+                reservation.release()
 
     # ---- review column dispatch ----
     # Review tasks are tasks that a worker moved to 'review' after
@@ -9651,6 +9864,21 @@ def _dispatch_once_locked(
                         {"reason": guard_reason},
                     )
             continue
+        reservation = None
+        if sweep_capacity is not None:
+            reservation, blocked_cap, capacity_count = sweep_capacity.reserve(
+                board=board,
+                task_id=row["id"],
+                profile=row["assignee"],
+                preview=dry_run,
+            )
+            if blocked_cap == "global":
+                break
+            if blocked_cap == "profile":
+                result.skipped_per_profile_capped.append(
+                    (row["id"], row["assignee"], capacity_count)
+                )
+                continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             spawned += 1
@@ -9659,62 +9887,68 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row["assignee"], 0) + 1
                 )
             continue
-        claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
-        if claimed is None:
-            continue
         try:
-            resolved_branch_name = None
-            if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
-            else:
-                workspace = resolve_workspace(claimed, board=board)
-        except Exception as exc:
-            auto = _record_spawn_failure(
-                conn, claimed.id, f"workspace: {exc}",
-                failure_limit=failure_limit,
-            )
-            if auto:
-                result.auto_blocked.append(claimed.id)
-            continue
-        # Persist the resolved workspace path so the worker can cd there.
-        set_workspace_path(conn, claimed.id, str(workspace))
-        if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
-        _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load the sdlc-review skill for review agents — it carries
-        # the review logic (AC verification, merge, etc.). The mandatory
-        # kanban lifecycle is already injected into every worker's system
-        # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
-        # review agent needs.
-        claimed.skills = list(
-            dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
-        )
-        _spawn = spawn_fn if spawn_fn is not None else _default_spawn
-        try:
-            import inspect
+            claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
+            if claimed is None:
+                continue
             try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
+                resolved_branch_name = None
+                if claimed.workspace_kind == "worktree":
+                    workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
                 else:
-                    pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
-            result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
-            spawned += 1
-            if _per_profile_cap is not None and claimed.assignee:
-                _per_profile_running[claimed.assignee] = (
-                    _per_profile_running.get(claimed.assignee, 0) + 1
+                    workspace = resolve_workspace(claimed, board=board)
+            except Exception as exc:
+                auto = _record_spawn_failure(
+                    conn, claimed.id, f"workspace: {exc}",
+                    failure_limit=failure_limit,
                 )
-        except Exception as exc:
-            auto = _record_spawn_failure(
-                conn, claimed.id, str(exc),
-                failure_limit=failure_limit,
+                if auto:
+                    result.auto_blocked.append(claimed.id)
+                continue
+            # Persist the resolved workspace path so the worker can cd there.
+            set_workspace_path(conn, claimed.id, str(workspace))
+            if claimed.workspace_kind == "worktree":
+                set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+            _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
+            # Force-load the sdlc-review skill for review agents — it carries
+            # the review logic (AC verification, merge, etc.). The mandatory
+            # kanban lifecycle is already injected into every worker's system
+            # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
+            # review agent needs.
+            claimed.skills = list(
+                dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
             )
-            if auto:
-                result.auto_blocked.append(claimed.id)
+            _spawn = spawn_fn if spawn_fn is not None else _default_spawn
+            try:
+                import inspect
+                try:
+                    sig = inspect.signature(_spawn)
+                    if "board" in sig.parameters:
+                        pid = _spawn(claimed, str(workspace), board=board)
+                    else:
+                        pid = _spawn(claimed, str(workspace))
+                except (TypeError, ValueError):
+                    pid = _spawn(claimed, str(workspace))
+                if pid:
+                    _set_worker_pid(conn, claimed.id, int(pid))
+                result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
+                spawned += 1
+                if reservation is not None:
+                    reservation.commit()
+                if _per_profile_cap is not None and claimed.assignee:
+                    _per_profile_running[claimed.assignee] = (
+                        _per_profile_running.get(claimed.assignee, 0) + 1
+                    )
+            except Exception as exc:
+                auto = _record_spawn_failure(
+                    conn, claimed.id, str(exc),
+                    failure_limit=failure_limit,
+                )
+                if auto:
+                    result.auto_blocked.append(claimed.id)
+        finally:
+            if reservation is not None:
+                reservation.release()
     return result
 
 

--- a/tests/gateway/test_kanban_global_worker_caps.py
+++ b/tests/gateway/test_kanban_global_worker_caps.py
@@ -1,0 +1,512 @@
+"""RED tests for gateway-wide kanban worker caps across real board DBs."""
+
+from __future__ import annotations
+
+import os
+import multiprocessing
+import sqlite3
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def multi_board_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    kb._INITIALIZED_PATHS.clear()
+    kb._DISPATCH_CAPACITY_RESERVATIONS.clear()
+    kb._DISPATCH_CAPACITY_SNAPSHOTS.clear()
+
+    for profile in ("alpha", "beta"):
+        (home / "profiles" / profile).mkdir(parents=True)
+    for board in ("board-a", "board-b"):
+        kb.create_board(board)
+    return ("board-a", "board-b")
+
+
+def _process_dispatch_one_board(home, board, start, results):
+    os.environ["HERMES_HOME"] = home
+    os.environ["HERMES_KANBAN_HOME"] = home
+    os.environ.pop("HERMES_KANBAN_BOARD", None)
+    kb._INITIALIZED_PATHS.clear()
+    capacity = kb.DispatchSweepCapacity((board,), max_in_progress=1)
+    start.wait(timeout=5)
+
+    def slow_spawn(*_args, **_kwargs):
+        time.sleep(0.5)
+        return os.getpid()
+
+    with kb.connect_closing(board=board) as conn:
+        result = kb.dispatch_once(
+            conn,
+            board=board,
+            spawn_fn=slow_spawn,
+            reconcile_orphans=False,
+            sweep_capacity=capacity,
+        )
+    results.put(len(result.spawned))
+
+
+def _create_ready(board: str, *, assignee: str, count: int) -> None:
+    with kb.connect_closing(board=board) as conn:
+        for index in range(count):
+            kb.create_task(
+                conn,
+                title=f"{board}-{assignee}-{index}",
+                assignee=assignee,
+                board=board,
+            )
+
+
+def _create_review(board: str, *, assignee: str) -> None:
+    with kb.connect_closing(board=board) as conn:
+        task_id = kb.create_task(
+            conn,
+            title=f"{board}-{assignee}-review",
+            assignee=assignee,
+            board=board,
+        )
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="ready for review",
+            expected_run_id=claimed.current_run_id,
+        )
+
+
+def _dispatch_board(board: str, **kwargs):
+    with kb.connect_closing(board=board) as conn:
+        return kb.dispatch_once(
+            conn,
+            board=board,
+            spawn_fn=lambda *_args, **_kwargs: os.getpid(),
+            reconcile_orphans=False,
+            **kwargs,
+        )
+
+
+def _gateway_style_sweep(boards: tuple[str, ...], **kwargs):
+    """Use the same independent-connect, per-board loop as the gateway."""
+    capacity = kb.DispatchSweepCapacity(
+        boards,
+        max_in_progress=kwargs.get("max_in_progress"),
+        max_in_progress_per_profile=kwargs.get("max_in_progress_per_profile"),
+    )
+    return [
+        _dispatch_board(board, sweep_capacity=capacity, **kwargs)
+        for board in boards
+    ]
+
+
+def _running(boards: tuple[str, ...], *, assignee: str | None = None) -> int:
+    total = 0
+    for board in boards:
+        with kb.connect_closing(board=board) as conn:
+            if assignee is None:
+                row = conn.execute(
+                    "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT COUNT(*) FROM tasks "
+                    "WHERE status = 'running' AND assignee = ?",
+                    (assignee,),
+                ).fetchone()
+            total += int(row[0])
+    return total
+
+
+def test_single_board_global_cap_still_limits_live_workers(multi_board_home):
+    board = multi_board_home[0]
+    _create_ready(board, assignee="alpha", count=3)
+
+    result = _dispatch_board(board, max_in_progress=2)
+
+    assert len(result.spawned) == 2
+    assert _running((board,)) == 2
+
+
+def test_gateway_sweep_applies_global_cap_across_all_board_dbs(multi_board_home):
+    boards = multi_board_home
+    for board in boards:
+        _create_ready(board, assignee="alpha", count=2)
+
+    results = _gateway_style_sweep(boards, max_in_progress=2)
+
+    assert sum(len(result.spawned) for result in results) == 2
+    assert _running(boards) == 2
+
+
+def test_gateway_sweep_applies_profile_cap_across_all_board_dbs(multi_board_home):
+    boards = multi_board_home
+    for board in boards:
+        _create_ready(board, assignee="alpha", count=1)
+        _create_ready(board, assignee="beta", count=1)
+
+    results = _gateway_style_sweep(
+        boards,
+        max_in_progress=4,
+        max_in_progress_per_profile=1,
+    )
+
+    assert _running(boards, assignee="alpha") == 1
+    assert _running(boards, assignee="beta") == 1
+    assert sum(len(result.spawned) for result in results) == 2
+
+
+def test_concurrent_board_claims_atomically_share_global_reservation(
+    multi_board_home,
+):
+    boards = multi_board_home
+    for board in boards:
+        _create_ready(board, assignee="alpha", count=1)
+
+    both_claimed = threading.Barrier(len(boards))
+
+    def spawn_after_competing_claims(*_args, **_kwargs):
+        try:
+            both_claimed.wait(timeout=1)
+        except threading.BrokenBarrierError:
+            pass
+        return os.getpid()
+
+    def dispatch(board: str):
+        with kb.connect_closing(board=board) as conn:
+            return kb.dispatch_once(
+                conn,
+                board=board,
+                spawn_fn=spawn_after_competing_claims,
+                max_in_progress=1,
+                reconcile_orphans=False,
+                sweep_capacity=capacity,
+            )
+
+    capacity = kb.DispatchSweepCapacity(boards, max_in_progress=1)
+    with ThreadPoolExecutor(max_workers=len(boards)) as pool:
+        results = list(pool.map(dispatch, boards))
+
+    assert sum(len(result.spawned) for result in results) == 1
+    assert _running(boards) == 1
+
+
+def test_overlapping_capacity_instances_coordinate_the_last_global_slot(
+    multi_board_home,
+):
+    boards = multi_board_home
+    for board in boards:
+        _create_ready(board, assignee="alpha", count=1)
+
+    capacities = [
+        kb.DispatchSweepCapacity(boards, max_in_progress=1)
+        for _ in boards
+    ]
+    both_spawns = threading.Barrier(len(boards))
+
+    def dispatch(item):
+        board, capacity = item
+
+        def spawn(*_args, **_kwargs):
+            try:
+                both_spawns.wait(timeout=1)
+            except threading.BrokenBarrierError:
+                pass
+            return os.getpid()
+
+        with kb.connect_closing(board=board) as conn:
+            return kb.dispatch_once(
+                conn,
+                board=board,
+                spawn_fn=spawn,
+                reconcile_orphans=False,
+                sweep_capacity=capacity,
+            )
+
+    with ThreadPoolExecutor(max_workers=len(boards)) as pool:
+        results = list(pool.map(dispatch, zip(boards, capacities)))
+
+    assert sum(len(result.spawned) for result in results) == 1
+    assert _running(boards) == 1
+
+
+def test_separate_processes_dispatching_different_boards_share_global_cap(
+    multi_board_home,
+):
+    boards = multi_board_home
+    for board in boards:
+        _create_ready(board, assignee="alpha", count=1)
+
+    ctx = multiprocessing.get_context("spawn")
+    start = ctx.Event()
+    results = ctx.Queue()
+    processes = [
+        ctx.Process(
+            target=_process_dispatch_one_board,
+            args=(str(kb.kanban_home()), board, start, results),
+        )
+        for board in boards
+    ]
+    for process in processes:
+        process.start()
+    start.set()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    assert sum(results.get(timeout=2) for _ in processes) == 1
+    assert _running(boards) == 1
+
+
+def test_unreadable_board_uses_last_count_without_blocking_healthy_board(
+    multi_board_home,
+    monkeypatch,
+):
+    healthy, unreadable = multi_board_home
+    _create_ready(healthy, assignee="alpha", count=2)
+    _create_ready(unreadable, assignee="beta", count=1)
+    with kb.connect_closing(board=unreadable) as conn:
+        task_id = conn.execute("SELECT id FROM tasks").fetchone()[0]
+        assert kb.claim_task(conn, task_id) is not None
+
+    capacity = kb.DispatchSweepCapacity(multi_board_home, max_in_progress=2)
+    reservation, blocked, _ = capacity.reserve(
+        board=healthy,
+        task_id="snapshot-probe",
+        profile="alpha",
+    )
+    assert blocked is None
+    assert reservation is not None
+    reservation.release()
+
+    original_connect_closing = kb.connect_closing
+
+    def fail_only_unreadable(*args, board=None, **kwargs):
+        if board == unreadable:
+            raise sqlite3.DatabaseError("database disk image is malformed")
+        return original_connect_closing(*args, board=board, **kwargs)
+
+    monkeypatch.setattr(kb, "connect_closing", fail_only_unreadable)
+
+    result = _dispatch_board(
+        healthy,
+        max_in_progress=2,
+        sweep_capacity=capacity,
+    )
+
+    assert len(result.spawned) == 1
+    assert _running((healthy,)) == 1
+
+
+def test_sweep_capacity_dry_run_reports_only_globally_bounded_profile_slots(
+    multi_board_home,
+):
+    boards = multi_board_home
+    for board in boards:
+        _create_ready(board, assignee="alpha", count=1)
+        _create_ready(board, assignee="beta", count=1)
+
+    results = _gateway_style_sweep(
+        boards,
+        dry_run=True,
+        max_in_progress=2,
+        max_in_progress_per_profile=1,
+    )
+
+    would_spawn = [spawn for result in results for spawn in result.spawned]
+    assert len(would_spawn) == 2
+    assert {assignee for _, assignee, _ in would_spawn} == {"alpha", "beta"}
+    assert _running(boards) == 0
+    for board in boards:
+        with kb.connect_closing(board=board) as conn:
+            assert conn.execute(
+                "SELECT COUNT(*) FROM tasks WHERE status = 'ready'"
+            ).fetchone()[0] == 2
+
+
+def test_gateway_sweep_shares_capacity_between_ready_and_review_lanes(
+    multi_board_home,
+):
+    boards = multi_board_home
+    _create_ready(boards[0], assignee="alpha", count=1)
+    _create_review(boards[1], assignee="beta")
+
+    results = _gateway_style_sweep(boards, max_in_progress=1)
+
+    assert sum(len(result.spawned) for result in results) == 1
+    assert _running(boards) == 1
+
+
+@pytest.mark.parametrize("failure_stage", ["lost_claim", "workspace", "spawn"])
+def test_failed_claim_or_launch_releases_shared_capacity_for_later_board(
+    multi_board_home,
+    monkeypatch,
+    failure_stage,
+):
+    boards = multi_board_home
+    for board in boards:
+        _create_ready(board, assignee="alpha", count=1)
+    capacity = kb.DispatchSweepCapacity(boards, max_in_progress=1)
+
+    original_claim = kb.claim_task
+    original_workspace = kb.resolve_workspace
+    if failure_stage == "lost_claim":
+        monkeypatch.setattr(
+            kb,
+            "claim_task",
+            lambda conn, task_id, **kwargs: (
+                None
+                if conn.execute(
+                    "SELECT title FROM tasks WHERE id = ?", (task_id,)
+                ).fetchone()[0].startswith(boards[0])
+                else original_claim(conn, task_id, **kwargs)
+            ),
+        )
+    elif failure_stage == "workspace":
+        def fail_first_workspace(task, *, board=None):
+            if board == boards[0]:
+                raise RuntimeError("workspace failed")
+            return original_workspace(task, board=board)
+
+        monkeypatch.setattr(kb, "resolve_workspace", fail_first_workspace)
+
+    def spawn(*_args, **_kwargs):
+        if failure_stage == "spawn":
+            raise RuntimeError("spawn failed")
+        return os.getpid()
+
+    with kb.connect_closing(board=boards[0]) as conn:
+        first = kb.dispatch_once(
+            conn,
+            board=boards[0],
+            spawn_fn=spawn,
+            failure_limit=2,
+            reconcile_orphans=False,
+            sweep_capacity=capacity,
+        )
+    with kb.connect_closing(board=boards[1]) as conn:
+        second = kb.dispatch_once(
+            conn,
+            board=boards[1],
+            spawn_fn=lambda *_args, **_kwargs: os.getpid(),
+            reconcile_orphans=False,
+            sweep_capacity=capacity,
+        )
+
+    assert first.spawned == []
+    assert len(second.spawned) == 1
+    assert _running(boards) == 1
+
+
+@pytest.mark.parametrize("lane", ["ready", "review"])
+@pytest.mark.parametrize(
+    "failure_stage",
+    ["claim_before", "claim_after", "workspace_path", "branch_name", "scratch_tip"],
+)
+def test_dispatch_exception_always_releases_capacity_reservation(
+    multi_board_home,
+    monkeypatch,
+    lane,
+    failure_stage,
+):
+    first_board, second_board = multi_board_home
+    if lane == "review":
+        _create_review(first_board, assignee="alpha")
+    else:
+        _create_ready(first_board, assignee="alpha", count=1)
+    _create_ready(second_board, assignee="beta", count=1)
+
+    with kb.connect_closing(board=first_board) as conn:
+        first_id = conn.execute("SELECT id FROM tasks").fetchone()[0]
+        if failure_stage == "branch_name":
+            conn.execute(
+                "UPDATE tasks SET workspace_kind = 'worktree' WHERE id = ?",
+                (first_id,),
+            )
+
+    claim_name = "claim_review_task" if lane == "review" else "claim_task"
+    original_claim = getattr(kb, claim_name)
+    original_set_workspace_path = kb.set_workspace_path
+    original_set_branch_name = kb.set_branch_name
+    original_resolve_worktree = kb._resolve_worktree_workspace
+    original_scratch_tip = kb._maybe_emit_scratch_tip
+
+    def fail_claim(conn, task_id, **kwargs):
+        if failure_stage == "claim_after":
+            original_claim(conn, task_id, **kwargs)
+        raise RuntimeError(failure_stage)
+
+    if failure_stage.startswith("claim_"):
+        monkeypatch.setattr(kb, claim_name, fail_claim)
+    elif failure_stage == "workspace_path":
+        monkeypatch.setattr(
+            kb,
+            "set_workspace_path",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError(failure_stage)
+            ),
+        )
+    elif failure_stage == "branch_name":
+        monkeypatch.setattr(
+            kb,
+            "_resolve_worktree_workspace",
+            lambda task, **_kwargs: (kb.workspaces_root(first_board) / task.id, "wt/test"),
+        )
+        monkeypatch.setattr(
+            kb,
+            "set_branch_name",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError(failure_stage)
+            ),
+        )
+    else:
+        monkeypatch.setattr(
+            kb,
+            "_maybe_emit_scratch_tip",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError(failure_stage)
+            ),
+        )
+
+    capacity = kb.DispatchSweepCapacity(multi_board_home, max_in_progress=1)
+    with kb.connect_closing(board=first_board) as conn:
+        with pytest.raises(RuntimeError, match=failure_stage):
+            kb.dispatch_once(
+                conn,
+                board=first_board,
+                spawn_fn=lambda *_args, **_kwargs: os.getpid(),
+                reconcile_orphans=False,
+                sweep_capacity=capacity,
+            )
+
+    assert not kb._DISPATCH_CAPACITY_RESERVATIONS
+    with kb.connect_closing(board=first_board) as conn:
+        first = kb.get_task(conn, first_id)
+        assert first is not None
+        assert first.consecutive_failures == 0
+        if first.status == "running":
+            assert kb.reclaim_task(conn, first_id, reason="test cleanup")
+
+    monkeypatch.setattr(kb, claim_name, original_claim)
+    monkeypatch.setattr(kb, "set_workspace_path", original_set_workspace_path)
+    monkeypatch.setattr(kb, "set_branch_name", original_set_branch_name)
+    monkeypatch.setattr(kb, "_resolve_worktree_workspace", original_resolve_worktree)
+    monkeypatch.setattr(kb, "_maybe_emit_scratch_tip", original_scratch_tip)
+    with kb.connect_closing(board=second_board) as conn:
+        second = kb.dispatch_once(
+            conn,
+            board=second_board,
+            spawn_fn=lambda *_args, **_kwargs: os.getpid(),
+            reconcile_orphans=False,
+            sweep_capacity=capacity,
+        )
+
+    assert len(second.spawned) == 1


### PR DESCRIPTION
## Summary
- Fixes `max_in_progress` being enforced independently by each board watcher, which can exceed the configured worker cap across boards.
- Adds an atomic global reservation shared across boards, plus per-profile reservations so each profile cap and the global cap are checked and claimed together before worker launch.
- Releases reservations on launch failures and watcher cleanup/completion paths so failed work cannot leak capacity.

## Changed files
- `gateway/kanban_watchers.py`
- `hermes_cli/kanban_db.py`
- `tests/gateway/test_kanban_global_worker_caps.py`

## Verification
- Focused suite: 22 tests passed.
- Independent reviewer suite: 46 tests passed.
- `ruff`, `py_compile`, and `git diff --check` passed.
- Final review: PASS.

## Rollout risk
Low and localized to Kanban worker admission/accounting. The main risk is stale or incorrectly released reservations reducing available concurrency; atomic reservation tests and explicit failure-path release coverage mitigate this. No configuration migration is required.