### PR TITLE
fix(update): warn when a failed dependency reinstall breaks the hermes launcher

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8558,7 +8558,7 @@ def _install_python_dependencies_with_optional_fallback(
 
     try:
         _install(["install", "-e", "."])
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
         _warn_if_hermes_launcher_broken()
         raise
 
@@ -8712,10 +8712,17 @@ def _warn_if_hermes_launcher_broken() -> None:
         "    This usually means files under the venv are not writable by the "
         "current user (for example, a previous update or install ran under sudo)."
     )
-    print(f"    Check ownership with: ls -la {scripts_dir}")
-    print(
-        f"    If it's owned by another user, fix it with: sudo chown -R \"$(id -un)\" {scripts_dir.parent}"
-    )
+    if _is_windows():
+        print(f"    Check permissions with: icacls {scripts_dir}")
+        print(
+            "    If it's not writable by the current user, take ownership with: "
+            f"takeown /r /d y /f {scripts_dir.parent}"
+        )
+    else:
+        print(f"    Check ownership with: ls -la {scripts_dir}")
+        print(
+            f"    If it's owned by another user, fix it with: sudo chown -R \"$(id -un)\" {scripts_dir.parent}"
+        )
     print("    Then re-run `hermes update` (or the setup script) to reinstall.")
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8714,7 +8714,7 @@ def _warn_if_hermes_launcher_broken() -> None:
     )
     print(f"    Check ownership with: ls -la {scripts_dir}")
     print(
-        f"    If it's owned by another user, fix it with: sudo chown -R \"$(id -un)\" {scripts_dir.parent.parent}"
+        f"    If it's owned by another user, fix it with: sudo chown -R \"$(id -un)\" {scripts_dir.parent}"
     )
     print("    Then re-run `hermes update` (or the setup script) to reinstall.")
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8556,7 +8556,11 @@ def _install_python_dependencies_with_optional_fallback(
             "  ⚠ Optional extras failed, reinstalling base dependencies and retrying extras individually..."
         )
 
-    _install(["install", "-e", "."])
+    try:
+        _install(["install", "-e", "."])
+    except subprocess.CalledProcessError:
+        _warn_if_hermes_launcher_broken()
+        raise
 
     failed_extras: list[str] = []
     installed_extras: list[str] = []
@@ -8678,6 +8682,41 @@ def _verify_console_scripts_installed(
         )
     else:
         print("  ✓ All console entry points restored")
+
+
+def _warn_if_hermes_launcher_broken() -> None:
+    """Surface a broken ``hermes`` launcher the moment an install fails.
+
+    ``_verify_console_scripts_installed`` only runs after a successful (or
+    warned-but-continuing) install, and only on Windows. On POSIX, ``uv``/pip
+    can still remove the old ``venv/bin/hermes`` shim before failing to write
+    its replacement — most commonly because the venv is not fully writable by
+    the current user (e.g. an earlier ``sudo hermes update``). The generic
+    "Update failed: Command ... exit status N" message that follows gives no
+    hint that the CLI itself is now unusable, so check on every platform
+    right after a failed base install and, if a shim is gone, say so (#83529).
+    """
+    scripts_dir = _venv_scripts_dir()
+    if scripts_dir is None:
+        return
+    missing = [
+        name
+        for name in _load_console_script_names()
+        if not (scripts_dir / name).is_file() and not (scripts_dir / f"{name}.exe").is_file()
+    ]
+    if not missing:
+        return
+    print()
+    print(f"  ✗ The `hermes` command is now broken: missing {', '.join(missing)} in {scripts_dir}")
+    print(
+        "    This usually means files under the venv are not writable by the "
+        "current user (for example, a previous update or install ran under sudo)."
+    )
+    print(f"    Check ownership with: ls -la {scripts_dir}")
+    print(
+        f"    If it's owned by another user, fix it with: sudo chown -R \"$(id -un)\" {scripts_dir.parent.parent}"
+    )
+    print("    Then re-run `hermes update` (or the setup script) to reinstall.")
 
 
 def _verify_core_dependencies_installed(

--- a/tests/hermes_cli/test_verify_console_scripts.py
+++ b/tests/hermes_cli/test_verify_console_scripts.py
@@ -117,6 +117,24 @@ class TestWarnIfHermesLauncherBroken:
 
         assert capsys.readouterr().out == ""
 
+    def test_warns_with_windows_appropriate_remedy_on_windows(
+        self, temp_pyproject, fake_scripts_dir, capsys
+    ):
+        (fake_scripts_dir / "hermes-agent").write_bytes(b"fake")
+        (fake_scripts_dir / "hermes-acp").write_bytes(b"fake")
+
+        with patch("hermes_cli.main._venv_scripts_dir", return_value=fake_scripts_dir), \
+             patch("hermes_cli.main._is_windows", return_value=True):
+            from hermes_cli.main import _warn_if_hermes_launcher_broken
+
+            _warn_if_hermes_launcher_broken()
+
+        out = capsys.readouterr().out
+        assert "ls -la" not in out
+        assert "chown" not in out
+        assert "icacls" in out
+        assert "takeown" in out
+
 
 class TestInstallPythonDependenciesWithOptionalFallback:
     """The base-install retry used to be unguarded — a failure here skipped
@@ -156,3 +174,42 @@ class TestInstallPythonDependenciesWithOptionalFallback:
         assert warned == [True]
         # First attempt was `.[all]`, second (unguarded) was bare `.`.
         assert len(calls) == 2
+
+    def test_base_install_oserror_warns_before_reraising(
+        self, temp_pyproject, fake_scripts_dir, monkeypatch
+    ):
+        """A permission error on file writes (not just a non-zero exit) must
+        also trigger the launcher-broken warning, not just CalledProcessError."""
+        import subprocess
+
+        import hermes_cli.main as main_mod
+
+        (fake_scripts_dir / "hermes-agent").write_bytes(b"fake")
+        (fake_scripts_dir / "hermes-acp").write_bytes(b"fake")
+
+        calls: list[list[str]] = []
+
+        def fake_run_quarantined_install(cmd, *, env=None, scripts_dir=None):
+            calls.append(cmd)
+            if len(calls) == 1:
+                # First attempt (`.[all]`) fails normally, falling through to
+                # the unguarded bare-`.` retry below.
+                raise subprocess.CalledProcessError(2, cmd)
+            raise PermissionError("[Errno 13] Permission denied")
+
+        warned = []
+        monkeypatch.setattr(main_mod, "_is_windows", lambda: False)
+        monkeypatch.setattr(main_mod, "_venv_scripts_dir", lambda: fake_scripts_dir)
+        monkeypatch.setattr(
+            main_mod, "_run_quarantined_install", fake_run_quarantined_install
+        )
+        monkeypatch.setattr(
+            main_mod,
+            "_warn_if_hermes_launcher_broken",
+            lambda: warned.append(True),
+        )
+
+        with pytest.raises(PermissionError):
+            main_mod._install_python_dependencies_with_optional_fallback(["uv", "pip"])
+
+        assert warned == [True]

--- a/tests/hermes_cli/test_verify_console_scripts.py
+++ b/tests/hermes_cli/test_verify_console_scripts.py
@@ -66,3 +66,92 @@ class TestVerifyConsoleScriptsInstalled:
 
         assert {"hermes.exe", "hermes-agent.exe", "hermes-acp.exe"} <= names
         assert "hermes-gateway.exe" in names
+
+
+class TestWarnIfHermesLauncherBroken:
+    """Tests for _warn_if_hermes_launcher_broken (issue #83529).
+
+    A failed base install on POSIX (permission-denied venv files, most often
+    from a prior privileged run) can delete ``venv/bin/hermes`` before
+    failing to write its replacement, leaving the CLI unusable with no
+    indication why. This warning must fire on every platform, not just
+    Windows.
+    """
+
+    def test_no_warning_when_all_shims_present(
+        self, temp_pyproject, fake_scripts_dir, capsys
+    ):
+        for name in ("hermes", "hermes-agent", "hermes-acp"):
+            (fake_scripts_dir / name).write_bytes(b"fake")
+
+        with patch("hermes_cli.main._venv_scripts_dir", return_value=fake_scripts_dir):
+            from hermes_cli.main import _warn_if_hermes_launcher_broken
+
+            _warn_if_hermes_launcher_broken()
+
+        assert capsys.readouterr().out == ""
+
+    def test_warns_when_hermes_shim_missing_on_posix(
+        self, temp_pyproject, fake_scripts_dir, capsys
+    ):
+        # hermes shim missing entirely; the other two survived.
+        (fake_scripts_dir / "hermes-agent").write_bytes(b"fake")
+        (fake_scripts_dir / "hermes-acp").write_bytes(b"fake")
+
+        with patch("hermes_cli.main._venv_scripts_dir", return_value=fake_scripts_dir):
+            from hermes_cli.main import _warn_if_hermes_launcher_broken
+
+            _warn_if_hermes_launcher_broken()
+
+        out = capsys.readouterr().out
+        assert "broken" in out
+        assert "hermes" in out
+        assert "chown" in out
+
+    def test_no_action_when_not_running_from_a_venv(self, temp_pyproject, capsys):
+        with patch("hermes_cli.main._venv_scripts_dir", return_value=None):
+            from hermes_cli.main import _warn_if_hermes_launcher_broken
+
+            _warn_if_hermes_launcher_broken()
+
+        assert capsys.readouterr().out == ""
+
+
+class TestInstallPythonDependenciesWithOptionalFallback:
+    """The base-install retry used to be unguarded — a failure here skipped
+    straight past every recovery check (#83529)."""
+
+    def test_base_install_failure_warns_before_reraising(
+        self, temp_pyproject, fake_scripts_dir, monkeypatch
+    ):
+        import subprocess
+
+        import hermes_cli.main as main_mod
+
+        (fake_scripts_dir / "hermes-agent").write_bytes(b"fake")
+        (fake_scripts_dir / "hermes-acp").write_bytes(b"fake")
+
+        calls: list[list[str]] = []
+
+        def fake_run_quarantined_install(cmd, *, env=None, scripts_dir=None):
+            calls.append(cmd)
+            raise subprocess.CalledProcessError(2, cmd)
+
+        warned = []
+        monkeypatch.setattr(main_mod, "_is_windows", lambda: False)
+        monkeypatch.setattr(main_mod, "_venv_scripts_dir", lambda: fake_scripts_dir)
+        monkeypatch.setattr(
+            main_mod, "_run_quarantined_install", fake_run_quarantined_install
+        )
+        monkeypatch.setattr(
+            main_mod,
+            "_warn_if_hermes_launcher_broken",
+            lambda: warned.append(True),
+        )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            main_mod._install_python_dependencies_with_optional_fallback(["uv", "pip"])
+
+        assert warned == [True]
+        # First attempt was `.[all]`, second (unguarded) was bare `.`.
+        assert len(calls) == 2

--- a/tests/hermes_cli/test_verify_console_scripts.py
+++ b/tests/hermes_cli/test_verify_console_scripts.py
@@ -106,7 +106,8 @@ class TestWarnIfHermesLauncherBroken:
         out = capsys.readouterr().out
         assert "broken" in out
         assert "hermes" in out
-        assert "chown" in out
+        chown_line = next(line for line in out.splitlines() if "chown" in line)
+        assert chown_line.endswith(f'sudo chown -R "$(id -un)" {fake_scripts_dir.parent}')
 
     def test_no_action_when_not_running_from_a_venv(self, temp_pyproject, capsys):
         with patch("hermes_cli.main._venv_scripts_dir", return_value=None):


### PR DESCRIPTION
## What does this PR do?

`hermes update` reinstalls Python dependencies with `uv pip install -e .[...]`, falling back to a bare `.[` install if the `[all]` extra fails. On POSIX, that bare fallback call was the *only* unguarded install attempt in `_install_python_dependencies_with_optional_fallback` — if it raised, the exception went straight to `cmd_update`'s generic handler, which prints `✗ Update failed: Command ... returned non-zero exit status 2` and exits. Nothing checks whether the install failure left the `hermes` launcher shim (`venv/bin/hermes`) actually missing.

That's exactly what happened in #83529: a permission-denied error removing a file under the venv's `dist-info` (most consistent with venv files not being writable by the current user — e.g. a previous `sudo hermes update`) caused `uv` to remove the old entry-point shim before failing to write its replacement. The user was left with a completely broken `hermes` command and zero indication of what happened or how to fix it — the update "destroyed" the CLI.

The existing `_verify_console_scripts_installed` check already handles the analogous Windows failure mode (from #52931), but it only runs *after* a successful/warned install and is gated to `_is_windows()` only, so it doesn't help here.

This adds a small, cross-platform check that runs the moment the previously-unguarded base install fails: `_warn_if_hermes_launcher_broken()` looks for the declared `[project.scripts]` entry points (`hermes`, `hermes-agent`, `hermes-acp`) in the venv's bin dir, and if any are gone, prints a clear diagnosis (venv likely not writable by the current user) and a concrete remedy (`chown` the venv, then re-run update) before re-raising so the existing error path and exit code are unchanged.

This does not attempt to repair the permission problem itself (that's environment-specific and out of scope for a CLI to fix silently) — it turns a silent, unexplained "your `hermes` command doesn't work anymore" into an explained, actionable failure.

**Update:** review caught that the printed `chown` remedy targeted `scripts_dir.parent.parent` — the entire project checkout (`.git`, config, logs, everything) — instead of `scripts_dir.parent`, the venv directory the diagnosis text actually describes. A user copy-pasting the original remedy would have recursively `chown`'d their whole source tree. Fixed to target the venv, and `test_warns_when_hermes_shim_missing_on_posix` now asserts the exact `chown` target (not just that the word "chown" appears) so this can't silently regress.

## Related Issue

Fixes #83529

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: wrap the previously-unguarded base install call in `_install_python_dependencies_with_optional_fallback` in `try/except`; add `_warn_if_hermes_launcher_broken()`, which checks the venv's bin dir for the declared console-script shims and prints a diagnosis + remedy if any are missing, on every platform (not just Windows).
- `tests/hermes_cli/test_verify_console_scripts.py`: added `TestWarnIfHermesLauncherBroken` (the new helper: no-op when shims are present or not running from a venv, warns with actionable text when a shim is missing) and `TestInstallPythonDependenciesWithOptionalFallback` (confirms the warning fires and the original exception still propagates when the base install fails).

## How to Test

1. Reproduce the failure shape: mock the base install to raise `subprocess.CalledProcessError` while `venv/bin/hermes` is missing from the target scripts dir.
2. Before this fix, the failure propagates silently with no mention that the `hermes` command itself is now broken — confirmed by checking out `hermes_cli/main.py` at the prior commit and re-running the new tests; they fail with `AttributeError`/`ImportError` because `_warn_if_hermes_launcher_broken` doesn't exist yet.
3. After this fix, the same failure path prints an explicit `✗ The \`hermes\` command is now broken: missing hermes in <dir>` message with a `chown` remedy, then re-raises so `hermes update`'s exit code and existing error message are unchanged.

Actual output:

```
$ source venv/bin/activate && python -m pytest tests/hermes_cli/test_verify_console_scripts.py -v
collected 6 items

tests/hermes_cli/test_verify_console_scripts.py::TestVerifyConsoleScriptsInstalled::test_no_action_when_all_shims_present PASSED
tests/hermes_cli/test_verify_console_scripts.py::TestVerifyConsoleScriptsInstalled::test_quarantine_shims_include_declared_console_scripts PASSED
tests/hermes_cli/test_verify_console_scripts.py::TestWarnIfHermesLauncherBroken::test_no_warning_when_all_shims_present PASSED
tests/hermes_cli/test_verify_console_scripts.py::TestWarnIfHermesLauncherBroken::test_warns_when_hermes_shim_missing_on_posix PASSED
tests/hermes_cli/test_verify_console_scripts.py::TestWarnIfHermesLauncherBroken::test_no_action_when_not_running_from_a_venv PASSED
tests/hermes_cli/test_verify_console_scripts.py::TestInstallPythonDependenciesWithOptionalFallback::test_base_install_failure_warns_before_reraising PASSED

6 passed in 0.27s
```

Re-verified after the `chown`-target fix above: reverted `hermes_cli/main.py` to the prior commit with `git checkout HEAD~1 -- hermes_cli/main.py` and re-ran `test_warns_when_hermes_shim_missing_on_posix` — it now fails (`chown` remedy points at the checkout root, not the venv), confirming the strengthened assertion actually catches the regression. Restored the fix and reran the full file: 6/6 pass again.

Also ran, all passing with no regressions:
```
python -m pytest tests/hermes_cli/test_verify_console_scripts.py tests/hermes_cli/test_update_interrupted_recovery.py tests/hermes_cli/test_verify_core_dependencies.py -v
12 passed in 0.38s
```

`ruff check hermes_cli/main.py tests/hermes_cli/test_verify_console_scripts.py` — all checks passed.
`scripts/check-windows-footguns.py --diff HEAD~1` — no footguns found.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu, via CI runner)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or architecture changed

---

🤖 Part of this change (implementation drafting and test scaffolding) was produced with AI assistance (Claude); the diagnosis, code, and tests were reviewed and verified by running the full local test suite for the affected paths before submitting.
