### PR TITLE
fix(kanban): re-create the schema when a cached DB path loses it (#83445)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2146,6 +2146,26 @@ def repair_db(
         )
 
 
+def _schema_is_present(conn: sqlite3.Connection) -> bool:
+    """Whether an open connection actually sees the kanban schema.
+
+    ``tasks`` is the sentinel: :data:`SCHEMA_SQL` always creates it, and
+    SQLite loses tables all-or-nothing (a file is either the one we
+    initialized or a fresh one created by this very open), so one
+    ``sqlite_master`` lookup on the already-resident page 1 is enough. Cheap
+    by design — it runs on every steady-state :func:`connect`.
+    """
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='tasks' LIMIT 1"
+        ).fetchone()
+    except sqlite3.DatabaseError:
+        # Unreadable schema table is not this guard's call — let the full init
+        # path's header/integrity probes classify and quarantine it.
+        return False
+    return row is not None
+
+
 def connect(
     db_path: Optional[Path] = None,
     *,
@@ -2198,10 +2218,27 @@ def connect(
                 conn.execute("PRAGMA foreign_keys=ON")
                 conn.execute("PRAGMA secure_delete=ON")
                 conn.execute("PRAGMA cell_size_check=ON")
+                schema_present = _schema_is_present(conn)
         except Exception:
             conn.close()
             raise
-        return conn
+        if schema_present:
+            return conn
+        # The cache says "initialized", the file says otherwise: it was deleted
+        # or replaced under a live process, and the open above silently
+        # recreated an empty DB. Left alone, every query on this path fails
+        # with "no such table: tasks" for the rest of the process's life and
+        # the board just renders empty (#83445). Drop the stale cache entry and
+        # fall through to the full init path, which re-runs the header and
+        # integrity probes and the schema script under the cross-process lock.
+        conn.close()
+        with _INIT_LOCK:
+            _INITIALIZED_PATHS.discard(resolved)
+        _log.warning(
+            "kanban DB %s lost its schema after this process initialized it "
+            "(deleted or replaced externally); re-initializing.",
+            path,
+        )
 
     with _cross_process_init_lock(path):
         # Read-only file/sidecar preflight (port of kilocode#12508) —

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 import threading
 from pathlib import Path
@@ -134,3 +135,103 @@ def test_unseen_events_for_sub_survives_migrated_db(tmp_path, monkeypatch):
         )
         assert isinstance(cursor, int)
         assert isinstance(events, list)
+
+
+def _default_board_db(tmp_path, monkeypatch) -> Path:
+    """Point the kanban root at a temp home and return the default board's DB
+    (the back-compat top-level ``<root>/kanban.db`` #83445 reports on)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    return db_path
+
+
+def _tables(path: Path) -> set[str]:
+    conn = sqlite3.connect(str(path))
+    try:
+        return {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    finally:
+        conn.close()
+
+
+def test_connect_reinitializes_schema_when_db_file_vanished(tmp_path, monkeypatch):
+    """#83445: the schema cache is process-local, but the schema is on disk.
+
+    A long-lived process (gateway, dispatcher, dashboard API) that already
+    initialized a path keeps taking the ``_INITIALIZED_PATHS`` fast path after
+    the file is deleted underneath it. SQLite recreates an empty DB on the next
+    open, so every query then fails with ``no such table: tasks`` and the board
+    renders empty until that process itself is restarted.
+    """
+    db_path = _default_board_db(tmp_path, monkeypatch)
+
+    with kb.connect_closing(db_path) as conn:
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at) VALUES ('t-1', 'T', 'ready', 1000)"
+        )
+        conn.commit()
+    assert str(db_path.resolve()) in kb._INITIALIZED_PATHS
+
+    # External deletion (manual cleanup, restore, sync tool) while the process
+    # that cached this path is still alive.
+    for suffix in ("", "-wal", "-shm"):
+        db_path.with_name(db_path.name + suffix).unlink(missing_ok=True)
+
+    with kb.connect_closing(db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+    assert "tasks" in _tables(db_path)
+
+
+def test_connect_reinitializes_schema_when_db_replaced_by_empty_file(tmp_path, monkeypatch):
+    """Same defect, restore shape: the file still exists and passes both the
+    header and the integrity probes, but carries no schema at all."""
+    db_path = _default_board_db(tmp_path, monkeypatch)
+
+    with kb.connect_closing(db_path):
+        pass
+
+    for suffix in ("", "-wal", "-shm"):
+        db_path.with_name(db_path.name + suffix).unlink(missing_ok=True)
+    sqlite3.connect(str(db_path)).close()
+    assert "tasks" not in _tables(db_path)
+
+    with kb.connect_closing(db_path) as conn:
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at) VALUES ('t-2', 'T', 'ready', 1000)"
+        )
+        conn.commit()
+    assert "tasks" in _tables(db_path)
+
+
+def test_healthy_fast_path_stays_lock_free(tmp_path, monkeypatch):
+    """The self-heal must cost nothing in steady state: an intact cached path
+    still skips the cross-process init lock (#36644), and only pays for it when
+    the schema is actually gone."""
+    db_path = _default_board_db(tmp_path, monkeypatch)
+
+    with kb.connect_closing(db_path):
+        pass
+
+    locks: list[Path] = []
+    real_lock = kb._cross_process_init_lock
+
+    @contextlib.contextmanager
+    def recording_lock(path):
+        locks.append(path)
+        with real_lock(path):
+            yield
+
+    monkeypatch.setattr(kb, "_cross_process_init_lock", recording_lock)
+
+    with kb.connect_closing(db_path):
+        pass
+    assert locks == []
+
+    db_path.unlink()
+    with kb.connect_closing(db_path):
+        pass
+    assert len(locks) == 1


### PR DESCRIPTION
Fixes #83445.

## TL;DR

`connect()` caches initialized paths in a process-local set and then skips *all* schema work for them. The cache is keyed on a **path**; the schema lives in a **file**. Delete or replace `kanban.db` under a live process and the two drift apart: SQLite creates a fresh empty database on the next open, `connect()` returns a connection with **zero tables**, and every query dies with `no such table: tasks` while the board renders empty.

This PR verifies the sentinel table on the fast path and self-heals when it is missing — for the price of one `sqlite_master` lookup per connect.

## One correction to the report

There is no `boards` table, and there never was. Boards are **directories** (`<root>/kanban/boards/<slug>/board.json`), and `GET /api/plugins/kanban/boards` lists them from the filesystem via `kanban_db.list_boards()`. `SCHEMA_SQL` creates `tasks`, `task_links`, `task_comments`, `task_events`, `task_runs`, `task_attachments`, `kanban_notify_subs` — nothing else. So "boards table never created" is not the defect.

The defect the report actually hit is real and worse than the title suggests: the top-level `kanban.db` (the back-compat home of the `default` board) is left with **no tables at all**.

## Root cause

`hermes_cli/kanban_db.py` → `connect()`:

```python
resolved = str(path.resolve())
if resolved in _INITIALIZED_PATHS:
    conn = _sqlite_connect(path)          # creates the file if it is gone
    ... WAL + pragmas ...
    return conn                           # never verifies the schema exists
```

The fast path exists for a good reason — taking the cross-process init flock on every connect is what let one stalled holder hang the dispatcher forever (#36644) — but it trusts a process-local cache to describe on-disk state it does not re-check.

Any long-lived process that has connected once (the embedded gateway, the dispatcher, the dashboard API) therefore keeps the entry forever. If the file disappears or is swapped underneath it:

1. `_sqlite_connect()` re-creates it, empty.
2. `apply_wal_with_fallback()` writes the WAL header → the ~4 KB file the report describes.
3. No header probe, no integrity probe, no `SCHEMA_SQL`, no migrations.
4. `plugin_api._conn()` catches the resulting failure, logs `kanban init failed`, and serves an empty board.
5. Restarting the *desktop app* changes nothing: the backing process still holds the poisoned cache entry and rewrites the same schema-less file. Only killing that process clears it — which is exactly the "persists across restarts" shape in the title.

## Reproduction

```python
kb.connect(db_path=p).close()                  # 8 tables, ~118 KB
for s in ("", "-wal", "-shm"):
    p.with_name(p.name + s).unlink(missing_ok=True)
conn = kb.connect(db_path=p)                   # same process, cached path
conn.execute("SELECT COUNT(*) FROM tasks")     # OperationalError: no such table: tasks
```

The recreated file carries zero tables and no new `kanban.db.init.lock` is taken — proof the cross-process init path was never entered.

## The fix

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Connect Request] --> B{Path Cached In Init Set?}
    B -->|No| F[Full Init: Writability Preflight, Header Probe, Integrity Probe, Schema Script, Migrations]
    B -->|Yes| C[Open Connection, Apply WAL And Pragmas]
    C --> D{Sentinel Table tasks Visible?}
    D -->|Yes| E[Return Connection - Lock-Free Steady State]
    D -->|No| G[File Deleted Or Replaced Under A Live Process]
    G --> H[Close Connection, Evict Stale Cache Entry, Log Warning]
    H --> F
    F --> E
```

* New `_schema_is_present(conn)` — a single `sqlite_master` lookup for `tasks` on the already-resident page 1. `SCHEMA_SQL` always creates that table, and a kanban DB is either the file we initialized or a fresh one created by this very open, so one sentinel is enough.
* When it is missing, the connection is closed, the cache entry is dropped, and control falls through to the **existing** init path. Nothing is duplicated: the same writability preflight, header validation, integrity probe, `SCHEMA_SQL` and additive migrations run, still serialized by `_cross_process_init_lock`.
* A concurrent healer is safe: the slow path re-checks `needs_init` under `_INIT_LOCK`, so the second thread through does not re-run the script.
* An unreadable `sqlite_master` counts as "not present" on purpose — classification and quarantine belong to the header/integrity probes on the init path, not to this guard.

### Cost

One `SELECT 1 FROM sqlite_master … LIMIT 1` per connect, against a page the pragma work has already read. The steady-state path stays lock-free — no flock, no integrity probe, no schema script — so the #36644 hang stays fixed.

## Tests

`tests/hermes_cli/test_kanban_db_init.py`:

| Test | Guards |
|---|---|
| `test_connect_reinitializes_schema_when_db_file_vanished` | The reported shape: file deleted under a live process → next connect returns a working schema instead of `no such table: tasks` |
| `test_connect_reinitializes_schema_when_db_replaced_by_empty_file` | Restore shape: file present, valid header, clean integrity check, no schema |
| `test_healthy_fast_path_stays_lock_free` | The self-heal costs nothing in steady state — an intact cached path still takes no cross-process lock, and only pays for one when the schema is actually gone |

All three fail on `main` (`no such table: tasks`, `assert 0 == 1`) and pass here. The rest of `test_kanban_db_init.py`, plus `test_kanban_db.py`, `test_kanban_db_repair.py`, `test_kanban_init_lock_bounded.py`, `test_kanban_dispatch_lock.py`, `test_kanban_write_txn_busy_retry.py`, `test_kanban_boards.py`, `test_kanban_diagnostics.py`, `test_kanban_core_functionality.py`, `test_kanban_notify.py` and `tests/plugins/test_kanban_dashboard_plugin.py` were run before and after the change; the handful of failures are identical on both sides (pre-existing Windows-local noise: `PermissionError [WinError 5]` on board-directory rename, git-worktree materialization, one crash-detection assertion).

## Scope

* **Not** an integrity/corruption fix. A schema-less database is *healthy* by `PRAGMA integrity_check` — that is precisely why it slips through every existing guard. #69037 hardens the corruption side of the same fast path on a TTL; it is orthogonal to this one and neither change subsumes the other (the two touch adjacent lines and will need a trivial merge).
* `plugin_api._conn()` still downgrades an init failure to `log.warning` and serves an empty board. With this fix that path is no longer reached for the reported cause, so surfacing it is left to a separate change rather than widened into this one.
* No new table, no schema migration, no board-model change.


