### PR TITLE
fix(desktop): keep serve backend alive through Windows launcher

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17656,9 +17656,26 @@ def _maybe_open_browser(
     threading.Thread(target=_open, daemon=True).start()
 
 
-def _is_serve_orphaned(original_ppid: int, getppid=os.getppid) -> bool:
-    """True when this process lost its original spawning parent (ppid changed)."""
-    return getppid() != original_ppid
+def _is_serve_orphaned(desktop_pid: int, pid_exists=None) -> bool:
+    """True when the Desktop process that owns this serve backend is gone.
+
+    ``HERMES_PARENT_PID`` is the Electron Desktop PID, not necessarily this
+    Python process's immediate PPID. On Windows the venv ``hermes.exe`` launcher
+    introduces one or more shim processes, so comparing ``os.getppid()`` to the
+    Electron PID incorrectly treats a healthy backend as orphaned and exits 0.
+    Probe the recorded Desktop PID directly instead.
+
+    Any liveness-probe failure is fail-safe: keep serving rather than killing a
+    backend whose owner could not be conclusively shown to be dead.
+    """
+    try:
+        if pid_exists is None:
+            from gateway.status import _pid_exists
+
+            pid_exists = _pid_exists
+        return not bool(pid_exists(int(desktop_pid)))
+    except Exception:
+        return False
 
 
 def _start_parent_death_watchdog() -> None:
@@ -17676,7 +17693,7 @@ def _start_parent_death_watchdog() -> None:
     if not raw:
         return
     try:
-        original_ppid = int(raw)
+        desktop_pid = int(raw)
     except (TypeError, ValueError):
         return
     try:
@@ -17685,7 +17702,7 @@ def _start_parent_death_watchdog() -> None:
         poll = 2.0
 
     def _loop() -> None:
-        while not _is_serve_orphaned(original_ppid):
+        while not _is_serve_orphaned(desktop_pid):
             time.sleep(poll)
         os._exit(0)
 
@@ -17693,9 +17710,8 @@ def _start_parent_death_watchdog() -> None:
 
 
 def _demo() -> None:
-    # orphan iff current ppid differs from the recorded spawning parent
-    assert _is_serve_orphaned(999999999, getppid=lambda: 1) is True
-    assert _is_serve_orphaned(42, getppid=lambda: 42) is False
+    assert _is_serve_orphaned(999999999, pid_exists=lambda _pid: False) is True
+    assert _is_serve_orphaned(42, pid_exists=lambda _pid: True) is False
     print("web_server parent-death watchdog self-check: OK")
 
 

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -1,0 +1,17 @@
+"""Regression tests for Desktop-owned ``hermes serve`` lifecycle tracking."""
+
+from hermes_cli.web_server import _is_serve_orphaned
+
+
+def test_parent_watchdog_tracks_recorded_desktop_pid_not_immediate_ppid():
+    """Windows venv launch shims must not make a live Desktop look orphaned."""
+
+    assert _is_serve_orphaned(4242, pid_exists=lambda pid: pid == 4242) is False
+    assert _is_serve_orphaned(4242, pid_exists=lambda _pid: False) is True
+
+
+def test_parent_watchdog_fails_safe_when_liveness_probe_errors():
+    def broken_probe(_pid: int) -> bool:
+        raise OSError("process table temporarily unavailable")
+
+    assert _is_serve_orphaned(4242, pid_exists=broken_probe) is False


### PR DESCRIPTION
## Summary

Fix a Windows desktop startup regression introduced by the `HERMES_PARENT_PID` parent-death watchdog.

The Desktop correctly passes its Electron PID in `HERMES_PARENT_PID`, but on Windows the backend is launched through the Hermes/venv executable shim. The backend Python process therefore does not have the Electron process as its immediate PPID. Comparing `os.getppid()` directly to `HERMES_PARENT_PID` makes a healthy backend look orphaned and the watchdog exits it with code 0 shortly after `HERMES_BACKEND_READY`.

## Observed failure

On Windows the sequence was reproducible as:

```text
HERMES_BACKEND_READY port=<ephemeral>
Hermes backend exited (0)
Hermes backend exited before it became ready (0)
```

The Desktop then reports that the background gateway could not start.

## Fix

Preserve the orphan-cleanup behavior, but treat `HERMES_PARENT_PID` as an ownership/liveness contract rather than an immediate-PPID contract:

- check whether the recorded Desktop PID is still alive using Hermes' existing Windows-safe `gateway.status._pid_exists()` helper;
- fail safe toward keeping the backend alive if liveness cannot be determined;
- retain the watchdog's clean `os._exit(0)` behavior once the actual Desktop owner process is gone;
- add focused regression coverage for a live Desktop owner, a dead Desktop owner, and liveness-probe failure.

The existing environment gate still leaves standalone `hermes serve` untouched when `HERMES_PARENT_PID` is absent.

This preserves the intent of the orphan-reap change while accounting for the Windows launcher/shim process tree.

## Verification

- focused watchdog/orphan regression suite: **10 passed**
- expanded related suite: **13 passed**
- `git diff --check`: **pass**
- end-to-end Windows shim probe with a live Desktop PID: backend announced `HERMES_BACKEND_READY` and remained alive beyond the watchdog grace interval
- real Desktop restart after the patch reached:

```text
HERMES_BACKEND_READY port=2347
Hermes backend is ready. Finalizing desktop startup
```

- live `/api/health` returned HTTP 200 with Hermes `0.20.0`

The change is limited to the watchdog implementation and its regression test.