### PR TITLE
feat(whatsapp): optionally mark self-chat replies unread after sending

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1552,6 +1552,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "send_read_receipts" in platform_cfg:
                     bridged["send_read_receipts"] = platform_cfg["send_read_receipts"]
+                if "mark_sent_unread" in platform_cfg:
+                    bridged["mark_sent_unread"] = platform_cfg["mark_sent_unread"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:
                     bridged["allowed_chats"] = platform_cfg["allowed_chats"]
                 if plat == Platform.TELEGRAM and "group_allowed_chats" in platform_cfg:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -455,6 +455,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             read_receipts if isinstance(read_receipts, bool)
             else str(read_receipts or "").strip().lower() in {"1", "true", "yes", "on"}
         )
+        mark_sent_unread = config.extra.get("mark_sent_unread", False)
+        self._mark_sent_unread = (
+            mark_sent_unread if isinstance(mark_sent_unread, bool)
+            else str(mark_sent_unread or "").strip().lower() in {"1", "true", "yes", "on"}
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -684,6 +689,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
                 "true" if self._send_read_receipts else "false"
+            )
+            bridge_env["WHATSAPP_MARK_SENT_UNREAD"] = (
+                "true" if self._mark_sent_unread else "false"
             )
             # Under multiplexing, the bridge subprocess runs with a copy of
             # os.environ that does NOT contain the secondary profile's .env

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -44,6 +44,7 @@ import {
   inboundReadReceiptKeys,
   inferMediaType,
   mediaPayloadForFile,
+  outboundUnreadTarget,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
@@ -83,6 +84,17 @@ const SEND_READ_RECEIPTS =
   process.env &&
   typeof process.env.WHATSAPP_SEND_READ_RECEIPTS === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_SEND_READ_RECEIPTS.toLowerCase());
+
+// Opt-in: in self-chat mode, mark the self-chat unread again after Hermes
+// successfully sends a reply. Self-chat replies come from the user's own
+// linked account, so WhatsApp leaves the conversation read and async
+// deliveries (cron reminders, briefings) are easy to miss. Default off,
+// preserving current behavior.
+const MARK_SENT_UNREAD =
+  typeof process !== 'undefined' &&
+  process.env &&
+  typeof process.env.WHATSAPP_MARK_SENT_UNREAD === 'string' &&
+  ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_MARK_SENT_UNREAD.toLowerCase());
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
@@ -833,6 +845,7 @@ app.post('/send', async (req, res) => {
   try {
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
+    let lastSent;
     for (let i = 0; i < chunks.length; i += 1) {
       const { content: payload, options } = buildTextSendPayload(chunks[i], {
         chatId,
@@ -843,8 +856,25 @@ app.post('/send', async (req, res) => {
       trackSentMessageId(sent);
       messageStore.remember(sent);
       if (sent?.key?.id) messageIds.push(sent.key.id);
+      lastSent = sent;
       if (chunks.length > 1 && i < chunks.length - 1) {
         await sleep(CHUNK_DELAY_MS);
+      }
+    }
+
+    const unreadTarget = outboundUnreadTarget({
+      mode: WHATSAPP_MODE,
+      enabled: MARK_SENT_UNREAD,
+      sentMessage: lastSent,
+    });
+    if (unreadTarget) {
+      try {
+        await sock.chatModify({ markRead: false, lastMessages: [unreadTarget] }, chatId);
+        console.log(`[bridge] sent_chat_marked_unread id=${unreadTarget.key.id}`);
+      } catch (err) {
+        // Send already succeeded; don't turn an unread-marking failure into
+        // a delivery failure.
+        console.warn('[bridge] failed to mark chat unread after send:', err.message);
       }
     }
 

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -506,6 +506,13 @@ export function inboundReadReceiptKeys({ key, enabled }) {
   return [key];
 }
 
+export function outboundUnreadTarget({ mode, enabled, sentMessage }) {
+  // Only self-chat mode shares a number with the recipient, so only there
+  // does an outgoing send leave WhatsApp's own read state to fix up.
+  if (!enabled || mode !== 'self-chat' || !sentMessage?.key?.id) return null;
+  return sentMessage;
+}
+
 export function mediaPayloadForFile({ buffer, filePath, mediaType, caption, fileName }) {
   const ext = filePath.toLowerCase().split('.').pop();
   const type = mediaType || inferMediaType(ext);

--- a/scripts/whatsapp-bridge/outbound_unread.test.mjs
+++ b/scripts/whatsapp-bridge/outbound_unread.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { outboundUnreadTarget } from './bridge_helpers.js';
+
+function makeSentMessage(id = 'sent-1') {
+  return { key: { id, remoteJid: '15551234567@s.whatsapp.net', fromMe: true } };
+}
+
+test('marks unread only in self-chat mode when enabled', () => {
+  const sentMessage = makeSentMessage();
+  assert.equal(
+    outboundUnreadTarget({ mode: 'self-chat', enabled: true, sentMessage }),
+    sentMessage,
+  );
+});
+
+test('bot mode never marks unread, even when enabled', () => {
+  const sentMessage = makeSentMessage();
+  assert.equal(
+    outboundUnreadTarget({ mode: 'bot', enabled: true, sentMessage }),
+    null,
+  );
+});
+
+test('disabled by default preserves current behavior', () => {
+  const sentMessage = makeSentMessage();
+  assert.equal(
+    outboundUnreadTarget({ mode: 'self-chat', enabled: false, sentMessage }),
+    null,
+  );
+});
+
+test('no-op when there is no sent message to target', () => {
+  assert.equal(
+    outboundUnreadTarget({ mode: 'self-chat', enabled: true, sentMessage: undefined }),
+    null,
+  );
+  assert.equal(
+    outboundUnreadTarget({ mode: 'self-chat', enabled: true, sentMessage: {} }),
+    null,
+  );
+});

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -54,6 +54,7 @@ def _make_adapter():
     adapter._bridge_process = None
     adapter._reply_prefix = None
     adapter._send_read_receipts = False
+    adapter._mark_sent_unread = False
     adapter._running = False
     adapter._message_handler = None
     adapter._fatal_error_code = None

--- a/tests/gateway/test_whatsapp_reply_prefix.py
+++ b/tests/gateway/test_whatsapp_reply_prefix.py
@@ -6,6 +6,8 @@ Covers:
 - Bridge subprocess receiving WHATSAPP_REPLY_PREFIX env var
 - config.yaml whatsapp.send_read_receipts bridging into PlatformConfig.extra
 - WhatsAppAdapter parsing send_read_receipts as a boolean
+- config.yaml whatsapp.mark_sent_unread bridging into PlatformConfig.extra
+- WhatsAppAdapter parsing mark_sent_unread as a boolean
 - Config version covers all ENV_VARS_BY_VERSION keys (regression guard)
 """
 
@@ -67,6 +69,20 @@ class TestConfigYamlBridging:
         assert wa_config is not None
         assert wa_config.extra.get("reply_prefix") == ""
 
+    def test_mark_sent_unread_bridged_from_yaml(self, tmp_path):
+        """whatsapp.mark_sent_unread in config.yaml sets PlatformConfig.extra."""
+        config_yaml = tmp_path / "config.yaml"
+        config_yaml.write_text("whatsapp:\n  mark_sent_unread: true\n")
+
+        with patch("gateway.config.get_hermes_home", return_value=tmp_path):
+            from gateway.config import load_gateway_config
+            with patch.dict("os.environ", {"WHATSAPP_ENABLED": "true"}, clear=False):
+                config = load_gateway_config()
+
+        wa_config = config.platforms.get(Platform.WHATSAPP)
+        assert wa_config is not None
+        assert wa_config.extra.get("mark_sent_unread") is True
+
 
 # ---------------------------------------------------------------------------
 # WhatsAppAdapter __init__
@@ -81,6 +97,25 @@ class TestAdapterInit:
         config = PlatformConfig(enabled=True, extra={"reply_prefix": "Bot\\n"})
         adapter = WhatsAppAdapter(config)
         assert adapter._reply_prefix == "Bot\\n"
+
+    def test_mark_sent_unread_defaults_off(self):
+        """Default off, preserving current behavior (per issue #83467)."""
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+        adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter._mark_sent_unread is False
+
+    def test_mark_sent_unread_from_extra(self):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+        config = PlatformConfig(enabled=True, extra={"mark_sent_unread": True})
+        adapter = WhatsAppAdapter(config)
+        assert adapter._mark_sent_unread is True
+
+    def test_mark_sent_unread_from_string_extra(self):
+        """Truthy-string extras (as YAML strings) coerce to bool, like send_read_receipts."""
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+        config = PlatformConfig(enabled=True, extra={"mark_sent_unread": "true"})
+        adapter = WhatsAppAdapter(config)
+        assert adapter._mark_sent_unread is True
 
 
 class TestReadReceiptPolicyOrdering:

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -54,6 +54,7 @@ def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
     adapter._bridge_process = None
     adapter._reply_prefix = None
     adapter._send_read_receipts = False
+    adapter._mark_sent_unread = False
     adapter._running = False
     adapter._message_handler = None
     adapter._fatal_error_code = None
@@ -188,6 +189,7 @@ class TestCacheDirEnvPassthrough:
             session_path=tmp_path / "session",
         )
         adapter._send_read_receipts = True
+        adapter._mark_sent_unread = True
         mock_proc = MagicMock()
         mock_proc.poll.return_value = 1
         mock_proc.returncode = 1
@@ -211,3 +213,4 @@ class TestCacheDirEnvPassthrough:
         assert env["HERMES_AUDIO_CACHE_DIR"] == str(get_audio_cache_dir())
         assert env["HERMES_DOCUMENT_CACHE_DIR"] == str(get_document_cache_dir())
         assert env["WHATSAPP_SEND_READ_RECEIPTS"] == "true"
+        assert env["WHATSAPP_MARK_SENT_UNREAD"] == "true"

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -188,6 +188,8 @@ When `send_read_receipts` is `true`, the adapter marks policy-accepted inbound m
 
 In **self-chat mode**, Hermes' replies and scheduled-job deliveries are sent from your own linked account, so WhatsApp leaves the conversation read — easy to miss an async cron reminder or briefing. Set `mark_sent_unread: true` to have the bridge mark the self-chat unread again immediately after a successful send. This only applies in self-chat mode (bot-mode replies are genuinely incoming on the recipient's phone) and only creates the unread indicator — it does not guarantee a push notification. Disabled by default, preserving current behavior.
 
+`mark_sent_unread` marks the whole conversation unread, which also reverses the effect of `send_read_receipts: true` on the inbound message that triggered the reply — the message you just marked read becomes unread again. If you run both settings together in self-chat mode, expect the chat to end up unread after each reply.
+
 ---
 
 ## Message Formatting & Delivery

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -181,9 +181,12 @@ whatsapp:
   reply_prefix: ""                          # Empty string disables the header
   # reply_prefix: "🤖 *My Bot*\n──────\n"  # Custom prefix (supports \n for newlines)
   send_read_receipts: false                 # Mark accepted inbound messages as read (blue ticks)
+  mark_sent_unread: false                   # Self-chat mode: mark the chat unread after Hermes replies
 ```
 
 When `send_read_receipts` is `true`, the adapter marks policy-accepted inbound messages as read after DM/group/mention filtering passes. Rejected messages (e.g., from non-allowlisted senders) are not marked read. Disabled by default for privacy. Changing this setting automatically restarts the bridge subprocess on the next connection.
+
+In **self-chat mode**, Hermes' replies and scheduled-job deliveries are sent from your own linked account, so WhatsApp leaves the conversation read — easy to miss an async cron reminder or briefing. Set `mark_sent_unread: true` to have the bridge mark the self-chat unread again immediately after a successful send. This only applies in self-chat mode (bot-mode replies are genuinely incoming on the recipient's phone) and only creates the unread indicator — it does not guarantee a push notification. Disabled by default, preserving current behavior.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

In WhatsApp `self-chat` mode, Hermes' replies and scheduled-job deliveries are sent from the user's own linked account, so WhatsApp treats them as outgoing and leaves the conversation read. Async messages — cron reminders, briefings — are easy to miss because there's no unread indicator.

This adds an opt-in `mark_sent_unread` setting. When enabled, and only in `self-chat` mode, the Baileys bridge marks the chat unread again immediately after a successful text send, using the exact final `WAMessage` returned by `sock.sendMessage` (including for chunked replies). Default is off, so existing deployments see no behavior change. A `chatModify` failure is logged but never turns an already-successful send into a reported delivery failure.

This is distinct from `send_read_receipts`, which governs whether *inbound* messages get marked read — this setting is about the outbound side.

## Related Issue

Fixes #83467

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `scripts/whatsapp-bridge/bridge_helpers.js` — new pure helper `outboundUnreadTarget({ mode, enabled, sentMessage })` that decides whether/what to mark unread (self-chat mode + enabled + a real sent message).
- `scripts/whatsapp-bridge/bridge.js` — reads opt-in `WHATSAPP_MARK_SENT_UNREAD` env var; after `/send` completes (all chunks), calls `sock.chatModify({ markRead: false, lastMessages: [lastSent] }, chatId)` when the helper says to, wrapped in try/catch so a `chatModify` failure never fails the response.
- `plugins/platforms/whatsapp/adapter.py` — parses `mark_sent_unread` from `config.extra` (bool or truthy string, mirroring `send_read_receipts`) and passes it to the bridge subprocess as `WHATSAPP_MARK_SENT_UNREAD`.
- `gateway/config.py` — bridges `mark_sent_unread` from `config.yaml` platform blocks into `PlatformConfig.extra`, same as the existing `send_read_receipts` bridging.
- `website/docs/user-guide/messaging/whatsapp.md` — documents the new `config.yaml` setting next to `send_read_receipts`.
- Tests: a new JS unit test for the pure helper (`outbound_unread.test.mjs`), plus Python tests for config.yaml bridging, adapter parsing, and bridge-subprocess env passthrough.

## How to Test

1. Set `whatsapp: { mark_sent_unread: true }` in `config.yaml` with `WHATSAPP_MODE=self-chat`.
2. Message the self-chat, or let a cron job deliver to it.
3. After Hermes' reply sends, the self-chat shows unread again even though it came from the same account.
4. With the setting left at its default (unset/false), or in `bot` mode, behavior is unchanged — nothing is marked unread.

### Automated tests

JS (pure helper, no live socket needed):
```
$ cd scripts/whatsapp-bridge && node --test outbound_unread.test.mjs
▶ marks unread only in self-chat mode when enabled
▶ bot mode never marks unread, even when enabled
▶ disabled by default preserves current behavior
▶ no-op when there is no sent message to target
# pass 4
# fail 0
```

Python (`scripts/run_tests.sh tests/gateway/test_whatsapp_reply_prefix.py tests/gateway/test_whatsapp_stale_bridge.py tests/gateway/test_whatsapp_connect.py`):
```
=== Summary: 3 files, 23 tests passed, 0 failed, 2 skipped (100% complete) ===
```

Verified both new test suites fail without their respective source changes (`git checkout HEAD~1 -- <file>`, confirmed red, then restored) before pushing.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the test suite and all relevant tests pass
- [x] I've added tests for my changes
- [x] Tested path: Linux (bridge behavior verified via unit tests against the pure helper + subprocess env-passthrough tests, not a live WhatsApp session)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/messaging/whatsapp.md`)
- [ ] `cli-config.yaml.example` — N/A (existing sibling setting `send_read_receipts` isn't documented there either; per-platform `extra` keys live in the platform docs page)
- [ ] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — bridge subprocess env var, no OS-specific code
- [ ] Tool descriptions/schemas — N/A (no model tool changed)

---

Note: this change was authored with AI assistance (Claude Code), with all diffs reviewed and tests verified locally before submission.
