### PR TITLE
feat(desktop): crews, knowledge graph & Hermes Office (Claw3d) plugins

### DIFF
--- a/apps/desktop/electron/claw3d.test.ts
+++ b/apps/desktop/electron/claw3d.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  adapterPortFromWsUrl,
+  buildOfficeEnv,
+  buildOfficeSettings,
+  gatewayWsUrl,
+  isWindowsCommandScript,
+  pickWindowsCommandCandidate,
+  writeOfficeFileIfChanged
+} from './claw3d'
+
+describe('command resolution helpers', () => {
+  it('recognises Windows script extensions', () => {
+    expect(isWindowsCommandScript('npm.cmd')).toBe(true)
+    expect(isWindowsCommandScript('npm.bat')).toBe(true)
+    expect(isWindowsCommandScript('npm.exe')).toBe(false)
+    expect(isWindowsCommandScript('npm')).toBe(false)
+  })
+
+  it('prefers .exe over scripts and raw names', () => {
+    const resolved = pickWindowsCommandCandidate(['npm', 'npm.cmd', 'C:\\node\\npm.exe'])
+    expect(resolved).toEqual({ command: 'C:\\node\\npm.exe', windowsScript: false })
+  })
+
+  it('falls back to a script when no exe is present', () => {
+    const resolved = pickWindowsCommandCandidate(['npm', 'npm.cmd'])
+    expect(resolved).toEqual({ command: 'npm.cmd', windowsScript: true })
+  })
+
+  it('returns null for an empty candidate list', () => {
+    expect(pickWindowsCommandCandidate([])).toBeNull()
+  })
+})
+
+describe('gatewayWsUrl', () => {
+  it('builds a ws URL with the token', () => {
+    expect(gatewayWsUrl('http://127.0.0.1:8642', 'sekret')).toBe('ws://127.0.0.1:8642/api/ws?token=sekret')
+  })
+
+  it('upgrades https to wss', () => {
+    expect(gatewayWsUrl('https://hermes.example.com', 'tok')).toBe('wss://hermes.example.com/api/ws?token=tok')
+  })
+
+  it('preserves a path prefix', () => {
+    expect(gatewayWsUrl('http://localhost:8642/hermes', 't')).toBe('ws://localhost:8642/hermes/api/ws?token=t')
+  })
+
+  it('falls back to the raw input on parse failure', () => {
+    expect(gatewayWsUrl('not a url', 't')).toBe('not a url')
+  })
+})
+
+describe('adapterPortFromWsUrl', () => {
+  it('derives the adapter port from the gateway port', () => {
+    expect(adapterPortFromWsUrl('ws://127.0.0.1:18968/api/ws?token=x')).toBe(18989)
+  })
+
+  it('falls back to the default when no port is present', () => {
+    expect(adapterPortFromWsUrl('ws://host/api/ws?token=x')).toBe(18989)
+  })
+})
+
+describe('buildOfficeEnv', () => {
+  it('writes the expected dotenv lines', () => {
+    const env = buildOfficeEnv({
+      port: 3000,
+      url: 'ws://127.0.0.1:18968/api/ws?token=x',
+      apiUrl: 'http://127.0.0.1:8642',
+      apiKey: 'x',
+      model: 'hermes',
+      adapterPort: 18989
+    })
+
+    expect(env).toContain('PORT=3000')
+    expect(env).toContain('HERMES_API_URL=http://127.0.0.1:8642')
+    expect(env).toContain('HERMES_API_KEY=x')
+    expect(env).toContain('HERMES_ADAPTER_PORT=18989')
+    expect(env).toContain('CLAW3D_GATEWAY_ADAPTER_TYPE=hermes')
+  })
+})
+
+describe('buildOfficeSettings', () => {
+  it('merges gateway config while preserving existing fields', () => {
+    const settings = buildOfficeSettings({ theme: 'dark' }, { url: 'http://127.0.0.1:8642', apiKey: 'k' })
+    const gateway = settings.gateway as Record<string, unknown>
+    const profiles = gateway.profiles as Record<string, { url: string; token: string }>
+    const lastKnownGood = gateway.lastKnownGood as { adapterType: string }
+    expect(settings.theme).toBe('dark')
+    expect(settings.adapter).toBe('hermes')
+    expect(gateway.url).toBe('http://127.0.0.1:8642')
+    expect(profiles.hermes).toEqual({ url: 'http://127.0.0.1:8642', token: 'k' })
+    expect(lastKnownGood.adapterType).toBe('hermes')
+  })
+
+  it('does not clobber an existing hermes profile', () => {
+    const existing = {
+      gateway: { profiles: { hermes: { url: 'http://old', token: 'old' }, other: { url: 'http://o', token: 't' } } }
+    }
+
+    const settings = buildOfficeSettings(existing, { url: 'http://new', apiKey: 'n' })
+    const profiles = (settings.gateway as Record<string, unknown>).profiles as Record<string, { url: string; token: string }>
+    expect(profiles.hermes).toEqual({ url: 'http://new', token: 'n' })
+    expect(profiles.other).toEqual({ url: 'http://o', token: 't' })
+  })
+})
+
+describe('writeOfficeFileIfChanged', () => {
+  it('writes when missing and skips identical content', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claw3d-test-'))
+    const file = join(dir, 'nested', 'settings.json')
+    expect(writeOfficeFileIfChanged(file, 'one')).toBe(true)
+    expect(writeOfficeFileIfChanged(file, 'one')).toBe(false)
+    writeFileSync(file, 'two')
+    expect(writeOfficeFileIfChanged(file, 'one')).toBe(true)
+  })
+})

--- a/apps/desktop/electron/claw3d.test.ts
+++ b/apps/desktop/electron/claw3d.test.ts
@@ -11,6 +11,7 @@ import {
   gatewayWsUrl,
   isWindowsCommandScript,
   pickWindowsCommandCandidate,
+  stripGatewayToken,
   writeOfficeFileIfChanged
 } from './claw3d'
 
@@ -65,6 +66,24 @@ describe('adapterPortFromWsUrl', () => {
   })
 })
 
+describe('stripGatewayToken', () => {
+  it('removes the token query parameter', () => {
+    expect(stripGatewayToken('ws://127.0.0.1:18968/api/ws?token=x')).toBe('ws://127.0.0.1:18968/api/ws')
+  })
+
+  it('keeps other query parameters', () => {
+    expect(stripGatewayToken('ws://127.0.0.1:18968/api/ws?token=x&other=1')).toBe('ws://127.0.0.1:18968/api/ws?other=1')
+  })
+
+  it('leaves a tokenless URL unchanged', () => {
+    expect(stripGatewayToken('ws://127.0.0.1:18968/api/ws')).toBe('ws://127.0.0.1:18968/api/ws')
+  })
+
+  it('falls back to the raw input on parse failure', () => {
+    expect(stripGatewayToken('not a url')).toBe('not a url')
+  })
+})
+
 describe('buildOfficeEnv', () => {
   it('writes the expected dotenv lines', () => {
     const env = buildOfficeEnv({
@@ -81,6 +100,23 @@ describe('buildOfficeEnv', () => {
     expect(env).toContain('HERMES_API_KEY=x')
     expect(env).toContain('HERMES_ADAPTER_PORT=18989')
     expect(env).toContain('CLAW3D_GATEWAY_ADAPTER_TYPE=hermes')
+  })
+
+  it('keeps the session token out of the client-bundle var', () => {
+    const env = buildOfficeEnv({
+      port: 3000,
+      url: 'ws://127.0.0.1:18968/api/ws?token=sekret',
+      apiUrl: 'http://127.0.0.1:8642',
+      apiKey: 'sekret',
+      model: 'hermes',
+      adapterPort: 18989
+    })
+
+    // NEXT_PUBLIC_* vars are inlined into the client bundle — the tokenized
+    // URL must only reach the server-side CLAW3D_GATEWAY_URL.
+    expect(env).toContain('NEXT_PUBLIC_GATEWAY_URL=ws://127.0.0.1:18968/api/ws\n')
+    expect(env).not.toContain('NEXT_PUBLIC_GATEWAY_URL=ws://127.0.0.1:18968/api/ws?token=')
+    expect(env).toContain('CLAW3D_GATEWAY_URL=ws://127.0.0.1:18968/api/ws?token=sekret')
   })
 })
 

--- a/apps/desktop/electron/claw3d.ts
+++ b/apps/desktop/electron/claw3d.ts
@@ -15,8 +15,7 @@
  */
 import type { ChildProcess} from 'child_process';
 import { execFileSync, spawn, spawnSync } from 'child_process'
-import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
-import http from 'http'
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs'
 import { createConnection } from 'net'
 import { homedir } from 'os'
 import { join } from 'path'
@@ -182,6 +181,19 @@ export function adapterPortFromWsUrl(url: string): number {
   return DEFAULT_ADAPTER_PORT
 }
 
+/** Strip the session token from a gateway URL. NEXT_PUBLIC_* values are
+ *  inlined into the client bundle by Next.js, so the tokenized URL must only
+ *  ever reach server-side vars (CLAW3D_GATEWAY_URL / CLAW3D_GATEWAY_TOKEN). */
+export function stripGatewayToken(url: string): string {
+  try {
+    const parsed = new URL(url)
+    parsed.searchParams.delete('token')
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
 export function buildOfficeEnv(opts: {
   port: number
   url: string
@@ -196,7 +208,7 @@ export function buildOfficeEnv(opts: {
     '# Auto-configured by Hermes Desktop',
     `PORT=${opts.port}`,
     `HOST=127.0.0.1`,
-    `NEXT_PUBLIC_GATEWAY_URL=${opts.url}`,
+    `NEXT_PUBLIC_GATEWAY_URL=${stripGatewayToken(opts.url)}`,
     `CLAW3D_GATEWAY_URL=${opts.url}`,
     `CLAW3D_GATEWAY_TOKEN=${opts.apiKey}`,
     `CLAW3D_GATEWAY_ADAPTER_TYPE=hermes`,
@@ -329,22 +341,6 @@ function probeTcp(port: number, host = '127.0.0.1', timeoutMs = 300): Promise<bo
   })
 }
 
-function probeHttp(url: string, timeoutMs = 1500): Promise<boolean> {
-  return new Promise(resolve => {
-    const req = http.request(url, { method: 'GET', timeout: timeoutMs }, res => {
-      res.resume()
-      resolve(true)
-    })
-
-    req.on('error', () => resolve(false))
-    req.on('timeout', () => {
-      req.destroy()
-      resolve(false)
-    })
-    req.end()
-  })
-}
-
 export interface Claw3dStatus {
   cloned: boolean
   installed: boolean
@@ -413,6 +409,45 @@ function isAdapterRunning(): boolean {
   const pid = readPid(ADAPTER_PID_FILE)
 
   if (pid && isProcessRunning(pid)) {return true}
+  cleanupPid(ADAPTER_PID_FILE)
+
+  return false
+}
+
+/** Trust a pid file's liveness claim blindly only while the child may still be
+ *  booting; after that, cross-check the TCP port so an OS-reused PID can't
+ *  keep reporting a dead server as "running". */
+const PID_STARTUP_GRACE_MS = 60_000
+
+function pidFileAgeMs(file: string): number {
+  try {
+    return Date.now() - statSync(file).mtimeMs
+  } catch {
+    return Number.POSITIVE_INFINITY
+  }
+}
+
+async function isDevServerLive(): Promise<boolean> {
+  if (devServerProcess && !devServerProcess.killed) {return true}
+  const pid = readPid(DEV_PID_FILE)
+
+  if (pid && isProcessRunning(pid)) {
+    if (pidFileAgeMs(DEV_PID_FILE) < PID_STARTUP_GRACE_MS) {return true}
+    if (await probeTcp(getClaw3dPort())) {return true}
+  }
+  cleanupPid(DEV_PID_FILE)
+
+  return false
+}
+
+async function isAdapterLive(): Promise<boolean> {
+  if (adapterProcess && !adapterProcess.killed) {return true}
+  const pid = readPid(ADAPTER_PID_FILE)
+
+  if (pid && isProcessRunning(pid)) {
+    if (pidFileAgeMs(ADAPTER_PID_FILE) < PID_STARTUP_GRACE_MS) {return true}
+    if (await probeTcp(DEFAULT_ADAPTER_PORT)) {return true}
+  }
   cleanupPid(ADAPTER_PID_FILE)
 
   return false
@@ -503,9 +538,9 @@ export async function getClaw3dStatus(profile?: string): Promise<Claw3dStatus> {
 
   if (installed) {void writeClaw3dSettings(profile)}
   const port = getClaw3dPort()
-  const devRunning = isDevServerRunning()
+  const devRunning = await isDevServerLive()
   const portInUse = devRunning ? false : await probeTcp(port)
-  const adapterUp = isAdapterRunning()
+  const adapterUp = await isAdapterLive()
 
   return {
     cloned,

--- a/apps/desktop/electron/claw3d.ts
+++ b/apps/desktop/electron/claw3d.ts
@@ -1,0 +1,873 @@
+/**
+ * Hermes Office (Claw3d) manager — spawn/manage the `fathah/hermes-office`
+ * 3D interface: clone + install the repo under HERMES_HOME/hermes-office,
+ * write its .env + ~/.openclaw/claw3d/settings.json from the active Hermes
+ * connection, run the Next.js dev server (:3000) and the
+ * hermes-gateway-adapter (:18989), and report status/logs to the renderer.
+ *
+ * Ported from the community `fathah/hermes-desktop` src/main/claw3d.ts,
+ * adapted to this app's connection model (the connection resolver is injected
+ * by electron/main.ts instead of reading fathah's installer config).
+ *
+ * Office needs a local/token gateway connection: the adapter authenticates
+ * with the gateway's session token via the legacy `Bearer` header, which the
+ * Hermes HTTP API accepts. OAuth-gated gateways are surfaced as unsupported.
+ */
+import type { ChildProcess} from 'child_process';
+import { execFileSync, spawn, spawnSync } from 'child_process'
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
+import http from 'http'
+import { createConnection } from 'net'
+import { homedir } from 'os'
+import { join } from 'path'
+
+const HERMES_OFFICE_REPO = 'https://github.com/fathah/hermes-office'
+const DEFAULT_PORT = 3000
+const DEFAULT_ADAPTER_PORT = 18989
+const CLAW3D_SETTINGS_DIR = join(homedir(), '.openclaw', 'claw3d')
+
+function hermesHome(): string {
+  return process.env.HERMES_HOME || join(homedir(), '.hermes')
+}
+
+const HERMES_OFFICE_DIR = join(hermesHome(), 'hermes-office')
+const DEV_PID_FILE = join(hermesHome(), 'claw3d-dev.pid')
+const ADAPTER_PID_FILE = join(hermesHome(), 'claw3d-adapter.pid')
+const PORT_FILE = join(hermesHome(), 'claw3d-port')
+
+/** Connection facts the renderer-facing manager needs (injected by main). */
+export interface OfficeConnection {
+  baseUrl: string
+  token: string
+  authMode: 'token' | 'oauth' | 'none' | string
+}
+
+type ConnectionResolver = (profile?: string) => Promise<OfficeConnection>
+
+let _resolveConnection: ConnectionResolver | null = null
+
+/** Inject the connection resolver (called once from electron/main.ts). */
+export function setConnectionResolver(resolver: ConnectionResolver | null): void {
+  _resolveConnection = resolver
+}
+
+async function resolveConnection(profile?: string): Promise<OfficeConnection> {
+  if (!_resolveConnection) {
+    return { baseUrl: `http://127.0.0.1:8642`, token: '', authMode: 'none' }
+  }
+
+  return _resolveConnection(profile)
+}
+
+let devServerProcess: ChildProcess | null = null
+let adapterProcess: ChildProcess | null = null
+let devServerLogs = ''
+let adapterLogs = ''
+let devServerError = ''
+let adapterError = ''
+
+export interface ResolvedCommand {
+  command: string
+  windowsScript: boolean
+}
+
+export interface CommandInvocation {
+  command: string
+  args: string[]
+  windowsVerbatimArguments?: boolean
+}
+
+type Claw3dScript = 'dev' | 'hermes-adapter'
+
+const CLAW3D_SCRIPT_ARGS: Record<Claw3dScript, string[]> = {
+  dev: ['server/index.js', '--dev'],
+  'hermes-adapter': ['server/hermes-gateway-adapter.js']
+}
+
+export function isWindowsCommandScript(command: string): boolean {
+  return /\.(cmd|bat)$/i.test(command)
+}
+
+export function pickWindowsCommandCandidate(candidates: string[]): ResolvedCommand | null {
+  const normalized = candidates.map(candidate => candidate.trim()).filter(Boolean)
+  const executable = normalized.find(candidate => /\.exe$/i.test(candidate))
+
+  if (executable) {return { command: executable, windowsScript: false }}
+  const script = normalized.find(isWindowsCommandScript)
+
+  if (script) {return { command: script, windowsScript: true }}
+  const fallback = normalized[0]
+
+  return fallback ? { command: fallback, windowsScript: false } : null
+}
+
+export function resolveCommandOnPath(command: string, envPath: string): ResolvedCommand | null {
+  const lookupCommand = process.platform === 'win32' ? 'where.exe' : 'which'
+
+  const result = spawnSync(lookupCommand, [command], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: envPath },
+    timeout: 5000,
+    windowsHide: true
+  })
+
+  if (result.error || result.status !== 0 || !result.stdout) {return null}
+  const candidates = result.stdout.split(/\r?\n/)
+
+  if (process.platform === 'win32') {return pickWindowsCommandCandidate(candidates)}
+  const resolved = candidates.map(candidate => candidate.trim()).find(Boolean)
+
+  return resolved ? { command: resolved, windowsScript: false } : null
+}
+
+export function resolveCommand(command: string, envPath: string): ResolvedCommand {
+  const resolved = resolveCommandOnPath(command, envPath)
+
+  if (resolved) {return resolved}
+
+  return { command, windowsScript: process.platform === 'win32' && isWindowsCommandScript(command) }
+}
+
+export function buildWindowsScriptCommandLine(
+  command: string,
+  args: string[],
+  options: { verbatim?: boolean } = {}
+): { command: string; args: string[]; windowsVerbatimArguments?: boolean } {
+  if (options.verbatim && isWindowsCommandScript(command)) {
+    return { command, args, windowsVerbatimArguments: true }
+  }
+
+  return { command, args }
+}
+
+export function createNpmCommandInvocation(resolved: ResolvedCommand, args: string[]): CommandInvocation {
+  return buildWindowsScriptCommandLine(resolved.command, args, {
+    verbatim: resolved.windowsScript
+  })
+}
+
+export function createClaw3dScriptInvocation(script: Claw3dScript, nodeCommand: string): CommandInvocation {
+  return {
+    command: nodeCommand,
+    args: CLAW3D_SCRIPT_ARGS[script]
+  }
+}
+
+export function setClaw3dPort(port: number): void {
+  safeWriteFile(PORT_FILE, String(port))
+}
+
+export function getClaw3dPort(): number {
+  try {
+    const parsed = parseInt(readFileSync(PORT_FILE, 'utf-8').trim(), 10)
+
+    if (!isNaN(parsed) && parsed > 0 && parsed < 65536) {return parsed}
+  } catch {
+    /* fresh */
+  }
+
+  return DEFAULT_PORT
+}
+
+export function adapterPortFromWsUrl(url: string): number {
+  try {
+    const parsed = new URL(url)
+    const port = parsed.port ? parseInt(parsed.port, 10) : NaN
+
+    if (!isNaN(port)) {return port + 21}
+  } catch {
+    /* not a URL */
+  }
+
+  return DEFAULT_ADAPTER_PORT
+}
+
+export function buildOfficeEnv(opts: {
+  port: number
+  url: string
+  apiUrl: string
+  apiKey: string
+  model: string
+  adapterPort?: number
+}): string {
+  const adapterPort = opts.adapterPort ?? adapterPortFromWsUrl(opts.url)
+
+  return [
+    '# Auto-configured by Hermes Desktop',
+    `PORT=${opts.port}`,
+    `HOST=127.0.0.1`,
+    `NEXT_PUBLIC_GATEWAY_URL=${opts.url}`,
+    `CLAW3D_GATEWAY_URL=${opts.url}`,
+    `CLAW3D_GATEWAY_TOKEN=${opts.apiKey}`,
+    `CLAW3D_GATEWAY_ADAPTER_TYPE=hermes`,
+    `HERMES_API_URL=${opts.apiUrl}`,
+    `HERMES_API_KEY=${opts.apiKey}`,
+    `HERMES_ADAPTER_PORT=${adapterPort}`,
+    `HERMES_MODEL=${opts.model || 'hermes'}`,
+    `HERMES_AGENT_NAME=Hermes`,
+    ''
+  ].join('\n')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+/** Derive the gateway WS URL (with token) from the HTTP base URL — mirrors
+ *  connection-config's buildGatewayWsUrl so Office's UI vars point at a live
+ *  WebSocket the same way the rest of the app connects. */
+export function gatewayWsUrl(baseUrl: string, token: string): string {
+  try {
+    const parsed = new URL(baseUrl)
+    const wsScheme = parsed.protocol === 'https:' ? 'wss' : 'ws'
+    const prefix = parsed.pathname.replace(/\/+$/, '')
+
+    return `${wsScheme}://${parsed.host}${prefix}/api/ws?token=${encodeURIComponent(token)}`
+  } catch {
+    return baseUrl
+  }
+}
+
+export function buildOfficeSettings(
+  existing: Record<string, unknown>,
+  opts: { url: string; apiKey: string }
+): Record<string, unknown> {
+  const existingGateway = isRecord(existing.gateway) ? existing.gateway : {}
+  const existingProfiles = isRecord(existingGateway.profiles) ? existingGateway.profiles : {}
+  const hermesProfile = { url: opts.url, token: opts.apiKey }
+
+  return {
+    ...existing,
+    adapter: 'hermes',
+    url: opts.url,
+    token: opts.apiKey,
+    gateway: {
+      ...existingGateway,
+      url: opts.url,
+      token: opts.apiKey,
+      adapterType: 'hermes',
+      profiles: { ...existingProfiles, hermes: hermesProfile },
+      lastKnownGood: { url: opts.url, token: opts.apiKey, adapterType: 'hermes' }
+    }
+  }
+}
+
+export function writeOfficeFileIfChanged(filePath: string, content: string): boolean {
+  try {
+    if (existsSync(filePath) && readFileSync(filePath, 'utf-8') === content) {return false}
+  } catch {
+    /* fall through to repair */
+  }
+
+  safeWriteFile(filePath, content)
+
+  return true
+}
+
+async function writeClaw3dSettings(profile?: string): Promise<void> {
+  const conn = await resolveConnection(profile)
+
+  if (conn.authMode === 'oauth') {return} // surfaced via status; never write a dead ticket
+
+  try {
+    mkdirSync(CLAW3D_SETTINGS_DIR, { recursive: true })
+    const settingsPath = join(CLAW3D_SETTINGS_DIR, 'settings.json')
+    let existing: Record<string, unknown> = {}
+
+    try {
+      existing = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    } catch {
+      /* fresh */
+    }
+
+    const settings = buildOfficeSettings(existing, {
+      url: conn.baseUrl,
+      apiKey: conn.token
+    })
+
+    writeOfficeFileIfChanged(settingsPath, JSON.stringify(settings, null, 2))
+  } catch {
+    /* non-fatal */
+  }
+
+  try {
+    if (existsSync(HERMES_OFFICE_DIR)) {
+      const envPath = join(HERMES_OFFICE_DIR, '.env')
+      writeOfficeFileIfChanged(
+        envPath,
+        buildOfficeEnv({
+          port: getClaw3dPort(),
+          url: gatewayWsUrl(conn.baseUrl, conn.token),
+          apiUrl: conn.baseUrl,
+          apiKey: conn.token,
+          model: 'hermes',
+          adapterPort: DEFAULT_ADAPTER_PORT
+        })
+      )
+    }
+  } catch {
+    /* non-fatal */
+  }
+}
+
+function probeTcp(port: number, host = '127.0.0.1', timeoutMs = 300): Promise<boolean> {
+  return new Promise(resolve => {
+    const socket = createConnection({ port, host })
+    socket.setTimeout(timeoutMs)
+    socket.on('connect', () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.on('error', () => {
+      socket.destroy()
+      resolve(false)
+    })
+    socket.on('timeout', () => {
+      socket.destroy()
+      resolve(false)
+    })
+  })
+}
+
+function probeHttp(url: string, timeoutMs = 1500): Promise<boolean> {
+  return new Promise(resolve => {
+    const req = http.request(url, { method: 'GET', timeout: timeoutMs }, res => {
+      res.resume()
+      resolve(true)
+    })
+
+    req.on('error', () => resolve(false))
+    req.on('timeout', () => {
+      req.destroy()
+      resolve(false)
+    })
+    req.end()
+  })
+}
+
+export interface Claw3dStatus {
+  cloned: boolean
+  installed: boolean
+  devServerRunning: boolean
+  adapterRunning: boolean
+  running: boolean
+  port: number
+  portInUse: boolean
+  url: string
+  error: string
+  oauthUnsupported: boolean
+}
+
+export interface Claw3dSetupProgress {
+  step: number
+  totalSteps: number
+  title: string
+  detail: string
+  log: string
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+function readPid(file: string): number | null {
+  try {
+    const pid = parseInt(readFileSync(file, 'utf-8').trim(), 10)
+
+    return isNaN(pid) ? null : pid
+  } catch {
+    return null
+  }
+}
+
+function writePid(file: string, pid: number): void {
+  safeWriteFile(file, String(pid))
+}
+
+function cleanupPid(file: string): void {
+  try {
+    unlinkSync(file)
+  } catch {
+    /* ignore */
+  }
+}
+
+function isDevServerRunning(): boolean {
+  if (devServerProcess && !devServerProcess.killed) {return true}
+  const pid = readPid(DEV_PID_FILE)
+
+  if (pid && isProcessRunning(pid)) {return true}
+  cleanupPid(DEV_PID_FILE)
+
+  return false
+}
+
+function isAdapterRunning(): boolean {
+  if (adapterProcess && !adapterProcess.killed) {return true}
+  const pid = readPid(ADAPTER_PID_FILE)
+
+  if (pid && isProcessRunning(pid)) {return true}
+  cleanupPid(ADAPTER_PID_FILE)
+
+  return false
+}
+
+function stripAnsi(input: string): string {
+  // eslint-disable-next-line no-control-regex
+  return input.replace(/\u001b\[[0-9;]*m/g, '')
+}
+
+function safeWriteFile(filePath: string, content: string): void {
+  try {
+    mkdirSync(join(filePath, '..'), { recursive: true })
+    writeFileSync(filePath, content)
+  } catch {
+    /* non-fatal */
+  }
+}
+
+function findNpm(envPath: string): ResolvedCommand {
+  if (process.platform === 'win32') {
+    const resolved = resolveCommandOnPath('npm', envPath)
+
+    if (resolved) {return resolved}
+  }
+
+  const home = homedir()
+
+  const candidates = [
+    ...(process.platform === 'win32'
+      ? [
+          process.env.NVM_SYMLINK ? join(process.env.NVM_SYMLINK, 'npm.cmd') : undefined,
+          join(home, 'AppData', 'Roaming', 'npm', 'npm.cmd'),
+          process.env.ProgramFiles ? join(process.env.ProgramFiles, 'nodejs', 'npm.cmd') : undefined,
+          process.env['ProgramFiles(x86)'] ? join(process.env['ProgramFiles(x86)'], 'nodejs', 'npm.cmd') : undefined
+        ]
+      : []),
+    join(home, '.volta', 'bin', 'npm'),
+    join(home, '.asdf', 'shims', 'npm'),
+    join(home, '.local', 'share', 'fnm', 'aliases', 'default', 'bin', 'npm'),
+    join(home, '.fnm', 'aliases', 'default', 'bin', 'npm'),
+    '/usr/local/bin/npm',
+    '/opt/homebrew/bin/npm'
+  ].filter((candidate): candidate is string => Boolean(candidate))
+
+  const nvmDir = process.env.NVM_DIR || join(home, '.nvm')
+  const nvmVersions = join(nvmDir, 'versions', 'node')
+
+  if (existsSync(nvmVersions)) {
+    try {
+      const versions = readdirSync(nvmVersions)
+        .filter(d => d.startsWith('v'))
+        .sort()
+        .reverse()
+
+      for (const v of versions) {candidates.unshift(join(nvmVersions, v, 'bin', 'npm'))}
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return { command: candidate, windowsScript: process.platform === 'win32' && isWindowsCommandScript(candidate) }
+    }
+  }
+
+  if (process.platform !== 'win32') {
+    const resolved = resolveCommandOnPath('npm', envPath)
+
+    if (resolved) {return resolved}
+  }
+
+  return resolveCommand('npm', envPath)
+}
+
+function envPath(): string {
+  const hermesNodeBin = join(hermesHome(), 'node', 'bin')
+  const parts = [hermesNodeBin, process.env.PATH || '']
+
+  return parts.filter(Boolean).join(process.platform === 'win32' ? ';' : ':')
+}
+
+export async function getClaw3dStatus(profile?: string): Promise<Claw3dStatus> {
+  const conn = await resolveConnection(profile)
+  const cloned = existsSync(join(HERMES_OFFICE_DIR, 'package.json'))
+  const installed = existsSync(join(HERMES_OFFICE_DIR, 'node_modules'))
+
+  if (installed) {void writeClaw3dSettings(profile)}
+  const port = getClaw3dPort()
+  const devRunning = isDevServerRunning()
+  const portInUse = devRunning ? false : await probeTcp(port)
+  const adapterUp = isAdapterRunning()
+
+  return {
+    cloned,
+    installed,
+    devServerRunning: devRunning,
+    adapterRunning: adapterUp,
+    running: devRunning && adapterUp,
+    port,
+    portInUse,
+    url: conn.baseUrl,
+    error: devServerError || adapterError || '',
+    oauthUnsupported: conn.authMode === 'oauth'
+  }
+}
+
+export async function setupClaw3d(
+  onProgress: (progress: Claw3dSetupProgress) => void,
+  profile?: string
+): Promise<void> {
+  const totalSteps = 2
+  let log = ''
+
+  function emit(step: number, title: string, text: string): void {
+    log += text
+    onProgress({ step, totalSteps, title, detail: text.trim().slice(0, 120), log })
+  }
+
+  const env = { ...process.env, PATH: envPath(), HOME: homedir(), TERM: 'dumb' }
+  const git = resolveCommand('git', env.PATH)
+
+  const cloned = existsSync(join(HERMES_OFFICE_DIR, 'package.json'))
+
+  if (!cloned) {
+    emit(1, 'Cloning Hermes Office repository…', 'Cloning from GitHub…\n')
+    await new Promise<void>((resolve, reject) => {
+      const gitClone = buildWindowsScriptCommandLine(git.command, ['clone', HERMES_OFFICE_REPO, HERMES_OFFICE_DIR], {
+        verbatim: git.windowsScript
+      })
+
+      const proc = spawn(gitClone.command, gitClone.args, {
+        cwd: homedir(),
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+        windowsVerbatimArguments: gitClone.windowsVerbatimArguments
+      })
+
+      proc.stdout?.on('data', (data: Buffer) =>
+        emit(1, 'Cloning Hermes Office repository…', stripAnsi(data.toString()))
+      )
+      proc.stderr?.on('data', (data: Buffer) =>
+        emit(1, 'Cloning Hermes Office repository…', stripAnsi(data.toString()))
+      )
+      proc.on('close', code => {
+        if (code === 0) {
+          emit(1, 'Cloning Hermes Office repository…', 'Clone complete.\n')
+          resolve()
+        } else {
+          reject(new Error(`git clone failed (exit code ${code})`))
+        }
+      })
+      proc.on('error', err => reject(new Error(`Failed to run git: ${err.message}`)))
+    })
+  } else {
+    emit(1, 'Hermes Office already cloned', 'Repository already exists, pulling latest…\n')
+    await new Promise<void>(resolve => {
+      const gitPull = buildWindowsScriptCommandLine(git.command, ['pull', '--ff-only'], { verbatim: git.windowsScript })
+
+      const proc = spawn(gitPull.command, gitPull.args, {
+        cwd: HERMES_OFFICE_DIR,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+        windowsVerbatimArguments: gitPull.windowsVerbatimArguments
+      })
+
+      proc.stdout?.on('data', (data: Buffer) => emit(1, 'Updating Hermes Office…', stripAnsi(data.toString())))
+      proc.stderr?.on('data', (data: Buffer) => emit(1, 'Updating Hermes Office…', stripAnsi(data.toString())))
+      proc.on('close', () => resolve())
+      proc.on('error', () => resolve())
+    })
+  }
+
+  emit(2, 'Installing dependencies…', 'Running npm install…\n')
+  const npm = createNpmCommandInvocation(findNpm(env.PATH), ['install'])
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(npm.command, npm.args, {
+      cwd: HERMES_OFFICE_DIR,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+      windowsVerbatimArguments: npm.windowsVerbatimArguments
+    })
+
+    proc.stdout?.on('data', (data: Buffer) => emit(2, 'Installing dependencies…', stripAnsi(data.toString())))
+    proc.stderr?.on('data', (data: Buffer) => emit(2, 'Installing dependencies…', stripAnsi(data.toString())))
+    proc.on('close', code => {
+      if (code === 0) {
+        emit(2, 'Installing dependencies…', 'Dependencies installed successfully.\n')
+        resolve()
+      } else {
+        reject(new Error(`npm install failed (exit code ${code})`))
+      }
+    })
+    proc.on('error', err => reject(new Error(`Failed to run npm: ${err.message}`)))
+  })
+
+  await writeClaw3dSettings(profile)
+}
+
+function killProcessTree(proc: ChildProcess): void {
+  if (!proc.pid) {return}
+
+  if (process.platform === 'win32') {
+    try {
+      execFileSync('taskkill', ['/F', '/T', '/PID', String(proc.pid)], { stdio: 'ignore' })
+    } catch {
+      try {
+        proc.kill('SIGKILL')
+      } catch {
+        /* already dead */
+      }
+    }
+  } else {
+    try {
+      process.kill(-proc.pid, 'SIGTERM')
+    } catch {
+      try {
+        proc.kill('SIGTERM')
+      } catch {
+        /* already dead */
+      }
+    }
+
+    const pid = proc.pid
+    setTimeout(() => {
+      try {
+        process.kill(-pid, 'SIGKILL')
+      } catch {
+        try {
+          process.kill(pid, 'SIGKILL')
+        } catch {
+          /* already dead */
+        }
+      }
+    }, 3000)
+  }
+}
+
+export function startDevServer(): boolean {
+  if (isDevServerRunning()) {return true}
+
+  if (!existsSync(join(HERMES_OFFICE_DIR, 'node_modules'))) {return false}
+
+  devServerError = ''
+  devServerLogs = ''
+  const port = getClaw3dPort()
+  const env = { ...process.env, PATH: envPath(), HOME: homedir(), TERM: 'dumb', PORT: String(port) }
+  const node = resolveCommand('node', env.PATH)
+  const devScript = createClaw3dScriptInvocation('dev', node.command)
+
+  const proc = spawn(devScript.command, devScript.args, {
+    cwd: HERMES_OFFICE_DIR,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+    windowsHide: true,
+    windowsVerbatimArguments: devScript.windowsVerbatimArguments
+  })
+
+  devServerProcess = proc
+
+  if (proc.pid) {writePid(DEV_PID_FILE, proc.pid)}
+
+  proc.stdout?.on('data', (data: Buffer) => {
+    devServerLogs += stripAnsi(data.toString())
+
+    if (devServerLogs.length > 2000) {devServerLogs = devServerLogs.slice(-2000)}
+  })
+  proc.stderr?.on('data', (data: Buffer) => {
+    const text = stripAnsi(data.toString())
+    devServerLogs += text
+
+    if (devServerLogs.length > 2000) {devServerLogs = devServerLogs.slice(-2000)}
+
+    if (/error|EADDRINUSE|ENOENT|failed|fatal/i.test(text) && !/warning/i.test(text)) {
+      devServerError = text.trim().slice(0, 300)
+    }
+  })
+  proc.on('close', code => {
+    if (code && code !== 0 && !devServerError) {
+      devServerError = `Dev server exited with code ${code}. Check if port ${port} is available.`
+    }
+
+    devServerProcess = null
+    cleanupPid(DEV_PID_FILE)
+  })
+
+  proc.unref()
+
+  return true
+}
+
+export function stopDevServer(): void {
+  if (devServerProcess) {
+    killProcessTree(devServerProcess)
+    devServerProcess = null
+  }
+
+  const pid = readPid(DEV_PID_FILE)
+
+  if (pid) {
+    try {
+      process.kill(-pid, 'SIGTERM')
+    } catch {
+      try {
+        process.kill(pid, 'SIGTERM')
+      } catch {
+        /* already dead */
+      }
+    }
+  }
+
+  cleanupPid(DEV_PID_FILE)
+}
+
+export function startAdapter(profile?: string): boolean {
+  if (isAdapterRunning()) {return true}
+
+  if (!existsSync(join(HERMES_OFFICE_DIR, 'node_modules'))) {return false}
+
+  adapterError = ''
+  adapterLogs = ''
+  const snapshot = lastConnectionSnapshot
+
+  const env = {
+    ...process.env,
+    PATH: envPath(),
+    HOME: homedir(),
+    TERM: 'dumb',
+    HERMES_ADAPTER_PORT: String(DEFAULT_ADAPTER_PORT),
+    ...(snapshot && snapshot.authMode !== 'oauth'
+      ? { HERMES_API_URL: snapshot.baseUrl, HERMES_API_KEY: snapshot.token }
+      : {})
+  }
+
+  const node = resolveCommand('node', env.PATH)
+  const adapterScript = createClaw3dScriptInvocation('hermes-adapter', node.command)
+
+  const proc = spawn(adapterScript.command, adapterScript.args, {
+    cwd: HERMES_OFFICE_DIR,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+    windowsHide: true,
+    windowsVerbatimArguments: adapterScript.windowsVerbatimArguments
+  })
+
+  adapterProcess = proc
+
+  if (proc.pid) {writePid(ADAPTER_PID_FILE, proc.pid)}
+
+  proc.stdout?.on('data', (data: Buffer) => {
+    adapterLogs += stripAnsi(data.toString())
+
+    if (adapterLogs.length > 2000) {adapterLogs = adapterLogs.slice(-2000)}
+  })
+  proc.stderr?.on('data', (data: Buffer) => {
+    const text = stripAnsi(data.toString())
+    adapterLogs += text
+
+    if (adapterLogs.length > 2000) {adapterLogs = adapterLogs.slice(-2000)}
+
+    if (/error|EADDRINUSE|ENOENT|failed|fatal/i.test(text) && !/warning/i.test(text)) {
+      adapterError = text.trim().slice(0, 300)
+    }
+  })
+  proc.on('close', code => {
+    if (code && code !== 0 && !adapterError) {
+      adapterError = `Hermes adapter exited with code ${code}`
+    }
+
+    adapterProcess = null
+    cleanupPid(ADAPTER_PID_FILE)
+  })
+
+  proc.unref()
+
+  return true
+}
+
+export function stopAdapter(): void {
+  if (adapterProcess) {
+    killProcessTree(adapterProcess)
+    adapterProcess = null
+  }
+
+  const pid = readPid(ADAPTER_PID_FILE)
+
+  if (pid) {
+    try {
+      process.kill(-pid, 'SIGTERM')
+    } catch {
+      try {
+        process.kill(pid, 'SIGTERM')
+      } catch {
+        /* already dead */
+      }
+    }
+  }
+
+  cleanupPid(ADAPTER_PID_FILE)
+}
+
+let lastConnectionSnapshot: OfficeConnection | null = null
+
+/** Keep a cheap synchronous snapshot for startAdapter's fast path. */
+export function setConnectionSnapshot(conn: OfficeConnection | null): void {
+  lastConnectionSnapshot = conn
+}
+
+export async function startAll(profile?: string): Promise<{ success: boolean; error?: string }> {
+  if (!existsSync(join(HERMES_OFFICE_DIR, 'node_modules'))) {
+    return { success: false, error: 'Hermes Office is not installed. Please install it first.' }
+  }
+
+  const conn = await resolveConnection(profile)
+  setConnectionSnapshot(conn)
+
+  if (conn.authMode === 'oauth') {
+    return {
+      success: false,
+      error: 'Office requires a local/token gateway connection (OAuth-gated gateways are not supported yet).'
+    }
+  }
+
+  await writeClaw3dSettings(profile)
+
+  const devOk = startDevServer()
+
+  if (!devOk) {return { success: false, error: `Failed to start dev server on port ${getClaw3dPort()}` }}
+
+  const adapterOk = startAdapter(profile)
+
+  if (!adapterOk) {return { success: false, error: 'Failed to start Hermes adapter' }}
+
+  return { success: true }
+}
+
+export function stopAll(): void {
+  stopDevServer()
+  stopAdapter()
+  devServerError = ''
+  adapterError = ''
+  lastConnectionSnapshot = null
+}
+
+export function getClaw3dLogs(): string {
+  return [
+    devServerLogs ? `=== Dev Server ===\n${devServerLogs}` : '',
+    adapterLogs ? `=== Adapter ===\n${adapterLogs}` : ''
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10026,8 +10026,14 @@ ipcMain.handle('hermes:claw3d:setup', async (event, profile) => {
       win.webContents.send('hermes:claw3d:setup-progress', progress)
     }
   }
-  await claw3d.setupClaw3d(broadcast, profile)
-  return { ok: true }
+  try {
+    await claw3d.setupClaw3d(broadcast, profile)
+    return { ok: true }
+  } catch (error) {
+    // Keep the declared { ok: boolean } IPC contract on git-clone/npm-install
+    // failures instead of rejecting the invoke with an unhandled error.
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  }
 })
 ipcMain.handle('hermes:claw3d:start', async (_event, profile) => claw3d.startAll(profile))
 ipcMain.handle('hermes:claw3d:stop', async () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -49,6 +49,7 @@ import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from '
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
+import * as claw3d from './claw3d'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
 import {
   authModeFromStatus,
@@ -10001,6 +10002,45 @@ function createWindow() {
 }
 
 ipcMain.handle('hermes:connection', async (_event, profile) => ensureBackend(profile))
+// ── Hermes Office (Claw3d) ──────────────────────────────────────────────────
+// The Office manager needs the active gateway connection (HTTP base URL +
+// session token) to write ~/.openclaw/claw3d/settings.json and the
+// hermes-office .env. Local/token connections work; OAuth-gated gateways are
+// surfaced as unsupported by getClaw3dStatus/startAll.
+claw3d.setConnectionResolver(async profile => {
+  const conn = await ensureBackend(profile)
+  let token = ''
+  if (conn.authMode !== 'oauth' && typeof conn.wsUrl === 'string') {
+    try {
+      token = new URL(conn.wsUrl).searchParams.get('token') ?? ''
+    } catch {
+      token = ''
+    }
+  }
+  return { baseUrl: conn.baseUrl, token, authMode: conn.authMode }
+})
+ipcMain.handle('hermes:claw3d:status', async (_event, profile) => claw3d.getClaw3dStatus(profile))
+ipcMain.handle('hermes:claw3d:setup', async (event, profile) => {
+  const broadcast = (progress: claw3d.Claw3dSetupProgress) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('hermes:claw3d:setup-progress', progress)
+    }
+  }
+  await claw3d.setupClaw3d(broadcast, profile)
+  return { ok: true }
+})
+ipcMain.handle('hermes:claw3d:start', async (_event, profile) => claw3d.startAll(profile))
+ipcMain.handle('hermes:claw3d:stop', async () => {
+  claw3d.stopAll()
+  return { ok: true }
+})
+ipcMain.handle('hermes:claw3d:logs', async () => ({ logs: claw3d.getClaw3dLogs() }))
+ipcMain.handle('hermes:claw3d:open', async (_event, profile) => {
+  const status = await claw3d.getClaw3dStatus(profile)
+  if (!status.running) return { ok: false, error: 'Office is not running' }
+  await shell.openExternal(`http://127.0.0.1:${status.port}`)
+  return { ok: true }
+})
 // Reconnect-after-wake recovery. A REMOTE primary backend has no child process,
 // so the 'exit'/'error' handlers that would clear a dead connection promise never
 // fire — once the remote becomes unreachable across a sleep/wake the renderer

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -5,6 +5,19 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   revalidateConnection: () => ipcRenderer.invoke('hermes:connection:revalidate'),
   touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
+  claw3d: {
+    getStatus: profile => ipcRenderer.invoke('hermes:claw3d:status', profile),
+    setup: profile => ipcRenderer.invoke('hermes:claw3d:setup', profile),
+    start: profile => ipcRenderer.invoke('hermes:claw3d:start', profile),
+    stop: () => ipcRenderer.invoke('hermes:claw3d:stop'),
+    getLogs: () => ipcRenderer.invoke('hermes:claw3d:logs'),
+    open: profile => ipcRenderer.invoke('hermes:claw3d:open', profile),
+    onSetupProgress: callback => {
+      const listener = (_event, progress) => callback(progress)
+      ipcRenderer.on('hermes:claw3d:setup-progress', listener)
+      return () => ipcRenderer.removeListener('hermes:claw3d:setup-progress', listener)
+    }
+  },
   openSessionWindow: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openSession', sessionId, opts),
   openWindow: () => ipcRenderer.invoke('hermes:window:openInstance'),
   claimAmbientCue: key => ipcRenderer.invoke('hermes:ambient:claim', key),

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -29,6 +29,31 @@ declare global {
       // reaper spares it while its chat is active.
       touchBackend: (profile?: string | null) => Promise<{ ok: boolean }>
       getGatewayWsUrl: (profile?: null | string) => Promise<GatewayWsUrlResult>
+      // Hermes Office (Claw3d) — 3D interface manager (dev server + gateway
+      // adapter). Local/token connections only; OAuth gateways are surfaced
+      // as unsupported through getStatus/start.
+      claw3d: {
+        getStatus: (profile?: null | string) => Promise<{
+          cloned: boolean
+          installed: boolean
+          devServerRunning: boolean
+          adapterRunning: boolean
+          running: boolean
+          port: number
+          portInUse: boolean
+          url: string
+          error: string
+          oauthUnsupported: boolean
+        }>
+        setup: (profile?: null | string) => Promise<{ ok: boolean }>
+        start: (profile?: null | string) => Promise<{ success: boolean; error?: string }>
+        stop: () => Promise<{ ok: boolean }>
+        getLogs: () => Promise<{ logs: string }>
+        open: (profile?: null | string) => Promise<{ ok: boolean; error?: string }>
+        onSetupProgress: (
+          callback: (progress: { step: number; totalSteps: number; title: string; detail: string; log: string }) => void
+        ) => () => void
+      }
       // Open (or focus) a standalone OS window for a single chat session so
       // the user can work with multiple chats side by side. Returns ok:false
       // with an error code when the sessionId is empty/invalid. `watch` opens

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -45,7 +45,7 @@ declare global {
           error: string
           oauthUnsupported: boolean
         }>
-        setup: (profile?: null | string) => Promise<{ ok: boolean }>
+        setup: (profile?: null | string) => Promise<{ ok: boolean; error?: string }>
         start: (profile?: null | string) => Promise<{ success: boolean; error?: string }>
         stop: () => Promise<{ ok: boolean }>
         getLogs: () => Promise<{ logs: string }>

--- a/apps/desktop/src/plugins/crews/api.ts
+++ b/apps/desktop/src/plugins/crews/api.ts
@@ -1,0 +1,174 @@
+/**
+ * Crews data layer. Everything goes through `ctx.rest` — the plugin's own
+ * `/api/plugins/crews/*` FastAPI router (plugins/crews/dashboard/plugin_api.py),
+ * reused as-is via the desktop's namespace-scoped REST door.
+ *
+ * Fetching, caching, polling, dedupe and invalidation are React Query's job
+ * (the app's standard, via the SDK). This module owns the query keys, the
+ * REST calls, the selected-crew atom, and the live /events socket binding.
+ */
+import { atom, type PluginRestOptions, type PluginStorage, queryClient, useValue } from '@hermes/plugin-sdk'
+
+import type { Crew, CrewEvent, CrewTemplate, Persona, Workflow, WorkflowRun } from './types'
+
+type Rest = <T>(path: string, opts?: PluginRestOptions) => Promise<T>
+type Socket = (path: string, onMessage: (data: unknown) => void) => () => void
+
+let rest: null | Rest = null
+
+/** Selected crew id — '' means the list view. Persisted. */
+export const $selectedCrewId = atom<string>('')
+/** Whether the create-crew dialog is open. */
+export const $createOpen = atom<boolean>(false)
+/** Template chosen to pre-fill the create dialog ('' = none). */
+export const $templateId = atom<string>('')
+/** The live activity feed — last N events for the selected crew. */
+export const $activityFeed = atom<CrewEvent[]>([])
+/** Task status map for the currently running workflow (taskId → status). */
+export const $workflowStatus = atom<Record<string, string>>({})
+/** Current workflow run id (when a run is in flight). */
+export const $activeRunId = atom<string | null>(null)
+
+const SELECTED_KEY = 'selectedCrewId'
+
+const MAX_FEED = 200
+
+function pushFeed(event: CrewEvent): void {
+  const feed = $activityFeed.get()
+  $activityFeed.set([...feed, event].slice(-MAX_FEED))
+}
+
+/** Bind the plugin's doors at register time and return a disposer. */
+export function bindApi(r: Rest, storage: PluginStorage, socket: Socket): () => void {
+  rest = r
+  const unsubs: Array<() => void> = []
+
+  $selectedCrewId.set(storage.get(SELECTED_KEY, ''))
+  unsubs.push($selectedCrewId.listen(value => storage.set(SELECTED_KEY, value)))
+
+  const close = socket('/events', data => onEvent(data as CrewEvent))
+
+  return () => {
+    unsubs.forEach(unsub => unsub())
+    close()
+    rest = null
+  }
+}
+
+function onEvent(event: CrewEvent): void {
+  if (!event || typeof event !== 'object' || !('type' in event)) {return}
+
+  // Keep the live feed fresh (only for the crew on screen).
+  const selected = $selectedCrewId.get()
+
+  if ('crewId' in event && selected && event.crewId === selected) {
+    pushFeed(event)
+  }
+
+  switch (event.type) {
+    case 'crew_updated':
+
+    case 'crew_deleted':
+      void queryClient.invalidateQueries({ queryKey: CREWS_KEY })
+
+      break
+
+    case 'member_status':
+      if ('crewId' in event) {
+        void queryClient.invalidateQueries({ queryKey: crewKey(event.crewId) })
+      }
+
+      break
+
+    case 'worker_end':
+
+    case 'task_status':
+      if ('crewId' in event) {
+        void queryClient.invalidateQueries({ queryKey: crewKey(event.crewId) })
+        void queryClient.invalidateQueries({ queryKey: workflowKey(event.crewId) })
+        void queryClient.invalidateQueries({ queryKey: runsKey(event.crewId) })
+      }
+
+      break
+
+    case 'run_started':
+
+    case 'run_end':
+      if ('crewId' in event) {
+        void queryClient.invalidateQueries({ queryKey: crewKey(event.crewId) })
+        void queryClient.invalidateQueries({ queryKey: runsKey(event.crewId) })
+      }
+
+      break
+
+    default:
+      break
+  }
+}
+
+function call<T>(path: string, opts?: PluginRestOptions): Promise<T> {
+  return rest ? rest<T>(path, opts) : Promise.reject(new Error('crews api not ready'))
+}
+
+// ── query keys ───────────────────────────────────────────────────────────────
+
+export const CREWS_KEY = ['crews', 'list'] as const
+export const PERSONAS_KEY = ['crews', 'personas'] as const
+export const TEMPLATES_KEY = ['crews', 'templates'] as const
+export const crewKey = (crewId: string) => ['crews', crewId] as const
+export const workflowKey = (crewId: string) => ['crews', crewId, 'workflow'] as const
+export const runsKey = (crewId: string) => ['crews', crewId, 'runs'] as const
+
+// ── reads ────────────────────────────────────────────────────────────────────
+
+export const fetchPersonas = () => call<{ ok: boolean; personas: Persona[] }>('/personas')
+export const fetchTemplates = () => call<{ ok: boolean; templates: CrewTemplate[] }>('/templates')
+export const fetchCrews = () => call<{ ok: boolean; crews: Crew[] }>('/crews')
+export const fetchCrew = (crewId: string) => call<{ ok: boolean; crew: Crew }>(`/crews/${encodeURIComponent(crewId)}`)
+export const fetchWorkflow = (crewId: string) =>
+  call<{ ok: boolean; workflow: Workflow | null }>(`/crews/${encodeURIComponent(crewId)}/workflow`)
+export const fetchRuns = (crewId: string) =>
+  call<{ ok: boolean; runs: WorkflowRun[] }>(`/crews/${encodeURIComponent(crewId)}/runs`)
+
+// ── writes ───────────────────────────────────────────────────────────────────
+
+export interface CreateCrewInput {
+  name: string
+  goal: string
+  members: Array<{ persona: string; role?: string; model?: string | null; profileName?: string | null }>
+}
+
+export const createCrew = (input: CreateCrewInput) =>
+  call<{ ok: boolean; crew: Crew }>('/crews', { method: 'POST', body: input })
+
+export const updateCrew = (crewId: string, patch: Record<string, unknown>) =>
+  call<{ ok: boolean; crew: Crew }>(`/crews/${encodeURIComponent(crewId)}`, { method: 'PATCH', body: patch })
+
+export const deleteCrew = (crewId: string) =>
+  call<{ ok: boolean }>(`/crews/${encodeURIComponent(crewId)}`, { method: 'DELETE' })
+
+export const cloneCrew = (crewId: string) =>
+  call<{ ok: boolean; crew: Crew }>(`/crews/${encodeURIComponent(crewId)}/clone`, { method: 'POST', body: {} })
+
+export const dispatchTask = (crewId: string, task: string, target: 'all' | string = 'all') =>
+  call<{ ok: boolean; dispatched: string[] }>(`/crews/${encodeURIComponent(crewId)}/dispatch`, {
+    method: 'POST',
+    body: { task, target }
+  })
+
+export const saveWorkflow = (crewId: string, tasks: Workflow['tasks'], edges: Workflow['edges']) =>
+  call<{ ok: boolean; workflow: Workflow }>(`/crews/${encodeURIComponent(crewId)}/workflow`, {
+    method: 'PUT',
+    body: { tasks, edges }
+  })
+
+export const runWorkflow = (crewId: string) =>
+  call<{ ok: boolean; runId: string }>(`/crews/${encodeURIComponent(crewId)}/workflow/run`, {
+    method: 'POST',
+    body: {}
+  })
+
+/** Subscribe to the live feed atom (used by the detail screen). */
+export function useActivityFeed(): CrewEvent[] {
+  return useValue($activityFeed)
+}

--- a/apps/desktop/src/plugins/crews/crew-detail.tsx
+++ b/apps/desktop/src/plugins/crews/crew-detail.tsx
@@ -1,0 +1,291 @@
+/**
+ * Crew detail — member grid with live status, task dispatch, the activity
+ * feed, and the visual workflow builder tab.
+ */
+import {
+  Badge,
+  Button,
+  cn,
+  ScrollArea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  StatusDot,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Textarea,
+  useMutation,
+  useQuery,
+  useQueryClient
+} from '@hermes/plugin-sdk'
+import { useState } from 'react'
+
+import {
+  $selectedCrewId,
+  crewKey,
+  deleteCrew,
+  dispatchTask,
+  fetchCrew,
+  fetchRuns,
+  fetchWorkflow,
+  runsKey,
+  useActivityFeed,
+  workflowKey
+} from './api'
+import { useCrewsI18n } from './i18n'
+import type { Crew, CrewEvent, CrewMember } from './types'
+import { WorkflowBuilder } from './workflow-builder'
+
+function memberTone(member: CrewMember): 'good' | 'muted' | 'warn' | 'bad' {
+  switch (member.status) {
+    case 'running':
+      return 'warn'
+
+    case 'done':
+      return 'good'
+
+    case 'error':
+      return 'bad'
+
+    default:
+      return 'muted'
+  }
+}
+
+function MemberCard({ member, k }: { member: CrewMember; k: ReturnType<typeof useCrewsI18n> }) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1.5 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-surface-secondary) p-3',
+        member.status === 'running' && 'border-(--ui-accent)'
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <StatusDot className={cn(member.status === 'running' && 'animate-pulse')} tone={memberTone(member)} />
+        <span className="font-medium text-(--ui-text-primary)">{member.displayName}</span>
+      </div>
+      <span className="text-xs text-(--ui-text-secondary)">{member.roleLabel}</span>
+      <div className="flex flex-wrap gap-1">
+        {member.model && <Badge variant="outline">{member.model}</Badge>}
+        <Badge variant="outline">{member.profileName ?? member.persona}</Badge>
+        <Badge variant="outline">{member.status}</Badge>
+      </div>
+      {member.lastActivity && (
+        <p className="line-clamp-3 text-[0.6875rem] leading-snug text-(--ui-text-tertiary)">{member.lastActivity}</p>
+      )}
+    </div>
+  )
+}
+
+function formatEvent(
+  ev: CrewEvent,
+  k: ReturnType<typeof useCrewsI18n>
+): { text: string; tone: 'good' | 'muted' | 'warn' | 'bad' } {
+  switch (ev.type) {
+    case 'member_status':
+      return {
+        text: `${ev.memberId.slice(0, 8)} → ${ev.status}${ev.detail ? ` — ${ev.detail}` : ''}`,
+        tone: ev.status === 'error' ? 'bad' : ev.status === 'running' ? 'warn' : 'good'
+      }
+
+    case 'task_status':
+      return {
+        text: `task ${ev.taskId.slice(0, 8)} → ${ev.status}${ev.detail ? ` — ${ev.detail}` : ''}`,
+        tone: ev.status === 'error' ? 'bad' : ev.status === 'running' ? 'warn' : 'good'
+      }
+
+    case 'worker_end':
+      return {
+        text: `worker ${(ev.memberId ?? ev.taskId ?? '').slice(0, 8)} finished ${ev.status}${ev.detail ?? ''}`,
+        tone: ev.status === 'error' ? 'bad' : 'good'
+      }
+
+    case 'activity':
+      return { text: ev.text.slice(0, 160), tone: 'muted' }
+
+    case 'run_started':
+      return { text: `workflow run ${ev.runId.slice(0, 8)} started`, tone: 'warn' }
+
+    case 'run_end':
+      return {
+        text: `workflow run ${ev.runId.slice(0, 8)} → ${ev.status}`,
+        tone: ev.status === 'error' ? 'bad' : 'good'
+      }
+
+    case 'crew_updated':
+      return { text: k.updated, tone: 'muted' }
+
+    case 'crew_deleted':
+      return { text: 'crew deleted', tone: 'bad' }
+
+    default:
+      return { text: JSON.stringify(ev).slice(0, 120), tone: 'muted' }
+  }
+}
+
+function DispatchPanel({ crew, k }: { crew: Crew; k: ReturnType<typeof useCrewsI18n> }) {
+  const qc = useQueryClient()
+  const [task, setTask] = useState('')
+  const [target, setTarget] = useState('all')
+
+  const dispatch = useMutation({
+    mutationFn: ({ taskText, targetId }: { taskText: string; targetId: string }) =>
+      dispatchTask(crew.id, taskText, targetId === 'all' ? 'all' : targetId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: crewKey(crew.id) })
+      setTask('')
+    }
+  })
+
+  const submit = () => {
+    const taskText = task.trim()
+
+    if (!taskText) {return}
+    dispatch.mutate({ taskText, targetId: target })
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-surface-secondary) p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium text-(--ui-text-primary)">{k.dispatch}</span>
+        <Select onValueChange={setTarget} value={target}>
+          <SelectTrigger aria-label={k.dispatchTo} className="w-[180px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{k.allMembers}</SelectItem>
+            {crew.members.map(m => (
+              <SelectItem key={m.id} value={m.id}>
+                {m.displayName}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Textarea onChange={e => setTask(e.target.value)} placeholder={k.dispatchPlaceholder} rows={2} value={task} />
+      <div className="flex justify-end">
+        <Button disabled={!task.trim() || dispatch.isPending} onClick={submit}>
+          {dispatch.isPending ? '…' : k.dispatch}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function ActivityFeed({ crewId, k }: { crewId: string; k: ReturnType<typeof useCrewsI18n> }) {
+  const feed = useActivityFeed()
+  const scoped = feed.filter(ev => 'crewId' in ev && ev.crewId === crewId)
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-surface-secondary) p-3">
+      <span className="text-sm font-medium text-(--ui-text-primary)">{k.activity}</span>
+      {scoped.length === 0 ? (
+        <p className="text-xs text-(--ui-text-tertiary)">{k.noActivity}</p>
+      ) : (
+        <ScrollArea className="min-h-0 flex-1">
+          <ul className="flex flex-col gap-1">
+            {scoped.map((ev, i) => {
+              const { text, tone } = formatEvent(ev, k)
+
+              return (
+                <li className="flex items-start gap-1.5 text-xs leading-snug" key={i}>
+                  <StatusDot tone={tone} />
+                  <span className="text-(--ui-text-secondary)">
+                    {new Date(ev.ts).toLocaleTimeString()} · {text}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        </ScrollArea>
+      )}
+    </div>
+  )
+}
+
+export function CrewDetail({ crewId }: { crewId: string }) {
+  const k = useCrewsI18n()
+  const qc = useQueryClient()
+  const [tab, setTab] = useState('overview')
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: crewKey(crewId),
+    queryFn: () => fetchCrew(crewId),
+    refetchInterval: 15_000
+  })
+
+  // Keep workflow + runs warm so the canvas tab opens with data.
+  useQuery({ queryKey: workflowKey(crewId), queryFn: () => fetchWorkflow(crewId) })
+  useQuery({ queryKey: runsKey(crewId), queryFn: () => fetchRuns(crewId), refetchInterval: 15_000 })
+
+  const remove = useMutation({
+    mutationFn: () => deleteCrew(crewId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['crews', 'list'] })
+      $selectedCrewId.set('')
+    }
+  })
+
+  if (isLoading) {
+    return <div className="flex h-full items-center justify-center text-sm text-(--ui-text-tertiary)">…</div>
+  }
+
+  if (isError || !data?.crew) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-(--ui-text-tertiary)">{k.notInstalled}</div>
+    )
+  }
+
+  const crew = data.crew
+
+  return (
+    <div className="flex h-full flex-col gap-3 p-4">
+      <div className="flex items-center gap-2">
+        <Button onClick={() => $selectedCrewId.set('')} size="sm" variant="ghost">
+          ← {k.back}
+        </Button>
+        <h1 className="text-lg font-semibold text-(--ui-text-primary)">{crew.name}</h1>
+        <Badge variant="outline">{crew.status}</Badge>
+        <span className="ml-auto flex gap-2">
+          <Button
+            onClick={() => {
+              if (window.confirm(k.deleteConfirm)) {remove.mutate()}
+            }}
+            size="sm"
+            variant="ghost"
+          >
+            {k.delete}
+          </Button>
+        </span>
+      </div>
+
+      {crew.goal && <p className="text-sm text-(--ui-text-secondary)">{crew.goal}</p>}
+
+      <Tabs onValueChange={setTab} value={tab}>
+        <TabsList>
+          <TabsTrigger value="overview">{k.overview}</TabsTrigger>
+          <TabsTrigger value="workflow">{k.workflow}</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {tab === 'overview' && (
+        <div className="flex min-h-0 flex-1 flex-col gap-3 lg:flex-row">
+          <div className="flex min-h-0 flex-1 flex-col gap-3">
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-2">
+              {crew.members.map(m => (
+                <MemberCard k={k} key={m.id} member={m} />
+              ))}
+            </div>
+            <DispatchPanel crew={crew} k={k} />
+          </div>
+          <ActivityFeed crewId={crewId} k={k} />
+        </div>
+      )}
+
+      {tab === 'workflow' && <WorkflowBuilder crewId={crewId} k={k} members={crew.members} />}
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/crews/crews-screen.tsx
+++ b/apps/desktop/src/plugins/crews/crews-screen.tsx
@@ -1,0 +1,409 @@
+/**
+ * Crews screen — crew list, create dialog (with template gallery), clone and
+ * delete. Selecting a crew opens the detail screen (internal selection atom;
+ * contributed routes are single-segment, so detail is state, not a route).
+ */
+import {
+  Badge,
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  EmptyState,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+  Tip,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  useValue
+} from '@hermes/plugin-sdk'
+import { useState } from 'react'
+
+import {
+  $createOpen,
+  $selectedCrewId,
+  $templateId,
+  cloneCrew,
+  createCrew,
+  type CreateCrewInput,
+  CREWS_KEY,
+  deleteCrew,
+  fetchCrews,
+  fetchPersonas,
+  fetchTemplates,
+  PERSONAS_KEY,
+  TEMPLATES_KEY
+} from './api'
+import { CrewDetail } from './crew-detail'
+import { useCrewsI18n } from './i18n'
+import type { Crew, Persona } from './types'
+
+const MAX_MEMBERS = 8
+
+interface MemberDraft {
+  persona: string
+  model: string
+  profileName: string
+}
+
+function MemberRow({
+  index,
+  draft,
+  personas,
+  onChange,
+  onRemove,
+  k
+}: {
+  index: number
+  draft: MemberDraft
+  personas: Persona[]
+  onChange: (next: MemberDraft) => void
+  onRemove: () => void
+  k: ReturnType<typeof useCrewsI18n>
+}) {
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-2">
+      <Select onValueChange={value => onChange({ ...draft, persona: value })} value={draft.persona}>
+        <SelectTrigger aria-label={`${k.persona} ${index + 1}`} className="w-full">
+          <SelectValue placeholder={k.memberPlaceholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {personas.map(p => (
+            <SelectItem key={p.id} value={p.id}>
+              {p.emoji} {p.name} — {p.role}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Input
+        aria-label={k.model}
+        onChange={e => onChange({ ...draft, model: e.target.value })}
+        placeholder={k.modelPlaceholder}
+        value={draft.model}
+      />
+      <Input
+        aria-label={k.profile}
+        onChange={e => onChange({ ...draft, profileName: e.target.value })}
+        placeholder={k.profilePlaceholder}
+        value={draft.profileName}
+      />
+      <Button aria-label="Remove member" onClick={onRemove} size="sm" variant="ghost">
+        ×
+      </Button>
+    </div>
+  )
+}
+
+function CreateCrewDialog({ personas, k }: { personas: Persona[]; k: ReturnType<typeof useCrewsI18n> }) {
+  const qc = useQueryClient()
+  const open = useValue($createOpen)
+  const { data: templates } = useQuery({ queryKey: TEMPLATES_KEY, queryFn: () => fetchTemplates(), staleTime: 60_000 })
+
+  const [name, setName] = useState('')
+  const [goal, setGoal] = useState('')
+  const [members, setMembers] = useState<MemberDraft[]>([{ persona: 'kai', model: '', profileName: '' }])
+  const [error, setError] = useState<string | null>(null)
+
+  const create = useMutation({
+    mutationFn: (input: CreateCrewInput) => createCrew(input),
+    onSuccess: data => {
+      qc.invalidateQueries({ queryKey: CREWS_KEY })
+      $createOpen.set(false)
+      $selectedCrewId.set(data.crew.id)
+      $templateId.set('')
+      resetForm()
+    },
+    onError: (err: Error) => setError(err.message || k.createFailed)
+  })
+
+  const resetForm = () => {
+    setName('')
+    setGoal('')
+    setMembers([{ persona: 'kai', model: '', profileName: '' }])
+    setError(null)
+  }
+
+  const applyTemplate = (templateId: string) => {
+    const tpl = templates?.templates.find(t => t.id === templateId)
+
+    if (!tpl) {return}
+    setName(tpl.name)
+    setGoal(tpl.goal)
+    setMembers(tpl.members.map(m => ({ persona: m.persona, model: '', profileName: '' })))
+    $templateId.set('')
+  }
+
+  const submit = () => {
+    if (!name.trim()) {return}
+
+    const cleanMembers = members
+      .filter(m => m.persona)
+      .map(m => ({
+        persona: m.persona,
+        model: m.model.trim() || null,
+        profileName: m.profileName.trim() || null
+      }))
+
+    create.mutate({ name: name.trim(), goal: goal.trim(), members: cleanMembers })
+  }
+
+  return (
+    <Dialog
+      onOpenChange={openState => {
+        if (!openState) {
+          $createOpen.set(false)
+          $templateId.set('')
+          resetForm()
+        }
+      }}
+      open={open}
+    >
+      <DialogContent className="max-h-[85vh] w-[640px] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{k.newCrew}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          {templates && templates.templates.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-xs text-(--ui-text-tertiary)">{k.templates}</span>
+              {templates.templates.map(t => (
+                <Tip key={t.id} label={k.templateGoal(t.name)}>
+                  <Badge className="cursor-pointer select-none" onClick={() => applyTemplate(t.id)} variant="outline">
+                    {t.name}
+                  </Badge>
+                </Tip>
+              ))}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-(--ui-text-secondary)" htmlFor="crew-name">
+              {k.crewName}
+            </label>
+            <Input id="crew-name" onChange={e => setName(e.target.value)} placeholder="Crew name" value={name} />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-(--ui-text-secondary)" htmlFor="crew-goal">
+              {k.goal}
+            </label>
+            <Textarea
+              id="crew-goal"
+              onChange={e => setGoal(e.target.value)}
+              placeholder={k.goalPlaceholder}
+              rows={2}
+              value={goal}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-(--ui-text-secondary)">{k.membersCount(members.length)}</span>
+              <Button
+                disabled={members.length >= MAX_MEMBERS}
+                onClick={() => setMembers([...members, { persona: '', model: '', profileName: '' }])}
+                size="sm"
+                variant="outline"
+              >
+                {k.addMember}
+              </Button>
+            </div>
+            {members.length === 0 && <p className="text-xs text-(--ui-text-tertiary)">{k.noMembersHint}</p>}
+            {members.map((m, i) => (
+              <MemberRow
+                draft={m}
+                index={i}
+                k={k}
+                key={i}
+                onChange={next => setMembers(members.map((mm, j) => (j === i ? next : mm)))}
+                onRemove={() => setMembers(members.filter((_, j) => j !== i))}
+                personas={personas}
+              />
+            ))}
+          </div>
+
+          {error && <p className="text-xs text-(--ui-danger,#f87171)">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={() => {
+              $createOpen.set(false)
+              $templateId.set('')
+              resetForm()
+            }}
+            variant="ghost"
+          >
+            {k.cancel}
+          </Button>
+          <Button disabled={!name.trim() || members.length === 0 || create.isPending} onClick={submit}>
+            {create.isPending ? '…' : k.create}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CrewCard({
+  crew,
+  k,
+  onOpen,
+  onClone,
+  onDelete
+}: {
+  crew: Crew
+  k: ReturnType<typeof useCrewsI18n>
+  onOpen: () => void
+  onClone: () => void
+  onDelete: () => void
+}) {
+  const running = crew.members.filter(m => m.status === 'running').length
+  const done = crew.members.filter(m => m.status === 'done').length
+
+  return (
+    <div
+      className={cn(
+        'group flex cursor-pointer flex-col gap-2 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-surface-secondary) p-3 text-left transition-colors',
+        'hover:border-(--ui-stroke-primary) hover:bg-(--chrome-action-hover)'
+      )}
+      onClick={onOpen}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {onOpen()}
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="font-medium text-(--ui-text-primary)">{crew.name}</span>
+        <span className="text-[0.6875rem] text-(--ui-text-tertiary)">{new Date(crew.updatedAt).toLocaleString()}</span>
+      </div>
+      {crew.goal && <p className="line-clamp-2 text-xs text-(--ui-text-secondary)">{crew.goal}</p>}
+      <div className="flex items-center gap-1.5">
+        {crew.members.slice(0, 8).map(m => (
+          <Tip key={m.id} label={`${m.displayName} — ${m.roleLabel}`}>
+            <span className={cn('text-sm leading-none', m.color)}>{m.displayName.charAt(0)}</span>
+          </Tip>
+        ))}
+        <span className="ml-auto text-[0.6875rem] text-(--ui-text-tertiary)">{k.members(crew.members.length)}</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        {running > 0 && (
+          <Badge variant="outline">
+            {running} {k.running}
+          </Badge>
+        )}
+        {done > 0 && (
+          <Badge variant="outline">
+            {done} {k.done}
+          </Badge>
+        )}
+        <span className="ml-auto opacity-0 transition-opacity group-hover:opacity-100">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild onClick={e => e.stopPropagation()}>
+              <Button
+                className="cursor-pointer px-1 text-(--ui-text-tertiary) hover:text-(--ui-text-primary)"
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                ⋯
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" onClick={e => e.stopPropagation()}>
+              <DropdownMenuItem onSelect={onClone}>{k.clone}</DropdownMenuItem>
+              <DropdownMenuItem onSelect={onDelete}>{k.delete}</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export function CrewsScreen() {
+  const k = useCrewsI18n()
+  const qc = useQueryClient()
+  const createOpen = useValue($createOpen)
+  const selectedCrewId = useValue($selectedCrewId)
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: CREWS_KEY,
+    queryFn: () => fetchCrews(),
+    refetchInterval: 30_000
+  })
+
+  const { data: personas } = useQuery({ queryKey: PERSONAS_KEY, queryFn: () => fetchPersonas(), staleTime: 60_000 })
+
+  const clone = useMutation({
+    mutationFn: (crewId: string) => cloneCrew(crewId),
+    onSuccess: data => {
+      qc.invalidateQueries({ queryKey: CREWS_KEY })
+      $selectedCrewId.set(data.crew.id)
+    }
+  })
+
+  const remove = useMutation({
+    mutationFn: (crewId: string) => deleteCrew(crewId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: CREWS_KEY })
+  })
+
+  const crews = data?.crews ?? []
+
+  if (selectedCrewId) {
+    return <CrewDetail crewId={selectedCrewId} />
+  }
+
+  if (isLoading) {
+    return <div className="flex h-full items-center justify-center text-sm text-(--ui-text-tertiary)">…</div>
+  }
+
+  if (isError) {
+    return <EmptyState description={k.notInstalledBody} title={k.notInstalled} />
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-3 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold text-(--ui-text-primary)">{k.title}</h1>
+        <Button onClick={() => $createOpen.set(true)}>{k.newCrew}</Button>
+      </div>
+
+      {crews.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center">
+          <EmptyState description={k.emptyBody} title={k.empty} />
+        </div>
+      ) : (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-3">
+          {crews.map(crew => (
+            <CrewCard
+              crew={crew}
+              k={k}
+              key={crew.id}
+              onClone={() => clone.mutate(crew.id)}
+              onDelete={() => {
+                if (window.confirm(k.deleteConfirm)) {remove.mutate(crew.id)}
+              }}
+              onOpen={() => $selectedCrewId.set(crew.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {createOpen && <CreateCrewDialog k={k} personas={personas?.personas ?? []} />}
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/crews/dag.test.ts
+++ b/apps/desktop/src/plugins/crews/dag.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import { autoLayout, blockedTaskIds, edgeExists, hasCycle, topoLayers } from './dag'
+
+const ids = ['a', 'b', 'c', 'd', 'e']
+
+describe('topoLayers', () => {
+  it('layers parallel tasks together (Kahn)', () => {
+    const layers = topoLayers(ids, [
+      { from: 'a', to: 'c' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'd' }
+    ])
+
+    // e is disconnected, so it joins the root layer with a and b.
+    expect(new Set(layers[0])).toEqual(new Set(['a', 'b', 'e']))
+    expect(layers[1]).toEqual(['c'])
+    expect(layers[2]).toEqual(['d'])
+    expect(layers.flat().length).toBe(5)
+  })
+
+  it('returns a single layer for disconnected tasks', () => {
+    const layers = topoLayers(['x', 'y'], [])
+    expect(layers).toHaveLength(1)
+    expect(new Set(layers[0])).toEqual(new Set(['x', 'y']))
+  })
+
+  it('chain lays out one task per layer', () => {
+    const layers = topoLayers(
+      ['p', 'q', 'r'],
+      [
+        { from: 'p', to: 'q' },
+        { from: 'q', to: 'r' }
+      ]
+    )
+
+    expect(layers).toEqual([['p'], ['q'], ['r']])
+  })
+})
+
+describe('hasCycle', () => {
+  it('detects a direct cycle', () => {
+    expect(
+      hasCycle(
+        ['a', 'b'],
+        [
+          { from: 'a', to: 'b' },
+          { from: 'b', to: 'a' }
+        ]
+      )
+    ).toBe(true)
+  })
+
+  it('detects an indirect cycle', () => {
+    expect(
+      hasCycle(
+        ['a', 'b', 'c'],
+        [
+          { from: 'a', to: 'b' },
+          { from: 'b', to: 'c' },
+          { from: 'c', to: 'a' }
+        ]
+      )
+    ).toBe(true)
+  })
+
+  it('accepts a DAG', () => {
+    expect(
+      hasCycle(
+        ['a', 'b', 'c'],
+        [
+          { from: 'a', to: 'b' },
+          { from: 'a', to: 'c' }
+        ]
+      )
+    ).toBe(false)
+  })
+
+  it('treats a self-loop as a cycle', () => {
+    expect(hasCycle(['a'], [{ from: 'a', to: 'a' }])).toBe(true)
+  })
+})
+
+describe('edgeExists', () => {
+  it('finds an existing edge', () => {
+    expect(edgeExists([{ from: 'a', to: 'b' }], 'a', 'b')).toBe(true)
+  })
+
+  it('does not treat the reverse direction as a duplicate', () => {
+    expect(edgeExists([{ from: 'a', to: 'b' }], 'b', 'a')).toBe(false)
+  })
+})
+
+describe('autoLayout', () => {
+  it('assigns x/y columns by layer and centers rows', () => {
+    const tasks = [
+      { id: 'a', label: '', prompt: '', assigneeId: null, x: 0, y: 0 },
+      { id: 'b', label: '', prompt: '', assigneeId: null, x: 0, y: 0 },
+      { id: 'c', label: '', prompt: '', assigneeId: null, x: 0, y: 0 }
+    ]
+
+    const laid = autoLayout(tasks, [
+      { from: 'a', to: 'c' },
+      { from: 'b', to: 'c' }
+    ])
+
+    const byId = new Map(laid.map(t => [t.id, t]))
+    // a and b share a column; c is in the next column.
+    expect(byId.get('a')!.x).toBeCloseTo(byId.get('b')!.x, 5)
+    expect(byId.get('c')!.x).toBeGreaterThan(byId.get('a')!.x)
+  })
+})
+
+describe('blockedTaskIds', () => {
+  it('blocks tasks whose dependencies are not done', () => {
+    const blocked = blockedTaskIds(['a', 'b'], [{ from: 'a', to: 'b' }], { a: 'running' })
+    expect(blocked.has('b')).toBe(true)
+  })
+
+  it('unblocks when the dependency completes', () => {
+    const blocked = blockedTaskIds(['a', 'b'], [{ from: 'a', to: 'b' }], { a: 'done' })
+    expect(blocked.has('b')).toBe(false)
+  })
+})

--- a/apps/desktop/src/plugins/crews/dag.ts
+++ b/apps/desktop/src/plugins/crews/dag.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure DAG helpers for the visual workflow builder — topological layering
+ * (Kahn), cycle detection, and auto-layout. Kept free of React/DOM so they
+ * are unit-testable and shared between the canvas and the save path.
+ */
+import type { WorkflowEdge, WorkflowTask } from './types'
+
+/** Detect a cycle in a task graph (DFS three-colour). */
+export function hasCycle(taskIds: string[], edges: WorkflowEdge[]): boolean {
+  const adj = new Map<string, string[]>()
+
+  for (const id of taskIds) {adj.set(id, [])}
+
+  for (const e of edges) {
+    const list = adj.get(e.from)
+
+    if (list) {list.push(e.to)}
+  }
+
+  const WHITE = 0
+  const GRAY = 1
+  const BLACK = 2
+  const color = new Map<string, number>()
+
+  for (const id of taskIds) {color.set(id, WHITE)}
+
+  const dfs = (id: string): boolean => {
+    color.set(id, GRAY)
+
+    for (const next of adj.get(id) ?? []) {
+      const c = color.get(next)
+
+      if (c === GRAY) {return true}
+
+      if (c === WHITE && dfs(next)) {return true}
+    }
+
+    color.set(id, BLACK)
+
+    return false
+  }
+
+  for (const id of taskIds) {
+    if (color.get(id) === WHITE && dfs(id)) {return true}
+  }
+
+  return false
+}
+
+/** Kahn BFS layers — tasks in the same layer can run in parallel. */
+export function topoLayers(taskIds: string[], edges: WorkflowEdge[]): string[][] {
+  const indegree = new Map<string, number>()
+  const adj = new Map<string, string[]>()
+
+  for (const id of taskIds) {
+    indegree.set(id, 0)
+    adj.set(id, [])
+  }
+
+  for (const e of edges) {
+    adj.get(e.from)?.push(e.to)
+    indegree.set(e.to, (indegree.get(e.to) ?? 0) + 1)
+  }
+
+  const layers: string[][] = []
+  let frontier = taskIds.filter(id => (indegree.get(id) ?? 0) === 0)
+
+  while (frontier.length > 0) {
+    layers.push(frontier)
+    const next: string[] = []
+
+    for (const node of frontier) {
+      for (const child of adj.get(node) ?? []) {
+        indegree.set(child, (indegree.get(child) ?? 0) - 1)
+
+        if ((indegree.get(child) ?? 0) === 0) {next.push(child)}
+      }
+    }
+
+    frontier = next
+  }
+
+  return layers
+}
+
+/** True when an edge already exists (either direction is treated as a
+ *  duplicate — the builder only allows one dependency per pair). */
+export function edgeExists(edges: WorkflowEdge[], from: string, to: string): boolean {
+  return edges.some(e => e.from === from && e.to === to)
+}
+
+/**
+ * Auto-layout: Kahn layers become parallel columns, left→right, with each
+ * layer's nodes vertically centred. Assigns x/y onto copies of the tasks.
+ */
+export function autoLayout(
+  tasks: WorkflowTask[],
+  edges: WorkflowEdge[],
+  opts: { columnGap?: number; rowGap?: number; nodeWidth?: number; nodeHeight?: number } = {}
+): WorkflowTask[] {
+  const { columnGap = 220, rowGap = 120, nodeWidth = 180, nodeHeight = 72 } = opts
+
+  const layers = topoLayers(
+    tasks.map(t => t.id),
+    edges
+  )
+
+  const position = new Map<string, { x: number; y: number }>()
+
+  const layerMax = Math.max(1, ...layers.map(l => l.length))
+  const totalHeight = layerMax * nodeHeight + (layerMax - 1) * rowGap
+
+  layers.forEach((layer, layerIndex) => {
+    const columnTop = totalHeight - (layer.length * nodeHeight + (layer.length - 1) * rowGap)
+    layer.forEach((taskId, rowIndex) => {
+      position.set(taskId, {
+        x: 80 + layerIndex * (nodeWidth + columnGap),
+        y: columnTop / 2 + rowIndex * (nodeHeight + rowGap)
+      })
+    })
+  })
+
+  return tasks.map(task => {
+    const pos = position.get(task.id)
+
+    return pos ? { ...task, x: pos.x, y: pos.y } : task
+  })
+}
+
+/** Tasks that are currently blocked (have an unfinished dependency). */
+export function blockedTaskIds(taskIds: string[], edges: WorkflowEdge[], status: Record<string, string>): Set<string> {
+  const blocked = new Set<string>()
+
+  for (const e of edges) {
+    if (status[e.from] !== 'done') {blocked.add(e.to)}
+  }
+
+  return blocked
+}

--- a/apps/desktop/src/plugins/crews/i18n.ts
+++ b/apps/desktop/src/plugins/crews/i18n.ts
@@ -1,0 +1,232 @@
+/**
+ * Plugin-scoped i18n for crews — bundles shipped under the plugin id via
+ * ctx.i18n.register, never touching core en.ts.
+ */
+import { type PluginLocaleBundles, usePluginI18n } from '@hermes/plugin-sdk'
+import { useMemo } from 'react'
+
+type CrewsMessages = {
+  nav: string
+  open: string
+  newCrewCommand: string
+  title: string
+  empty: string
+  emptyBody: string
+  newCrew: string
+  back: string
+  crewName: string
+  goal: string
+  goalPlaceholder: string
+  members: (n: number) => string
+  dispatch: string
+  dispatchTo: string
+  dispatchPlaceholder: string
+  allMembers: string
+  running: string
+  idle: string
+  done: string
+  error: string
+  activity: string
+  noActivity: string
+  workflow: string
+  overview: string
+  workflowEmpty: string
+  workflowEmptyBody: string
+  addTask: string
+  connect: string
+  connectHint: string
+  autoLayout: string
+  runWorkflow: string
+  runningNow: string
+  save: string
+  saved: string
+  delete: string
+  clone: string
+  deleteConfirm: string
+  taskLabel: string
+  taskLabelPlaceholder: string
+  taskPrompt: string
+  taskPromptPlaceholder: string
+  assignee: string
+  dependencies: string
+  status: string
+  newTask: string
+  cancel: string
+  create: string
+  templates: string
+  templateGoal: (name: string) => string
+  persona: string
+  model: string
+  modelPlaceholder: string
+  profile: string
+  profilePlaceholder: string
+  profileHint: string
+  addMember: string
+  membersCount: (n: number) => string
+  memberPlaceholder: string
+  noMembers: string
+  noMembersHint: string
+  dispatchFailed: string
+  createFailed: string
+  runFailed: string
+  noCrewSelected: string
+  updated: string
+  notInstalled: string
+  notInstalledBody: string
+  workerLog: string
+}
+
+const en: CrewsMessages = {
+  nav: 'Crews',
+  open: 'Crews: Open crews',
+  newCrewCommand: 'Crews: New crew',
+  title: 'Crews',
+  empty: 'No crews yet',
+  emptyBody:
+    'Create a crew of specialised agents — each member runs in its own Hermes profile with an isolated workspace.',
+  newCrew: 'New crew',
+  back: 'All crews',
+  crewName: 'Name',
+  goal: 'Goal',
+  goalPlaceholder: 'What is this crew working toward?',
+  members: n => `${n} members`,
+  dispatch: 'Dispatch task',
+  dispatchTo: 'Dispatch to',
+  dispatchPlaceholder: 'Describe the task for the crew…',
+  allMembers: 'All members',
+  running: 'running',
+  idle: 'idle',
+  done: 'done',
+  error: 'error',
+  activity: 'Activity',
+  noActivity: 'No activity yet — dispatch a task to see the feed.',
+  workflow: 'Workflow',
+  overview: 'Overview',
+  workflowEmpty: 'No workflow yet',
+  workflowEmptyBody: 'Build a DAG of tasks — each task runs as a one-shot agent prompt in topological order.',
+  addTask: 'Add task',
+  connect: 'Connect',
+  connectHint: 'Click a task, then click another to add a dependency',
+  autoLayout: 'Auto layout',
+  runWorkflow: 'Run workflow',
+  runningNow: 'Running…',
+  save: 'Save',
+  saved: 'Saved',
+  delete: 'Delete',
+  clone: 'Clone',
+  deleteConfirm: 'Delete this crew?',
+  taskLabel: 'Label',
+  taskLabelPlaceholder: 'e.g. Research API surface',
+  taskPrompt: 'Prompt',
+  taskPromptPlaceholder: 'Full prompt sent to the assignee agent…',
+  assignee: 'Assignee',
+  dependencies: 'Dependencies',
+  status: 'Status',
+  newTask: 'New task',
+  cancel: 'Cancel',
+  create: 'Create',
+  templates: 'Templates',
+  templateGoal: name => `Pre-fill with ${name}`,
+  persona: 'Persona',
+  model: 'Model',
+  modelPlaceholder: 'e.g. auto (leave empty for profile default)',
+  profile: 'Profile',
+  profilePlaceholder: 'hermes profile name (defaults to the persona)',
+  profileHint: 'Each member runs in its own profile with an isolated workspace.',
+  addMember: 'Add member',
+  membersCount: n => `${n} of 8 members`,
+  memberPlaceholder: 'Pick a persona',
+  noMembers: 'No members yet',
+  noMembersHint: 'Add at least one persona to dispatch work.',
+  dispatchFailed: 'Dispatch failed',
+  createFailed: 'Could not create crew',
+  runFailed: 'Could not start workflow run',
+  noCrewSelected: 'Select a crew',
+  updated: 'updated',
+  notInstalled: 'Crews backend is not mounted',
+  notInstalledBody:
+    'Enable the crews plugin (Settings → Plugins) and restart the gateway, or run hermes with the dashboard server.',
+  workerLog: 'Worker log'
+}
+
+const ja: CrewsMessages = {
+  nav: 'クルー',
+  open: 'クルー: クルーを開く',
+  newCrewCommand: 'クルー: 新しいクルー',
+  title: 'クルー',
+  empty: 'クルーがまだありません',
+  emptyBody:
+    '専門エージェントのチームを作成 — 各メンバーは独自の Hermes プロファイルで実行され、作業領域が分離されます。',
+  newCrew: '新しいクルー',
+  back: 'すべてのクルー',
+  crewName: '名前',
+  goal: '目標',
+  goalPlaceholder: 'このクルーが目指すものは？',
+  members: n => `${n} 人のメンバー`,
+  dispatch: 'タスクを配信',
+  dispatchTo: '配信先',
+  dispatchPlaceholder: 'クルーへのタスクを説明…',
+  allMembers: '全メンバー',
+  running: '実行中',
+  idle: '待機中',
+  done: '完了',
+  error: 'エラー',
+  activity: 'アクティビティ',
+  noActivity: 'まだアクティビティがありません — タスクを配信するとフィードが表示されます。',
+  workflow: 'ワークフロー',
+  overview: '概要',
+  workflowEmpty: 'ワークフローがまだありません',
+  workflowEmptyBody:
+    'タスクのDAGを構築 — 各タスクはトポロジカル順にワンショットのエージェントプロンプトとして実行されます。',
+  addTask: 'タスクを追加',
+  connect: '接続',
+  connectHint: 'タスクをクリックし、次に別のタスクをクリックして依存関係を追加',
+  autoLayout: '自動レイアウト',
+  runWorkflow: 'ワークフローを実行',
+  runningNow: '実行中…',
+  save: '保存',
+  saved: '保存済み',
+  delete: '削除',
+  clone: '複製',
+  deleteConfirm: 'このクルーを削除しますか？',
+  taskLabel: 'ラベル',
+  taskLabelPlaceholder: '例: API サーフェスを調査',
+  taskPrompt: 'プロンプト',
+  taskPromptPlaceholder: '担当エージェントに送る完全なプロンプト…',
+  assignee: '担当',
+  dependencies: '依存関係',
+  status: 'ステータス',
+  newTask: '新しいタスク',
+  cancel: 'キャンセル',
+  create: '作成',
+  templates: 'テンプレート',
+  templateGoal: name => `${name} でプリフィル`,
+  persona: 'ペルソナ',
+  model: 'モデル',
+  modelPlaceholder: '例: auto（空欄でプロファイル既定）',
+  profile: 'プロファイル',
+  profilePlaceholder: 'hermes プロファイル名（既定はペルソナ）',
+  profileHint: '各メンバーは独自のプロファイルで実行され、作業領域が分離されます。',
+  addMember: 'メンバーを追加',
+  membersCount: n => `${n} / 8 メンバー`,
+  memberPlaceholder: 'ペルソナを選択',
+  noMembers: 'メンバーがいません',
+  noMembersHint: 'タスクを配信するには少なくとも1人のペルソナを追加してください。',
+  dispatchFailed: '配信に失敗しました',
+  createFailed: 'クルーを作成できませんでした',
+  runFailed: 'ワークフローの実行を開始できませんでした',
+  noCrewSelected: 'クルーを選択',
+  updated: '更新',
+  notInstalled: 'Crews バックエンドがマウントされていません',
+  notInstalledBody:
+    'クループラグインを有効化（設定 → プラグイン）してゲートウェイを再起動するか、ダッシュボードサーバー付きで hermes を実行してください。',
+  workerLog: 'ワーカーログ'
+}
+
+export const CREWS_LOCALES: PluginLocaleBundles = { en, ja }
+
+export function useCrewsI18n(): CrewsMessages {
+  const t = usePluginI18n('crews')
+
+  return useMemo(() => t as unknown as CrewsMessages, [t])
+}

--- a/apps/desktop/src/plugins/crews/plugin.tsx
+++ b/apps/desktop/src/plugins/crews/plugin.tsx
@@ -1,0 +1,77 @@
+/**
+ * Crews — multi-agent crew orchestration: crew list + detail (members,
+ * dispatch, live activity feed) and the visual DAG workflow builder.
+ * Backend is the bundled `plugins/crews/dashboard/plugin_api.py` router,
+ * reached through ctx.rest (/api/plugins/crews/*).
+ *
+ * Ships OFF by default — it inventories in Settings ▸ Plugins and registers
+ * nothing until the user flips the switch (same contract as kanban).
+ */
+import {
+  type HermesPlugin,
+  host,
+  PALETTE_AREA,
+  type PaletteContribution,
+  type RouteContribution,
+  ROUTES_AREA,
+  SIDEBAR_NAV_AREA,
+  type SidebarNavContribution
+} from '@hermes/plugin-sdk'
+
+import { $createOpen, bindApi } from './api'
+import { CrewsScreen } from './crews-screen'
+import { CREWS_LOCALES } from './i18n'
+
+const plugin: HermesPlugin = {
+  id: 'crews',
+  name: 'Crews',
+  description:
+    'Multi-agent crews — named groups of specialised profile agents, one-shot task dispatch, DAG workflow builder, and a live activity feed.',
+  defaultEnabled: false,
+  register(ctx) {
+    ctx.i18n.register(CREWS_LOCALES)
+    ctx.onDispose(bindApi(ctx.rest, ctx.storage, ctx.socket))
+
+    const newCrew = () => {
+      $createOpen.set(true)
+      host.navigate('/crews')
+    }
+
+    ctx.registerMany([
+      {
+        id: 'page',
+        area: ROUTES_AREA,
+        data: { path: '/crews' } satisfies RouteContribution,
+        render: () => <CrewsScreen />
+      },
+      {
+        id: 'nav',
+        area: SIDEBAR_NAV_AREA,
+        order: 55,
+        data: { codicon: 'organization', label: 'Crews', path: '/crews' } satisfies SidebarNavContribution
+      },
+      {
+        id: 'open',
+        area: PALETTE_AREA,
+        data: {
+          id: 'crews.open',
+          label: 'Crews: Open crews',
+          keywords: ['crews', 'agents', 'multi-agent', 'team'],
+          run: () => host.navigate('/crews')
+        } satisfies PaletteContribution
+      },
+      {
+        id: 'new-crew',
+        area: PALETTE_AREA,
+        data: {
+          id: 'crews.newCrew',
+          label: 'Crews: New crew',
+          keywords: ['crews', 'new', 'create', 'team'],
+          run: newCrew
+        } satisfies PaletteContribution
+      }
+    ])
+  }
+}
+
+export default plugin

--- a/apps/desktop/src/plugins/crews/types.ts
+++ b/apps/desktop/src/plugins/crews/types.ts
@@ -1,0 +1,107 @@
+/** Crew + workflow data model, mirrored from plugins/crews/dashboard/plugin_api.py. */
+
+export type CrewMemberStatus = 'idle' | 'running' | 'done' | 'error'
+export type CrewStatus = 'draft' | 'active' | 'paused' | 'complete'
+export type WorkflowTaskStatus = 'idle' | 'running' | 'done' | 'error'
+
+export interface Persona {
+  id: string
+  name: string
+  role: string
+  emoji: string
+  color: string
+  specialties: string[]
+}
+
+export interface CrewTemplate {
+  id: string
+  name: string
+  category: string
+  goal: string
+  members: Array<{ persona: string }>
+}
+
+export interface CrewMember {
+  id: string
+  persona: string
+  displayName: string
+  roleLabel: string
+  color: string
+  role: string
+  model: string | null
+  profileName: string | null
+  status: CrewMemberStatus
+  lastActivity: string | null
+}
+
+export interface Crew {
+  id: string
+  name: string
+  goal: string
+  status: CrewStatus
+  createdAt: number
+  updatedAt: number
+  members: CrewMember[]
+}
+
+export interface WorkflowTask {
+  id: string
+  label: string
+  prompt: string
+  assigneeId: string | null
+  x: number
+  y: number
+  status?: WorkflowTaskStatus
+  lastActivity?: string | null
+}
+
+export interface WorkflowEdge {
+  from: string
+  to: string
+}
+
+export interface Workflow {
+  id: string
+  crewId: string
+  tasks: WorkflowTask[]
+  edges: WorkflowEdge[]
+  createdAt: number
+  updatedAt: number
+}
+
+export interface WorkflowRun {
+  id: string
+  crewId: string
+  status: 'running' | 'complete' | 'error'
+  tasks: Record<string, WorkflowTaskStatus>
+  startedAt: number
+  finishedAt: number | null
+}
+
+/** Live event from the /events socket. */
+export type CrewEvent =
+  | { type: 'crew_updated'; crewId: string; ts: string }
+  | { type: 'crew_deleted'; crewId: string; ts: string }
+  | { type: 'member_status'; crewId: string; memberId: string; status: CrewMemberStatus; detail?: string; ts: string }
+  | {
+      type: 'task_status'
+      crewId: string
+      runId?: string | null
+      taskId: string
+      status: WorkflowTaskStatus
+      detail?: string
+      ts: string
+    }
+  | {
+      type: 'worker_end'
+      crewId: string
+      memberId?: string | null
+      taskId?: string | null
+      status: CrewMemberStatus | WorkflowTaskStatus
+      detail?: string
+      activity?: string
+      ts: string
+    }
+  | { type: 'activity'; crewId: string; memberId?: string | null; taskId?: string | null; text: string; ts: string }
+  | { type: 'run_started'; crewId: string; runId: string; ts: string }
+  | { type: 'run_end'; crewId: string; runId: string; status: string; ts: string }

--- a/apps/desktop/src/plugins/crews/workflow-builder.tsx
+++ b/apps/desktop/src/plugins/crews/workflow-builder.tsx
@@ -1,0 +1,503 @@
+/**
+ * Visual workflow builder — pure-SVG DAG canvas (no graph library):
+ * pan/zoom, node drag, connect mode with cycle detection, Kahn auto-layout,
+ * and live per-node status while a run is in flight (server-driven via the
+ * workflow query, invalidated by the /events socket).
+ */
+import {
+  Badge,
+  Button,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+  useMutation,
+  useQuery,
+  useQueryClient
+} from '@hermes/plugin-sdk'
+import { type PointerEvent as RPointerEvent, useEffect, useMemo, useRef, useState } from 'react'
+
+import { fetchWorkflow, runsKey, runWorkflow, saveWorkflow, workflowKey } from './api'
+import { autoLayout, edgeExists, hasCycle } from './dag'
+import type { useCrewsI18n } from './i18n'
+import type { CrewMember, WorkflowEdge, WorkflowTask } from './types'
+
+const NODE_W = 180
+const NODE_H = 72
+const MARKER_ID = 'crews-arrowhead'
+
+function statusTone(status?: string): string {
+  switch (status) {
+    case 'running':
+      return 'var(--ui-accent)'
+
+    case 'done':
+      return 'var(--ui-success, #34d399)'
+
+    case 'error':
+      return 'var(--ui-danger, #f87171)'
+
+    default:
+      return 'var(--ui-stroke-secondary)'
+  }
+}
+
+function newTaskId(): string {
+  return `t${Math.random().toString(36).slice(2, 10)}`
+}
+
+function bezierPath(x1: number, y1: number, x2: number, y2: number): string {
+  const dx = Math.max(40, Math.abs(x2 - x1) / 2)
+
+  return `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`
+}
+
+export function WorkflowBuilder({
+  crewId,
+  members,
+  k
+}: {
+  crewId: string
+  members: CrewMember[]
+  k: ReturnType<typeof useCrewsI18n>
+}) {
+  const qc = useQueryClient()
+  const { data } = useQuery({ queryKey: workflowKey(crewId), queryFn: () => fetchWorkflow(crewId) })
+  const workflow = data?.workflow ?? null
+
+  const [tasks, setTasks] = useState<WorkflowTask[]>([])
+  const [edges, setEdges] = useState<WorkflowEdge[]>([])
+  const [loaded, setLoaded] = useState(false)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [connectMode, setConnectMode] = useState(false)
+  const [connectSource, setConnectSource] = useState<string | null>(null)
+  const [connectError, setConnectError] = useState<string | null>(null)
+  const [scale, setScale] = useState(1)
+  const [pan, setPan] = useState({ x: 40, y: 40 })
+  const [dirty, setDirty] = useState(false)
+
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const panRef = useRef<{ startX: number; startY: number; panX: number; panY: number } | null>(null)
+  const dragRef = useRef<{ id: string; dx: number; dy: number; moved: boolean } | null>(null)
+
+  // Hydrate local draft from the server workflow once.
+  useEffect(() => {
+    if (workflow && !loaded) {
+      setTasks(workflow.tasks)
+      setEdges(workflow.edges)
+      setLoaded(true)
+    }
+  }, [workflow, loaded])
+
+  // Non-passive wheel zoom (must not scroll the page).
+  useEffect(() => {
+    const svg = svgRef.current
+
+    if (!svg) {return}
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1
+      setScale(s => Math.min(4, Math.max(0.25, s * factor)))
+    }
+
+    svg.addEventListener('wheel', onWheel, { passive: false })
+
+    return () => svg.removeEventListener('wheel', onWheel)
+  }, [])
+
+  const memberById = useMemo(() => new Map(members.map(m => [m.id, m])), [members])
+
+  const save = useMutation({
+    mutationFn: () => saveWorkflow(crewId, tasks, edges),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: workflowKey(crewId) })
+      setDirty(false)
+    }
+  })
+
+  const run = useMutation({
+    mutationFn: () => runWorkflow(crewId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: workflowKey(crewId) })
+      qc.invalidateQueries({ queryKey: runsKey(crewId) })
+    }
+  })
+
+  const canRun =
+    tasks.length > 0 &&
+    !hasCycle(
+      tasks.map(t => t.id),
+      edges
+    )
+
+  const addTask = () => {
+    const offset = tasks.length * 12
+
+    const task: WorkflowTask = {
+      id: newTaskId(),
+      label: '',
+      prompt: '',
+      assigneeId: null,
+      x: 40 + offset,
+      y: 40 + offset
+    }
+
+    setTasks([...tasks, task])
+    setSelectedId(task.id)
+    setDirty(true)
+  }
+
+  const updateTask = (id: string, patch: Partial<WorkflowTask>) => {
+    setTasks(tasks.map(t => (t.id === id ? { ...t, ...patch } : t)))
+    setDirty(true)
+  }
+
+  const removeTask = (id: string) => {
+    setTasks(tasks.filter(t => t.id !== id))
+    setEdges(edges.filter(e => e.from !== id && e.to !== id))
+    setSelectedId(null)
+    setDirty(true)
+  }
+
+  const tryConnect = (from: string, to: string) => {
+    if (from === to) {return}
+
+    if (edgeExists(edges, from, to)) {
+      setConnectError('That dependency already exists')
+
+      return
+    }
+
+    const nextEdges = [...edges, { from, to }]
+
+    if (
+      hasCycle(
+        tasks.map(t => t.id),
+        nextEdges
+      )
+    ) {
+      setConnectError('That would create a cycle')
+
+      return
+    }
+
+    setEdges(nextEdges)
+    setConnectError(null)
+    setDirty(true)
+  }
+
+  const layout = () => {
+    setTasks(autoLayout(tasks, edges))
+    setDirty(true)
+  }
+
+  const selected = selectedId ? tasks.find(t => t.id === selectedId) : null
+
+  // ── pointer handlers ──────────────────────────────────────────────────────
+
+  const onBackgroundPointerDown = (e: RPointerEvent<SVGSVGElement>) => {
+    if (e.target !== e.currentTarget) {return}
+    panRef.current = { startX: e.clientX, startY: e.clientY, panX: pan.x, panY: pan.y }
+    ;(e.currentTarget as SVGSVGElement).setPointerCapture(e.pointerId)
+  }
+
+  const onBackgroundPointerMove = (e: RPointerEvent<SVGSVGElement>) => {
+    if (!panRef.current) {return}
+    setPan({
+      x: panRef.current.panX + (e.clientX - panRef.current.startX),
+      y: panRef.current.panY + (e.clientY - panRef.current.startY)
+    })
+  }
+
+  const onBackgroundPointerUp = (e: RPointerEvent<SVGSVGElement>) => {
+    panRef.current = null
+    ;(e.currentTarget as SVGSVGElement).releasePointerCapture(e.pointerId)
+  }
+
+  const onNodePointerDown = (e: RPointerEvent<SVGGElement>, task: WorkflowTask) => {
+    e.stopPropagation()
+
+    if (connectMode) {
+      return // connect mode: handled on click
+    }
+
+    dragRef.current = {
+      id: task.id,
+      dx: e.clientX - task.x * scale - pan.x,
+      dy: e.clientY - task.y * scale - pan.y,
+      moved: false
+    }
+    ;(e.currentTarget as SVGGElement).setPointerCapture(e.pointerId)
+  }
+
+  const onNodePointerMove = (e: RPointerEvent<SVGGElement>) => {
+    const drag = dragRef.current
+
+    if (!drag) {return}
+    const x = (e.clientX - drag.dx - pan.x) / scale
+    const y = (e.clientY - drag.dy - pan.y) / scale
+
+    if (
+      Math.abs(x - (tasks.find(t => t.id === drag.id)?.x ?? 0)) > 0.5 ||
+      Math.abs(y - (tasks.find(t => t.id === drag.id)?.y ?? 0)) > 0.5
+    ) {
+      drag.moved = true
+    }
+
+    updateTask(drag.id, { x, y })
+  }
+
+  const onNodePointerUp = (e: RPointerEvent<SVGGElement>, task: WorkflowTask) => {
+    const drag = dragRef.current
+    dragRef.current = null
+    ;(e.currentTarget as SVGGElement).releasePointerCapture(e.pointerId)
+
+    if (drag?.moved) {return} // dragged — not a click
+
+    if (connectMode) {
+      if (connectSource && connectSource !== task.id) {
+        tryConnect(connectSource, task.id)
+        setConnectSource(null)
+        setConnectMode(false)
+      } else {
+        setConnectSource(task.id)
+      }
+
+      return
+    }
+
+    setSelectedId(task.id)
+  }
+
+  // ── render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Button onClick={addTask} size="sm" variant="outline">
+          {k.addTask}
+        </Button>
+        <Button
+          onClick={() => {
+            setConnectMode(!connectMode)
+            setConnectSource(null)
+            setConnectError(null)
+          }}
+          size="sm"
+          variant={connectMode ? 'default' : 'outline'}
+        >
+          {k.connect}
+        </Button>
+        <Button disabled={tasks.length === 0} onClick={layout} size="sm" variant="outline">
+          {k.autoLayout}
+        </Button>
+        <span className="mx-1 h-4 w-px bg-(--ui-stroke-secondary)" />
+        <Button disabled={!dirty || save.isPending} onClick={() => save.mutate()} size="sm" variant="outline">
+          {save.isPending ? '…' : k.save}
+        </Button>
+        <Button disabled={!canRun || run.isPending} onClick={() => run.mutate()} size="sm">
+          {run.isPending ? k.runningNow : k.runWorkflow}
+        </Button>
+        <span className="mx-1 h-4 w-px bg-(--ui-stroke-secondary)" />
+        <Button onClick={() => setScale(s => Math.min(4, s * 1.25))} size="sm" variant="ghost">
+          +
+        </Button>
+        <Button onClick={() => setScale(s => Math.max(0.25, s / 1.25))} size="sm" variant="ghost">
+          −
+        </Button>
+        <span className="text-[0.6875rem] tabular-nums text-(--ui-text-tertiary)">{Math.round(scale * 100)}%</span>
+        {connectMode && !connectSource && (
+          <span className="text-[0.6875rem] text-(--ui-text-tertiary)">{k.connectHint}</span>
+        )}
+        {connectMode && connectSource && (
+          <span className="text-[0.6875rem] text-(--ui-text-tertiary)">{k.connectHint}</span>
+        )}
+        {connectError && <span className="text-[0.6875rem] text-(--ui-danger,#f87171)">{connectError}</span>}
+      </div>
+
+      {tasks.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 rounded-lg border border-(--ui-stroke-secondary)">
+          <span className="text-sm text-(--ui-text-secondary)">{k.workflowEmpty}</span>
+          <span className="text-xs text-(--ui-text-tertiary)">{k.workflowEmptyBody}</span>
+          <Button className="mt-2" onClick={addTask} size="sm" variant="outline">
+            {k.addTask}
+          </Button>
+        </div>
+      ) : (
+        <div className="relative min-h-0 flex-1 overflow-hidden rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-surface-secondary)">
+          <svg
+            className="h-full w-full cursor-grab active:cursor-grabbing select-none"
+            onPointerDown={onBackgroundPointerDown}
+            onPointerMove={onBackgroundPointerMove}
+            onPointerUp={onBackgroundPointerUp}
+            ref={svgRef}
+          >
+            <defs>
+              <marker
+                id={MARKER_ID}
+                markerHeight="7"
+                markerWidth="7"
+                orient="auto-start-reverse"
+                refX="9"
+                refY="5"
+                viewBox="0 0 10 10"
+              >
+                <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ui-stroke-secondary)" />
+              </marker>
+            </defs>
+
+            <g transform={`translate(${pan.x} ${pan.y}) scale(${scale})`}>
+              {edges.map((edge, i) => {
+                const from = tasks.find(t => t.id === edge.from)
+                const to = tasks.find(t => t.id === edge.to)
+
+                if (!from || !to) {return null}
+                const active = from.status === 'running' || to.status === 'running'
+
+                return (
+                  <g
+                    className="cursor-pointer"
+                    key={i}
+                    onClick={() => {
+                      setEdges(edges.filter((_, j) => j !== i))
+                      setDirty(true)
+                    }}
+                  >
+                    <path
+                      d={bezierPath(from.x + NODE_W, from.y + NODE_H / 2, to.x, to.y + NODE_H / 2)}
+                      fill="none"
+                      markerEnd={`url(#${MARKER_ID})`}
+                      stroke={active ? 'var(--ui-accent)' : 'var(--ui-stroke-secondary)'}
+                      strokeWidth={active ? 2 : 1.25}
+                    />
+                    {/* Wide invisible hit area for edge deletion */}
+                    <path
+                      d={bezierPath(from.x + NODE_W, from.y + NODE_H / 2, to.x, to.y + NODE_H / 2)}
+                      fill="none"
+                      stroke="transparent"
+                      strokeWidth={14}
+                    />
+                  </g>
+                )
+              })}
+
+              {tasks.map(task => {
+                const tone = statusTone(task.status)
+                const isSelected = selectedId === task.id
+                const isConnectSource = connectSource === task.id
+
+                return (
+                  <g
+                    className="cursor-pointer"
+                    key={task.id}
+                    onPointerDown={e => onNodePointerDown(e, task)}
+                    onPointerMove={onNodePointerMove}
+                    onPointerUp={e => onNodePointerUp(e, task)}
+                    transform={`translate(${task.x} ${task.y})`}
+                  >
+                    <rect
+                      fill="var(--ui-surface)"
+                      height={NODE_H}
+                      rx={8}
+                      stroke={isConnectSource ? 'var(--ui-accent)' : tone}
+                      strokeWidth={isSelected ? 2 : 1.25}
+                      width={NODE_W}
+                    />
+                    <text className="pointer-events-none" fill="var(--ui-text-primary)" fontSize={12} x={10} y={18}>
+                      {task.label || '(untitled)'}
+                    </text>
+                    <text className="pointer-events-none" fill="var(--ui-text-tertiary)" fontSize={10} x={10} y={36}>
+                      {task.assigneeId ? (memberById.get(task.assigneeId)?.displayName ?? 'member') : k.allMembers}
+                    </text>
+                    <text className="pointer-events-none" fill="var(--ui-text-tertiary)" fontSize={10} x={10} y={54}>
+                      {task.status ?? 'idle'}
+                    </text>
+                    {isSelected && (
+                      <text
+                        className="pointer-events-none"
+                        fill="var(--ui-text-tertiary)"
+                        fontSize={12}
+                        textAnchor="end"
+                        x={NODE_W - 10}
+                        y={18}
+                      >
+                        ✕
+                      </text>
+                    )}
+                  </g>
+                )
+              })}
+            </g>
+          </svg>
+
+          {/* Right-side task editor panel */}
+          {selected && (
+            <div className="absolute inset-y-0 right-0 flex w-[300px] flex-col gap-2 overflow-y-auto border-l border-(--ui-stroke-secondary) bg-(--ui-surface) p-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-(--ui-text-primary)">{k.taskLabel}</span>
+                <Button onClick={() => removeTask(selected.id)} size="sm" variant="ghost">
+                  {k.delete}
+                </Button>
+              </div>
+              <Input
+                onChange={e => updateTask(selected.id, { label: e.target.value })}
+                placeholder={k.taskLabelPlaceholder}
+                value={selected.label}
+              />
+              <span className="text-xs text-(--ui-text-secondary)">{k.taskPrompt}</span>
+              <Textarea
+                onChange={e => updateTask(selected.id, { prompt: e.target.value })}
+                placeholder={k.taskPromptPlaceholder}
+                rows={5}
+                value={selected.prompt}
+              />
+              <span className="text-xs text-(--ui-text-secondary)">{k.assignee}</span>
+              <Select
+                onValueChange={value => updateTask(selected.id, { assigneeId: value === 'all' ? null : value })}
+                value={selected.assigneeId ?? 'all'}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{k.allMembers}</SelectItem>
+                  {members.map(m => (
+                    <SelectItem key={m.id} value={m.id}>
+                      {m.displayName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <span className="text-xs text-(--ui-text-secondary)">{k.dependencies}</span>
+              <div className="flex flex-wrap gap-1">
+                {edges
+                  .filter(e => e.to === selected.id)
+                  .map(e => {
+                    const dep = tasks.find(t => t.id === e.from)
+
+                    return (
+                      <Badge key={e.from} variant="outline">
+                        {dep?.label || e.from.slice(0, 8)}
+                      </Badge>
+                    )
+                  })}
+                {edges.filter(e => e.to === selected.id).length === 0 && (
+                  <span className="text-xs text-(--ui-text-tertiary)">—</span>
+                )}
+              </div>
+              {selected.status && (
+                <span className="text-xs text-(--ui-text-secondary)">
+                  {k.status}: <Badge variant="outline">{selected.status}</Badge>
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/knowledge/api.ts
+++ b/apps/desktop/src/plugins/knowledge/api.ts
@@ -1,0 +1,48 @@
+/**
+ * Knowledge data layer — ctx.rest to the bundled plugins/knowledge Python
+ * router (/api/plugins/knowledge/*). Graph + list + read + search, cached by
+ * React Query with a slow refetch so external edits to the wiki show up.
+ */
+import { atom, type PluginRestOptions, queryClient } from '@hermes/plugin-sdk'
+
+import type { KnowledgeGraph, KnowledgePage, KnowledgePageMeta, KnowledgeSearchMatch } from './types'
+
+type Rest = <T>(path: string, opts?: PluginRestOptions) => Promise<T>
+
+let rest: null | Rest = null
+
+/** Selected page path for the reader panel. */
+export const $selectedPage = atom<string | null>(null)
+
+export function bindApi(r: Rest): () => void {
+  rest = r
+
+  return () => {
+    rest = null
+  }
+}
+
+function call<T>(path: string, opts?: PluginRestOptions): Promise<T> {
+  return rest ? rest<T>(path, opts) : Promise.reject(new Error('knowledge api not ready'))
+}
+
+// ── query keys ───────────────────────────────────────────────────────────────
+
+export const GRAPH_KEY = ['knowledge', 'graph'] as const
+export const LIST_KEY = ['knowledge', 'list'] as const
+export const pageKey = (path: string) => ['knowledge', 'page', path] as const
+export const searchKey = (q: string) => ['knowledge', 'search', q] as const
+
+// ── reads ────────────────────────────────────────────────────────────────────
+
+export const fetchGraph = () => call<KnowledgeGraph>('/graph')
+export const fetchList = () => call<{ ok: boolean; pages: KnowledgePageMeta[] }>('/list')
+export const fetchPage = (path: string) => call<KnowledgePage>(`/read?path=${encodeURIComponent(path)}`)
+export const searchPages = (q: string) =>
+  call<{ ok: boolean; matches: KnowledgeSearchMatch[] }>(`/search?q=${encodeURIComponent(q)}`)
+
+/** Invalidate graph + list after external wiki edits (e.g. from the agent). */
+export function invalidateKnowledge(): void {
+  void queryClient.invalidateQueries({ queryKey: GRAPH_KEY })
+  void queryClient.invalidateQueries({ queryKey: LIST_KEY })
+}

--- a/apps/desktop/src/plugins/knowledge/force-layout.test.ts
+++ b/apps/desktop/src/plugins/knowledge/force-layout.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { forceLayout, nodeRadius } from './force-layout'
+
+describe('forceLayout', () => {
+  it('returns a position for every node', () => {
+    const pos = forceLayout(['a', 'b', 'c'], [{ source: 'a', target: 'b' }])
+    expect(pos.size).toBe(3)
+
+    for (const id of ['a', 'b', 'c']) {
+      const p = pos.get(id)!
+      expect(Number.isFinite(p.x)).toBe(true)
+      expect(Number.isFinite(p.y)).toBe(true)
+    }
+  })
+
+  it('is deterministic for the same input', () => {
+    const nodes = ['a', 'b', 'c', 'd']
+
+    const edges = [
+      { source: 'a', target: 'b' },
+      { source: 'b', target: 'c' }
+    ]
+
+    const p1 = forceLayout(nodes, edges)
+    const p2 = forceLayout(nodes, edges)
+    expect(p1.get('a')).toEqual(p2.get('a'))
+    expect(p1.get('c')).toEqual(p2.get('c'))
+  })
+
+  it('stays inside the viewport bounds', () => {
+    const nodes = Array.from({ length: 12 }, (_, i) => `n${i}`)
+    const edges = []
+
+    for (let i = 1; i < 12; i += 1) {edges.push({ source: `n${i - 1}`, target: `n${i}` })}
+    const pos = forceLayout(nodes, edges, { width: 300, height: 200 })
+
+    for (const id of nodes) {
+      const p = pos.get(id)!
+      expect(p.x).toBeGreaterThanOrEqual(0)
+      expect(p.x).toBeLessThanOrEqual(300)
+      expect(p.y).toBeGreaterThanOrEqual(0)
+      expect(p.y).toBeLessThanOrEqual(200)
+    }
+  })
+
+  it('handles an empty graph', () => {
+    expect(forceLayout([], []).size).toBe(0)
+  })
+})
+
+describe('nodeRadius', () => {
+  it('grows with degree but caps out', () => {
+    expect(nodeRadius(0)).toBeLessThan(nodeRadius(4))
+    expect(nodeRadius(100)).toBeLessThanOrEqual(nodeRadius(200))
+    expect(nodeRadius(10000)).toBeLessThanOrEqual(18)
+  })
+})

--- a/apps/desktop/src/plugins/knowledge/force-layout.ts
+++ b/apps/desktop/src/plugins/knowledge/force-layout.ts
@@ -1,0 +1,162 @@
+/**
+ * Synchronous force-directed layout for the knowledge graph — Coulomb
+ * repulsion between all node pairs + Hooke springs along edges, run for a
+ * fixed iteration count so results are deterministic and testable.
+ *
+ * Ported from the approach used by Hermes-Studio's knowledge browser.
+ */
+export interface LayoutNode {
+  id: string
+  x: number
+  y: number
+  degree: number
+}
+
+export interface LayoutEdge {
+  source: string
+  target: string
+}
+
+export interface ForceLayoutOptions {
+  width?: number
+  height?: number
+  iterations?: number
+  /** Coulomb repulsion strength (scaled by 1/d²). */
+  repulsion?: number
+  /** Hooke spring strength. */
+  attraction?: number
+  /** Natural spring length. */
+  springLength?: number
+  seed?: number
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/**
+ * Compute 2-D positions for the node set. Returns a Map<id, {x,y}> with
+ * positions bounded to the requested viewport.
+ */
+export function forceLayout(
+  nodeIds: string[],
+  edges: LayoutEdge[],
+  opts: ForceLayoutOptions = {}
+): Map<string, { x: number; y: number }> {
+  const {
+    width = 800,
+    height = 560,
+    iterations = 280,
+    repulsion = 1_800,
+    attraction = 0.045,
+    springLength = 110,
+    seed = 42
+  } = opts
+
+  const rng = mulberry32(seed)
+  const degree = new Map<string, number>()
+
+  for (const id of nodeIds) {degree.set(id, 0)}
+
+  for (const e of edges) {
+    degree.set(e.source, (degree.get(e.source) ?? 0) + 1)
+    degree.set(e.target, (degree.get(e.target) ?? 0) + 1)
+  }
+
+  // Deterministic initial placement: ring around the centre, hubs inward.
+  const pos = new Map<string, { x: number; y: number }>()
+  const n = nodeIds.length
+  const cx = width / 2
+  const cy = height / 2
+  nodeIds.forEach((id, i) => {
+    const angle = (i / Math.max(1, n)) * Math.PI * 2 + rng() * 0.15
+    const radius = Math.min(width, height) * 0.3 + rng() * 40
+    pos.set(id, { x: cx + Math.cos(angle) * radius, y: cy + Math.sin(angle) * radius })
+  })
+
+  const adjacency = new Map<string, string[]>()
+
+  for (const id of nodeIds) {adjacency.set(id, [])}
+
+  for (const e of edges) {
+    adjacency.get(e.source)?.push(e.target)
+    adjacency.get(e.target)?.push(e.source)
+  }
+
+  const displacement = new Map<string, { x: number; y: number }>()
+
+  for (let iter = 0; iter < iterations; iter += 1) {
+    for (const id of nodeIds) {displacement.set(id, { x: 0, y: 0 })}
+    const cooling = 1 - iter / iterations
+
+    // Repulsion — all pairs.
+    for (let i = 0; i < n; i += 1) {
+      const a = nodeIds[i]!
+      const pa = pos.get(a)!
+
+      for (let j = i + 1; j < n; j += 1) {
+        const b = nodeIds[j]!
+        const pb = pos.get(b)!
+        const dx = pa.x - pb.x
+        const dy = pa.y - pb.y
+        const distSq = Math.max(dx * dx + dy * dy, 1)
+        const dist = Math.sqrt(distSq)
+        const force = (repulsion / distSq) * cooling
+        const fx = (dx / dist) * force
+        const fy = (dy / dist) * force
+        const da = displacement.get(a)!
+        const db = displacement.get(b)!
+        da.x += fx
+        da.y += fy
+        db.x -= fx
+        db.y -= fy
+      }
+    }
+
+    // Attraction — springs along edges.
+    for (const e of edges) {
+      const pa = pos.get(e.source)
+      const pb = pos.get(e.target)
+
+      if (!pa || !pb) {continue}
+      const dx = pb.x - pa.x
+      const dy = pb.y - pa.y
+      const dist = Math.max(Math.sqrt(dx * dx + dy * dy), 1)
+      const force = (dist - springLength) * attraction
+      const fx = (dx / dist) * force
+      const fy = (dy / dist) * force
+      const da = displacement.get(e.source)!
+      const db = displacement.get(e.target)!
+      da.x += fx
+      da.y += fy
+      db.x -= fx
+      db.y -= fy
+    }
+
+    // Apply, clamping to the viewport.
+    for (const id of nodeIds) {
+      const p = pos.get(id)!
+      const d = displacement.get(id)!
+      p.x += Math.max(-24, Math.min(24, d.x))
+      p.y += Math.max(-24, Math.min(24, d.y))
+      p.x = Math.max(24, Math.min(width - 24, p.x))
+      p.y = Math.max(24, Math.min(height - 24, p.y))
+    }
+  }
+
+  return pos
+}
+
+/** Node radius by degree: hubs larger, orphans small. */
+export function nodeRadius(degree: number): number {
+  return 5 + Math.min(13, Math.sqrt(degree) * 4)
+}

--- a/apps/desktop/src/plugins/knowledge/i18n.ts
+++ b/apps/desktop/src/plugins/knowledge/i18n.ts
@@ -1,0 +1,96 @@
+/** Plugin-scoped i18n for knowledge — English + Japanese bundles. */
+import { type PluginLocaleBundles, usePluginI18n } from '@hermes/plugin-sdk'
+import { useMemo } from 'react'
+
+type KnowledgeMessages = {
+  nav: string
+  open: string
+  title: string
+  graph: string
+  pages: string
+  search: string
+  searchPlaceholder: string
+  noResults: string
+  emptyTitle: string
+  emptyBody: string
+  stats: (nodes: number, edges: number) => string
+  hoverDim: string
+  legend: string
+  backlinks: (n: number) => string
+  links: (n: number) => string
+  tags: string
+  modified: string
+  summary: string
+  untitled: string
+  refresh: string
+  close: string
+  notInstalled: string
+  notInstalledBody: string
+  openPage: string
+}
+
+const en: KnowledgeMessages = {
+  nav: 'Knowledge',
+  open: 'Knowledge: Open knowledge graph',
+  title: 'Knowledge Graph',
+  graph: 'Graph',
+  pages: 'Pages',
+  search: 'Search',
+  searchPlaceholder: 'Search the wiki…',
+  noResults: 'No matches',
+  emptyTitle: 'No knowledge pages yet',
+  emptyBody:
+    'Drop Markdown files (with [[wiki-links]]) into your knowledge folder and they appear here as graph nodes. The folder was created at ~/.hermes/knowledge.',
+  stats: (nodes, edges) => `${nodes} nodes · ${edges} edges`,
+  hoverDim: 'Hover a node to highlight its connections',
+  legend: 'Node types',
+  backlinks: n => `${n} backlinks`,
+  links: n => `${n} links`,
+  tags: 'Tags',
+  modified: 'Modified',
+  summary: 'Summary',
+  untitled: 'Untitled',
+  refresh: 'Refresh',
+  close: 'Close',
+  notInstalled: 'Knowledge backend is not mounted',
+  notInstalledBody:
+    'Enable the knowledge plugin (Settings → Plugins) and restart the gateway, or run hermes with the dashboard server.',
+  openPage: 'Open page'
+}
+
+const ja: KnowledgeMessages = {
+  nav: 'ナレッジ',
+  open: 'ナレッジ: ナレッジグラフを開く',
+  title: 'ナレッジグラフ',
+  graph: 'グラフ',
+  pages: 'ページ',
+  search: '検索',
+  searchPlaceholder: 'ウィキを検索…',
+  noResults: '一致なし',
+  emptyTitle: 'ナレッジページがまだありません',
+  emptyBody:
+    '[[wikiリンク]]を含む Markdown ファイルをナレッジフォルダに置くと、グラフのノードとして表示されます。フォルダは ~/.hermes/knowledge に作成されました。',
+  stats: (nodes, edges) => `${nodes} ノード · ${edges} エッジ`,
+  hoverDim: 'ノードにホバーすると接続をハイライト',
+  legend: 'ノードタイプ',
+  backlinks: n => `${n} バックリンク`,
+  links: n => `${n} リンク`,
+  tags: 'タグ',
+  modified: '更新',
+  summary: '概要',
+  untitled: '無題',
+  refresh: '更新',
+  close: '閉じる',
+  notInstalled: 'ナレッジバックエンドがマウントされていません',
+  notInstalledBody:
+    'ナレッジプラグインを有効化（設定 → プラグイン）してゲートウェイを再起動するか、ダッシュボードサーバー付きで hermes を実行してください。',
+  openPage: 'ページを開く'
+}
+
+export const KNOWLEDGE_LOCALES: PluginLocaleBundles = { en, ja }
+
+export function useKnowledgeI18n(): KnowledgeMessages {
+  const t = usePluginI18n('knowledge')
+
+  return useMemo(() => t as unknown as KnowledgeMessages, [t])
+}

--- a/apps/desktop/src/plugins/knowledge/knowledge-screen.tsx
+++ b/apps/desktop/src/plugins/knowledge/knowledge-screen.tsx
@@ -1,0 +1,437 @@
+/**
+ * Knowledge screen — force-directed SVG canvas (zoom, pan, node drag, hover
+ * highlight), legend, stats, plus a sidebar with the page list, search, and
+ * a reader that follows [[wiki-links]] and backlinks.
+ */
+import {
+  Button,
+  cn,
+  EmptyState,
+  Input,
+  ScrollArea,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  useQuery,
+  useValue
+} from '@hermes/plugin-sdk'
+import { type PointerEvent as RPointerEvent, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  $selectedPage,
+  fetchGraph,
+  fetchList,
+  fetchPage,
+  GRAPH_KEY,
+  LIST_KEY,
+  pageKey,
+  searchKey,
+  searchPages
+} from './api'
+import { forceLayout, nodeRadius } from './force-layout'
+import { useKnowledgeI18n } from './i18n'
+import type { KnowledgeNode } from './types'
+
+const TYPE_COLORS: Record<string, string> = {
+  guide: '#60a5fa',
+  project: '#a78bfa',
+  reference: '#2dd4bf',
+  concept: '#fbbf24',
+  note: '#94a3b8'
+}
+
+function typeColor(type?: string | null): string {
+  return (type && TYPE_COLORS[type.toLowerCase()]) || '#94a3b8'
+}
+
+function GraphCanvas({
+  nodes,
+  edges,
+  onOpen,
+  k
+}: {
+  nodes: KnowledgeNode[]
+  edges: Array<{ source: string; target: string }>
+  onOpen: (id: string) => void
+  k: ReturnType<typeof useKnowledgeI18n>
+}) {
+  const [scale, setScale] = useState(1)
+  const [pan, setPan] = useState({ x: 0, y: 0 })
+  const [hovered, setHovered] = useState<string | null>(null)
+  const [overrides, setOverrides] = useState<Record<string, { x: number; y: number }>>({})
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const panRef = useRef<{ startX: number; startY: number; panX: number; panY: number } | null>(null)
+  const dragRef = useRef<{ id: string; dx: number; dy: number; moved: boolean } | null>(null)
+
+  const degree = useMemo(() => {
+    const map = new Map<string, number>()
+
+    for (const n of nodes) {map.set(n.id, 0)}
+
+    for (const e of edges) {
+      map.set(e.source, (map.get(e.source) ?? 0) + 1)
+      map.set(e.target, (map.get(e.target) ?? 0) + 1)
+    }
+
+    return map
+  }, [nodes, edges])
+
+  const base = useMemo(
+    () =>
+      forceLayout(
+        nodes.map(n => n.id),
+        edges,
+        { width: 900, height: 620 }
+      ),
+    // Deterministic on the graph shape; recompute only when the shape changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [nodes.map(n => n.id).join('|'), edges.map(e => `${e.source}>${e.target}`).join('|')]
+  )
+
+  const posOf = (id: string) => overrides[id] ?? base.get(id) ?? { x: 0, y: 0 }
+
+  useEffect(() => {
+    const svg = svgRef.current
+
+    if (!svg) {return}
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1
+      setScale(s => Math.min(4, Math.max(0.25, s * factor)))
+    }
+
+    svg.addEventListener('wheel', onWheel, { passive: false })
+
+    return () => svg.removeEventListener('wheel', onWheel)
+  }, [])
+
+  const onBackgroundPointerDown = (e: RPointerEvent<SVGSVGElement>) => {
+    if (e.target !== e.currentTarget) {return}
+    panRef.current = { startX: e.clientX, startY: e.clientY, panX: pan.x, panY: pan.y }
+    ;(e.currentTarget as SVGSVGElement).setPointerCapture(e.pointerId)
+  }
+
+  const onBackgroundPointerMove = (e: RPointerEvent<SVGSVGElement>) => {
+    if (!panRef.current) {return}
+    setPan({
+      x: panRef.current.panX + (e.clientX - panRef.current.startX),
+      y: panRef.current.panY + (e.clientY - panRef.current.startY)
+    })
+  }
+
+  const onBackgroundPointerUp = (e: RPointerEvent<SVGSVGElement>) => {
+    panRef.current = null
+    ;(e.currentTarget as SVGSVGElement).releasePointerCapture(e.pointerId)
+  }
+
+  const onNodePointerDown = (e: RPointerEvent<SVGGElement>, id: string) => {
+    e.stopPropagation()
+    const p = posOf(id)
+    dragRef.current = { id, dx: e.clientX - p.x * scale - pan.x, dy: e.clientY - p.y * scale - pan.y, moved: false }
+    ;(e.currentTarget as SVGGElement).setPointerCapture(e.pointerId)
+  }
+
+  const onNodePointerMove = (e: RPointerEvent<SVGGElement>) => {
+    const drag = dragRef.current
+
+    if (!drag) {return}
+    const x = (e.clientX - drag.dx - pan.x) / scale
+    const y = (e.clientY - drag.dy - pan.y) / scale
+    const current = posOf(drag.id)
+
+    if (Math.abs(x - current.x) > 0.5 || Math.abs(y - current.y) > 0.5) {drag.moved = true}
+    setOverrides(prev => ({ ...prev, [drag.id]: { x, y } }))
+  }
+
+  const onNodePointerUp = (e: RPointerEvent<SVGGElement>, id: string) => {
+    const drag = dragRef.current
+    dragRef.current = null
+    ;(e.currentTarget as SVGGElement).releasePointerCapture(e.pointerId)
+
+    if (drag?.moved) {return}
+    onOpen(id)
+  }
+
+  return (
+    <div className="relative h-full w-full overflow-hidden rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-surface-secondary)">
+      <svg
+        className="h-full w-full cursor-grab select-none active:cursor-grabbing"
+        onPointerDown={onBackgroundPointerDown}
+        onPointerMove={onBackgroundPointerMove}
+        onPointerUp={onBackgroundPointerUp}
+        ref={svgRef}
+      >
+        <g transform={`translate(${pan.x} ${pan.y}) scale(${scale})`}>
+          {edges.map((e, i) => {
+            const a = posOf(e.source)
+            const b = posOf(e.target)
+            const active = hovered === e.source || hovered === e.target
+
+            return (
+              <line
+                key={i}
+                stroke={active ? 'var(--ui-accent)' : 'var(--ui-stroke-secondary)'}
+                strokeWidth={active ? 1.5 : 1}
+                x1={a.x}
+                x2={b.x}
+                y1={a.y}
+                y2={b.y}
+              />
+            )
+          })}
+
+          {nodes.map(node => {
+            const p = posOf(node.id)
+            const dim = hovered !== null && hovered !== node.id
+
+            const linked =
+              hovered === null ||
+              hovered === node.id ||
+              edges.some(
+                e => (e.source === hovered && e.target === node.id) || (e.target === hovered && e.source === node.id)
+              )
+
+            const radius = nodeRadius(degree.get(node.id) ?? 0)
+
+            return (
+              <g
+                className={cn('cursor-pointer', dim && 'opacity-40')}
+                key={node.id}
+                onPointerDown={e => onNodePointerDown(e, node.id)}
+                onPointerEnter={() => setHovered(node.id)}
+                onPointerLeave={() => setHovered(null)}
+                onPointerMove={onNodePointerMove}
+                onPointerUp={e => onNodePointerUp(e, node.id)}
+                opacity={hovered === null || linked ? 1 : 0.22}
+                transform={`translate(${p.x} ${p.y})`}
+              >
+                <circle fill={typeColor(node.type)} opacity={0.85} r={radius} />
+                {hovered === node.id && (
+                  <circle fill="none" r={radius + 3} stroke="var(--ui-accent)" strokeWidth={1.5} />
+                )}
+                <text fill="var(--ui-text-secondary)" fontSize={10} textAnchor="middle" y={radius + 12}>
+                  {node.title.length > 24 ? `${node.title.slice(0, 24)}…` : node.title}
+                </text>
+              </g>
+            )
+          })}
+        </g>
+      </svg>
+
+      {/* Legend — only when typed nodes exist */}
+      {nodes.some(n => n.type) && (
+        <div className="absolute bottom-2 left-2 flex flex-col gap-1 rounded-md border border-(--ui-stroke-secondary) bg-(--ui-surface) p-2">
+          <span className="text-[0.6875rem] text-(--ui-text-tertiary)">{k.legend}</span>
+          {Object.entries(TYPE_COLORS).map(([type, color]) => {
+            if (!nodes.some(n => (n.type ?? '').toLowerCase() === type)) {return null}
+
+            return (
+              <span className="flex items-center gap-1.5 text-[0.6875rem] text-(--ui-text-secondary)" key={type}>
+                <span className="inline-block size-2 rounded-full" style={{ backgroundColor: color }} />
+                {type}
+              </span>
+            )
+          })}
+        </div>
+      )}
+
+      <div className="absolute bottom-2 right-2 flex items-center gap-1">
+        <Button onClick={() => setScale(s => Math.min(4, s * 1.25))} size="sm" variant="ghost">
+          +
+        </Button>
+        <Button onClick={() => setScale(s => Math.max(0.25, s / 1.25))} size="sm" variant="ghost">
+          −
+        </Button>
+        <span className="text-[0.6875rem] tabular-nums text-(--ui-text-tertiary)">
+          {k.stats(nodes.length, edges.length)} · {Math.round(scale * 100)}%
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function Reader({ path, k }: { path: string; k: ReturnType<typeof useKnowledgeI18n> }) {
+  const { data, isLoading } = useQuery({ queryKey: pageKey(path), queryFn: () => fetchPage(path) })
+
+  if (isLoading) {
+    return <div className="p-3 text-sm text-(--ui-text-tertiary)">…</div>
+  }
+
+  if (!data?.ok) {
+    return <div className="p-3 text-sm text-(--ui-text-tertiary)">{k.notInstalled}</div>
+  }
+
+  const { meta, content, backlinks } = data
+  // Render [[wiki-links]] as clickable buttons that navigate the reader.
+  const parts = content.split(/(\[\[[^\]]+\]\])/g).filter(Boolean)
+
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h2 className="text-sm font-semibold text-(--ui-text-primary)">{meta.title}</h2>
+          <p className="text-[0.6875rem] text-(--ui-text-tertiary)">{meta.path}</p>
+        </div>
+        <Button onClick={() => $selectedPage.set(null)} size="sm" variant="ghost">
+          ✕
+        </Button>
+      </div>
+
+      {meta.type && <span className="text-[0.6875rem] text-(--ui-text-secondary)">type: {meta.type}</span>}
+      {meta.summary && <p className="text-xs text-(--ui-text-secondary)">{meta.summary}</p>}
+      {meta.tags.length > 0 && (
+        <p className="text-[0.6875rem] text-(--ui-text-tertiary)">
+          {k.tags}: {meta.tags.join(', ')}
+        </p>
+      )}
+
+      <div className="max-h-72 overflow-y-auto whitespace-pre-wrap rounded-md border border-(--ui-stroke-secondary) bg-(--ui-surface) p-2 text-xs leading-relaxed text-(--ui-text-secondary)">
+        {parts.map((part, i) => {
+          const m = part.match(/^\[\[([^\]]+)\]\]$/)
+
+          if (!m) {return <span key={i}>{part}</span>}
+          const target = m[1]!.split('|')[0]!.split('#')[0]!.trim()
+
+          return (
+            <button
+              className="mx-0.5 inline cursor-pointer rounded bg-(--ui-accent-soft) px-1 text-(--ui-accent) hover:underline"
+              key={i}
+              onClick={() => $selectedPage.set(`${target}.md`)}
+              type="button"
+            >
+              {target}
+            </button>
+          )
+        })}
+      </div>
+
+      {backlinks.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-(--ui-text-secondary)">{k.backlinks(backlinks.length)}</span>
+          {backlinks.map(b => (
+            <button
+              className="cursor-pointer text-left text-xs text-(--ui-accent) hover:underline"
+              key={b}
+              onClick={() => $selectedPage.set(b)}
+              type="button"
+            >
+              {b}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function KnowledgeScreen() {
+  const k = useKnowledgeI18n()
+  const selected = useValue($selectedPage)
+  const [tab, setTab] = useState<'pages' | 'search'>('pages')
+  const [query, setQuery] = useState('')
+
+  const {
+    data: graph,
+    isLoading,
+    isError
+  } = useQuery({ queryKey: GRAPH_KEY, queryFn: () => fetchGraph(), refetchInterval: 60_000 })
+
+  const { data: list } = useQuery({ queryKey: LIST_KEY, queryFn: () => fetchList(), refetchInterval: 60_000 })
+
+  const { data: search } = useQuery({
+    queryKey: searchKey(query),
+    queryFn: () => searchPages(query),
+    enabled: query.trim().length > 0
+  })
+
+  if (isLoading) {
+    return <div className="flex h-full items-center justify-center text-sm text-(--ui-text-tertiary)">…</div>
+  }
+
+  if (isError || !graph?.ok) {
+    return <EmptyState description={k.notInstalledBody} title={k.notInstalled} />
+  }
+
+  return (
+    <div className="flex h-full gap-3 p-4">
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <h1 className="text-lg font-semibold text-(--ui-text-primary)">{k.title}</h1>
+          <span className="text-[0.6875rem] text-(--ui-text-tertiary)">{graph.root}</span>
+        </div>
+        {graph.nodes.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center">
+            <EmptyState description={k.emptyBody} title={k.emptyTitle} />
+          </div>
+        ) : (
+          <GraphCanvas edges={graph.edges} k={k} nodes={graph.nodes} onOpen={id => $selectedPage.set(id)} />
+        )}
+      </div>
+
+      <div className="flex w-[340px] shrink-0 flex-col overflow-hidden rounded-lg border border-(--ui-stroke-secondary)">
+        {selected ? (
+          <Reader k={k} path={selected} />
+        ) : (
+          <>
+            <Tabs onValueChange={value => setTab(value as 'pages' | 'search')} value={tab}>
+              <TabsList className="m-2">
+                <TabsTrigger value="pages">{k.pages}</TabsTrigger>
+                <TabsTrigger value="search">{k.search}</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            {tab === 'search' && (
+              <div className="px-2 pb-2">
+                <Input onChange={e => setQuery(e.target.value)} placeholder={k.searchPlaceholder} value={query} />
+              </div>
+            )}
+            <ScrollArea className="min-h-0 flex-1">
+              {tab === 'pages' && (
+                <ul className="flex flex-col">
+                  {(list?.pages ?? []).map(page => (
+                    <button
+                      className="flex cursor-pointer flex-col gap-0.5 border-b border-(--ui-stroke-secondary) px-3 py-2 text-left hover:bg-(--chrome-action-hover)"
+                      key={page.path}
+                      onClick={() => $selectedPage.set(page.path)}
+                      type="button"
+                    >
+                      <span className="text-sm text-(--ui-text-primary)">{page.title}</span>
+                      <span className="text-[0.6875rem] text-(--ui-text-tertiary)">{page.path}</span>
+                    </button>
+                  ))}
+                  {(list?.pages ?? []).length === 0 && (
+                    <p className="p-3 text-xs text-(--ui-text-tertiary)">{k.emptyTitle}</p>
+                  )}
+                </ul>
+              )}
+              {tab === 'search' && (
+                <ul className="flex flex-col">
+                  {(search?.matches ?? []).map((m, i) => (
+                    <button
+                      className="flex cursor-pointer flex-col gap-0.5 border-b border-(--ui-stroke-secondary) px-3 py-2 text-left hover:bg-(--chrome-action-hover)"
+                      key={i}
+                      onClick={() => $selectedPage.set(m.path)}
+                      type="button"
+                    >
+                      <span className="text-sm text-(--ui-text-primary)">{m.title}</span>
+                      <span className="text-[0.6875rem] text-(--ui-text-tertiary)">
+                        {m.path}:{m.line}
+                      </span>
+                      <span className="line-clamp-2 text-xs text-(--ui-text-secondary)">{m.text}</span>
+                    </button>
+                  ))}
+                  {query.trim().length > 0 && (search?.matches ?? []).length === 0 && (
+                    <p className="p-3 text-xs text-(--ui-text-tertiary)">{k.noResults}</p>
+                  )}
+                  {query.trim().length === 0 && (
+                    <p className="p-3 text-xs text-(--ui-text-tertiary)">{k.searchPlaceholder}</p>
+                  )}
+                </ul>
+              )}
+            </ScrollArea>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/knowledge/plugin.tsx
+++ b/apps/desktop/src/plugins/knowledge/plugin.tsx
@@ -1,0 +1,60 @@
+/**
+ * Knowledge — interactive force-directed knowledge graph over the
+ * ~/.hermes/knowledge markdown wiki, plus page browser, search, and reader.
+ * Backend is the bundled plugins/knowledge/dashboard/plugin_api.py router.
+ *
+ * Ships OFF by default — inventories in Settings ▸ Plugins.
+ */
+import {
+  type HermesPlugin,
+  host,
+  PALETTE_AREA,
+  type PaletteContribution,
+  type RouteContribution,
+  ROUTES_AREA,
+  SIDEBAR_NAV_AREA,
+  type SidebarNavContribution
+} from '@hermes/plugin-sdk'
+
+import { bindApi } from './api'
+import { KNOWLEDGE_LOCALES } from './i18n'
+import { KnowledgeScreen } from './knowledge-screen'
+
+const plugin: HermesPlugin = {
+  id: 'knowledge',
+  name: 'Knowledge',
+  description:
+    'Interactive knowledge graph over the ~/.hermes/knowledge markdown wiki — force-directed canvas, page browser, search, links and backlinks.',
+  defaultEnabled: false,
+  register(ctx) {
+    ctx.i18n.register(KNOWLEDGE_LOCALES)
+    ctx.onDispose(bindApi(ctx.rest))
+
+    ctx.registerMany([
+      {
+        id: 'page',
+        area: ROUTES_AREA,
+        data: { path: '/knowledge' } satisfies RouteContribution,
+        render: () => <KnowledgeScreen />
+      },
+      {
+        id: 'nav',
+        area: SIDEBAR_NAV_AREA,
+        order: 56,
+        data: { codicon: 'graph', label: 'Knowledge', path: '/knowledge' } satisfies SidebarNavContribution
+      },
+      {
+        id: 'open',
+        area: PALETTE_AREA,
+        data: {
+          id: 'knowledge.open',
+          label: 'Knowledge: Open knowledge graph',
+          keywords: ['knowledge', 'graph', 'wiki', 'memory', 'notes'],
+          run: () => host.navigate('/knowledge')
+        } satisfies PaletteContribution
+      }
+    ])
+  }
+}
+
+export default plugin

--- a/apps/desktop/src/plugins/knowledge/types.ts
+++ b/apps/desktop/src/plugins/knowledge/types.ts
@@ -1,0 +1,50 @@
+/** Knowledge graph data model, mirrored from plugins/knowledge/dashboard/plugin_api.py. */
+
+export interface KnowledgeNode {
+  id: string
+  title: string
+  type?: string | null
+  tags: string[]
+}
+
+export interface KnowledgeEdge {
+  source: string
+  target: string
+}
+
+export interface KnowledgeGraph {
+  ok: boolean
+  root: string
+  nodes: KnowledgeNode[]
+  edges: KnowledgeEdge[]
+}
+
+export interface KnowledgePageMeta {
+  path: string
+  name: string
+  title: string
+  type?: string | null
+  domain?: string | null
+  status?: string | null
+  tags: string[]
+  summary?: string | null
+  created?: string | null
+  updated?: string | null
+  size: number
+  modified: string
+  wikilinks: string[]
+}
+
+export interface KnowledgePage {
+  ok: boolean
+  meta: KnowledgePageMeta
+  content: string
+  backlinks: string[]
+}
+
+export interface KnowledgeSearchMatch {
+  path: string
+  title: string
+  line: number
+  text: string
+}

--- a/apps/desktop/src/plugins/office/api.ts
+++ b/apps/desktop/src/plugins/office/api.ts
@@ -1,0 +1,46 @@
+/** Hermes Office (Claw3d) — renderer-side API over the Electron claw3d bridge. */
+import { atom } from '@hermes/plugin-sdk'
+
+export interface OfficeStatus {
+  cloned: boolean
+  installed: boolean
+  devServerRunning: boolean
+  adapterRunning: boolean
+  running: boolean
+  port: number
+  portInUse: boolean
+  url: string
+  error: string
+  oauthUnsupported: boolean
+}
+
+export interface SetupProgress {
+  step: number
+  totalSteps: number
+  title: string
+  detail: string
+  log: string
+}
+
+/** Setup progress ('' = not running). */
+export const $setupProgress = atom<SetupProgress | null>(null)
+
+function bridge() {
+  return window.hermesDesktop.claw3d
+}
+
+export function bindOfficeApi(): () => void {
+  const off = bridge().onSetupProgress(progress => $setupProgress.set(progress))
+
+  return () => {
+    off()
+    $setupProgress.set(null)
+  }
+}
+
+export const getStatus = (profile?: string | null) => bridge().getStatus(profile)
+export const runSetup = (profile?: string | null) => bridge().setup(profile)
+export const startOffice = (profile?: string | null) => bridge().start(profile)
+export const stopOffice = () => bridge().stop()
+export const getLogs = () => bridge().getLogs()
+export const openOffice = (profile?: string | null) => bridge().open(profile)

--- a/apps/desktop/src/plugins/office/i18n.ts
+++ b/apps/desktop/src/plugins/office/i18n.ts
@@ -1,0 +1,119 @@
+/** Plugin-scoped i18n for office (Claw3d) — English + Japanese bundles. */
+import { type PluginLocaleBundles, usePluginI18n } from '@hermes/plugin-sdk'
+import { useMemo } from 'react'
+
+type OfficeMessages = {
+  nav: string
+  open: string
+  title: string
+  subtitle: string
+  notCloned: string
+  notInstalled: string
+  running: string
+  stopped: string
+  devServer: string
+  adapter: string
+  port: string
+  gateway: string
+  oauthUnsupported: string
+  oauthUnsupportedBody: string
+  portInUse: string
+  error: string
+  noError: string
+  setup: string
+  setupTitle: string
+  start: string
+  stop: string
+  openBrowser: string
+  refresh: string
+  logs: string
+  noLogs: string
+  step: (step: number, total: number, title: string) => string
+  setupDone: string
+  setupFailed: string
+  startFailed: string
+  stopFailed: string
+  statusTitle: string
+  actions: string
+}
+
+const en: OfficeMessages = {
+  nav: 'Office',
+  open: 'Office: Open Hermes Office',
+  title: 'Hermes Office (Claw3d)',
+  subtitle: 'A visual 3D interface for Hermes — runs the hermes-office dev server and a gateway adapter on localhost.',
+  notCloned: 'Not installed',
+  notInstalled: 'Installed, dependencies pending',
+  running: 'Running',
+  stopped: 'Stopped',
+  devServer: 'Dev server',
+  adapter: 'Gateway adapter',
+  port: 'Port',
+  gateway: 'Gateway',
+  oauthUnsupported: 'OAuth gateway',
+  oauthUnsupportedBody:
+    'Office requires a local or token-authenticated gateway connection. Switch the connection in Settings to enable it.',
+  portInUse: 'Port in use by another process',
+  error: 'Error',
+  noError: 'No errors',
+  setup: 'Install / Update',
+  setupTitle: 'Installing Hermes Office…',
+  start: 'Start Office',
+  stop: 'Stop',
+  openBrowser: 'Open in browser',
+  refresh: 'Refresh',
+  logs: 'Logs',
+  noLogs: 'No logs yet.',
+  step: (step, total, title) => `Step ${step} of ${total} — ${title}`,
+  setupDone: 'Hermes Office installed. Start it from the Office page.',
+  setupFailed: 'Setup failed',
+  startFailed: 'Could not start Office',
+  stopFailed: 'Could not stop Office',
+  statusTitle: 'Status',
+  actions: 'Actions'
+}
+
+const ja: OfficeMessages = {
+  nav: 'オフィス',
+  open: 'オフィス: Hermes Office を開く',
+  title: 'Hermes Office (Claw3d)',
+  subtitle:
+    'Hermes 用の3Dビジュアルインターフェース — hermes-office 開発サーバーとゲートウェイアダプターを localhost で実行します。',
+  notCloned: '未インストール',
+  notInstalled: 'インストール済み（依存関係の準備中）',
+  running: '実行中',
+  stopped: '停止中',
+  devServer: '開発サーバー',
+  adapter: 'ゲートウェイアダプター',
+  port: 'ポート',
+  gateway: 'ゲートウェイ',
+  oauthUnsupported: 'OAuth ゲートウェイ',
+  oauthUnsupportedBody:
+    'Office にはローカルまたはトークン認証のゲートウェイ接続が必要です。設定で接続を切り替えてください。',
+  portInUse: '別のプロセスがポートを使用中',
+  error: 'エラー',
+  noError: 'エラーなし',
+  setup: 'インストール / 更新',
+  setupTitle: 'Hermes Office をインストール中…',
+  start: 'Office を起動',
+  stop: '停止',
+  openBrowser: 'ブラウザで開く',
+  refresh: '更新',
+  logs: 'ログ',
+  noLogs: 'ログはまだありません。',
+  step: (step, total, title) => `ステップ ${step} / ${total} — ${title}`,
+  setupDone: 'Hermes Office がインストールされました。Office ページから起動してください。',
+  setupFailed: 'セットアップに失敗しました',
+  startFailed: 'Office を起動できませんでした',
+  stopFailed: 'Office を停止できませんでした',
+  statusTitle: 'ステータス',
+  actions: 'アクション'
+}
+
+export const OFFICE_LOCALES: PluginLocaleBundles = { en, ja }
+
+export function useOfficeI18n(): OfficeMessages {
+  const t = usePluginI18n('office')
+
+  return useMemo(() => t as unknown as OfficeMessages, [t])
+}

--- a/apps/desktop/src/plugins/office/office-screen.tsx
+++ b/apps/desktop/src/plugins/office/office-screen.tsx
@@ -71,7 +71,9 @@ export function OfficeScreen() {
     setActionError(null)
 
     try {
-      await runSetup()
+      const result = await runSetup()
+
+      if (!result.ok) {setActionError(result.error ?? k.setupFailed)}
       await refetch()
     } catch (err) {
       setActionError(err instanceof Error ? err.message : k.setupFailed)

--- a/apps/desktop/src/plugins/office/office-screen.tsx
+++ b/apps/desktop/src/plugins/office/office-screen.tsx
@@ -1,0 +1,221 @@
+/**
+ * Hermes Office (Claw3d) — status, install/update, start/stop, logs and
+ * browser-open for the hermes-office 3D interface, driven by the Electron
+ * main-process manager (electron/claw3d.ts) through window.hermesDesktop.
+ */
+import {
+  Badge,
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  ScrollArea,
+  StatusDot,
+  useQuery,
+  useValue
+} from '@hermes/plugin-sdk'
+import { useState } from 'react'
+
+import {
+  $setupProgress,
+  getLogs,
+  getStatus,
+  type OfficeStatus,
+  openOffice,
+  runSetup,
+  startOffice,
+  stopOffice
+} from './api'
+import { useOfficeI18n } from './i18n'
+
+function StatusRow({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-2 text-sm">
+      <span className="text-(--ui-text-secondary)">{label}</span>
+      <span
+        className={cn(
+          'flex items-center gap-1.5',
+          ok === false ? 'text-(--ui-danger,#f87171)' : 'text-(--ui-text-primary)'
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+export function OfficeScreen() {
+  const k = useOfficeI18n()
+  const progress = useValue($setupProgress)
+  const [showLogs, setShowLogs] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const { data: status, refetch } = useQuery({
+    queryKey: ['office', 'status'],
+    queryFn: () => getStatus(),
+    refetchInterval: 5_000
+  })
+
+  const { data: logs } = useQuery({
+    queryKey: ['office', 'logs'],
+    queryFn: () => getLogs(),
+    refetchInterval: 5_000,
+    enabled: showLogs
+  })
+
+  const s: OfficeStatus | undefined = status
+
+  const doSetup = async () => {
+    setActionError(null)
+
+    try {
+      await runSetup()
+      await refetch()
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : k.setupFailed)
+    }
+  }
+
+  const doStart = async () => {
+    setActionError(null)
+    const result = await startOffice()
+
+    if (!result.success) {setActionError(result.error ?? k.startFailed)}
+    await refetch()
+  }
+
+  const doStop = async () => {
+    setActionError(null)
+
+    try {
+      await stopOffice()
+      await refetch()
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : k.stopFailed)
+    }
+  }
+
+  const doOpen = async () => {
+    setActionError(null)
+    const result = await openOffice()
+
+    if (!result.ok) {setActionError(result.error ?? k.openBrowser)}
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-3 overflow-y-auto p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold text-(--ui-text-primary)">{k.title}</h1>
+          <p className="text-xs text-(--ui-text-secondary)">{k.subtitle}</p>
+        </div>
+        <Button onClick={() => void refetch()} size="sm" variant="ghost">
+          {k.refresh}
+        </Button>
+      </div>
+
+      {s?.oauthUnsupported && (
+        <div className="rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-surface-secondary) p-3 text-sm text-(--ui-text-secondary)">
+          {k.oauthUnsupportedBody}
+        </div>
+      )}
+
+      <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-3">
+        <div className="flex flex-col gap-2 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-surface-secondary) p-3">
+          <div className="flex items-center gap-2">
+            <StatusDot className={cn(s?.running && 'animate-pulse')} tone={s?.running ? 'good' : 'muted'} />
+            <span className="text-sm font-medium text-(--ui-text-primary)">{s?.running ? k.running : k.stopped}</span>
+            <Badge className="ml-auto" variant="outline">
+              {s?.cloned ? (s?.installed ? 'installed' : k.notInstalled) : k.notCloned}
+            </Badge>
+          </div>
+          <StatusRow
+            label={k.devServer}
+            ok={s ? s.devServerRunning : undefined}
+            value={s?.devServerRunning ? k.running : k.stopped}
+          />
+          <StatusRow
+            label={k.adapter}
+            ok={s ? s.adapterRunning : undefined}
+            value={s?.adapterRunning ? k.running : k.stopped}
+          />
+          <StatusRow label={k.port} value={s ? String(s.port) : '—'} />
+          <StatusRow label={k.gateway} value={s?.url ?? '—'} />
+          {s?.portInUse && <StatusRow label={k.portInUse} ok={false} value="⚠" />}
+          <StatusRow label={k.error} ok={s ? !s.error : undefined} value={s?.error || k.noError} />
+        </div>
+
+        <div className="flex flex-col gap-2 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-surface-secondary) p-3">
+          <span className="text-sm font-medium text-(--ui-text-primary)">{k.actions}</span>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              disabled={!s?.cloned || Boolean(progress)}
+              onClick={() => void doSetup()}
+              size="sm"
+              variant="outline"
+            >
+              {k.setup}
+            </Button>
+            <Button
+              disabled={!s?.installed || s?.running || Boolean(progress)}
+              onClick={() => void doStart()}
+              size="sm"
+            >
+              {k.start}
+            </Button>
+            <Button disabled={!s?.running} onClick={() => void doStop()} size="sm" variant="outline">
+              {k.stop}
+            </Button>
+            <Button disabled={!s?.running} onClick={() => void doOpen()} size="sm" variant="outline">
+              {k.openBrowser}
+            </Button>
+            <Button onClick={() => setShowLogs(v => !v)} size="sm" variant="ghost">
+              {k.logs}
+            </Button>
+          </div>
+          {actionError && <p className="text-xs text-(--ui-danger,#f87171)">{actionError}</p>}
+          {s?.oauthUnsupported && <p className="text-xs text-(--ui-text-tertiary)">{k.oauthUnsupportedBody}</p>}
+        </div>
+      </div>
+
+      {showLogs && (
+        <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-(--ui-stroke-secondary)">
+          <div className="border-b border-(--ui-stroke-secondary) px-3 py-2 text-sm font-medium text-(--ui-text-primary)">
+            {k.logs}
+          </div>
+          <ScrollArea className="min-h-0 flex-1">
+            <pre className="whitespace-pre-wrap p-3 font-mono text-xs leading-relaxed text-(--ui-text-secondary)">
+              {logs?.logs || k.noLogs}
+            </pre>
+          </ScrollArea>
+        </div>
+      )}
+
+      <Dialog onOpenChange={() => undefined} open={Boolean(progress)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{k.setupTitle}</DialogTitle>
+          </DialogHeader>
+          {progress && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm text-(--ui-text-primary)">
+                {k.step(progress.step, progress.totalSteps, progress.title)}
+              </span>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-(--ui-stroke-secondary)">
+                <div
+                  className="h-full bg-(--ui-accent) transition-all"
+                  style={{ width: `${(progress.step / Math.max(1, progress.totalSteps)) * 100}%` }}
+                />
+              </div>
+              <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap rounded-md bg-(--ui-surface) p-2 font-mono text-[0.6875rem] text-(--ui-text-secondary)">
+                {progress.log}
+              </pre>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/office/plugin.tsx
+++ b/apps/desktop/src/plugins/office/plugin.tsx
@@ -1,0 +1,58 @@
+/**
+ * Hermes Office (Claw3d) — a page that manages the hermes-office 3D
+ * interface (dev server + gateway adapter) through the Electron bridge.
+ * Ships OFF by default — inventories in Settings ▸ Plugins.
+ */
+import {
+  type HermesPlugin,
+  host,
+  PALETTE_AREA,
+  type PaletteContribution,
+  type RouteContribution,
+  ROUTES_AREA,
+  SIDEBAR_NAV_AREA,
+  type SidebarNavContribution
+} from '@hermes/plugin-sdk'
+
+import { bindOfficeApi } from './api'
+import { OFFICE_LOCALES } from './i18n'
+import { OfficeScreen } from './office-screen'
+
+const plugin: HermesPlugin = {
+  id: 'office',
+  name: 'Office',
+  description:
+    'Hermes Office (Claw3d) — 3D visual interface: install, start/stop the hermes-office dev server and gateway adapter, view logs.',
+  defaultEnabled: false,
+  register(ctx) {
+    ctx.i18n.register(OFFICE_LOCALES)
+    ctx.onDispose(bindOfficeApi())
+
+    ctx.registerMany([
+      {
+        id: 'page',
+        area: ROUTES_AREA,
+        data: { path: '/office' } satisfies RouteContribution,
+        render: () => <OfficeScreen />
+      },
+      {
+        id: 'nav',
+        area: SIDEBAR_NAV_AREA,
+        order: 57,
+        data: { codicon: 'browser', label: 'Office', path: '/office' } satisfies SidebarNavContribution
+      },
+      {
+        id: 'open',
+        area: PALETTE_AREA,
+        data: {
+          id: 'office.open',
+          label: 'Office: Open Hermes Office',
+          keywords: ['office', 'claw3d', '3d', 'hermes office'],
+          run: () => host.navigate('/office')
+        } satisfies PaletteContribution
+      }
+    ])
+  }
+}
+
+export default plugin

--- a/plugins/crews/dashboard/manifest.json
+++ b/plugins/crews/dashboard/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "crews",
+  "label": "Crews",
+  "description": "Multi-agent crews — named groups of specialised profile agents, one-shot task dispatch, DAG workflow builder and live activity feed",
+  "icon": "People",
+  "version": "1.0.0",
+  "api": "plugin_api.py"
+}

--- a/plugins/crews/dashboard/plugin_api.py
+++ b/plugins/crews/dashboard/plugin_api.py
@@ -1,0 +1,939 @@
+"""
+Crews — multi-agent crew orchestration backend.
+
+A crew is a named group of specialised Hermes agents working toward a shared
+goal. Each member maps to a named persona (Roger the frontender, Ada the QA,
+Nova the security reviewer, …) and runs as a profile-scoped `hermes chat -q`
+worker so its file system and session history stay isolated in
+``~/.hermes/profiles/<name>/``.
+
+This module owns:
+
+* the crew store (``$HERMES_HOME/crews/crews.json``) and the per-crew DAG
+  workflow store (``$HERMES_HOME/crews/workflows.json``),
+* dispatch — spawning one profile worker per targeted member,
+* workflow runs — executing a DAG in topological layers, one worker per task,
+* a live ``/events`` WebSocket that streams member/task status + activity so
+  the desktop UI can render a real-time feed.
+
+Route prefix (mounted by the dashboard): ``/api/plugins/crews``.
+
+Adapted from the crews + workflow features of the community
+`JPeetz/Hermes-Studio` web UI, re-architected for Hermes' plugin surface:
+file-backed JSON stores instead of TanStack server routes, and the
+battle-tested `hermes chat -q` worker-spawn pattern from the kanban
+dispatcher instead of a long-lived SSE server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel, ConfigDict, Field
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# ─── Locations ────────────────────────────────────────────────────────────────
+
+def _hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def _crews_root() -> Path:
+    root = _hermes_home() / "crews"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+CREWS_FILE = None  # resolved lazily via _crews_root()
+WORKFLOWS_FILE = None
+
+
+def _crews_file() -> Path:
+    return _crews_root() / "crews.json"
+
+
+def _workflows_file() -> Path:
+    return _crews_root() / "workflows.json"
+
+
+def _logs_dir(crew_id: str) -> Path:
+    d = _crews_root() / "logs" / crew_id
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _profile_home(name: str) -> Path:
+    return _hermes_home() / "profiles" / name
+
+
+# ─── Personas ─────────────────────────────────────────────────────────────────
+
+PERSONAS: list[dict[str, Any]] = [
+    {"id": "roger", "name": "Roger", "role": "Frontend Developer", "emoji": "🎨", "color": "text-blue-400",
+     "specialties": ["react", "css", "tailwind", "ui", "ux", "component", "layout", "style", "design", "frontend", "page", "landing"]},
+    {"id": "sally", "name": "Sally", "role": "Backend Architect", "emoji": "🏗️", "color": "text-purple-400",
+     "specialties": ["api", "server", "database", "backend", "node", "express", "route", "endpoint", "schema", "migration", "sql", "rpc"]},
+    {"id": "bill", "name": "Bill", "role": "Marketing Expert", "emoji": "📣", "color": "text-orange-400",
+     "specialties": ["marketing", "seo", "content", "copy", "brand", "social", "campaign", "analytics", "growth"]},
+    {"id": "ada", "name": "Ada", "role": "QA Engineer", "emoji": "🔍", "color": "text-emerald-400",
+     "specialties": ["test", "qa", "bug", "fix", "error", "debug", "lint", "type", "typescript", "validate", "audit"]},
+    {"id": "max", "name": "Max", "role": "DevOps Specialist", "emoji": "⚙️", "color": "text-amber-400",
+     "specialties": ["deploy", "docker", "ci", "cd", "build", "config", "infra", "monitor", "log", "performance"]},
+    {"id": "luna", "name": "Luna", "role": "Research Analyst", "emoji": "🔬", "color": "text-cyan-400",
+     "specialties": ["research", "analyze", "compare", "report", "data", "insight", "strategy", "plan", "review"]},
+    {"id": "kai", "name": "Kai", "role": "Full-Stack Engineer", "emoji": "⚡", "color": "text-yellow-400",
+     "specialties": ["fullstack", "feature", "implement", "build", "create", "scaffold", "refactor", "update", "upgrade"]},
+    {"id": "nova", "name": "Nova", "role": "Security Specialist", "emoji": "🛡️", "color": "text-red-400",
+     "specialties": ["security", "auth", "permission", "encrypt", "vulnerability", "scan", "protect", "firewall", "token"]},
+]
+
+PERSONA_BY_ID = {p["id"]: p for p in PERSONAS}
+
+DEFAULT_ROLE_BY_PERSONA: dict[str, str] = {
+    "roger": "executor", "sally": "executor", "kai": "executor", "max": "executor",
+    "ada": "reviewer", "luna": "reviewer", "nova": "reviewer", "bill": "specialist",
+}
+
+# ─── Templates ────────────────────────────────────────────────────────────────
+
+CREW_TEMPLATES: list[dict[str, Any]] = [
+    {"id": "research-team", "name": "Research Team", "category": "Research",
+     "goal": "Research the topic, cross-check sources, and produce a cited report.",
+     "members": [{"persona": "luna"}, {"persona": "ada"}]},
+    {"id": "fullstack-squad", "name": "Full-Stack Squad", "category": "Engineering",
+     "goal": "Ship the feature end-to-end: frontend, backend, and integration.",
+     "members": [{"persona": "roger"}, {"persona": "sally"}, {"persona": "kai"}]},
+    {"id": "code-review-crew", "name": "Code Review Crew", "category": "Engineering",
+     "goal": "Review the change for correctness, security, and regressions.",
+     "members": [{"persona": "ada"}, {"persona": "nova"}, {"persona": "luna"}]},
+    {"id": "ops-team", "name": "Ops Team", "category": "Operations",
+     "goal": "Deploy, monitor, and harden the service.",
+     "members": [{"persona": "max"}, {"persona": "nova"}]},
+]
+
+# ─── Stores ───────────────────────────────────────────────────────────────────
+
+CREW_STATUSES = {"draft", "active", "paused", "complete"}
+MEMBER_STATUSES = {"idle", "running", "done", "error"}
+TASK_STATUSES = {"idle", "running", "done", "error"}
+
+_store: dict[str, Any] = {"crews": {}}
+_workflow_store: dict[str, Any] = {"workflows": {}}
+_save_timer: Optional[asyncio.TimerHandle] = None
+
+# ─── Live event bus ───────────────────────────────────────────────────────────
+
+_subscribers: set[WebSocket] = set()
+# (crew_id, member_id | task_id) → WorkerRecord for in-flight workers
+_workers: dict[tuple[str, str], "WorkerRecord"] = {}
+# run_id → RunState for in-flight + recent workflow runs
+_runs: dict[str, "RunState"] = {}
+
+
+class WorkerRecord:
+    __slots__ = ("proc", "log_path", "crew_id", "member_id", "task_id", "started_at")
+
+    def __init__(self, proc, log_path: Path, crew_id: str, member_id: Optional[str], task_id: Optional[str]):
+        self.proc = proc
+        self.log_path = log_path
+        self.crew_id = crew_id
+        self.member_id = member_id
+        self.task_id = task_id
+        self.started_at = time.time()
+
+
+class RunState:
+    __slots__ = ("id", "crew_id", "status", "tasks", "started_at", "finished_at")
+
+    def __init__(self, crew_id: str):
+        self.id = uuid.uuid4().hex[:12]
+        self.crew_id = crew_id
+        self.status = "running"  # running | complete | error
+        self.tasks: dict[str, str] = {}  # task_id → status
+        self.started_at = time.time()
+        self.finished_at: Optional[float] = None
+
+
+def _load_store() -> None:
+    global _store, _workflow_store
+    try:
+        f = _crews_file()
+        if f.exists():
+            parsed = json.loads(f.read_text("utf-8"))
+            if isinstance(parsed, dict) and isinstance(parsed.get("crews"), dict):
+                _store = parsed
+    except Exception:
+        pass
+    try:
+        f = _workflows_file()
+        if f.exists():
+            parsed = json.loads(f.read_text("utf-8"))
+            if isinstance(parsed, dict) and isinstance(parsed.get("workflows"), dict):
+                # Guard against old data missing x/y positions.
+                for wf in parsed["workflows"].values():
+                    tasks = wf.get("tasks") or []
+                    for i, task in enumerate(tasks):
+                        task.setdefault("x", 80 + (i % 4) * 220)
+                        task.setdefault("y", 80 + (i // 4) * 120)
+                _workflow_store = parsed
+    except Exception:
+        pass
+
+
+def _schedule_save() -> None:
+    global _save_timer
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop (sync/threadpool context) — write immediately.
+        _save_now()
+        return
+
+    async def _flush() -> None:
+        _save_now()
+
+    if _save_timer is not None:
+        _save_timer.cancel()
+    _save_timer = loop.call_later(1.0, lambda: asyncio.ensure_future(_flush()))
+
+
+def _save_now() -> None:
+    try:
+        _crews_file().write_text(json.dumps(_store, indent=2, ensure_ascii=False), "utf-8")
+    except Exception:
+        pass
+    try:
+        _workflows_file().write_text(json.dumps(_workflow_store, indent=2, ensure_ascii=False), "utf-8")
+    except Exception:
+        pass
+
+
+# ─── Event broadcast ──────────────────────────────────────────────────────────
+
+def _broadcast(event: dict[str, Any]) -> None:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return  # no running loop — nothing to notify (sync/threadpool context)
+    payload = json.dumps(event, ensure_ascii=False)
+    dead: list[WebSocket] = []
+    for ws in list(_subscribers):
+        try:
+            loop.create_task(ws.send_text(payload))
+        except Exception:
+            dead.append(ws)
+    for ws in dead:
+        _subscribers.discard(ws)
+
+
+def _ws_upgrade_authorized(ws: "WebSocket") -> bool:
+    """Delegate to the dashboard's canonical WS auth gate (same as kanban)."""
+    try:
+        from hermes_cli import web_server as _ws
+    except Exception:
+        return True  # bare-FastAPI test harness
+    return bool(_ws._ws_auth_ok(ws))
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
+
+
+def _member_dict(member: dict[str, Any]) -> dict[str, Any]:
+    return dict(member)
+
+
+def _crew_dict(crew: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": crew["id"],
+        "name": crew["name"],
+        "goal": crew["goal"],
+        "status": crew["status"],
+        "createdAt": crew["createdAt"],
+        "updatedAt": crew["updatedAt"],
+        "members": [_member_dict(m) for m in crew["members"]],
+    }
+
+
+def _get_crew(crew_id: str) -> Optional[dict[str, Any]]:
+    return _store["crews"].get(crew_id)
+
+
+def _touch(crew: dict[str, Any]) -> None:
+    crew["updatedAt"] = int(time.time() * 1000)
+
+
+def _profile_name_for(member: dict[str, Any]) -> str:
+    """Resolve the worker profile for a member — explicit profileName or the
+    persona slug. Sanitised so it can never escape the profiles directory."""
+    raw = (member.get("profileName") or member["persona"]).strip()
+    sanitized = re.sub(r"[^A-Za-z0-9_-]", "-", raw).strip("-") or "agent"
+    return sanitized[:64]
+
+
+def _resolve_hermes_argv() -> list[str]:
+    """Resolve the ``hermes`` invocation as argv parts (kanban pattern)."""
+    env_bin = os.environ.get("HERMES_BIN", "").strip()
+    if env_bin:
+        return [env_bin]
+    which = shutil.which("hermes")
+    if which:
+        return [which]
+    return [sys.executable, "-m", "hermes_cli.main"]
+
+
+def _tail_log(path: Path, max_chars: int = 400) -> str:
+    try:
+        data = path.read_text("utf-8", errors="replace")
+    except Exception:
+        return ""
+    data = data.strip()
+    if len(data) <= max_chars:
+        return data
+    return "…" + data[-max_chars:]
+
+
+async def _watch_worker(record: WorkerRecord) -> None:
+    """Await a worker subprocess, update statuses, tail the log, broadcast."""
+    crew_id, member_id, task_id = record.crew_id, record.member_id, record.task_id
+    last_tail = ""
+
+    async def _pulse() -> None:
+        nonlocal last_tail
+        try:
+            tail = _tail_log(record.log_path)
+        except Exception:
+            tail = ""
+        if tail and tail != last_tail:
+            last_tail = tail
+            _broadcast({
+                "type": "activity",
+                "crewId": crew_id,
+                "memberId": member_id,
+                "taskId": task_id,
+                "text": tail[-300:],
+                "ts": _now_iso(),
+            })
+
+    pulse_task = asyncio.ensure_future(_pulse_loop(2.0, _pulse))
+    try:
+        await asyncio.to_thread(record.proc.wait)
+        code = record.proc.returncode
+        status = "done" if code == 0 else "error"
+        detail = "" if code == 0 else f" (exit {code})"
+    except Exception as exc:
+        status = "error"
+        detail = f" ({exc})"
+    finally:
+        pulse_task.cancel()
+        _workers.pop((crew_id, member_id or task_id or ""), None)
+
+    tail = _tail_log(record.log_path)
+    if member_id:
+        _set_member_status(crew_id, member_id, status, tail)
+    if task_id:
+        _set_task_status(crew_id, task_id, status, tail)
+    _broadcast({
+        "type": "worker_end",
+        "crewId": crew_id,
+        "memberId": member_id,
+        "taskId": task_id,
+        "status": status,
+        "detail": detail,
+        "activity": tail[-300:],
+        "ts": _now_iso(),
+    })
+
+
+async def _pulse_loop(interval: float, fn) -> None:
+    try:
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                await fn()
+            except Exception:
+                pass
+    except asyncio.CancelledError:
+        pass
+
+
+def _spawn_worker(crew: dict[str, Any], member: dict[str, Any], task_text: str,
+                  task_id: Optional[str] = None) -> WorkerRecord:
+    """Spawn a profile-scoped ``hermes -p <profile> chat -q <task>`` worker."""
+    profile = _profile_name_for(member)
+    profile_home = _profile_home(profile)
+    profile_home.mkdir(parents=True, exist_ok=True)
+
+    cmd = _resolve_hermes_argv() + ["-p", profile, "chat", "-q", task_text]
+    if member.get("model"):
+        cmd += ["-m", str(member["model"])]
+
+    log_path = _logs_dir(crew["id"]) / f"{task_id or member['id']}.log"
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(profile_home)
+    env["TERM"] = "dumb"
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(profile_home),
+            stdin=subprocess.DEVNULL,
+            stdout=open(log_path, "ab"),
+            stderr=subprocess.STDOUT,
+            env=env,
+            start_new_session=True,
+            creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            "`hermes` executable not found on PATH. Install Hermes Agent or "
+            "activate its venv before dispatching crew work."
+        )
+
+    record = WorkerRecord(proc, log_path, crew["id"], member["id"], task_id)
+    _workers[(crew["id"], task_id or member["id"])] = record
+    asyncio.ensure_future(_watch_worker(record))
+    return record
+
+
+def _set_member_status(crew_id: str, member_id: str, status: str, activity: Optional[str] = None) -> None:
+    crew = _get_crew(crew_id)
+    if not crew:
+        return
+    member = next((m for m in crew["members"] if m["id"] == member_id), None)
+    if not member:
+        return
+    if status not in MEMBER_STATUSES:
+        return
+    member["status"] = status
+    if activity is not None:
+        member["lastActivity"] = activity
+    _touch(crew)
+    _schedule_save()
+
+
+def _set_task_status(crew_id: str, task_id: str, status: str, activity: Optional[str] = None) -> None:
+    workflow = _workflow_store["workflows"].get(crew_id)
+    if not workflow:
+        return
+    task = next((t for t in (workflow.get("tasks") or []) if t["id"] == task_id), None)
+    if not task:
+        return
+    task["status"] = status
+    if activity is not None:
+        task["lastActivity"] = activity
+    workflow["updatedAt"] = int(time.time() * 1000)
+    _schedule_save()
+
+
+def _validate_dag(tasks: list[dict[str, Any]], edges: list[dict[str, Any]]) -> None:
+    """Raise HTTPException 400 on unknown refs or cycles (Kahn)."""
+    task_ids = {t["id"] for t in tasks}
+    for e in edges:
+        if e["from"] not in task_ids or e["to"] not in task_ids:
+            raise HTTPException(status_code=400, detail="Edge references unknown task id")
+
+    indegree = {tid: 0 for tid in task_ids}
+    adj: dict[str, list[str]] = {tid: [] for tid in task_ids}
+    for e in edges:
+        adj[e["from"]].append(e["to"])
+        indegree[e["to"]] += 1
+    queue = [tid for tid, deg in indegree.items() if deg == 0]
+    seen = 0
+    while queue:
+        node = queue.pop()
+        seen += 1
+        for nxt in adj[node]:
+            indegree[nxt] -= 1
+            if indegree[nxt] == 0:
+                queue.append(nxt)
+    if seen != len(task_ids):
+        raise HTTPException(status_code=400, detail="Workflow contains a cycle")
+
+
+def _topo_layers(tasks: list[dict[str, Any]], edges: list[dict[str, Any]]) -> list[list[str]]:
+    """Kahn BFS layers — parallel columns of tasks that can run together."""
+    task_ids = [t["id"] for t in tasks]
+    indegree = {tid: 0 for tid in task_ids}
+    adj: dict[str, list[str]] = {tid: [] for tid in task_ids}
+    for e in edges:
+        adj[e["from"]].append(e["to"])
+        indegree[e["to"]] += 1
+
+    layers: list[list[str]] = []
+    frontier = [tid for tid in task_ids if indegree[tid] == 0]
+    while frontier:
+        layers.append(frontier)
+        nxt: list[str] = []
+        for node in frontier:
+            for child in adj[node]:
+                indegree[child] -= 1
+                if indegree[child] == 0:
+                    nxt.append(child)
+        frontier = nxt
+    return layers
+
+
+# ─── Pydantic bodies ──────────────────────────────────────────────────────────
+
+class MemberInput(BaseModel):
+    persona: str
+    role: Optional[str] = None
+    model: Optional[str] = None
+    profileName: Optional[str] = None
+
+
+class CreateCrewBody(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    goal: str = Field(default="", max_length=2000)
+    members: list[MemberInput] = Field(default_factory=list, max_length=8)
+
+
+class PatchCrewBody(BaseModel):
+    name: Optional[str] = None
+    goal: Optional[str] = None
+    status: Optional[str] = None
+    memberId: Optional[str] = None
+    memberStatus: Optional[str] = None
+    lastActivity: Optional[str] = None
+
+
+class DispatchBody(BaseModel):
+    task: str = Field(min_length=1, max_length=8000)
+    target: Optional[str] = None  # member id, or omitted/"all"
+
+
+class WorkflowTaskBody(BaseModel):
+    id: str
+    label: str = ""
+    prompt: str = ""
+    assigneeId: Optional[str] = None
+    x: float = 0
+    y: float = 0
+
+
+class WorkflowEdgeBody(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    from_: str = Field(alias="from")
+    to: str
+
+
+class UpsertWorkflowBody(BaseModel):
+    tasks: list[WorkflowTaskBody]
+    edges: list[WorkflowEdgeBody]
+
+
+# ─── Routes ───────────────────────────────────────────────────────────────────
+
+@router.get("/personas")
+def list_personas() -> dict[str, Any]:
+    return {"ok": True, "personas": PERSONAS}
+
+
+@router.get("/templates")
+def list_templates() -> dict[str, Any]:
+    return {"ok": True, "templates": CREW_TEMPLATES}
+
+
+@router.get("/crews")
+def list_crews() -> dict[str, Any]:
+    crews = sorted(_store["crews"].values(), key=lambda c: c["updatedAt"], reverse=True)
+    return {"ok": True, "crews": [_crew_dict(c) for c in crews]}
+
+
+@router.post("/crews")
+async def create_crew(body: CreateCrewBody) -> dict[str, Any]:
+    name = body.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="name is required")
+    if len(body.members) > 8:
+        raise HTTPException(status_code=400, detail="A crew may have at most 8 members")
+
+    now = int(time.time() * 1000)
+    crew = {
+        "id": uuid.uuid4().hex,
+        "name": name,
+        "goal": body.goal.strip(),
+        "status": "draft",
+        "createdAt": now,
+        "updatedAt": now,
+        "members": [],
+    }
+    for m in body.members:
+        persona = PERSONA_BY_ID.get(m.persona)
+        if persona is None:
+            raise HTTPException(status_code=400, detail=f"Unknown persona: {m.persona}")
+        crew["members"].append({
+            "id": uuid.uuid4().hex,
+            "persona": persona["id"],
+            "displayName": f"{persona['emoji']} {persona['name']}",
+            "roleLabel": persona["role"],
+            "color": persona["color"],
+            "role": m.role or DEFAULT_ROLE_BY_PERSONA.get(persona["id"], "executor"),
+            "model": m.model or None,
+            "profileName": m.profileName or None,
+            "status": "idle",
+            "lastActivity": None,
+        })
+    _store["crews"][crew["id"]] = crew
+    _save_now()
+    _broadcast({"type": "crew_updated", "crewId": crew["id"], "ts": _now_iso()})
+    return {"ok": True, "crew": _crew_dict(crew)}
+
+
+@router.get("/crews/{crew_id}")
+def get_crew(crew_id: str) -> dict[str, Any]:
+    crew = _get_crew(crew_id)
+    if not crew:
+        raise HTTPException(status_code=404, detail="Crew not found")
+    return {"ok": True, "crew": _crew_dict(crew)}
+
+
+@router.patch("/crews/{crew_id}")
+async def patch_crew(crew_id: str, body: PatchCrewBody) -> dict[str, Any]:
+    crew = _get_crew(crew_id)
+    if not crew:
+        raise HTTPException(status_code=404, detail="Crew not found")
+
+    if body.memberId is not None:
+        member = next((m for m in crew["members"] if m["id"] == body.memberId), None)
+        if member is None:
+            raise HTTPException(status_code=404, detail="Member not found")
+        if body.memberStatus is not None:
+            if body.memberStatus not in MEMBER_STATUSES:
+                raise HTTPException(status_code=400, detail="Invalid member status")
+            member["status"] = body.memberStatus
+        if body.lastActivity is not None:
+            member["lastActivity"] = body.lastActivity
+        _touch(crew)
+        _schedule_save()
+        return {"ok": True, "crew": _crew_dict(crew)}
+
+    if body.name is not None:
+        name = body.name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="name cannot be empty")
+        crew["name"] = name
+    if body.goal is not None:
+        crew["goal"] = body.goal.strip()
+    if body.status is not None:
+        if body.status not in CREW_STATUSES:
+            raise HTTPException(status_code=400, detail="Invalid crew status")
+        crew["status"] = body.status
+    _touch(crew)
+    _schedule_save()
+    _broadcast({"type": "crew_updated", "crewId": crew_id, "ts": _now_iso()})
+    return {"ok": True, "crew": _crew_dict(crew)}
+
+
+@router.delete("/crews/{crew_id}")
+async def delete_crew(crew_id: str) -> dict[str, Any]:
+    if crew_id not in _store["crews"]:
+        raise HTTPException(status_code=404, detail="Crew not found")
+    del _store["crews"][crew_id]
+    _workflow_store["workflows"].pop(crew_id, None)
+    _save_now()
+    _broadcast({"type": "crew_deleted", "crewId": crew_id, "ts": _now_iso()})
+    return {"ok": True}
+
+
+@router.post("/crews/{crew_id}/clone")
+async def clone_crew(crew_id: str) -> dict[str, Any]:
+    crew = _get_crew(crew_id)
+    if not crew:
+        raise HTTPException(status_code=404, detail="Crew not found")
+    now = int(time.time() * 1000)
+    clone = {
+        "id": uuid.uuid4().hex,
+        "name": f"{crew['name']} (copy)",
+        "goal": crew["goal"],
+        "status": "draft",
+        "createdAt": now,
+        "updatedAt": now,
+        "members": [
+            {
+                "id": uuid.uuid4().hex,
+                "persona": m["persona"],
+                "displayName": m["displayName"],
+                "roleLabel": m["roleLabel"],
+                "color": m["color"],
+                "role": m.get("role", "executor"),
+                "model": m.get("model"),
+                "profileName": m.get("profileName"),
+                "status": "idle",
+                "lastActivity": None,
+            }
+            for m in crew["members"]
+        ],
+    }
+    _store["crews"][clone["id"]] = clone
+    _save_now()
+    return {"ok": True, "crew": _crew_dict(clone)}
+
+
+@router.post("/crews/{crew_id}/dispatch")
+async def dispatch_crew(crew_id: str, body: DispatchBody) -> dict[str, Any]:
+    crew = _get_crew(crew_id)
+    if not crew:
+        raise HTTPException(status_code=404, detail="Crew not found")
+    task = body.task.strip()
+    if not task:
+        raise HTTPException(status_code=400, detail="task is required")
+
+    target = body.target
+    if target and target != "all":
+        members = [m for m in crew["members"] if m["id"] == target]
+        if not members:
+            raise HTTPException(status_code=400, detail="no matching members found")
+    else:
+        members = list(crew["members"])
+    if not members:
+        raise HTTPException(status_code=400, detail="crew has no members")
+
+    crew["status"] = "active"
+    _touch(crew)
+
+    dispatched: list[str] = []
+    for member in members:
+        member["status"] = "running"
+        dispatched.append(member["id"])
+        _broadcast({"type": "member_status", "crewId": crew_id, "memberId": member["id"],
+                    "status": "running", "ts": _now_iso()})
+        try:
+            _spawn_worker(crew, member, task)
+        except RuntimeError as exc:
+            member["status"] = "error"
+            _broadcast({"type": "member_status", "crewId": crew_id, "memberId": member["id"],
+                        "status": "error", "detail": str(exc), "ts": _now_iso()})
+    _schedule_save()
+    return {"ok": True, "dispatched": dispatched, "crewId": crew_id}
+
+
+@router.get("/crews/{crew_id}/workflow")
+def get_workflow(crew_id: str) -> dict[str, Any]:
+    if crew_id not in _store["crews"]:
+        raise HTTPException(status_code=404, detail="Crew not found")
+    workflow = _workflow_store["workflows"].get(crew_id)
+    if workflow is None:
+        return {"ok": True, "workflow": None}
+    return {"ok": True, "workflow": {
+        "id": workflow["id"],
+        "crewId": workflow["crewId"],
+        "tasks": workflow.get("tasks", []),
+        "edges": workflow.get("edges", []),
+        "createdAt": workflow["createdAt"],
+        "updatedAt": workflow["updatedAt"],
+    }}
+
+
+@router.put("/crews/{crew_id}/workflow")
+async def upsert_workflow(crew_id: str, body: UpsertWorkflowBody) -> dict[str, Any]:
+    if crew_id not in _store["crews"]:
+        raise HTTPException(status_code=404, detail="Crew not found")
+
+    tasks = [t.model_dump(by_alias=True) for t in body.tasks]
+    edges = [e.model_dump(by_alias=True) for e in body.edges]
+    for task in tasks:
+        task.pop("from_", None)
+        task.pop("status", None)
+        task.pop("lastActivity", None)
+
+    _validate_dag(tasks, edges)
+
+    now = int(time.time() * 1000)
+    existing = _workflow_store["workflows"].get(crew_id)
+    if existing:
+        existing.update({"tasks": tasks, "edges": edges, "updatedAt": now})
+        workflow = existing
+    else:
+        workflow = {
+            "id": uuid.uuid4().hex,
+            "crewId": crew_id,
+            "tasks": tasks,
+            "edges": edges,
+            "createdAt": now,
+            "updatedAt": now,
+        }
+        _workflow_store["workflows"][crew_id] = workflow
+    _schedule_save()
+    return {"ok": True, "workflow": {
+        "id": workflow["id"], "crewId": workflow["crewId"],
+        "tasks": workflow["tasks"], "edges": workflow["edges"],
+        "createdAt": workflow["createdAt"], "updatedAt": workflow["updatedAt"],
+    }}
+
+
+@router.delete("/crews/{crew_id}/workflow")
+async def delete_workflow(crew_id: str) -> dict[str, Any]:
+    if crew_id not in _store["crews"]:
+        raise HTTPException(status_code=404, detail="Crew not found")
+    _workflow_store["workflows"].pop(crew_id, None)
+    _schedule_save()
+    return {"ok": True}
+
+
+@router.post("/crews/{crew_id}/workflow/run")
+async def run_workflow(crew_id: str) -> dict[str, Any]:
+    crew = _get_crew(crew_id)
+    if not crew:
+        raise HTTPException(status_code=404, detail="Crew not found")
+    workflow = _workflow_store["workflows"].get(crew_id)
+    if workflow is None or not workflow.get("tasks"):
+        raise HTTPException(status_code=400, detail="No workflow defined for this crew")
+    tasks = workflow["tasks"]
+    edges = workflow["edges"]
+    _validate_dag(tasks, edges)
+
+    run = RunState(crew_id)
+    for task in tasks:
+        run.tasks[task["id"]] = "idle"
+        task["status"] = "idle"
+        task.pop("lastActivity", None)
+    _runs[run.id] = run
+    if len(_runs) > 20:
+        # Keep only the 20 most recent runs per crew in memory.
+        for rid in sorted(_runs, key=lambda r: _runs[r].started_at)[: max(0, len(_runs) - 20)]:
+            if _runs[rid].crew_id == crew_id and _runs[rid].status != "running":
+                _runs.pop(rid, None)
+
+    crew["status"] = "active"
+    _touch(crew)
+    _schedule_save()
+    _broadcast({"type": "run_started", "crewId": crew_id, "runId": run.id, "ts": _now_iso()})
+    asyncio.ensure_future(_execute_workflow_run(crew_id, run, tasks, edges))
+    return {"ok": True, "runId": run.id}
+
+
+async def _execute_workflow_run(crew_id: str, run: RunState, tasks: list[dict[str, Any]],
+                                edges: list[dict[str, Any]]) -> None:
+    crew = _get_crew(crew_id)
+    if not crew:
+        run.status = "error"
+        return
+    member_by_id = {m["id"]: m for m in crew["members"]}
+    task_by_id = {t["id"]: t for t in tasks}
+    layers = _topo_layers(tasks, edges)
+
+    try:
+        for layer in layers:
+            futures: list[asyncio.Future] = []
+            for task_id in layer:
+                task = task_by_id[task_id]
+                run.tasks[task_id] = "running"
+                task["status"] = "running"
+                _schedule_save()
+                _broadcast({"type": "task_status", "crewId": crew_id, "runId": run.id,
+                            "taskId": task_id, "status": "running", "ts": _now_iso()})
+
+                prompt = (task.get("prompt") or "").strip()
+                if not prompt:
+                    run.tasks[task_id] = "done"
+                    task["status"] = "done"
+                    _broadcast({"type": "task_status", "crewId": crew_id, "runId": run.id,
+                                "taskId": task_id, "status": "done", "ts": _now_iso()})
+                    continue
+
+                assignee_id = task.get("assigneeId")
+                if assignee_id:
+                    targets = [member_by_id[assignee_id]] if assignee_id in member_by_id else []
+                else:
+                    targets = list(crew["members"])
+                for member in targets:
+                    member["status"] = "running"
+                    try:
+                        _spawn_worker(crew, member, prompt, task_id=task_id)
+                    except RuntimeError as exc:
+                        run.tasks[task_id] = "error"
+                        task["status"] = "error"
+                        _broadcast({"type": "task_status", "crewId": crew_id, "runId": run.id,
+                                    "taskId": task_id, "status": "error", "detail": str(exc), "ts": _now_iso()})
+                        break
+                    futures.append(asyncio.ensure_future(_wait_worker(crew_id, member["id"], task_id)))
+
+            if futures:
+                await asyncio.gather(*futures, return_exceptions=True)
+
+        run.status = "complete"
+        run.finished_at = time.time()
+        _broadcast({"type": "run_end", "crewId": crew_id, "runId": run.id,
+                    "status": "complete", "ts": _now_iso()})
+    except Exception as exc:  # pragma: no cover - defensive
+        log.warning("workflow run %s failed: %s", run.id, exc)
+        run.status = "error"
+        run.finished_at = time.time()
+        _broadcast({"type": "run_end", "crewId": crew_id, "runId": run.id,
+                    "status": "error", "ts": _now_iso()})
+
+
+async def _wait_worker(crew_id: str, member_id: str, task_id: str) -> None:
+    """Wait for a task's worker(s) to finish and fold the outcome into the run."""
+    key = (crew_id, task_id)
+    record = _workers.get(key)
+    if record is None:
+        return
+    try:
+        await asyncio.to_thread(record.proc.wait)
+    except Exception:
+        pass
+    status = "done" if record.proc.returncode == 0 else "error"
+    run = next((r for r in _runs.values() if r.crew_id == crew_id and r.status == "running"), None)
+    if run is not None:
+        run.tasks[task_id] = status
+    task = next((t for t in (_workflow_store["workflows"].get(crew_id, {}).get("tasks") or [])
+                 if t["id"] == task_id), None)
+    if task is not None:
+        task["status"] = status
+    _schedule_save()
+    _broadcast({"type": "task_status", "crewId": crew_id, "runId": run.id if run else None,
+                "taskId": task_id, "status": status, "ts": _now_iso()})
+
+
+@router.get("/crews/{crew_id}/runs")
+def list_runs(crew_id: str) -> dict[str, Any]:
+    runs = [r for r in _runs.values() if r.crew_id == crew_id]
+    runs.sort(key=lambda r: r.started_at, reverse=True)
+    return {"ok": True, "runs": [
+        {
+            "id": r.id, "crewId": r.crew_id, "status": r.status,
+            "tasks": r.tasks, "startedAt": r.started_at, "finishedAt": r.finished_at,
+        }
+        for r in runs
+    ]}
+
+
+@router.websocket("/events")
+async def events_socket(ws: WebSocket) -> None:
+    if not _ws_upgrade_authorized(ws):
+        await ws.close(code=4401)
+        return
+    await ws.accept()
+    _subscribers.add(ws)
+    try:
+        while True:
+            await ws.receive_text()  # ping/pong keepalive; ignore payloads
+    except WebSocketDisconnect:
+        pass
+    finally:
+        _subscribers.discard(ws)
+
+
+# Bootstrap on module import (guarded for reloads/tests).
+_load_store()

--- a/plugins/knowledge/dashboard/manifest.json
+++ b/plugins/knowledge/dashboard/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "knowledge",
+  "label": "Knowledge",
+  "description": "Interactive knowledge graph over the ~/.hermes/knowledge markdown wiki — force-directed canvas, page browser, search, links and backlinks",
+  "icon": "Graph",
+  "version": "1.0.0",
+  "api": "plugin_api.py"
+}

--- a/plugins/knowledge/dashboard/plugin_api.py
+++ b/plugins/knowledge/dashboard/plugin_api.py
@@ -1,0 +1,303 @@
+"""
+Knowledge — interactive knowledge graph over a markdown wiki.
+
+Scans ``$HERMES_HOME/knowledge/**/*.md`` (created on first use) and builds a
+graph of the pages' ``[[wikilink]]`` relationships so the desktop UI can
+render a force-directed knowledge graph, browse pages, search, and follow
+links/backlinks.
+
+Frontmatter fields (YAML) are surfaced as node metadata:
+
+* ``title`` — display title (falls back to the file name)
+* ``type`` — node type (guide / project / reference / concept / note / …)
+  used for node colours
+* ``tags``, ``summary``, ``domain``, ``status``, ``created``, ``updated``
+
+Adapted from the knowledge browser of the community `JPeetz/Hermes-Studio`
+web UI. Route prefix (mounted by the dashboard): ``/api/plugins/knowledge``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - pyyaml is a core dependency
+    yaml = None
+
+log = __import__("logging").getLogger(__name__)
+
+router = APIRouter()
+
+# ─── Locations ────────────────────────────────────────────────────────────────
+
+def _hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def _knowledge_root() -> Path:
+    root = Path(os.environ.get("HERMES_KNOWLEDGE_DIR") or (_hermes_home() / "knowledge"))
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+SKIP_DIRS = {".git", "node_modules", ".obsidian", ".trash"}
+
+
+def _seed_readme_if_empty(root: Path) -> None:
+    """Drop a small README so a fresh install never shows an empty graph and
+    the wiki-link format is discoverable."""
+    readme = root / "README.md"
+    if readme.exists():
+        return
+    try:
+        readme.write_text(
+            "# Knowledge\n"
+            "\n"
+            "Welcome to your Hermes knowledge wiki. Every `.md` file in this\n"
+            "folder (and subfolders) becomes a node in the **Knowledge Graph**.\n"
+            "\n"
+            "## Linking pages\n"
+            "\n"
+            "Use wiki-links to connect pages — the graph is built from them:\n"
+            "\n"
+            "```\n"
+            "See [[concepts/agents]] for details.\n"
+            "```\n"
+            "\n"
+            "## Frontmatter\n"
+            "\n"
+            "Optional YAML frontmatter gives nodes metadata:\n"
+            "\n"
+            "```\n"
+            "---\n"
+            "title: Agents\n"
+            "type: concept\n"
+            "tags: [agent, orchestration]\n"
+            "summary: How Hermes agents work.\n"
+            "---\n"
+            "```\n"
+            "\n"
+            "Type is used for node colours (guide / project / reference /\n"
+            "concept / note / …).\n",
+            "utf-8",
+        )
+    except Exception:
+        pass
+
+
+# ─── Parsing ─────────────────────────────────────────────────────────────────
+
+def _parse_frontmatter(raw: str) -> tuple[dict[str, Any], str]:
+    if not raw.startswith("---"):
+        return {}, raw
+    match = re.match(r"^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$", raw)
+    if not match:
+        return {}, raw
+    data: dict[str, Any] = {}
+    if yaml is not None:
+        try:
+            parsed = yaml.safe_load(match.group(1))
+            if isinstance(parsed, dict):
+                data = parsed
+        except Exception:
+            data = {}
+    return data, match.group(2) or ""
+
+
+def _clean_wikilink_target(input_: str) -> str:
+    return (input_.split("|")[0].split("#")[0] or "").strip()
+
+
+def _extract_wikilinks(content: str) -> list[str]:
+    links: list[str] = []
+    seen: set[str] = set()
+    for match in re.finditer(r"\[\[([^\]]+)\]\]", content):
+        target = _clean_wikilink_target(match.group(1) or "")
+        if target and target not in seen:
+            seen.add(target)
+            links.append(target)
+    return links
+
+
+def _normalize_tag_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    if isinstance(value, str):
+        return [v.strip() for v in value.split(",") if v.strip()]
+    return []
+
+
+def _normalize_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def _page_meta(relative_path: str, stat) -> dict[str, Any]:
+    raw = _read_text_safe(_knowledge_root() / relative_path)
+    data, content = _parse_frontmatter(raw)
+    modified = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(stat.st_mtime))
+    name = Path(relative_path).name
+    title = _normalize_str(data.get("title")) or Path(relative_path).stem
+    updated = _normalize_str(data.get("updated")) or modified
+    return {
+        "path": relative_path,
+        "name": name,
+        "title": title,
+        "type": _normalize_str(data.get("type")),
+        "domain": _normalize_str(data.get("domain")),
+        "status": _normalize_str(data.get("status")),
+        "tags": _normalize_tag_list(data.get("tags")),
+        "summary": _normalize_str(data.get("summary")),
+        "created": _normalize_str(data.get("created")),
+        "updated": updated,
+        "size": stat.st_size,
+        "modified": modified,
+        "wikilinks": _extract_wikilinks(content),
+    }
+
+
+def _read_text_safe(path: Path) -> str:
+    try:
+        return path.read_text("utf-8", errors="replace")
+    except Exception:
+        return ""
+
+
+def _walk_markdown(root: Path) -> list[dict[str, Any]]:
+    pages: list[dict[str, Any]] = []
+    if not root.exists():
+        return pages
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for name in filenames:
+            if not name.lower().endswith(".md"):
+                continue
+            full = Path(dirpath) / name
+            try:
+                stat = full.stat()
+            except Exception:
+                continue
+            if not stat.st_mode or not full.is_file():
+                continue
+            rel = full.relative_to(root).as_posix()
+            pages.append(_page_meta(rel, stat))
+    pages.sort(key=lambda p: (p.get("updated") or p["modified"], p["path"]), reverse=True)
+    return pages
+
+
+def _wikilink_resolver(pages: list[dict[str, Any]]) -> dict[str, str]:
+    by_path: dict[str, str] = {}
+    by_name: dict[str, str] = {}
+    for page in pages:
+        by_path[page["path"][:-3].lower() if page["path"].lower().endswith(".md") else page["path"].lower()] = page["path"]
+        by_name[Path(page["path"]).stem.lower()] = page["path"]
+    return {**by_path, **by_name}
+
+
+def _resolve_link(resolver: dict[str, str], link_text: str) -> Optional[str]:
+    cleaned = _clean_wikilink_target(link_text)
+    if not cleaned:
+        return None
+    normalized = cleaned.replace("\\", "/").strip()
+    if normalized.lower().endswith(".md"):
+        normalized = normalized[:-3]
+    return resolver.get(normalized.lower())
+
+
+# ─── Routes ───────────────────────────────────────────────────────────────────
+
+@router.get("/graph")
+def graph() -> dict[str, Any]:
+    root = _knowledge_root()
+    _seed_readme_if_empty(root)
+    pages = _walk_markdown(root)
+    resolver = _wikilink_resolver(pages)
+
+    edges: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for page in pages:
+        for link in page["wikilinks"]:
+            target = _resolve_link(resolver, link)
+            if not target:
+                continue
+            key = (page["path"], target)
+            if key not in seen:
+                seen.add(key)
+                edges.append({"source": page["path"], "target": target})
+
+    return {
+        "ok": True,
+        "root": str(root),
+        "nodes": [
+            {"id": p["path"], "title": p["title"], "type": p["type"], "tags": p["tags"]}
+            for p in pages
+        ],
+        "edges": edges,
+    }
+
+
+@router.get("/list")
+def list_pages() -> dict[str, Any]:
+    _seed_readme_if_empty(_knowledge_root())
+    return {"ok": True, "pages": _walk_markdown(_knowledge_root())}
+
+
+@router.get("/read")
+def read_page(path: str = Query(..., description="Relative path under the knowledge root")) -> dict[str, Any]:
+    root = _knowledge_root()
+    normalized = path.replace("\\", "/").strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="Path is required")
+    if normalized.startswith("/") or ".." in normalized.split("/"):
+        raise HTTPException(status_code=400, detail="Path traversal is not allowed")
+    if not normalized.lower().endswith(".md"):
+        raise HTTPException(status_code=400, detail="Only Markdown files are allowed")
+
+    full = (root / normalized).resolve()
+    if not str(full).startswith(str(root.resolve())):
+        raise HTTPException(status_code=400, detail="Resolved path is outside knowledge root")
+    if not full.is_file():
+        raise HTTPException(status_code=404, detail="Knowledge page not found")
+
+    stat = full.stat()
+    meta = _page_meta(normalized, stat)
+    raw = _read_text_safe(full)
+    _, content = _parse_frontmatter(raw)
+
+    pages = _walk_markdown(root)
+    resolver = _wikilink_resolver(pages)
+    backlinks = [
+        p["path"]
+        for p in pages
+        if p["path"] != normalized
+        and any(_resolve_link(resolver, link) == normalized for link in p["wikilinks"])
+    ]
+
+    return {"ok": True, "meta": meta, "content": content, "backlinks": backlinks}
+
+
+@router.get("/search")
+def search_pages(q: str = Query(..., min_length=1, max_length=200)) -> dict[str, Any]:
+    needle = q.strip().lower()
+    if not needle:
+        return {"ok": True, "matches": []}
+    pages = _walk_markdown(_knowledge_root())
+    matches: list[dict[str, Any]] = []
+    for page in pages:
+        raw = _read_text_safe(_knowledge_root() / page["path"])
+        for idx, line in enumerate(raw.splitlines(), start=1):
+            if needle in line.lower():
+                matches.append({"path": page["path"], "title": page["title"], "line": idx, "text": line})
+                if len(matches) >= 200:
+                    return {"ok": True, "matches": matches}
+    return {"ok": True, "matches": matches}

--- a/tests/plugins/crews/test_crews_plugin.py
+++ b/tests/plugins/crews/test_crews_plugin.py
@@ -1,0 +1,134 @@
+"""Tests for the crews plugin backend (plugins/crews/dashboard/plugin_api.py).
+
+Focus on the pure logic — store CRUD, pydantic validation, DAG validation and
+topological layering — without spawning real `hermes` workers.
+"""
+
+import importlib.util
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PLUGIN = _REPO_ROOT / "plugins" / "crews" / "dashboard" / "plugin_api.py"
+
+
+@pytest.fixture(scope="module")
+def api(tmp_path_factory):
+    hermes_home = tmp_path_factory.mktemp("hermes-home")
+    spec = importlib.util.spec_from_file_location("hermes_dashboard_plugin_crews_test", _PLUGIN)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    mod._store["crews"] = {}
+    mod._workflow_store["workflows"] = {}
+    # Point the stores at the tmp HERMES_HOME for later assertions.
+    mod._hermes_home = lambda: hermes_home  # type: ignore[method-assign]
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _fresh_stores(api):
+    api._store["crews"] = {}
+    api._workflow_store["workflows"] = {}
+    yield
+    api._store["crews"] = {}
+    api._workflow_store["workflows"] = {}
+
+
+def test_create_crew_roundtrip(api):
+    result = asyncio.run(api.create_crew(api.CreateCrewBody(name="Squad", goal="Ship it", members=[
+        api.MemberInput(persona="kai"),
+        api.MemberInput(persona="ada", model="auto"),
+    ])))
+    crew = result["crew"]
+    assert crew["name"] == "Squad"
+    assert crew["status"] == "draft"
+    assert len(crew["members"]) == 2
+    assert crew["members"][0]["persona"] == "kai"
+    assert crew["members"][0]["displayName"].startswith("⚡")
+    assert crew["members"][1]["model"] == "auto"
+    assert api.get_crew(crew["id"]) is not None
+
+
+def test_create_crew_unknown_persona_rejected(api):
+    with pytest.raises(Exception) as exc:
+        asyncio.run(api.create_crew(api.CreateCrewBody(name="Bad", members=[api.MemberInput(persona="nope")])))
+    assert "Unknown persona" in str(exc.value)
+
+
+def test_crew_at_most_8_members(api):
+    members = [api.MemberInput(persona="kai") for _ in range(9)]
+    with pytest.raises(Exception) as exc:
+        asyncio.run(api.create_crew(api.CreateCrewBody(name="Big", members=members)))
+    assert "at most 8" in str(exc.value)
+
+
+def test_clone_crew(api):
+    crew = asyncio.run(api.create_crew(api.CreateCrewBody(name="Original", members=[api.MemberInput(persona="luna")])))["crew"]
+    clone = asyncio.run(api.clone_crew(crew["id"]))["crew"]
+    assert clone["id"] != crew["id"]
+    assert clone["name"] == "Original (copy)"
+    assert len(clone["members"]) == 1
+    assert all(m["status"] == "idle" for m in clone["members"])
+
+
+def test_member_status_patch(api):
+    crew = asyncio.run(api.create_crew(api.CreateCrewBody(name="S", members=[api.MemberInput(persona="nova")])))["crew"]
+    member_id = crew["members"][0]["id"]
+    result = asyncio.run(api.patch_crew(crew["id"], api.PatchCrewBody(memberId=member_id, memberStatus="running")))
+    assert result["crew"]["members"][0]["status"] == "running"
+
+
+def test_workflow_upsert_and_cycle_rejection(api):
+    crew = asyncio.run(api.create_crew(api.CreateCrewBody(name="W", members=[api.MemberInput(persona="kai")])))["crew"]
+    tasks = [
+        api.WorkflowTaskBody(id="a", label="A", prompt="do a"),
+        api.WorkflowTaskBody(id="b", label="B", prompt="do b"),
+    ]
+    edges = [api.WorkflowEdgeBody(from_="a", to="b")]
+    workflow = asyncio.run(api.upsert_workflow(crew["id"], api.UpsertWorkflowBody(tasks=tasks, edges=edges)))
+    assert workflow["workflow"]["edges"] == [{"from": "a", "to": "b"}]
+
+    # Cycle must be rejected server-side.
+    cycle_edges = [api.WorkflowEdgeBody(from_="a", to="b"), api.WorkflowEdgeBody(from_="b", to="a")]
+    with pytest.raises(Exception) as exc:
+        asyncio.run(api.upsert_workflow(crew["id"], api.UpsertWorkflowBody(tasks=tasks, edges=cycle_edges)))
+    assert "cycle" in str(exc.value)
+
+
+def test_topo_layers(api):
+    layers = api._topo_layers(
+        [{"id": "a"}, {"id": "b"}, {"id": "c"}, {"id": "d"}],
+        [{"from": "a", "to": "c"}, {"from": "b", "to": "c"}, {"from": "c", "to": "d"}],
+    )
+    # a,b (parallel) → c → d
+    assert set(layers[0]) == {"a", "b"}
+    assert layers[1] == ["c"]
+    assert layers[2] == ["d"]
+
+
+def test_validate_dag_unknown_edge(api):
+    with pytest.raises(Exception) as exc:
+        api._validate_dag(
+            [{"id": "a"}],
+            [{"from": "a", "to": "ghost"}],
+        )
+    assert "unknown task" in str(exc.value)
+
+
+def test_profile_name_sanitization(api):
+    member = {"persona": "roger", "profileName": "../evil"}
+    assert api._profile_name_for(member) == "evil"
+    assert api._profile_name_for({"persona": "kai", "profileName": ""}) == "kai"
+
+
+def test_personas_and_templates(api):
+    personas = api.list_personas()["personas"]
+    assert len(personas) == 8
+    assert {p["id"] for p in personas} == {"roger", "sally", "bill", "ada", "max", "luna", "kai", "nova"}
+    templates = api.list_templates()["templates"]
+    assert len(templates) >= 3

--- a/tests/plugins/knowledge/test_knowledge_plugin.py
+++ b/tests/plugins/knowledge/test_knowledge_plugin.py
@@ -1,0 +1,103 @@
+"""Tests for the knowledge plugin backend (plugins/knowledge/dashboard/plugin_api.py).
+
+Exercises the wiki scanner against a temp knowledge dir: frontmatter parsing,
+[[wikilink]] extraction, graph construction, read with backlinks, and search.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PLUGIN = _REPO_ROOT / "plugins" / "knowledge" / "dashboard" / "plugin_api.py"
+
+
+@pytest.fixture()
+def api(tmp_path, monkeypatch):
+    knowledge_dir = tmp_path / "knowledge"
+    monkeypatch.setenv("HERMES_KNOWLEDGE_DIR", str(knowledge_dir))
+    spec = importlib.util.spec_from_file_location("hermes_dashboard_plugin_knowledge_test", _PLUGIN)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write(root: Path, rel: str, content: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, "utf-8")
+
+
+def test_empty_graph_seeds_readme(api):
+    graph = api.graph()
+    assert graph["ok"] is True
+    # The seed README is itself a node.
+    assert len(graph["nodes"]) == 1
+    assert graph["nodes"][0]["id"] == "README.md"
+    readme = Path(os.environ["HERMES_KNOWLEDGE_DIR"]) / "README.md"
+    assert readme.exists()
+    assert "[[wiki-links]]" in readme.read_text("utf-8") or "wiki-links" in readme.read_text("utf-8")
+
+
+def test_graph_nodes_and_edges(api):
+    root = Path(os.environ["HERMES_KNOWLEDGE_DIR"])
+    _write(root, "agents.md", "---\ntitle: Agents\ntype: concept\n---\nSee [[tools]] and [[concepts/agents]].")
+    _write(root, "tools.md", "---\ntitle: Tools\n---\nUsed by [[agents]].")
+    _write(root, "concepts/agents.md", "# Nested\nLinks to [[tools]].")
+
+    graph = api.graph()
+    assert len(graph["nodes"]) == 4  # 3 pages + seeded README
+    ids = {n["id"] for n in graph["nodes"]}
+    assert {"agents.md", "tools.md", "concepts/agents.md"} <= ids
+    edges = {(e["source"], e["target"]) for e in graph["edges"]}
+    # agents.md → tools.md (by name), agents.md → concepts/agents.md (by path)
+    assert ("agents.md", "tools.md") in edges
+    assert ("agents.md", "concepts/agents.md") in edges
+    assert ("tools.md", "agents.md") in edges
+    # Concepts page node carries its frontmatter type.
+    by_id = {n["id"]: n for n in graph["nodes"]}
+    assert by_id["agents.md"]["type"] == "concept"
+
+
+def test_read_page_with_backlinks(api):
+    root = Path(os.environ["HERMES_KNOWLEDGE_DIR"])
+    _write(root, "a.md", "---\ntitle: A\n---\nLinks [[b]].")
+    _write(root, "b.md", "---\ntitle: B\n---\nBody.")
+
+    page = api.read_page(path="b.md")
+    assert page["meta"]["title"] == "B"
+    assert page["backlinks"] == ["a.md"]
+
+    with pytest.raises(Exception):
+        api.read_page(path="../../etc/passwd")
+    with pytest.raises(Exception):
+        api.read_page(path="missing.md")
+
+
+def test_search(api):
+    root = Path(os.environ["HERMES_KNOWLEDGE_DIR"])
+    _write(root, "one.md", "---\ntitle: One\n---\nThe quick brown fox.")
+    _write(root, "two.md", "---\ntitle: Two\n---\nNothing here.")
+
+    result = api.search_pages(q="brown")
+    assert len(result["matches"]) == 1
+    assert result["matches"][0]["path"] == "one.md"
+    assert result["matches"][0]["line"] == 4  # frontmatter closes on line 3
+
+
+def test_wikilink_aliases_and_headings(api):
+    root = Path(os.environ["HERMES_KNOWLEDGE_DIR"])
+    _write(root, "guide.md", "---\ntitle: Guide\n---\nSee [[other-page|Alias]] and [[page#section]].")
+    _write(root, "other-page.md", "# Other")
+    _write(root, "page.md", "# Page")
+
+    graph = api.graph()
+    edges = {(e["source"], e["target"]) for e in graph["edges"]}
+    # Alias targets clean to the page name; headings strip.
+    assert ("guide.md", "other-page.md") in edges
+    assert ("guide.md", "page.md") in edges


### PR DESCRIPTION
## Summary

Brings four community-proven Hermes features into the first-party desktop app + agent, re-architected onto Hermes' existing plugin surface (bundled Python plugin routers + bundled desktop plugins, same contract as the in-tree kanban plugin). No core agent runtime changes.

1. **Multi-Agent Crews** — named groups of specialised persona agents (Roger, Sally, Ada, Kai, Nova, Luna, Max, Bill). Each member runs as a profile-scoped `hermes -p <profile> chat -q` worker with its own model override and isolated workspace. Dispatch a task to all members or one member, watch live status + activity over a `/events` WebSocket. Clone crews; 4 built-in templates.
2. **Visual Workflow Builder** — per-crew DAG editor (pure SVG, no graph library): pan/zoom, node drag, connect mode with instant cycle detection, Kahn auto-layout, server-side cycle validation on save, and runs that dispatch tasks in topological layers with live per-node status.
3. **Interactive Knowledge Graph** — force-directed SVG canvas over the `~/.hermes/knowledge` markdown wiki (created + seeded with a README on first use). Nodes sized by degree, typed colours, hover neighbour highlight, legend + stats; sidebar with page list, search, and a reader that follows `[[wiki-links]]` and backlinks.
4. **Hermes Office (Claw3d)** — manager for the `fathah/hermes-office` 3D interface: clone/install the repo under `HERMES_HOME`, write `~/.openclaw/claw3d/settings.json` + `.env` from the active gateway connection, start/stop the dev server (`:3000`) and `hermes-gateway-adapter` (`:18989`), with pid files, log capture, and an Office page (status, install progress, logs, open in browser).

All desktop features ship **opt-in** (`defaultEnabled: false`), inventorying in Settings → Plugins like kanban.

## Where things live

- Backend plugins (mounted at `/api/plugins/<name>/` by the dashboard):
  - `plugins/crews/dashboard/plugin_api.py` (+ `manifest.json`) — crew/workflow stores (`$HERMES_HOME/crews/`), dispatch + workflow run via the kanban worker-spawn pattern, `/events` WebSocket
  - `plugins/knowledge/dashboard/plugin_api.py` (+ `manifest.json`) — wiki scanner, frontmatter + wikilink parsing, graph/list/read/search
- Desktop plugins (auto-discovered by `src/contrib/plugins.ts`):
  - `apps/desktop/src/plugins/crews/` — list, create dialog + templates, crew detail (members/dispatch/activity), SVG workflow builder
  - `apps/desktop/src/plugins/knowledge/` — force-directed canvas + browser/search/reader
  - `apps/desktop/src/plugins/office/` — Office status/setup/logs page
- Electron bridge: `apps/desktop/electron/claw3d.ts` (manager), `main.ts` (`hermes:claw3d:*` IPC), `preload.ts` + `src/global.d.ts` types

## Design notes

- **Crews dispatch** reuses the battle-tested kanban pattern (`hermes -p <profile> chat -q` one-shot subprocess with profile-scoped `HERMES_HOME`, `-m` model override, log files, `CREATE_NO_WINDOW` on Windows) rather than reimplementing agent execution in the renderer — consistent with the desktop's "agent behavior lives behind the gateway" rule. Members are real profiles, so their work is isolated and their session history lands in `~/.hermes/profiles/<name>/`.
- **Knowledge graph** reads the wiki directory (like Hermes-Studio) and is fully additive — nothing in core touches it; the dir is created only when the plugin is used.
- **Office auth**: the hermes-gateway-adapter authenticates with the gateway session token via the legacy `Bearer` header, which the Hermes HTTP API accepts. OAuth-gated gateways are surfaced as unsupported in the UI (status + start error) rather than writing a dead ticket.

## Verification

- `tsc -p . --noEmit` (renderer) — clean
- `tsc -p tsconfig.electron.json --noEmit` — clean
- `eslint src/plugins/crews src/plugins/knowledge src/plugins/office electron/claw3d.ts electron/claw3d.test.ts` — 0 errors
- `vitest run` (new suites: `dag.test.ts`, `force-layout.test.ts`, `claw3d.test.ts`) — 31/31 pass
- `pytest tests/plugins/crews tests/plugins/knowledge` — 15/15 pass
- `prettier` applied to all new files

## Follow-ups (out of scope for this PR)

- Crew member "open chat" linking to a live gateway session (dispatch currently spawns one-shot workers; sessions are per-profile history, not live chats)
- Office SSH-remote mode and OAuth-gated gateway support
- Knowledge graph: memory-entry nodes + wiki-link reconciliation with the agent's own memory store
