### PR TITLE
fix: strip empty tool_calls at wire boundary for DeepSeek compatibility

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -272,6 +272,14 @@ class ChatCompletionsTransport(ProviderTransport):
                 break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
+                # Empty tool_calls arrays are rejected by strict
+                # OpenAI-compatible providers (DeepSeek v4 returns HTTP 400
+                # "empty array").  The pre-send sanitizer strips them, but
+                # downstream passes (thinking-only drop, repair merge) can
+                # reintroduce the key.  Catch at the wire boundary. (#83312)
+                if not tool_calls and msg.get("role") == "assistant":
+                    needs_sanitize = True
+                    break
                 for tc in tool_calls:
                     if isinstance(tc, dict) and (
                         "call_id" in tc
@@ -347,6 +355,18 @@ class ChatCompletionsTransport(ProviderTransport):
                             copied_tool_calls[tc_idx] = copied_tc
                 if copied_tool_calls is not None:
                     mutable_msg()["tool_calls"] = copied_tool_calls
+            # Defense-in-depth: drop tool_calls key entirely when the
+            # array is empty (or non-list).  Strict OpenAI-compatible
+            # providers reject "tool_calls": [] with HTTP 400.  The
+            # pre-send sanitizer strips these, but downstream passes
+            # can reintroduce the key on the per-call copy. (#83312)
+            if (
+                isinstance(msg, dict)
+                and msg.get("role") == "assistant"
+                and "tool_calls" in msg
+                and not (isinstance(msg["tool_calls"], list) and msg["tool_calls"])
+            ):
+                mutable_msg().pop("tool_calls", None)
         return sanitized
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

DeepSeek v4 returns HTTP 400 when an assistant message carries `tool_calls: []` (empty array), permanently wedging the session. The pre-send sanitizer (`sanitize_api_messages`) strips these correctly, but downstream passes (thinking-only drop, repair merge) can reintroduce the key on the per-call copy after the sanitizer runs.

This PR adds defense-in-depth in `ChatCompletionsTransport.convert_messages()` — the final wire-boundary chokepoint — to strip empty/invalid `tool_calls` arrays from assistant messages right before the request is sent.

## Changes

- **Fast-path detection**: Updated the `needs_sanitize` check to trigger when an assistant message has an empty `tool_calls` array, ensuring the sanitizer loop runs
- **Wire-boundary stripping**: After the existing tool_calls field cleanup (codex fields, extra_content), drop the `tool_calls` key entirely from assistant messages where the value is empty or non-list

## Why this works

The fix is at the transport layer (`convert_messages`), which is the last transformation before the API call. Every code path — main loop, summary path, retries, fallback re-builds — passes through this method. Even if future code reintroduces empty `tool_calls` arrays, the wire boundary catches them.

## Test Plan

- [x] All 46 existing `test_chat_completions.py` tests pass
- [ ] Verified that empty `tool_calls: []` on assistant messages is stripped before reaching the API

Fixes #83312