### PR TITLE
fix(agent): recover bounded Codex false stops across runtimes

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3515,6 +3515,7 @@ def classify_codex_terminal(
     from agent.conversation_compression import _is_real_user_message
     from agent.terminal_continuation import (
         CONTINUATION_NUDGE,
+        LEGACY_CONTINUATION_NUDGE,
         ContinuationFacts,
         classify_terminal_continuation,
         count_substantive_tools,
@@ -3528,7 +3529,8 @@ def classify_codex_terminal(
                 isinstance(msg, dict)
                 and _is_real_user_message(msg)
                 and not msg.get("_terminal_continuation_scaffold")
-                and msg.get("content") != CONTINUATION_NUDGE
+                and msg.get("content")
+                not in (CONTINUATION_NUDGE, LEGACY_CONTINUATION_NUDGE)
             )
         ),
         default=-1,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3480,105 +3480,113 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
 
 
 
+_WORKSPACE_MARKERS = (
+    "directory",
+    "current directory",
+    "folder",
+    "repo",
+    "repository",
+    "codebase",
+    "workspace",
+    "project files",
+    "local files",
+    "filesystem",
+    "file system",
+    "path",
+)
+
+
+def classify_codex_terminal(
+    agent,
+    user_message: Any,
+    assistant_content: str,
+    messages: List[Dict[str, Any]],
+    *,
+    require_workspace: bool = True,
+    terminal_completed: bool = True,
+    finish_reason: Optional[str] = "stop",
+    continuation_attempts: int = 0,
+    interrupted: bool = False,
+    transport_error: bool = False,
+    pending_background: bool = False,
+):
+    """Build current-turn facts and return the shared continuation reason."""
+    from agent.codex_responses_adapter import _summarize_user_message_for_log
+    from agent.conversation_compression import _is_real_user_message
+    from agent.terminal_continuation import (
+        CONTINUATION_NUDGE,
+        ContinuationFacts,
+        classify_terminal_continuation,
+        count_substantive_tools,
+    )
+
+    current_turn_start = max(
+        (
+            idx
+            for idx, msg in enumerate(messages)
+            if (
+                isinstance(msg, dict)
+                and _is_real_user_message(msg)
+                and not msg.get("_terminal_continuation_scaffold")
+                and msg.get("content") != CONTINUATION_NUDGE
+            )
+        ),
+        default=-1,
+    )
+    current_turn_messages = messages[current_turn_start + 1 :]
+    assistant_text = agent._strip_think_blocks(assistant_content or "").strip()
+    user_text = _summarize_user_message_for_log(user_message).strip()
+    scope_text = f"{user_text} {assistant_text}".lower()
+    workspace_scoped = (
+        not require_workspace
+        or any(marker in scope_text for marker in _WORKSPACE_MARKERS)
+        or "~/" in scope_text
+        or bool(re.search(r"(?:^|\s)/(?:[a-z0-9_.-]+/)*[a-z0-9_.-]+", scope_text))
+        or bool(re.search(r"\b[a-z]:\\", scope_text))
+    )
+
+    return classify_terminal_continuation(
+        ContinuationFacts(
+            runtime=str(getattr(agent, "api_mode", "") or ""),
+            terminal_completed=terminal_completed,
+            finish_reason=finish_reason,
+            substantive_tool_count=count_substantive_tools(current_turn_messages),
+            assistant_text=assistant_text,
+            user_text=user_text,
+            workspace_scoped=workspace_scoped,
+            continuation_attempts=continuation_attempts,
+            interrupted=interrupted,
+            transport_error=transport_error,
+            pending_background=pending_background,
+            allow_non_codex=not require_workspace,
+        )
+    )
+
+
 def looks_like_codex_intermediate_ack(
     agent,
     user_message: Any,
     assistant_content: str,
     messages: List[Dict[str, Any]],
     require_workspace: bool = True,
+    continuation_attempts: int = 0,
 ) -> bool:
-    """Detect a planning/ack message that should continue instead of ending the turn.
+    """Compatibility bool for callers that do not need the reason value.
 
-    ``require_workspace`` (default True) keeps the original codex-coding scope:
-    the ack must reference a filesystem/repo workspace. The conversation loop
-    passes ``require_workspace=False`` when the user has explicitly opted into
-    intent-ack continuation for all api_modes (``agent.intent_ack_continuation``
-    is ``true`` or a model-list), so general autonomous workflows ("I'll run a
-    health check on the server", "I'll start the deployment") — which carry a
-    future-ack and an action verb but no filesystem reference — are caught too.
-    The future-ack + short-content + no-prior-tools + action-verb requirements
-    always apply, which is what keeps conversational "I'll help you brainstorm"
-    replies from tripping it.
+    ``continuation_attempts`` must be supplied by any caller using this as a
+    retry gate. Runtime loops should prefer :func:`classify_codex_terminal` so
+    they can distinguish exhaustion and emit the durable pause notice.
     """
-    if any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in messages):
-        return False
+    from agent.terminal_continuation import ContinuationReason
 
-    assistant_text = agent._strip_think_blocks(assistant_content or "").strip().lower()
-    if not assistant_text:
-        return False
-    if len(assistant_text) > 1200:
-        return False
-
-    has_future_ack = bool(
-        re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
-    )
-    if not has_future_ack:
-        return False
-
-    action_markers = (
-        "look into",
-        "look at",
-        "inspect",
-        "scan",
-        "check",
-        "analyz",
-        "review",
-        "explore",
-        "read",
-        "open",
-        "run",
-        "test",
-        "fix",
-        "debug",
-        "search",
-        "find",
-        "walkthrough",
-        "report back",
-        "summarize",
-    )
-    workspace_markers = (
-        "directory",
-        "current directory",
-        "current dir",
-        "cwd",
-        "repo",
-        "repository",
-        "codebase",
-        "project",
-        "folder",
-        "filesystem",
-        "file tree",
-        "files",
-        "path",
-    )
-
-    assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
-    if not assistant_mentions_action:
-        return False
-
-    # Opted-in (all-api_mode) path: a future-ack + action verb + no prior tool
-    # call is enough — the user asked us to keep going when the model only
-    # announces intent, regardless of whether a filesystem is involved.
-    if not require_workspace:
-        return True
-
-    # ``user_message`` is typed ``str`` but can arrive as an OpenAI-style
-    # multi-part content list (``[{type:"text",...}, {type:"image_url",...}]``)
-    # for vision requests routed through the OpenAI-compat API server. A
-    # truthy list survives ``(user_message or "")`` and then ``.strip()``
-    # raises ``AttributeError`` — flatten to text first.
-    from agent.codex_responses_adapter import _summarize_user_message_for_log
-
-    user_text = _summarize_user_message_for_log(user_message).strip().lower()
-    user_targets_workspace = (
-        any(marker in user_text for marker in workspace_markers)
-        or "~/" in user_text
-        or "/" in user_text
-    )
-    assistant_targets_workspace = any(
-        marker in assistant_text for marker in workspace_markers
-    )
-    return user_targets_workspace or assistant_targets_workspace
+    return classify_codex_terminal(
+        agent,
+        user_message,
+        assistant_content,
+        messages,
+        require_workspace=require_workspace,
+        continuation_attempts=continuation_attempts,
+    ) not in {ContinuationReason.NONE, ContinuationReason.BUDGET_EXHAUSTED}
 
 
 def intent_ack_continuation_mode(agent) -> str:
@@ -3586,9 +3594,9 @@ def intent_ack_continuation_mode(agent) -> str:
 
     Returns one of:
       * ``"off"``        — never continue.
-      * ``"codex_only"`` — historical scope: continue only on the
-        ``codex_responses`` api_mode, and only for codebase/workspace acks
-        (``require_workspace=True``).
+      * ``"codex_only"`` — conservative automatic scope: continue only on
+        ``codex_responses`` or ``codex_app_server``, and only for
+        codebase/workspace turns (``require_workspace=True``).
       * ``"all"``        — user opted in for every api_mode; continue on any
         future-ack + action verb (``require_workspace=False``).
 
@@ -3607,16 +3615,20 @@ def intent_ack_continuation_mode(agent) -> str:
         model_lower = (agent.model or "").lower()
         return "all" if any(p.lower() in model_lower for p in mode if isinstance(p, str)) else "off"
     # "auto" or any unrecognised value — historical codex-only behavior.
-    return "codex_only" if agent.api_mode == "codex_responses" else "off"
+    return (
+        "codex_only"
+        if agent.api_mode in {"codex_responses", "codex_app_server"}
+        else "off"
+    )
 
 
 def intent_ack_continuation_enabled(agent) -> bool:
     """Whether intent-ack continuation should fire at all for this turn.
 
-    The ``codex_ack_continuations < 2`` per-turn cap and the
-    ``looks_like_codex_intermediate_ack`` detector are applied by the caller;
-    this only decides the on/off gate. Callers that also need to know whether
-    the workspace requirement applies should use ``intent_ack_continuation_mode``
+    The shared classifier applies the two-recovery per-turn cap and the
+    terminal/safety evidence gates; this helper only decides the configured
+    runtime scope. Callers that also need to know whether the workspace
+    requirement applies should use ``intent_ack_continuation_mode``
     directly (``"codex_only"`` ⇒ require_workspace=True, ``"all"`` ⇒ False).
     """
     return intent_ack_continuation_mode(agent) != "off"

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,7 @@ from agent.stream_single_writer import claim_stream_writer, stream_writer_is_cur
 from agent.terminal_continuation import (
     BUDGET_EXHAUSTED_NOTICE,
     CONTINUATION_NUDGE,
+    MAX_TERMINAL_CONTINUATIONS,
     ContinuationReason,
 )
 
@@ -736,8 +737,31 @@ def run_codex_app_server_turn(
             )
         ]
 
+    def _apply_recovery_failure_notice(completed_turn) -> None:
+        original_text = completed_turn.final_text
+        checkpoint = fallback_candidate_text or original_text
+        detail = str(completed_turn.error or "interrupted")
+        completed_turn.final_text = (
+            f"{checkpoint.rstrip()}\n\n"
+            f"PAUSED — Codex app-server continuation failed: {detail}. "
+            "Fall back to the default runtime with `/codex-runtime auto`."
+        )
+        for projected in reversed(completed_turn.projected_messages):
+            if (
+                isinstance(projected, dict)
+                and projected.get("role") == "assistant"
+                and not projected.get("tool_calls")
+                and projected.get("content") == original_text
+            ):
+                projected["content"] = completed_turn.final_text
+                break
+        else:
+            completed_turn.projected_messages.append(
+                {"role": "assistant", "content": completed_turn.final_text}
+            )
+
     try:
-        for continuation_attempt in range(3):
+        for continuation_attempt in range(MAX_TERMINAL_CONTINUATIONS + 1):
             native_turn_attempts += 1
             current_turn = agent._codex_session.run_turn(user_input=next_input)
             codex_turns.append(current_turn)
@@ -759,6 +783,15 @@ def run_codex_app_server_turn(
                 or getattr(current_turn, "should_retire", False)
                 or not current_turn.final_text
             ):
+                if (
+                    current_turn.error is not None
+                    or getattr(current_turn, "should_retire", False)
+                    or (
+                        current_turn.interrupted
+                        and not getattr(agent, "_interrupt_requested", False)
+                    )
+                ):
+                    _apply_recovery_failure_notice(current_turn)
                 if fallback_candidate_text and not current_turn.final_text:
                     current_turn.final_text = fallback_candidate_text
                     current_turn.projected_messages.append(

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -23,6 +23,11 @@ from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+from agent.terminal_continuation import (
+    BUDGET_EXHAUSTED_NOTICE,
+    CONTINUATION_NUDGE,
+    ContinuationReason,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -694,9 +699,199 @@ def run_codex_app_server_turn(
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
+    codex_turns = []
+    native_turn_attempts = 0
+    next_input = user_message
+    fallback_candidate_text = None
+    retry_exception = None
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        for continuation_attempt in range(3):
+            native_turn_attempts += 1
+            current_turn = agent._codex_session.run_turn(user_input=next_input)
+            codex_turns.append(current_turn)
+
+            # A user stop can race with native turn/completed after the session
+            # has built TurnResult but before this wrapper decides to recover.
+            if getattr(agent, "_interrupt_requested", False):
+                current_turn.interrupted = True
+                if fallback_candidate_text and not current_turn.final_text:
+                    current_turn.final_text = fallback_candidate_text
+                    current_turn.projected_messages.append(
+                        {"role": "assistant", "content": fallback_candidate_text}
+                    )
+                break
+
+            if (
+                current_turn.interrupted
+                or current_turn.error is not None
+                or getattr(current_turn, "should_retire", False)
+                or not current_turn.final_text
+            ):
+                if fallback_candidate_text and not current_turn.final_text:
+                    current_turn.final_text = fallback_candidate_text
+                    current_turn.projected_messages.append(
+                        {"role": "assistant", "content": fallback_candidate_text}
+                    )
+                break
+
+            from agent.agent_runtime_helpers import (
+                classify_codex_terminal,
+                intent_ack_continuation_mode,
+            )
+
+            ack_mode = intent_ack_continuation_mode(agent)
+            projected_so_far = [
+                projected
+                for completed_turn in codex_turns
+                for projected in completed_turn.projected_messages
+            ]
+            continuation_reason = (
+                classify_codex_terminal(
+                    agent,
+                    user_message=user_message,
+                    assistant_content=current_turn.final_text,
+                    messages=[*messages, *projected_so_far],
+                    require_workspace=(ack_mode == "codex_only"),
+                    terminal_completed=bool(
+                        getattr(current_turn, "native_completed", False)
+                    ),
+                    finish_reason="completed",
+                    continuation_attempts=continuation_attempt,
+                    interrupted=current_turn.interrupted,
+                    transport_error=current_turn.error is not None,
+                )
+                if ack_mode != "off" and agent.valid_tool_names
+                else ContinuationReason.NONE
+            )
+            if continuation_reason is ContinuationReason.NONE:
+                break
+            if continuation_reason is ContinuationReason.BUDGET_EXHAUSTED:
+                pause_candidate_text = current_turn.final_text
+                current_turn.final_text = (
+                    f"{pause_candidate_text.rstrip()}\n\n"
+                    f"{BUDGET_EXHAUSTED_NOTICE}"
+                )
+                pause_projected = False
+                for projected in reversed(current_turn.projected_messages):
+                    if (
+                        isinstance(projected, dict)
+                        and projected.get("role") == "assistant"
+                        and not projected.get("tool_calls")
+                        and projected.get("content") == pause_candidate_text
+                    ):
+                        projected["content"] = current_turn.final_text
+                        pause_projected = True
+                        break
+                if not pause_projected:
+                    current_turn.projected_messages.append(
+                        {"role": "assistant", "content": current_turn.final_text}
+                    )
+                break
+
+            # The outer conversation loop consumed the initial app-server turn.
+            # Every native recovery must consume another iteration before launch.
+            iteration_budget = getattr(agent, "iteration_budget", None)
+            if iteration_budget is not None and not iteration_budget.consume():
+                pause_candidate_text = current_turn.final_text
+                current_turn.final_text = (
+                    f"{pause_candidate_text.rstrip()}\n\n"
+                    f"{BUDGET_EXHAUSTED_NOTICE}"
+                )
+                pause_projected = False
+                for projected in reversed(current_turn.projected_messages):
+                    if (
+                        isinstance(projected, dict)
+                        and projected.get("role") == "assistant"
+                        and not projected.get("tool_calls")
+                        and projected.get("content") == pause_candidate_text
+                    ):
+                        projected["content"] = current_turn.final_text
+                        pause_projected = True
+                        break
+                if not pause_projected:
+                    current_turn.projected_messages.append(
+                        {"role": "assistant", "content": current_turn.final_text}
+                    )
+                break
+
+            # Keep real tool events, but discard the premature assistant
+            # candidate from Hermes' durable/projected transcript. The native
+            # Codex thread remains append-only and receives the nudge below.
+            removed_candidate = False
+            retained_projected = []
+            for projected in reversed(current_turn.projected_messages):
+                if (
+                    not removed_candidate
+                    and isinstance(projected, dict)
+                    and projected.get("role") == "assistant"
+                    and not projected.get("tool_calls")
+                    and projected.get("content") == current_turn.final_text
+                ):
+                    removed_candidate = True
+                    continue
+                retained_projected.append(projected)
+            current_turn.projected_messages = list(reversed(retained_projected))
+            if not removed_candidate:
+                refund = getattr(iteration_budget, "refund", None)
+                if callable(refund):
+                    refund()
+                logger.warning(
+                    "codex app-server false-stop candidate was not projected; "
+                    "skipping automatic continuation"
+                )
+                break
+            fallback_candidate_text = current_turn.final_text
+
+            logger.info(
+                "codex app-server false stop detected (%s); continuing (%d/2)",
+                continuation_reason.value,
+                continuation_attempt + 1,
+            )
+            try:
+                agent._touch_activity(
+                    "codex app-server false stop; continuing"
+                )
+            except Exception:
+                pass
+            next_input = CONTINUATION_NUDGE
+
+        final_turn = codex_turns[-1]
+        turn = SimpleNamespace(
+            final_text=final_turn.final_text,
+            projected_messages=[
+                projected
+                for completed_turn in codex_turns
+                for projected in completed_turn.projected_messages
+                if not (
+                    isinstance(projected, dict)
+                    and projected.get("role") == "user"
+                    and projected.get("content") == CONTINUATION_NUDGE
+                )
+            ],
+            tool_iterations=sum(
+                completed_turn.tool_iterations for completed_turn in codex_turns
+            ),
+            interrupted=final_turn.interrupted,
+            native_completed=getattr(final_turn, "native_completed", False),
+            error=final_turn.error,
+            turn_id=final_turn.turn_id,
+            thread_id=final_turn.thread_id,
+            token_usage_last=getattr(final_turn, "token_usage_last", None),
+            token_usage_total=getattr(final_turn, "token_usage_total", None),
+            model_context_window=getattr(
+                final_turn, "model_context_window", None
+            ),
+            compacted=any(
+                getattr(completed_turn, "compacted", False)
+                for completed_turn in codex_turns
+            ),
+            should_retire=any(
+                getattr(completed_turn, "should_retire", False)
+                for completed_turn in codex_turns
+            ),
+        )
     except Exception as exc:
+        retry_exception = exc
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn
         # respawns from scratch instead of reusing a dead client.
@@ -705,33 +900,86 @@ def run_codex_app_server_turn(
         except Exception:
             pass
         agent._codex_session = None
-        _user_interrupted = bool(
-            getattr(agent, "_interrupt_requested", False)
+        if not codex_turns:
+            _record_codex_app_server_usage(
+                agent, SimpleNamespace(token_usage_last=None)
+            )
+            _user_interrupted = bool(
+                getattr(agent, "_interrupt_requested", False)
+            )
+            _interrupt_message = (
+                getattr(agent, "_interrupt_message", None)
+                if _user_interrupted
+                else None
+            )
+            if _user_interrupted:
+                agent.clear_interrupt()
+            return {
+                "final_response": (
+                    f"Codex app-server turn failed: {exc}. "
+                    "Fall back to default runtime with `/codex-runtime auto`."
+                ),
+                "messages": messages,
+                "api_calls": native_turn_attempts,
+                "completed": False,
+                "partial": True,
+                "interrupted": _user_interrupted,
+                **(
+                    {"interrupt_message": _interrupt_message}
+                    if _interrupt_message
+                    else {}
+                ),
+                "error": str(exc),
+            }
+
+        # A retry exception happened after at least one native turn completed.
+        # Preserve those turns through the normal persistence/accounting path
+        # and terminate with the latest removed checkpoint plus an explicit
+        # failure notice.
+        final_turn = codex_turns[-1]
+        checkpoint = fallback_candidate_text or final_turn.final_text
+        failure_notice = (
+            f"PAUSED — Codex app-server continuation failed: {exc}. "
+            "Fall back to the default runtime with `/codex-runtime auto`."
         )
-        _interrupt_message = (
-            getattr(agent, "_interrupt_message", None)
-            if _user_interrupted
-            else None
+        failure_text = (
+            f"{checkpoint.rstrip()}\n\n{failure_notice}"
+            if checkpoint
+            else failure_notice
         )
-        if _user_interrupted:
-            agent.clear_interrupt()
-        return {
-            "final_response": (
-                f"Codex app-server turn failed: {exc}. "
-                f"Fall back to default runtime with `/codex-runtime auto`."
+        projected_messages = [
+            projected
+            for completed_turn in codex_turns
+            for projected in completed_turn.projected_messages
+            if not (
+                isinstance(projected, dict)
+                and projected.get("role") == "user"
+                and projected.get("content") == CONTINUATION_NUDGE
+            )
+        ]
+        projected_messages.append({"role": "assistant", "content": failure_text})
+        turn = SimpleNamespace(
+            final_text=failure_text,
+            projected_messages=projected_messages,
+            tool_iterations=sum(
+                completed_turn.tool_iterations for completed_turn in codex_turns
             ),
-            "messages": messages,
-            "api_calls": 0,
-            "completed": False,
-            "partial": True,
-            "interrupted": _user_interrupted,
-            **(
-                {"interrupt_message": _interrupt_message}
-                if _interrupt_message
-                else {}
+            interrupted=bool(getattr(agent, "_interrupt_requested", False)),
+            native_completed=False,
+            error=str(retry_exception),
+            turn_id=final_turn.turn_id,
+            thread_id=final_turn.thread_id,
+            token_usage_last=getattr(final_turn, "token_usage_last", None),
+            token_usage_total=getattr(final_turn, "token_usage_total", None),
+            model_context_window=getattr(
+                final_turn, "model_context_window", None
             ),
-            "error": str(exc),
-        }
+            compacted=any(
+                getattr(completed_turn, "compacted", False)
+                for completed_turn in codex_turns
+            ),
+            should_retire=True,
+        )
 
     # This runtime bypasses the normal conversation-loop finalizer. Mirror its
     # interrupt handoff/cleanup so a hard stop cannot poison the next turn and a
@@ -814,9 +1062,15 @@ def run_codex_app_server_turn(
     agent._iters_since_skill = (
         getattr(agent, "_iters_since_skill", 0) + turn.tool_iterations
     )
-    _record_codex_app_server_compaction(agent, turn)
-    usage_result = _record_codex_app_server_usage(agent, turn)
-    api_calls = 1
+    usage_result = {}
+    for completed_turn in codex_turns:
+        _record_codex_app_server_compaction(agent, completed_turn)
+        usage_result = _record_codex_app_server_usage(agent, completed_turn)
+    for _ in range(len(codex_turns), native_turn_attempts):
+        _record_codex_app_server_usage(
+            agent, SimpleNamespace(token_usage_last=None)
+        )
+    api_calls = native_turn_attempts
 
     # Now check the skill nudge AFTER iters were incremented — same
     # pattern the chat_completions path uses (line ~15432).
@@ -848,6 +1102,7 @@ def run_codex_app_server_turn(
     if (
         turn.final_text
         and not turn.interrupted
+        and turn.error is None
         and (should_review_memory or should_review_skills)
     ):
         try:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -704,6 +704,38 @@ def run_codex_app_server_turn(
     next_input = user_message
     fallback_candidate_text = None
     retry_exception = None
+
+    def _apply_pause_notice(completed_turn) -> None:
+        candidate_text = completed_turn.final_text
+        completed_turn.final_text = (
+            f"{candidate_text.rstrip()}\n\n{BUDGET_EXHAUSTED_NOTICE}"
+        )
+        for projected in reversed(completed_turn.projected_messages):
+            if (
+                isinstance(projected, dict)
+                and projected.get("role") == "assistant"
+                and not projected.get("tool_calls")
+                and projected.get("content") == candidate_text
+            ):
+                projected["content"] = completed_turn.final_text
+                break
+        else:
+            completed_turn.projected_messages.append(
+                {"role": "assistant", "content": completed_turn.final_text}
+            )
+
+    def _merged_projections(completed_turns):
+        return [
+            projected
+            for completed_turn in completed_turns
+            for projected in completed_turn.projected_messages
+            if not (
+                isinstance(projected, dict)
+                and projected.get("role") == "user"
+                and projected.get("content") == CONTINUATION_NUDGE
+            )
+        ]
+
     try:
         for continuation_attempt in range(3):
             native_turn_attempts += 1
@@ -766,26 +798,7 @@ def run_codex_app_server_turn(
             if continuation_reason is ContinuationReason.NONE:
                 break
             if continuation_reason is ContinuationReason.BUDGET_EXHAUSTED:
-                pause_candidate_text = current_turn.final_text
-                current_turn.final_text = (
-                    f"{pause_candidate_text.rstrip()}\n\n"
-                    f"{BUDGET_EXHAUSTED_NOTICE}"
-                )
-                pause_projected = False
-                for projected in reversed(current_turn.projected_messages):
-                    if (
-                        isinstance(projected, dict)
-                        and projected.get("role") == "assistant"
-                        and not projected.get("tool_calls")
-                        and projected.get("content") == pause_candidate_text
-                    ):
-                        projected["content"] = current_turn.final_text
-                        pause_projected = True
-                        break
-                if not pause_projected:
-                    current_turn.projected_messages.append(
-                        {"role": "assistant", "content": current_turn.final_text}
-                    )
+                _apply_pause_notice(current_turn)
                 break
 
             # The app-server path bypasses the outer conversation loop's
@@ -794,26 +807,7 @@ def run_codex_app_server_turn(
             # `native_turn_attempts` above but does not consume this budget.
             iteration_budget = getattr(agent, "iteration_budget", None)
             if iteration_budget is not None and not iteration_budget.consume():
-                pause_candidate_text = current_turn.final_text
-                current_turn.final_text = (
-                    f"{pause_candidate_text.rstrip()}\n\n"
-                    f"{BUDGET_EXHAUSTED_NOTICE}"
-                )
-                pause_projected = False
-                for projected in reversed(current_turn.projected_messages):
-                    if (
-                        isinstance(projected, dict)
-                        and projected.get("role") == "assistant"
-                        and not projected.get("tool_calls")
-                        and projected.get("content") == pause_candidate_text
-                    ):
-                        projected["content"] = current_turn.final_text
-                        pause_projected = True
-                        break
-                if not pause_projected:
-                    current_turn.projected_messages.append(
-                        {"role": "assistant", "content": current_turn.final_text}
-                    )
+                _apply_pause_notice(current_turn)
                 break
 
             # Keep real tool events, but discard the premature assistant
@@ -860,16 +854,7 @@ def run_codex_app_server_turn(
         final_turn = codex_turns[-1]
         turn = SimpleNamespace(
             final_text=final_turn.final_text,
-            projected_messages=[
-                projected
-                for completed_turn in codex_turns
-                for projected in completed_turn.projected_messages
-                if not (
-                    isinstance(projected, dict)
-                    and projected.get("role") == "user"
-                    and projected.get("content") == CONTINUATION_NUDGE
-                )
-            ],
+            projected_messages=_merged_projections(codex_turns),
             tool_iterations=sum(
                 completed_turn.tool_iterations for completed_turn in codex_turns
             ),
@@ -949,16 +934,7 @@ def run_codex_app_server_turn(
             if checkpoint
             else failure_notice
         )
-        projected_messages = [
-            projected
-            for completed_turn in codex_turns
-            for projected in completed_turn.projected_messages
-            if not (
-                isinstance(projected, dict)
-                and projected.get("role") == "user"
-                and projected.get("content") == CONTINUATION_NUDGE
-            )
-        ]
+        projected_messages = _merged_projections(codex_turns)
         projected_messages.append({"role": "assistant", "content": failure_text})
         turn = SimpleNamespace(
             final_text=failure_text,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -788,8 +788,10 @@ def run_codex_app_server_turn(
                     )
                 break
 
-            # The outer conversation loop consumed the initial app-server turn.
-            # Every native recovery must consume another iteration before launch.
+            # The app-server path bypasses the outer conversation loop's
+            # iteration accounting. This secondary budget therefore caps only
+            # native recovery turns; the initial native turn is counted by
+            # `native_turn_attempts` above but does not consume this budget.
             iteration_budget = getattr(agent, "iteration_budget", None)
             if iteration_budget is not None and not iteration_budget.consume():
                 pause_candidate_text = current_turn.final_text

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4606,6 +4606,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             _LENGTH_CONTINUATION_NETWORK_STUB,
             _LENGTH_CONTINUATION_OUTPUT_LIMIT,
         )
+        from agent.terminal_continuation import LEGACY_CONTINUATION_NUDGE
 
         return text in {
             COMPRESSION_CONTINUATION_USER_CONTENT,
@@ -4613,6 +4614,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             MAX_ITERATIONS_SUMMARY_REQUEST,
             _CODEX_INCOMPLETE_NUDGE,
             _CODEX_ACK_CONTINUATION_NUDGE,
+            LEGACY_CONTINUATION_NUDGE,
             _DROPPED_TOOLCALL_NUDGE_CONTENT,
             _EMPTY_TOOL_RESPONSE_NUDGE,
             _LENGTH_CONTINUATION_NETWORK_STUB,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1931,6 +1931,7 @@ _SYNTHETIC_USER_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
     "_dropped_toolcall_nudge",
+    "_terminal_continuation_scaffold",
 )
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -826,13 +826,13 @@ _CODEX_INCOMPLETE_NUDGE = (
 )
 
 
-# Re-prompt sent after a Codex/Responses turn ends with an acknowledgment-only
-# reply (no tool calls, no final answer) — named so
-# agent.context_compressor's _is_synthetic_compression_user_turn can
-# recognize it by content the same way it recognizes _CODEX_INCOMPLETE_NUDGE.
-_CODEX_ACK_CONTINUATION_NUDGE = (
-    "[System: Continue now. Execute the required tool calls and only "
-    "send your final answer after completing the task.]"
+# Re-prompt sent after a Codex turn ends with a false-stop response. Imported
+# from the shared policy module so the normal and app-server runtimes cannot
+# drift. The private alias preserves context-compressor content matching.
+from agent.terminal_continuation import (
+    BUDGET_EXHAUSTED_NOTICE as _TERMINAL_CONTINUATION_EXHAUSTED_NOTICE,
+    CONTINUATION_NUDGE as _CODEX_ACK_CONTINUATION_NUDGE,
+    ContinuationReason as _ContinuationReason,
 )
 
 # Re-prompt sent when a provider returns finish_reason="tool_calls" with an
@@ -7322,39 +7322,68 @@ def run_conversation(
                 agent._clear_status_buffer()
 
                 from agent.agent_runtime_helpers import (
+                    classify_codex_terminal,
                     intent_ack_continuation_mode,
                 )
 
                 _ack_mode = intent_ack_continuation_mode(agent)
-                if (
-                    _ack_mode != "off"
-                    and agent.valid_tool_names
-                    and codex_ack_continuations < 2
-                    and agent._looks_like_codex_intermediate_ack(
-                        user_message=user_message,
-                        assistant_content=final_response,
-                        messages=messages,
+                if _ack_mode != "off" and agent.valid_tool_names:
+                    _continuation_reason = classify_codex_terminal(
+                        agent,
+                        user_message,
+                        final_response,
+                        messages,
                         require_workspace=(_ack_mode == "codex_only"),
+                        terminal_completed=True,
+                        finish_reason=finish_reason,
+                        continuation_attempts=codex_ack_continuations,
                     )
-                ):
+                else:
+                    _continuation_reason = _ContinuationReason.NONE
+
+                if _continuation_reason is _ContinuationReason.BUDGET_EXHAUSTED:
+                    final_response = (
+                        f"{final_response.rstrip()}\n\n"
+                        f"{_TERMINAL_CONTINUATION_EXHAUSTED_NOTICE}"
+                    )
+                elif _continuation_reason is not _ContinuationReason.NONE:
                     codex_ack_continuations += 1
-                    interim_msg = agent._build_assistant_message(assistant_message, "incomplete")
+                    interim_msg = agent._build_assistant_message(
+                        assistant_message, "incomplete"
+                    )
+                    interim_msg["_terminal_continuation_scaffold"] = True
                     messages.append(interim_msg)
-                    agent._emit_interim_assistant_message(interim_msg)
+                    interim_msg["_terminal_continuation_previewed"] = bool(
+                        agent._emit_interim_assistant_message(interim_msg)
+                    )
 
                     continue_msg = {
                         "role": "user",
                         "content": _CODEX_ACK_CONTINUATION_NUDGE,
+                        "_terminal_continuation_scaffold": True,
                     }
                     messages.append(continue_msg)
                     agent._session_messages = messages
-                    # An acknowledgment is explicitly non-final. Do not let its
-                    # text suppress iteration-limit summarization if this
-                    # continuation consumes the remaining budget.
+                    # This candidate+nudge pair is recovery scaffolding. It is
+                    # stripped from every durable/exported transcript once the
+                    # retry reaches a true terminal.
                     final_response = None
                     continue
 
-                codex_ack_continuations = 0
+                if any(
+                    isinstance(msg, dict)
+                    and msg.get("_terminal_continuation_scaffold")
+                    for msg in messages
+                ):
+                    messages[:] = [
+                        msg
+                        for msg in messages
+                        if not (
+                            isinstance(msg, dict)
+                            and msg.get("_terminal_continuation_scaffold")
+                        )
+                    ]
+                    agent._session_messages = messages
 
                 if truncated_response_parts:
                     final_response = _join_truncated_parts([*truncated_response_parts, final_response])
@@ -7369,6 +7398,13 @@ def run_conversation(
                 final_response = agent._strip_think_blocks(final_response).strip()
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                if (
+                    _continuation_reason
+                    is _ContinuationReason.BUDGET_EXHAUSTED
+                ):
+                    # Keep exhaustion truthful across resume/replay, not only
+                    # in the immediate delivery payload.
+                    final_msg["content"] = final_response
 
                 # ── Dropped tool-call recovery (copilot/Claude) ────────
                 # Some providers (observed: claude-opus-4.8 / claude-sonnet-4.5

--- a/agent/terminal_continuation.py
+++ b/agent/terminal_continuation.py
@@ -113,6 +113,8 @@ _ALLOWED_FINISH_REASONS = {None, "", "stop", "completed"}
 
 
 class ContinuationReason(str, Enum):
+    # Enum members are singletons in Python; callers intentionally use ``is``
+    # so only this policy's canonical sentinel is treated as no-continuation.
     NONE = "none"
     INITIAL_INTENT_ACK = "initial_intent_ack"
     POST_TOOL_IMMEDIATE_ACTION = "post_tool_immediate_action"

--- a/agent/terminal_continuation.py
+++ b/agent/terminal_continuation.py
@@ -1,0 +1,230 @@
+"""Pure policy for recovering Codex turns that stop while work is unfinished.
+
+This module decides *whether* a native model terminal is a false stop. Runtime
+adapters remain responsible for retry mechanics, transcript hygiene, streaming,
+and accounting. Keeping the classifier pure makes the safety contract directly
+testable and prevents provider adapters from drifting.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Iterable
+
+MAX_TERMINAL_CONTINUATIONS = 2
+
+CONTINUATION_NUDGE = (
+    "[System: Your response says the current task is still incomplete. Continue "
+    "the task now and complete the remaining work, using tools as needed. If "
+    "you are genuinely blocked or waiting for user input, state that explicitly.]"
+)
+
+BUDGET_EXHAUSTED_NOTICE = (
+    "PAUSED — automatic continuation budget exhausted while the response still "
+    "indicated unfinished work. Say ‘continue’ to resume."
+)
+
+_HOUSEKEEPING_TOOLS = {
+    "memory",
+    "todo",
+    "supermemory-save",
+    "supermemory_store",
+}
+
+_ACTION_PATTERN = (
+    r"(?:apply|analy[sz]|bring|build|check|continu|debug|delegate|delete|deploy|"
+    r"execut|finish|find|fix|implement|inspect|install|kick\s+off|launch|"
+    r"look\s+(?:at|into)|migrat|open|patch|port|read|reconcil|report\s+back|"
+    r"rerun|review|run|scan|scaffold|search|set(?:ting)?\s+(?:it\s+)?up|start|"
+    r"summari[sz]|test|updat|verif|writ)\w*"
+)
+_EXECUTION_REQUEST_RE = re.compile(
+    r"\b(?:apply|build|complete|continu|finish|fix|implement|migrat|patch|port|"
+    r"reconcil|updat|writ)\w*\b"
+)
+_REPORT_ONLY_RE = re.compile(r"\b(?:audit|assess|analy[sz]|report|review)\w*\b")
+_ANNOUNCE_RE = re.compile(
+    r"\b(?:i['’]ll|i\s+will|i(?:['’]m|\s+am)\s+going\s+to|"
+    r"let\s+me(?!\s+know)|now\s+let\s+me|going\s+straight\s+to|"
+    r"i\s+can\s+do\s+that|i\s+can\s+help\s+with\s+that|"
+    r"now\s+i['’]ll|now\s+i(?:['’]m|\s+am)(?:\s+going\s+to)?|"
+    r"next,?\s+i['’]ll|next,?\s+i\s+will)\b"
+    r"(?:(?![,.:;!?\n]|\b(?:never|not)\b).){0,80}?\b"
+    + _ACTION_PATTERN
+    + r"\b",
+    re.IGNORECASE,
+)
+_POST_TOOL_PROGRESS_RE = re.compile(
+    r"\b(?:"
+    r"i(?:['’]m|\s+am)\s+now|"
+    r"now\s+i(?:['’]m|\s+am)|"
+    r"next,?\s+i(?:['’]ll|\s+will)|"
+    r"i(?:['’]ll|\s+will)\s+now"
+    r")\s+(?!(?:done|unable|finished|complete)\b)"
+    r"(?:(?![.!?\n])\S+\s+){0,8}"
+    + _ACTION_PATTERN
+    + r"\b",
+    re.IGNORECASE,
+)
+_UNFINISHED_RE = re.compile(
+    r"\b(?:remaining\s+work|unfinished|still\s+failing|tests?\s+(?:are\s+)?"
+    r"still\s+fail|not\s+(?:complete|finished|ready|promotable)|"
+    r"still\s+(?:need|needs|required)|i\s+still\s+need)\b",
+    re.IGNORECASE,
+)
+_BLOCK_OR_WAIT_RE = re.compile(
+    r"\b(?:awaiting\s+(?:approval|confirmation|input)|blocked\s+(?:on|by)|"
+    r"cannot\s+continue|can['’]t\s+continue|need\s+your\s+"
+    r"(?:approval|confirmation|credentials?|input|password|token)|"
+    r"unable\s+to\s+(?:continue|run|execute|access|complete)|"
+    r"waiting\s+(?:for|on)\s+[^.!?\n]{0,100}\b"
+    r"(?:finish|complete|return|result)|"
+    r"(?:build|deploy|job|task|command|process|tests?(?:\s+suite)?)\s+"
+    r"(?:is\s+)?(?:still\s+running|in\s+flight|hasn['’]t\s+returned|"
+    r"has\s+not\s+returned)|"
+    r"process\s+is\s+still\s+running|unavailable\s+(?:dependency|service)|"
+    r"let\s+me\s+know|would\s+you\s+like|if\s+you['’]?d?\s+"
+    r"(?:like|prefer)|if\s+you\s+want|next\s+steps?\s+could\s+include)\b",
+    re.IGNORECASE,
+)
+_REFUSAL_OR_IDIOM_RE = re.compile(
+    r"\b(?:i['’]ll\s+never|i\s+will\s+(?:never|not)|check\s+in(?:\s+with)?|"
+    r"run\s+through|open\s+with|build\s+on|read\s+you|"
+    r"walk\s+you\s+through)\b",
+    re.IGNORECASE,
+)
+_DONE_RE = re.compile(
+    r"\b(?:done|finished|implementation\s+is\s+complete|all\s+tests?\s+pass|"
+    r"requested\s+(?:audit|review|task)\s+is\s+complete)\b",
+    re.IGNORECASE,
+)
+_ALLOWED_FINISH_REASONS = {None, "", "stop", "completed"}
+
+
+class ContinuationReason(str, Enum):
+    NONE = "none"
+    INITIAL_INTENT_ACK = "initial_intent_ack"
+    POST_TOOL_IMMEDIATE_ACTION = "post_tool_immediate_action"
+    POST_TOOL_EXPLICIT_UNFINISHED = "post_tool_explicit_unfinished"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+
+
+@dataclass(frozen=True)
+class ContinuationFacts:
+    runtime: str
+    terminal_completed: bool
+    finish_reason: str | None
+    substantive_tool_count: int
+    assistant_text: str
+    user_text: str
+    workspace_scoped: bool
+    continuation_attempts: int = 0
+    interrupted: bool = False
+    transport_error: bool = False
+    pending_background: bool = False
+    allow_non_codex: bool = False
+
+
+def _tool_name_by_call_id(messages: Iterable[Dict[str, Any]]) -> Dict[str, str]:
+    names: Dict[str, str] = {}
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        for call in message.get("tool_calls") or []:
+            if not isinstance(call, dict):
+                continue
+            call_id = str(call.get("id") or "")
+            function = call.get("function") or {}
+            name = function.get("name") if isinstance(function, dict) else None
+            name = name or call.get("name")
+            if call_id and name:
+                names[call_id] = str(name)
+    return names
+
+
+def count_substantive_tools(messages: Iterable[Dict[str, Any]]) -> int:
+    """Count current-turn tool results, excluding known state-maintenance tools.
+
+    Unknown tool names count as substantive. This avoids disabling recovery for
+    provider-native or newly added execution tools while ensuring todo/memory
+    bookkeeping alone cannot trigger a post-tool continuation.
+    """
+    rows = list(messages)
+    names = _tool_name_by_call_id(rows)
+    count = 0
+    for message in rows:
+        if not isinstance(message, dict) or message.get("role") != "tool":
+            continue
+        call_id = str(message.get("tool_call_id") or "")
+        name = str(message.get("name") or names.get(call_id) or "").lower()
+        if name in _HOUSEKEEPING_TOOLS:
+            continue
+        count += 1
+    return count
+
+
+def _execution_posture(user_text: str) -> bool:
+    text = user_text.lower()
+    if _EXECUTION_REQUEST_RE.search(text):
+        return True
+    return not _REPORT_ONLY_RE.search(text) and bool(_ACTION_PATTERN_RE.search(text))
+
+
+_ACTION_PATTERN_RE = re.compile(r"\b" + _ACTION_PATTERN + r"\b", re.IGNORECASE)
+
+
+def classify_terminal_continuation(facts: ContinuationFacts) -> ContinuationReason:
+    """Return a reasoned continuation decision for a completed native turn."""
+    if (
+        not facts.terminal_completed
+        or facts.interrupted
+        or facts.transport_error
+        or facts.pending_background
+        or (facts.finish_reason or "").lower() not in _ALLOWED_FINISH_REASONS
+    ):
+        return ContinuationReason.NONE
+
+    if not facts.allow_non_codex:
+        if facts.runtime not in {"codex_responses", "codex_app_server"}:
+            return ContinuationReason.NONE
+        if not facts.workspace_scoped:
+            return ContinuationReason.NONE
+
+    text = (facts.assistant_text or "").strip()
+    if not text:
+        return ContinuationReason.NONE
+    lower = text.lower()
+    tail = lower[-2400:]
+
+    if (
+        facts.pending_background
+        or "?" in lower
+        or _BLOCK_OR_WAIT_RE.search(lower)
+        or _REFUSAL_OR_IDIOM_RE.search(lower)
+    ):
+        return ContinuationReason.NONE
+
+    unfinished = bool(_UNFINISHED_RE.search(tail))
+    if _DONE_RE.search(tail) and not unfinished:
+        return ContinuationReason.NONE
+
+    reason = ContinuationReason.NONE
+    if facts.substantive_tool_count <= 0:
+        if len(text) <= 1200 and _ANNOUNCE_RE.search(lower):
+            reason = ContinuationReason.INITIAL_INTENT_ACK
+    elif _POST_TOOL_PROGRESS_RE.search(tail) or _ANNOUNCE_RE.search(tail):
+        reason = ContinuationReason.POST_TOOL_IMMEDIATE_ACTION
+    elif (
+        unfinished
+        and _execution_posture(facts.user_text)
+        and _ACTION_PATTERN_RE.search(tail)
+    ):
+        reason = ContinuationReason.POST_TOOL_EXPLICIT_UNFINISHED
+
+    if reason is not ContinuationReason.NONE and (
+        facts.continuation_attempts >= MAX_TERMINAL_CONTINUATIONS
+    ):
+        return ContinuationReason.BUDGET_EXHAUSTED
+    return reason

--- a/agent/terminal_continuation.py
+++ b/agent/terminal_continuation.py
@@ -21,6 +21,14 @@ CONTINUATION_NUDGE = (
     "you are genuinely blocked or waiting for user input, state that explicitly.]"
 )
 
+# Persisted by the original Codex acknowledgement-recovery path without an
+# ephemeral metadata flag. Keep recognizing it so pre-upgrade sessions do not
+# mistake transport scaffolding for a new human turn after resume/compaction.
+LEGACY_CONTINUATION_NUDGE = (
+    "[System: Continue now. Execute the required tool calls and only send your "
+    "final answer after completing the task.]"
+)
+
 BUDGET_EXHAUSTED_NOTICE = (
     "PAUSED — automatic continuation budget exhausted while the response still "
     "indicated unfinished work. Say ‘continue’ to resume."
@@ -75,7 +83,8 @@ _UNFINISHED_RE = re.compile(
     re.IGNORECASE,
 )
 _BLOCK_OR_WAIT_RE = re.compile(
-    r"\b(?:awaiting\s+(?:approval|confirmation|input)|blocked\s+(?:on|by)|"
+    r"\b(?:wait(?:ing)?\s+(?:for|on)\s+(?:you|your)\b|"
+    r"awaiting\s+(?:approval|confirmation|input)|blocked\s+(?:on|by)|"
     r"cannot\s+continue|can['’]t\s+continue|need\s+your\s+"
     r"(?:approval|confirmation|credentials?|input|password|token)|"
     r"unable\s+to\s+(?:continue|run|execute|access|complete)|"

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -68,6 +68,10 @@ class TurnResult:
     final_text: str = ""
     projected_messages: list[dict] = field(default_factory=list)
     tool_iterations: int = 0
+    # True only after a matching native ``turn/completed`` notification with a
+    # completed (or omitted) status. Deadline-accepted assistant text is usable
+    # as a response but must never authorize an automatic continuation.
+    native_completed: bool = False
     interrupted: bool = False
     error: Optional[str] = None  # Set if turn ended in a non-recoverable error
     turn_id: Optional[str] = None
@@ -736,6 +740,7 @@ class CodexAppServerSession:
                 turn_status = (
                     (note.get("params") or {}).get("turn") or {}
                 ).get("status")
+                result.native_completed = turn_status in {None, "completed"}
                 if turn_status and turn_status not in {"completed", "interrupted"}:
                     err_obj = (
                         (note.get("params") or {}).get("turn") or {}

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -67,6 +67,18 @@ def _drop_verification_continuation_scaffolding(messages) -> None:
     ]
 
 
+def _drop_terminal_continuation_scaffolding(messages) -> None:
+    """Drop both halves of false-stop recovery pairs on every exit path."""
+    messages[:] = [
+        message
+        for message in messages
+        if not (
+            isinstance(message, dict)
+            and message.get("_terminal_continuation_scaffold")
+        )
+    ]
+
+
 def finalize_turn(
     agent,
     *,
@@ -92,9 +104,44 @@ def finalize_turn(
     """
     from agent.conversation_loop import logger
 
+    # False-stop retries use a paired assistant-candidate/user-nudge scaffold.
+    # Capture the latest real checkpoint before removing the retry context so a
+    # non-terminal recovery exit can restore it durably.
+    terminal_continuation_fallback_message = next(
+        (
+            message
+            for message in reversed(messages)
+            if isinstance(message, dict)
+            and message.get("role") == "assistant"
+            and message.get("_terminal_continuation_scaffold")
+            and str(message.get("content") or "").strip()
+        ),
+        None,
+    )
+    terminal_continuation_fallback = (
+        str(terminal_continuation_fallback_message.get("content") or "").strip()
+        if terminal_continuation_fallback_message
+        else None
+    )
+    terminal_continuation_previewed = bool(
+        terminal_continuation_fallback_message
+        and terminal_continuation_fallback_message.get(
+            "_terminal_continuation_previewed"
+        )
+    )
+    _drop_terminal_continuation_scaffolding(messages)
+
     budget_exhausted = (
         api_call_count >= agent.max_iterations
         or agent.iteration_budget.remaining <= 0
+    )
+    final_response_text = str(final_response or "").strip()
+    terminal_continuation_has_no_answer = (
+        not final_response_text
+        or final_response_text == "(empty)"
+        or final_response_text.startswith(
+            "⚠️ The model produced only internal reasoning and no final answer"
+        )
     )
     budget_fallback_eligible = (
         budget_exhausted
@@ -102,11 +149,23 @@ def finalize_turn(
         and not failed
         and str(_turn_exit_reason) in {"unknown", "budget_exhausted"}
     )
-    continuation_budget_exhausted = (
+    pending_verification_fallback = (
         final_response is None
         and bool(_pending_verification_response)
         and budget_fallback_eligible
     )
+    if (
+        terminal_continuation_fallback
+        and terminal_continuation_has_no_answer
+        and not (final_response is None and budget_fallback_eligible)
+    ):
+        final_response = terminal_continuation_fallback
+        messages.append(
+            {"role": "assistant", "content": terminal_continuation_fallback}
+        )
+        if terminal_continuation_previewed:
+            agent._response_was_previewed = True
+    continuation_budget_exhausted = pending_verification_fallback
 
     iteration_limit_fallback = False
     preserved_verification_fallback = False

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -154,15 +154,18 @@ def finalize_turn(
         and bool(_pending_verification_response)
         and budget_fallback_eligible
     )
+    terminal_continuation_restored = False
     if (
         terminal_continuation_fallback
         and terminal_continuation_has_no_answer
         and not (final_response is None and budget_fallback_eligible)
     ):
+        # Defer transcript closure until trailing empty-response scaffolding
+        # has been removed below. Appending here would put the restored
+        # checkpoint after an `_empty_terminal_sentinel`, hiding that sentinel
+        # from the trailing-only cleanup and creating assistant→assistant rows.
         final_response = terminal_continuation_fallback
-        messages.append(
-            {"role": "assistant", "content": terminal_continuation_fallback}
-        )
+        terminal_continuation_restored = True
         if terminal_continuation_previewed:
             agent._response_was_previewed = True
     continuation_budget_exhausted = pending_verification_fallback
@@ -365,7 +368,9 @@ def finalize_turn(
         # Compare content (not just role) so a verification candidate that
         # matches the final response is not duplicated at budget
         # exhaustion. (#65919 §7)
-        if final_response and not interrupted:
+        if final_response and (
+            not interrupted or terminal_continuation_restored
+        ):
             try:
                 _tail = messages[-1] if messages else None
             except Exception:

--- a/run_agent.py
+++ b/run_agent.py
@@ -251,6 +251,8 @@ _EPHEMERAL_SCAFFOLDING_FLAGS = (
     # drive the bounded retry. Persisting them would replay the internal
     # retry instruction as user-authored context on resume.
     "_dropped_toolcall_nudge",
+    # false-stop recovery pair: premature assistant candidate + user nudge
+    "_terminal_continuation_scaffold",
 )
 
 
@@ -1758,11 +1760,17 @@ class AIAgent:
         assistant_content: str,
         messages: List[Dict[str, Any]],
         require_workspace: bool = True,
+        continuation_attempts: int = 0,
     ) -> bool:
         """Forwarder — see ``agent.agent_runtime_helpers.looks_like_codex_intermediate_ack``."""
         from agent.agent_runtime_helpers import looks_like_codex_intermediate_ack
         return looks_like_codex_intermediate_ack(
-            self, user_message, assistant_content, messages, require_workspace
+            self,
+            user_message,
+            assistant_content,
+            messages,
+            require_workspace,
+            continuation_attempts,
         )
 
     def _extract_reasoning(self, assistant_message) -> Optional[str]:
@@ -6343,7 +6351,7 @@ class AIAgent:
 
     def _emit_interim_assistant_message(
         self, assistant_msg: Dict[str, Any]
-    ) -> None:
+    ) -> bool:
         """Surface a real mid-turn assistant commentary message to the UI layer.
 
         Does NOT set ``_response_was_previewed`` — that flag means "the final
@@ -6356,7 +6364,7 @@ class AIAgent:
         """
         cb = getattr(self, "interim_assistant_callback", None)
         if cb is None or not isinstance(assistant_msg, dict):
-            return
+            return False
         commentary_parts = self._extract_codex_interim_visible_parts(assistant_msg)
         undelivered_parts: List[str] = []
         pending_keys: set[str] = set()
@@ -6380,7 +6388,7 @@ class AIAgent:
             or visible == "(empty)"
             or self._interim_text_was_delivered(visible)
         ):
-            return
+            return False
         already_streamed = self._interim_content_was_streamed(visible)
         try:
             cb(visible, already_streamed=already_streamed)
@@ -6389,8 +6397,10 @@ class AIAgent:
                     self._record_delivered_interim_text(part)
             else:
                 self._record_delivered_interim_text(visible)
+            return True
         except Exception:
             logger.debug("interim_assistant_callback error", exc_info=True)
+            return False
 
     def _ensure_stream_writer_state(self) -> None:
         """Lazily create the single-writer guard fields (#65991).

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -239,7 +239,8 @@ def test_codex_recovery_error_stops_and_preserves_real_tool_events():
     durable_text = "\n".join(
         str(message.get("content") or "") for message in result["messages"]
     )
-    assert result["final_response"] == first.final_text
+    assert first.final_text in result["final_response"]
+    assert "PAUSED" in result["final_response"]
     assert "Running tests." in durable_text
     assert "25 failed" in durable_text
     assert "I'm now implementing the remaining" in durable_text
@@ -345,7 +346,8 @@ def test_codex_recovery_interruption_stops_without_third_turn():
     durable_text = "\n".join(
         str(message.get("content") or "") for message in result["messages"]
     )
-    assert result["final_response"] == first.final_text
+    assert first.final_text in result["final_response"]
+    assert "PAUSED" in result["final_response"]
     assert "25 failed" in durable_text
     assert "I'm now implementing the remaining" in durable_text
     assert "still incomplete" not in durable_text
@@ -553,6 +555,71 @@ def test_codex_false_stop_budget_exhaustion_is_visible():
     assert agent._codex_session.run_turn.call_count == 3
     assert "PAUSED" in result["final_response"]
     assert "budget exhausted" in result["final_response"]
+
+
+def test_codex_false_stop_loop_uses_shared_continuation_cap(monkeypatch):
+    from agent import codex_runtime
+
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    monkeypatch.setattr(codex_runtime, "MAX_TERMINAL_CONTINUATIONS", 1, raising=False)
+    session = agent._codex_session
+    session.run_turn.side_effect = [
+        _false_stop_turn("turn-1"),
+        _false_stop_turn("turn-2"),
+    ]
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-shared-cap",
+    )
+
+    assert session.run_turn.call_count == 2
+
+
+def test_codex_partial_retry_error_returns_checkpoint_with_pause_notice():
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    first = _false_stop_turn("turn-1")
+    failed = SimpleNamespace(
+        interrupted=False,
+        native_completed=False,
+        error="transport failed",
+        thread_id="thread-1",
+        turn_id="turn-2",
+        projected_messages=[{"role": "assistant", "content": "partial retry output"}],
+        tool_iterations=0,
+        final_text="partial retry output",
+        should_retire=True,
+        compacted=False,
+    )
+    agent._codex_session.run_turn.side_effect = [first, failed]
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-partial-retry-error",
+    )
+
+    assert result["error"] == "transport failed"
+    assert first.final_text in result["final_response"]
+    assert "PAUSED" in result["final_response"]
+    assert "partial retry output" not in result["final_response"]
 
 
 def test_codex_user_interrupt_is_reported_and_cleared():

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -58,6 +58,7 @@ def _make_agent(session_db=None, session_id="sess-codex"):
     agent._session_db = session_db
     agent._session_db_created = True
     agent.session_id = session_id
+    agent._interrupt_requested = False
     return agent
 
 
@@ -74,6 +75,484 @@ def test_codex_success_flushes_and_reports_persisted():
     assert result["completed"] is True
     # With the agent as sole persister, the gateway must SKIP its DB write.
     assert result["agent_persisted"] is True
+
+
+def test_codex_initial_exception_counts_attempt(monkeypatch):
+    from agent import codex_runtime
+
+    agent = _make_agent(session_db=None)
+    agent._codex_session.run_turn.side_effect = RuntimeError("initial turn crashed")
+    recorded_turns = []
+
+    def record_usage(_agent, turn):
+        recorded_turns.append(getattr(turn, "turn_id", None))
+        return {}
+
+    monkeypatch.setattr(
+        codex_runtime,
+        "_record_codex_app_server_usage",
+        record_usage,
+    )
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-initial-error",
+    )
+
+    assert result["api_calls"] == 1
+    assert result["error"] == "initial turn crashed"
+    assert agent._codex_session is None
+    assert recorded_turns == [None]
+
+
+def test_codex_false_stop_continues_same_app_server_thread(monkeypatch):
+    from agent import codex_runtime
+
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    request = "Continue implementing the fix in /app until tests pass."
+    first = SimpleNamespace(
+        interrupted=False,
+        native_completed=True,
+        error=None,
+        thread_id="thread-1",
+        turn_id="turn-1",
+        projected_messages=[
+            {"role": "assistant", "content": "Running tests.", "tool_calls": [{"id": "t1"}]},
+            {"role": "tool", "tool_call_id": "t1", "content": "25 failed"},
+            {
+                "role": "assistant",
+                "content": "I'm now implementing the remaining workspace fixes and rerunning tests.",
+            },
+        ],
+        tool_iterations=1,
+        final_text="I'm now implementing the remaining workspace fixes and rerunning tests.",
+        should_retire=False,
+        compacted=False,
+    )
+    second = SimpleNamespace(
+        interrupted=False,
+        native_completed=True,
+        error=None,
+        thread_id="thread-1",
+        turn_id="turn-2",
+        projected_messages=[{"role": "assistant", "content": "Implemented and verified: 122 passed."}],
+        tool_iterations=0,
+        final_text="Implemented and verified: 122 passed.",
+        should_retire=False,
+        compacted=False,
+    )
+    agent._codex_session.run_turn.side_effect = [first, second]
+    recorded_turns = []
+    monkeypatch.setattr(
+        codex_runtime,
+        "_record_codex_app_server_usage",
+        lambda _agent, turn: recorded_turns.append(turn.turn_id) or {},
+    )
+    monkeypatch.setattr(
+        codex_runtime,
+        "_record_codex_app_server_compaction",
+        lambda _agent, turn: False,
+    )
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-1",
+    )
+
+    assert agent._codex_session.run_turn.call_count == 2
+    assert agent._codex_session.run_turn.call_args_list[0].kwargs["user_input"] == request
+    assert "still incomplete" in agent._codex_session.run_turn.call_args_list[1].kwargs["user_input"]
+    assert result["final_response"] == second.final_text
+    assert result["api_calls"] == 2
+    assert recorded_turns == ["turn-1", "turn-2"]
+    assert result["messages"][-3:] == first.projected_messages + second.projected_messages
+    durable_text = "\n".join(str(message.get("content") or "") for message in result["messages"])
+    assert "I'm now implementing the remaining" not in durable_text
+    assert "still incomplete" not in durable_text
+
+
+def _false_stop_turn(turn_id: str, *, native_completed: bool = True):
+    text = "I'm now implementing the remaining workspace fixes and rerunning tests."
+    return SimpleNamespace(
+        interrupted=False,
+        native_completed=native_completed,
+        error=None,
+        thread_id="thread-1",
+        turn_id=turn_id,
+        projected_messages=[
+            {"role": "assistant", "content": "Running tests.", "tool_calls": [{"id": f"tool-{turn_id}"}]},
+            {"role": "tool", "tool_call_id": f"tool-{turn_id}", "content": "25 failed"},
+            {"role": "assistant", "content": text},
+        ],
+        tool_iterations=1,
+        final_text=text,
+        should_retire=False,
+        compacted=False,
+    )
+
+
+def test_codex_recovery_error_stops_and_preserves_real_tool_events():
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    first = _false_stop_turn("turn-1")
+    failed = SimpleNamespace(
+        interrupted=False,
+        native_completed=False,
+        error="transport failed",
+        thread_id="thread-1",
+        turn_id="turn-2",
+        projected_messages=[],
+        tool_iterations=0,
+        final_text="",
+        should_retire=True,
+        compacted=False,
+    )
+    agent._codex_session.run_turn.side_effect = [first, failed]
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-error",
+    )
+
+    assert result["api_calls"] == 2
+    assert result["error"] == "transport failed"
+    assert agent._codex_session is None
+    durable_text = "\n".join(
+        str(message.get("content") or "") for message in result["messages"]
+    )
+    assert result["final_response"] == first.final_text
+    assert "Running tests." in durable_text
+    assert "25 failed" in durable_text
+    assert "I'm now implementing the remaining" in durable_text
+    assert "still incomplete" not in durable_text
+    agent._sync_external_memory_for_turn.assert_not_called()
+    agent._spawn_background_review.assert_not_called()
+
+
+def test_codex_recovery_exception_preserves_completed_turn(monkeypatch):
+    from agent import codex_runtime
+
+    agent = _make_agent(session_db=object())
+    agent._flush_messages_to_session_db.return_value = True
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    first = _false_stop_turn("turn-1")
+    session = agent._codex_session
+    session.run_turn.side_effect = [first, RuntimeError("retry crashed")]
+    recorded_turns = []
+
+    def record_usage(_agent, turn):
+        recorded_turns.append(getattr(turn, "turn_id", None))
+        return {}
+
+    monkeypatch.setattr(
+        codex_runtime,
+        "_record_codex_app_server_usage",
+        record_usage,
+    )
+    monkeypatch.setattr(
+        codex_runtime,
+        "_record_codex_app_server_compaction",
+        lambda _agent, turn: False,
+    )
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-exception",
+    )
+
+    assert session.run_turn.call_count == 2
+    assert agent._codex_session is None
+    assert result["api_calls"] == 2
+    assert result["error"] == "retry crashed"
+    assert first.final_text in result["final_response"]
+    durable_text = "\n".join(
+        str(message.get("content") or "") for message in result["messages"]
+    )
+    assert "Running tests." in durable_text
+    assert "25 failed" in durable_text
+    assert first.final_text in durable_text
+    agent._flush_messages_to_session_db.assert_called_once()
+    flushed_messages = agent._flush_messages_to_session_db.call_args.args[0]
+    flushed_text = "\n".join(
+        str(message.get("content") or "") for message in flushed_messages
+    )
+    assert "25 failed" in flushed_text
+    assert first.final_text in flushed_text
+    assert recorded_turns == ["turn-1", None]
+
+
+def test_codex_recovery_interruption_stops_without_third_turn():
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    interrupted = SimpleNamespace(
+        interrupted=True,
+        native_completed=False,
+        error=None,
+        thread_id="thread-1",
+        turn_id="turn-2",
+        projected_messages=[],
+        tool_iterations=0,
+        final_text="",
+        should_retire=False,
+        compacted=False,
+    )
+    first = _false_stop_turn("turn-1")
+    agent._codex_session.run_turn.side_effect = [first, interrupted]
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-interrupt",
+    )
+
+    assert agent._codex_session.run_turn.call_count == 2
+    assert result["completed"] is False
+    assert result["partial"] is True
+    durable_text = "\n".join(
+        str(message.get("content") or "") for message in result["messages"]
+    )
+    assert result["final_response"] == first.final_text
+    assert "25 failed" in durable_text
+    assert "I'm now implementing the remaining" in durable_text
+    assert "still incomplete" not in durable_text
+
+
+def test_codex_user_interrupt_during_empty_recovery_restores_checkpoint():
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    first = _false_stop_turn("turn-1")
+    interrupted_recovery = SimpleNamespace(
+        interrupted=True,
+        native_completed=False,
+        error=None,
+        thread_id="thread-1",
+        turn_id="turn-2",
+        projected_messages=[],
+        tool_iterations=0,
+        final_text="",
+        should_retire=False,
+        compacted=False,
+    )
+
+    def _run_turn(*, user_input):
+        if agent._codex_session.run_turn.call_count == 2:
+            agent._interrupt_requested = True
+        return first if agent._codex_session.run_turn.call_count == 1 else interrupted_recovery
+
+    agent._codex_session.run_turn.side_effect = _run_turn
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-user-interrupt-recovery",
+    )
+
+    assert agent._codex_session.run_turn.call_count == 2
+    assert result["interrupted"] is True
+    assert result["final_response"] == first.final_text
+    durable_text = "\n".join(
+        str(message.get("content") or "") for message in result["messages"]
+    )
+    assert "25 failed" in durable_text
+    assert first.final_text in durable_text
+    assert "still incomplete" not in durable_text
+
+
+def test_codex_deadline_accepted_text_does_not_auto_continue():
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    turn = _false_stop_turn("turn-deadline", native_completed=False)
+    agent._codex_session.run_turn.return_value = turn
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-deadline",
+    )
+
+    assert agent._codex_session.run_turn.call_count == 1
+    assert result["final_response"] == turn.final_text
+
+
+def test_codex_user_interrupt_between_native_turn_and_nudge_stops_recovery():
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    first = _false_stop_turn("turn-interrupt-race")
+    second = SimpleNamespace(
+        interrupted=False,
+        native_completed=True,
+        error=None,
+        thread_id="thread-1",
+        turn_id="turn-should-not-run",
+        projected_messages=[{"role": "assistant", "content": "unexpected"}],
+        tool_iterations=0,
+        final_text="unexpected",
+        should_retire=False,
+        compacted=False,
+    )
+
+    def _run_turn(*, user_input):
+        if agent._codex_session.run_turn.call_count == 1:
+            agent._interrupt_requested = True
+            return first
+        return second
+
+    agent._codex_session.run_turn.side_effect = _run_turn
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-interrupt-race",
+    )
+
+    assert agent._codex_session.run_turn.call_count == 1
+    assert result["interrupted"] is True
+    assert result["final_response"] == first.final_text
+
+
+def test_codex_pause_does_not_overwrite_non_candidate_tool_call_row():
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    turn = _false_stop_turn("turn-projection-mismatch")
+    candidate_text = turn.final_text
+    turn.projected_messages = turn.projected_messages[:-1]
+    tool_call_projection = next(
+        message for message in turn.projected_messages if message.get("tool_calls")
+    )
+    tool_call_projection["content"] = candidate_text
+    agent._codex_session.run_turn.return_value = turn
+    agent.iteration_budget.consume.return_value = False
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-projection-mismatch",
+    )
+
+    assert agent._codex_session.run_turn.call_count == 1
+    tool_call_row = next(
+        message for message in result["messages"] if message.get("tool_calls")
+    )
+    assert tool_call_row["content"] == candidate_text
+    assert tool_call_row.get("tool_calls")
+    assert result["messages"][-1]["role"] == "assistant"
+    assert not result["messages"][-1].get("tool_calls")
+    assert "PAUSED" in result["messages"][-1]["content"]
+
+
+def test_codex_false_stop_respects_outer_iteration_budget():
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    first = _false_stop_turn("turn-budget")
+    agent._codex_session.run_turn.return_value = first
+    agent.iteration_budget.consume.return_value = False
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-no-headroom",
+    )
+
+    assert agent._codex_session.run_turn.call_count == 1
+    assert result["api_calls"] == 1
+    assert "PAUSED" in result["final_response"]
+    assert "PAUSED" in result["messages"][-1]["content"]
+
+
+def test_codex_false_stop_budget_exhaustion_is_visible():
+    agent = _make_agent(session_db=None)
+    agent.api_mode = "codex_app_server"
+    agent.model = "gpt-5.6-terra"
+    agent._intent_ack_continuation = "auto"
+    agent.valid_tool_names = {"terminal"}
+    agent._strip_think_blocks.side_effect = lambda content: content
+    agent._codex_session.run_turn.side_effect = [
+        _false_stop_turn("turn-1"),
+        _false_stop_turn("turn-2"),
+        _false_stop_turn("turn-3"),
+    ]
+    request = "Continue implementing the fix in /app until tests pass."
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=request,
+        original_user_message=request,
+        messages=[{"role": "user", "content": request}],
+        effective_task_id="task-budget",
+    )
+
+    assert agent._codex_session.run_turn.call_count == 3
+    assert "PAUSED" in result["final_response"]
+    assert "budget exhausted" in result["final_response"]
 
 
 def test_codex_user_interrupt_is_reported_and_cleared():

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -20,6 +20,7 @@ from agent.conversation_compression import (
     _ensure_compressed_has_user_turn,
     compress_context,
 )
+from agent.terminal_continuation import CONTINUATION_NUDGE
 from hermes_state import SessionDB
 from tools.todo_tool import TODO_INJECTION_HEADER
 
@@ -270,8 +271,7 @@ def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
             id="codex_incomplete_nudge",
         ),
         pytest.param(
-            "[System: Continue now. Execute the required tool calls and only "
-            "send your final answer after completing the task.]",
+            CONTINUATION_NUDGE,
             id="codex_ack_continuation_nudge",
         ),
         pytest.param(

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -275,6 +275,11 @@ def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
             id="codex_ack_continuation_nudge",
         ),
         pytest.param(
+            "[System: Continue now. Execute the required tool calls and only "
+            "send your final answer after completing the task.]",
+            id="codex_ack_continuation_nudge_legacy",
+        ),
+        pytest.param(
             "Your previous turn indicated a tool call but none was "
             "included. Do not narrate a plan or restate intent — issue "
             "the actual tool call now to continue the task.",

--- a/tests/agent/test_intent_ack_continuation.py
+++ b/tests/agent/test_intent_ack_continuation.py
@@ -14,11 +14,15 @@ gates relate, not snapshots of the marker lists.
 from types import SimpleNamespace
 from typing import Union
 
+import pytest
+
 from agent.agent_runtime_helpers import (
+    classify_codex_terminal,
     intent_ack_continuation_enabled,
     intent_ack_continuation_mode,
     looks_like_codex_intermediate_ack,
 )
+from agent.terminal_continuation import CONTINUATION_NUDGE, ContinuationReason
 
 
 def _agent(
@@ -75,6 +79,7 @@ def test_missing_attr_defaults_to_auto():
 def test_enabled_is_mode_not_off():
     assert intent_ack_continuation_enabled(_agent(True, "chat_completions")) is True
     assert intent_ack_continuation_enabled(_agent("auto", "codex_responses")) is True
+    assert intent_ack_continuation_enabled(_agent("auto", "codex_app_server")) is True
     assert intent_ack_continuation_enabled(_agent("auto", "chat_completions")) is False
     assert intent_ack_continuation_enabled(_agent(False, "codex_responses")) is False
 
@@ -116,8 +121,256 @@ def test_all_path_drops_workspace_requirement():
     )
 
 
-# ── detector: guardrails that hold regardless of workspace ───────────────────
+def test_historical_tool_does_not_disable_current_turn_ack():
+    """Old tool history must not permanently disable the per-turn guard."""
+    a = _agent("auto", "codex_responses")
+    msgs = [
+        {"role": "user", "content": "Check /tmp/old.txt"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "old"}]},
+        {"role": "tool", "tool_call_id": "old", "content": "done"},
+        {"role": "assistant", "content": "The old check is complete."},
+        {"role": "user", "content": CODE_USER},
+    ]
 
+    assert looks_like_codex_intermediate_ack(
+        a, CODE_USER, CODE_ACK, msgs, require_workspace=True
+    )
+
+
+def test_synthetic_nudge_does_not_reset_current_turn_tool_evidence():
+    a = _agent("auto", "codex_responses")
+    request = "Continue implementing the fix in /app until tests pass."
+    checkpoint = (
+        "The candidate is not promotable. Remaining work: implement the "
+        "workspace fix and rerun the failing tests."
+    )
+    messages = [
+        {"role": "user", "content": request},
+        {"role": "assistant", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "25 failed"},
+        {
+            "role": "assistant",
+            "content": "I'm now implementing the remaining workspace fix.",
+            "_terminal_continuation_scaffold": True,
+        },
+        {
+            "role": "user",
+            "content": CONTINUATION_NUDGE,
+            "_terminal_continuation_scaffold": True,
+        },
+    ]
+
+    assert classify_codex_terminal(
+        a,
+        request,
+        checkpoint,
+        messages,
+        continuation_attempts=1,
+    ) is ContinuationReason.POST_TOOL_EXPLICIT_UNFINISHED
+
+
+def test_other_synthetic_user_rows_do_not_reset_current_turn_tool_evidence():
+    a = _agent("auto", "codex_responses")
+    request = "Continue implementing the fix in /app until tests pass."
+    checkpoint = (
+        "The candidate is not promotable. Remaining work: implement the "
+        "workspace fix and rerun the failing tests."
+    )
+    messages = [
+        {"role": "user", "content": request},
+        {"role": "assistant", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "25 failed"},
+        {
+            "role": "user",
+            "content": "Run the required verification before finishing.",
+            "_verification_stop_synthetic": True,
+        },
+    ]
+
+    assert classify_codex_terminal(
+        a,
+        request,
+        checkpoint,
+        messages,
+        continuation_attempts=1,
+    ) is ContinuationReason.POST_TOOL_EXPLICIT_UNFINISHED
+
+
+def test_codex_post_tool_progressive_action_is_not_terminal():
+    """A Codex model must not end after announcing its next concrete action."""
+    a = _agent("auto", "codex_responses")
+    msgs = [
+        {"role": "user", "content": "Continue implementing the fix in /app"},
+        {"role": "assistant", "content": "Running focused tests.", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "51 passed"},
+    ]
+    progress = (
+        "The focused tests pass. I'm now porting the remaining workspace checks "
+        "and rerunning the suite."
+    )
+
+    assert looks_like_codex_intermediate_ack(
+        a,
+        "Continue implementing the fix in /app",
+        progress,
+        msgs,
+        require_workspace=True,
+    )
+
+
+def test_codex_explicit_unfinished_checkpoint_is_not_terminal():
+    """A stopped checkpoint with actionable remaining work must continue."""
+    a = _agent("auto", "codex_responses")
+    request = "Continue implementing the local fix in /app until the tests pass."
+    msgs = [
+        {"role": "user", "content": request},
+        {"role": "assistant", "content": "Running the suite.", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "25 failed, 97 passed"},
+    ]
+    checkpoint = (
+        "I have stopped at that verified local checkpoint; there is no background "
+        "process running. The candidate is not promotable. Remaining work: implement "
+        "workspace release lifecycle and rerun the failing tests."
+    )
+
+    assert looks_like_codex_intermediate_ack(
+        a, request, checkpoint, msgs, require_workspace=True
+    )
+
+
+def test_post_tool_checkpoint_waiting_for_approval_is_terminal():
+    a = _agent("auto", "codex_responses")
+    request = "Continue implementing the local fix in /app."
+    msgs = [
+        {"role": "user", "content": request},
+        {"role": "assistant", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "ready"},
+    ]
+    checkpoint = (
+        "I have stopped at this checkpoint. Remaining work requires a production "
+        "restart, and I need your approval before continuing."
+    )
+
+    assert not looks_like_codex_intermediate_ack(
+        a, request, checkpoint, msgs, require_workspace=True
+    )
+
+
+def test_review_only_checkpoint_report_is_terminal():
+    a = _agent("auto", "codex_responses")
+    request = "Audit the candidate in /app and report its readiness."
+    msgs = [
+        {"role": "user", "content": request},
+        {"role": "assistant", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "25 failed"},
+    ]
+    report = (
+        "I have stopped at the verified checkpoint. The candidate is not promotable. "
+        "Remaining work belongs to the implementation phase."
+    )
+
+    assert not looks_like_codex_intermediate_ack(
+        a, request, report, msgs, require_workspace=True
+    )
+
+
+def test_post_tool_signoff_is_terminal():
+    a = _agent("auto", "codex_responses")
+    request = "Review the code in /app."
+    msgs = [
+        {"role": "user", "content": request},
+        {"role": "assistant", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "done"},
+    ]
+
+    assert not looks_like_codex_intermediate_ack(
+        a,
+        request,
+        "The review is complete. Let me know if you'd like me to implement the fix.",
+        msgs,
+        require_workspace=True,
+    )
+
+
+def test_unfinished_checkpoint_without_current_tool_is_terminal():
+    a = _agent("auto", "codex_responses")
+    request = "Continue implementing the fix in /app."
+    msgs = [{"role": "user", "content": request}]
+    checkpoint = "I have stopped at this checkpoint. Remaining work is not complete."
+
+    assert not looks_like_codex_intermediate_ack(
+        a, request, checkpoint, msgs, require_workspace=True
+    )
+
+
+# Adapted from the adversarial false-positive corpus in PR #69779. These are
+# terminal conversational/approval/refusal responses, not executable promises.
+@pytest.mark.parametrize(
+    "content",
+    [
+        "Let me know if you'd like me to inspect the repository files.",
+        "I'll deploy it, but let me know if you'd prefer another approach.",
+        "Would you like me to deploy it now?",
+        "I'll admit, building rapport with a new team takes time.",
+        "I'll never run that command on production.",
+        "I will never delete your data without asking.",
+        "I'll be brief\nrun the tests when you are ready.",
+        "I'll run through my reasoning first.",
+        "I'll open with a quick summary.",
+        "Let me build on your earlier point.",
+        "Let me read you the key line.",
+        "Now I'll walk you through the tradeoffs.",
+        "I'll check in with you next week.",
+        "Now I am done reviewing the code and everything runs.",
+        "Now I am unable to run the tests because docker is down.",
+    ],
+)
+def test_conversational_or_waiting_prose_is_terminal(content):
+    a = _agent(True, "chat_completions")
+    assert not looks_like_codex_intermediate_ack(
+        a,
+        "Help me plan the repository work.",
+        content,
+        [{"role": "user", "content": "Help me plan the repository work."}],
+        require_workspace=False,
+    )
+
+
+def test_compatibility_wrapper_honors_explicit_recovery_budget():
+    agent = _agent("auto", "codex_responses", "gpt-5.6-terra")
+    messages = [{"role": "user", "content": CODE_USER}]
+
+    assert looks_like_codex_intermediate_ack(
+        agent,
+        CODE_USER,
+        CODE_ACK,
+        messages,
+        continuation_attempts=0,
+    )
+    assert not looks_like_codex_intermediate_ack(
+        agent,
+        CODE_USER,
+        CODE_ACK,
+        messages,
+        continuation_attempts=2,
+    )
+
+
+def test_agent_compatibility_forwarder_carries_recovery_budget():
+    from run_agent import AIAgent
+
+    agent = _agent("auto", "codex_responses", "gpt-5.6-terra")
+    messages = [{"role": "user", "content": CODE_USER}]
+    assert not AIAgent._looks_like_codex_intermediate_ack(
+        agent,
+        CODE_USER,
+        CODE_ACK,
+        messages,
+        continuation_attempts=2,
+    )
+
+
+# ── detector: guardrails that hold regardless of workspace ───────────────────
 
 
 

--- a/tests/agent/test_intent_ack_continuation.py
+++ b/tests/agent/test_intent_ack_continuation.py
@@ -169,6 +169,34 @@ def test_synthetic_nudge_does_not_reset_current_turn_tool_evidence():
     ) is ContinuationReason.POST_TOOL_EXPLICIT_UNFINISHED
 
 
+def test_legacy_nudge_does_not_reset_current_turn_tool_evidence():
+    a = _agent("auto", "codex_responses")
+    request = "Continue implementing the fix in /app until tests pass."
+    checkpoint = (
+        "The candidate is not promotable. Remaining work: implement the "
+        "workspace fix and rerun the failing tests."
+    )
+    legacy_nudge = (
+        "[System: Continue now. Execute the required tool calls and only send "
+        "your final answer after completing the task.]"
+    )
+    messages = [
+        {"role": "user", "content": request},
+        {"role": "assistant", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "25 failed"},
+        {"role": "assistant", "content": "I'm now implementing the remaining fix."},
+        {"role": "user", "content": legacy_nudge},
+    ]
+
+    assert classify_codex_terminal(
+        a,
+        request,
+        checkpoint,
+        messages,
+        continuation_attempts=1,
+    ) is ContinuationReason.POST_TOOL_EXPLICIT_UNFINISHED
+
+
 def test_other_synthetic_user_rows_do_not_reset_current_turn_tool_evidence():
     a = _agent("auto", "codex_responses")
     request = "Continue implementing the fix in /app until tests pass."

--- a/tests/agent/test_terminal_continuation.py
+++ b/tests/agent/test_terminal_continuation.py
@@ -167,6 +167,7 @@ def test_blockers_approval_credentials_questions_and_waits_are_terminal():
         "Waiting for the build to finish. I'm now deploying the remaining changes.",
         "The deploy is in flight; next I'll run the remaining checks.",
         "The background job hasn't returned yet. I'm now applying the next patch.",
+        "Applied the change. Next, I'll wait for your review before deploying.",
         "I am blocked by an unavailable external dependency.",
         "Would you like me to update the README?",
         "Let me know if you want me to run more tests.",

--- a/tests/agent/test_terminal_continuation.py
+++ b/tests/agent/test_terminal_continuation.py
@@ -1,0 +1,231 @@
+"""Pure terminal-continuation policy tests.
+
+The classifier owns *whether* a completed model turn should continue. Runtime
+loops own *how* to retry and how to keep retry scaffolding ephemeral.
+"""
+
+from agent.terminal_continuation import (
+    ContinuationFacts,
+    ContinuationReason,
+    classify_terminal_continuation,
+    count_substantive_tools,
+)
+
+
+def _facts(**overrides):
+    values = {
+        "runtime": "codex_responses",
+        "terminal_completed": True,
+        "finish_reason": "stop",
+        "substantive_tool_count": 0,
+        "assistant_text": "I'll inspect the repository now.",
+        "user_text": "Inspect the repository in /app and fix the issue.",
+        "workspace_scoped": True,
+        "continuation_attempts": 0,
+        "interrupted": False,
+        "transport_error": False,
+        "pending_background": False,
+    }
+    values.update(overrides)
+    return ContinuationFacts(**values)
+
+
+def test_initial_intent_ack_is_reasoned():
+    assert classify_terminal_continuation(_facts()) is ContinuationReason.INITIAL_INTENT_ACK
+
+
+def test_post_tool_immediate_action_is_reasoned():
+    facts = _facts(
+        substantive_tool_count=2,
+        assistant_text=(
+            "The focused tests pass. I'm now porting the remaining workspace "
+            "checks and rerunning the suite."
+        ),
+    )
+    assert (
+        classify_terminal_continuation(facts)
+        is ContinuationReason.POST_TOOL_IMMEDIATE_ACTION
+    )
+
+
+def test_long_post_tool_unfinished_tail_is_reasoned():
+    summary = "Completed checks. " + ("Evidence and analysis. " * 150)
+    tail = (
+        "Tests are still failing and this is not promotable. Remaining work: "
+        "fix workspace release handling and rerun the suite."
+    )
+    facts = _facts(
+        substantive_tool_count=3,
+        assistant_text=summary + tail,
+        user_text="Continue implementing the fix in /app until it is complete.",
+    )
+    assert (
+        classify_terminal_continuation(facts)
+        is ContinuationReason.POST_TOOL_EXPLICIT_UNFINISHED
+    )
+
+
+def test_audit_report_with_remaining_work_is_terminal():
+    facts = _facts(
+        substantive_tool_count=3,
+        assistant_text=(
+            "The candidate is not promotable. Remaining work: fix workspace "
+            "release handling and rerun the suite."
+        ),
+        user_text="Audit the candidate in /app and report what remains.",
+    )
+    assert classify_terminal_continuation(facts) is ContinuationReason.NONE
+
+
+def test_unfinished_text_without_substantive_tool_is_terminal():
+    facts = _facts(
+        substantive_tool_count=0,
+        assistant_text="Remaining work: fix the release path and rerun tests.",
+    )
+    assert classify_terminal_continuation(facts) is ContinuationReason.NONE
+
+
+def test_housekeeping_tools_do_not_count_as_substantive():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "todo-1", "function": {"name": "todo", "arguments": "{}"}},
+                {"id": "mem-1", "function": {"name": "memory", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "todo-1", "content": "updated"},
+        {"role": "tool", "tool_call_id": "mem-1", "content": "saved"},
+    ]
+    assert count_substantive_tools(messages) == 0
+
+
+def test_unknown_and_execution_tools_count_as_substantive():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "term-1",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "term-1", "content": "tests passed"},
+        {"role": "tool", "tool_call_id": "unknown-1", "content": "result"},
+    ]
+    assert count_substantive_tools(messages) == 2
+
+
+def test_historical_tools_are_excluded_by_current_turn_slice():
+    history = [
+        {"role": "assistant", "tool_calls": [{"id": "old", "function": {"name": "terminal"}}]},
+        {"role": "tool", "tool_call_id": "old", "content": "old result"},
+        {"role": "user", "content": "New task in /app"},
+    ]
+    current_turn = history[3:]
+    assert count_substantive_tools(current_turn) == 0
+
+
+def test_budget_exhaustion_has_explicit_reason():
+    facts = _facts(continuation_attempts=2)
+    assert classify_terminal_continuation(facts) is ContinuationReason.BUDGET_EXHAUSTED
+
+
+def test_terminal_state_guards_precede_lexical_detection():
+    assert (
+        classify_terminal_continuation(_facts(terminal_completed=False))
+        is ContinuationReason.NONE
+    )
+    assert (
+        classify_terminal_continuation(_facts(interrupted=True))
+        is ContinuationReason.NONE
+    )
+    assert (
+        classify_terminal_continuation(_facts(transport_error=True))
+        is ContinuationReason.NONE
+    )
+    assert (
+        classify_terminal_continuation(_facts(finish_reason="length"))
+        is ContinuationReason.NONE
+    )
+    assert (
+        classify_terminal_continuation(_facts(finish_reason="content_filter"))
+        is ContinuationReason.NONE
+    )
+    assert (
+        classify_terminal_continuation(_facts(pending_background=True))
+        is ContinuationReason.NONE
+    )
+
+
+def test_blockers_approval_credentials_questions_and_waits_are_terminal():
+    endings = [
+        "I need your approval before I update production.",
+        "I need your deployment token before I can continue.",
+        "The process is still running; waiting for completion.",
+        "Waiting for the build to finish. I'm now deploying the remaining changes.",
+        "The deploy is in flight; next I'll run the remaining checks.",
+        "The background job hasn't returned yet. I'm now applying the next patch.",
+        "I am blocked by an unavailable external dependency.",
+        "Would you like me to update the README?",
+        "Let me know if you want me to run more tests.",
+    ]
+    for text in endings:
+        assert (
+            classify_terminal_continuation(
+                _facts(substantive_tool_count=1, assistant_text=text)
+            )
+            is ContinuationReason.NONE
+        )
+
+
+def test_early_safety_boundary_is_not_hidden_by_long_actionable_tail():
+    assistant_text = (
+        "I need your approval and deployment token before touching production. "
+        + ("Evidence and analysis. " * 160)
+        + "Next, I'll run the migration and finish the remaining work."
+    )
+    facts = _facts(
+        substantive_tool_count=3,
+        assistant_text=assistant_text,
+        user_text="Continue implementing the migration in /app until complete.",
+    )
+    assert classify_terminal_continuation(facts) is ContinuationReason.NONE
+
+
+def test_genuine_completion_and_optional_next_steps_are_terminal():
+    endings = [
+        "Done; all tests pass and the implementation is complete.",
+        "The requested audit is complete. Next steps could include refactoring.",
+        "I will not delete production data.",
+    ]
+    for text in endings:
+        assert (
+            classify_terminal_continuation(
+                _facts(substantive_tool_count=1, assistant_text=text)
+            )
+            is ContinuationReason.NONE
+        )
+
+
+def test_non_codex_or_non_workspace_auto_scope_is_terminal():
+    assert (
+        classify_terminal_continuation(_facts(runtime="chat_completions"))
+        is ContinuationReason.NONE
+    )
+    assert (
+        classify_terminal_continuation(_facts(workspace_scoped=False))
+        is ContinuationReason.NONE
+    )
+
+
+def test_app_server_uses_same_policy_only_after_native_completion():
+    facts = _facts(runtime="codex_app_server")
+    assert classify_terminal_continuation(facts) is ContinuationReason.INITIAL_INTENT_ACK
+    assert (
+        classify_terminal_continuation(
+            _facts(runtime="codex_app_server", terminal_completed=False)
+        )
+        is ContinuationReason.NONE
+    )

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -277,6 +277,107 @@ def test_no_answer_sentinel_restores_latest_continuation_checkpoint(
     }
 
 
+def test_restored_checkpoint_follows_trailing_terminal_sentinel_cleanup(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent._response_was_previewed = False
+
+    def drop_trailing_scaffolding(messages):
+        while messages and messages[-1].get("_empty_terminal_sentinel"):
+            messages.pop()
+
+    agent._drop_trailing_empty_response_scaffolding = drop_trailing_scaffolding
+    checkpoint = "I'm now fixing the remaining tests."
+    messages = [
+        {"role": "user", "content": "finish the work"},
+        {
+            "role": "assistant",
+            "content": checkpoint,
+            "_terminal_continuation_scaffold": True,
+        },
+        {
+            "role": "user",
+            "content": "continue",
+            "_terminal_continuation_scaffold": True,
+        },
+        {
+            "role": "assistant",
+            "content": "(empty)",
+            "_empty_terminal_sentinel": True,
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="(empty)",
+        api_call_count=2,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="finish the work",
+        original_user_message="finish the work",
+        _should_review_memory=False,
+        _turn_exit_reason="empty_response_exhausted",
+    )
+
+    assert result["final_response"] == checkpoint
+    assert result["messages"] == [
+        {"role": "user", "content": "finish the work"},
+        {"role": "assistant", "content": checkpoint},
+    ]
+    assert agent.persisted_messages == result["messages"]
+    assert not any(
+        message.get("_empty_terminal_sentinel")
+        for message in result["messages"]
+    )
+
+
+def test_interrupted_restored_checkpoint_closes_user_tail_after_cleanup(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent._response_was_previewed = False
+    checkpoint = "I'm now fixing the remaining tests."
+    messages = [
+        {"role": "user", "content": "finish the work"},
+        {
+            "role": "assistant",
+            "content": checkpoint,
+            "_terminal_continuation_scaffold": True,
+        },
+        {
+            "role": "user",
+            "content": "continue",
+            "_terminal_continuation_scaffold": True,
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=2,
+        interrupted=True,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="finish the work",
+        original_user_message="finish the work",
+        _should_review_memory=False,
+        _turn_exit_reason="interrupted",
+    )
+
+    assert result["final_response"] == checkpoint
+    assert result["messages"] == [
+        {"role": "user", "content": "finish the work"},
+        {"role": "assistant", "content": checkpoint},
+    ]
+    assert agent.persisted_messages == result["messages"]
+
+
 @pytest.mark.parametrize(
     ("failed", "interrupted"),
     [(True, False), (False, True)],

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from agent.turn_finalizer import finalize_turn
 
 
@@ -126,6 +128,208 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
     assert result["messages"][-1] == {"role": "assistant", "content": "Done."}
     assert agent.persisted_messages is not None
     assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}
+
+
+def test_nonterminal_retry_exit_restores_latest_continuation_checkpoint(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent._response_was_previewed = False
+    checkpoint = "I'm now fixing the remaining tests."
+    messages = [
+        {"role": "user", "content": "finish the work"},
+        {
+            "role": "assistant",
+            "content": checkpoint,
+            "_terminal_continuation_scaffold": True,
+        },
+        {
+            "role": "user",
+            "content": "continue",
+            "_terminal_continuation_scaffold": True,
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=2,
+        interrupted=False,
+        failed=True,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="finish the work",
+        original_user_message="finish the work",
+        _should_review_memory=False,
+        _turn_exit_reason="empty_response_exhausted",
+    )
+
+    assert result["completed"] is False
+    assert result["response_previewed"] is False
+    assert result["final_response"] == checkpoint
+    assert result["messages"][-1] == {"role": "assistant", "content": checkpoint}
+    assert agent.persisted_messages is not None
+    assert agent.persisted_messages[-1] == {"role": "assistant", "content": checkpoint}
+    assert not any(
+        message.get("_terminal_continuation_scaffold")
+        for message in result["messages"]
+        if isinstance(message, dict)
+    )
+
+
+def test_restored_checkpoint_preserves_proven_interim_delivery(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent._response_was_previewed = False
+    checkpoint = "I'm now fixing the remaining tests."
+    messages = [
+        {"role": "user", "content": "finish the work"},
+        {
+            "role": "assistant",
+            "content": checkpoint,
+            "_terminal_continuation_scaffold": True,
+            "_terminal_continuation_previewed": True,
+        },
+        {
+            "role": "user",
+            "content": "continue",
+            "_terminal_continuation_scaffold": True,
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=2,
+        interrupted=False,
+        failed=True,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="finish the work",
+        original_user_message="finish the work",
+        _should_review_memory=False,
+        _turn_exit_reason="empty_response_exhausted",
+    )
+
+    assert result["final_response"] == checkpoint
+    assert result["response_previewed"] is True
+    assert result["messages"][-1] == {"role": "assistant", "content": checkpoint}
+
+
+@pytest.mark.parametrize(
+    "sentinel",
+    [
+        "(empty)",
+        (
+            "⚠️ The model produced only internal reasoning and no final answer, "
+            "despite retries. Its last reasoning, which may contain the answer:\n\n"
+            "I should continue."
+        ),
+    ],
+)
+def test_no_answer_sentinel_restores_latest_continuation_checkpoint(
+    monkeypatch, sentinel
+):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent._response_was_previewed = False
+    checkpoint = "I'm now fixing the remaining tests."
+    messages = [
+        {"role": "user", "content": "finish the work"},
+        {
+            "role": "assistant",
+            "content": checkpoint,
+            "_terminal_continuation_scaffold": True,
+        },
+        {
+            "role": "user",
+            "content": "continue",
+            "_terminal_continuation_scaffold": True,
+        },
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=sentinel,
+        api_call_count=2,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="finish the work",
+        original_user_message="finish the work",
+        _should_review_memory=False,
+        _turn_exit_reason="empty_response_exhausted",
+    )
+
+    assert result["final_response"] == checkpoint
+    assert result["response_previewed"] is False
+    assert result["messages"][-1] == {"role": "assistant", "content": checkpoint}
+    assert agent.persisted_messages is not None
+    assert agent.persisted_messages[-1] == {
+        "role": "assistant",
+        "content": checkpoint,
+    }
+
+
+@pytest.mark.parametrize(
+    ("failed", "interrupted"),
+    [(True, False), (False, True)],
+)
+def test_newer_recovery_text_wins_over_stale_checkpoint(
+    monkeypatch, failed, interrupted
+):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent._response_was_previewed = False
+    checkpoint = "I'm now fixing the remaining tests."
+    newer = "The recovery completed a newer partial result."
+    messages = [
+        {"role": "user", "content": "finish the work"},
+        {
+            "role": "assistant",
+            "content": checkpoint,
+            "_terminal_continuation_scaffold": True,
+            "_terminal_continuation_previewed": True,
+        },
+        {
+            "role": "user",
+            "content": "continue",
+            "_terminal_continuation_scaffold": True,
+        },
+        {"role": "assistant", "content": newer},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=newer,
+        api_call_count=2,
+        interrupted=interrupted,
+        failed=failed,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="finish the work",
+        original_user_message="finish the work",
+        _should_review_memory=False,
+        _turn_exit_reason="interrupted" if interrupted else "recovery_failed",
+    )
+
+    assert result["final_response"] == newer
+    assert result["response_previewed"] is False
+    assert result["messages"][-1] == {"role": "assistant", "content": newer}
+    assert not any(
+        message.get("_terminal_continuation_scaffold")
+        for message in result["messages"]
+        if isinstance(message, dict)
+    )
+    assert all(message.get("content") != checkpoint for message in result["messages"])
 
 
 def test_final_response_fills_pure_tool_call_tail(monkeypatch):

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -279,6 +279,46 @@ class TestRunTurn:
         ]
 
 
+    def test_stale_completion_on_same_thread_does_not_complete_active_turn(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "turn-stale-001",
+                "status": "completed",
+                "error": None,
+            },
+        )
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-fake-001",
+            turnId="turn-fake-001",
+            item={
+                "type": "agentMessage",
+                "id": "active-message",
+                "text": "active turn complete",
+            },
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "turn-fake-001",
+                "status": "completed",
+                "error": None,
+            },
+        )
+
+        result = make_session(client).run_turn("continue", turn_timeout=2.0)
+
+        assert result.turn_id == "turn-fake-001"
+        assert result.native_completed is True
+        assert result.final_text == "active turn complete"
+        assert result.projected_messages == [
+            {"role": "assistant", "content": "active turn complete"}
+        ]
+
 
     def test_tool_iteration_counter_ticks(self):
         client = FakeClient()
@@ -704,6 +744,26 @@ class TestSessionRetirement:
 
 
 
+    def test_native_interrupted_status_is_not_native_completion(self):
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m1", "text": "partial"},
+            threadId="t",
+            turnId="tu1",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "interrupted", "error": None},
+        )
+        result = make_session(client).run_turn("hi", turn_timeout=1.0)
+
+        assert result.final_text == "partial"
+        assert result.interrupted is False
+        assert result.native_completed is False
+
+
     def test_final_agent_message_without_turn_completed_is_recovered(self):
         """A completed assistant item is still a usable terminal response when
         codex omits turn/completed and then goes quiet.
@@ -722,6 +782,7 @@ class TestSessionRetirement:
             notification_poll_timeout=0.01,
         )
         assert r.final_text == "done"
+        assert r.native_completed is False
         assert r.interrupted is False
         assert r.error is None
         assert r.should_retire is False
@@ -795,6 +856,7 @@ class TestSessionRetirement:
         # Should NOT be a retirement case.
         assert r.tool_iterations == 1
         assert r.final_text == "tool finished"
+        assert r.native_completed is True
         assert r.should_retire is False
         assert r.interrupted is False
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1574,8 +1574,11 @@ def test_interim_commentary_is_not_marked_already_streamed_without_callbacks(mon
         {"text": text, "already_streamed": already_streamed}
     )
 
-    agent._emit_interim_assistant_message({"role": "assistant", "content": "short version: yes"})
+    delivered = agent._emit_interim_assistant_message(
+        {"role": "assistant", "content": "short version: yes"}
+    )
 
+    assert delivered is True
     assert observed == {
         "text": "short version: yes",
         "already_streamed": False,

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -122,6 +122,89 @@ def test_intermediate_ack_uses_summary_instead_of_premature_text(agent, monkeypa
     assert result["final_response"] == "verified summary."
     assert result["turn_exit_reason"] == "max_iterations_reached(1/1)"
     agent._handle_max_iterations.assert_called_once()
+    assert not any(
+        isinstance(message, dict)
+        and message.get("_terminal_continuation_scaffold")
+        for message in result["messages"]
+    )
+    transcript_text = "\n".join(
+        str(message.get("content") or "") for message in result["messages"]
+    )
+    assert "I'll inspect the files now" not in transcript_text
+    assert "still incomplete" not in transcript_text
+
+
+def test_terminal_continuation_budget_exhaustion_is_visible(agent, monkeypatch):
+    agent.max_iterations = 3
+    agent.iteration_budget.max_total = 3
+    agent.valid_tool_names = ["web_search"]
+    agent._intent_ack_continuation = True
+    answers = iter([_response("I'll inspect the files now") for _ in range(3)])
+    agent._interruptible_api_call = lambda _kwargs: next(answers)
+    delivered = []
+    agent.interim_assistant_callback = lambda text, **_kw: delivered.append(text)
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=False),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("inspect /tmp/project")
+
+    assert result["api_calls"] == 3
+    assert result["response_previewed"] is False
+    assert delivered == ["I'll inspect the files now"]
+    assert all("PAUSED" not in text for text in delivered)
+    assert "PAUSED" in result["final_response"]
+    assert "budget exhausted" in result["final_response"]
+    assert not any(
+        isinstance(message, dict)
+        and message.get("_terminal_continuation_scaffold")
+        for message in result["messages"]
+    )
+    assert [message["role"] for message in result["messages"]] == [
+        "user",
+        "assistant",
+    ]
+    assert "PAUSED" in result["messages"][-1]["content"]
+    assert "budget exhausted" in result["messages"][-1]["content"]
+
+
+def test_verification_rounds_share_original_turn_continuation_budget(
+    agent, monkeypatch
+):
+    """Synthetic verification rounds must not reset the human-turn cap."""
+    agent.max_iterations = 6
+    agent.iteration_budget.max_total = 6
+    agent.valid_tool_names = ["web_search"]
+    agent._intent_ack_continuation = True
+    agent._looks_like_codex_intermediate_ack = MagicMock(return_value=True)
+    answers = iter(
+        [
+            _response("I'll inspect the files now"),
+            _response("candidate one"),
+            _response("I'll inspect the files now"),
+            _response("candidate two"),
+            _response("I'll inspect the files now"),
+            _response("candidate three"),
+        ]
+    )
+    agent._interruptible_api_call = lambda _kwargs: next(answers)
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "1")
+
+    with (
+        patch(
+            "agent.verification_stop.build_verify_on_stop_nudge",
+            side_effect=["verify it", "verify it", None],
+        ),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("inspect /tmp/project")
+
+    assert result["api_calls"] == 5
+    assert "PAUSED" in result["final_response"]
+    assert "budget exhausted" in result["final_response"]
+    assert "candidate three" not in result["final_response"]
 
 
 def test_later_verified_response_supersedes_pending_report(agent, monkeypatch):


### PR DESCRIPTION
## Problem

Hermes can accept a provider-returned progress checkpoint as a completed turn even when the response explicitly promises more work or says the task remains unfinished. This can stop tool-driven tasks prematurely.

The existing recovery paths do not consistently cover:

- post-tool progress checkpoints;
- verification or synthetic rounds sharing one human-turn budget;
- Codex Responses and Codex app-server parity;
- native app-server completion identity and stale completion notifications;
- persistence and restoration ordering after bounded recovery.

## Changes

- Add a shared pure terminal-continuation policy for Codex runtimes.
- Cap recovery at two automatic continuations per original human turn; verification and synthetic rounds share that cap.
- Require trusted native `turn/completed` identity before app-server recovery.
- Keep recovery scaffolding ephemeral while preserving genuine tool projections and strict role alternation.
- Persist an explicit `PAUSED` notice when recovery or iteration budgets are exhausted.
- Preserve the latest valid checkpoint without letting stale restored text overwrite newer recovery output.
- Keep the legacy acknowledgement-nudge literal synthetic during resume and compaction so pre-upgrade transcripts remain compatible.
- Treat explicit waits for the user or the user's review as terminal rather than spending a recovery attempt.
- Consolidate duplicate app-server pause/projection paths into local helpers.

## Safety boundaries

Automatic recovery does not run through:

- user interruption;
- approval, confirmation, credential, or password requests;
- questions or explicit user-input waits;
- active background jobs or processes;
- transport errors, invalid finish reasons, or untrusted/stale app-server completion events;
- genuine completion or refusal language.

Recovery remains bounded and consumes the app-server iteration budget. No tools, environment variables, prompt mutations, external telemetry, or provider-specific credentials are introduced.

## Verification

Against current `main` (`a1bfbccc02d5bfdaef1568facfca2cc1456c59f0`):

- Ruff: pass (one unrelated pre-existing invalid-`noqa` warning in `run_agent.py`).
- `py_compile`: pass.
- `git diff --check`: pass.
- Changed-path suite: **178 passed**.
- Adjacent Codex runtime/transport/app-server/TUI suite: **184 passed**.
- Full `tests/run_agent`: **1,498 passed, 4 skipped, 2 deselected**.
- Secret/private-instance scan: no findings.

One earlier broad candidate run observed an order-dependent credential-pool mock failure. The failing test collects before this PR's changed `tests/run_agent` files; it passed alone and in paired isolation, the clean-base full suite passed in the same environment, and two later full candidate runs passed. No candidate-adjacent causal path was found.

## Related work and credit

This reconciles the false-stop family covered by:

- #69778 / #69779 — current-turn acknowledgement detection and adversarial false-positive corpus, by @ClaySecAI;
- #78113 — bounded narrated-continuation detection, by @yingliang-zhang;
- #57610 — post-tool progress placeholders, by @ithelpm.

The adversarial corpus adaptation remains credited in test comments. This PR is intended as one architectural reconciliation rather than a novelty claim; the authors above are explicitly invited to review whether their reported scenarios are covered.

Closes #69778 if maintainers agree this shared bounded policy supersedes the narrower open implementations.
