### PR TITLE
fix(desktop): stop painting a merged tool-call turn twice, out of order

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1168,6 +1168,118 @@ describe('preserveLocalPendingTurnMessages', () => {
     expect(preserveLocalPendingTurnMessages(next, [...next, settledLocalStream])).toBe(next)
   })
 
+  // #81xxx: a tool-call turn commits as ONE merged assistant row (narration +
+  // tool calls + final answer coalesced by toChatMessages), so neither local
+  // bubble equals it and both used to be re-appended — the reply rendered
+  // twice. Image-generation turns hit this on every hydrate.
+  it('does not re-append the bubbles of a turn the transcript merged into one row', () => {
+    const previous = [
+      msg('1-user', 'user', 'generate the image'),
+      msg('assistant-stream-a', 'assistant', 'Switching provider off Codex.', { pending: false, interim: true }),
+      msg('assistant-stream-b', 'assistant', "Here's Alia — same pose.", { pending: false })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'generate the image'),
+      msg('2-assistant-stored', 'assistant', "Switching provider off Codex.Here's Alia — same pose.")
+    ]
+
+    const preserved = preserveLocalPendingTurnMessages(next, previous)
+
+    expect(preserved.filter(message => message.role === 'assistant')).toHaveLength(1)
+    expect(preserved).toBe(next)
+  })
+
+  // The ordering half of the same bug: preserved rows are appended to the END,
+  // so a stale copy of an older turn lands BELOW a newer committed turn and the
+  // transcript stops reading chronologically.
+  it('does not append a stale merged-turn bubble after a newer committed turn', () => {
+    const previous = [
+      msg('1-user', 'user', 'question A'),
+      msg('assistant-stream-a1', 'assistant', 'narration A', { pending: false, interim: true }),
+      msg('assistant-stream-a2', 'assistant', 'answer A', { pending: false })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'question A'),
+      msg('2-assistant-stored', 'assistant', 'narration Aanswer A'),
+      msg('3-user-stored', 'user', 'question B')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).at(-1)).toMatchObject({ id: '3-user-stored' })
+  })
+
+  // The over-drop guard on the run reconstruction: a settled reply with no
+  // authoritative counterpart at its ordinal must survive even when a committed
+  // answer happens to contain its words. Only an exact reconstruction may drop.
+  it('keeps a settled reply that an unrelated committed answer merely contains', () => {
+    const previous = [
+      msg('1-user', 'user', 'q'),
+      msg('assistant-stream-a', 'assistant', 'narration', { pending: false, interim: true }),
+      msg('assistant-stream-b', 'assistant', 'ok', { pending: false })
+    ]
+
+    const next = [msg('1-user', 'user', 'q'), msg('2-assistant', 'assistant', 'narration and this is not ok at all')]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toContain('assistant-stream-b')
+  })
+
+  // Data loss guard. A settled bubble carrying only reasoning / tool calls adds
+  // no text to the reconstruction, so a run must not extend across it and claim
+  // it: the renderer holds the ONLY copy of that structure, and the committed
+  // text does not account for it. Found by adversarial testing of the run
+  // matcher — it regressed against HEAD before this guard existed.
+  it('does not drop an uncommitted text-less bubble trailing a matched run', () => {
+    const structural: ChatMessage = {
+      id: 'assistant-stream-structural',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', text: 'thinking' },
+        { type: 'tool-call', toolCallId: 't1', toolName: 'terminal', result: 'x' }
+      ],
+      pending: false
+    } as ChatMessage
+
+    const previous = [
+      msg('1-user', 'user', 'q'),
+      msg('assistant-stream-a', 'assistant', 'narration', { pending: false, interim: true }),
+      msg('assistant-stream-b', 'assistant', 'answer', { pending: false }),
+      structural
+    ]
+
+    const next = [msg('1-user-stored', 'user', 'q'), msg('2-assistant-stored', 'assistant', 'narrationanswer')]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toContain(
+      'assistant-stream-structural'
+    )
+  })
+
+  // Reconstruction runs on every hydrate, so its cost must not scale with how
+  // many bubbles the renderer is holding. The naive "join every candidate run"
+  // form measured 1.1s at 120 settled bubbles and 8.4s at 240 — a main-thread
+  // freeze worse than the duplicate being fixed. Bounding the run by the
+  // longest committed reply keeps it flat; this guards that bound, not a
+  // specific timing (the threshold is ~100x the observed ~1ms, so it fails on
+  // a return to quadratic/cubic growth and not on a slow machine).
+  it('does not scale superlinearly with the number of settled local bubbles', () => {
+    const worstCase = (count: number) => {
+      const previous: ChatMessage[] = []
+
+      for (let index = 0; index < count; index += 1) {
+        previous.push(msg(`assistant-stream-${index}`, 'assistant', `bubble ${index} `.repeat(40), { pending: false }))
+      }
+
+      // Nothing matches, so every run is explored to its bound.
+      return { next: [msg('auth-1', 'assistant', 'an unrelated committed answer')], previous }
+    }
+
+    const { next, previous } = worstCase(240)
+    const startedAt = performance.now()
+    preserveLocalPendingTurnMessages(next, previous)
+
+    expect(performance.now() - startedAt).toBeLessThan(100)
+  })
+
   // The reply finished locally but the gateway had not committed it when the
   // session was reopened — the local row is the only copy and must survive.
   it('keeps a settled stream row the authoritative history has not committed', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1052,6 +1052,118 @@ describe('preserveLocalPendingTurnMessages', () => {
     expect(preserveLocalPendingTurnMessages(next, [...next, settledLocalStream])).toBe(next)
   })
 
+  // #81xxx: a tool-call turn commits as ONE merged assistant row (narration +
+  // tool calls + final answer coalesced by toChatMessages), so neither local
+  // bubble equals it and both used to be re-appended — the reply rendered
+  // twice. Image-generation turns hit this on every hydrate.
+  it('does not re-append the bubbles of a turn the transcript merged into one row', () => {
+    const previous = [
+      msg('1-user', 'user', 'generate the image'),
+      msg('assistant-stream-a', 'assistant', 'Switching provider off Codex.', { pending: false, interim: true }),
+      msg('assistant-stream-b', 'assistant', "Here's Alia — same pose.", { pending: false })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'generate the image'),
+      msg('2-assistant-stored', 'assistant', "Switching provider off Codex.Here's Alia — same pose.")
+    ]
+
+    const preserved = preserveLocalPendingTurnMessages(next, previous)
+
+    expect(preserved.filter(message => message.role === 'assistant')).toHaveLength(1)
+    expect(preserved).toBe(next)
+  })
+
+  // The ordering half of the same bug: preserved rows are appended to the END,
+  // so a stale copy of an older turn lands BELOW a newer committed turn and the
+  // transcript stops reading chronologically.
+  it('does not append a stale merged-turn bubble after a newer committed turn', () => {
+    const previous = [
+      msg('1-user', 'user', 'question A'),
+      msg('assistant-stream-a1', 'assistant', 'narration A', { pending: false, interim: true }),
+      msg('assistant-stream-a2', 'assistant', 'answer A', { pending: false })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'question A'),
+      msg('2-assistant-stored', 'assistant', 'narration Aanswer A'),
+      msg('3-user-stored', 'user', 'question B')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).at(-1)).toMatchObject({ id: '3-user-stored' })
+  })
+
+  // The over-drop guard on the run reconstruction: a settled reply with no
+  // authoritative counterpart at its ordinal must survive even when a committed
+  // answer happens to contain its words. Only an exact reconstruction may drop.
+  it('keeps a settled reply that an unrelated committed answer merely contains', () => {
+    const previous = [
+      msg('1-user', 'user', 'q'),
+      msg('assistant-stream-a', 'assistant', 'narration', { pending: false, interim: true }),
+      msg('assistant-stream-b', 'assistant', 'ok', { pending: false })
+    ]
+
+    const next = [msg('1-user', 'user', 'q'), msg('2-assistant', 'assistant', 'narration and this is not ok at all')]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toContain('assistant-stream-b')
+  })
+
+  // Data loss guard. A settled bubble carrying only reasoning / tool calls adds
+  // no text to the reconstruction, so a run must not extend across it and claim
+  // it: the renderer holds the ONLY copy of that structure, and the committed
+  // text does not account for it. Found by adversarial testing of the run
+  // matcher — it regressed against HEAD before this guard existed.
+  it('does not drop an uncommitted text-less bubble trailing a matched run', () => {
+    const structural: ChatMessage = {
+      id: 'assistant-stream-structural',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', text: 'thinking' },
+        { type: 'tool-call', toolCallId: 't1', toolName: 'terminal', result: 'x' }
+      ],
+      pending: false
+    } as ChatMessage
+
+    const previous = [
+      msg('1-user', 'user', 'q'),
+      msg('assistant-stream-a', 'assistant', 'narration', { pending: false, interim: true }),
+      msg('assistant-stream-b', 'assistant', 'answer', { pending: false }),
+      structural
+    ]
+
+    const next = [msg('1-user-stored', 'user', 'q'), msg('2-assistant-stored', 'assistant', 'narrationanswer')]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toContain(
+      'assistant-stream-structural'
+    )
+  })
+
+  // Reconstruction runs on every hydrate, so its cost must not scale with how
+  // many bubbles the renderer is holding. The naive "join every candidate run"
+  // form measured 1.1s at 120 settled bubbles and 8.4s at 240 — a main-thread
+  // freeze worse than the duplicate being fixed. Bounding the run by the
+  // longest committed reply keeps it flat; this guards that bound, not a
+  // specific timing (the threshold is ~100x the observed ~1ms, so it fails on
+  // a return to quadratic/cubic growth and not on a slow machine).
+  it('does not scale superlinearly with the number of settled local bubbles', () => {
+    const worstCase = (count: number) => {
+      const previous: ChatMessage[] = []
+
+      for (let index = 0; index < count; index += 1) {
+        previous.push(msg(`assistant-stream-${index}`, 'assistant', `bubble ${index} `.repeat(40), { pending: false }))
+      }
+
+      // Nothing matches, so every run is explored to its bound.
+      return { next: [msg('auth-1', 'assistant', 'an unrelated committed answer')], previous }
+    }
+
+    const { next, previous } = worstCase(240)
+    const startedAt = performance.now()
+    preserveLocalPendingTurnMessages(next, previous)
+
+    expect(performance.now() - startedAt).toBeLessThan(100)
+  })
+
   // The reply finished locally but the gateway had not committed it when the
   // session was reopened — the local row is the only copy and must survive.
   it('keeps a settled stream row the authoritative history has not committed', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -463,6 +463,112 @@ const withAuthoritativeTurnState = (local: ChatMessage, authoritative: ChatMessa
   return merged
 }
 
+/** Collapse whitespace runs so a bubble join can't defeat the reconstruction. */
+const normalizeWhitespace = (value: string): string => value.replace(/\s+/g, ' ').trim()
+
+const visibleReplyText = (message: ChatMessage): string => textWithoutReferenceLines(chatMessageText(message))
+
+/**
+ * Local settled assistant rows whose reply the authoritative transcript already
+ * renders — identified by RECONSTRUCTING the committed row from them.
+ *
+ * A settled stream row the transcript already carries must be dropped, or it is
+ * painted a second time. The previous test for that was exact text equality
+ * against some authoritative row, which misses the shape a tool-call turn
+ * actually commits in: `toChatMessages` coalesces a whole turn (sealed interim
+ * narration, tool calls, final answer) into ONE assistant message, so the
+ * committed text is the CONCATENATION of the local bubbles. Neither bubble
+ * equals it, so both survived — the answer rendered twice, and because
+ * preserved rows are appended to the END, the stale copy also landed after any
+ * newer turn the transcript had already committed, which is what breaks
+ * chronological order in a long session.
+ *
+ * Matching a contiguous RUN of local bubbles against the merged row is what
+ * makes this safe. A bare `includes` would let an unrelated authoritative
+ * answer that merely contains a short reply ("ok", "Done.") silently swallow
+ * it; requiring the run to reconstruct the committed text exactly cannot.
+ *
+ * Cost is bounded by the longest committed reply, not by transcript length: a
+ * run is abandoned as soon as its reconstruction outgrows the largest
+ * authoritative row, since appending more bubbles can only make it longer. The
+ * naive "try every run" form was measured at 1.1s for 120 settled bubbles and
+ * 8.4s for 240 — a main-thread freeze worse than the duplicate it fixes —
+ * because each candidate re-joined and re-normalized the whole slice. Here the
+ * reconstruction is accumulated incrementally instead.
+ */
+function repliesCarriedByAuthoritative(
+  nextMessages: ChatMessage[],
+  settledLocalReplies: readonly ChatMessage[]
+): Set<string> {
+  const covered = new Set<string>()
+
+  if (!settledLocalReplies.length) {
+    return covered
+  }
+
+  const authoritativeTexts = new Set(
+    nextMessages
+      .filter(message => message.role === 'assistant')
+      .map(message => normalizeWhitespace(visibleReplyText(message)))
+      .filter(Boolean)
+  )
+
+  if (!authoritativeTexts.size) {
+    return covered
+  }
+
+  // No run whose reconstruction is longer than the largest committed reply can
+  // ever match, and a run only grows — so this is the inner loop's hard stop.
+  let longestAuthoritative = 0
+
+  for (const text of authoritativeTexts) {
+    longestAuthoritative = Math.max(longestAuthoritative, text.length)
+  }
+
+  // Normalizing each bubble in isolation would be wrong: the merged row is the
+  // join of the RAW texts, and a bubble ending in whitespace next to one
+  // starting with it collapses to a single space only when normalized together.
+  const rawTexts = settledLocalReplies.map(visibleReplyText)
+
+  for (let start = 0; start < settledLocalReplies.length; start += 1) {
+    let accumulated = ''
+    // Longest match wins: a turn's bubbles belong to the row that contains all
+    // of them, not to a shorter coincidental prefix match.
+    let matchedEnd = -1
+
+    for (let end = start; end < settledLocalReplies.length; end += 1) {
+      accumulated += rawTexts[end]
+      const reconstructed = normalizeWhitespace(accumulated)
+
+      if (reconstructed.length > longestAuthoritative) {
+        break
+      }
+
+      // A text-less bubble (reasoning / tool calls only) contributes nothing to
+      // the reconstruction, so extending the run across it would claim — and
+      // therefore DROP — a row the committed text does not account for. Its
+      // structure is the renderer's only copy, so that is silent data loss.
+      // Only a bubble that actually contributed text may close a run.
+      if (reconstructed && rawTexts[end].trim() && authoritativeTexts.has(reconstructed)) {
+        matchedEnd = end
+      }
+    }
+
+    if (matchedEnd < 0) {
+      continue
+    }
+
+    for (let index = start; index <= matchedEnd; index += 1) {
+      covered.add(settledLocalReplies[index].id)
+    }
+
+    // Resume after the claimed run — `start += 1` advances past matchedEnd.
+    start = matchedEnd
+  }
+
+  return covered
+}
+
 export function preserveLocalPendingTurnMessages(
   nextMessages: ChatMessage[],
   previousMessages: ChatMessage[]
@@ -512,6 +618,22 @@ export function preserveLocalPendingTurnMessages(
   }
 
   const latestAuthoritativeUser = [...nextMessages].reverse().find(message => message.role === 'user')
+
+  // Settled local reply bubbles, in transcript order — the run a committed
+  // tool-call turn is reconstructed from (see repliesCarriedByAuthoritative).
+  //
+  // Deliberately WIDER than the `isPendingAssistant` test used in the loop
+  // below: a standalone `assistant-interim-*` bubble is never preserved on its
+  // own, but its text IS part of the merged row, so it has to take part in the
+  // reconstruction or the run can no longer rebuild what the backend committed.
+  const settledLocalReplies = previousMessages.filter(
+    message =>
+      message.role === 'assistant' &&
+      message.pending !== true &&
+      (message.interim === true || message.id.startsWith('assistant-stream-'))
+  )
+
+  const repliesAlreadyCommitted = repliesCarriedByAuthoritative(nextMessages, settledLocalReplies)
   const preserved: ChatMessage[] = []
   // Authoritative id → richer local pending row. Replacing (not appending)
   // avoids painting both the empty inflight shell and the full stream bubble.
@@ -567,17 +689,11 @@ export function preserveLocalPendingTurnMessages(
     // the authoritative transcript already carries under its committed id is
     // stale: ordinal pairing can't see it, because the commit shifted the row
     // one ordinal earlier, and re-appending it renders the same answer twice
-    // (#70209). Only text-identical rows are dropped — a settled row the backend
-    // has NOT committed yet is the only copy of that reply and must survive.
-    if (
-      isPendingAssistant &&
-      message.pending !== true &&
-      nextMessages.some(
-        candidate =>
-          candidate.role === 'assistant' &&
-          textWithoutReferenceLines(chatMessageText(candidate)) === textWithoutReferenceLines(chatMessageText(message))
-      )
-    ) {
+    // (#70209). The committed row may be the whole turn merged into one bubble,
+    // so the match is made by reconstructing it from the run of local bubbles —
+    // a settled row the backend has NOT committed yet is the only copy of that
+    // reply and must survive.
+    if (isPendingAssistant && message.pending !== true && repliesAlreadyCommitted.has(message.id)) {
       continue
     }
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -500,6 +500,112 @@ const withAuthoritativeTurnState = (local: ChatMessage, authoritative: ChatMessa
   return merged
 }
 
+/** Collapse whitespace runs so a bubble join can't defeat the reconstruction. */
+const normalizeWhitespace = (value: string): string => value.replace(/\s+/g, ' ').trim()
+
+const visibleReplyText = (message: ChatMessage): string => textWithoutReferenceLines(chatMessageText(message))
+
+/**
+ * Local settled assistant rows whose reply the authoritative transcript already
+ * renders — identified by RECONSTRUCTING the committed row from them.
+ *
+ * A settled stream row the transcript already carries must be dropped, or it is
+ * painted a second time. The previous test for that was exact text equality
+ * against some authoritative row, which misses the shape a tool-call turn
+ * actually commits in: `toChatMessages` coalesces a whole turn (sealed interim
+ * narration, tool calls, final answer) into ONE assistant message, so the
+ * committed text is the CONCATENATION of the local bubbles. Neither bubble
+ * equals it, so both survived — the answer rendered twice, and because
+ * preserved rows are appended to the END, the stale copy also landed after any
+ * newer turn the transcript had already committed, which is what breaks
+ * chronological order in a long session.
+ *
+ * Matching a contiguous RUN of local bubbles against the merged row is what
+ * makes this safe. A bare `includes` would let an unrelated authoritative
+ * answer that merely contains a short reply ("ok", "Done.") silently swallow
+ * it; requiring the run to reconstruct the committed text exactly cannot.
+ *
+ * Cost is bounded by the longest committed reply, not by transcript length: a
+ * run is abandoned as soon as its reconstruction outgrows the largest
+ * authoritative row, since appending more bubbles can only make it longer. The
+ * naive "try every run" form was measured at 1.1s for 120 settled bubbles and
+ * 8.4s for 240 — a main-thread freeze worse than the duplicate it fixes —
+ * because each candidate re-joined and re-normalized the whole slice. Here the
+ * reconstruction is accumulated incrementally instead.
+ */
+function repliesCarriedByAuthoritative(
+  nextMessages: ChatMessage[],
+  settledLocalReplies: readonly ChatMessage[]
+): Set<string> {
+  const covered = new Set<string>()
+
+  if (!settledLocalReplies.length) {
+    return covered
+  }
+
+  const authoritativeTexts = new Set(
+    nextMessages
+      .filter(message => message.role === 'assistant')
+      .map(message => normalizeWhitespace(visibleReplyText(message)))
+      .filter(Boolean)
+  )
+
+  if (!authoritativeTexts.size) {
+    return covered
+  }
+
+  // No run whose reconstruction is longer than the largest committed reply can
+  // ever match, and a run only grows — so this is the inner loop's hard stop.
+  let longestAuthoritative = 0
+
+  for (const text of authoritativeTexts) {
+    longestAuthoritative = Math.max(longestAuthoritative, text.length)
+  }
+
+  // Normalizing each bubble in isolation would be wrong: the merged row is the
+  // join of the RAW texts, and a bubble ending in whitespace next to one
+  // starting with it collapses to a single space only when normalized together.
+  const rawTexts = settledLocalReplies.map(visibleReplyText)
+
+  for (let start = 0; start < settledLocalReplies.length; start += 1) {
+    let accumulated = ''
+    // Longest match wins: a turn's bubbles belong to the row that contains all
+    // of them, not to a shorter coincidental prefix match.
+    let matchedEnd = -1
+
+    for (let end = start; end < settledLocalReplies.length; end += 1) {
+      accumulated += rawTexts[end]
+      const reconstructed = normalizeWhitespace(accumulated)
+
+      if (reconstructed.length > longestAuthoritative) {
+        break
+      }
+
+      // A text-less bubble (reasoning / tool calls only) contributes nothing to
+      // the reconstruction, so extending the run across it would claim — and
+      // therefore DROP — a row the committed text does not account for. Its
+      // structure is the renderer's only copy, so that is silent data loss.
+      // Only a bubble that actually contributed text may close a run.
+      if (reconstructed && rawTexts[end].trim() && authoritativeTexts.has(reconstructed)) {
+        matchedEnd = end
+      }
+    }
+
+    if (matchedEnd < 0) {
+      continue
+    }
+
+    for (let index = start; index <= matchedEnd; index += 1) {
+      covered.add(settledLocalReplies[index].id)
+    }
+
+    // Resume after the claimed run — `start += 1` advances past matchedEnd.
+    start = matchedEnd
+  }
+
+  return covered
+}
+
 export function preserveLocalPendingTurnMessages(
   nextMessages: ChatMessage[],
   previousMessages: ChatMessage[]
@@ -559,6 +665,22 @@ export function preserveLocalPendingTurnMessages(
   }
 
   const latestAuthoritativeUser = [...nextMessages].reverse().find(message => message.role === 'user')
+
+  // Settled local reply bubbles, in transcript order — the run a committed
+  // tool-call turn is reconstructed from (see repliesCarriedByAuthoritative).
+  //
+  // Deliberately WIDER than the `isPendingAssistant` test used in the loop
+  // below: a standalone `assistant-interim-*` bubble is never preserved on its
+  // own, but its text IS part of the merged row, so it has to take part in the
+  // reconstruction or the run can no longer rebuild what the backend committed.
+  const settledLocalReplies = previousMessages.filter(
+    message =>
+      message.role === 'assistant' &&
+      message.pending !== true &&
+      (message.interim === true || message.id.startsWith('assistant-stream-'))
+  )
+
+  const repliesAlreadyCommitted = repliesCarriedByAuthoritative(nextMessages, settledLocalReplies)
   const preserved: ChatMessage[] = []
   // Authoritative id → richer local pending row. Replacing (not appending)
   // avoids painting both the empty inflight shell and the full stream bubble.
@@ -614,17 +736,11 @@ export function preserveLocalPendingTurnMessages(
     // the authoritative transcript already carries under its committed id is
     // stale: ordinal pairing can't see it, because the commit shifted the row
     // one ordinal earlier, and re-appending it renders the same answer twice
-    // (#70209). Only text-identical rows are dropped — a settled row the backend
-    // has NOT committed yet is the only copy of that reply and must survive.
-    if (
-      isPendingAssistant &&
-      message.pending !== true &&
-      nextMessages.some(
-        candidate =>
-          candidate.role === 'assistant' &&
-          textWithoutReferenceLines(chatMessageText(candidate)) === textWithoutReferenceLines(chatMessageText(message))
-      )
-    ) {
+    // (#70209). The committed row may be the whole turn merged into one bubble,
+    // so the match is made by reconstructing it from the run of local bubbles —
+    // a settled row the backend has NOT committed yet is the only copy of that
+    // reply and must survive.
+    if (isPendingAssistant && message.pending !== true && repliesAlreadyCommitted.has(message.id)) {
       continue
     }
 


### PR DESCRIPTION
## Symptom

Two reports that turn out to be one bug:

1. An assistant reply is **painted twice**.
2. **Newer messages appear above older ones** — the newest message is no longer at the bottom, so you have to scroll up to find it.

Any turn that narrates before calling a tool reproduces this on every hydrate. Image-generation turns hit it every time, which is where it was noticed.

## Cause

A tool-call turn is committed as **one** assistant row — `toChatMessages` (`lib/chat-messages.ts`) coalesces the sealed interim narration, the tool calls and the final answer into a single message. The live renderer holds those same texts as **separate** bubbles.

`preserveLocalPendingTurnMessages` decided a settled local reply was already committed by comparing it for **exact text equality** against some authoritative row:

```ts
nextMessages.some(candidate =>
  candidate.role === 'assistant' &&
  textWithoutReferenceLines(chatMessageText(candidate)) ===
    textWithoutReferenceLines(chatMessageText(message)))
```

Against the merged row, neither the narration bubble nor the final-answer bubble equals it, so **both** survived and were re-appended. That is symptom 1. And because preserved rows are appended to the **end** of the array, the stale copy lands after whatever newer turn the transcript already carries — that is symptom 2. Same defect, two faces.

## Fix

Decide the question by **reconstructing** the committed row: a contiguous run of settled local bubbles is accumulated and matched against the authoritative text.

Containment alone would be wrong — an unrelated committed answer could swallow a short reply like `ok` or `Done.` — so only an *exact* reconstruction may drop a row. Dropping a reply the backend has not committed is permanent loss of a visible answer, and that is the failure mode this is written to avoid.

Two hazards found while testing the fix, closed here rather than left for later:

- **Text-less bubbles.** A bubble carrying only reasoning / tool calls contributes nothing to the reconstruction, so a run could extend across it and claim it even though the committed text never accounted for it. The renderer holds the only copy of that structure. Only a bubble that actually contributed text may close a run.
- **Cost.** This runs on every hydrate. Re-joining every candidate run measured **1.1s at 120** settled bubbles and **8.4s at 240** — a main-thread freeze worse than the duplicate being fixed. The run is now accumulated incrementally and bounded by the longest committed reply: **1ms at 240**.

## Testing

- Both symptoms reproduced as failing tests before any source change.
- The two regression tests were RED-proofed in a clean worktree at the base commit: they fail without the fix, pass with it.
- The text-less-bubble test is a genuine regression guard — it passes at base, failed against the first draft of this fix, and passes now.
- The cost bound is asserted as a behavior contract (~100x headroom over the observed ~1ms), so it fails on a return to quadratic growth rather than on a slow machine.
- Full desktop UI suite green: **406 files / 3639 tests**. `tsc --noEmit` and `eslint` clean.

## Scope

Two files, no API or behavior change beyond the defect. Verified against current `main`.

One pre-existing issue found and deliberately **not** touched here: `normalizeWhitespace` collapsing whitespace on both sides can in principle equate distinct content. It behaves identically at base and is unrelated to this bug class.