### PR TITLE
fix(vision): detect Anthropic dimension-limit error for browser_vision resize

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -656,7 +656,8 @@ def _is_image_size_error(error: Exception) -> bool:
     return any(hint in err_str for hint in (
         "too large", "payload", "413", "content_too_large",
         "request_too_large", "image_url", "invalid_request",
-        "exceeds", "size limit",
+        "exceeds", "exceed", "size limit", "dimensions exceed",
+        "max allowed size",
     ))
 
 


### PR DESCRIPTION
## Problem

When `browser_vision` captures a screenshot that exceeds Anthropic's 8000-pixel dimension limit, the API returns:

```
At least one of the image dimensions exceed max allowed size: 8000 pixels
```

The `_is_image_size_error()` helper in `tools/vision_tools.py` checked for `"exceeds"` (with trailing *s*) but the actual error message uses `"exceed"` (no *s*). The auto-resize + retry path in both `browser_tool.py` and `vision_tools.py` was therefore never triggered on this specific rejection — `browser_vision` hard-failed instead of downscaling and retrying.

## Fix

Add `"exceed"`, `"dimensions exceed"`, and `"max allowed size"` to the hint list so the resize path fires correctly on Anthropic dimension rejections.

## Test

```python
err_str = "At least one of the image dimensions exceed max allowed size: 8000 pixels".lower()
hints = (..., "exceed", "dimensions exceed", "max allowed size")
any(h in err_str for h in hints)  # True
```

No behaviour change for errors that were already detected.