### PR TITLE
fix(discord): log failed VC playback

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3761,6 +3761,18 @@ class DiscordAdapter(BasePlatformAdapter):
             if str(text_ch_id) == str(chat_id) and self.is_in_voice_channel(gid):
                 logger.info("[%s] Playing TTS in voice channel (guild=%d)", self.name, gid)
                 success = await self.play_in_voice_channel(gid, audio_path)
+                if not success:
+                    vc = self._voice_clients.get(gid)
+                    logger.warning(
+                        "[%s] Discord voice playback returned False "
+                        "(guild=%s chat=%s connected=%s playing=%s audio=%s)",
+                        self.name,
+                        gid,
+                        chat_id,
+                        vc.is_connected() if vc else False,
+                        vc.is_playing() if vc else False,
+                        os.path.basename(audio_path),
+                    )
                 return SendResult(success=success)
         return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1742,6 +1742,32 @@ class TestVoiceTTSPlayback:
         assert result.success is True
         assert played == [(111, "/tmp/tts.ogg")]
 
+    @pytest.mark.asyncio
+    async def test_play_tts_logs_false_vc_playback_without_attachment_fallback(self, caplog):
+        """A failed connected-VC attempt remains attachment-free but observable."""
+        adapter = self._make_discord_adapter()
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.is_playing.return_value = False
+        adapter._voice_clients[111] = mock_vc
+        adapter._voice_text_channels[111] = 123
+        adapter.play_in_voice_channel = AsyncMock(return_value=False)
+        adapter.send_voice = AsyncMock()
+
+        result = await adapter.play_tts(chat_id="123", audio_path="/tmp/tts.ogg")
+
+        assert result.success is False
+        adapter.send_voice.assert_not_awaited()
+        assert any(
+            "Discord voice playback returned False" in record.getMessage()
+            and "guild=111" in record.getMessage()
+            and "chat=123" in record.getMessage()
+            and "connected=True" in record.getMessage()
+            and "playing=False" in record.getMessage()
+            and "audio=tts.ogg" in record.getMessage()
+            for record in caplog.records
+        )
+
 
     # -- Runner dedup --
 


### PR DESCRIPTION
## Summary
- log a warning with bounded Discord VC routing/runtime state when playback returns `False`
- preserve the existing no-attachment fallback behavior
- cover the false-result path with a focused regression test

## Tests
- `scripts/run_tests.sh tests/gateway/test_voice_command.py tests/gateway/test_auto_voice_reply_format.py tests/gateway/test_send_voice_reply_notify.py`