### PR TITLE
Inspired by ChatGPT Work: extend hermes import-agent with Cursor support

### DIFF
--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -1,9 +1,10 @@
 """hermes import-agent — import Claude Code / Codex CLI setups into Hermes.
 
 Usage:
-    hermes import-agent                       # auto-detect ~/.claude or ~/.codex
+    hermes import-agent                       # auto-detect ~/.claude, ~/.codex or ~/.cursor
     hermes import-agent claude-code           # import from ~/.claude
     hermes import-agent codex                 # import from ~/.codex
+    hermes import-agent cursor                # import from ~/.cursor
     hermes import-agent claude-code --dry-run # preview only, no changes
     hermes import-agent codex --source /path/to/.codex
 
@@ -29,6 +30,15 @@ codex (~/.codex):
     config.toml [mcp_servers.*]     → config.yaml mcp_servers
     memories/*.md                   → memory entries in HERMES_HOME/memories/MEMORY.md
     skills/<name>/SKILL.md          → HERMES_HOME/skills/codex-imports/<name>/
+
+cursor (~/.cursor):
+    AGENTS.md                       → memory entries in HERMES_HOME/memories/MEMORY.md
+    rules/*.md, rules/*.mdc         → memory entries (frontmatter stripped)
+    mcp.json mcpServers             → config.yaml mcp_servers
+    skills/**/<name>/SKILL.md       → HERMES_HOME/skills/cursor-imports/<name>/
+                                      (Cursor supports nested category dirs;
+                                      the skill's identity is the folder that
+                                      holds SKILL.md, so discovery is recursive)
 
 Secrets are NEVER imported: credential files (.credentials.json, auth.json)
 are ignored, and MCP server env vars with secret-looking names (KEY, TOKEN,
@@ -59,16 +69,18 @@ ENTRY_DELIMITER = "\n§\n"
 # default memory limit).
 MEMORY_CHAR_LIMIT = 20_000
 
-SUPPORTED_AGENTS = ("claude-code", "codex")
+SUPPORTED_AGENTS = ("claude-code", "codex", "cursor")
 
 _AGENT_DEFAULT_DIRS = {
     "claude-code": ".claude",
     "codex": ".codex",
+    "cursor": ".cursor",
 }
 
 _SKILL_CATEGORY = {
     "claude-code": "claude-code-imports",
     "codex": "codex-imports",
+    "cursor": "cursor-imports",
 }
 
 # Env var names that look like credentials — never copied into config.yaml.
@@ -79,12 +91,27 @@ _SECRET_KEY_RE = re.compile(
 )
 
 # Files inside the source tree that hold credentials — never read.
-_CREDENTIAL_FILENAMES = (".credentials.json", "auth.json", "credentials.json")
+_CREDENTIAL_FILENAMES = (
+    ".credentials.json", "auth.json", "credentials.json", "cli-config.json",
+)
+
+# Leading YAML frontmatter block (used by Cursor .mdc rules and SKILL.md).
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n.*?\n---\s*\n", re.DOTALL)
 
 
 def is_secret_key(key: str) -> bool:
     """Return True when an env-var name looks like a credential."""
     return bool(_SECRET_KEY_RE.search(key or ""))
+
+
+def strip_frontmatter(text: str) -> str:
+    """Drop a leading ``---`` YAML frontmatter block, if present.
+
+    Cursor rule files (``.mdc``) carry frontmatter (``description``,
+    ``globs``, ``alwaysApply``) that is routing metadata, not instructions —
+    importing it as memory entries would just add noise.
+    """
+    return _FRONTMATTER_RE.sub("", text or "", count=1)
 
 
 def normalize_text(text: str) -> str:
@@ -469,6 +496,8 @@ class AgentImporter:
             return self.build_report()
         if self.agent == "claude-code":
             self._run_claude_code()
+        elif self.agent == "cursor":
+            self._run_cursor()
         else:
             self._run_codex()
         return self.build_report()
@@ -496,6 +525,12 @@ class AgentImporter:
                                 kind="mcp-servers")
         self.import_memories_dir(self.source_root / "memories")
         self.import_skills(self.source_root / "skills")
+
+    def _run_cursor(self) -> None:
+        self.import_context_file(self.source_root / "AGENTS.md", kind="agents-md")
+        self.import_cursor_rules(self.source_root / "rules")
+        self.import_mcp_servers(self._cursor_mcp_servers(), kind="mcp-servers")
+        self.import_skills(self.source_root / "skills", recursive=True)
 
     # -- parsers (fail soft: bad files become per-item error records) -------
 
@@ -551,6 +586,21 @@ class AgentImporter:
             return {}
         return data if isinstance(data, dict) else {}
 
+    def _cursor_mcp_servers(self) -> Dict[str, Any]:
+        """Collect mcpServers from ~/.cursor/mcp.json."""
+        path = self.source_root / "mcp.json"
+        if not path.exists():
+            return {}
+        try:
+            data = json.loads(read_text(path))
+        except (json.JSONDecodeError, OSError) as exc:
+            self.record("mcp-servers", path, None, "error",
+                        f"Could not parse mcp.json: {exc}")
+            return {}
+        if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
+            return data["mcpServers"]
+        return {}
+
     # -- mappers -------------------------------------------------------------
 
     def import_context_file(self, source: Path, kind: str) -> None:
@@ -591,6 +641,36 @@ class AgentImporter:
                         "No importable entries found")
             return
         self._merge_memory_entries("memories", memories_dir, destination, incoming)
+
+    def import_cursor_rules(self, rules_dir: Path) -> None:
+        """cursor rules/*.md + rules/*.mdc → memory entries in MEMORY.md.
+
+        ``.mdc`` files carry YAML frontmatter with routing metadata
+        (``globs``, ``alwaysApply``); it is stripped so only the instruction
+        body becomes memory entries.
+        """
+        destination = self.target_root / "memories" / "MEMORY.md"
+        if not rules_dir.is_dir():
+            self.record("rules", None, destination, "skipped",
+                        "No rules directory found")
+            return
+        incoming: List[str] = []
+        rule_files = sorted(
+            p for p in rules_dir.rglob("*")
+            if p.is_file() and p.suffix in (".md", ".mdc")
+        )
+        for rule_file in rule_files:
+            try:
+                incoming.extend(extract_markdown_entries(
+                    strip_frontmatter(read_text(rule_file))))
+            except OSError as exc:
+                self.record("rules", rule_file, destination, "error",
+                            f"Could not read file: {exc}")
+        if not incoming:
+            self.record("rules", rules_dir, destination, "skipped",
+                        "No importable entries found")
+            return
+        self._merge_memory_entries("rules", rules_dir, destination, incoming)
 
     def _merge_memory_entries(self, kind: str, source: Path,
                               destination: Path, incoming: List[str]) -> None:
@@ -804,28 +884,48 @@ class AgentImporter:
             config["mcp_servers"] = existing
             dump_yaml_file(destination, config)
 
-    def import_skills(self, source_root: Path) -> None:
-        """skills/<name>/SKILL.md dirs → HERMES_HOME/skills/<category>/<name>."""
+    def import_skills(self, source_root: Path, recursive: bool = False) -> None:
+        """skills/<name>/SKILL.md dirs → HERMES_HOME/skills/<category>/<name>.
+
+        ``recursive=True`` (Cursor) also discovers nested category layouts
+        like ``skills/shipping/land-it/SKILL.md`` — per Cursor's docs the
+        skill's identity is the folder containing SKILL.md, not the parent
+        category, so ``land-it`` is imported flat under the Hermes category
+        dir.  Name collisions across categories are per-item conflicts.
+        """
         category = _SKILL_CATEGORY[self.agent]
         destination_root = self.target_root / "skills" / category
         if not source_root.is_dir():
             self.record("skills", None, destination_root, "skipped",
                         "No skills directory found")
             return
-        skill_dirs = [
-            p for p in sorted(source_root.iterdir())
-            if p.is_dir() and (p / "SKILL.md").exists()
-        ]
+        if recursive:
+            skill_dirs = sorted(
+                {p.parent for p in source_root.rglob("SKILL.md")
+                 if p.parent != source_root}
+            )
+        else:
+            skill_dirs = [
+                p for p in sorted(source_root.iterdir())
+                if p.is_dir() and (p / "SKILL.md").exists()
+            ]
         if not skill_dirs:
             self.record("skills", source_root, destination_root, "skipped",
                         "No skills with SKILL.md found")
             return
+        planned: set = set()
         for skill_dir in skill_dirs:
             destination = destination_root / skill_dir.name
+            if skill_dir.name in planned:
+                self.record("skill", skill_dir, destination, "conflict",
+                            "Duplicate skill name in source tree — "
+                            "already imported from another category")
+                continue
             if destination.exists() and not self.overwrite:
                 self.record("skill", skill_dir, destination, "conflict",
                             "Destination skill already exists")
                 continue
+            planned.add(skill_dir.name)
             if self.execute:
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 if destination.exists():
@@ -866,13 +966,15 @@ def import_agent_command(args) -> None:
         detected = detect_agents()
         if not detected:
             print()
-            print_error("No supported agent setup found (~/.claude or ~/.codex).")
+            print_error("No supported agent setup found "
+                        "(~/.claude, ~/.codex, or ~/.cursor).")
             print_info("Specify one explicitly: hermes import-agent claude-code --source /path")
             return
         if len(detected) > 1 and explicit_source is None:
             print()
             print_info("Multiple agent setups detected: " + ", ".join(detected))
-            print_info("Pick one: hermes import-agent claude-code   or   hermes import-agent codex")
+            print_info("Pick one: hermes import-agent " +
+                       "   or   hermes import-agent ".join(detected))
             return
         agent = detected[0]
 

--- a/hermes_cli/subcommands/import_agent.py
+++ b/hermes_cli/subcommands/import_agent.py
@@ -14,11 +14,12 @@ def build_import_agent_parser(subparsers, *, cmd_import_agent: Callable) -> None
     """Attach the ``import-agent`` subcommand to ``subparsers``."""
     parser = subparsers.add_parser(
         "import-agent",
-        help="Import a Claude Code or Codex CLI setup into Hermes",
+        help="Import a Claude Code, Codex CLI, or Cursor setup into Hermes",
         description=(
             "One-command import of another coding agent's setup into Hermes. "
-            "Maps CLAUDE.md/AGENTS.md instructions, permission allowlists, MCP "
-            "servers, skills, and memories into their Hermes equivalents. "
+            "Maps CLAUDE.md/AGENTS.md instructions, Cursor rules, permission "
+            "allowlists, MCP servers, skills, and memories into their Hermes "
+            "equivalents. "
             "Always shows a preview before making changes. API keys and "
             "credentials are never imported — run 'hermes setup' for those."
         ),
@@ -26,12 +27,18 @@ def build_import_agent_parser(subparsers, *, cmd_import_agent: Callable) -> None
     parser.add_argument(
         "agent",
         nargs="?",
-        choices=["claude-code", "codex"],
-        help="Which agent to import from (default: auto-detect ~/.claude or ~/.codex)",
+        choices=["claude-code", "codex", "cursor"],
+        help=(
+            "Which agent to import from "
+            "(default: auto-detect ~/.claude, ~/.codex, or ~/.cursor)"
+        ),
     )
     parser.add_argument(
         "--source",
-        help="Path to the agent's config directory (default: ~/.claude or ~/.codex)",
+        help=(
+            "Path to the agent's config directory "
+            "(default: ~/.claude, ~/.codex, or ~/.cursor)"
+        ),
     )
     parser.add_argument(
         "--dry-run",

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -168,6 +168,68 @@ def snapshot_tree(root: Path) -> dict:
     }
 
 
+CURSOR_AGENTS_MD = """# Cursor global instructions
+
+- Always run tests before committing
+"""
+
+CURSOR_RULE_MDC = """---
+description: Python style rules
+globs: "**/*.py"
+alwaysApply: false
+---
+
+- Use dataclasses for plain data containers
+- Never use mutable default arguments
+"""
+
+
+@pytest.fixture()
+def cursor_tree(profile_env):
+    """Build a fake ~/.cursor tree."""
+    root = profile_env / ".cursor"
+    root.mkdir()
+    (root / "AGENTS.md").write_text(CURSOR_AGENTS_MD, encoding="utf-8")
+    rules = root / "rules"
+    rules.mkdir()
+    (rules / "python.mdc").write_text(CURSOR_RULE_MDC, encoding="utf-8")
+    (rules / "general.md").write_text(
+        "- Prefer small focused commits\n", encoding="utf-8")
+    (root / "mcp.json").write_text(json.dumps({
+        "mcpServers": {
+            "linear": {
+                "command": "npx",
+                "args": ["-y", "linear-mcp"],
+                "env": {
+                    "LINEAR_API_KEY": "lin_SECRET",
+                    "LINEAR_TEAM": "hermes",
+                },
+            },
+            "remote-docs": {
+                "url": "https://mcp.example.com/http",
+                "headers": {
+                    "Authorization": "Bearer xyz",
+                    "X-Env": "prod",
+                },
+            },
+        },
+    }), encoding="utf-8")
+    # CLI credential file — must never be read
+    (root / "cli-config.json").write_text(
+        json.dumps({"apiKey": "cur_SUPERSECRET"}), encoding="utf-8")
+    # Flat skill
+    flat = root / "skills" / "tdd"
+    flat.mkdir(parents=True)
+    (flat / "SKILL.md").write_text(
+        "---\nname: tdd\n---\n\nRed, green, refactor.\n", encoding="utf-8")
+    # Nested (categorized) skill — identity is the folder holding SKILL.md
+    nested = root / "skills" / "shipping" / "land-it"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: land-it\n---\n\nLand the PR.\n", encoding="utf-8")
+    return root
+
+
 def run_import(agent, source, hermes_home, execute, overwrite=False):
     return AgentImporter(
         agent=agent,
@@ -186,10 +248,13 @@ class TestDetection:
     def test_detects_claude_and_codex(self, claude_tree, codex_tree):
         assert detect_agents() == ["claude-code", "codex"]
 
+    def test_detects_cursor(self, cursor_tree):
+        assert detect_agents() == ["cursor"]
+
 
     def test_unsupported_agent_raises(self, hermes_home, tmp_path):
         with pytest.raises(ValueError):
-            AgentImporter("cursor", tmp_path, hermes_home)
+            AgentImporter("windsurf", tmp_path, hermes_home)
 
 
 class TestRuleMapping:
@@ -296,6 +361,75 @@ class TestCodexImport:
 
     def test_skill_copied(self, report, hermes_home):
         assert (hermes_home / "skills" / "codex-imports" / "db-migrate" / "SKILL.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Cursor real run
+# ---------------------------------------------------------------------------
+
+class TestCursorImport:
+    @pytest.fixture()
+    def report(self, cursor_tree, hermes_home):
+        return run_import("cursor", cursor_tree, hermes_home, execute=True)
+
+    def test_agents_md_lands_in_memory(self, report, hermes_home):
+        memory = (hermes_home / "memories" / "MEMORY.md").read_text()
+        assert "Always run tests before committing" in memory
+
+    def test_rules_land_in_memory_with_frontmatter_stripped(
+            self, report, hermes_home):
+        memory = (hermes_home / "memories" / "MEMORY.md").read_text()
+        assert "mutable default arguments" in memory
+        assert "small focused commits" in memory
+        # .mdc frontmatter is routing metadata, not instructions
+        assert "alwaysApply" not in memory
+        assert "globs" not in memory
+
+    def test_mcp_servers_from_mcp_json(self, report, hermes_home):
+        config = yaml.safe_load((hermes_home / "config.yaml").read_text())
+        linear = config["mcp_servers"]["linear"]
+        assert linear["command"] == "npx"
+        assert linear["env"] == {"LINEAR_TEAM": "hermes"}
+        remote = config["mcp_servers"]["remote-docs"]
+        assert remote["url"] == "https://mcp.example.com/http"
+        assert remote["headers"] == {"X-Env": "prod"}
+
+    def test_flat_and_nested_skills_copied(self, report, hermes_home):
+        root = hermes_home / "skills" / "cursor-imports"
+        assert (root / "tdd" / "SKILL.md").exists()
+        # nested category dir flattens to the SKILL.md-holding folder name
+        assert (root / "land-it" / "SKILL.md").exists()
+        assert not (root / "shipping").exists()
+
+    def test_no_secret_values_anywhere(self, cursor_tree, hermes_home):
+        run_import("cursor", cursor_tree, hermes_home, execute=True)
+        blob = "".join(
+            p.read_text(encoding="utf-8", errors="replace")
+            for p in sorted(hermes_home.rglob("*")) if p.is_file()
+        )
+        assert "lin_SECRET" not in blob
+        assert "cur_SUPERSECRET" not in blob
+        assert "Bearer xyz" not in blob
+
+    def test_dry_run_writes_nothing(self, cursor_tree, hermes_home):
+        before = snapshot_tree(hermes_home)
+        report = run_import("cursor", cursor_tree, hermes_home, execute=False)
+        assert snapshot_tree(hermes_home) == before
+        assert report["summary"]["imported"] > 0
+
+    def test_duplicate_nested_skill_name_conflicts(
+            self, cursor_tree, hermes_home):
+        dup = cursor_tree / "skills" / "debugging" / "tdd"
+        dup.mkdir(parents=True)
+        (dup / "SKILL.md").write_text(
+            "---\nname: tdd\n---\n\nOther tdd.\n", encoding="utf-8")
+        report = run_import("cursor", cursor_tree, hermes_home, execute=True)
+        skill_items = [i for i in report["items"] if i["kind"] == "skill"]
+        conflicts = [i for i in skill_items if i["status"] == "conflict"]
+        assert len(conflicts) == 1
+        assert "Duplicate skill name" in conflicts[0]["reason"]
+        # exactly one tdd landed
+        assert (hermes_home / "skills" / "cursor-imports" / "tdd" / "SKILL.md").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -704,7 +838,7 @@ class TestCliWiring:
         subparsers = parser.add_subparsers(dest="command")
         build_import_agent_parser(subparsers, cmd_import_agent=lambda a: None)
         with pytest.raises(SystemExit):
-            parser.parse_args(["import-agent", "cursor"])
+            parser.parse_args(["import-agent", "windsurf"])
 
     def test_command_dry_run_via_cli_writes_nothing(
             self, claude_tree, hermes_home, capsys):

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -90,7 +90,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes sessions` | Browse, export, prune, rename, and delete sessions. |
 | `hermes insights` | Show token/cost/activity analytics. |
 | `hermes claw` | OpenClaw migration helpers. |
-| `hermes import-agent` | Import a Claude Code (`~/.claude`) or Codex CLI (`~/.codex`) setup. |
+| `hermes import-agent` | Import a Claude Code (`~/.claude`), Codex CLI (`~/.codex`), or Cursor (`~/.cursor`) setup. |
 | `hermes dashboard` | Launch the web dashboard for managing config, API keys, and sessions. |
 | `hermes serve` | Start the Hermes backend server (headless; powers the desktop app and remote backends). |
 | `hermes desktop` (alias `gui`) | Build and launch the native Electron desktop app. |
@@ -1538,15 +1538,15 @@ hermes claw migrate --source /home/user/old-openclaw
 ## `hermes import-agent`
 
 ```bash
-hermes import-agent [claude-code|codex] [options]
+hermes import-agent [claude-code|codex|cursor] [options]
 ```
 
-Import a **Claude Code** (`~/.claude`) or **OpenAI Codex CLI** (`~/.codex`) setup into Hermes. Maps `CLAUDE.md`/`AGENTS.md` instructions to memory entries, `Bash(...)` permission allow/deny rules to `command_allowlist`/`approvals.deny`, MCP servers to `mcp_servers` in `config.yaml`, and skill directories into `~/.hermes/skills/`. Always previews before applying; API keys and credentials are never imported.
+Import a **Claude Code** (`~/.claude`), **OpenAI Codex CLI** (`~/.codex`), or **Cursor** (`~/.cursor`) setup into Hermes. Maps `CLAUDE.md`/`AGENTS.md` instructions and Cursor rules to memory entries, `Bash(...)` permission allow/deny rules to `command_allowlist`/`approvals.deny`, MCP servers to `mcp_servers` in `config.yaml`, and skill directories into `~/.hermes/skills/`. Always previews before applying; API keys and credentials are never imported.
 
 | Option | Description |
 | --- | --- |
-| `agent` | `claude-code` or `codex` (default: auto-detect). |
-| `--source <path>` | Custom source directory (default: `~/.claude` or `~/.codex`). |
+| `agent` | `claude-code`, `codex`, or `cursor` (default: auto-detect). |
+| `--source <path>` | Custom source directory (default: `~/.claude`, `~/.codex`, or `~/.cursor`). |
 | `--dry-run` | Preview only — write nothing. |
 | `--overwrite` | Replace conflicting MCP servers / skills (default: skip). |
 | `--yes`, `-y` | Skip confirmation prompts. |

--- a/website/docs/user-guide/import-from-other-agents.md
+++ b/website/docs/user-guide/import-from-other-agents.md
@@ -1,17 +1,18 @@
 ---
 sidebar_position: 9
 title: "Import from Other Agents"
-description: "One-command import of a Claude Code (~/.claude) or OpenAI Codex CLI (~/.codex) setup into Hermes — instructions, allowlists, MCP servers, skills, and memories."
+description: "One-command import of a Claude Code (~/.claude), OpenAI Codex CLI (~/.codex), or Cursor (~/.cursor) setup into Hermes — instructions, rules, allowlists, MCP servers, skills, and memories."
 ---
 
 # Import from Other Agents
 
-`hermes import-agent` imports your existing **Claude Code** or **OpenAI Codex CLI** setup into Hermes with one command. It follows the same preview-first pattern as [`hermes claw migrate`](../guides/migrate-from-openclaw.md): you always see a per-item plan before anything is written, and `--dry-run` never touches disk.
+`hermes import-agent` imports your existing **Claude Code**, **OpenAI Codex CLI**, or **Cursor** setup into Hermes with one command. It follows the same preview-first pattern as [`hermes claw migrate`](../guides/migrate-from-openclaw.md): you always see a per-item plan before anything is written, and `--dry-run` never touches disk.
 
 ```bash
-hermes import-agent                    # auto-detect ~/.claude or ~/.codex
+hermes import-agent                    # auto-detect ~/.claude, ~/.codex, or ~/.cursor
 hermes import-agent claude-code        # import from ~/.claude
 hermes import-agent codex              # import from ~/.codex
+hermes import-agent cursor             # import from ~/.cursor
 hermes import-agent claude-code --dry-run          # preview only
 hermes import-agent codex --source /path/to/.codex # custom location
 hermes import-agent claude-code --overwrite --yes  # replace conflicts, skip prompts
@@ -41,9 +42,20 @@ Claude's `Bash(npm run test:*)` prefix rules become `npm run test*` globs. Non-`
 | `memories/*.md` | Memory entries in `~/.hermes/memories/MEMORY.md` |
 | `skills/<name>/` (dirs with `SKILL.md`) | `~/.hermes/skills/codex-imports/<name>/` |
 
+### Cursor (`~/.cursor`)
+
+| Cursor | Hermes |
+|---|---|
+| `AGENTS.md` (global instructions) | Memory entries in `~/.hermes/memories/MEMORY.md` |
+| `rules/*.md`, `rules/*.mdc` (User Rules) | Memory entries in `~/.hermes/memories/MEMORY.md` |
+| `mcp.json` → `mcpServers` | `mcp_servers` in `config.yaml` |
+| `skills/**/<name>/` (dirs with `SKILL.md`, nested categories supported) | `~/.hermes/skills/cursor-imports/<name>/` |
+
+`.mdc` rule frontmatter (`description`, `globs`, `alwaysApply`) is routing metadata for Cursor's rule engine and is stripped — only the instruction body is imported. Cursor allows nested skill category folders (`skills/shipping/land-it/SKILL.md`); per Cursor's own semantics the skill's identity is the folder containing `SKILL.md`, so nested skills import flat as `cursor-imports/land-it/`. Duplicate skill names across categories are reported as conflicts.
+
 ## What is never imported
 
-**API keys and credentials.** Credential files (`~/.claude/.credentials.json`, `~/.codex/auth.json`) are never read, and MCP server environment variables or headers with secret-looking names (`*_TOKEN`, `*_API_KEY`, `Authorization`, ...) are stripped and listed in the report so you can re-add them deliberately. Run `hermes setup` to configure providers, or add secrets to `~/.hermes/.env`.
+**API keys and credentials.** Credential files (`~/.claude/.credentials.json`, `~/.codex/auth.json`, `~/.cursor/cli-config.json`) are never read, and MCP server environment variables or headers with secret-looking names (`*_TOKEN`, `*_API_KEY`, `Authorization`, ...) are stripped and listed in the report so you can re-add them deliberately. Run `hermes setup` to configure providers, or add secrets to `~/.hermes/.env`.
 
 ## Behavior notes
 


### PR DESCRIPTION
## Summary
`hermes import-agent` now imports Cursor setups (`~/.cursor`) — a user switching from Cursor gets their rules, MCP servers, and skills into Hermes with one command.

Weekly ChatGPT Work scout, Aug 11 2026. Source: [Codex CLI 0.147.0 release notes](https://learn.chatgpt.com/docs/changelog) (Aug 7, 2026) — "Import Cursor-managed skills and synchronize changes to imported Claude and Cursor conversations". OpenAI's agent stack now treats Cursor as a first-class import source; Hermes' existing `hermes import-agent` covered Claude Code and Codex CLI, so this closes the gap by extending the same detect → parse → map → apply pipeline rather than adding anything new to the core.

## Changes
- `hermes_cli/agent_import.py`: `cursor` added to `SUPPORTED_AGENTS`; new `_run_cursor()`, `_cursor_mcp_servers()` (mcp.json), `import_cursor_rules()` (rules/*.md + *.mdc with YAML frontmatter stripped — `globs`/`alwaysApply` are Cursor routing metadata, not instructions), `strip_frontmatter()` helper
- `import_skills(recursive=True)`: discovers Cursor's nested category layout (`skills/shipping/land-it/SKILL.md`) — per Cursor's docs the skill's identity is the folder holding `SKILL.md`, so nested skills import flat; duplicate names across categories become per-item conflicts
- `cli-config.json` added to the never-read credential filenames; auto-detect includes `~/.cursor` and the multi-detect hint enumerates whatever was found
- `hermes_cli/subcommands/import_agent.py`: `cursor` choice + updated help text
- `website/docs/user-guide/import-from-other-agents.md`, `website/docs/reference/cli-commands.md`: Cursor mapping table + option docs

## Mapping
| Cursor | Hermes |
|---|---|
| `AGENTS.md` | memory entries |
| `rules/*.md`, `rules/*.mdc` | memory entries (frontmatter stripped) |
| `mcp.json` → `mcpServers` | `config.yaml` `mcp_servers` (secrets stripped) |
| `skills/**/<name>/SKILL.md` | `skills/cursor-imports/<name>/` |
| `cli-config.json` | never read |

## Validation
| | Result |
|---|---|
| `tests/hermes_cli/test_agent_import.py` | 56/56 pass (8 new in `TestCursorImport`: frontmatter strip, nested-skill flattening, dupe-name conflict, secrets-never-imported, dry-run write-nothing, mcp.json mapping) |
| E2E | real `import_agent_command()` run against an isolated `HERMES_HOME` + fake `~/.cursor` tree: preview → apply, memory/config/skills all landed, `GH_TOKEN` stripped and reported |
| ruff | clean |

## Infographic

![Import from Cursor](https://v3b.fal.media/files/b/0aa5da2b/Nte5DBKgPnpMOVlvY2M5X_Ncm4lAIL.png)
