### PR TITLE
fix(desktop): scope Messaging requests to the active profile

### DIFF
--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -5,13 +5,16 @@ import {
   getActionStatus,
   getElevenLabsVoices,
   getMemoryProviderConfig,
+  getMessagingPlatforms,
   getStatus,
   restartGateway,
   saveMemoryProviderConfig,
   setApiRequestProfile,
   speakText,
+  testMessagingPlatform,
   transcribeAudio,
-  updateHermes
+  updateHermes,
+  updateMessagingPlatform
 } from './hermes'
 
 // Contract: every backend-targeted action helper must carry the active gateway
@@ -31,11 +34,13 @@ describe('backend action helpers are profile-scoped', () => {
     delete (window as { hermesDesktop?: unknown }).hermesDesktop
   })
 
-  const lastProfile = () => api.mock.calls.at(-1)?.[0].profile
-
   it('omits profile when none is active (single-profile users unaffected)', () => {
     void getStatus()
-    expect(lastProfile()).toBeUndefined()
+    void getMessagingPlatforms()
+
+    for (const call of api.mock.calls) {
+      expect(call[0].profile).toBeUndefined()
+    }
   })
 
   it('forwards the active profile to memory provider config calls', () => {
@@ -79,5 +84,29 @@ describe('backend action helpers are profile-scoped', () => {
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBe('jarvis')
     }
+  })
+
+  it('forwards the active profile to messaging platform endpoints', () => {
+    setApiRequestProfile('hmbot2')
+    const update = { enabled: true, env: { TELEGRAM_BOT_TOKEN: 'replacement-token' } }
+
+    void getMessagingPlatforms()
+    void updateMessagingPlatform('telegram', update)
+    void testMessagingPlatform('telegram')
+
+    expect(api.mock.calls.map(call => call[0])).toEqual([
+      { profile: 'hmbot2', path: '/api/messaging/platforms' },
+      {
+        profile: 'hmbot2',
+        path: '/api/messaging/platforms/telegram',
+        method: 'PUT',
+        body: update
+      },
+      {
+        profile: 'hmbot2',
+        path: '/api/messaging/platforms/telegram/test',
+        method: 'POST'
+      }
+    ])
   })
 })

--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -38,6 +38,8 @@ describe('backend action helpers are profile-scoped', () => {
     void getStatus()
     void getMessagingPlatforms()
 
+    expect(api.mock.calls).toHaveLength(2)
+
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBeUndefined()
     }

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1264,6 +1264,7 @@ export function grantComputerUsePermissions(): Promise<ActionResponse> {
 
 export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
   return window.hermesDesktop.api<MessagingPlatformsResponse>({
+    ...profileScoped(),
     path: '/api/messaging/platforms'
   })
 }
@@ -1273,6 +1274,7 @@ export function updateMessagingPlatform(
   body: MessagingPlatformUpdate
 ): Promise<{ ok: boolean; platform: string }> {
   return window.hermesDesktop.api<{ ok: boolean; platform: string }>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}`,
     method: 'PUT',
     body
@@ -1281,6 +1283,7 @@ export function updateMessagingPlatform(
 
 export function testMessagingPlatform(platformId: string): Promise<MessagingPlatformTestResponse> {
   return window.hermesDesktop.api<MessagingPlatformTestResponse>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
     method: 'POST'
   })

--- a/docs/superpowers/plans/2026-08-11-issue-83391-messaging-profile-scope.md
+++ b/docs/superpowers/plans/2026-08-11-issue-83391-messaging-profile-scope.md
@@ -1,0 +1,188 @@
+# Desktop Messaging Profile Scope Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route desktop messaging-platform reads, updates, and tests through the profile selected in the desktop UI.
+
+**Architecture:** Reuse the renderer's existing `profileScoped()` request descriptor so Electron can choose the selected profile's backend or append the profile query for a shared remote backend. Keep the backend endpoints and Messaging Platforms page unchanged because both already honor profile-scoped requests.
+
+**Tech Stack:** TypeScript, Electron IPC bridge, Vitest
+
+---
+
+## File Structure
+
+- Modify `apps/desktop/src/hermes-profile-scope.test.ts`: add the regression contract for all three messaging-platform helpers.
+- Modify `apps/desktop/src/hermes.ts`: attach the existing active-profile descriptor to each messaging-platform request.
+
+### Task 1: Add The Messaging Profile-Scope Contract
+
+**Files:**
+- Test: `apps/desktop/src/hermes-profile-scope.test.ts:3-15,83`
+- Modify: `apps/desktop/src/hermes.ts:1265-1286`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add the three messaging helpers to the existing import:
+
+```ts
+import {
+  checkHermesUpdate,
+  getActionStatus,
+  getElevenLabsVoices,
+  getMemoryProviderConfig,
+  getMessagingPlatforms,
+  getStatus,
+  restartGateway,
+  saveMemoryProviderConfig,
+  setApiRequestProfile,
+  speakText,
+  testMessagingPlatform,
+  transcribeAudio,
+  updateHermes,
+  updateMessagingPlatform
+} from './hermes'
+```
+
+Add this test inside `describe('backend action helpers are profile-scoped', ...)`:
+
+```ts
+it('forwards the active profile to messaging platform endpoints', () => {
+  setApiRequestProfile('hmbot2')
+  const update = { enabled: true, env: { TELEGRAM_BOT_TOKEN: 'replacement-token' } }
+
+  void getMessagingPlatforms()
+  void updateMessagingPlatform('telegram', update)
+  void testMessagingPlatform('telegram')
+
+  expect(api.mock.calls.map(call => call[0])).toEqual([
+    { profile: 'hmbot2', path: '/api/messaging/platforms' },
+    {
+      profile: 'hmbot2',
+      path: '/api/messaging/platforms/telegram',
+      method: 'PUT',
+      body: update
+    },
+    {
+      profile: 'hmbot2',
+      path: '/api/messaging/platforms/telegram/test',
+      method: 'POST'
+    }
+  ])
+})
+```
+
+Also extend the existing single-profile compatibility test so the messaging
+read is covered explicitly:
+
+```ts
+it('omits profile when none is active (single-profile users unaffected)', () => {
+  void getStatus()
+  void getMessagingPlatforms()
+
+  for (const call of api.mock.calls) {
+    expect(call[0].profile).toBeUndefined()
+  }
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+npm --prefix apps/desktop run test:ui -- src/hermes-profile-scope.test.ts
+```
+
+Expected: FAIL in `forwards the active profile to messaging platform endpoints`; each messaging request is missing `profile: 'hmbot2'`.
+
+- [ ] **Step 3: Implement the minimal profile propagation**
+
+Update only the three request descriptors in `apps/desktop/src/hermes.ts`:
+
+```ts
+export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
+  return window.hermesDesktop.api<MessagingPlatformsResponse>({
+    ...profileScoped(),
+    path: '/api/messaging/platforms'
+  })
+}
+
+export function updateMessagingPlatform(
+  platformId: string,
+  body: MessagingPlatformUpdate
+): Promise<{ ok: boolean; platform: string }> {
+  return window.hermesDesktop.api<{ ok: boolean; platform: string }>({
+    ...profileScoped(),
+    path: `/api/messaging/platforms/${encodeURIComponent(platformId)}`,
+    method: 'PUT',
+    body
+  })
+}
+
+export function testMessagingPlatform(platformId: string): Promise<MessagingPlatformTestResponse> {
+  return window.hermesDesktop.api<MessagingPlatformTestResponse>({
+    ...profileScoped(),
+    path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
+    method: 'POST'
+  })
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+npm --prefix apps/desktop run test:ui -- src/hermes-profile-scope.test.ts
+```
+
+Expected: PASS for the complete `hermes-profile-scope.test.ts` file.
+
+- [ ] **Step 5: Commit the tested fix**
+
+```bash
+git add apps/desktop/src/hermes.ts apps/desktop/src/hermes-profile-scope.test.ts
+git commit -m "fix(desktop): scope messaging requests to active profile"
+```
+
+### Task 2: Verify The Change Against The Wider Repository
+
+**Files:**
+- Verify: `apps/desktop/src/hermes.ts`
+- Verify: `apps/desktop/src/hermes-profile-scope.test.ts`
+
+- [ ] **Step 1: Run the complete desktop unit-test suite**
+
+```bash
+npm --prefix apps/desktop test
+```
+
+Expected: all UI and Electron Vitest projects pass.
+
+- [ ] **Step 2: Run desktop type checking and linting**
+
+```bash
+npm --prefix apps/desktop run typecheck
+npm --prefix apps/desktop run lint
+```
+
+Expected: both commands exit with status 0 and report no errors.
+
+- [ ] **Step 3: Run the repository Python suite required by AGENTS.md**
+
+```bash
+source venv/bin/activate
+python -m pytest tests/ -q
+```
+
+Expected: the full Python test suite exits with status 0 and no failures.
+
+- [ ] **Step 4: Inspect the final diff and worktree**
+
+```bash
+git diff origin/main...HEAD --check
+git status --short --branch
+```
+
+Expected: no whitespace errors; the branch contains only the design, plan, regression test, and three profile-scope additions.

--- a/docs/superpowers/plans/2026-08-11-issue-83391-messaging-profile-scope.md
+++ b/docs/superpowers/plans/2026-08-11-issue-83391-messaging-profile-scope.md
@@ -21,7 +21,7 @@
 - Test: `apps/desktop/src/hermes-profile-scope.test.ts:3-15,83`
 - Modify: `apps/desktop/src/hermes.ts:1265-1286`
 
-- [ ] **Step 1: Write the failing regression test**
+- [x] **Step 1: Write the failing regression test**
 
 Add the three messaging helpers to the existing import:
 
@@ -86,7 +86,7 @@ it('omits profile when none is active (single-profile users unaffected)', () => 
 })
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run:
 
@@ -96,7 +96,7 @@ npm --prefix apps/desktop run test:ui -- src/hermes-profile-scope.test.ts
 
 Expected: FAIL in `forwards the active profile to messaging platform endpoints`; each messaging request is missing `profile: 'hmbot2'`.
 
-- [ ] **Step 3: Implement the minimal profile propagation**
+- [x] **Step 3: Implement the minimal profile propagation**
 
 Update only the three request descriptors in `apps/desktop/src/hermes.ts`:
 
@@ -129,7 +129,7 @@ export function testMessagingPlatform(platformId: string): Promise<MessagingPlat
 }
 ```
 
-- [ ] **Step 4: Run the focused test and verify GREEN**
+- [x] **Step 4: Run the focused test and verify GREEN**
 
 Run:
 
@@ -139,7 +139,7 @@ npm --prefix apps/desktop run test:ui -- src/hermes-profile-scope.test.ts
 
 Expected: PASS for the complete `hermes-profile-scope.test.ts` file.
 
-- [ ] **Step 5: Commit the tested fix**
+- [x] **Step 5: Commit the tested fix**
 
 ```bash
 git add apps/desktop/src/hermes.ts apps/desktop/src/hermes-profile-scope.test.ts
@@ -152,7 +152,7 @@ git commit -m "fix(desktop): scope messaging requests to active profile"
 - Verify: `apps/desktop/src/hermes.ts`
 - Verify: `apps/desktop/src/hermes-profile-scope.test.ts`
 
-- [ ] **Step 1: Run the complete desktop unit-test suite**
+- [x] **Step 1: Run the complete desktop unit-test suite**
 
 ```bash
 npm --prefix apps/desktop test
@@ -160,7 +160,7 @@ npm --prefix apps/desktop test
 
 Expected: all UI and Electron Vitest projects pass.
 
-- [ ] **Step 2: Run desktop type checking and linting**
+- [x] **Step 2: Run desktop type checking and linting**
 
 ```bash
 npm --prefix apps/desktop run typecheck
@@ -169,7 +169,7 @@ npm --prefix apps/desktop run lint
 
 Expected: both commands exit with status 0 and report no errors.
 
-- [ ] **Step 3: Run the repository Python suite required by AGENTS.md**
+- [x] **Step 3: Run the repository Python suite required by AGENTS.md**
 
 ```bash
 source venv/bin/activate
@@ -178,7 +178,7 @@ python -m pytest tests/ -q
 
 Expected: the full Python test suite exits with status 0 and no failures.
 
-- [ ] **Step 4: Inspect the final diff and worktree**
+- [x] **Step 4: Inspect the final diff and worktree**
 
 ```bash
 git diff origin/main...HEAD --check

--- a/docs/superpowers/specs/2026-08-11-issue-83391-messaging-profile-scope-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-83391-messaging-profile-scope-design.md
@@ -85,3 +85,11 @@ required full verification suite.
 No configuration or data migration is required. The fix changes only request
 routing when a non-default profile is active; default-profile and
 single-profile behavior remains unchanged.
+
+Known limitation: when multiple profiles share one remote backend, switching
+profiles does not remount `MessagingView`. Its platform data lives in local
+React state and does not respond to `invalidateProfileScopedQueries()`, so the
+page can continue showing the previous profile's credentials until it is
+manually refreshed. This change intentionally fixes request routing only;
+refreshing local Messaging state on a shared-remote profile switch is follow-up
+work.

--- a/docs/superpowers/specs/2026-08-11-issue-83391-messaging-profile-scope-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-83391-messaging-profile-scope-design.md
@@ -1,0 +1,87 @@
+# Issue #83391: Desktop Messaging Profile Scope
+
+## Context
+
+The desktop renderer stores the selected management profile through
+`setApiRequestProfile()`. Profile-aware REST helpers spread `profileScoped()`
+into their `HermesApiRequest`, allowing Electron to route local profiles to the
+correct pooled backend and shared remote profiles to the correct `?profile=`
+scope.
+
+The three messaging-platform helpers omit that request field:
+
+- `getMessagingPlatforms()`
+- `updateMessagingPlatform()`
+- `testMessagingPlatform()`
+
+As a result, Electron routes these requests through the primary/default
+backend even after the user selects another profile. The backend endpoints
+already accept a profile, and the web dashboard already scopes the same three
+operations correctly.
+
+## Goals
+
+- Read messaging credentials and status from the selected desktop profile.
+- Write messaging configuration only to the selected desktop profile.
+- Test messaging state against the selected desktop profile.
+- Preserve existing single-profile behavior when no profile is selected.
+
+## Non-Goals
+
+- Change backend endpoint behavior or profile resolution.
+- Change the Messaging Platforms page or its state management.
+- Change gateway multiplexing or Electron backend-pool architecture.
+- Add manual query-string construction in the renderer helpers.
+
+## Design
+
+Add `...profileScoped()` to each of the three messaging-platform API request
+descriptors in `apps/desktop/src/hermes.ts`. This uses the existing desktop
+profile-routing contract rather than introducing another profile source or
+passing profile names through page components.
+
+The resulting data flow is:
+
+1. The profile store calls `setApiRequestProfile()` when the active profile
+   changes.
+2. A messaging helper includes that profile in its `HermesApiRequest`.
+3. Electron routes a local profile to its pooled backend, or appends the
+   profile query parameter when a shared remote backend requires it.
+4. The existing backend endpoint reads, writes, or tests the target profile.
+
+When no profile is active, `profileScoped()` returns an empty object, preserving
+the primary/default backend path for single-profile users. Request paths,
+methods, bodies, platform ID encoding, and existing error propagation remain
+unchanged.
+
+## Alternatives Considered
+
+1. Automatically scope selected endpoint prefixes inside the Electron API
+   bridge. This could prevent future omissions, but it broadens routing policy
+   in a shared boundary and risks scoping endpoints that are intentionally
+   global.
+2. Pass the active profile explicitly from the Messaging Platforms page into
+   every helper. This duplicates global profile state across components and
+   makes the helper API inconsistent with the rest of the desktop bridge.
+
+The existing `profileScoped()` contract is the smallest and most consistent
+fix.
+
+## Testing
+
+Extend `apps/desktop/src/hermes-profile-scope.test.ts` with a regression test
+that selects a non-default profile, calls all three messaging helpers, and
+asserts that every captured `HermesApiRequest` carries that profile. The test
+also checks the expected paths, methods, and update body so the read, write,
+and test operations are each covered.
+
+The test must fail against the current implementation because all three
+requests omit `profile`, then pass after the production change. Run the focused
+desktop test first, followed by the desktop test suite and the repository's
+required full verification suite.
+
+## Compatibility And Rollout
+
+No configuration or data migration is required. The fix changes only request
+routing when a non-default profile is active; default-profile and
+single-profile behavior remains unchanged.


### PR DESCRIPTION
## Summary

- scope Desktop Messaging platform read, update, and test requests to the active profile
- add regression coverage for active-profile forwarding and the unscoped single-profile path
- document the shared-remote refresh limitation and track it separately in #83587

## Test Plan

- [x] `npm --prefix apps/desktop run test:ui -- src/hermes-profile-scope.test.ts` (5 passed)
- [x] `npm --prefix apps/desktop test` (500 files / 4700 tests passed, 1 file / 2 tests skipped)
- [x] `npm --prefix apps/desktop run typecheck`
- [x] `npm --prefix apps/desktop run lint` (0 errors; 88 existing warnings)
- [x] `git diff origin/main...HEAD --check`

Closes #83391.

Related: #76899.
Follow-up: #83587.