### PR TITLE
fix(doctor): don't hint npm audit fix commands that ETARGET on the min-release-age band

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2235,28 +2235,37 @@ def run_doctor(args):
             _whatsapp_bridge_dir = resolve_whatsapp_bridge_dir()
         except Exception:
             _whatsapp_bridge_dir = PROJECT_ROOT / "scripts" / "whatsapp-bridge"
-        # npm 11.10-11.16 honor .npmrc's `min-release-age` but ignore
-        # `min-release-age-exclude`, so `npm audit fix` on that band ETARGETs
-        # on every package we deliberately exempted. Detect it once so the
-        # remediation hint below doesn't send the user into that failure.
-        _npm_release_age_unsafe = False
-        try:
-            from hermes_cli.npm_engine import npm_ignores_min_release_age_exclude
-
-            _npm_version_probe = subprocess.run(
-                [_npm_bin, "--version"],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10,
-            )
-            _npm_version = _npm_version_probe.stdout.strip() if _npm_version_probe.returncode == 0 else None
-            _npm_release_age_unsafe = npm_ignores_min_release_age_exclude(_npm_version)
-        except Exception:
-            _npm_version = None
         npm_audit_targets = [
             (PROJECT_ROOT, "Browser tools (agent-browser)", ["--workspaces=false"]),
             (PROJECT_ROOT, "web workspace", ["--workspace", "web"]),
             (PROJECT_ROOT, "ui-tui workspace", ["--workspace", "ui-tui"]),
             (_whatsapp_bridge_dir, "WhatsApp bridge", []),
         ]
+        # npm 11.10-11.16 honor .npmrc's `min-release-age` but ignore
+        # `min-release-age-exclude`, so `npm audit fix` on that band ETARGETs
+        # on every package we deliberately exempted. Detect it once so the
+        # remediation hint below doesn't send the user into that failure —
+        # but only when some target actually has node_modules to audit, so a
+        # bare checkout (or a hung/aliased npm) doesn't pay this probe on
+        # every doctor run.
+        _npm_version = None
+        _npm_release_age_unsafe = False
+        _has_npm_audit_target = any(
+            ((PROJECT_ROOT if audit_extra else npm_dir) / "node_modules").exists()
+            for npm_dir, _label, audit_extra in npm_audit_targets
+        )
+        if _has_npm_audit_target:
+            try:
+                from hermes_cli.npm_engine import npm_ignores_min_release_age_exclude
+
+                _npm_version_probe = subprocess.run(
+                    [_npm_bin, "--version"],
+                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
+                )
+                _npm_version = _npm_version_probe.stdout.strip() if _npm_version_probe.returncode == 0 else None
+                _npm_release_age_unsafe = npm_ignores_min_release_age_exclude(_npm_version)
+            except Exception:
+                _npm_version = None
         for npm_dir, label, audit_extra in npm_audit_targets:
             # For workspace-scoped audits run from PROJECT_ROOT the
             # node_modules check must use the workspace root; standalone dirs

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2235,6 +2235,22 @@ def run_doctor(args):
             _whatsapp_bridge_dir = resolve_whatsapp_bridge_dir()
         except Exception:
             _whatsapp_bridge_dir = PROJECT_ROOT / "scripts" / "whatsapp-bridge"
+        # npm 11.10-11.16 honor .npmrc's `min-release-age` but ignore
+        # `min-release-age-exclude`, so `npm audit fix` on that band ETARGETs
+        # on every package we deliberately exempted. Detect it once so the
+        # remediation hint below doesn't send the user into that failure.
+        _npm_release_age_unsafe = False
+        try:
+            from hermes_cli.npm_engine import npm_ignores_min_release_age_exclude
+
+            _npm_version_probe = subprocess.run(
+                [_npm_bin, "--version"],
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10,
+            )
+            _npm_version = _npm_version_probe.stdout.strip() if _npm_version_probe.returncode == 0 else None
+            _npm_release_age_unsafe = npm_ignores_min_release_age_exclude(_npm_version)
+        except Exception:
+            _npm_version = None
         npm_audit_targets = [
             (PROJECT_ROOT, "Browser tools (agent-browser)", ["--workspaces=false"]),
             (PROJECT_ROOT, "web workspace", ["--workspace", "web"]),
@@ -2274,15 +2290,20 @@ def run_doctor(args):
                     # manual fix command for these build-tool advisories.
                     fix_cmd = None
                 elif audit_extra == ["--workspaces=false"]:
-                    fix_cmd = f"cd {npm_dir} && npm audit fix --workspaces=false"
+                    fix_cmd = None if _npm_release_age_unsafe else f"cd {npm_dir} && npm audit fix --workspaces=false"
                 else:
-                    fix_cmd = f"cd {npm_dir} && npm audit fix"
+                    fix_cmd = None if _npm_release_age_unsafe else f"cd {npm_dir} && npm audit fix"
                 if total == 0:
                     check_ok(f"{label} deps", "(no known vulnerabilities)")
                 elif critical > 0 or high > 0:
                     if fix_cmd:
                         vuln_detail = (
                             f"{critical} critical, {high} high, {moderate} moderate — run: {fix_cmd}"
+                        )
+                    elif _npm_release_age_unsafe:
+                        vuln_detail = (
+                            f"{critical} critical, {high} high, {moderate} moderate — "
+                            f"npm {_npm_version} can't fix this here (see note below)"
                         )
                     else:
                         vuln_detail = (
@@ -2293,7 +2314,14 @@ def run_doctor(args):
                         f"{label} deps",
                         f"({vuln_detail})"
                     )
-                    if audit_extra and audit_extra[0] == "--workspace":
+                    if _npm_release_age_unsafe:
+                        check_info(
+                            f"  ^ npm {_npm_version} honors min-release-age but ignores "
+                            "min-release-age-exclude (npm 11.10-11.16) — 'npm audit fix' "
+                            "here ETARGETs on packages .npmrc exempts (e.g. "
+                            "brace-expansion). Upgrade npm first: npm install -g npm@latest"
+                        )
+                    elif audit_extra and audit_extra[0] == "--workspace":
                         # The web/ui-tui workspace advisories are in build-time
                         # tooling (esbuild/vite, etc.), not runtime code that ships
                         # to users. Manual npm remediation may error with a known

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2296,11 +2296,12 @@ def run_doctor(args):
                 if total == 0:
                     check_ok(f"{label} deps", "(no known vulnerabilities)")
                 elif critical > 0 or high > 0:
+                    is_workspace_target = bool(audit_extra and audit_extra[0] == "--workspace")
                     if fix_cmd:
                         vuln_detail = (
                             f"{critical} critical, {high} high, {moderate} moderate — run: {fix_cmd}"
                         )
-                    elif _npm_release_age_unsafe:
+                    elif not is_workspace_target and _npm_release_age_unsafe:
                         vuln_detail = (
                             f"{critical} critical, {high} high, {moderate} moderate — "
                             f"npm {_npm_version} can't fix this here (see note below)"
@@ -2314,23 +2315,29 @@ def run_doctor(args):
                         f"{label} deps",
                         f"({vuln_detail})"
                     )
-                    if _npm_release_age_unsafe:
+                    if is_workspace_target:
+                        # The web/ui-tui workspace advisories are in build-time
+                        # tooling (esbuild/vite, etc.), not runtime code that ships
+                        # to users. Manual npm remediation may error with a known
+                        # arborist crash (edgesOut / isDescendantOf) on this monorepo
+                        # tree — in that case it is an npm bug, not a Hermes one. This
+                        # is unrelated to the min-release-age band, so it takes
+                        # precedence over that (unfixable-either-way) explanation.
+                        check_info(
+                            "  ^ build-time tooling (not runtime); if manual npm remediation "
+                            "errors with an arborist crash it's a known npm bug — clears "
+                            "via a lockfile bump"
+                        )
+                    elif _npm_release_age_unsafe:
+                        # is_workspace_target is already handled above, so this only
+                        # fires for the browser-tools / whatsapp-bridge targets, where
+                        # min-release-age-exclude is the actual reason a fix can't be
+                        # hinted.
                         check_info(
                             f"  ^ npm {_npm_version} honors min-release-age but ignores "
                             "min-release-age-exclude (npm 11.10-11.16) — 'npm audit fix' "
                             "here ETARGETs on packages .npmrc exempts (e.g. "
                             "brace-expansion). Upgrade npm first: npm install -g npm@latest"
-                        )
-                    elif audit_extra and audit_extra[0] == "--workspace":
-                        # The web/ui-tui workspace advisories are in build-time
-                        # tooling (esbuild/vite, etc.), not runtime code that ships
-                        # to users. Manual npm remediation may error with a known
-                        # arborist crash (edgesOut / isDescendantOf) on this monorepo
-                        # tree — in that case it is an npm bug, not a Hermes one.
-                        check_info(
-                            "  ^ build-time tooling (not runtime); if manual npm remediation "
-                            "errors with an arborist crash it's a known npm bug — clears "
-                            "via a lockfile bump"
                         )
                     issues.append(
                         f"{label} has {total} npm "

--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -46,12 +46,35 @@ __all__ = [
     "managed_npm_prefix",
     "upgrade_managed_npm",
     "maybe_repair_npm_engine",
+    "npm_ignores_min_release_age_exclude",
 ]
 
 # npm prints `npm error notsup Required: {...}` on npm >= 10 and
 # `npm ERR! notsup Required: {...}` on older releases.
 _REQUIRED_RE = re.compile(r"Required:\s*(\{.*?\})")
 _ACTUAL_RE = re.compile(r"Actual:\s*(\{.*?\})")
+
+# npm's own version string: "11.12.1", optionally with a pre-release suffix.
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)")
+
+
+def npm_ignores_min_release_age_exclude(version: str | None) -> bool:
+    """Return True when npm *version* is the 11.10.0-11.16.x "bad band".
+
+    That band honors ``min-release-age`` but ignores
+    ``min-release-age-exclude``, both of which the repo's ``.npmrc`` sets, so
+    it fails ``npm audit`` / ``npm audit fix`` with ``ETARGET`` on any package
+    we deliberately exempted (e.g. ``brace-expansion``) — see #83544. Mirrors
+    ``npm_supports_npmrc`` in ``scripts/install.sh``, which steers a fresh
+    install away from this band; this covers the audit path a system npm
+    still takes after install.
+    """
+    match = _VERSION_RE.match(str(version).strip()) if version else None
+    if not match:
+        return False
+    major, minor = int(match.group(1)), int(match.group(2))
+    return major == 11 and 10 <= minor <= 16
+
 
 # Wall-clock cap for the self-upgrade. The measured in-place upgrade of a
 # managed tree takes ~1s; this only has to cover a slow registry.

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1419,12 +1419,15 @@ class TestDoctorNpmAuditMinReleaseAgeBand:
     brace-expansion) — see #83544. On that band, doctor must not hand out a
     command it knows will fail."""
 
-    def _run(self, monkeypatch, tmp_path, npm_version, inject_workspace_vulns=False):
+    def _run(self, monkeypatch, tmp_path, npm_version, inject_workspace_vulns=False,
+             create_node_modules=True, version_calls=None):
         home = tmp_path / ".hermes"
         home.mkdir(parents=True, exist_ok=True)
         (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
         project = tmp_path / "project"
-        (project / "node_modules").mkdir(parents=True, exist_ok=True)
+        project.mkdir(parents=True, exist_ok=True)
+        if create_node_modules:
+            (project / "node_modules").mkdir(parents=True, exist_ok=True)
 
         monkeypatch.delenv("TERMUX_VERSION", raising=False)
         monkeypatch.delenv("PREFIX", raising=False)
@@ -1446,6 +1449,8 @@ class TestDoctorNpmAuditMinReleaseAgeBand:
 
         def fake_run(cmd, **kwargs):
             if cmd[:2] == [npm_bin, "--version"]:
+                if version_calls is not None:
+                    version_calls.append(cmd)
                 return _subprocess.CompletedProcess(cmd, 0, f"{npm_version}\n", "")
             if cmd[:3] == [npm_bin, "audit", "--json"]:
                 is_flagged_target = "--workspaces=false" in cmd or (
@@ -1502,3 +1507,12 @@ class TestDoctorNpmAuditMinReleaseAgeBand:
         # (--workspaces=false) target, which has no unrelated arborist issue.
         assert out.count("can't fix this here") == 1
         assert "npm install -g npm@latest" in out
+
+    def test_no_node_modules_skips_the_version_probe(self, monkeypatch, tmp_path):
+        """No audit target has node_modules, so no audit can run either way —
+        `npm --version` must not be probed just to compute an unused band
+        check (see #83602 review)."""
+        version_calls = []
+        self._run(monkeypatch, tmp_path, "11.12.1", create_node_modules=False,
+                   version_calls=version_calls)
+        assert version_calls == []

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1410,3 +1410,80 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+class TestDoctorNpmAuditMinReleaseAgeBand:
+    """npm 11.10-11.16 honor `min-release-age` but ignore
+    `min-release-age-exclude` (both set in .npmrc), so the `npm audit fix`
+    command doctor hints at ETARGETs on any exempted package (e.g.
+    brace-expansion) — see #83544. On that band, doctor must not hand out a
+    command it knows will fail."""
+
+    def _run(self, monkeypatch, tmp_path, npm_version):
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+        project = tmp_path / "project"
+        (project / "node_modules").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.delenv("PREFIX", raising=False)
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        npm_bin = "/usr/bin/npm"
+
+        def fake_which(cmd, path=None):
+            if path is not None:
+                return None
+            return npm_bin if cmd == "npm" else None
+
+        monkeypatch.setattr(doctor_mod.shutil, "which", fake_which)
+
+        import json as _json
+        import subprocess as _subprocess
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == [npm_bin, "--version"]:
+                return _subprocess.CompletedProcess(cmd, 0, f"{npm_version}\n", "")
+            if cmd[:3] == [npm_bin, "audit", "--json"]:
+                vulns = (
+                    {"critical": 1, "high": 0, "moderate": 0}
+                    if "--workspaces=false" in cmd
+                    else {"critical": 0, "high": 0, "moderate": 0}
+                )
+                payload = {"metadata": {"vulnerabilities": vulns}}
+                return _subprocess.CompletedProcess(cmd, 0, _json.dumps(payload), "")
+            return _subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    def test_bad_band_npm_does_not_hint_a_command_that_will_etarget(self, monkeypatch, tmp_path):
+        out = self._run(monkeypatch, tmp_path, "11.12.1")
+        assert "npm audit fix --workspaces=false" not in out
+        assert "npm 11.12.1 honors min-release-age but ignores" in out
+        assert "npm install -g npm@latest" in out
+
+    def test_good_npm_still_gets_the_fix_command(self, monkeypatch, tmp_path):
+        out = self._run(monkeypatch, tmp_path, "11.17.0")
+        assert "npm audit fix --workspaces=false" in out
+        assert "honors min-release-age" not in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1419,7 +1419,7 @@ class TestDoctorNpmAuditMinReleaseAgeBand:
     brace-expansion) — see #83544. On that band, doctor must not hand out a
     command it knows will fail."""
 
-    def _run(self, monkeypatch, tmp_path, npm_version):
+    def _run(self, monkeypatch, tmp_path, npm_version, inject_workspace_vulns=False):
         home = tmp_path / ".hermes"
         home.mkdir(parents=True, exist_ok=True)
         (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
@@ -1448,9 +1448,12 @@ class TestDoctorNpmAuditMinReleaseAgeBand:
             if cmd[:2] == [npm_bin, "--version"]:
                 return _subprocess.CompletedProcess(cmd, 0, f"{npm_version}\n", "")
             if cmd[:3] == [npm_bin, "audit", "--json"]:
+                is_flagged_target = "--workspaces=false" in cmd or (
+                    inject_workspace_vulns and "--workspace" in cmd
+                )
                 vulns = (
                     {"critical": 1, "high": 0, "moderate": 0}
-                    if "--workspaces=false" in cmd
+                    if is_flagged_target
                     else {"critical": 0, "high": 0, "moderate": 0}
                 )
                 payload = {"metadata": {"vulnerabilities": vulns}}
@@ -1487,3 +1490,15 @@ class TestDoctorNpmAuditMinReleaseAgeBand:
         out = self._run(monkeypatch, tmp_path, "11.17.0")
         assert "npm audit fix --workspaces=false" in out
         assert "honors min-release-age" not in out
+
+    def test_bad_band_npm_workspace_advisory_keeps_arborist_message(self, monkeypatch, tmp_path):
+        """web/ui-tui workspace advisories can't be auto-fixed because of a
+        known arborist crash, unrelated to the min-release-age band. That
+        explanation must win even when npm also happens to be in the bad
+        band — see #83544 review."""
+        out = self._run(monkeypatch, tmp_path, "11.12.1", inject_workspace_vulns=True)
+        assert out.count("build-time tooling (not runtime)") == 2
+        # The min-release-age explanation still applies to the non-workspace
+        # (--workspaces=false) target, which has no unrelated arborist issue.
+        assert out.count("can't fix this here") == 1
+        assert "npm install -g npm@latest" in out

--- a/tests/hermes_cli/test_npm_engine.py
+++ b/tests/hermes_cli/test_npm_engine.py
@@ -16,6 +16,7 @@ from hermes_cli.npm_engine import (
     is_ebadengine,
     managed_npm_prefix,
     maybe_repair_npm_engine,
+    npm_ignores_min_release_age_exclude,
     required_npm_range,
 )
 
@@ -335,3 +336,26 @@ class TestRepoRangeIsSatisfiable:
             + "\n"
         )
         assert required_npm_range(synthetic) == npm_range
+
+
+class TestNpmIgnoresMinReleaseAgeExclude:
+    """npm 11.10.0-11.16.x honor `min-release-age` but ignore
+    `min-release-age-exclude` — see #83544, where a user hit ETARGET on
+    brace-expansion (a package .npmrc explicitly exempts) via `npm audit
+    fix` on a version in this band."""
+
+    @pytest.mark.parametrize(
+        "version", ["11.10.0", "11.12.1", "11.16.0", "11.16.9"]
+    )
+    def test_bad_band_is_flagged(self, version):
+        assert npm_ignores_min_release_age_exclude(version)
+
+    @pytest.mark.parametrize(
+        "version", ["10.9.8", "11.9.9", "11.17.0", "12.0.2", "9.6.7"]
+    )
+    def test_versions_outside_the_band_are_not_flagged(self, version):
+        assert not npm_ignores_min_release_age_exclude(version)
+
+    @pytest.mark.parametrize("version", [None, "", "not-a-version"])
+    def test_unresolvable_version_is_not_flagged(self, version):
+        assert not npm_ignores_min_release_age_exclude(version)


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` audits Node.js dependencies and, when it finds a
critical/high vulnerability, prints a `npm audit fix ...` command as a
remediation hint. On a system npm in the 11.10.0-11.16.x range, running that
exact command fails:

```
npm warn Unknown project config "min-release-age-exclude"
npm error code ETARGET
npm error notarget No matching version found for brace-expansion@5.0.8
```

That band honors `.npmrc`'s `min-release-age` config but ignores
`min-release-age-exclude` (also set in `.npmrc`), so the 14-day age gate
gets applied to every package we deliberately exempted (`brace-expansion`,
`js-yaml`, `nanoid`, etc.) — any of them published in the last 14 days then
ETARGETs.

This isn't a new discovery: `scripts/install.sh`'s `npm_supports_npmrc()`
already detects this exact band and steers a *fresh install* to a
Hermes-managed npm outside it, and `tests/test_engines_satisfiable.py`
enforces that `package.json`'s `engines.npm` range excludes it too. But
`engines.npm` / `engine-strict` only gates `npm install` / `npm ci` — it does
nothing for the direct `npm audit` / `npm audit fix` calls `hermes doctor`
makes (or hints at) on whatever npm happens to be on PATH. A user with a
bad-band system npm sails past `hermes doctor`'s own checks and straight into
the ETARGET the CLI hints at.

## Related Issue

Fixes the npm/`hermes doctor` portion of #83544 ("Multiple problems
encountered during Hermes Agent upgrade and daily usage" — Issue 3:
"`hermes doctor` reports 3 high-severity npm vulnerabilities... Both
`hermes doctor --fix` and manual `npm audit fix` fail" with the exact
`min-release-age-exclude` / `brace-expansion` ETARGET quoted above). The
issue also raises context-compaction, cron model drift, python-docx, and
model-safety-refusal concerns that are separate problems tracked/worked on
elsewhere; this PR scopes to the one concretely reproducible, in-repo bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/npm_engine.py`: add `npm_ignores_min_release_age_exclude(version)`,
  a pure version-band check mirroring `npm_supports_npmrc()` in
  `scripts/install.sh` (npm 11.10.0-11.16.x → `True`).
- `hermes_cli/doctor.py`: in the npm audit section, probe `npm --version`
  once and, when it falls in that band, suppress the `npm audit fix` hint
  and print a `check_info` explaining why (references `.npmrc`'s exclusion
  list and points at `npm install -g npm@latest`) instead of handing out a
  command already known to fail. The web/ui-tui workspace-scoped audit
  targets keep their pre-existing "build-time tooling / arborist crash"
  explanation regardless of the npm band: their `fix_cmd` is already `None`
  for an unrelated reason (a known arborist bug on workspace-filtered
  `npm audit fix`), and that explanation must take precedence over the new
  min-release-age one rather than being silently overwritten by it.
- Tests: `tests/hermes_cli/test_npm_engine.py` (pure unit tests for the new
  band check) and `tests/hermes_cli/test_doctor.py` (end-to-end
  `run_doctor()` run with a mocked npm 11.12.1 reporting a critical
  vulnerability — asserts the doomed `npm audit fix --workspaces=false` hint
  is gone and the explanatory note is shown; a second test confirms a
  non-bad-band npm still gets the normal hint; a third test confirms that
  when the web/ui-tui workspace targets *also* carry a vulnerability under a
  bad-band npm, they still show the arborist-crash explanation, not the
  min-release-age one).

## How to Test

1. `python3 -m pytest tests/hermes_cli/test_npm_engine.py tests/hermes_cli/test_doctor.py -q`
2. Confirmed the new tests fail without the fix: reverting
   `hermes_cli/doctor.py` + `hermes_cli/npm_engine.py` (keeping the new
   tests) reproduces the exact symptom —
   `test_bad_band_npm_does_not_hint_a_command_that_will_etarget` fails
   because the output still contains `npm audit fix --workspaces=false`, and
   (after review) `test_bad_band_npm_workspace_advisory_keeps_arborist_message`
   fails because the web/ui-tui workspace advisories wrongly show the
   min-release-age message instead of the arborist-crash one.
3. `ruff check hermes_cli/doctor.py hermes_cli/npm_engine.py tests/hermes_cli/test_doctor.py tests/hermes_cli/test_npm_engine.py` → all checks passed.

### Real output

```
$ python3 -m pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_npm_engine.py -q
........................................................................ [ 85%]
............                                                             [100%]
84 passed in 11.55s
```

### Post-review fix

An independent review caught a regression in the first version of this PR:
the new `elif _npm_release_age_unsafe:` branches were spliced in *ahead of*
the pre-existing `audit_extra[0] == "--workspace"` check in the same
if/elif chain. For the web/ui-tui workspace audit targets, `fix_cmd` is
already unconditionally `None` for an unrelated reason (the arborist crash
noted above) — but because the band-check branch came first, a bad-band
system npm would silently swap out that correct explanation for the
min-release-age one and hint `npm install -g npm@latest`, which does
nothing for the actual (arborist) problem. Fixed by reordering so the
workspace-target check is evaluated first, and added a regression test
(`test_bad_band_npm_workspace_advisory_keeps_arborist_message`) that
injects vulnerabilities into the web/ui-tui workspace targets under a
bad-band npm and asserts the arborist message wins.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` (scoped to the touched files; full suite not run in this sandbox) and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — not tested on a real Windows box with a bad-band system npm (the reporter's exact environment); verified via unit/integration tests with a mocked npm version instead

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

## Disclosure

Prepared with AI assistance (an autonomous coding agent) under human review.

## Screenshots / Logs

See "Real output" above.
