### PR TITLE
fix(cron): application-level cron job bug fixes

### DIFF
--- a/.github/workflows/skills-index-freshness.yml
+++ b/.github/workflows/skills-index-freshness.yml
@@ -109,6 +109,10 @@ jobs:
             echo "Summary:      ${{ steps.probe.outputs.summary }}"
           fi
 
+      - name: Checkout
+        if: steps.probe.outputs.status != 'ok'
+        uses: actions/checkout@v4
+
       - name: Get GitHub App token
         if: steps.probe.outputs.status != 'ok'
         id: app-token

--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -20,7 +20,7 @@ jobs:
     # Only run on the upstream repository, not on forks
     if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     environment: trusted-automation
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/scripts/build_skills_index.py
+++ b/scripts/build_skills_index.py
@@ -162,9 +162,13 @@ def batch_resolve_paths(skills: list, auth: GitHubAuth) -> list:
     print(f"    {len(by_repo)} unique repos to scan", flush=True)
 
     resolved_count = 0
+    _completed_repos = 0
+    _total_repos = len(by_repo)
+    _resolve_start = time.time()
 
     # Fetch trees in parallel (up to 6 concurrent)
     def _resolve_repo(repo: str, entries: list):
+        nonlocal _completed_repos
         tree = _fetch_repo_tree(repo, auth)
         if not tree:
             return 0
@@ -232,6 +236,14 @@ def batch_resolve_paths(skills: list, auth: GitHubAuth) -> list:
             except Exception as e:
                 repo = futures[future]
                 print(f"    Warning: {repo}: {e}", file=sys.stderr)
+            _completed_repos += 1
+            if _completed_repos % 50 == 0:
+                elapsed = time.time() - _resolve_start
+                rate = _completed_repos / elapsed if elapsed > 0 else 0
+                remaining = (_total_repos - _completed_repos) / rate if rate > 0 else 0
+                print(f"    Progress: {_completed_repos}/{_total_repos} repos "
+                      f"({resolved_count} resolved, {elapsed:.0f}s elapsed, "
+                      f"~{remaining:.0f}s remaining)", flush=True)
 
     elapsed = time.time() - start
     print(f"  Resolved {resolved_count}/{len(skills_sh)} paths ({elapsed:.1f}s)",


### PR DESCRIPTION
## Summary

Fixes 3 application-level bugs from the Hermes cron RCA (task t_e83b6477).

### Changes

**1. skills-index-freshness.yml — missing checkout (RCA §4)**
The freshness watchdog correctly detects index degradation but crashes when trying to open a GitHub issue because there's no `actions/checkout` before the `get-app-token` composite action. Added a conditional checkout step.

Before: `Can't find 'action.yml' ... Did you forget to run actions/checkout?`
After: checkout runs → token resolves → issue opens.

**2. skills-index.yml — build timeout (RCA §5)**
`build-index` job timed out at 15m on the last 4 scheduled runs, leaving the skills index 505+ hours stale. Increased to 30m to accommodate the larger catalog (20k+ skills.sh + 50k+ ClawHub).

**3. build_skills_index.py — progress visibility (RCA §5)**
Added progress logging to `batch_resolve_paths` (the biggest time black box — fetches trees for hundreds of GitHub repos). Logs every 50 repos with count, elapsed time, and ETA so CI timeout causes are visible.

### Test plan
- [x] Python compile check passes
- [x] YAML validation passes
- [ ] CI workflow runs successfully on next scheduled trigger
- [ ] Freshness watchdog can open issues after index degradation

### Related
- RCA document: attachments/t_41dd1490/cron-rca.md (kanban board: conduit)
- Parent task: t_41dd1490 (root cause diagnosis)
- Config/secrets fixes handled by sibling task t_6e612417