### PR TITLE
Enforce ownership review on terminal fallback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -88,7 +88,11 @@ from agent.retry_utils import (
 from agent.trajectory import has_incomplete_scratchpad
 # Bind before the turn starts so a source-tree swap cannot load a skewed
 # finalizer at turn end.
-from agent.turn_finalizer import finalize_turn
+from agent.turn_finalizer import (
+    _PRE_VERIFY_FALLBACK_SOURCES,
+    _pre_verify_continuation_for_candidate,
+    finalize_turn,
+)
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
@@ -1598,6 +1602,14 @@ def run_conversation(
     # reused as the final response — not merely because any interim was
     # streamed. (#65919 review: response-loss blocker)
     _pending_verification_response_previewed = False
+    # Provenance keeps the ownership fallback scoped to the two completion
+    # gates that require it. Kanban stop uses the same pending-response slot
+    # but must retain its existing terminal-tool behavior.
+    _pending_verification_source = None
+    # A pre-existing grace flag already represents this turn's one allowance.
+    # Once consumed, a second rejection must finalize fail-closed instead of
+    # recursively arming another provider call.
+    _pre_verify_budget_grace_used = bool(agent._budget_grace_call)
     # If pre-API compression fires after MoA advisors have produced guidance,
     # retain that ephemeral output and rebase it onto the compacted transcript
     # on the next loop iteration. This prevents a second advisor fan-out.
@@ -1631,7 +1643,106 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
-    while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+    def _finalize_current_turn(*, allow_pre_verify_budget_grace=False):
+        result = finalize_turn(
+            agent,
+            final_response=final_response,
+            api_call_count=api_call_count,
+            interrupted=interrupted,
+            failed=failed,
+            messages=messages,
+            conversation_history=conversation_history,
+            effective_task_id=effective_task_id,
+            turn_id=turn_id,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            _should_review_memory=_should_review_memory,
+            _turn_exit_reason=_turn_exit_reason,
+            _pending_verification_response=_pending_verification_response,
+            _pending_verification_response_previewed=(
+                _pending_verification_response_previewed
+            ),
+            _pending_verification_source=_pending_verification_source,
+            _allow_pre_verify_budget_grace=allow_pre_verify_budget_grace,
+        )
+        # A grace allowance belongs to this turn only. The normal provider
+        # path consumes it, but an interrupt/redirect can finalize before that
+        # call starts; never let the flag leak into a later user turn.
+        if not result.get("_retry_with_budget_grace"):
+            agent._budget_grace_call = False
+        return result
+
+    while (
+        api_call_count < agent.max_iterations
+        and agent.iteration_budget.remaining > 0
+    ) or agent._budget_grace_call or (
+        _pending_verification_response is not None
+        and _pending_verification_source in _PRE_VERIFY_FALLBACK_SOURCES
+    ):
+        _has_regular_iteration = (
+            api_call_count < agent.max_iterations
+            and agent.iteration_budget.remaining > 0
+        )
+        if (
+            not _has_regular_iteration
+            and not agent._budget_grace_call
+            and _pending_verification_response is not None
+            and _pending_verification_source
+            in _PRE_VERIFY_FALLBACK_SOURCES
+        ):
+            # Reconsider the held candidate at the common finalizer. At the
+            # ordinary API-call cap only, a rejection may consume the loop's
+            # existing one-call grace allowance. Shared-budget exhaustion does
+            # not get to exceed its owner.
+            _fallback_result = _finalize_current_turn(
+                allow_pre_verify_budget_grace=(
+                    api_call_count >= agent.max_iterations
+                    and not _pre_verify_budget_grace_used
+                )
+            )
+            if not _fallback_result.get("_retry_with_budget_grace"):
+                return _fallback_result
+
+            _continuation_directive = _fallback_result[
+                "continuation_directive"
+            ]
+            # The common-finalizer recheck is a real ownership attempt. Move
+            # the counter forward before the recovery response is evaluated so
+            # hooks do not see the same attempt number twice.
+            agent._pre_verify_nudges = (
+                getattr(agent, "_pre_verify_nudges", 0) + 1
+            )
+            _pre_verify_budget_grace_used = True
+            agent._budget_grace_call = True
+            _pending_verification_response = None
+            _pending_verification_response_previewed = False
+            _pending_verification_source = None
+
+            # Reuse the existing synthetic continuation row so role
+            # alternation stays intact and the recovery provider call sees the
+            # finalizer's current ownership directive.
+            for _message in reversed(messages):
+                if not isinstance(_message, dict):
+                    continue
+                if (
+                    _message.get("role") == "user"
+                    and (
+                        _message.get("_pre_verify_synthetic")
+                        or _message.get("_verification_stop_synthetic")
+                    )
+                ):
+                    _message["content"] = _continuation_directive
+                    _message["_pre_verify_synthetic"] = True
+                    break
+            else:
+                messages.append({
+                    "role": "user",
+                    "content": _continuation_directive,
+                    "_pre_verify_synthetic": True,
+                })
+            agent._session_messages = messages
+            continue
+
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:
             _apply_active_turn_redirect(agent, messages, _redirect_text)
@@ -7464,17 +7575,32 @@ def run_conversation(
                         getattr(agent, "_verification_stop_nudges", 0) + 1
                     )
                     final_msg["finish_reason"] = "verification_required"
-                    # The assistant response is real content — persist it and
-                    # emit to the UI as an interim message so the user sees the
-                    # attempted final answer before the verification loop runs.
-                    # Only the nudge is flagged synthetic so it gets stripped
-                    # from the durable transcript (#65919 §7).
-                    agent._emit_interim_assistant_message(final_msg)
+                    _can_continue_verification = (
+                        api_call_count < agent.max_iterations
+                        and agent.iteration_budget.remaining > 0
+                    )
+                    # With ordinary continuation budget, surface the candidate
+                    # as interim progress. At the terminal boundary it must be
+                    # buffered until the common finalizer rechecks ownership;
+                    # a rejected completion claim must never reach the UI.
+                    if _can_continue_verification:
+                        agent._emit_interim_assistant_message(final_msg)
                     messages.append(final_msg)
-                    try:
-                        agent._flush_messages_to_session_db(messages, conversation_history)
-                    except Exception:
-                        logger.debug("verify-on-stop interim flush failed", exc_info=True)
+                    # A candidate with no ordinary continuation budget must
+                    # first cross the common finalizer's ownership check. Keep
+                    # it live for that decision, but do not make a potentially
+                    # rejected terminal claim append-only durable yet.
+                    if _can_continue_verification:
+                        try:
+                            agent._flush_messages_to_session_db(
+                                messages,
+                                conversation_history,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "verify-on-stop interim flush failed",
+                                exc_info=True,
+                            )
                     messages.append({
                         "role": "user",
                         "content": _verify_nudge,
@@ -7497,6 +7623,7 @@ def run_conversation(
                     _pending_verification_response_previewed = (
                         agent._interim_content_was_streamed(final_response or "")
                     )
+                    _pending_verification_source = "verification_stop"
                     final_response = None
                     continue
 
@@ -7505,48 +7632,24 @@ def run_conversation(
                 # going one more turn. The shipped guidance is folded into the
                 # evidence-based verify-on-stop nudge above, so this path has no
                 # default continuation cost.
-                _verify_nudge2 = None
-                _edited = sorted(getattr(agent, "_turn_file_mutation_paths", set()) or [])
                 _attempt = getattr(agent, "_pre_verify_nudges", 0)
-                try:
-                    from agent.verify_hooks import max_verify_nudges
-                    from hermes_cli.lifecycle import has_hook
-                    from hermes_cli.plugins import get_pre_verify_continue_message
-
-                    if _edited and has_hook("pre_verify") and _attempt < max_verify_nudges():
-                        # Posture is fixed for the session — resolve once + cache.
-                        coding = getattr(agent, "_resolved_is_coding", None)
-                        if coding is None:
-                            from agent.coding_context import is_coding_context
-                            coding = bool(is_coding_context(platform=getattr(agent, "platform", "") or ""))
-                            agent._resolved_is_coding = coding
-                        _verify_nudge2 = get_pre_verify_continue_message(
-                            session_id=getattr(agent, "session_id", None) or "",
-                            platform=getattr(agent, "platform", "") or "",
-                            model=getattr(agent, "model", "") or "",
-                            coding=coding,
-                            attempt=_attempt,
-                            final_response=final_response,
-                            changed_paths=_edited,
-                        )
-                except Exception:
-                    logger.debug("pre_verify hook check failed", exc_info=True)
-                    _verify_nudge2 = None
+                _verify_nudge2 = _pre_verify_continuation_for_candidate(
+                    agent,
+                    final_response,
+                    logger,
+                    respect_nudge_limit=not _pre_verify_budget_grace_used,
+                )
 
                 if _verify_nudge2:
                     agent._pre_verify_nudges = _attempt + 1
                     final_msg["finish_reason"] = "verify_hook_continue"
-                    # The assistant response is real content — persist it and
-                    # emit to the UI as an interim message so the user sees the
-                    # attempted final answer before the pre_verify loop runs.
-                    # Only the nudge is flagged synthetic so it gets stripped
-                    # from the durable transcript (#65919 §7).
-                    agent._emit_interim_assistant_message(final_msg)
+                    # The ownership hook rejected this completion candidate.
+                    # Keep the assistant/user pair live for the bounded
+                    # continuation request, but do not emit or flush the
+                    # rejected candidate. The common finalizer removes this
+                    # flagged row unless a later ownership recheck allows it.
+                    final_msg["_pre_verify_synthetic"] = True
                     messages.append(final_msg)
-                    try:
-                        agent._flush_messages_to_session_db(messages, conversation_history)
-                    except Exception:
-                        logger.debug("pre_verify interim flush failed", exc_info=True)
                     messages.append({
                         "role": "user",
                         "content": _verify_nudge2,
@@ -7559,6 +7662,7 @@ def run_conversation(
                     _pending_verification_response_previewed = (
                         agent._interim_content_was_streamed(final_response or "")
                     )
+                    _pending_verification_source = "pre_verify"
                     final_response = None
                     continue
 
@@ -7609,6 +7713,7 @@ def run_conversation(
                     _pending_verification_response_previewed = (
                         agent._interim_content_was_streamed(final_response or "")
                     )
+                    _pending_verification_source = "kanban_stop"
                     final_response = None
                     continue
 
@@ -7731,26 +7836,9 @@ def run_conversation(
                 messages.append({"role": "assistant", "content": final_response})
                 break
     
-    # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
-    # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
-    # result dict is returned exactly as before.
-    return finalize_turn(
-        agent,
-        final_response=final_response,
-        api_call_count=api_call_count,
-        interrupted=interrupted,
-        failed=failed,
-        messages=messages,
-        conversation_history=conversation_history,
-        effective_task_id=effective_task_id,
-        turn_id=turn_id,
-        user_message=user_message,
-        original_user_message=original_user_message,
-        _should_review_memory=_should_review_memory,
-        _turn_exit_reason=_turn_exit_reason,
-        _pending_verification_response=_pending_verification_response,
-        _pending_verification_response_previewed=_pending_verification_response_previewed,
-    )
+    # Every post-loop exit, including ownership fallback, crosses the common
+    # finalizer before its result is returned.
+    return _finalize_current_turn()
 
 
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -8,11 +8,11 @@ budget-exhaustion summary, trajectory save, session persist, turn diagnostics,
 response transforms, result-dict assembly, steer drain, and the memory/skill
 review trigger.
 
-Behavior-neutral: the body is moved unchanged. All ``agent.*`` side effects fire
-exactly as before; only the post-loop *locals* are passed in as keyword args, and
-the assembled ``result`` dict is returned to ``run_conversation`` which returns it
-to the caller. The function is synchronous with a single return — mirroring the
-region it replaces (no awaits, no early returns).
+The extraction was behavior-neutral; this module now also owns decisions that
+must be common to every post-loop exit, including verification-candidate
+fallback. All post-loop locals are passed as keyword args and the assembled
+``result`` dict is returned to ``run_conversation``. The function remains
+synchronous.
 
 Module ``logger`` is imported lazily inside the body (``from
 agent.conversation_loop import logger``) so this module never imports
@@ -43,28 +43,120 @@ def _is_pure_tool_call_tail(msg: dict) -> bool:
     return not flatten_message_text(msg.get("content")).strip()
 
 
-# Verification continuation scaffolding flags: verify-on-stop / pre_verify
-# inject a synthetic user nudge to keep the agent going one more turn.
-# These nudges must be stripped from returned/live history to avoid
-# role-alternation breaks and poisoning the resumed transcript. The
-# assistant response is real content and is not flagged. (#65919 §7)
+# Verification continuation scaffolding flags. verify-on-stop / pre_verify
+# inject a synthetic user nudge to keep the agent going one more turn; the
+# ownership fallback also marks an assistant candidate only after rejecting
+# it. Allowed assistant responses remain real, unflagged content. All flagged
+# rows must be stripped to preserve role alternation and resumed history.
+# (#65919 §7)
 _VERIFICATION_CONTINUATION_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+)
+
+_PRE_VERIFY_FALLBACK_SOURCES = frozenset({"pre_verify", "verification_stop"})
+_PRE_VERIFY_HOOK_FAILURE_CONTINUATION = (
+    "The pre-verify completion check failed. Continue working and retry "
+    "verification before reporting completion."
 )
 
 
 def _drop_verification_continuation_scaffolding(messages) -> None:
     """Remove verification-continuation nudge messages from *messages* in place.
 
-    Only the synthetic nudges carry these flags, so this strips just the
-    nudges while preserving the real attempted-final-answer that was
-    persisted to state.db.
+    This strips synthetic nudges and any candidate the ownership boundary
+    rejected, while preserving allowed attempted-final answers.
     """
     messages[:] = [
         m for m in messages
         if not (isinstance(m, dict) and any(m.get(f) for f in _VERIFICATION_CONTINUATION_FLAGS))
     ]
+
+
+def _pre_verify_continuation_for_candidate(
+    agent,
+    candidate,
+    logger,
+    *,
+    respect_nudge_limit=False,
+):
+    """Return the ownership hook's continuation directive for *candidate*.
+
+    A held completion candidate is allowed only when the configured
+    ``pre_verify`` boundary can be evaluated successfully. Hook failures are
+    therefore a fail-closed continuation, not permission to publish the held
+    answer.
+    """
+    changed_paths = sorted(
+        getattr(agent, "_turn_file_mutation_paths", set()) or []
+    )
+    if not changed_paths:
+        return None
+
+    try:
+        attempt = getattr(agent, "_pre_verify_nudges", 0)
+        if respect_nudge_limit:
+            from agent.verify_hooks import max_verify_nudges
+
+            if attempt >= max_verify_nudges():
+                return None
+
+        from hermes_cli.lifecycle import has_hook
+
+        if not has_hook("pre_verify"):
+            return None
+
+        coding = getattr(agent, "_resolved_is_coding", None)
+        if coding is None:
+            from agent.coding_context import is_coding_context
+
+            coding = bool(
+                is_coding_context(
+                    platform=getattr(agent, "platform", "") or ""
+                )
+            )
+            agent._resolved_is_coding = coding
+
+        from hermes_cli.plugins import get_pre_verify_continue_message
+
+        return get_pre_verify_continue_message(
+            session_id=getattr(agent, "session_id", None) or "",
+            platform=getattr(agent, "platform", "") or "",
+            model=getattr(agent, "model", "") or "",
+            coding=coding,
+            attempt=attempt,
+            final_response=candidate,
+            changed_paths=changed_paths,
+        )
+    except Exception:
+        logger.warning(
+            "pre_verify hook failed while evaluating a completion candidate",
+            exc_info=True,
+        )
+        return _PRE_VERIFY_HOOK_FAILURE_CONTINUATION
+
+
+def _mark_pending_candidate_rejected(messages, candidate) -> None:
+    """Mark the newest held candidate as rejected retry scaffolding."""
+    saw_continuation_nudge = False
+    for message in reversed(messages):
+        if not isinstance(message, dict):
+            continue
+        if any(message.get(flag) for flag in _VERIFICATION_CONTINUATION_FLAGS):
+            saw_continuation_nudge = True
+            continue
+        if (
+            message.get("role") == "assistant"
+            and (
+                saw_continuation_nudge
+                or message.get("content") == candidate
+            )
+        ):
+            # Reuse an existing persistence-scaffolding flag: transports strip
+            # it before the recovery request, while the finalizer and SessionDB
+            # projection both drop the rejected assistant row afterward.
+            message["_pre_verify_synthetic"] = True
+            return
 
 
 def finalize_turn(
@@ -84,12 +176,10 @@ def finalize_turn(
     _turn_exit_reason,
     _pending_verification_response=None,
     _pending_verification_response_previewed=False,
+    _pending_verification_source=None,
+    _allow_pre_verify_budget_grace=False,
 ):
-    """Run the post-loop finalization and return the turn ``result`` dict.
-
-    Lifted verbatim from ``run_conversation`` (the region after the main agent
-    loop). See module docstring.
-    """
+    """Run common post-loop finalization and return the turn ``result`` dict."""
     from agent.conversation_loop import logger
 
     budget_exhausted = (
@@ -110,21 +200,66 @@ def finalize_turn(
 
     iteration_limit_fallback = False
     preserved_verification_fallback = False
+    pre_verify_continuation = None
     if continuation_budget_exhausted:
-        # A verification/continuation gate deliberately withheld a composed
-        # answer, then consumed the remaining budget before producing a newer
-        # one. Preserve that exact answer instead of replacing it with another
-        # fallible model call. The explicit pending value is the provenance
-        # guard: unrelated error/recovery exits can never enter this branch.
-        final_response = _pending_verification_response
-        # Mark the turn as previewed only when the reused candidate was
-        # actually streamed to the user as interim content. (#65919 review:
-        # response-loss blocker)
-        if _pending_verification_response_previewed:
-            agent._response_was_previewed = True
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
-        iteration_limit_fallback = True
-        preserved_verification_fallback = True
+        if _pending_verification_source in _PRE_VERIFY_FALLBACK_SOURCES:
+            pre_verify_continuation = _pre_verify_continuation_for_candidate(
+                agent,
+                _pending_verification_response,
+                logger,
+            )
+
+        if pre_verify_continuation:
+            if _allow_pre_verify_budget_grace:
+                _mark_pending_candidate_rejected(
+                    messages,
+                    _pending_verification_response,
+                )
+                return {
+                    "_retry_with_budget_grace": True,
+                    "continuation_directive": pre_verify_continuation,
+                }
+
+            # The ownership boundary rejected the held completion claim. Keep
+            # the directive observable, but never publish or durably retain the
+            # rejected candidate as the terminal answer.
+            _mark_pending_candidate_rejected(
+                messages,
+                _pending_verification_response,
+            )
+            final_response = pre_verify_continuation
+            _turn_exit_reason = "pre_verify_continuation_required"
+            iteration_limit_fallback = True
+        else:
+            # A verification/continuation gate deliberately withheld a composed
+            # answer, then consumed the remaining budget before producing a newer
+            # one. Preserve that exact answer instead of replacing it with another
+            # fallible model call. The explicit pending value is the provenance
+            # guard: unrelated error/recovery exits can never enter this branch.
+            final_response = _pending_verification_response
+            # Mark the turn as previewed only when the reused candidate was
+            # actually streamed to the user as interim content. (#65919 review:
+            # response-loss blocker)
+            if _pending_verification_response_previewed:
+                agent._response_was_previewed = True
+            else:
+                # A terminal verification candidate was intentionally buffered
+                # until this common finalizer could allow it. Preserve the
+                # existing interim-UI contract for an allowed candidate while
+                # never emitting a candidate that the ownership recheck
+                # rejected (that branch returned above).
+                _emit_interim = getattr(
+                    agent,
+                    "_emit_interim_assistant_message",
+                    None,
+                )
+                if callable(_emit_interim):
+                    _emit_interim(
+                        {"role": "assistant", "content": final_response}
+                    )
+            _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+            iteration_limit_fallback = True
+            preserved_verification_fallback = True
     elif final_response is None and budget_fallback_eligible:
         # Budget exhausted — ask the model for a summary via one extra
         # API call with tools stripped.  _handle_max_iterations injects a
@@ -196,6 +331,7 @@ def finalize_turn(
     completed = (
         final_response is not None
         and not failed
+        and not pre_verify_continuation
         and (
             api_call_count < agent.max_iterations
             or normal_text_response
@@ -688,6 +824,8 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    if pre_verify_continuation:
+        result["continuation_directive"] = pre_verify_continuation
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True + an explanation in

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -95,6 +95,8 @@ def _finalize(
     exit_reason,
     api_call_count=60,
     pending_verification_response=None,
+    pending_verification_source=None,
+    messages=None,
 ):
     return finalize_turn(
         agent,
@@ -102,7 +104,7 @@ def _finalize(
         api_call_count=api_call_count,
         interrupted=False,
         failed=False,
-        messages=[{"role": "user", "content": "task"}],
+        messages=messages or [{"role": "user", "content": "task"}],
         conversation_history=[],
         effective_task_id="task",
         turn_id="turn",
@@ -111,6 +113,7 @@ def _finalize(
         _should_review_memory=False,
         _turn_exit_reason=exit_reason,
         _pending_verification_response=pending_verification_response,
+        _pending_verification_source=pending_verification_source,
     )
 
 
@@ -157,6 +160,7 @@ def test_pending_response_does_not_mask_later_terminal_exit(
         _should_review_memory=False,
         _turn_exit_reason=exit_reason,
         _pending_verification_response="stale premature report",
+        _pending_verification_source="pre_verify",
     )
 
     assert result["final_response"] is None
@@ -196,6 +200,80 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
     )
 
 
+@pytest.mark.parametrize("pending_source", ["pre_verify", "verification_stop"])
+@pytest.mark.parametrize("api_call_count", [60, 3])
+def test_rejected_pre_verify_candidate_fails_closed_at_iteration_fallback(
+    monkeypatch, pending_source, api_call_count
+):
+    directive = "Run the focused tests before reporting completion."
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: name == "pre_verify")
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_pre_verify_continue_message",
+        lambda **_kwargs: directive,
+    )
+    agent = _LimitAgent()
+    agent.platform = "cli"
+    agent._resolved_is_coding = True
+    agent._turn_file_mutation_paths = {"changed.py"}
+
+    result = _finalize(
+        agent,
+        final_response=None,
+        exit_reason="unknown",
+        api_call_count=api_call_count,
+        pending_verification_response="unverified completion claim",
+        pending_verification_source=pending_source,
+        messages=[
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "unverified completion claim"},
+            {
+                "role": "user",
+                "content": "check ownership",
+                "_pre_verify_synthetic": True,
+            },
+        ],
+    )
+
+    assert result["final_response"] == directive
+    assert result["continuation_directive"] == directive
+    assert result["turn_exit_reason"] == "pre_verify_continuation_required"
+    assert result["completed"] is False
+    assert agent._handle_max_iterations_called is False
+    assert "unverified completion claim" not in {
+        message.get("content") for message in result["messages"]
+    }
+
+
+def test_pre_verify_hook_exception_fails_closed_with_observable_directive(monkeypatch):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+
+    def raise_hook_error(**_kwargs):
+        raise RuntimeError("hook transport unavailable")
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_pre_verify_continue_message",
+        raise_hook_error,
+    )
+    agent = _LimitAgent()
+    agent.platform = "cli"
+    agent._resolved_is_coding = True
+    agent._turn_file_mutation_paths = {"changed.py"}
+
+    result = _finalize(
+        agent,
+        final_response=None,
+        exit_reason="unknown",
+        pending_verification_response="unverified completion claim",
+        pending_verification_source="verification_stop",
+    )
+
+    assert result["turn_exit_reason"] == "pre_verify_continuation_required"
+    assert result["completed"] is False
+    assert result["final_response"] == result["continuation_directive"]
+    assert "pre-verify completion check failed" in result["final_response"]
+    assert agent._handle_max_iterations_called is False
+
+
 def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch):
     """When budget exhaustion preserves a verification candidate that is
     already the tail assistant message, the finalizer must NOT append a
@@ -233,5 +311,3 @@ def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch)
     assert agent.persisted_messages is not None
     persisted_roles = [m["role"] for m in agent.persisted_messages]
     assert persisted_roles == ["user", "assistant"]
-
-

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -88,12 +88,13 @@ def test_pre_verify_preserves_composed_report_at_budget_limit(agent, monkeypatch
     agent._interruptible_api_call = model_call
     agent._handle_max_iterations = MagicMock(return_value="replacement summary")
     monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+    ownership_check = MagicMock(side_effect=["run project tests", None])
 
     with (
         patch("hermes_cli.plugins.has_hook", side_effect=lambda name: name == "pre_verify"),
         patch(
             "hermes_cli.plugins.get_pre_verify_continue_message",
-            return_value="run project tests",
+            ownership_check,
         ),
         patch("agent.verify_hooks.max_verify_nudges", return_value=2),
         patch("hermes_cli.plugins.invoke_hook", return_value=[]),
@@ -101,6 +102,8 @@ def test_pre_verify_preserves_composed_report_at_budget_limit(agent, monkeypatch
         result = agent.run_conversation("edit changed.py")
 
     _assert_pending_response_survives(agent, result)
+    assert ownership_check.call_count == 2
+    assert agent._budget_grace_call is False
     # The assistant response persists (it is real, unflagged content).
     assert not result["messages"][1].get("_pre_verify_synthetic")
 
@@ -144,6 +147,218 @@ def test_later_verified_response_supersedes_pending_report(agent, monkeypatch):
     assert result["final_response"] == "verified final report"
     assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
     assert result["completed"] is True
+    agent._handle_max_iterations.assert_not_called()
+
+
+def test_pre_verify_rejection_at_api_cap_gets_one_grace_call(agent, monkeypatch):
+    answers = iter([
+        _response("unverified completion claim"),
+        _response("verified recovery report"),
+    ])
+    provider_calls = []
+
+    def model_call(api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        provider_calls.append(api_kwargs)
+        return next(answers)
+
+    directive = "Run the focused tests before reporting completion."
+    ownership_check = MagicMock(side_effect=[directive, directive, None])
+    agent._interruptible_api_call = model_call
+    agent._handle_max_iterations = MagicMock(return_value="replacement summary")
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+
+    with (
+        patch("hermes_cli.plugins.has_hook", side_effect=lambda name: name == "pre_verify"),
+        patch(
+            "hermes_cli.plugins.get_pre_verify_continue_message",
+            ownership_check,
+        ),
+        patch("agent.verify_hooks.max_verify_nudges", return_value=1),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("edit changed.py")
+
+    assert result["final_response"] == "verified recovery report"
+    assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
+    assert result["completed"] is True
+    assert len(provider_calls) == 2
+    assert provider_calls[1]["messages"][-1]["content"] == directive
+    assert [message["role"] for message in result["messages"]] == [
+        "user",
+        "assistant",
+    ]
+    assert ownership_check.call_count == 3
+    assert agent._budget_grace_call is False
+    agent._handle_max_iterations.assert_not_called()
+
+
+def test_repeated_pre_verify_rejection_after_grace_fails_closed(agent, monkeypatch):
+    answers = iter([
+        _response("first unverified claim"),
+        _response("rejected recovery blocker"),
+    ])
+    provider_calls = []
+
+    def model_call(api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        provider_calls.append(api_kwargs)
+        return next(answers)
+
+    directive = "Verification still owns this turn; continue testing."
+    delivered_interims = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: delivered_interims.append(text)
+    )
+    agent._interruptible_api_call = model_call
+    agent._handle_max_iterations = MagicMock(return_value="replacement summary")
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+
+    with (
+        patch("hermes_cli.plugins.has_hook", side_effect=lambda name: name == "pre_verify"),
+        patch(
+            "hermes_cli.plugins.get_pre_verify_continue_message",
+            return_value=directive,
+        ),
+        patch("agent.verify_hooks.max_verify_nudges", return_value=1),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("edit changed.py")
+
+    assert result["final_response"] == directive
+    assert result["continuation_directive"] == directive
+    assert result["turn_exit_reason"] == "pre_verify_continuation_required"
+    assert result["completed"] is False
+    assert len(provider_calls) == 2
+    assert agent._budget_grace_call is False
+    assert delivered_interims == []
+    assert "rejected recovery blocker" not in {
+        message.get("content") for message in result["messages"]
+    }
+    assert [message["role"] for message in result["messages"]] == [
+        "user",
+        "assistant",
+    ]
+    agent._handle_max_iterations.assert_not_called()
+
+
+def test_finalizer_recheck_advances_attempt_before_grace_recovery(agent, monkeypatch):
+    answers = iter([
+        _response("unverified completion claim"),
+        _response("verified recovery report"),
+    ])
+    agent._interruptible_api_call = lambda _kwargs: (
+        setattr(agent, "_turn_file_mutation_paths", {"changed.py"})
+        or next(answers)
+    )
+    attempts = []
+
+    def ownership_check(**kwargs):
+        attempts.append(kwargs["attempt"])
+        return "Run validation before completion." if kwargs["attempt"] == 0 else None
+
+    agent._handle_max_iterations = MagicMock(return_value="replacement summary")
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "1")
+
+    with (
+        patch(
+            "agent.verification_stop.build_verify_on_stop_nudge",
+            side_effect=["verify it", None],
+        ),
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch(
+            "hermes_cli.plugins.get_pre_verify_continue_message",
+            side_effect=ownership_check,
+        ),
+        patch("agent.verify_hooks.max_verify_nudges", return_value=1),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("edit changed.py")
+
+    assert result["final_response"] == "verified recovery report"
+    assert result["completed"] is True
+    assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
+    assert attempts == [0, 1]
+    assert agent._pre_verify_nudges == 1
+    assert agent._budget_grace_call is False
+    agent._handle_max_iterations.assert_not_called()
+
+
+def test_interrupt_during_finalizer_recheck_clears_grace_flag(agent, monkeypatch):
+    def model_call(_api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        return _response("unverified completion claim")
+
+    hook_calls = 0
+
+    def ownership_check(**_kwargs):
+        nonlocal hook_calls
+        hook_calls += 1
+        if hook_calls == 2:
+            agent.interrupt("stop")
+        return "Continue verification."
+
+    agent._interruptible_api_call = model_call
+    agent._handle_max_iterations = MagicMock(return_value="replacement summary")
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch(
+            "hermes_cli.plugins.get_pre_verify_continue_message",
+            side_effect=ownership_check,
+        ),
+        patch("agent.verify_hooks.max_verify_nudges", return_value=1),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("edit changed.py")
+
+    assert result["interrupted"] is True
+    assert result["completed"] is False
+    assert hook_calls == 2
+    assert agent._budget_grace_call is False
+
+
+def test_pre_verify_hook_exception_never_publishes_completion_claim(agent, monkeypatch):
+    provider_calls = []
+    answers = iter([
+        _response("first unverified claim"),
+        _response("rejected recovery blocker"),
+    ])
+
+    def model_call(api_kwargs):
+        agent._turn_file_mutation_paths = {"changed.py"}
+        provider_calls.append(api_kwargs)
+        return next(answers)
+
+    def raise_hook_error(**_kwargs):
+        raise RuntimeError("hook transport unavailable")
+
+    agent._interruptible_api_call = model_call
+    agent._handle_max_iterations = MagicMock(return_value="replacement summary")
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+
+    with (
+        patch("hermes_cli.plugins.has_hook", side_effect=lambda name: name == "pre_verify"),
+        patch(
+            "hermes_cli.plugins.get_pre_verify_continue_message",
+            side_effect=raise_hook_error,
+        ),
+        patch("agent.verify_hooks.max_verify_nudges", return_value=3),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("edit changed.py")
+
+    directive = result["continuation_directive"]
+    assert "pre-verify completion check failed" in directive
+    assert result["final_response"] == directive
+    assert result["turn_exit_reason"] == "pre_verify_continuation_required"
+    assert result["completed"] is False
+    assert len(provider_calls) == 2
+    assert provider_calls[1]["messages"][-1]["content"] == directive
+    assert "rejected recovery blocker" not in {
+        message.get("content") for message in result["messages"]
+    }
     agent._handle_max_iterations.assert_not_called()
 
 
@@ -251,5 +466,3 @@ def test_streamed_interim_then_different_summary_not_marked_previewed(agent, mon
     # CRITICAL: response_previewed must be False — the interim narration was
     # NOT the final response, so the CLI must render the summary.
     assert result["response_previewed"] is False
-
-


### PR DESCRIPTION
Summary: replayed the exact four-path ownership-fallback change onto current origin/main and verified it in an isolated worktree.\n\nCommit: 3edc0474166b5c9c8279138e4daeb5810a756cf3\nChanged paths: agent/conversation_loop.py; agent/turn_finalizer.py; tests/agent/test_turn_finalizer_iteration_limit_exit.py; tests/run_agent/test_verification_continuation_budget.py\nEvidence: focused pytest 22 passed; Ruff passed; py_compile passed; git diff --check passed; current-base branch is clean and 0/0 with its fork upstream.\nSafety: no live runtime, gateway, cron, provider, credential, delivery, or trading activation occurred. This PR is a review handoff only; do not infer ticket closure or runtime activation from it.