### PR TITLE
fix(desktop): confirm parent death before the serve watchdog self-reaps (#83555)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17696,9 +17696,46 @@ def _maybe_open_browser(
     threading.Thread(target=_open, daemon=True).start()
 
 
-def _is_serve_orphaned(original_ppid: int, getppid=os.getppid) -> bool:
-    """True when this process lost its original spawning parent (ppid changed)."""
-    return getppid() != original_ppid
+def _is_serve_orphaned(original_ppid: int, getppid=os.getppid, pid_exists=None) -> bool:
+    """True when the recorded spawning parent is actually gone.
+
+    A changed ppid is only EVIDENCE of orphaning, not proof (#83555). On
+    Windows, a uv-created ``relocatable = true`` venv ships
+    ``venv\\Scripts\\python.exe`` as a ~45 KB trampoline that launches the real
+    interpreter as its own child and waits on it, so the backend's parent is
+    always that trampoline and never the desktop process that recorded
+    HERMES_PARENT_PID. Treating the mismatch as orphaning made
+    ``_start_parent_death_watchdog`` fire on the FIRST poll of a completely
+    healthy install — ``os._exit(0)`` before ``HERMES_BACKEND_READY`` — so
+    Hermes Desktop never booted and its repair path escalated to a venv
+    reinstall that could not fix it.
+
+    So confirm the mismatch by probing whether the recorded parent is still
+    alive; only a parent that is really gone means we were orphaned. Uses
+    ``gateway.status._pid_exists`` rather than ``os.kill(pid, 0)``: on Windows
+    CPython routes signal 0 through ``GenerateConsoleCtrlEvent``, so the
+    "harmless" liveness probe can actually signal the target.
+
+    Fails SAFE — if the probe itself errors we report "not orphaned" and keep
+    serving. A stray backend is recoverable; a desktop that never boots is the
+    bug being fixed here.
+    """
+    if getppid() == original_ppid:
+        return False
+    if pid_exists is None:
+        from gateway.status import _pid_exists
+
+        pid_exists = _pid_exists
+    try:
+        return not pid_exists(original_ppid)
+    except Exception:
+        _log.debug(
+            "serve parent-death watchdog: liveness probe for pid %s failed; "
+            "treating parent as alive",
+            original_ppid,
+            exc_info=True,
+        )
+        return False
 
 
 def _start_parent_death_watchdog() -> None:
@@ -17733,9 +17770,12 @@ def _start_parent_death_watchdog() -> None:
 
 
 def _demo() -> None:
-    # orphan iff current ppid differs from the recorded spawning parent
-    assert _is_serve_orphaned(999999999, getppid=lambda: 1) is True
+    # orphan iff the recorded spawning parent is really gone
+    assert _is_serve_orphaned(999999999, getppid=lambda: 1, pid_exists=lambda _p: False) is True
     assert _is_serve_orphaned(42, getppid=lambda: 42) is False
+    # #83555: a Windows uv trampoline interposes itself, so ppid never matches
+    # even though the desktop parent is alive and well — not orphaned.
+    assert _is_serve_orphaned(42, getppid=lambda: 77, pid_exists=lambda _p: True) is False
     print("web_server parent-death watchdog self-check: OK")
 
 

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -1,0 +1,131 @@
+"""Serve parent-death watchdog must not self-reap a healthy backend — #83555.
+
+`hermes serve` spawned by Hermes Desktop exits 0 before printing
+HERMES_BACKEND_READY on Windows, so the desktop never boots and its repair
+path escalates to a venv reinstall that cannot fix it. Cause: the watchdog
+treated *any* ppid change as orphaning, but on a uv `relocatable = true` venv
+`venv\\Scripts\\python.exe` is a trampoline that launches the real interpreter
+as its own child — so getppid() is always the trampoline, never the desktop
+process recorded in HERMES_PARENT_PID, and the watchdog fired on the first
+poll of a completely healthy install.
+
+These tests pin the distinction the fix rests on: a changed ppid is evidence
+of orphaning, a dead recorded parent is proof.
+"""
+
+import hermes_cli.web_server as ws
+
+
+ALIVE = lambda _pid: True  # noqa: E731 - probe stubs, terse on purpose
+DEAD = lambda _pid: False  # noqa: E731
+
+
+# ---------------------------------------------------------------------------
+# The regression
+# ---------------------------------------------------------------------------
+
+
+def test_trampoline_interposed_parent_is_not_orphaned():
+    """The #83555 case: ppid is the trampoline, desktop parent still alive."""
+    assert ws._is_serve_orphaned(4242, getppid=lambda: 777, pid_exists=ALIVE) is False
+
+
+def test_unchanged_ppid_is_not_orphaned_without_probing():
+    """The common POSIX case short-circuits — no probe call at all."""
+    calls = []
+
+    def _probe(pid):
+        calls.append(pid)
+        return True
+
+    assert ws._is_serve_orphaned(42, getppid=lambda: 42, pid_exists=_probe) is False
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# The behavior that must NOT regress: real orphaning still self-reaps
+# ---------------------------------------------------------------------------
+
+
+def test_dead_recorded_parent_is_orphaned():
+    """a9a0648f4's purpose: parent really died, so reap this backend."""
+    assert ws._is_serve_orphaned(4242, getppid=lambda: 1, pid_exists=DEAD) is True
+
+
+def test_reparented_to_init_with_dead_parent_is_orphaned():
+    """POSIX: ppid becomes 1 and the recorded parent is gone."""
+    assert ws._is_serve_orphaned(31337, getppid=lambda: 1, pid_exists=DEAD) is True
+
+
+# ---------------------------------------------------------------------------
+# Fail-safe: a broken probe must not kill a healthy backend
+# ---------------------------------------------------------------------------
+
+
+def test_probe_failure_reports_not_orphaned():
+    """A stray backend is recoverable; a desktop that never boots is not."""
+
+    def _boom(_pid):
+        raise OSError("access denied")
+
+    assert ws._is_serve_orphaned(4242, getppid=lambda: 777, pid_exists=_boom) is False
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_default_probe_is_the_non_killing_helper(monkeypatch):
+    """Must not fall back to os.kill(pid, 0): on Windows CPython routes signal
+    0 through GenerateConsoleCtrlEvent, so the 'harmless' liveness probe can
+    actually signal the target."""
+    seen = []
+
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_pid_exists", lambda pid: seen.append(pid) or True)
+    assert ws._is_serve_orphaned(4242, getppid=lambda: 777) is False
+    assert seen == [4242]
+
+
+def test_watchdog_is_noop_without_parent_pid(monkeypatch):
+    """Standalone `hermes serve` must never start the watchdog thread."""
+    monkeypatch.delenv("HERMES_PARENT_PID", raising=False)
+    started = []
+    monkeypatch.setattr(
+        ws.threading, "Thread", lambda *a, **k: started.append(k) or _NoThread()
+    )
+    ws._start_parent_death_watchdog()
+    assert started == []
+
+
+class _NoThread:
+    def start(self):  # pragma: no cover - only reached on regression
+        raise AssertionError("watchdog thread must not start")
+
+
+def test_watchdog_starts_when_desktop_records_a_parent(monkeypatch):
+    monkeypatch.setenv("HERMES_PARENT_PID", "4242")
+    started = {}
+
+    class _Thread:
+        def __init__(self, **kwargs):
+            started.update(kwargs)
+
+        def start(self):
+            started["started"] = True
+
+    monkeypatch.setattr(ws.threading, "Thread", lambda *a, **k: _Thread(**k))
+    ws._start_parent_death_watchdog()
+    assert started.get("started") is True
+    assert started.get("daemon") is True
+    assert started.get("name") == "serve-parent-watchdog"
+
+
+def test_watchdog_ignores_a_malformed_parent_pid(monkeypatch):
+    monkeypatch.setenv("HERMES_PARENT_PID", "not-a-pid")
+    monkeypatch.setattr(
+        ws.threading, "Thread", lambda *a, **k: (_ for _ in ()).throw(AssertionError())
+    )
+    ws._start_parent_death_watchdog()  # must not raise


### PR DESCRIPTION
Fixes #83555.

## The failure

Hermes Desktop never boots on Windows. `hermes serve` exits `0` before printing `HERMES_BACKEND_READY`, boot reports `Hermes backend exited (0)`, and after 3 soft restarts `bootstrap-repair-guard.ts` escalates to a full venv reinstall — which can't help, because nothing is actually broken.

`_is_serve_orphaned()` treated **any** ppid change as orphaning:

```python
return getppid() != original_ppid
```

On a uv-created `relocatable = true` venv, `venv\Scripts\python.exe` is a ~45 KB **trampoline** that launches the real interpreter as its own child and waits on it. The backend's parent is therefore always that trampoline, never the Electron process recorded in `HERMES_PARENT_PID`. So the predicate is True on the *first* poll of a completely healthy install, and `_start_parent_death_watchdog()` runs before the READY print — the backend kills itself on every boot. Standalone `hermes serve` is unaffected (no `HERMES_PARENT_PID`), which is exactly why only the desktop app broke. Regression from a9a0648f4.

## The fix

A changed ppid is *evidence* of orphaning; a dead recorded parent is *proof*. Confirm before exiting — the shape the reporter proposed and @tutan0558 independently confirmed works.

Three deliberate choices:

- **Probe via `gateway.status._pid_exists`, not `os.kill(pid, 0)`.** On Windows CPython collides `sig=0` with `CTRL_C_EVENT` and routes it through `GenerateConsoleCtrlEvent`, so the "harmless" liveness probe can actually signal the target. That helper is the repo's canonical non-killing check and already treats a zombie parent as gone. Lazily imported inside the function, matching how `hermes_cli/gateway.py` consumes it.
- **Fails safe.** If the probe itself raises, report not-orphaned and keep serving. A stray backend is recoverable; a desktop that never boots is the bug being fixed.
- **No `create_time` / PID-reuse plumbing.** `tests/test_slash_worker_watchdog.py` pins that contract for the sibling watchdog, so this keeps the same shape rather than quietly diverging. Residual risk is a parent that dies *and* has its PID recycled within one 2s poll — which leaves a stray backend rather than killing a healthy one, and the pre-existing reap sweeps still cover it.

## Verification

I'm on the affected configuration (Windows 11, uv trampoline venv, `pyvenv.cfg` `uv = 0.10.12`, `python.exe` 47,104 bytes), so this was checked against the real failure, not just reasoned about. Spawning exactly as `apps/desktop/electron/main.ts` does, with the parent alive and healthy:

```
before:  spawner=26136  getppid()=62020  _is_serve_orphaned -> True    # backend self-kills
after:   spawner=16688  getppid()=30876  _is_serve_orphaned -> False   # trampoline still interposed
```

And the watchdog's actual purpose still works — a recorded parent that is really gone still returns `True`, so orphaned backends are still reaped.

9 tests: the trampoline case, the no-probe short-circuit when ppid is unchanged, both real-orphan paths, the probe-failure fail-safe, that the default probe is the non-killing helper, and watchdog wiring (no-op without `HERMES_PARENT_PID`, correct thread setup, malformed pid ignored). The module's `_demo()` self-check gained the regression case. `tests/test_slash_worker_watchdog.py`, `test_serve_command.py`, `test_gateway_windows.py` all still pass; ruff clean.

## One related finding, deliberately not fixed here

`tui_gateway/slash_worker.py:55` `_is_orphaned` has the identical predicate, and it *is* reachable on Windows — `tui_gateway/server.py:342` spawns it with `sys.executable`, which on this venv **is** the trampoline (verified: `sys.executable` → `.venv\Scripts\python.exe`, 47,104 bytes). `tools/mcp_stdio_watchdog.py:57` has the same predicate but is POSIX-only by construction (the wrap site gates on `os.name == "posix"`), so it is genuinely unaffected.

I left slash_worker alone because that file carries an explicit signature-contract test and this PR is the desktop-boot fix three people reported. Happy to extend it here in the same shape (the fix fits without changing its signature) or send it separately — reviewer's call.

Credit: root-caused in the issue by its author, including the trampoline diagnosis and the suggested guard; @tutan0558 confirmed the fix independently on a second install.