### PR TITLE
fix: strip PYTHONPATH from browser-use subprocess env

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -137,6 +137,11 @@ def _build_browser_env() -> dict:
     for _key in _BROWSER_PASSTHROUGH_KEYS:
         if _key in os.environ:
             env[_key] = os.environ[_key]
+    # Strip PYTHONPATH — browser-use runs under its own isolated Python (uvx/pipx),
+    # often a different minor version than Hermes' venv. A leaked PYTHONPATH pointing
+    # at Hermes' site-packages causes cross-version C-extension load failures
+    # (e.g. pydantic_core compiled for 3.11 loaded by 3.14 → ModuleNotFoundError).
+    env.pop("PYTHONPATH", None)
     return env
 
 try:


### PR DESCRIPTION
## Problem

`browser_exec` fails with a hard crash when browser-use runs under a different Python minor version than Hermes:

```
ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'
```

## Root Cause

browser-use runs in its own isolated Python environment (via `uvx`/`pipx`), which is often a **different minor version** than Hermes' venv. For example, on this machine:

- Hermes venv: **Python 3.11**
- browser-use (via `uvx`): **Python 3.14**

Hermes sets `PYTHONPATH` pointing at its own `site-packages` (`/…/hermes-agent/venv/lib/python3.11/site-packages`). When this `PYTHONPATH` leaks into the browser-use subprocess environment, the isolated Python 3.14 tries to import C extensions compiled for 3.11 — most commonly `pydantic_core` — and crashes because the compiled `.so` has an incompatible ABI tag (`cpython-311-darwin.so` cannot be loaded by 3.14).

### Reproduction

```bash
# Fails — PYTHONPATH leaks 3.11 site-packages into 3.14:
PYTHONPATH="/…/venv/lib/python3.11/site-packages" uvx browser-use --version
# → ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'

# Works — clean environment:
env -u PYTHONPATH uvx browser-use --version
# → 0.1.8
```

## Fix

Strip `PYTHONPATH` from the browser subprocess env in `_build_browser_env()`, so browser-use's isolated Python uses only its own dependency tree.

`hermes_subprocess_env()` already strips `VIRTUAL_ENV` and `CONDA_PREFIX` (the active-venv markers) for exactly this reason — cross-project Python environment clobbering. `PYTHONPATH` is the same class of leak but was missed.

## Verification

```python
import os
os.environ["PYTHONPATH"] = "/…/venv/lib/python3.11/site-packages"
from tools.browser_tool import _build_browser_env
env = _build_browser_env()
assert "PYTHONPATH" not in env  # ✅ fixed
```

```bash
$ env -u PYTHONPATH uvx browser-use --version
0.1.8  # ✅
```

<!-- This is an automated self-PR summary generated by an AI assistant on behalf of the contributor. -->