### PR TITLE
fix(desktop): show a new-session button in the Home chat-list header

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -6,7 +6,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 
 import { PlatformAvatar } from '@/app/messaging/platform-icon'
-import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '@/components/ui/context-menu'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
@@ -21,7 +20,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem
 } from '@/components/ui/sidebar'
-import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
+import { TipKeybindLabel } from '@/components/ui/tooltip'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -134,7 +133,6 @@ import {
 import type { SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
-import { SidebarFilterMenu } from './filter-menu'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
 import { ProfileRail } from './profile-switcher'
@@ -147,19 +145,18 @@ import {
   overlayLivePreviews,
   PROJECT_PREVIEW_COUNT,
   ProjectBackRow,
-  ProjectMenu,
   projectTreeCwd,
   sessionRecency as sessionTime,
   type SidebarProjectTree,
   type SidebarSessionGroup,
   type SidebarWorkspaceTree,
   sortProjectsForOverview,
-  StartWorkButton,
   useRepoWorktreeMap
 } from './projects'
 import { WorktreeDialog } from './projects/worktree-dialog'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId } from './session-index'
+import { SessionsHeaderAction } from './sessions-header-action'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
@@ -223,18 +220,6 @@ const SCROLL_GUTTER = '[scrollbar-gutter:stable]'
 
 // A non-session group's scroll body: own scroller when tall, flattened when compact.
 const GROUP_BODY = cn(SCROLL_Y, COMPACT_FLAT)
-
-// Section-header action icons stay hidden until the whole header row is hovered
-// (group/section lives on SidebarSectionHeader), mirroring the artifacts/file
-// browser header affordances. focus-visible keeps them keyboard-reachable.
-const HEADER_ACTION_BTN =
-  'text-(--ui-text-tertiary) opacity-0 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/section:opacity-100 focus-visible:opacity-100'
-
-// The view toggle (overview group toggle / in-project back) is the one control
-// that stays visible at all times — it's the stable navigation affordance, not
-// a hover-revealed action.
-const HEADER_NAV_BTN =
-  'text-(--ui-text-tertiary) opacity-70 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100'
 
 // FTS results cover sessions that aren't in the loaded page; synthesize a
 // minimal SessionInfo so they render in the same row component (resume works
@@ -1597,63 +1582,17 @@ export function ChatSidebar({
                 grouping={showArchived || rankedGlobally ? 'none' : grouping === 'status' ? 'status' : 'date'}
                 groups={displayAgentGroups}
                 headerAction={
-                  inProject && enteredProject ? (
-                    <div className="group/workspace flex shrink-0 items-center gap-0.5">
-                      {enteredProject.path && <StartWorkButton repoPath={enteredProject.path} />}
-                      {/* Home has no folder and no record to rename, theme, or delete. */}
-                      {!enteredProject.isNoProject && (
-                        <ProjectMenu
-                          isActive={enteredProject.id === activeProjectId}
-                          onExitScope={exitProjectScope}
-                          project={enteredProject}
-                          scoped
-                        />
-                      )}
-                      <div className="grid size-6 place-items-center">
-                        <Tip label={s.showProjects}>
-                          <Button
-                            aria-label={s.showProjects}
-                            className={HEADER_NAV_BTN}
-                            onClick={event => {
-                              event.stopPropagation()
-                              exitProjectScope()
-                            }}
-                            size="icon-xs"
-                            variant="ghost"
-                          >
-                            <Codicon name="list-unordered" size="0.75rem" />
-                          </Button>
-                        </Tip>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="flex shrink-0 items-center gap-0.5">
-                      {!showAllProfiles ? (
-                        <Tip label={agentsGrouped ? s.projects.newButton : s.nav['new-session']}>
-                          <Button
-                            aria-label={agentsGrouped ? s.projects.newButton : s.nav['new-session']}
-                            className={HEADER_ACTION_BTN}
-                            onClick={event => {
-                              event.stopPropagation()
-
-                              if (agentsGrouped) {
-                                openProjectCreate()
-                              } else {
-                                onNewSessionInWorkspace(null)
-                              }
-                            }}
-                            size="icon-xs"
-                            variant="ghost"
-                          >
-                            <Codicon name="add" size="0.75rem" />
-                          </Button>
-                        </Tip>
-                      ) : null}
-                      <div className="grid size-6 place-items-center">
-                        <SidebarFilterMenu className={HEADER_NAV_BTN} />
-                      </div>
-                    </div>
-                  )
+                  <SessionsHeaderAction
+                    activeProjectId={activeProjectId}
+                    agentsGrouped={agentsGrouped}
+                    enteredProject={enteredProject}
+                    inProject={inProject}
+                    labels={{ newProject: s.projects.newButton, newSession: s.nav['new-session'], showProjects: s.showProjects }}
+                    onExitProjectScope={exitProjectScope}
+                    onNewSessionInWorkspace={onNewSessionInWorkspace}
+                    onOpenProjectCreate={openProjectCreate}
+                    showAllProfiles={showAllProfiles}
+                  />
                 }
                 label={sessionsLabel}
                 labelMeta={

--- a/apps/desktop/src/app/chat/sidebar/new-session-header-button.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/new-session-header-button.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { NewSessionHeaderButton } from './new-session-header-button'
+
+afterEach(cleanup)
+
+// #83479: the Home section header rendered only its "back to projects"
+// button, with no affordance to start a new session — this asserts the
+// button is actually there and wired up, not just that some handler exists.
+describe('NewSessionHeaderButton', () => {
+  it('renders a button with the given label and fires onClick', () => {
+    const onClick = vi.fn()
+    render(<NewSessionHeaderButton label="New session" onClick={onClick} />)
+
+    const button = screen.getByRole('button', { name: 'New session' })
+    button.click()
+
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('wraps the button in a Tip with the label as the trigger', () => {
+    render(<NewSessionHeaderButton label="New session" onClick={vi.fn()} />)
+
+    const button = screen.getByRole('button', { name: 'New session' })
+    expect(button.closest('[data-slot="tooltip-trigger"]')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/new-session-header-button.tsx
+++ b/apps/desktop/src/app/chat/sidebar/new-session-header-button.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
+
+interface NewSessionHeaderButtonProps {
+  className?: string
+  label: string
+  onClick: () => void
+}
+
+/** The "+" affordance for starting a new session from a sidebar section header.
+ *  Shared by the flat Sessions header and the Home project header (#83479 —
+ *  Home used to render only its "back to projects" button, with no way to
+ *  start a new session from there). */
+export function NewSessionHeaderButton({ className, label, onClick }: NewSessionHeaderButtonProps) {
+  return (
+    <Tip label={label}>
+      <Button
+        aria-label={label}
+        className={className}
+        onClick={event => {
+          event.stopPropagation()
+          onClick()
+        }}
+        size="icon-xs"
+        variant="ghost"
+      >
+        <Codicon name="add" size="0.75rem" />
+      </Button>
+    </Tip>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/sessions-header-action.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-header-action.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SidebarProjectTree } from './projects'
+import { SessionsHeaderAction } from './sessions-header-action'
+
+afterEach(cleanup)
+
+const LABELS = { newProject: 'New project', newSession: 'New session', showProjects: 'Show projects' }
+
+const HOME_PROJECT: SidebarProjectTree = {
+  id: 'no-project',
+  isNoProject: true,
+  label: 'Home',
+  path: null,
+  repos: [],
+  sessionCount: 0
+}
+
+// #83479: entering the synthetic "Home" bucket (a project view with no
+// folder of its own) rendered only the "back to projects" button — no way
+// to start a new session from there without leaving Home first.
+describe('SessionsHeaderAction — Home', () => {
+  it('shows a "New session" button when the entered project is Home', () => {
+    render(
+      <SessionsHeaderAction
+        activeProjectId={null}
+        agentsGrouped
+        enteredProject={HOME_PROJECT}
+        inProject
+        labels={LABELS}
+        onExitProjectScope={vi.fn()}
+        onNewSessionInWorkspace={vi.fn()}
+        onOpenProjectCreate={vi.fn()}
+        showAllProfiles={false}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'New session' })).toBeTruthy()
+  })
+
+  it('starts a new session (path null) when the button is clicked', () => {
+    const onNewSessionInWorkspace = vi.fn()
+
+    render(
+      <SessionsHeaderAction
+        activeProjectId={null}
+        agentsGrouped
+        enteredProject={HOME_PROJECT}
+        inProject
+        labels={LABELS}
+        onExitProjectScope={vi.fn()}
+        onNewSessionInWorkspace={onNewSessionInWorkspace}
+        onOpenProjectCreate={vi.fn()}
+        showAllProfiles={false}
+      />
+    )
+
+    screen.getByRole('button', { name: 'New session' }).click()
+
+    expect(onNewSessionInWorkspace).toHaveBeenCalledWith(null)
+  })
+
+  it('still shows the "back to projects" button alongside it', () => {
+    render(
+      <SessionsHeaderAction
+        activeProjectId={null}
+        agentsGrouped
+        enteredProject={HOME_PROJECT}
+        inProject
+        labels={LABELS}
+        onExitProjectScope={vi.fn()}
+        onNewSessionInWorkspace={vi.fn()}
+        onOpenProjectCreate={vi.fn()}
+        showAllProfiles={false}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Show projects' })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/sessions-header-action.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-header-action.test.tsx
@@ -6,6 +6,13 @@ import { SessionsHeaderAction } from './sessions-header-action'
 
 afterEach(cleanup)
 
+// SessionsHeaderAction only branches on ProjectMenu vs. NewSessionHeaderButton;
+// ProjectMenu's own behavior (rename/theme/delete) has its own test file.
+vi.mock('./projects', () => ({
+  ProjectMenu: () => <div data-testid="project-menu" />,
+  StartWorkButton: () => null
+}))
+
 const LABELS = { newProject: 'New project', newSession: 'New session', showProjects: 'Show projects' }
 
 const HOME_PROJECT: SidebarProjectTree = {
@@ -13,6 +20,15 @@ const HOME_PROJECT: SidebarProjectTree = {
   isNoProject: true,
   label: 'Home',
   path: null,
+  repos: [],
+  sessionCount: 0
+}
+
+const REAL_PROJECT: SidebarProjectTree = {
+  id: 'p1',
+  isNoProject: false,
+  label: 'Real project',
+  path: '/repo',
   repos: [],
   sessionCount: 0
 }
@@ -37,6 +53,27 @@ describe('SessionsHeaderAction — Home', () => {
     )
 
     expect(screen.getByRole('button', { name: 'New session' })).toBeTruthy()
+  })
+
+  // It's the only way to start a session from Home, so it shouldn't be
+  // hover-revealed like the flat view's "+" — unlike the "back to projects"
+  // button beside it, which uses the same always-visible treatment.
+  it('keeps the "New session" button always visible rather than hover-revealed', () => {
+    render(
+      <SessionsHeaderAction
+        activeProjectId={null}
+        agentsGrouped
+        enteredProject={HOME_PROJECT}
+        inProject
+        labels={LABELS}
+        onExitProjectScope={vi.fn()}
+        onNewSessionInWorkspace={vi.fn()}
+        onOpenProjectCreate={vi.fn()}
+        showAllProfiles={false}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'New session' }).className).not.toMatch(/opacity-0\b/)
   })
 
   it('starts a new session (path null) when the button is clicked', () => {
@@ -77,5 +114,29 @@ describe('SessionsHeaderAction — Home', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Show projects' })).toBeTruthy()
+  })
+})
+
+// The real-project branch was moved furthest from its original inline form
+// during the #83479 refactor, so lock down that it still renders ProjectMenu
+// (rename/theme/delete) rather than the Home/flat-view "+" button.
+describe('SessionsHeaderAction — real project', () => {
+  it('renders ProjectMenu (not the new-session button) when the entered project has a path', () => {
+    render(
+      <SessionsHeaderAction
+        activeProjectId={null}
+        agentsGrouped
+        enteredProject={REAL_PROJECT}
+        inProject
+        labels={LABELS}
+        onExitProjectScope={vi.fn()}
+        onNewSessionInWorkspace={vi.fn()}
+        onOpenProjectCreate={vi.fn()}
+        showAllProfiles={false}
+      />
+    )
+
+    expect(screen.getByTestId('project-menu')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'New session' })).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/sessions-header-action.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-header-action.tsx
@@ -1,0 +1,106 @@
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
+
+import { SidebarFilterMenu } from './filter-menu'
+import { NewSessionHeaderButton } from './new-session-header-button'
+import { ProjectMenu, type SidebarProjectTree, StartWorkButton } from './projects'
+
+// Section-header action icons stay hidden until the whole header row is hovered
+// (group/section lives on SidebarSectionHeader), mirroring the artifacts/file
+// browser header affordances. focus-visible keeps them keyboard-reachable.
+const HEADER_ACTION_BTN =
+  'text-(--ui-text-tertiary) opacity-0 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/section:opacity-100 focus-visible:opacity-100'
+
+// The view toggle (overview group toggle / in-project back) is the one control
+// that stays visible at all times — it's the stable navigation affordance, not
+// a hover-revealed action.
+const HEADER_NAV_BTN =
+  'text-(--ui-text-tertiary) opacity-70 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100'
+
+interface SessionsHeaderActionProps {
+  activeProjectId: null | string
+  agentsGrouped: boolean
+  enteredProject?: SidebarProjectTree
+  inProject: boolean
+  labels: {
+    newProject: string
+    newSession: string
+    showProjects: string
+  }
+  onExitProjectScope: () => void
+  onNewSessionInWorkspace: (path: null | string) => void
+  onOpenProjectCreate: () => void
+  showAllProfiles: boolean
+}
+
+/** The Sessions section header's trailing action(s): a "+" to start a new
+ *  session (or project, when grouped), plus the filter menu at the overview
+ *  / "back to projects" and project-menu controls once a project is entered.
+ *  Home is a synthetic entered "project" with no folder of its own — it still
+ *  needs the "+" (#83479), just not the rename/theme/delete `ProjectMenu`. */
+export function SessionsHeaderAction({
+  activeProjectId,
+  agentsGrouped,
+  enteredProject,
+  inProject,
+  labels,
+  onExitProjectScope,
+  onNewSessionInWorkspace,
+  onOpenProjectCreate,
+  showAllProfiles
+}: SessionsHeaderActionProps) {
+  if (inProject && enteredProject) {
+    return (
+      <div className="group/workspace flex shrink-0 items-center gap-0.5">
+        {enteredProject.path && <StartWorkButton repoPath={enteredProject.path} />}
+        {/* Home has no folder and no record to rename, theme, or delete. */}
+        {enteredProject.isNoProject ? (
+          <NewSessionHeaderButton
+            className={HEADER_ACTION_BTN}
+            label={labels.newSession}
+            onClick={() => onNewSessionInWorkspace(null)}
+          />
+        ) : (
+          <ProjectMenu
+            isActive={enteredProject.id === activeProjectId}
+            onExitScope={onExitProjectScope}
+            project={enteredProject}
+            scoped
+          />
+        )}
+        <div className="grid size-6 place-items-center">
+          <Tip label={labels.showProjects}>
+            <Button
+              aria-label={labels.showProjects}
+              className={HEADER_NAV_BTN}
+              onClick={event => {
+                event.stopPropagation()
+                onExitProjectScope()
+              }}
+              size="icon-xs"
+              variant="ghost"
+            >
+              <Codicon name="list-unordered" size="0.75rem" />
+            </Button>
+          </Tip>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex shrink-0 items-center gap-0.5">
+      {!showAllProfiles ? (
+        <NewSessionHeaderButton
+          className={HEADER_ACTION_BTN}
+          label={agentsGrouped ? labels.newProject : labels.newSession}
+          onClick={() => (agentsGrouped ? onOpenProjectCreate() : onNewSessionInWorkspace(null))}
+        />
+      ) : null}
+      <div className="grid size-6 place-items-center">
+        <SidebarFilterMenu className={HEADER_NAV_BTN} />
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/sessions-header-action.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-header-action.tsx
@@ -54,10 +54,12 @@ export function SessionsHeaderAction({
     return (
       <div className="group/workspace flex shrink-0 items-center gap-0.5">
         {enteredProject.path && <StartWorkButton repoPath={enteredProject.path} />}
-        {/* Home has no folder and no record to rename, theme, or delete. */}
+        {/* Home has no folder and no record to rename, theme, or delete. It's
+            also the only way to start a session from Home, so keep it
+            visible rather than hover-revealed like the flat view's "+". */}
         {enteredProject.isNoProject ? (
           <NewSessionHeaderButton
-            className={HEADER_ACTION_BTN}
+            className={HEADER_NAV_BTN}
             label={labels.newSession}
             onClick={() => onNewSessionInWorkspace(null)}
           />


### PR DESCRIPTION
## Summary

Fixes #83479.

From the desktop app, grouping the sidebar by project and drilling into
the synthetic **Home** bucket (sessions that belong to no project) left
you with no way to start a new session — the section header showed only
the "back to projects" button.

Root cause: `apps/desktop/src/app/chat/sidebar/index.tsx`'s Sessions
section header rendered a `ProjectMenu` (rename/theme/delete) for any
entered project and a "+ new session" button only in the flat
(ungrouped) view. Home is a synthetic entered "project" (`isNoProject:
true`, no folder), so it fell into the "entered project" branch and got
neither the `ProjectMenu` (correctly, since it already special-cased
Home to skip that) nor the "+" button (the gap).

## Changes

- `apps/desktop/src/app/chat/sidebar/index.tsx` — extracted the
  Sessions section header's trailing action into a new
  `SessionsHeaderAction` component, and give it a "+" new-session
  button when the entered project is Home, matching the flat view's
  existing affordance.
- `apps/desktop/src/app/chat/sidebar/sessions-header-action.tsx` (new)
  — the extracted header-action component (project-entered vs. flat
  view, with Home as a third case inside "project-entered").
- `apps/desktop/src/app/chat/sidebar/new-session-header-button.tsx`
  (new) — the shared "+" button, now used by both Home and the flat
  view instead of duplicated JSX.
- Tests for both new components.

This keeps the diff testable without mounting the full `ChatSidebar`
(which pulls in ~30 nanostores) while removing the duplicated button
markup that existed for the flat-view case.

## Test plan

Added `sessions-header-action.test.tsx`, which reproduces the bug
directly: rendering `SessionsHeaderAction` with an entered "Home"
project (`isNoProject: true`) now finds a "New session" button that
calls `onNewSessionInWorkspace(null)`, and the existing "back to
projects" button is still there. Confirmed these two assertions fail
against the pre-fix logic (reverted the `isNoProject` branch locally,
reran the tests, restored it):

```
✓ shows a "New session" button when the entered project is Home       # fails pre-fix
✓ starts a new session (path null) when the button is clicked         # fails pre-fix
✓ still shows the "back to projects" button alongside it              # passes either way
```

Also added `new-session-header-button.test.tsx` for the shared button
component.

Full suite run:

```
$ npx vitest run --project ui src/app/chat/sidebar
 Test Files  15 passed (15)
      Tests  124 passed (124)
```

```
$ npm run typecheck
> tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.e2e.json --noEmit
(clean)
```

```
$ npx eslint src/app/chat/sidebar/index.tsx src/app/chat/sidebar/sessions-header-action.tsx \
    src/app/chat/sidebar/new-session-header-button.tsx src/app/chat/sidebar/sessions-header-action.test.tsx \
    src/app/chat/sidebar/new-session-header-button.test.tsx
(clean)
```

## AI assistance disclosure

This PR was drafted by an autonomous coding agent (Claude, via
Anthropic's Claude Code) and reviewed before submission.
