### PR TITLE
fix(cli): curator adopt --dry-run reports already-managed skills

### DIFF
--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -368,9 +368,18 @@ def _cmd_adopt(args) -> int:
 
     dry_run = bool(getattr(args, "dry_run", False))
     if dry_run:
-        print(f"curator: would adopt {len(names)} skill(s) (dry run):")
-        for n in names:
-            print(f"  + {n}")
+        # Mirror the real run's per-name decision: skills already under
+        # curator management are reported as such (same message the real
+        # path prints) instead of being listed as adoption candidates, so
+        # the dry run answers "is this skill already adopted?".
+        already_managed = [n for n in names if skill_usage.is_curator_managed(n)]
+        pending = [n for n in names if not skill_usage.is_curator_managed(n)]
+        for n in already_managed:
+            print(f"curator: '{n}' is already curator-managed")
+        if pending:
+            print(f"curator: would adopt {len(pending)} skill(s) (dry run):")
+            for n in pending:
+                print(f"  + {n}")
         return 0
 
     # Bulk adoption is a real lifecycle change (adopted skills become

--- a/tests/hermes_cli/test_curator_adopt.py
+++ b/tests/hermes_cli/test_curator_adopt.py
@@ -1,0 +1,60 @@
+"""Tests for `hermes curator adopt` — explicit provenance handover.
+
+Covers the --dry-run decision path: it must consult the usage registry
+(.usage.json) and report already curator-managed skills as such, instead of
+listing them under "would adopt" like never-adopted skills.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def test_adopt_dry_run_reports_already_managed(monkeypatch, capsys):
+    import hermes_cli.curator as curator_cli
+    import tools.skill_usage as skill_usage
+
+    monkeypatch.setattr(skill_usage, "is_curator_managed", lambda name: True)
+    args = SimpleNamespace(
+        skill=["my-skill"], all_unmanaged=False, dry_run=True, yes=False
+    )
+    assert curator_cli._cmd_adopt(args) == 0
+    out = capsys.readouterr().out
+    assert "'my-skill' is already curator-managed" in out
+    assert "would adopt" not in out
+    assert "+ my-skill" not in out
+
+
+def test_adopt_dry_run_lists_unmanaged_only(monkeypatch, capsys):
+    import hermes_cli.curator as curator_cli
+    import tools.skill_usage as skill_usage
+
+    monkeypatch.setattr(
+        skill_usage, "is_curator_managed", lambda name: name == "managed-skill"
+    )
+    args = SimpleNamespace(
+        skill=["managed-skill", "fresh-skill"],
+        all_unmanaged=False,
+        dry_run=True,
+        yes=False,
+    )
+    assert curator_cli._cmd_adopt(args) == 0
+    out = capsys.readouterr().out
+    assert "'managed-skill' is already curator-managed" in out
+    assert "would adopt 1 skill(s) (dry run):" in out
+    assert "+ fresh-skill" in out
+    assert "+ managed-skill" not in out
+
+
+def test_adopt_dry_run_unmanaged(monkeypatch, capsys):
+    import hermes_cli.curator as curator_cli
+    import tools.skill_usage as skill_usage
+
+    monkeypatch.setattr(skill_usage, "is_curator_managed", lambda name: False)
+    args = SimpleNamespace(
+        skill=["fresh-skill"], all_unmanaged=False, dry_run=True, yes=False
+    )
+    assert curator_cli._cmd_adopt(args) == 0
+    out = capsys.readouterr().out
+    assert "would adopt 1 skill(s) (dry run):" in out
+    assert "+ fresh-skill" in out


### PR DESCRIPTION
## Summary
`hermes curator adopt <name> --dry-run` reported `would adopt` for skills that are **already curator-managed**. The dry-run path printed the argument list verbatim without consulting `.usage.json`, so it could not answer "is this skill already adopted?" — the exact question a dry run exists to answer.

## Change
- `hermes_cli/curator.py::_cmd_adopt`: the dry-run path now partitions `names` into `already_managed` (via `is_curator_managed()`, the public alias of the `created_by: agent` check in `.usage.json`) and `pending`. Already-managed skills are reported with the **same message the real path uses** (`curator: '<n>' is already curator-managed`); the `would adopt N skill(s)` section only shows pending skills. `--all-unmanaged --dry-run` is untouched (candidates already come from `list_unmanaged_skill_names()`).
- `tests/hermes_cli/test_curator_adopt.py` (new): already-adopted → `already curator-managed` with no `would adopt`/`+ name`; mixed (1 managed + 1 new) → managed reported, `would adopt 1 skill(s)` with only `+ fresh-skill`; plus the general dry-run shape.

## Verification
- `tests/hermes_cli/test_curator_adopt.py` + `test_curator_usage.py`: **6 passed**.
- Neighboring curator suites + `tests/tools/test_skill_usage.py`: **27 passed**.

Closes #83573