### PR TITLE
fix(desktop): honor voice.silence_duration in voice conversation mode

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -13,6 +13,7 @@ import {
 import { isVoiceStopCommand } from '@/lib/voice-stop-word'
 import { notify, notifyError } from '@/store/notifications'
 import { $voicePlayback } from '@/store/voice-playback'
+import { $voiceSilenceMs } from '@/store/voice-prefs'
 
 import { useMicRecorder } from './use-mic-recorder'
 
@@ -234,9 +235,11 @@ export function useVoiceConversation({
 
     try {
       // VAD tuning mirrors `tools.voice_mode` defaults so the browser loop matches the CLI.
+      // silenceMs honors `voice.silence_duration` from config.yaml (default 3s) —
+      // see $voiceSilenceMs — instead of a fixed pause threshold.
       await handle.start({
         silenceLevel: 0.075,
-        silenceMs: 1_250,
+        silenceMs: $voiceSilenceMs.get(),
         idleSilenceMs: 12_000,
         onError: error => {
           notifyError(error, voiceCopy.microphoneFailed)

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -18,6 +18,7 @@ import {
 import {
   applyAutoSpeakFromConfig,
   applyThinkingSoundFromConfig,
+  applyVoiceSilenceMsFromConfig,
   applyVoiceStopPhraseFromConfig
 } from '@/store/voice-prefs'
 
@@ -113,6 +114,7 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         applyAutoSpeakFromConfig(config)
         applyVoiceStopPhraseFromConfig(config)
         applyThinkingSoundFromConfig(config)
+        applyVoiceSilenceMsFromConfig(config)
       } catch {
         // Config is nice-to-have; chat still works without it.
       }

--- a/apps/desktop/src/lib/voice-barge-in.ts
+++ b/apps/desktop/src/lib/voice-barge-in.ts
@@ -19,6 +19,8 @@
 // - Detection is a windowed majority (>=80% of the last SUSTAINED_MS above
 //   trigger) so intra-word energy dips don't reset progress.
 
+import { $voiceSilenceMs } from '@/store/voice-prefs'
+
 const CALIBRATION_MS = 400
 const SUSTAINED_MS = 300
 const SUSTAINED_MAJORITY = 0.8
@@ -32,7 +34,6 @@ const PLAYBACK_GRACE_MS = 500
 const PLAYBACK_GAP_FOR_GRACE_MS = 1_000
 const FLOOR_SAMPLE_CAP = 200 // ~3s of quiet-phase levels at rAF cadence
 const PRE_ROLL_RESTART_MS = 5_000 // cap pre-roll: restart the recorder while quiet
-const UTTERANCE_SILENCE_MS = 1_250 // matches the voice loop's silenceMs
 const UTTERANCE_MAX_MS = 30_000
 
 export interface BargeMonitorCallbacks {
@@ -306,7 +307,10 @@ export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): (
             quietSince ??= now
           }
 
-          if ((quietSince && now - quietSince >= UTTERANCE_SILENCE_MS) || now - trippedAt >= UTTERANCE_MAX_MS) {
+          // Reads the shared silence threshold live (not captured at monitor
+          // start) so it matches the voice loop's silenceMs — see
+          // $voiceSilenceMs — even if config reloads mid-turn.
+          if ((quietSince && now - quietSince >= $voiceSilenceMs.get()) || now - trippedAt >= UTTERANCE_MAX_MS) {
             finishCapture()
 
             return

--- a/apps/desktop/src/store/voice-prefs.test.ts
+++ b/apps/desktop/src/store/voice-prefs.test.ts
@@ -5,7 +5,7 @@ vi.mock('@/hermes', () => ({
   saveHermesConfig: vi.fn(async () => undefined)
 }))
 
-import { $voiceStopPhrase, applyVoiceStopPhraseFromConfig } from './voice-prefs'
+import { $voiceSilenceMs, $voiceStopPhrase, applyVoiceSilenceMsFromConfig, applyVoiceStopPhraseFromConfig } from './voice-prefs'
 
 describe('applyVoiceStopPhraseFromConfig', () => {
   it('defaults to "stop" when the key is absent (backend default applies)', () => {
@@ -34,5 +34,34 @@ describe('applyVoiceStopPhraseFromConfig', () => {
   it('malformed entries are skipped; all-blank list disables', () => {
     applyVoiceStopPhraseFromConfig({ voice: { stop_phrases: ['  ', ''] } })
     expect($voiceStopPhrase.get()).toBeNull()
+  })
+})
+
+describe('applyVoiceSilenceMsFromConfig', () => {
+  it('converts a configured silence_duration from seconds to milliseconds', () => {
+    applyVoiceSilenceMsFromConfig({ voice: { silence_duration: 10 } })
+    expect($voiceSilenceMs.get()).toBe(10_000)
+  })
+
+  it('falls back to the documented 3s default when the key is absent', () => {
+    applyVoiceSilenceMsFromConfig({ voice: {} })
+    expect($voiceSilenceMs.get()).toBe(3_000)
+
+    applyVoiceSilenceMsFromConfig(null)
+    expect($voiceSilenceMs.get()).toBe(3_000)
+  })
+
+  it('falls back to the default for non-numeric or non-positive values (hand-edited config.yaml)', () => {
+    applyVoiceSilenceMsFromConfig({ voice: { silence_duration: true } })
+    expect($voiceSilenceMs.get()).toBe(3_000)
+
+    applyVoiceSilenceMsFromConfig({ voice: { silence_duration: '5' } })
+    expect($voiceSilenceMs.get()).toBe(3_000)
+
+    applyVoiceSilenceMsFromConfig({ voice: { silence_duration: 0 } })
+    expect($voiceSilenceMs.get()).toBe(3_000)
+
+    applyVoiceSilenceMsFromConfig({ voice: { silence_duration: -1 } })
+    expect($voiceSilenceMs.get()).toBe(3_000)
   })
 })

--- a/apps/desktop/src/store/voice-prefs.ts
+++ b/apps/desktop/src/store/voice-prefs.ts
@@ -37,6 +37,27 @@ export function applyVoiceStopPhraseFromConfig(
   $voiceStopPhrase.set(first ?? null)
 }
 
+// `voice.silence_duration` — seconds of silence after speech before a voice-
+// conversation turn auto-submits. Documented default 3.0s (hermes_cli/
+// config_defaults.py), honored by the CLI/TUI/gateway capture paths but
+// previously hardcoded to 1.25s in the desktop renderer's mic loop. Stored in
+// ms since that's what MediaRecorder timing consumes.
+const DEFAULT_VOICE_SILENCE_MS = 3_000
+
+export const $voiceSilenceMs = atom<number>(DEFAULT_VOICE_SILENCE_MS)
+
+/** Seed the silence-duration atom from a loaded config payload (mount / refresh).
+ *  Shape-safe like the gateway's lookup (tui_gateway/server.py): non-numeric or
+ *  non-positive falls back to the documented default rather than disabling the
+ *  auto-stop or crashing on a hand-edited config.yaml. */
+export function applyVoiceSilenceMsFromConfig(
+  config: { voice?: { silence_duration?: unknown } | null } | null | undefined
+) {
+  const raw = config?.voice?.silence_duration
+
+  $voiceSilenceMs.set(typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw * 1_000 : DEFAULT_VOICE_SILENCE_MS)
+}
+
 // `voice.thinking_sound` — ambient bubble blips while the agent works during a
 // voice conversation (default on, matching the backend default).
 export const $thinkingSoundEnabled = atom<boolean>(true)

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -349,6 +349,7 @@ export interface HermesConfig {
     auto_tts?: boolean
     stop_phrases?: unknown
     thinking_sound?: unknown
+    silence_duration?: unknown
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

In Hermes Desktop voice conversation mode, the mic loop ended the user's turn
after a hardcoded **1.25 seconds of silence** in the renderer
(`use-voice-conversation.ts`). `voice.silence_duration` from `config.yaml`
(documented default 3.0s, "Seconds of silence before auto-stop") is honored by
the CLI (`cli.py`), TUI/gateway (`tui_gateway/server.py`), and full-duplex
listener (`tools/voice_mode.py`) capture paths, but was ignored by the desktop
renderer — so desktop users could not tune the pause threshold, and a brief
mid-thought pause cut the turn off and submitted a partial recording. Raising
`voice.silence_duration` in `config.yaml` had no effect on desktop while the
CLI path honored the new value.

This adds a `$voiceSilenceMs` nanostore atom in `store/voice-prefs.ts`,
following the same pattern already used there for `voice.auto_tts`,
`voice.stop_phrases`, and `voice.thinking_sound`: seeded from the loaded
config with a shape-safe numeric fallback (mirrors the gateway's
`tui_gateway/server.py:14020-14031` lookup — non-numeric/non-positive values
fall back to the documented 3.0s default instead of crashing or disabling
auto-stop on a hand-edited config). `use-voice-conversation.ts` now reads
`$voiceSilenceMs.get()` for `silenceMs` instead of the hardcoded `1_250`, and
`voice-barge-in.ts`'s utterance-endpoint check reads the same atom live
(instead of its own hardcoded `UTTERANCE_SILENCE_MS` constant) so the barge-in
monitor and the main mic loop stay matched, per the issue's suggested fix.

## Related Issue

Fixes #83518

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/voice-prefs.ts` — add `$voiceSilenceMs` atom +
  `applyVoiceSilenceMsFromConfig()`
- `apps/desktop/src/app/session/hooks/use-hermes-config.ts` — seed the atom on
  config load/refresh
- `apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts` — read
  `$voiceSilenceMs.get()` instead of the hardcoded `1_250` for `silenceMs`
- `apps/desktop/src/lib/voice-barge-in.ts` — read the same atom for the
  utterance-endpoint silence check instead of the separate hardcoded
  `UTTERANCE_SILENCE_MS`
- `apps/desktop/src/types/hermes.ts` — add `silence_duration` to the `voice`
  config type
- `apps/desktop/src/store/voice-prefs.test.ts` — tests for
  `applyVoiceSilenceMsFromConfig` (conversion, default fallback, shape-safety)

## How to Test

1. `cd apps/desktop && npm install` (workspace deps install at the repo root)
2. `npx vitest run src/store/voice-prefs.test.ts` — new tests cover seconds→ms
   conversion, default fallback when the key is absent, and shape-safe
   fallback for non-numeric/non-positive values (bool, string, 0, negative)
3. Set `voice.silence_duration: 10` in `config.yaml`, start a desktop voice
   conversation, and confirm a 5-8s mid-thought pause no longer ends the turn.

### Test output (this PR)

```
 Test Files  3 passed (3)
      Tests  19 passed (19)
```
(`src/store/voice-prefs.test.ts`, `src/app/chat/composer/hooks/use-voice-conversation.test.tsx`,
`src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx`)

Full desktop suite: `npx vitest run` → **4701 passed, 2 skipped, 0 failed**
(500 files).

`npx tsc -p . --noEmit` and `npx tsc -p tsconfig.electron.json --noEmit` both
clean. `npx eslint src/ electron/` — 0 errors (88 pre-existing warnings,
unrelated to this change).

Confirmed the new tests fail without the fix (`git checkout HEAD~1 --
apps/desktop/src/store/voice-prefs.ts` then re-running
`voice-prefs.test.ts`): `TypeError: applyVoiceSilenceMsFromConfig is not a
function`, 3/8 tests failing.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — not tested in a live Electron build (no
      display/audio device in this environment); verified via the vitest
      suite and by reading the config-propagation path (`use-hermes-config.ts`
      → `voice-prefs.ts` → `use-voice-conversation.ts` / `voice-barge-in.ts`)

### Documentation & Housekeeping

- [ ] N/A — no README/docs changes needed; `voice.silence_duration` is
      already documented in `config_defaults.py` and `cli-config.yaml.example`
- [ ] N/A — no config keys added, only a desktop consumer of an existing key
- [ ] N/A — no architecture/workflow change
- [x] Cross-platform impact considered — pure renderer/TS change, no
      platform-specific APIs touched
- [ ] N/A — no tool schemas changed

## AI assistance disclosure

This PR was prepared with AI assistance (an autonomous coding agent), with
the changes reviewed against the issue, the existing `voice-prefs.ts`
config-atom pattern, and the CLI/gateway shape-safe fallback convention
before submission.
