### PR TITLE
fix(kanban): fallback summary→result in complete_task to prevent NULL results

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4903,6 +4903,15 @@ def complete_task(
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
+
+    # ``tasks.result`` is the user-visible deliverable.  When a worker
+    # completes a task with only ``summary=`` (the common path), the
+    # ``result`` column would stay NULL, making the card unreadable in
+    # the board UI and the notifier.  Fall back to ``summary`` so the
+    # field is always populated.
+    if result is None and summary is not None:
+        result = summary
+
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(


### PR DESCRIPTION
## Summary
- When workers call `complete_task(summary=...)` without passing `result=`, the `tasks.result` column stayed NULL, making cards unreadable in the board UI and the notifier.
- Now `result` falls back to `summary` when `None`, so the field is always populated.
- Backfilled 136 existing done+NULL-result tasks from `task_runs.summary` (1 correctly excluded — only a blocked run, no summary to copy).

## Test plan
- Zero test regressions (4 pre-existing failures unchanged on clean HEAD).
- Verified the fallback path with a repro script against a temp DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)