### PR TITLE
fix(agent): honor non-local backend cwd instead of validating it against the local filesystem

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -69,18 +69,28 @@ def _session_cwd_override() -> str:
 def resolve_agent_cwd() -> Path:
     # A non-local backend's configured cwd lives on the backend's filesystem,
     # not this host's — Path.is_dir() would always be False there and discard
-    # a valid remote path in favor of the host's launch dir (#83515).
+    # a valid remote path in favor of the host's launch dir (#83515). Nor can
+    # `~` be expanded here: expanduser() would resolve it against this host's
+    # HOME, not the remote's, silently pointing the agent at the wrong path.
+    # Kept verbatim instead, matching tui_gateway/methods_session.py's
+    # session.create handling of a remote raw_cwd.
     remote = (os.environ.get("TERMINAL_ENV") or "").strip().lower() in _REMOTE_TERMINAL_BACKENDS
     override = _session_cwd_override()
     if override:
+        if remote:
+            logger.debug("cwd validation skipped for remote backend: %s", override)
+            return Path(override)
         p = Path(override).expanduser()
-        if remote or p.is_dir():
+        if p.is_dir():
             return p
         logger.warning("configured working directory does not exist: %s", override)
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
+        if remote:
+            logger.debug("cwd validation skipped for remote backend: %s", raw)
+            return Path(raw)
         p = Path(raw).expanduser()
-        if remote or p.is_dir():
+        if p.is_dir():
             return p
         logger.warning("TERMINAL_CWD does not exist: %s", raw)
     return Path(os.getcwd())

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -18,6 +18,15 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Non-local backends whose cwd lives on a different filesystem than this
+# process — keep in sync with agent/prompt_builder.py:_REMOTE_TERMINAL_BACKENDS.
+# Duplicated rather than imported to avoid a circular import (prompt_builder
+# imports resolve_agent_cwd from this module).
+_REMOTE_TERMINAL_BACKENDS = frozenset({
+    "docker", "singularity", "modal", "daytona", "ssh",
+    "vercel_sandbox", "managed_modal",
+})
+
 _UNSET: Any = object()
 
 _SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
@@ -58,16 +67,20 @@ def _session_cwd_override() -> str:
 
 
 def resolve_agent_cwd() -> Path:
+    # A non-local backend's configured cwd lives on the backend's filesystem,
+    # not this host's — Path.is_dir() would always be False there and discard
+    # a valid remote path in favor of the host's launch dir (#83515).
+    remote = (os.environ.get("TERMINAL_ENV") or "").strip().lower() in _REMOTE_TERMINAL_BACKENDS
     override = _session_cwd_override()
     if override:
         p = Path(override).expanduser()
-        if p.is_dir():
+        if remote or p.is_dir():
             return p
         logger.warning("configured working directory does not exist: %s", override)
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
-        if p.is_dir():
+        if remote or p.is_dir():
             return p
         logger.warning("TERMINAL_CWD does not exist: %s", raw)
     return Path(os.getcwd())

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -110,3 +110,33 @@ class TestRemoteBackendSkipsLocalValidation:
         monkeypatch.setenv("TERMINAL_CWD", str(missing))
         assert resolve_agent_cwd() == Path(os.getcwd())
 
+    def test_remote_session_cwd_is_not_expanded_locally(self, monkeypatch):
+        # `~` in a remote path means the backend's home, not this host's —
+        # expanding it here (as the local-backend arm does) would silently
+        # substitute the wrong directory. Must match session.create's
+        # verbatim raw_cwd handling in tui_gateway/methods_session.py.
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_CWD", "/workspace")
+        token = set_session_cwd("~/project")
+        try:
+            assert resolve_agent_cwd() == Path("~/project")
+        finally:
+            rt._SESSION_CWD.reset(token)
+
+    def test_remote_terminal_cwd_is_not_expanded_locally(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_CWD", "~/project")
+        assert resolve_agent_cwd() == Path("~/project")
+
+
+class TestRemoteBackendListStaysInSync:
+    """_REMOTE_TERMINAL_BACKENDS is duplicated (to dodge a circular import)
+    between agent/runtime_cwd.py and agent/prompt_builder.py. A backend added
+    to only one would keep being treated as local by the other — assert they
+    agree."""
+
+    def test_matches_prompt_builder(self):
+        import agent.prompt_builder as pb
+
+        assert rt._REMOTE_TERMINAL_BACKENDS == pb._REMOTE_TERMINAL_BACKENDS
+

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -79,3 +79,34 @@ class TestSessionCwdOverride:
         finally:
             rt._SESSION_CWD.reset(token)
 
+
+class TestRemoteBackendSkipsLocalValidation:
+    """#83515: an SSH (or other remote) backend's cwd lives on the backend's
+    filesystem, not this host's — Path.is_dir() is always False for a path
+    that only exists on the remote target, so it must not be used to reject
+    an otherwise-valid remote cwd."""
+
+    def test_resolve_agent_cwd_honors_nonexistent_remote_session_cwd(self, monkeypatch):
+        remote = "/workspace/research"  # does not exist on this host
+        assert not Path(remote).is_dir()
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_CWD", "/workspace")
+        token = set_session_cwd(remote)
+        try:
+            assert resolve_agent_cwd() == Path(remote)
+        finally:
+            rt._SESSION_CWD.reset(token)
+
+    def test_resolve_agent_cwd_honors_nonexistent_remote_terminal_cwd(self, monkeypatch):
+        remote = "/workspace"  # does not exist on this host either
+        assert not Path(remote).is_dir()
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_CWD", remote)
+        assert resolve_agent_cwd() == Path(remote)
+
+    def test_local_backend_still_rejects_nonexistent_cwd(self, monkeypatch, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CWD", str(missing))
+        assert resolve_agent_cwd() == Path(os.getcwd())
+

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -873,6 +873,34 @@ def test_terminal_task_cwd_ssh_sentinel_cwd_uses_remote_home(monkeypatch):
     assert server._terminal_task_cwd({"cwd": "/host/session/dir"}) == "~"
 
 
+def test_session_create_ssh_preserves_remote_project_cwd(monkeypatch):
+    """#83515: a Desktop Project whose primary path only exists on the SSH
+    target must stay the session's cwd through session.create — not get
+    silently discarded by a local os.path.isdir() check and replaced with
+    the global terminal.cwd or the gateway's own launch dir."""
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **kw: None)
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_CWD", "/workspace")
+    remote_project = "/workspace/research"
+    assert not os.path.isdir(remote_project)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.create",
+            "params": {"cols": 80, "cwd": remote_project},
+        }
+    )
+    sid = resp["result"]["session_id"]
+    session = server._sessions[sid]
+
+    assert session["explicit_cwd"] is True
+    assert session["cwd"] == remote_project
+    assert server._terminal_task_cwd(session) == remote_project
+
+    server._sessions.pop(sid, None)
+
+
 class _ChunkyStdout:
     def __init__(self):
         self.parts: list[str] = []

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -27,11 +27,19 @@ def _(rid, params: dict) -> dict:
     # workspace (see _ensure_session_db_row); otherwise it lands in "No
     # workspace" instead of whatever folder the desktop launched in.
     raw_cwd = str(params.get("cwd") or "").strip()
-    try:
-        explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
-    except Exception:
-        explicit_cwd = False
-    resolved_cwd = _completion_cwd(params)
+    if raw_cwd and _effective_terminal_backend() != "local":
+        # A non-local backend's cwd (SSH, Docker, ...) lives on the backend's
+        # filesystem, not this host's — os.path.isdir() would always be False
+        # and silently discard a valid client-chosen workspace, falling back
+        # to the gateway's own launch dir (#83515).
+        explicit_cwd = True
+        resolved_cwd = raw_cwd
+    else:
+        try:
+            explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
+        except Exception:
+            explicit_cwd = False
+        resolved_cwd = _completion_cwd(params)
     source = _resolve_session_source(str(params.get("source") or "").strip() or None)
     _enable_gateway_prompts()
 


### PR DESCRIPTION
## What does this PR do?

Fixes a split-brain cwd bug on non-local terminal backends (SSH, Docker, Modal, ...): a session's client-chosen workspace was silently discarded and replaced with the gateway's own launch directory (or the global `terminal.cwd`) because two code paths validated the configured cwd with a *local* `os.path.isdir()` check — which is always `False` for a path that only exists on the backend, not on the host running Hermes.

- `tui_gateway/methods_session.py` (`session.create`): `explicit_cwd` was computed as `os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))`. For a non-local backend this is always `False`, so the session was never marked as having an explicit workspace, and `resolved_cwd = _completion_cwd(params)` (itself host-`isdir`-gated) fell back to `os.getcwd()` — the session's own `cwd` field ended up pointing at the gateway's launch dir instead of the workspace the client asked for.
- `agent/runtime_cwd.py` (`resolve_agent_cwd`): rejected a configured/session cwd with `Path.is_dir()` and logged `"configured working directory does not exist: ..."` / `"TERMINAL_CWD does not exist: ..."` whenever the path only exists on the remote backend, falling back to `os.getcwd()`.

Both are fixed the same way: when the active terminal backend is non-local (checked via the existing `_effective_terminal_backend()` helper in `tui_gateway/server.py`, and the existing `_REMOTE_TERMINAL_BACKENDS` set — duplicated into `runtime_cwd.py` to avoid a circular import, matching the existing pattern in `tools/env_probe.py`), the configured path is treated as authoritative and passed through unvalidated rather than checked against the local filesystem. Local backends are unaffected — they still validate as before.

## Related Issue

Fixes #83515

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_session.py`: `session.create` now treats a non-empty client-provided `cwd` as explicit for non-local backends without a local `isdir()` check.
- `agent/runtime_cwd.py`: `resolve_agent_cwd()` skips local `Path.is_dir()` validation when `TERMINAL_ENV` is a remote backend (ssh/docker/singularity/modal/daytona/vercel_sandbox/managed_modal).
- `tests/test_tui_gateway_server.py`: regression test creating an SSH-backend session whose cwd doesn't exist on the local host, asserting `explicit_cwd`/`cwd`/`_terminal_task_cwd()` all preserve the remote path.
- `tests/agent/test_runtime_cwd.py`: regression tests for `resolve_agent_cwd()` honoring a nonexistent-locally session/`TERMINAL_CWD` path under `TERMINAL_ENV=ssh`, plus a control test confirming local backends still reject a genuinely missing directory.

## How to Test

1. `python3 -m pytest tests/agent/test_runtime_cwd.py -k RemoteBackend -q`
2. `python3 -m pytest tests/test_tui_gateway_server.py -k session_create_ssh_preserves -q`
3. Full suite: `python3 -m pytest tests/test_tui_gateway_server.py tests/agent/test_runtime_cwd.py -q` → **533 + 12 passed**

Confirmed each new test fails without the fix (`git checkout HEAD~1 -- agent/runtime_cwd.py tui_gateway/methods_session.py` then re-run):

```
FAILED tests/agent/test_runtime_cwd.py::TestRemoteBackendSkipsLocalValidation::test_resolve_agent_cwd_honors_nonexistent_remote_session_cwd
  AssertionError: assert PosixPath('.../work') == PosixPath('/workspace/research')
  WARNING  agent.runtime_cwd:runtime_cwd.py:66 configured working directory does not exist: /workspace/research
  WARNING  agent.runtime_cwd:runtime_cwd.py:72 TERMINAL_CWD does not exist: /workspace

FAILED tests/test_tui_gateway_server.py::test_session_create_ssh_preserves_remote_project_cwd
  assert False is True   # session["explicit_cwd"]
```

Both pass after re-applying the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (checked #80878, #81805, #58159, #40900, and other open cwd/SSH PRs — none address this specific `session.create`/`resolve_agent_cwd` local-`isdir` rejection of a valid remote path)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` for the affected files and all tests pass
- [x] I've added tests for my changes
- [x] Tested on: Linux (Ubuntu, CI runner)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

## Notes on AI assistance

This PR was prepared with the help of an AI coding agent (Claude), which investigated the reported symptom against current `main`, wrote the fix and regression tests, and verified the tests fail without the fix and pass with it. All changes were reviewed before submission.
