### PR TITLE
fix(skills): restore timestamped curator archives

### DIFF
--- a/contributors/emails/zhoujiari2008@163.com
+++ b/contributors/emails/zhoujiari2008@163.com
@@ -1,0 +1,1 @@
+szzhoujiarui

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -393,6 +393,38 @@ def test_is_agent_created(skills_home):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("timestamp", ["20260727000000", "20260727-000000"])
+def test_archived_skill_names_round_trip_timestamped_directories(
+    skills_home,
+    timestamp,
+):
+    from tools.skill_usage import list_archived_skill_names, restore_skill
+
+    skills_dir = skills_home / "skills"
+    archive_dir = skills_dir / ".archive"
+    archived_skill = _write_skill(archive_dir, "airtable")
+    archived_skill.rename(archive_dir / f"airtable-{timestamp}")
+
+    assert list_archived_skill_names() == ["airtable"]
+
+    ok, _message = restore_skill("airtable")
+
+    assert ok is True
+    assert (skills_dir / "airtable" / "SKILL.md").exists()
+
+
+def test_restore_does_not_match_timestamp_like_sibling_name(skills_home):
+    from tools.skill_usage import restore_skill
+
+    archive_dir = skills_home / "skills" / ".archive"
+    _write_skill(archive_dir, "git-helpers-20260727000000")
+
+    ok, message = restore_skill("git")
+
+    assert ok is False
+    assert message == "skill 'git' not found in archive"
+
+
 # ---------------------------------------------------------------------------
 # Reporting
 # ---------------------------------------------------------------------------

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -390,17 +390,40 @@ def list_agent_created_skill_names() -> List[str]:
     return sorted(set(names))
 
 
+def _is_archive_timestamp(value: str) -> bool:
+    """Recognize timestamps written by archive_skill and legacy curator moves."""
+    if len(value) == 14 and value.isdigit():
+        return True
+    return (
+        len(value) == 15
+        and value[8] == "-"
+        and value[:8].isdigit()
+        and value[9:].isdigit()
+    )
+
+
+def _archived_skill_name(path: Path) -> str:
+    """Return the canonical skill name represented by an archive directory."""
+    declared_name = _read_skill_name(path / "SKILL.md", fallback="")
+    if declared_name:
+        return declared_name
+    stem, separator, suffix = path.name.rpartition("-")
+    if separator and stem and _is_archive_timestamp(suffix):
+        return stem
+    return path.name
+
+
 def list_archived_skill_names() -> List[str]:
     """Enumerate skills in ``~/.hermes/skills/.archive/``.
 
-    Archive layout is flat (``.archive/<skill>/``) as set by ``archive_skill``,
-    so the directory name is the skill name. Used by ``hermes curator
-    list-archived`` to help users pass a name to ``hermes curator restore``.
+    Collision timestamps are directory disambiguators, not part of the skill
+    name. Return canonical names so every result can be passed directly to
+    ``hermes curator restore``.
     """
     archive_root = _archive_dir()
     if not archive_root.exists():
         return []
-    return sorted({p.name for p in archive_root.iterdir() if p.is_dir()})
+    return sorted({_archived_skill_name(p) for p in archive_root.iterdir() if p.is_dir()})
 
 
 def _read_skill_name(skill_md: Path, fallback: str) -> str:
@@ -1163,20 +1186,18 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     candidates = [p for p in archive_root.rglob("*") if p.is_dir() and p.name == skill_name]
     if not candidates:
         # A name collision makes archive_skill() disambiguate by appending its
-        # UTC timestamp ("<skill>-YYYYMMDDHHMMSS", a 14-digit suffix), so only
-        # that exact shape is another copy of THIS skill. A bare
+        # UTC timestamp ("<skill>-YYYYMMDDHHMMSS"). Older curator moves used
+        # "<skill>-YYYYMMDD-HHMMSS"; accept both strict timestamp shapes. A bare
         # startswith(f"{skill_name}-") also swallows unrelated sibling skills —
         # restoring "git" would otherwise pull an archived "git-helpers" out of
-        # the archive and rename it to "git", destroying the sibling's only
-        # copy. Require the suffix to be the timestamp archive_skill writes.
+        # the archive and rename it to "git", destroying the sibling's only copy.
         prefix = f"{skill_name}-"
         candidates = sorted(
             [
                 p for p in archive_root.rglob("*")
                 if p.is_dir()
                 and p.name.startswith(prefix)
-                and len(p.name) - len(prefix) == 14
-                and p.name[len(prefix):].isdigit()
+                and _is_archive_timestamp(p.name[len(prefix):])
             ],
             reverse=True,
         )


### PR DESCRIPTION
## What does this PR do?

Makes curator archive listing and restoration round-trippable for timestamped archive directories.

`list_archived_skill_names()` now reports the canonical skill name from `SKILL.md`, with a strict timestamp fallback for incomplete archives. `restore_skill()` accepts both timestamps produced by `archive_skill()` and the historical hyphenated timestamps produced by curator-assisted moves.

The timestamp recognizer remains strict, preserving the existing protection that prevents restoring `git` from matching a sibling such as `git-helpers`.

## Related Issue

Fixes #83580

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated `tools/skill_usage.py` to normalize archived directory names and recognize both supported timestamp layouts.
- Added archive list/restore round-trip coverage to `tests/tools/test_skill_usage.py`.
- Added regression coverage for the `git` versus timestamp-like sibling-name boundary.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_skill_usage.py -q` in a configured development environment.
2. Archive directories named `<skill>-YYYYMMDDHHMMSS` and `<skill>-YYYYMMDD-HHMMSS`.
3. Confirm `hermes curator list-archived` prints `<skill>` and `hermes curator restore <skill>` restores each directory.

Local validation on Linux:

```text
tests/tools/test_skill_usage.py: 28 passed
ruff check tools/skill_usage.py tests/tools/test_skill_usage.py: passed
python3 scripts/check-windows-footguns.py --all: passed
git diff --check: passed
```

The local checkout did not include the complete development dependency set, so the focused test file ran through the canonical runner with `--confcutdir=tests/tools`. CI will exercise the normal repository conftest and broader suite.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

N/A. This change affects CLI archive discovery and filesystem restoration behavior.
