### PR TITLE
feat(skills): pin GitHub branch and PR installs to commits

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -502,7 +502,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
-               name_override: str = "") -> None:
+               name_override: str = "", ref: str = "", pr: str = "") -> None:
     """Fetch, quarantine, scan, confirm, and install a skill.
 
     ``name_override`` lets non-interactive callers (slash commands, gateway,
@@ -533,7 +533,20 @@ def do_install(identifier: str, category: str = "", force: bool = False,
 
     c.print(f"\n[bold]Fetching:[/] {identifier}")
 
-    meta, bundle, _matched_source = _resolve_source_meta_and_bundle(identifier, sources)
+    if ref or pr:
+        from tools.skills_hub import GitHubSource
+        github_source = next((source for source in sources if isinstance(source, GitHubSource)), None)
+        if github_source is None:
+            c.print("[bold red]Error:[/] GitHub source is unavailable.\n")
+            return
+        try:
+            meta = github_source.inspect(identifier)
+            bundle = github_source.fetch(identifier, ref=ref or None, pr=pr or None)
+        except ValueError as exc:
+            c.print(f"[bold red]Error:[/] {exc}\n")
+            return
+    else:
+        meta, bundle, _matched_source = _resolve_source_meta_and_bundle(identifier, sources)
 
     if not bundle:
         # Check if any source hit GitHub API rate limit
@@ -1711,7 +1724,8 @@ def skills_command(args) -> None:
     elif action == "install":
         do_install(args.identifier, category=args.category, force=args.force,
                    skip_confirm=getattr(args, "yes", False),
-                   name_override=getattr(args, "name", "") or "")
+                   name_override=getattr(args, "name", "") or "",
+                   ref=getattr(args, "ref", "") or "", pr=getattr(args, "pr", "") or "")
     elif action == "inspect":
         do_inspect(args.identifier)
     elif action == "list":
@@ -1865,11 +1879,13 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
 
     elif action == "install":
         if not args:
-            c.print("[bold red]Usage:[/] /skills install <identifier-or-url> [--name <name>] [--category <cat>] [--force] [--now]\n")
+            c.print("[bold red]Usage:[/] /skills install <identifier-or-url> [--name <name>] [--category <cat>] [--ref <ref>|--pr <number-or-url>] [--force] [--now]\n")
             return
         identifier = args[0]
         category = ""
         name_override = ""
+        ref = ""
+        pr = ""
         # Slash commands run inside prompt_toolkit where input() hangs.
         # Always skip confirmation — the user typing the command is implicit consent.
         skip_confirm = True
@@ -1882,9 +1898,16 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
                 category = args[i + 1]
             elif a == "--name" and i + 1 < len(args):
                 name_override = args[i + 1]
+            elif a == "--ref" and i + 1 < len(args):
+                ref = args[i + 1]
+            elif a == "--pr" and i + 1 < len(args):
+                pr = args[i + 1]
+        if ref and pr:
+            c.print("[bold red]Error:[/] Specify either --ref or --pr, not both.\n")
+            return
         do_install(identifier, category=category, force=force,
                    skip_confirm=skip_confirm, invalidate_cache=invalidate_cache,
-                   name_override=name_override, console=c)
+                   name_override=name_override, ref=ref, pr=pr, console=c)
 
     elif action == "inspect":
         if not args:

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -101,6 +101,13 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
     skills_install.add_argument(
         "--force", action="store_true", help="Install despite blocked scan verdict"
     )
+    selector_group = skills_install.add_mutually_exclusive_group()
+    selector_group.add_argument(
+        "--ref", default="", help="Git branch/ref or full 40-character commit SHA (GitHub skills only)"
+    )
+    selector_group.add_argument(
+        "--pr", default="", help="GitHub PR number or URL (same-repository PRs only)"
+    )
     skills_install.add_argument(
         "--yes",
         "-y",

--- a/tests/hermes_cli/test_skills_git_refs.py
+++ b/tests/hermes_cli/test_skills_git_refs.py
@@ -1,0 +1,37 @@
+"""CLI and slash parsing coverage for immutable GitHub skill selectors."""
+
+import sys
+from unittest.mock import patch
+
+
+def test_cli_install_forwards_ref(monkeypatch):
+    from hermes_cli.main import main
+
+    captured = {}
+    monkeypatch.setattr("hermes_cli.skills_hub.skills_command", lambda args: captured.update(ref=args.ref, pr=args.pr))
+    monkeypatch.setattr(sys, "argv", ["hermes", "skills", "install", "owner/repo/demo", "--ref", "release/v1"])
+    main()
+    assert captured == {"ref": "release/v1", "pr": ""}
+
+
+def test_cli_install_forwards_pr(monkeypatch):
+    from hermes_cli.main import main
+
+    captured = {}
+    monkeypatch.setattr("hermes_cli.skills_hub.skills_command", lambda args: captured.update(ref=args.ref, pr=args.pr))
+    monkeypatch.setattr(sys, "argv", ["hermes", "skills", "install", "owner/repo/demo", "--pr", "42"])
+    main()
+    assert captured == {"ref": "", "pr": "42"}
+
+
+def test_slash_install_forwards_ref_and_rejects_conflicting_selector():
+    from hermes_cli.skills_hub import handle_skills_slash
+
+    with patch("hermes_cli.skills_hub.do_install") as install:
+        handle_skills_slash("/skills install owner/repo/demo --ref release/v1")
+        assert install.call_args.kwargs["ref"] == "release/v1"
+        assert install.call_args.kwargs["pr"] == ""
+
+    with patch("hermes_cli.skills_hub.do_install") as install:
+        handle_skills_slash("/skills install owner/repo/demo --ref main --pr 42")
+        install.assert_not_called()

--- a/tests/tools/test_skills_hub_git_refs.py
+++ b/tests/tools/test_skills_hub_git_refs.py
@@ -1,0 +1,136 @@
+"""Focused coverage for immutable GitHub skill installs."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.skills_hub import GitHubAuth, GitHubSource, HubLockFile
+
+
+FULL_SHA = "a" * 40
+
+
+def _response(payload, *, content=b""):
+    response = MagicMock(status_code=200, content=content)
+    response.json.return_value = payload
+    return response
+
+
+def test_fetch_full_sha_uses_sha_tree_and_records_checkout_metadata(monkeypatch):
+    source = GitHubSource(auth=GitHubAuth())
+    calls = []
+
+    def github_get(url, **kwargs):
+        calls.append(url)
+        if url.endswith(f"/git/trees/{FULL_SHA}"):
+            return _response({"sha": FULL_SHA, "truncated": False, "tree": [
+                {"path": "skills/demo/SKILL.md", "type": "blob", "mode": "100644", "sha": "skill"},
+                {"path": "skills/demo/scripts/run.py", "type": "blob", "mode": "100644", "sha": "script"},
+            ]})
+        if url.endswith("/git/blobs/skill"):
+            return _response({}, content=b"---\nname: demo\n---\n# Demo\n")
+        if url.endswith("/git/blobs/script"):
+            return _response({}, content=b"print('ok')\n")
+        raise AssertionError(url)
+
+    monkeypatch.setattr(source, "_github_get", github_get)
+    bundle = source.fetch("owner/repo/skills/demo", ref=FULL_SHA)
+
+    assert bundle is not None
+    assert set(bundle.files) == {"SKILL.md", "scripts/run.py"}
+    assert bundle.metadata["git"]["selector_type"] == "commit"
+    assert bundle.metadata["git"]["requested_selector"] == FULL_SHA
+    assert bundle.metadata["git"]["resolved_sha"] == FULL_SHA
+    assert "resolved_at" in bundle.metadata["git"]
+    assert all("/contents/" not in call for call in calls)
+
+
+def test_fetch_branch_resolves_once_then_reads_immutable_sha_tree(monkeypatch):
+    source = GitHubSource(auth=GitHubAuth())
+    calls = []
+
+    def github_get(url, **kwargs):
+        calls.append(url)
+        if url.endswith("/commits/release/v1"):
+            return _response({"sha": FULL_SHA})
+        if url.endswith(f"/git/trees/{FULL_SHA}"):
+            return _response({"truncated": False, "tree": [
+                {"path": "demo/SKILL.md", "type": "blob", "mode": "100644", "sha": "skill"},
+            ]})
+        if url.endswith("/git/blobs/skill"):
+            return _response({}, content=b"# Demo")
+        raise AssertionError(url)
+
+    monkeypatch.setattr(source, "_github_get", github_get)
+    bundle = source.fetch("owner/repo/demo", ref="release/v1")
+
+    assert bundle is not None
+    assert bundle.metadata["git"]["selector_type"] == "ref"
+    assert bundle.metadata["git"]["requested_selector"] == "release/v1"
+    assert bundle.metadata["git"]["resolved_sha"] == FULL_SHA
+    assert sum("/commits/release/v1" in call for call in calls) == 1
+
+
+@pytest.mark.parametrize("short_sha", ["a" * 7, "A" * 39])
+def test_fetch_rejects_short_commit_sha(short_sha):
+    source = GitHubSource(auth=GitHubAuth())
+    with pytest.raises(ValueError, match="full 40-character commit SHA"):
+        source.fetch("owner/repo/demo", ref=short_sha)
+
+
+def test_fetch_pr_locks_same_repo_head_provenance(monkeypatch):
+    source = GitHubSource(auth=GitHubAuth())
+
+    def github_get(url, **kwargs):
+        if url.endswith("/pulls/42"):
+            return _response({"number": 42, "html_url": "https://github.com/owner/repo/pull/42", "head": {
+                "sha": FULL_SHA, "ref": "feature", "label": "owner:feature",
+                "repo": {"full_name": "owner/repo"},
+            }})
+        if url.endswith(f"/git/trees/{FULL_SHA}"):
+            return _response({"truncated": False, "tree": [
+                {"path": "demo/SKILL.md", "type": "blob", "mode": "100644", "sha": "skill"},
+            ]})
+        if url.endswith("/git/blobs/skill"):
+            return _response({}, content=b"# Demo")
+        raise AssertionError(url)
+
+    monkeypatch.setattr(source, "_github_get", github_get)
+    bundle = source.fetch("owner/repo/demo", pr="https://github.com/owner/repo/pull/42")
+
+    assert bundle is not None
+    git = bundle.metadata["git"]
+    assert git["selector_type"] == "pr"
+    assert git["requested_selector"] == "https://github.com/owner/repo/pull/42"
+    assert git["pr"]["number"] == 42
+    assert git["pr"]["head_repo"] == "owner/repo"
+    assert git["pr"]["head_sha"] == FULL_SHA
+
+
+def test_fetch_rejects_fork_pr_by_default(monkeypatch):
+    source = GitHubSource(auth=GitHubAuth())
+    monkeypatch.setattr(source, "_github_get", lambda *_args, **_kwargs: _response({
+        "head": {"sha": FULL_SHA, "repo": {"full_name": "fork/repo"}},
+    }))
+
+    with pytest.raises(ValueError, match="Fork PR"):
+        source.fetch("owner/repo/demo", pr="42")
+
+
+def test_lock_file_preserves_immutable_git_provenance(tmp_path):
+    metadata = {
+        "git": {
+            "selector_type": "pr",
+            "requested_selector": "42",
+            "resolved_sha": FULL_SHA,
+            "resolved_at": "2026-08-10T00:00:00+00:00",
+            "pr": {"number": 42, "head_sha": FULL_SHA, "head_repo": "owner/repo"},
+        }
+    }
+    lock = HubLockFile(path=tmp_path / "lock.json")
+    lock.record_install(
+        name="demo", source="github", identifier="owner/repo/demo", trust_level="community",
+        scan_verdict="pass", skill_hash="hash", install_path="demo", files=["SKILL.md"],
+        metadata=metadata,
+    )
+    assert lock.get_installed("demo")["metadata"] == metadata

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -526,6 +526,10 @@ def github_provider_for(repo: str) -> Optional[str]:
 # source ids — they narrow the merged results to GitHub-tap skills carrying the
 # matching ``extra.provider`` label (see ``_filter_results_by_provider``).
 _PROVIDER_FILTER_VALUES = frozenset(v.lower() for v in GITHUB_TAP_PROVIDERS.values())
+_FULL_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_GITHUB_PR_URL_RE = re.compile(
+    r"^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)/?$", re.IGNORECASE
+)
 
 
 def _filter_results_by_provider(
@@ -630,39 +634,42 @@ class GitHubSource(SkillSource):
 
         return results[:limit]
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
-        """
-        Download a skill from GitHub.
-        identifier format: "owner/repo/path/to/skill-dir"
-        """
+    def fetch(
+        self, identifier: str, *, ref: Optional[str] = None, pr: Optional[str] = None,
+    ) -> Optional[SkillBundle]:
+        """Download a skill, optionally pinned to an immutable GitHub checkout."""
         parts = identifier.split("/", 2)
         if len(parts) < 3:
             return None
-
         repo = f"{parts[0]}/{parts[1]}"
-        skill_path = parts[2]
+        skill_path = parts[2].rstrip("/")
 
-        skill_md = self._fetch_file_content(repo, f"{skill_path.rstrip('/')}/SKILL.md")
+        if ref is not None or pr is not None:
+            if ref and pr:
+                raise ValueError("Specify either --ref or --pr, not both")
+            checkout = self._resolve_immutable_checkout(repo, ref=ref, pr=pr)
+            if checkout is None:
+                return None
+            resolved_sha, git_metadata = checkout
+            return self._fetch_skill_at_sha(repo, skill_path, identifier, resolved_sha, git_metadata)
+
+        # Preserve the legacy default-branch path for existing installs.
+        skill_md = self._fetch_file_content(repo, f"{skill_path}/SKILL.md")
         if skill_md is None:
             return None
         referenced = _referenced_support_paths(skill_md)
         if referenced is None:
             return None
-
         files: Dict[str, Union[str, bytes]] = {"SKILL.md": skill_md}
         tree = self._get_repo_tree(repo)
         if tree is not None:
             branch, entries = tree
-            prefix = f"{skill_path.rstrip('/')}/"
+            prefix = f"{skill_path}/"
             entries_by_path = {item.get("path", ""): item for item in entries}
             for rel_path in sorted(referenced):
                 item_path = f"{prefix}{rel_path}"
                 item = entries_by_path.get(item_path)
-                if item is None:
-                    logger.warning("Referenced skill support file is missing: %s", item_path)
-                    return None
-                if item.get("type") != "blob" or item.get("mode") == "120000":
-                    logger.warning("Rejected non-regular file in skill bundle: %s", item_path)
+                if item is None or item.get("type") != "blob" or item.get("mode") == "120000":
                     return None
                 content = self._fetch_file_bytes(repo, item_path)
                 if content is None:
@@ -671,29 +678,100 @@ class GitHubSource(SkillSource):
             revision = self._tree_revisions.get(repo) or branch
         else:
             for rel_path in referenced:
-                content = self._fetch_file_bytes(repo, f"{skill_path.rstrip('/')}/{rel_path}")
+                content = self._fetch_file_bytes(repo, f"{skill_path}/{rel_path}")
                 if content is None:
                     return None
                 files[rel_path] = content
             revision = ""
-
-        skill_name = skill_path.rstrip("/").split("/")[-1]
-        trust = self.trust_level_for(identifier)
-
         return SkillBundle(
-            name=skill_name,
-            files=files,
-            source="github",
-            identifier=identifier,
-            trust_level=trust,
-            metadata={
-                "source_url": (
-                    f"https://github.com/{repo}/tree/{revision}/{skill_path}"
-                    if revision else f"https://github.com/{repo}/{skill_path}"
-                ),
-                "source_revision": revision,
-            },
+            name=skill_path.split("/")[-1], files=files, source="github", identifier=identifier,
+            trust_level=self.trust_level_for(identifier),
+            metadata={"source_url": f"https://github.com/{repo}/tree/{revision}/{skill_path}" if revision else f"https://github.com/{repo}/{skill_path}", "source_revision": revision},
         )
+
+    def _resolve_immutable_checkout(self, repo: str, *, ref: Optional[str], pr: Optional[str]) -> Optional[Tuple[str, Dict[str, Any]]]:
+        """Resolve a branch/PR once; every subsequent request is SHA-addressed."""
+        requested = pr if pr is not None else ref
+        if not isinstance(requested, str) or not requested.strip():
+            raise ValueError("Git selector must not be empty")
+        requested, resolved_at = requested.strip(), datetime.now(timezone.utc).isoformat()
+        if pr is not None:
+            match = _GITHUB_PR_URL_RE.fullmatch(requested)
+            if match:
+                if f"{match.group(1)}/{match.group(2)}".lower() != repo.lower():
+                    raise ValueError("GitHub PR URL repository must match the skill identifier")
+                number = int(match.group(3))
+            elif requested.isdigit() and int(requested) > 0:
+                number = int(requested)
+            else:
+                raise ValueError("--pr must be a positive GitHub PR number or pull-request URL")
+            response = self._github_get(f"https://api.github.com/repos/{repo}/pulls/{number}")
+            if response is None or response.status_code != 200:
+                return None
+            data = response.json()
+            if not isinstance(data, dict):
+                return None
+            head = data.get("head", {})
+            if not isinstance(head, dict):
+                return None
+            head_repo = head.get("repo") or {}
+            if not isinstance(head_repo, dict):
+                return None
+            head_repo_name, resolved_sha = head_repo.get("full_name", ""), head.get("sha", "")
+            if not isinstance(head_repo_name, str) or head_repo_name.lower() != repo.lower():
+                raise ValueError("Fork PRs are rejected by default")
+            if not isinstance(resolved_sha, str) or not _FULL_GIT_SHA_RE.fullmatch(resolved_sha):
+                return None
+            resolved_sha = resolved_sha.lower()
+            return resolved_sha, {"selector_type": "pr", "requested_selector": requested, "resolved_sha": resolved_sha, "resolved_at": resolved_at, "pr": {"number": data.get("number", number), "url": data.get("html_url", f"https://github.com/{repo}/pull/{number}"), "head_sha": resolved_sha, "head_ref": head.get("ref", ""), "head_label": head.get("label", ""), "head_repo": head_repo_name}}
+        if _FULL_GIT_SHA_RE.fullmatch(requested):
+            resolved_sha, selector_type = requested.lower(), "commit"
+        elif re.fullmatch(r"[0-9a-fA-F]{1,39}", requested):
+            raise ValueError("Commit SHAs must be full 40-character commit SHA values")
+        else:
+            response = self._github_get(f"https://api.github.com/repos/{repo}/commits/{requested}")
+            if response is None or response.status_code != 200:
+                return None
+            resolved_sha = response.json().get("sha", "")
+            if not isinstance(resolved_sha, str) or not _FULL_GIT_SHA_RE.fullmatch(resolved_sha):
+                return None
+            resolved_sha, selector_type = resolved_sha.lower(), "ref"
+        return resolved_sha, {"selector_type": selector_type, "requested_selector": requested, "resolved_sha": resolved_sha, "resolved_at": resolved_at}
+
+    def _fetch_skill_at_sha(self, repo: str, skill_path: str, identifier: str, resolved_sha: str, git_metadata: Dict[str, Any]) -> Optional[SkillBundle]:
+        """Fetch the complete regular-file skill tree from an isolated SHA tree."""
+        response = self._github_get(f"https://api.github.com/repos/{repo}/git/trees/{resolved_sha}", params={"recursive": "1"}, timeout=30)
+        if response is None or response.status_code != 200:
+            return None
+        tree_data = response.json()
+        if not isinstance(tree_data, dict) or tree_data.get("truncated"):
+            return None
+        prefix = f"{skill_path}/"
+        entries = [e for e in tree_data.get("tree", []) if isinstance(e, dict) and str(e.get("path", "")).startswith(prefix)]
+        if not any(e.get("path") == f"{skill_path}/SKILL.md" and e.get("type") == "blob" and e.get("mode") != "120000" for e in entries):
+            return None
+        files: Dict[str, Union[str, bytes]] = {}
+        for entry in entries:
+            if entry.get("type") != "blob" or entry.get("mode") == "120000" or not isinstance(entry.get("sha"), str):
+                return None
+            blob = self._github_get(f"https://api.github.com/repos/{repo}/git/blobs/{entry['sha']}", headers={**self.auth.get_headers(), "Accept": "application/vnd.github.v3.raw"})
+            if blob is None or blob.status_code != 200:
+                return None
+            try:
+                relative_path = _validate_bundle_rel_path(entry["path"][len(prefix):])
+            except ValueError:
+                # A pinned checkout is still untrusted input. Fail closed rather
+                # than allowing an unsupported path to escape the skill bundle.
+                return None
+            files[relative_path] = blob.content
+        skill_md = files.get("SKILL.md")
+        if not isinstance(skill_md, bytes):
+            return None
+        try:
+            files["SKILL.md"] = skill_md.decode("utf-8")
+        except (KeyError, UnicodeDecodeError):
+            return None
+        return SkillBundle(name=skill_path.split("/")[-1], files=files, source="github", identifier=identifier, trust_level=self.trust_level_for(identifier), metadata={"source_url": f"https://github.com/{repo}/tree/{resolved_sha}/{skill_path}", "source_revision": resolved_sha, "git": git_metadata})
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
         """Fetch just the SKILL.md metadata for preview."""


### PR DESCRIPTION
Adds --ref and --pr resolution to immutable GitHub SHAs, full skill-directory fetch from the resolved tree, lock provenance, and fail-closed fork/short-SHA handling. Focused suite: 188 passed.