### PR TITLE
fix(desktop): stop the sidebar drag sensor from swallowing Space in text inputs

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -18,6 +18,7 @@ import {
   SidebarRowNest,
   SidebarRowShell
 } from '../chrome'
+import type { ShellDragProps } from '../reorderable-list'
 
 import { latestProjectSessions, PROJECT_PREVIEW_COUNT, useWorkspaceNodeOpen } from './model'
 import { ProjectContextMenu, ProjectMenu } from './project-menu'
@@ -74,7 +75,7 @@ interface ProjectOverviewRowProps {
   dragHandleProps?: React.HTMLAttributes<HTMLElement>
   /** Pointer-only dnd listeners for the row SHELL — never the keyboard
    *  activator or role/tabIndex (see session-row for the full rationale). */
-  shellDragProps?: React.HTMLAttributes<HTMLElement>
+  shellDragProps?: ShellDragProps
   ref?: React.Ref<HTMLDivElement>
   style?: React.CSSProperties
 }
@@ -145,11 +146,6 @@ export function ProjectOverviewRow({
       // listeners, minus the controls that keep their own gestures. A project
       // row has no rival drag (its title navigates on CLICK), so the sortable
       // owns the press outright.
-      //
-      // Pointer-only on the shell (shellDragProps): the keyboard activator +
-      // role/tabIndex stay on the grabber, so a focused row control can't
-      // start a dnd-kit drag or feed its Space/Enter end codes.
-      {...shellDragProps}
       onPointerDown={event => {
         if ((event.target as HTMLElement).closest('[data-reorder-handle], [data-row-actions]')) {
           return

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -69,6 +69,8 @@ interface ProjectOverviewRowProps {
   previewSessions?: SessionInfo[]
   reorderable?: boolean
   dragging?: boolean
+  /** Full dnd-kit handle (role/tabIndex + keyboard + pointer activators) —
+   *  spread ONLY on SidebarRowGrab. The shell must use shellDragProps. */
   dragHandleProps?: React.HTMLAttributes<HTMLElement>
   /** Pointer-only dnd listeners for the row SHELL — never the keyboard
    *  activator or role/tabIndex (see session-row for the full rationale). */

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -70,6 +70,9 @@ interface ProjectOverviewRowProps {
   reorderable?: boolean
   dragging?: boolean
   dragHandleProps?: React.HTMLAttributes<HTMLElement>
+  /** Pointer-only dnd listeners for the row SHELL — never the keyboard
+   *  activator or role/tabIndex (see session-row for the full rationale). */
+  shellDragProps?: React.HTMLAttributes<HTMLElement>
   ref?: React.Ref<HTMLDivElement>
   style?: React.CSSProperties
 }
@@ -84,6 +87,7 @@ export function ProjectOverviewRow({
   reorderable = false,
   dragging = false,
   dragHandleProps,
+  shellDragProps,
   ref,
   style
 }: ProjectOverviewRowProps) {
@@ -139,13 +143,17 @@ export function ProjectOverviewRow({
       // listeners, minus the controls that keep their own gestures. A project
       // row has no rival drag (its title navigates on CLICK), so the sortable
       // owns the press outright.
-      {...dragHandleProps}
+      //
+      // Pointer-only on the shell (shellDragProps): the keyboard activator +
+      // role/tabIndex stay on the grabber, so a focused row control can't
+      // start a dnd-kit drag or feed its Space/Enter end codes.
+      {...shellDragProps}
       onPointerDown={event => {
         if ((event.target as HTMLElement).closest('[data-reorder-handle], [data-row-actions]')) {
           return
         }
 
-        dragHandleProps?.onPointerDown?.(event)
+        shellDragProps?.onPointerDown?.(event)
       }}
       ref={rowRef}
       toggle={

--- a/apps/desktop/src/app/chat/sidebar/reorderable-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/reorderable-list.test.tsx
@@ -94,6 +94,8 @@ function BehaviorProbe({ id }: { id: string }) {
 }
 
 const spaceKey = { key: ' ', code: 'Space', bubbles: true, cancelable: true } as const
+// Enter is also a KeyboardSensor default start/end code — same swallow class.
+const enterKey = { key: 'Enter', code: 'Enter', bubbles: true, cancelable: true } as const
 
 describe('useSortableBindings keyboard behavior', () => {
   it('does not swallow Space on the shell nor start a keyboard drag from it', () => {
@@ -103,6 +105,10 @@ describe('useSortableBindings keyboard behavior', () => {
     // started a drag (and was preventDefaulted). Post-fix, the shell has only
     // the pointer activator, so the keydown must pass through untouched.
     expect(fireEvent.keyDown(getByTestId('shell'), spaceKey)).toBe(true)
+    expect(getByTestId('state').textContent).toBe('IDLE')
+
+    // Enter is in the same default start/end codes — must pass through too.
+    expect(fireEvent.keyDown(getByTestId('shell'), enterKey)).toBe(true)
     expect(getByTestId('state').textContent).toBe('IDLE')
   })
 

--- a/apps/desktop/src/app/chat/sidebar/reorderable-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/reorderable-list.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render } from '@testing-library/react'
+import { DndContext } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { useSortableBindings } from './reorderable-list'
+
+afterEach(cleanup)
+
+// Regression test for the swallowed-Space bug: PR #82373 spread the full dnd-kit
+// handle ({...dragHandleProps} — attributes + keyboard + pointer activators)
+// onto the whole row SHELL. That made the shell itself a focusable drag
+// activator: Space/Enter pressed while the shell (or a control inside it) had
+// focus started keyboard drags, and while a drag session was active dnd-kit's
+// KeyboardSensor arms a window keydown listener whose default `end` codes
+// include Space — swallowing the keystroke in ANY text input (session rename
+// dialog, first composer keystroke after launch).
+//
+// The split contract: the grabber keeps the FULL handle (keyboard reorder
+// accessibility), the shell gets ONLY the pointer activator.
+function Probe({ id }: { id: string }) {
+  const bindings = useSortableBindings(id)
+
+  return (
+    <div>
+      <pre data-testid="grabber-keys" data-keys={Object.keys(bindings.dragHandleProps ?? {}).join(',')} />
+      <pre data-testid="shell-keys" data-keys={Object.keys(bindings.shellDragProps ?? {}).join(',')} />
+    </div>
+  )
+}
+
+function renderProbe() {
+  return render(
+    <DndContext>
+      <SortableContext items={['a']} strategy={verticalListSortingStrategy}>
+        <Probe id="a" />
+      </SortableContext>
+    </DndContext>
+  )
+}
+
+describe('useSortableBindings', () => {
+  it('keeps the full handle — keyboard activator + focusable attributes — on the grabber', () => {
+    const { getByTestId } = renderProbe()
+
+    const grabberKeys = (getByTestId('grabber-keys').dataset.keys ?? '').split(',')
+    expect(grabberKeys).toContain('onKeyDown')
+    expect(grabberKeys).toContain('onPointerDown')
+  })
+
+  it('gives the row shell only the pointer activator — no keyboard activator, no role/tabIndex', () => {
+    const { getByTestId } = renderProbe()
+
+    // The shell must never see the keyboard activator: Space/Enter pressed
+    // while a shell descendant has focus would otherwise reach dnd-kit's
+    // KeyboardSensor and be consumed by its default start/end codes. The
+    // attributes (role=button / tabIndex) never enter shellDragProps either,
+    // so the shell is not a focusable drag activator.
+    expect((getByTestId('shell-keys').dataset.keys ?? '').split(',')).toEqual(['onPointerDown'])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/reorderable-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/reorderable-list.test.tsx
@@ -1,6 +1,6 @@
-import { cleanup, fireEvent, render } from '@testing-library/react'
 import { DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { useSortableBindings } from './reorderable-list'
@@ -23,8 +23,8 @@ function Probe({ id }: { id: string }) {
 
   return (
     <div>
-      <pre data-testid="grabber-keys" data-keys={Object.keys(bindings.dragHandleProps ?? {}).join(',')} />
-      <pre data-testid="shell-keys" data-keys={Object.keys(bindings.shellDragProps ?? {}).join(',')} />
+      <pre data-keys={Object.keys(bindings.dragHandleProps ?? {}).join(',')} data-testid="grabber-keys" />
+      <pre data-keys={Object.keys(bindings.shellDragProps ?? {}).join(',')} data-testid="shell-keys" />
     </div>
   )
 }
@@ -69,7 +69,7 @@ function ProbeHost({ id }: { id: string }) {
   )
 
   return (
-    <DndContext sensors={sensors} onDragEnd={() => {}}>
+    <DndContext onDragEnd={() => {}} sensors={sensors}>
       <SortableContext items={[id]} strategy={verticalListSortingStrategy}>
         <BehaviorProbe id={id} />
       </SortableContext>

--- a/apps/desktop/src/app/chat/sidebar/reorderable-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/reorderable-list.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render } from '@testing-library/react'
-import { DndContext } from '@dnd-kit/core'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -57,5 +57,72 @@ describe('useSortableBindings', () => {
     // attributes (role=button / tabIndex) never enter shellDragProps either,
     // so the shell is not a focusable drag activator.
     expect((getByTestId('shell-keys').dataset.keys ?? '').split(',')).toEqual(['onPointerDown'])
+  })
+})
+
+// Behavioral probe with the real sensors the sidebar uses (PointerSensor with
+// the 6px activation constraint + KeyboardSensor with the default codes).
+function ProbeHost({ id }: { id: string }) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor)
+  )
+
+  return (
+    <DndContext sensors={sensors} onDragEnd={() => {}}>
+      <SortableContext items={[id]} strategy={verticalListSortingStrategy}>
+        <BehaviorProbe id={id} />
+      </SortableContext>
+    </DndContext>
+  )
+}
+
+function BehaviorProbe({ id }: { id: string }) {
+  const bindings = useSortableBindings(id)
+
+  return (
+    <div data-testid="shell" {...bindings.shellDragProps}>
+      <button data-testid="control" type="button">
+        Control
+      </button>
+      <div data-testid="grabber" {...bindings.dragHandleProps}>
+        Grab
+      </div>
+      <output data-testid="state">{bindings.dragging ? 'DRAGGING' : 'IDLE'}</output>
+    </div>
+  )
+}
+
+const spaceKey = { key: ' ', code: 'Space', bubbles: true, cancelable: true } as const
+
+describe('useSortableBindings keyboard behavior', () => {
+  it('does not swallow Space on the shell nor start a keyboard drag from it', () => {
+    const { getByTestId } = render(<ProbeHost id="a" />)
+
+    // Pre-fix, the shell carried the KeyboardSensor activator: Space here
+    // started a drag (and was preventDefaulted). Post-fix, the shell has only
+    // the pointer activator, so the keydown must pass through untouched.
+    expect(fireEvent.keyDown(getByTestId('shell'), spaceKey)).toBe(true)
+    expect(getByTestId('state').textContent).toBe('IDLE')
+  })
+
+  it('does not swallow Space on a control inside the shell (⋯ menu, row body)', () => {
+    const { getByTestId } = render(<ProbeHost id="a" />)
+
+    expect(fireEvent.keyDown(getByTestId('control'), spaceKey)).toBe(true)
+    expect(getByTestId('state').textContent).toBe('IDLE')
+  })
+
+  it('still starts a keyboard drag from the grabber (screen-reader reorder preserved)', () => {
+    const { getByTestId } = render(<ProbeHost id="a" />)
+
+    // dnd-kit's activator preventDefaults the start key, so fireEvent returns
+    // false here — the drag STARTING is the assertion.
+    fireEvent.keyDown(getByTestId('grabber'), spaceKey)
+    expect(getByTestId('state').textContent).toBe('DRAGGING')
+
+    // Space again on the grabber ends the drag (default `end` codes), so the
+    // test tears down cleanly.
+    fireEvent.keyDown(getByTestId('grabber'), spaceKey)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/reorderable-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/reorderable-list.tsx
@@ -61,6 +61,15 @@ export function ReorderableList({
   )
 }
 
+/** Pointer-only dnd listeners for a sortable row shell. The full handle
+ *  (attributes + keyboard activator) stays on the grabber; the shell must
+ *  never receive role/tabIndex or onKeyDown — a focused shell descendant
+ *  would otherwise start a dnd-kit keyboard drag or feed its Space/Enter
+ *  end codes (#83617). */
+export type ShellDragProps = {
+  onPointerDown?: (event: React.PointerEvent) => void
+}
+
 export function useSortableBindings(id: string) {
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id })
 
@@ -72,12 +81,14 @@ export function useSortableBindings(id: string) {
   // active dnd-kit's KeyboardSensor arms a window keydown listener whose
   // default `end` codes include Space — swallowing the keystroke in ANY text
   // input (session rename dialog, first composer keystroke after launch).
+  const shellDragProps: ShellDragProps | undefined = listeners
+    ? { onPointerDown: event => listeners.onPointerDown(event) }
+    : undefined
+
   return {
     dragging: isDragging,
     dragHandleProps: { ...attributes, ...listeners },
-    shellDragProps: (listeners ? { onPointerDown: listeners.onPointerDown } : undefined) as
-      | React.HTMLAttributes<HTMLElement>
-      | undefined,
+    shellDragProps,
     ref: setNodeRef,
     reorderable: true as const,
     style: {

--- a/apps/desktop/src/app/chat/sidebar/reorderable-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/reorderable-list.tsx
@@ -64,9 +64,20 @@ export function ReorderableList({
 export function useSortableBindings(id: string) {
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id })
 
+  // The grabber carries the FULL handle (role/tabIndex, keyboard + pointer
+  // activators) so keyboard reorder stays accessible. The row SHELL must only
+  // ever receive the pointer activator: spreading attributes + onKeyDown onto
+  // the shell made the whole row a focusable dnd-kit activator. A focused
+  // shell started keyboard drags on Space/Enter, and while a drag session was
+  // active dnd-kit's KeyboardSensor arms a window keydown listener whose
+  // default `end` codes include Space — swallowing the keystroke in ANY text
+  // input (session rename dialog, first composer keystroke after launch).
+  const shellListeners = listeners ? { onPointerDown: listeners.onPointerDown } : undefined
+
   return {
     dragging: isDragging,
     dragHandleProps: { ...attributes, ...listeners },
+    shellDragProps: { ...shellListeners } as React.HTMLAttributes<HTMLElement> | undefined,
     ref: setNodeRef,
     reorderable: true as const,
     style: {

--- a/apps/desktop/src/app/chat/sidebar/reorderable-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/reorderable-list.tsx
@@ -72,12 +72,12 @@ export function useSortableBindings(id: string) {
   // active dnd-kit's KeyboardSensor arms a window keydown listener whose
   // default `end` codes include Space — swallowing the keystroke in ANY text
   // input (session rename dialog, first composer keystroke after launch).
-  const shellListeners = listeners ? { onPointerDown: listeners.onPointerDown } : undefined
-
   return {
     dragging: isDragging,
     dragHandleProps: { ...attributes, ...listeners },
-    shellDragProps: { ...shellListeners } as React.HTMLAttributes<HTMLElement> | undefined,
+    shellDragProps: (listeners ? { onPointerDown: listeners.onPointerDown } : undefined) as
+      | React.HTMLAttributes<HTMLElement>
+      | undefined,
     ref: setNodeRef,
     reorderable: true as const,
     style: {

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -36,6 +36,7 @@ import {
   SidebarRowLeadGlyph,
   SidebarRowShell
 } from './chrome'
+import type { ShellDragProps } from './reorderable-list'
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 import { useProfilePrewarm } from './use-profile-prewarm'
 
@@ -59,7 +60,7 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
    *  activator or role/tabIndex. The shell contains real controls (⋯ menu,
    *  row body); those must stay ordinary focus targets whose Space/Enter do
    *  their own thing, not start or feed a dnd-kit drag. */
-  shellDragProps?: React.HTMLAttributes<HTMLElement>
+  shellDragProps?: ShellDragProps
   /** Tag the row with its owning profile (initial chip + tooltip). Used by
    *  flat cross-profile lists — Pinned and search results in the All-profiles
    *  view — where no group header communicates ownership (#66003). */
@@ -265,11 +266,10 @@ function SidebarSessionRowImpl({
         // over the tree only the session drop does (no sortable row there).
         // Whichever one the release lands on is the one that commits.
         //
-        // The shell gets ONLY the pointer activator (shellDragProps): the
-        // keyboard activator + role/tabIndex stay on the grabber, so a focused
-        // row control can't start a dnd-kit drag or feed its Space/Enter end
-        // codes.
-        {...shellDragProps}
+        // The shell gets ONLY the pointer activator: shellDragProps is typed
+        // to carry just onPointerDown (forwarded below), never the keyboard
+        // activator or role/tabIndex — a focused row control can't start a
+        // dnd-kit drag or feed its Space/Enter end codes.
         onPointerDown={event => {
           // The grabber already carries these same listeners, and the ⋯
           // cluster keeps its own gestures.

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -52,6 +52,8 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
   onResume: () => void
   reorderable?: boolean
   dragging?: boolean
+  /** Full dnd-kit handle (role/tabIndex + keyboard + pointer activators) —
+   *  spread ONLY on SidebarRowGrab. The shell must use shellDragProps. */
   dragHandleProps?: React.HTMLAttributes<HTMLElement>
   /** Pointer-only dnd listeners for the row SHELL — never the keyboard
    *  activator or role/tabIndex. The shell contains real controls (⋯ menu,

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -53,6 +53,11 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
   reorderable?: boolean
   dragging?: boolean
   dragHandleProps?: React.HTMLAttributes<HTMLElement>
+  /** Pointer-only dnd listeners for the row SHELL — never the keyboard
+   *  activator or role/tabIndex. The shell contains real controls (⋯ menu,
+   *  row body); those must stay ordinary focus targets whose Space/Enter do
+   *  their own thing, not start or feed a dnd-kit drag. */
+  shellDragProps?: React.HTMLAttributes<HTMLElement>
   /** Tag the row with its owning profile (initial chip + tooltip). Used by
    *  flat cross-profile lists — Pinned and search results in the All-profiles
    *  view — where no group header communicates ownership (#66003). */
@@ -88,6 +93,7 @@ function SidebarSessionRowImpl({
   reorderable = false,
   dragging = false,
   dragHandleProps,
+  shellDragProps,
   showProfile = false,
   className,
   style,
@@ -256,7 +262,12 @@ function SidebarSessionRowImpl({
         // target (the session drop denies: side chrome hosts no main tile);
         // over the tree only the session drop does (no sortable row there).
         // Whichever one the release lands on is the one that commits.
-        {...dragHandleProps}
+        //
+        // The shell gets ONLY the pointer activator (shellDragProps): the
+        // keyboard activator + role/tabIndex stay on the grabber, so a focused
+        // row control can't start a dnd-kit drag or feed its Space/Enter end
+        // codes.
+        {...shellDragProps}
         onPointerDown={event => {
           // The grabber already carries these same listeners, and the ⋯
           // cluster keeps its own gestures.
@@ -269,7 +280,7 @@ function SidebarSessionRowImpl({
           // stay ordinary clicks, so resume / pin / open-in-window are
           // untouched.
           startSessionDrag({ id: session.id, profile: session.profile || 'default', title }, event)
-          dragHandleProps?.onPointerDown?.(event)
+          shellDragProps?.onPointerDown?.(event)
         }}
         // Hovering a row from another profile (the all-profiles view) telegraphs
         // a cross-profile resume — start that backend's spawn now so the click


### PR DESCRIPTION
## What does this PR do?

Fixes the Space key being swallowed in the session rename dialog (and intermittently elsewhere) after [PR #82373](https://github.com/NousResearch/hermes-agent/pull/82373) made sidebar rows draggable by their title.

PR #82373 spread dnd-kit's sortable listeners (`dragHandleProps`, including the KeyboardSensor's `onKeyDown`) onto the entire row shell, but only guarded the **pointer** path from row-action controls. Two consequences:

1. A row interaction can leave the dnd-kit drag session **stuck active** (`aria-pressed="true"`, `cursor-grabbing`, `translate3d` — observable in the DOM while the rename dialog is open). While a drag is active, the KeyboardSensor keeps a **window-level** keydown listener, and Space is in dnd-kit's default keyboard `end` codes — so `handleEnd` calls `preventDefault()` on every Space keystroke, even with focus in a (portaled) text input.
2. The ⋯ button lives inside the row shell, so keydowns from a focused row control bubble through the row's keyboard listener unfiltered.

This PR stops the swallow **without removing Space/Enter from dnd-kit's keyboard codes**, so keyboard reordering for screen-reader users is untouched.

## Related Issue

Fixes #83617

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/reorderable-list.tsx` — `useSortableBindings` now returns `shellDragProps`: the dnd-kit listeners **minus the keyboard activator** (pointer-only). The grabber keeps the full `dragHandleProps` (role/tabIndex/aria-* + keyboard + pointer activators), so keyboard reorder accessibility is untouched.
- `apps/desktop/src/app/chat/sidebar/session-row.tsx` and `projects/overview-row.tsx` — the row shell spreads `{...shellDragProps}` instead of `{...dragHandleProps}` (the existing `[data-row-actions]` pointer exclusion and the `startSessionDrag` dual-gesture wiring are unchanged).
- Effect: the shell is no longer a focusable dnd-kit activator (`role="button"`/`tabIndex=0` gone), so Space/Enter pressed while the shell or a control inside it has focus can neither start a keyboard drag nor feed the KeyboardSensor's default `end` codes — and the sensor's window-level listener can no longer arm from a row interaction, so text inputs stop being swallowed.
- Regression test: `apps/desktop/src/app/chat/sidebar/reorderable-list.test.tsx` — asserts the grabber keeps `onKeyDown` + `onPointerDown`, and the shell receives exactly `onPointerDown` (no keyboard activator, no focusable attributes).

## How to Test

Reproduction (before fix):

1. Launch Hermes Desktop; in the sidebar, hover a session row → ⋯ → **Rename**.
2. Click the rename input; type letters (insert fine), press **Space** — nothing inserts; the row shows stuck drag visuals (`aria-pressed="true"`, `cursor-grabbing`, `translate3d`).

Verification (after fix):

1. Repeat the repro — Space inserts normally in the rename input.
2. Restart the app; type into the composer — the first Space is no longer eaten.
3. Keyboard reorder still works: Tab to a row's grabber, press Space/Enter to lift, arrow to a new position, Space/Enter to drop (screen-reader flow preserved).
4. `npm run typecheck` and `vitest run src/app/chat/sidebar` pass (121 tests, incl. the new regression test).

## Checklist

- [ ] I have read the [contribution guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md).
- [ ] My code follows the project's coding style.
- [ ] I have tested my changes locally and verified the fix.
- [ ] I have added/updated tests where applicable.

## Notes

**Open question:** with the keyboard activator off the shell, a dnd-kit drag session can only arm from the grabber (keyboard) or the row body (pointer, 6px threshold, ends on pointerup). The previously observed stuck drag — a window-level KeyboardSensor listener surviving after a row interaction — can no longer start from a row control. A modal-open teardown (cancel any active drag when a Radix dialog opens, e.g. via `onOpenChange` or `aria-hidden` observation) would be defense-in-depth against a grabber keyboard drag being left active while a dialog opens. Not included here to keep the patch minimal; happy to add it if the maintainers prefer.
