### PR TITLE
fix(agent): make sanitize_api_messages a fixpoint so dedup cannot re-wedge sessions (#83312)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3506,8 +3506,10 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         # content, which is a second, independent 400 ("messages must have
         # non-empty content"). So re-run both invariant passes over the deduped
         # list instead: cheap (only on the rare dedup path), idempotent, and it
-        # covers any future pass inserted before this return — not just this
-        # one. Order matters: drop the empty arrays first so the content healer
+        # covers both of those invariants no matter where above they were
+        # broken. It does NOT cover every possible future pass — a new pass
+        # inserted before this return would need the same re-run treatment.
+        # Order matters: drop the empty arrays first so the content healer
         # sees the turn as genuinely payload-less and substitutes a placeholder.
         messages = drop_empty_tool_calls_arrays(messages)
         messages = repair_empty_non_final_messages(messages)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3272,6 +3272,51 @@ def repair_empty_non_final_messages(
     return messages
 
 
+def drop_empty_tool_calls_arrays(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Strip empty / malformed ``tool_calls`` from assistant messages.
+
+    An assistant message carrying ``tool_calls: []`` (an empty array) — or a
+    non-list value under the key — is semantically identical to an assistant
+    message with no tool calls, but strict OpenAI-compatible providers reject
+    the empty array outright: DeepSeek v4 returns HTTP 400 "Invalid
+    'messages[N].tool_calls': empty array. Expected an array with minimum
+    length 1, but got an empty array instead." (#58755, follow-up to #56980).
+
+    Empty arrays reach here from session resume, host-fed histories, the
+    consecutive-assistant merge in ``repair_message_sequence`` (which preserves
+    a pre-existing ``[]`` on the surviving turn), and — the reason this lives in
+    a reusable helper rather than inline — from ``sanitize_api_messages``' own
+    later dedup pass, which can empty an array it did not create (#83312).
+
+    Per the #56980 review this normalization belongs on the per-call copy, not
+    in ``repair_message_sequence``, which would destructively rewrite the
+    persisted trajectory. Shallow-copy the message before dropping the key so
+    stored history (and prompt caching) stays byte-stable.
+    """
+    normalized: List[Dict[str, Any]] = []
+    dropped = 0
+    for msg in messages:
+        if (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and "tool_calls" in msg
+            and not (isinstance(msg["tool_calls"], list) and msg["tool_calls"])
+        ):
+            msg = {k: v for k, v in msg.items() if k != "tool_calls"}
+            dropped += 1
+        normalized.append(msg)
+    if dropped:
+        _ra().logger.debug(
+            "Pre-call sanitizer: dropped empty/invalid tool_calls on %d "
+            "assistant message(s)",
+            dropped,
+        )
+        return normalized
+    return messages
+
+
 def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Fix orphaned tool_call / tool_result pairs before every LLM call.
 
@@ -3302,39 +3347,7 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     messages = repair_empty_non_final_messages(messages)
 
     # --- Drop empty / malformed tool_calls arrays on assistant messages ---
-    # An assistant message carrying ``tool_calls: []`` (an empty array) — or a
-    # non-list value under the key — is semantically identical to an assistant
-    # message with no tool calls, but strict OpenAI-compatible providers reject
-    # the empty array outright: DeepSeek v4 returns HTTP 400 "Invalid
-    # 'messages[N].tool_calls': empty array. Expected an array with minimum
-    # length 1, but got an empty array instead." (#58755, follow-up to #56980).
-    # Empty arrays reach here from session resume, host-fed histories, or the
-    # consecutive-assistant merge in ``repair_message_sequence`` (which
-    # preserves a pre-existing ``[]`` on the surviving turn). This is the final
-    # pre-API chokepoint, so normalize defensively — and, per the #56980
-    # review, do it HERE on the per-call copy rather than in
-    # ``repair_message_sequence``, which would destructively rewrite the
-    # persisted trajectory. Shallow-copy the message before dropping the key so
-    # stored history (and prompt caching) stays byte-stable.
-    normalized: List[Dict[str, Any]] = []
-    dropped_empty_tool_calls = 0
-    for msg in messages:
-        if (
-            isinstance(msg, dict)
-            and msg.get("role") == "assistant"
-            and "tool_calls" in msg
-            and not (isinstance(msg["tool_calls"], list) and msg["tool_calls"])
-        ):
-            msg = {k: v for k, v in msg.items() if k != "tool_calls"}
-            dropped_empty_tool_calls += 1
-        normalized.append(msg)
-    if dropped_empty_tool_calls:
-        messages = normalized
-        _ra().logger.debug(
-            "Pre-call sanitizer: dropped empty/invalid tool_calls on %d "
-            "assistant message(s)",
-            dropped_empty_tool_calls,
-        )
+    messages = drop_empty_tool_calls_arrays(messages)
 
     # --- Repair tool_calls whose function.name is empty/missing ---
     # Some providers (and partially-streamed responses) emit a tool_call with
@@ -3476,6 +3489,28 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+        # --- Re-establish the invariants the passes above already enforced ---
+        # This sanitizer is only useful if it is a fixpoint: every invariant it
+        # claims must still hold on the value it returns. The dedup pass breaks
+        # that. When EVERY call on an assistant turn is a duplicate (the normal
+        # shape after ``repair_message_sequence`` merges consecutive assistant
+        # turns and unions their call lists onto the text turn), ``kept_tcs``
+        # is empty and the turn is rewritten to ``tool_calls: []`` — re-creating
+        # the exact payload the empty-array pass deleted a few steps earlier,
+        # after that pass can no longer see it. DeepSeek then 400s on every
+        # send, and because the poisoned turn is persisted the session is
+        # wedged permanently (#83312).
+        #
+        # Healing at this one site would only cover the empty-array half. A
+        # collapsed turn that carried no text also comes back with empty
+        # content, which is a second, independent 400 ("messages must have
+        # non-empty content"). So re-run both invariant passes over the deduped
+        # list instead: cheap (only on the rare dedup path), idempotent, and it
+        # covers any future pass inserted before this return — not just this
+        # one. Order matters: drop the empty arrays first so the content healer
+        # sees the turn as genuinely payload-less and substitutes a placeholder.
+        messages = drop_empty_tool_calls_arrays(messages)
+        messages = repair_empty_non_final_messages(messages)
     return messages
 
 
@@ -4076,6 +4111,7 @@ __all__ = [
     "invoke_tool",
     "repair_tool_call",
     "sanitize_api_messages",
+    "drop_empty_tool_calls_arrays",
     "looks_like_codex_intermediate_ack",
     "copy_reasoning_content_for_api",
     "cleanup_dead_connections",

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -380,3 +380,71 @@ def test_sanitize_drops_empty_tool_calls_array():
 
 
 
+
+
+# ── Sanitizer fixpoint: dedup must not re-break earlier invariants ──────────
+# The tool_call_id dedup pass runs AFTER the empty-array and empty-content
+# passes. When every call on an assistant turn is a duplicate, dedup rewrites
+# that turn to ``tool_calls: []`` — re-creating the exact payload the earlier
+# pass deleted, where nothing downstream can see it. DeepSeek 400s on every
+# subsequent send and the persisted turn wedges the session (#83312).
+
+
+def _wedge_transcript(text: str | None) -> list[dict]:
+    """Transcript whose last assistant turn re-uses an already-seen call id.
+
+    This is the shape ``repair_message_sequence`` produces when it merges two
+    consecutive assistant turns and unions their tool_calls onto the survivor.
+    """
+    call = {
+        "id": "call_dup",
+        "type": "function",
+        "function": {"name": "read_file", "arguments": "{}"},
+    }
+    return [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": None, "tool_calls": [call]},
+        {"role": "tool", "tool_call_id": "call_dup", "content": "file body"},
+        {"role": "assistant", "content": text, "tool_calls": [dict(call)]},
+        {"role": "user", "content": "and now?"},
+    ]
+
+
+def test_dedup_does_not_reintroduce_empty_tool_calls_array():
+    """Collapsing every call on a turn must drop the key, not leave ``[]``."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    out = sanitize_api_messages(_wedge_transcript("here is the file"))
+
+    assert not any(
+        m.get("role") == "assistant" and m.get("tool_calls") == [] for m in out
+    ), "dedup re-introduced the empty tool_calls array DeepSeek rejects"
+    survivor = [m for m in out if m.get("content") == "here is the file"][0]
+    assert "tool_calls" not in survivor
+
+
+def test_dedup_collapse_heals_contentless_turn():
+    """A collapsed turn that carried no text must not be sent with empty
+    content either — that is a second, independent 400 ("messages must have
+    non-empty content"), so the content healer has to re-run after dedup."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    out = sanitize_api_messages(_wedge_transcript(""))
+
+    assistants = [m for m in out if m.get("role") == "assistant"]
+    assert all(
+        m.get("content") or m.get("tool_calls") for m in assistants[:-1]
+    ), "a non-final assistant turn survived with neither content nor tool_calls"
+    assert not any(m.get("tool_calls") == [] for m in assistants)
+
+
+def test_sanitize_is_a_fixpoint_over_the_wedge_transcript():
+    """Sanitizing twice must equal sanitizing once. Any invariant a pass
+    enforces has to still hold on the value the function returns, otherwise a
+    later pass can silently undo an earlier one."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    for text in ("here is the file", "", None):
+        once = sanitize_api_messages(_wedge_transcript(text))
+        twice = sanitize_api_messages([dict(m) for m in once])
+        assert once == twice, f"sanitizer not idempotent for content={text!r}"

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -448,3 +448,18 @@ def test_sanitize_is_a_fixpoint_over_the_wedge_transcript():
         once = sanitize_api_messages(_wedge_transcript(text))
         twice = sanitize_api_messages([dict(m) for m in once])
         assert once == twice, f"sanitizer not idempotent for content={text!r}"
+
+        surviving_call_ids = {
+            call.get("id")
+            for m in once
+            if m.get("role") == "assistant"
+            for call in (m.get("tool_calls") or [])
+        }
+        orphaned = [
+            m
+            for m in once
+            if m.get("role") == "tool" and m.get("tool_call_id") not in surviving_call_ids
+        ]
+        assert not orphaned, (
+            f"dedup left orphaned tool result(s) with no matching call: {orphaned!r}"
+        )


### PR DESCRIPTION
Fixes #83312.

## The bug is real, and it is not where the issue says it is

The issue reports that `tool_calls: []` reaches DeepSeek "after the sanitizer already stripped it". That is accurate as an observation, but the payload is not surviving the sanitizer — **the sanitizer creates it.**

`sanitize_api_messages` is an ordered pipeline. Two of its passes enforce invariants near the top:

- `repair_empty_non_final_messages` — no non-final turn may have empty content
- the empty-`tool_calls` drop — no assistant turn may carry `tool_calls: []`

The tool_call_id dedup pass runs **last**. When *every* call on an assistant turn is a duplicate, `kept_tcs` is empty and the turn is rewritten to `tool_calls: []` — re-creating the exact payload that was deleted a few steps earlier, at a point where nothing downstream can see it.

That "every call is a duplicate" shape is not exotic. It is what `repair_message_sequence` produces when it merges two consecutive assistant turns and unions their call lists onto the surviving text turn, which is why the issue's reporters correlate the failure with the `Repaired N message-alternation violations` log line.

Because the poisoned turn is persisted, every later send fails identically. The session is wedged permanently — restart included.

## Reproduction

```
user      "hi"
assistant content=None, tool_calls=[call_dup]
tool      call_dup -> "file body"
assistant content="here is the file", tool_calls=[call_dup]   <- duplicate id
user      "and now?"
```

On `main`, `sanitize_api_messages` returns the 4th message as `{"role": "assistant", "content": "here is the file", "tool_calls": []}` → HTTP 400 `Invalid 'messages[3].tool_calls': empty array`.

## Why patching the dedup site is only half a fix

Several open PRs (#83315, #80827, #82252, #77377, #74906, #64843) drop the key at the dedup site, and #82252 additionally re-runs an empty-array sweep afterwards. Credit where due: that closes the empty-array half.

It leaves the other half open. If the collapsed turn carried **no text**, it comes back with empty content and no tool calls. That is a second, independent 400 — `all messages must have non-empty content except for the final one` (INVALID_REQUEST_BODY) — and the content healer that exists to fix exactly this already ran, several passes earlier, back when the turn still had tool calls and therefore looked like it had a payload. The session stays wedged; only the error string changes.

## This PR: make the sanitizer a fixpoint

A sanitizer is only useful if every invariant it claims still holds on the value it returns. This restores that property instead of patching one symptom site:

1. Extract the empty-array normalization into `drop_empty_tool_calls_arrays` — the same code, now callable, so nothing is duplicated.
2. After dedup, **re-run both invariant passes** on the deduped list, gated on `removed_dupes` so the common path is untouched.

Order matters: arrays are dropped first, so the content healer sees a genuinely payload-less turn and substitutes its placeholder.

This covers both 400 classes, and covers any future pass inserted before the `return` — not just this one.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Transcript] --> B[Role Allowlist]
    B --> C[Heal Empty Content]
    C --> D[Drop Empty tool_calls]
    D --> E[Pair Orphan Calls / Results]
    E --> F[Dedup tool_call_ids]
    F -->|All calls duplicate| G[Turn Rewritten To tool_calls Empty Array]
    G -->|main| H[HTTP 400 Empty Array]
    G -->|main, turn had no text| I[HTTP 400 Empty Content]
    H --> J[Session Wedged Permanently]
    I --> J
    G -->|this PR| K[Re-run Drop Empty tool_calls]
    K --> L[Re-run Heal Empty Content]
    L --> M[Invariants Hold On Return]
    M --> N[Request Accepted]
```

## Tests

`tests/run_agent/test_message_sequence_repair.py` (extended, no new file):

- `test_dedup_does_not_reintroduce_empty_tool_calls_array` — the empty-array 400
- `test_dedup_collapse_heals_contentless_turn` — the empty-content 400 the site patches miss
- `test_sanitize_is_a_fixpoint_over_the_wedge_transcript` — `sanitize(sanitize(x)) == sanitize(x)`

All three fail on `main` and pass here. Full file: 17 passed. `test_agent_guardrails.py` + `test_restore_alternation_repair.py`: 43 passed. `test_tool_call_incremental_persistence.py` shows 9 passed / 4 failed both with and without this change (pre-existing local Windows failures, unrelated).

 ## Infographic :


<img width="1376" height="768" alt="sanitize_fixpoint_oriental" src="https://github.com/user-attachments/assets/b207a52b-4eba-44b5-ba14-9ec3f222a764" />

 
