### PR TITLE
fix(node): keep an unreadable managed Node tree off PATH

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -666,12 +666,44 @@ def find_node_executable(command: str) -> str | None:
     return find_node_executable_on_path(command)
 
 
+def path_entry_usable(candidate: Path) -> bool:
+    """Return True when *candidate* is a directory we can actually enumerate.
+
+    A PATH entry has to clear a higher bar than "is a directory". An
+    unreadable directory — one whose ACL denies traversal, which an
+    interrupted or elevated install can leave behind at ``$HERMES_HOME/node``
+    — still stats as a directory, so an ``is_dir()`` check happily puts it on
+    PATH. Windows process creation then *fails* on that entry rather than
+    skipping it: ``spawn`` returns ``EPERM`` (errno -4048) as soon as an
+    unreadable directory precedes the real one, so a single bad entry breaks
+    every child process, not just the ones wanting a managed runtime.
+
+    That is not hypothetical. It is how the packaged desktop build died —
+    ``cross-env`` could not spawn ``node`` at all, because the managed tree
+    prepended here was unreadable::
+
+        Error: spawn EPERM
+            at ChildProcess.spawn (node:internal/child_process:441:11)
+            at spawn (node_modules/cross-spawn/index.js:12:24)
+
+    So probe by *listing*, not by stat-ing: a tree we cannot enumerate has to
+    stay off PATH entirely. ``scandir`` raises on the first entry when the
+    directory is unreadable, so this stays O(1) rather than walking the tree.
+    """
+    try:
+        with os.scandir(candidate) as entries:
+            next(entries, None)
+    except OSError:
+        return False
+    return True
+
+
 def with_hermes_node_path(env: dict[str, str] | None = None) -> dict[str, str]:
-    """Return *env* with Hermes-managed Node directories prepended to PATH."""
+    """Return *env* with usable Hermes-managed Node directories prepended to PATH."""
     merged = dict(os.environ if env is None else env)
     existing = merged.get("PATH", "")
     parts = [p for p in existing.split(os.pathsep) if p]
-    managed = [str(path) for path in iter_hermes_node_dirs() if path.is_dir()]
+    managed = [str(path) for path in iter_hermes_node_dirs() if path_entry_usable(path)]
     for entry in reversed(managed):
         if entry not in parts:
             parts.insert(0, entry)

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -147,6 +147,43 @@ class TestHermesManagedNode:
         assert find_node_executable("npm") is None
         assert find_node_executable("npm") != str(path_npm)
 
+    def test_unreadable_managed_tree_is_kept_off_path(self, tmp_path, monkeypatch):
+        """An unreadable managed tree must not be prepended to PATH.
+
+        Windows process creation *fails* on an unreadable PATH entry rather
+        than skipping it — ``spawn`` returns ``EPERM`` (errno -4048) as soon as
+        one precedes the real directory — so injecting the tree breaks every
+        child process, not just the ones wanting a managed runtime. That is how
+        the packaged desktop build died: ``cross-env`` could not spawn ``node``
+        at all.
+
+        An ``is_dir()`` check cannot catch this, because an unreadable
+        directory still stats as a directory. Usability is probed by listing.
+        """
+        home = tmp_path / "hermes"
+        node_dir = home / "node"
+        node_dir.mkdir(parents=True)
+        readable = tmp_path / "other-home" / "node"
+        readable.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        real_scandir = os.scandir
+
+        def _deny_unreadable(path=".", *args, **kwargs):
+            if Path(path) == node_dir:
+                raise PermissionError(13, "Access is denied", str(path))
+            return real_scandir(path, *args, **kwargs)
+
+        monkeypatch.setattr(os, "scandir", _deny_unreadable)
+
+        entries = with_hermes_node_path({"PATH": "/usr/bin"})["PATH"].split(os.pathsep)
+        assert str(node_dir) not in entries
+
+        # Positive control: a tree we *can* enumerate is still prepended, so
+        # the probe rejects unreadable trees rather than all of them.
+        monkeypatch.setenv("HERMES_HOME", str(readable.parent))
+        assert str(readable) in with_hermes_node_path({"PATH": "/usr/bin"})["PATH"]
+
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX shell stubs; Windows uses .cmd shims")

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1160,10 +1160,19 @@ def _managed_runtime_path_entries() -> list[str]:
     mid-process (``heal_hermes_managed_node``, a first browser install).
     """
     try:
-        from hermes_constants import get_hermes_home, iter_hermes_node_dirs
+        from hermes_constants import (
+            get_hermes_home,
+            iter_hermes_node_dirs,
+            path_entry_usable,
+        )
 
         candidates = [*iter_hermes_node_dirs(), get_hermes_home() / "bin"]
-        return [str(d) for d in candidates if d.is_dir()]
+        # ``is_dir()`` is not a strong enough test: an unreadable directory
+        # still stats as one, and Windows process creation fails outright
+        # (``spawn EPERM``) on an unreadable PATH entry rather than skipping
+        # it — so adding one would break every command the agent runs in the
+        # subshell, not just the ones wanting a managed runtime.
+        return [str(d) for d in candidates if path_entry_usable(d)]
     except Exception:
         return []
 


### PR DESCRIPTION
## What does this PR do?

Stops Hermes from prepending a Node runtime directory it **cannot read** to `PATH`.

`with_hermes_node_path()` and `_managed_runtime_path_entries()` both selected managed runtime dirs with `is_dir()`. An unreadable directory — one whose ACL denies traversal, which an interrupted or elevated install can leave behind at `$HERMES_HOME/node` — still stats as a directory, so it went onto `PATH` anyway.

Windows process creation then **fails on that entry instead of skipping it**. `spawn` returns `EPERM` (errno -4048) as soon as an unreadable directory precedes the real one, so one bad entry breaks *every* child process, not just the ones that wanted a managed runtime.

Reproduced directly on Windows 11 (Node v24.16.0):

```
clean PATH:                        out: v24.16.0
unreadable dir prepended to PATH:  err: EPERM
```

Where it actually bit: the packaged desktop build, with `cross-env` unable to spawn `node` at all.

```
Error: spawn EPERM
    at ChildProcess.spawn (node:internal/child_process:441:11)
    at spawn (node_modules/cross-spawn/index.js:12:24)
```

The fix adds `path_entry_usable()`, which probes by **listing** instead of stat-ing — the only way to distinguish "is a directory" from "is a directory I can traverse". `scandir` raises on the first entry when the dir is unreadable, so it stays O(1).

### Scope — deliberately the PATH half only

The *resolution* half of this problem (bare `Path.is_file()` probes propagating `OSError` out of `find_hermes_node_executable` and friends) is already covered by #70725 and #75419, so this PR does not touch those call sites — no competing duplicate.

Those PRs and this one are complementary, and neither subsumes the other: they stop the resolver from crashing on an unreadable tree, while this stops that same tree from being handed to every child process. #75419 notes that "the caller's job is to keep such a tree out of the PATH" — this is that caller-side fix.

## Related Issue

No existing issue found for the PATH/`EPERM` behaviour (searched issues and PRs for `spawn EPERM`, `with_hermes_node_path`, `_managed_runtime_path_entries`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_constants.py` — add `path_entry_usable()`; use it in `with_hermes_node_path()` instead of `is_dir()`.
- `tools/environments/local.py` — use it in `_managed_runtime_path_entries()`, which was injecting the same unreadable dir into the agent's terminal subshell `PATH`. The existing `try/except Exception` there prevented a crash but not the bad entry.
- `tests/test_hermes_constants.py` — `test_unreadable_managed_tree_is_kept_off_path`, with a positive control asserting a *readable* tree is still prepended (so the probe rejects unreadable trees, not all trees).

## How to Test

1. Make a managed tree unreadable — on Windows, a dir whose ACL denies traversal at `%LOCALAPPDATA%\hermes\node`; the directory itself still stats fine while every child access raises `PermissionError: [WinError 5]`.
2. Before: `hermes desktop --build-only --force-build` fails with `Error: spawn EPERM` out of `cross-env`.
3. After: the build completes and produces `release/win-unpacked/Hermes.exe`.
4. `pytest tests/test_hermes_constants.py -q`

The new test fails without the source change (the unreadable dir appears in the returned `PATH`) and passes with it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/test_hermes_constants.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 Pro 26200, Python 3.11.15, Node v24.16.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the new helper documents the `EPERM` failure mode it exists to prevent
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — `scandir` raising `OSError` on an unreadable dir is portable; on POSIX an unreadable `PATH` entry is skipped rather than fatal, so this is a no-op there beyond not advertising a dir it cannot use
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Desktop build after the fix:

```
✓ Desktop packaged app ready: apps\desktop\release\win-unpacked\Hermes.exe (not launching; --build-only)
```
