### PR TITLE
Add --skip-build to skip web UI build during install and update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5680,6 +5680,14 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     """
     if not (web_dir / "package.json").exists():
         return True
+    # --skip-build left at install time (or by hand): never build the web UI
+    # on launch. The install script writes $HERMES_HOME/.skip-webui-build to
+    # carry the opt-out forward; honor it here so `hermes serve` / `hermes
+    # dashboard` / `hermes gui` start without running `npm run build`.
+    from hermes_constants import get_hermes_home
+
+    if (get_hermes_home() / ".skip-webui-build").exists():
+        return True
     try:
         import fcntl
     except ImportError:

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -73,4 +73,10 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
     )
+    update_parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        default=False,
+        help="Skip rebuilding the web dashboard UI (and any app builds) during this update. Use when an existing web_dist is already present and you want a faster update; the next `hermes serve`/`hermes dashboard` will fallback to a build if the dist is missing.",
+    )
     update_parser.set_defaults(func=cmd_update)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -381,6 +381,19 @@ def _web_toolchain_roots(web_dir: Path) -> tuple[Path, ...]:
     """
     return (web_dir, web_dir.parent)
 
+def _webui_build_skipped_via_install_marker() -> bool:
+    """True when install.sh was run with --skip-build (persistent opt-out).
+
+    ``install.sh --skip-build`` writes ``$HERMES_HOME/.skip-webui-build`` so the
+    web dashboard SPA is never built at first launch. ``hermes update`` should
+    honor the same opt-out: if the marker is present, skip the web UI build
+    here too (mirrors the launch-time skip in ``_build_web_ui``).
+    """
+    try:
+        return (get_hermes_home() / ".skip-webui-build").exists()
+    except Exception:
+        return False
+
 def _print_curator_first_run_notice() -> None:
     """Print a short heads-up about the skill curator after `hermes update`.
 
@@ -1010,7 +1023,12 @@ def _update_via_zip(args):
         _m().sys.exit(1)
 
     node_failures = _update_node_dependencies()
-    _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+    if getattr(args, "skip_build", False):
+        print("→ Skipping web UI build (--skip-build); using existing dist")
+    elif _webui_build_skipped_via_install_marker():
+        print("→ Skipping web UI build (install was run with --skip-build); using existing dist")
+    else:
+        _m()._build_web_ui(_m().PROJECT_ROOT / "web")
 
     # Sync skills
     try:
@@ -4489,7 +4507,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("    https://hermes-agent.nousresearch.com")
 
         node_failures = _update_node_dependencies()
-        _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+        if getattr(args, "skip_build", False):
+            print("→ Skipping web UI build (--skip-build); using existing dist")
+        elif _webui_build_skipped_via_install_marker():
+            print("→ Skipping web UI build (install was run with --skip-build); using existing dist")
+        else:
+            _m()._build_web_ui(_m().PROJECT_ROOT / "web")
 
         # Rebuild the desktop app if the source tree changed since the last
         # build.  ``hermes desktop --build-only`` uses the content-hash stamp

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,6 +81,7 @@ STAGE_NAME=""
 JSON_OUTPUT=false
 NON_INTERACTIVE=false
 INCLUDE_DESKTOP=false
+SKIP_WEBUI_BUILD=false
 
 # Detect non-interactive mode (e.g. curl | bash)
 # When stdin is not a terminal, read -p will fail with EOF,
@@ -142,6 +143,10 @@ while [[ $# -gt 0 ]]; do
             INCLUDE_DESKTOP=true
             shift
             ;;
+        --skip-build|-SkipBuild)
+            SKIP_WEBUI_BUILD=true
+            shift
+            ;;
         --dir)
             INSTALL_DIR="$2"
             INSTALL_DIR_EXPLICIT=true
@@ -177,6 +182,10 @@ while [[ $# -gt 0 ]]; do
             echo "  --json         Print a JSON result frame for --stage"
             echo "  --non-interactive  Skip stages that require user input"
             echo "  --include-desktop  Also build the desktop app (apps/desktop -> Hermes.app)"
+            echo "  --skip-build   Skip the web dashboard UI build at first launch"
+            echo "                   (writes \$HERMES_HOME/.skip-webui-build; 'hermes serve'/"
+            echo "                   'hermes dashboard' will not run 'npm run build' and will"
+            echo "                   serve a 404 / require a manual build if no dist exists)"
             echo "  --dir PATH     Installation directory"
             echo "                   default (non-root):  ~/.hermes/hermes-agent"
             echo "                   default (root, Linux): /usr/local/lib/hermes-agent"
@@ -3264,6 +3273,17 @@ run_stage_body() {
             resolve_install_layout
             print_success
             write_bootstrap_marker
+            # --skip-build: leave a persistent opt-out marker so the web UI is
+            # NOT built at first launch (hermes serve/dashboard/gui would
+            # otherwise run `npm run build`). The install itself never builds
+            # the web SPA — it's built lazily on first launch — so this marker
+            # is what actually defers/skips that build. Same idea as the
+            # pre-existing `hermes update --skip-build` / `hermes serve
+            # --skip-build` flags, but set at install time and sticky per HOME.
+            if [ "$SKIP_WEBUI_BUILD" = true ]; then
+                touch "$HERMES_HOME/.skip-webui-build"
+                log_info "Wrote $HERMES_HOME/.skip-webui-build (web UI build skipped at first launch)"
+            fi
             # Code-scoped stamp: write next to the install tree, not into
             # $HERMES_HOME. $HERMES_HOME is a shared data dir (it can be
             # bind-mounted into a Docker gateway too), so a stamp there gets


### PR DESCRIPTION
## Summary

Users who do not need the web dashboard can avoid the expensive `npm run build` of the web SPA (Vite/tsc) during install, update, and first launch. This adds a consistent `--skip-build` opt-out across all three surfaces.

## Motivation

The web dashboard SPA is rebuilt via `npm run build` (tsc + Vite) at several points. For users who only use the CLI / TUI / desktop surfaces, this build is wasted time and compute on every `install.sh` run and every `hermes update`. This change lets them opt out once at install time and have that choice respected everywhere.

## Changes

- **`scripts/install.sh`**: new `--skip-build` flag. Writes a persistent marker `$HERMES_HOME/.skip-webui-build` in the `complete` stage. (The installer itself never builds the web SPA — it is built lazily at first launch — so this marker is what actually carries the opt-out forward.)
- **`hermes_cli/main.py`** (`_build_web_ui`): honor the `.skip-webui-build` marker so `hermes serve` / `hermes dashboard` / `hermes gui` skip the launch-time build.
- **`hermes update`**: recognize the install marker at both the git-pull and ZIP-fallback call sites and skip the web UI build, printing a clear message. Also adds an explicit `hermes update --skip-build` flag.
- **`hermes_cli/subcommands/update.py`**: register the `--skip-build` argument on the `update` subparser.

## Behavior matrix

| Scenario | Web UI build |
|---|---|
| Default install + `hermes update` | built (unchanged) |
| `install.sh --skip-build` → first launch | skipped (marker) |
| `install.sh --skip-build` → `hermes update` | skipped (marker recognized) |
| `hermes update --skip-build` | skipped (explicit flag) |
| `hermes serve --skip-build` (pre-existing) | skipped |

## Notes / caveats

- Skipping the build means no `web_dist` exists; the dashboard/serve surfaces will serve a 404 until a manual `npm run build` (or dropping the marker) is done. This matches the pre-existing `--skip-build` semantics on `serve`/`dashboard`/`gui`.
- The marker is sticky per `$HERMES_HOME`; remove `$HERMES_HOME/.skip-webui-build` to re-enable automatic builds.

## Test plan

- [x] `bash -n scripts/install.sh` passes
- [x] `py_compile` on edited modules passes
- [x] Existing web-ui/update tests pass (`tests/hermes_cli/test_web_ui_build.py`, `test_dashboard_web_dist_validation.py`, `test_cmd_update.py`)
- [x] Runtime proof: `_build_web_ui` returns skip when marker present; `_webui_build_skipped_via_install_marker()` toggles with marker presence; update decision matrix correct.
