### PR TITLE
fix(desktop): parent-death watchdog kills serve backends under uv venv shims on Windows

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17697,8 +17697,21 @@ def _maybe_open_browser(
 
 
 def _is_serve_orphaned(original_ppid: int, getppid=os.getppid) -> bool:
-    """True when this process lost its original spawning parent (ppid changed)."""
-    return getppid() != original_ppid
+    """True when this process lost its original spawning parent (ppid changed).
+
+    On Windows, uv-managed venvs use a redirector shim for ``Scripts/python.exe``
+    that launches the real CPython as its child, so ``getppid()`` returns the
+    shim's PID, never the desktop's. A strict ppid comparison would then mark
+    every desktop-spawned backend as orphaned and kill it via ``os._exit(0)``
+    right after it announces READY. Prefer a liveness probe on the recorded
+    parent PID (psutil if available), falling back to the ppid comparison.
+    """
+    try:
+        import psutil
+
+        return not psutil.pid_exists(original_ppid)
+    except Exception:
+        return getppid() != original_ppid
 
 
 def _start_parent_death_watchdog() -> None:
@@ -17733,9 +17746,16 @@ def _start_parent_death_watchdog() -> None:
 
 
 def _demo() -> None:
-    # orphan iff current ppid differs from the recorded spawning parent
-    assert _is_serve_orphaned(999999999, getppid=lambda: 1) is True
-    assert _is_serve_orphaned(42, getppid=lambda: 42) is False
+    # orphan iff the recorded spawning parent is gone (ppid comparison
+    # fallback kept for the no-psutil path)
+    try:
+        import psutil  # noqa: F401
+
+        assert _is_serve_orphaned(999999999) is True
+        assert _is_serve_orphaned(__import__("os").getpid()) is False
+    except Exception:
+        assert _is_serve_orphaned(999999999, getppid=lambda: 1) is True
+        assert _is_serve_orphaned(42, getppid=lambda: 42) is False
     print("web_server parent-death watchdog self-check: OK")
 
 


### PR DESCRIPTION
## Fix: parent-death watchdog kills serve backends under uv venv shims on Windows

### Symptom
After `hermes update` to the release containing `a9a0648f4`, the desktop app opens but fails to boot the backend:

```
[hermes] HERMES_BACKEND_READY port=64275
[hermes] Hermes backend exited (0)
[hermes] [boot] Desktop boot failed: Hermes backend exited before it became ready (0).
```

The backend announces READY, then cleanly `os._exit(0)` before the desktop's health check completes. Repair loop repeats the same exit.

### Root cause
`a9a0648f4` added a parent-death watchdog where `_is_serve_orphaned` compares `getppid() != HERMES_PARENT_PID`. On Windows with a **uv-managed venv**, `venv\Scripts\python.exe` is a redirector shim (~45 KB) that launches the real CPython (`%APPDATA%\uv\python\cpython-3.11-...\python.exe`) as its **child**. The process actually running `hermes serve` therefore has `getppid()` = the shim's PID — never the Electron PID passed via `HERMES_PARENT_PID`. The watchdog concludes "orphaned" on its first poll (~2 s) and kills the healthy backend.

This is a regression: the pre-update desktop did not set `HERMES_PARENT_PID`, so the watchdog was a no-op.

### Fix
`_is_serve_orphaned` now probes **liveness of the recorded parent PID** (`psutil.pid_exists`) instead of strict ppid equality, with the ppid comparison as fallback when psutil is unavailable:

```python
def _is_serve_orphaned(original_ppid: int, getppid=os.getppid) -> bool:
    try:
        import psutil
        return not psutil.pid_exists(original_ppid)
    except Exception:
        return getppid() != original_ppid
```

`_demo()` self-check updated to match. The liveness probe is the robust general fix: it also covers any future intermediate-process wrapper, not just uv shims.

### Verification
- Repro: `hermes serve` with `HERMES_PARENT_PID=<live pid>` set exits within ~10 s pre-fix; stays alive >12 s past READY post-fix.
- `_demo()` passes both directions (dead pid → orphaned; live pid → not).
- Desktop boots to "Hermes backend is ready. Finalizing desktop startup".

### Known limitation (documented, not blocking)
`pid_exists` can't distinguish parent-death from PID reuse by an unrelated process; in that rare case the orphaned backend would not exit. A stricter check (e.g. also comparing `psutil.Process(pid).create_time()`) could be a follow-up. The current fix trades a boot-breaking false positive for a rare false negative — strictly better.

### Affects
Windows users whose venv was created by uv (uv venv / uv-managed install) — every desktop boot after the `a9a0648f4` release.
