### PR TITLE
fix(cron): normalize literal 'auto' model/provider pins to the default resolution

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2963,6 +2963,24 @@ BLOCKED_CONFIG_MARKER = "[blocked_config]"
 BLOCKED_CONFIG_SILENT_MARKER = "[blocked_config:silent]"
 
 
+def _normalize_auto_pin(value):
+    """Treat the literal ``"auto"`` sentinel as unpinned.
+
+    Jobs created via ``cronjob create model=auto provider=auto`` persist the
+    sentinel string verbatim. Downstream resolution code interprets any
+    non-empty pin as an explicit choice, so without normalization the literal
+    ``"auto"`` reaches the wire as a model name (rejected, e.g. HTTP 401
+    "Model auto is not supported") or bypasses the cron-fleet / config
+    defaults on the provider axis and reroutes the run through the fallback
+    chain — silently spending an unrelated provider's balance every tick.
+    "auto" is not a model or provider literally named "auto"; it means
+    "follow the default resolution", so map it to ``None`` (unpinned).
+    """
+    if isinstance(value, str) and value.strip().lower() == "auto":
+        return None
+    return value
+
+
 def _cron_preflight_enabled(cfg: dict) -> bool:
     """Whether cron pre-dispatch configuration validation is enabled.
 
@@ -2992,12 +3010,14 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
         return None  # fail-open: never block on a preflight-internal error
 
     _cron_cfg = cfg.get("cron") if isinstance(cfg.get("cron"), dict) else {}
-    requested = (
-        job.get("provider")
-        or str((_cron_cfg or {}).get("model_provider") or "").strip()
-        or None
+    requested = _normalize_auto_pin(job.get("provider")) or str(
+        (_cron_cfg or {}).get("model_provider") or ""
+    ).strip() or None
+    model = (
+        _normalize_auto_pin(job.get("model"))
+        or os.getenv("HERMES_MODEL")
+        or ""
     )
-    model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
     from hermes_cli.auth import AuthError
 
@@ -3691,7 +3711,13 @@ def run_job(
         # re-read from storage every tick so a ``cronjob action=update
         # model=...`` after a failed run takes effect on the next tick — there
         # is no in-memory cache.
-        model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        #
+        # Normalize the literal ``"auto"`` sentinel (see ``_normalize_auto_pin``)
+        # on both axes so the default resolution applies, mirroring the
+        # auxiliary-path normalization in agent/auxiliary_client.py.
+        _job_model_pinned = _normalize_auto_pin(job.get("model"))
+        _job_provider_pinned = _normalize_auto_pin(job.get("provider"))
+        model = _job_model_pinned or os.getenv("HERMES_MODEL") or ""
 
         # cron.model / cron.model_provider: a deliberate cron-fleet default
         # so unattended jobs stop shadowing chat `/model` switches. When an
@@ -3729,7 +3755,7 @@ def run_job(
                     _cron_default_provider = str(
                         _cron_cfg_for_model.get("model_provider") or ""
                     ).strip()
-                if not job.get("model"):
+                if not _job_model_pinned:
                     if _cron_default_model:
                         # Cron-fleet default beats the global chat model: it is
                         # the user's explicit "cron runs on this" setting.
@@ -3891,7 +3917,7 @@ def run_job(
             else ""
         )
         primary_provider_for_drift = (
-            str(job.get("provider") or "").strip().lower()
+            str(_job_provider_pinned or "").strip().lower()
             or configured_provider_for_drift
             or None
         )
@@ -3905,7 +3931,7 @@ def run_job(
                 # Per-job user pin wins; otherwise the cron-fleet default
                 # provider (cron.model_provider); otherwise resolve from
                 # persisted global config.
-                "requested": job.get("provider") or _cron_default_provider or None,
+                "requested": _job_provider_pinned or _cron_default_provider or None,
                 # Derive provider-specific api_mode from the model this job
                 # will actually run (per-job pin > env > config default), not
                 # the stale persisted default — mirrors the fallback path
@@ -3998,7 +4024,7 @@ def run_job(
             _provider_snapshot = (job.get("provider_snapshot") or "").strip().lower()
             if (
                 _provider_snapshot
-                and not (job.get("provider") or "").strip()
+                and not _job_provider_pinned
                 and not _cron_default_provider
             ):
                 _current_provider = str(
@@ -4011,7 +4037,7 @@ def run_job(
             _model_snapshot = (job.get("model_snapshot") or "").strip().lower()
             if (
                 _model_snapshot
-                and not (job.get("model") or "").strip()
+                and not _job_model_pinned
                 and not _cron_default_model
             ):
                 _current_model = str(primary_model_for_drift or "").strip().lower()

--- a/tests/cron/test_cron_auto_literal_normalization.py
+++ b/tests/cron/test_cron_auto_literal_normalization.py
@@ -1,0 +1,218 @@
+"""Literal ``"auto"`` model/provider normalization for cron jobs.
+
+Background: jobs created via ``cronjob create model=auto provider=auto``
+persist the sentinel string verbatim. Before this fix the run path treated
+the non-empty string as a pin:
+
+  - ``model = job.get("model") or ...`` kept ``"auto"`` and skipped the
+    config-default block (``if not job.get("model")``), so the literal
+    ``"auto"`` reached the provider as a model name. The API rejects it
+    (HTTP 401 "Model auto is not supported") and the fallback chain
+    silently reroutes the run to the first fallback_providers entry —
+    spending an unrelated provider's balance on every tick.
+  - ``"requested": job.get("provider") or ...`` passed ``"auto"`` past the
+    cron.model_provider fleet default.
+
+The fix normalizes the literal ``"auto"`` (case-insensitive) on both axes
+to "unpinned" so the default resolution (cron.model > config model.default
+> HERMES_MODEL) applies — mirroring the auxiliary-path normalization in
+agent/auxiliary_client.py.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Ensure project root is importable.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import _normalize_auto_pin, run_job
+
+
+def _base_job(**overrides):
+    job = {
+        "id": "auto-norm-test",
+        "name": "auto norm test",
+        "prompt": "hello",
+        "model": None,
+        "provider": None,
+        "model_snapshot": None,
+        "provider_snapshot": None,
+        "base_url": None,
+    }
+    job.update(overrides)
+    return job
+
+
+def _write_config(tmp_path, text):
+    (tmp_path / "config.yaml").write_text(text, encoding="utf-8")
+
+
+def _run_job(job, tmp_path, resolve_spy):
+    """Drive run_job with resolve_runtime_provider spied and AIAgent mocked.
+
+    Returns (success, agent_kwargs_or_None).
+    """
+    fake_db = MagicMock()
+
+    def _fake_resolve(**kwargs):
+        resolve_spy.append(kwargs)
+        return {
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "provider": "test-provider",
+            "api_mode": "chat_completions",
+        }
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             side_effect=_fake_resolve,
+         ), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent_cls.return_value = mock_agent
+
+        success, _output, _final_response, _error = run_job(job)
+        agent_kwargs = mock_agent_cls.call_args.kwargs if mock_agent_cls.called else None
+
+    return success, agent_kwargs
+
+
+class TestNormalizeAutoPin:
+    def test_literal_auto_maps_to_none(self):
+        assert _normalize_auto_pin("auto") is None
+
+    def test_case_and_whitespace_insensitive(self):
+        assert _normalize_auto_pin("AUTO") is None
+        assert _normalize_auto_pin(" Auto ") is None
+
+    def test_real_pins_pass_through(self):
+        assert _normalize_auto_pin("deepseek-v4-flash") == "deepseek-v4-flash"
+        assert _normalize_auto_pin("automatic-model") == "automatic-model"
+        assert _normalize_auto_pin(None) is None
+        assert _normalize_auto_pin("") == ""
+
+
+class TestPreflightAutoNormalization:
+    """The pre-dispatch provider-key probe mirrors run_job's resolution and
+    must see the same normalized values — otherwise it resolves against the
+    literal ``"auto"`` while the actual run resolves against the config
+    default, so the probe can miss a genuinely missing key (or falsely
+    block a run that the fallback chain would rescue)."""
+
+    def test_preflight_sees_fleet_provider_not_literal_auto(self, tmp_path):
+        from cron.scheduler import _preflight_check_provider_key
+
+        cfg = {
+            "cron": {"model": "fleet-model", "model_provider": "fleet-provider"},
+        }
+        job = _base_job(model="auto", provider="auto")
+        calls = []
+
+        def _fake_resolve(**kwargs):
+            calls.append(kwargs)
+            return {"provider": "fleet-provider"}
+
+        with patch("cron.scheduler.get_fallback_chain", return_value=[]), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 side_effect=_fake_resolve,
+             ):
+            result = _preflight_check_provider_key(job, cfg)
+
+        assert result is None, f"preflight should pass, got: {result}"
+        assert calls, "resolve_runtime_provider was not probed"
+        assert calls[0]["requested"] == "fleet-provider", (
+            f"preflight must normalize provider='auto' before probing; "
+            f"got requested={calls[0]['requested']!r}"
+        )
+
+
+class TestLiteralAutoNormalization:
+    def test_model_auto_resolves_to_config_default(self, tmp_path):
+        """model='auto' must NOT reach the wire; config default applies."""
+        _write_config(
+            tmp_path,
+            "model:\n  default: deepseek-v4-flash\n  provider: opencode-go\n",
+        )
+        resolve_spy = []
+        success, agent_kwargs = _run_job(
+            _base_job(model="auto", provider="auto"), tmp_path, resolve_spy
+        )
+        assert success, "job with model=auto should run after normalization"
+        assert agent_kwargs is not None, "AIAgent should have been constructed"
+        assert agent_kwargs["model"] == "deepseek-v4-flash", (
+            f"literal 'auto' leaked into the model slot: {agent_kwargs['model']!r}"
+        )
+        # Every resolution probe (the pre-dispatch provider-key preflight
+        # and the actual run resolution) must never receive the literal
+        # sentinel. The preflight probe reads the real user config, so its
+        # resolved model may legitimately differ from this test's config
+        # default — only the final run resolution must match it.
+        assert resolve_spy, "resolve_runtime_provider was not called"
+        for i, call in enumerate(resolve_spy):
+            target = str(call.get("target_model") or "").strip().lower()
+            assert target != "auto", (
+                f"resolve call #{i} got literal 'auto' in the model slot: "
+                f"{call['target_model']!r}"
+            )
+        assert resolve_spy[-1]["target_model"] == "deepseek-v4-flash", (
+            "the final run resolution must use the config default, got "
+            f"{resolve_spy[-1]['target_model']!r}"
+        )
+
+    def test_provider_auto_does_not_short_circuit_fleet_default(self, tmp_path):
+        """provider='auto' must not shadow cron.model_provider."""
+        _write_config(
+            tmp_path,
+            "model:\n  default: deepseek-v4-flash\n"
+            "cron:\n  model: fleet-model\n  model_provider: fleet-provider\n",
+        )
+        resolve_spy = []
+        success, agent_kwargs = _run_job(
+            _base_job(model="auto", provider="auto"), tmp_path, resolve_spy
+        )
+        assert success
+        assert resolve_spy, "resolve_runtime_provider was not called"
+        assert resolve_spy[0]["requested"] == "fleet-provider", (
+            f"provider='auto' should normalize to unpinned so cron.model_provider "
+            f"applies; got requested={resolve_spy[0]['requested']!r}"
+        )
+        assert agent_kwargs["model"] == "fleet-model"
+
+    def test_model_auto_case_insensitive(self, tmp_path):
+        """'AUTO' / ' Auto ' normalize the same way."""
+        _write_config(tmp_path, "model:\n  default: resolved-model\n")
+        resolve_spy = []
+        success, agent_kwargs = _run_job(
+            _base_job(model=" AUTO ", provider="Auto"), tmp_path, resolve_spy
+        )
+        assert success
+        assert agent_kwargs["model"] == "resolved-model"
+
+    def test_explicit_pin_still_wins(self, tmp_path):
+        """A real (non-'auto') per-job pin is untouched."""
+        _write_config(tmp_path, "model:\n  default: config-default\n")
+        resolve_spy = []
+        success, agent_kwargs = _run_job(
+            _base_job(model="pinned-model", provider="pinned-provider"),
+            tmp_path,
+            resolve_spy,
+        )
+        assert success
+        assert agent_kwargs["model"] == "pinned-model"
+        assert resolve_spy[0]["requested"] == "pinned-provider"
+
+    def test_unpinned_job_still_follows_config_default(self, tmp_path):
+        """Regression: None-valued axes keep the pre-existing behavior."""
+        _write_config(tmp_path, "model:\n  default: config-default\n")
+        resolve_spy = []
+        success, agent_kwargs = _run_job(_base_job(), tmp_path, resolve_spy)
+        assert success
+        assert agent_kwargs["model"] == "config-default"


### PR DESCRIPTION
## What does this PR do?

Normalizes the literal `"auto"` sentinel stored in cron job `model` / `provider` fields to "unpinned" so the default resolution chain applies, instead of sending `model=auto` to the provider wire.

Jobs created via `cronjob action=create model=auto provider=auto` persist the sentinel verbatim. The run path treated any non-empty pin string as an explicit choice, so:

- `"auto"` reached the provider as a model name and was rejected (HTTP 401 `Model auto is not supported`); the retry ladder then rerouted every tick through `fallback_providers`, silently spending an unrelated provider's balance.
- On the provider axis, `"auto"` bypassed the `cron.model_provider` fleet default into `resolve_runtime_provider(requested="auto")`, matching no configured provider.

The fix adds a shared `_normalize_auto_pin()` helper mapping the literal `"auto"` (case-insensitive, stripped) to `None`, used by both `run_job` and the pre-dispatch provider-key preflight (`_preflight_check_provider_key`), which mirrored the same un-normalized computation. Explicit real pins pass through untouched. This mirrors the auxiliary-path normalization already present in `agent/auxiliary_client.py`.

## Related Issue

Fixes #83596

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`:
  - new `_normalize_auto_pin()` helper (maps literal `"auto"` → `None`)
  - `run_job`: normalize `job.get("model")` / `job.get("provider")` before pin handling, so the config-default block (`cron.model` > `config model.default` > `HERMES_MODEL`) and `cron.model_provider` apply
  - `_preflight_check_provider_key`: same normalization, so the preflight probes resolution with the same values the actual run uses
- `tests/cron/test_cron_auto_literal_normalization.py`: 9 new tests (helper unit tests, preflight normalization, model-axis normalization, fleet-default interaction, case-insensitivity, explicit-pin passthrough, unpinned regression)

## How to Test

1. Create a job with `"model": "auto", "provider": "auto"` in `jobs.json` (or `cronjob action=create model=auto provider=auto`).
2. Before the fix: `agent.log` shows `model=auto` on the wire and `HTTP 401: Model auto is not supported` on every tick.
3. After the fix: the job resolves the configured default model/provider and runs normally.
4. `pytest tests/cron/ -q` — 524 passed, 1 skipped (9 new tests included); `ruff check` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

> Note: ran the full `tests/cron/` suite (524 passed, 1 skipped) plus `ruff check` on the changed files; the change is contained to the cron run path.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Field evidence before the fix (`agent.log`, literal `auto` on the wire, repeated every tick):

```text
INFO [cron_807319e2d242_20260811_050026] run_agent: OpenAI client created (chat_completion_request, shared=False) provider=<provider> base_url=<base_url> model=auto
WARNING [cron_807319e2d242_20260811_050026] agent.conversation_loop: API call failed (attempt 1/3) error_type=AuthenticationError provider=<provider> model=auto summary=HTTP 401: Model auto is not supported
```
