### PR TITLE
fix(agent): parse SGLang output-cap error wording (#83521)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1565,6 +1565,19 @@ def get_context_length_from_provider_error(
     return None
 
 
+def _parse_sglang_token_split(error_lower: str) -> Optional[Tuple[int, int]]:
+    """Extract (context_window, input_tokens) from SGLang's error wording, or None.
+
+    Shared by parse_available_output_tokens_from_error() and is_output_cap_error()
+    so the two numeric extractions can't drift apart if SGLang changes its wording.
+    """
+    m_ctx = re.search(r'maximum context length of (\d+)\s*token', error_lower)
+    m_input = re.search(r'(\d+)\s*tokens from the input messages', error_lower)
+    if m_ctx and m_input:
+        return int(m_ctx.group(1)), int(m_input.group(1))
+    return None
+
+
 def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     """Detect an "output cap too large" error and return how many output tokens are available.
 
@@ -1701,10 +1714,10 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     # Available output = window - input. When the input alone already meets
     # or exceeds the window this stays None, so the caller falls through to
     # compression instead of futilely shrinking the output cap.
-    _m_sglang_ctx = re.search(r'maximum context length of (\d+)\s*token', error_lower)
-    _m_sglang_input = re.search(r'(\d+)\s*tokens from the input messages', error_lower)
-    if _m_sglang_ctx and _m_sglang_input:
-        _available = int(_m_sglang_ctx.group(1)) - int(_m_sglang_input.group(1))
+    _sglang_split = _parse_sglang_token_split(error_lower)
+    if _sglang_split:
+        _ctx, _input = _sglang_split
+        _available = _ctx - _input
         if _available >= 1:
             return _available
 
@@ -1781,9 +1794,8 @@ def is_output_cap_error(error_msg: str) -> bool:
     # SGLang reports both figures explicitly; when the input alone already
     # meets or exceeds the context window this is a genuine overflow, not an
     # output-cap error, even though the wording also names a completion cap.
-    _m_ctx = re.search(r'maximum context length of (\d+)\s*token', error_lower)
-    _m_input = re.search(r'(\d+)\s*tokens from the input messages', error_lower)
-    if _m_ctx and _m_input and int(_m_input.group(1)) >= int(_m_ctx.group(1)):
+    _sglang_split = _parse_sglang_token_split(error_lower)
+    if _sglang_split and _sglang_split[1] >= _sglang_split[0]:
         return False
 
     return True

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1610,6 +1610,14 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # The input itself fits — this is purely an output-cap error, so reduce
         # max_tokens and retry; do NOT compress.
         "range of max_tokens should be" in error_lower
+    ) or (
+        # SGLang phrasing (#83521): both the input and completion token counts
+        # are reported explicitly, e.g.
+        #   "... maximum context length of 131072 tokens. You requested a
+        #    total of 132528 tokens: 66992 tokens from the input messages and
+        #    65536 tokens for the completion. ..."
+        "tokens from the input messages" in error_lower
+        and "tokens for the completion" in error_lower
     )
     if not is_output_cap_error:
         return None
@@ -1685,6 +1693,21 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         if _available >= 1:
             return _available
 
+    # SGLang style: input tokens and completion (output) tokens are both
+    # reported explicitly, alongside the context window, e.g.
+    #   "Requested token count exceeds the model's maximum context length of
+    #    131072 tokens. You requested a total of 132528 tokens: 66992 tokens
+    #    from the input messages and 65536 tokens for the completion."
+    # Available output = window - input. When the input alone already meets
+    # or exceeds the window this stays None, so the caller falls through to
+    # compression instead of futilely shrinking the output cap.
+    _m_sglang_ctx = re.search(r'maximum context length of (\d+)\s*token', error_lower)
+    _m_sglang_input = re.search(r'(\d+)\s*tokens from the input messages', error_lower)
+    if _m_sglang_ctx and _m_sglang_input:
+        _available = int(_m_sglang_ctx.group(1)) - int(_m_sglang_input.group(1))
+        if _available >= 1:
+            return _available
+
     return None
 
 
@@ -1717,6 +1740,7 @@ def is_output_cap_error(error_msg: str) -> bool:
         "max_tokens" in error_lower
         or "max_output_tokens" in error_lower
         or "max_completion_tokens" in error_lower
+        or "tokens for the completion" in error_lower       # SGLang
     )
     if not mentions_output_param:
         return False
@@ -1730,6 +1754,8 @@ def is_output_cap_error(error_msg: str) -> bool:
             and "maximum context length" in error_lower)
         or ("requested" in error_lower                      # LM Studio / llama.cpp
             and "output tokens" in error_lower)
+        or ("tokens from the input messages" in error_lower  # SGLang
+            and "tokens for the completion" in error_lower)
         or "should be" in error_lower                       # generic "max_tokens should be <= N"
         or "less than or equal" in error_lower
         or "must be" in error_lower
@@ -1749,7 +1775,18 @@ def is_output_cap_error(error_msg: str) -> bool:
         or "prompt contains" in error_lower
         or "reduce the length" in error_lower
     )
-    return not input_overflow_signal
+    if input_overflow_signal:
+        return False
+
+    # SGLang reports both figures explicitly; when the input alone already
+    # meets or exceeds the context window this is a genuine overflow, not an
+    # output-cap error, even though the wording also names a completion cap.
+    _m_ctx = re.search(r'maximum context length of (\d+)\s*token', error_lower)
+    _m_input = re.search(r'(\d+)\s*tokens from the input messages', error_lower)
+    if _m_ctx and _m_input and int(_m_input.group(1)) >= int(_m_ctx.group(1)):
+        return False
+
+    return True
 
 
 def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -68,6 +68,42 @@ class TestParseDashScopeOutputCap:
         assert parse_available_output_tokens_from_error(msg) == 32768
 
 
+class TestParseSglangOutputCap:
+    """SGLang reports the input and completion token counts explicitly,
+    separate from the context window (#83521)."""
+
+    _SGLANG_MSG = (
+        "Requested token count exceeds the model's maximum context length of "
+        "131072 tokens. You requested a total of 132528 tokens: 66992 tokens "
+        "from the input messages and 65536 tokens for the completion. Please "
+        "reduce the number of tokens in the input messages or the completion "
+        "to fit within the limit."
+    )
+
+    def test_sglang_format(self):
+        # available output = 131072 - 66992 = 64080
+        assert parse_available_output_tokens_from_error(self._SGLANG_MSG) == 64080
+
+    def test_sglang_is_output_cap(self):
+        assert is_output_cap_error(self._SGLANG_MSG) is True
+
+    def test_sglang_case_insensitive_and_whitespace(self):
+        msg = self._SGLANG_MSG.upper().replace(":", " : ")
+        assert parse_available_output_tokens_from_error(msg) == 64080
+        assert is_output_cap_error(msg) is True
+
+    def test_sglang_genuine_input_overflow_routes_to_compression(self):
+        # Input tokens alone already meet/exceed the context window -> a
+        # real overflow, not an output-cap error, even with the same wording.
+        msg = (
+            "Requested token count exceeds the model's maximum context length "
+            "of 100000 tokens. You requested a total of 150000 tokens: 120000 "
+            "tokens from the input messages and 30000 tokens for the completion."
+        )
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+
+
 class TestIsOutputCapError:
     """`is_output_cap_error` is the broader yes/no gate that keeps an
     output-cap 400 out of the compression death-loop even when we can't parse


### PR DESCRIPTION
## What does this PR do?

An OpenAI-compatible SGLang endpoint rejects a request whose input fits by
itself but whose input plus requested completion exceeds the model context
window, with wording of this shape:

```text
Requested token count exceeds the model's maximum context length of 131072 tokens. You requested a total of 132528 tokens: 66992 tokens from the input messages and 65536 tokens for the completion. Please reduce the number of tokens in the input messages or the completion to fit within the limit.
```

Neither `parse_available_output_tokens_from_error()` nor
`is_output_cap_error()` recognized this sentence shape (it does not contain
`max_tokens`, `available_tokens`, or any of the other already-handled
phrasings). The request therefore fell into context compression instead of
retrying with a smaller `max_tokens`. Because compression cannot materially
shrink a conversation whose actual problem is the output cap, the turn ends
with a misleading `Context length exceeded (N tokens). Cannot compress
further.` once the protected tail can no longer shrink.

This is the same general failure family as #63161 (vLLM) and #78405/PR
#81289 (Azure) — a distinct provider wording that neither existing parser
recognized.

## Related Issue

Fixes #83521

## Changes Made

- `agent/model_metadata.py`:
  - `parse_available_output_tokens_from_error()`: recognize the SGLang
    phrasing (`... tokens from the input messages and ... tokens for the
    completion`) and derive the available output budget as
    `context_window - input_tokens`, extracted from `maximum context length
    of N tokens`. Guarded so a genuine input overflow (`input_tokens >=
    context_window`) returns `None` and falls through to compression.
  - `is_output_cap_error()`: recognize the same wording as an output-cap
    signal (widening the `max_tokens`-only gate to also match `tokens for
    the completion`, since this wording never mentions `max_tokens`
    literally), with the same numeric input-vs-window guard so a genuine
    overflow still routes to compression.
- `tests/test_output_cap_parsing.py`: 4 new cases — the verbatim SGLang
  sentence, the `is_output_cap_error` classification, a case/whitespace
  variation, and a genuine input-overflow case (input tokens ≥ context
  window) that must still return `None` / `False` and route to compression.

## How to Test

1. Reproduce the parser gap on `main` (before this fix):
   ```python
   from agent.model_metadata import parse_available_output_tokens_from_error, is_output_cap_error
   msg = (
       "Requested token count exceeds the model's maximum context length of 131072 tokens. "
       "You requested a total of 132528 tokens: 66992 tokens from the input messages "
       "and 65536 tokens for the completion. Please reduce the number of tokens in "
       "the input messages or the completion to fit within the limit."
   )
   parse_available_output_tokens_from_error(msg)  # None (before fix)
   is_output_cap_error(msg)                       # False (before fix)
   ```
   After this fix: `parse_available_output_tokens_from_error(msg) == 64080`
   (`131072 - 66992`), `is_output_cap_error(msg) is True`.

2. Unit tests:
   ```bash
   pytest tests/test_output_cap_parsing.py tests/test_ctx_halving_fix.py tests/agent/test_model_metadata.py -q
   ```
   Result: **98 passed**.

3. Regression on the run_agent output-cap/compression paths:
   ```bash
   pytest tests/run_agent/test_run_agent.py -k "output or compress or context" -q
   ```
   Result: **15 passed**.

4. Verified the 3 new format-parsing tests fail without the fix (checked out
   the pre-fix `agent/model_metadata.py` via `git stash`, reran):
   ```
   FAILED tests/test_output_cap_parsing.py::TestParseSglangOutputCap::test_sglang_format - assert None == 64080
   FAILED tests/test_output_cap_parsing.py::TestParseSglangOutputCap::test_sglang_is_output_cap - assert False is True
   FAILED tests/test_output_cap_parsing.py::TestParseSglangOutputCap::test_sglang_case_insensitive_and_whitespace - assert None == 64080
   3 failed, 14 passed
   ```
   (The 4th new test, the genuine-input-overflow guard, correctly passes
   either way since both old and new code return `None`/`False` for it.)

5. Lint: `ruff check agent/model_metadata.py tests/test_output_cap_parsing.py` → All checks passed.
6. `python3 scripts/check-windows-footguns.py agent/model_metadata.py tests/test_output_cap_parsing.py` → No Windows footguns found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding regression coverage)

## AI assistance disclosure

This PR was authored with the help of an AI coding assistant (Claude), under
human/automated-pipeline supervision. The fix was verified against the exact
reproduction in #83521 on current `main`, and new tests were confirmed to
fail without the change before it was committed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched existing issues/PRs for duplicates before starting
