### PR TITLE
fix(desktop): add macOS CoreGraphics window enumeration fallback

### DIFF
--- a/apps/desktop/electron/window-below.test.ts
+++ b/apps/desktop/electron/window-below.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { type EnumeratedWindow, enumerationFailureNote, pickWindowBelow } from './window-below'
+import {
+  type EnumeratedWindow,
+  enumerateViaMacJxa,
+  enumerateWindowsWithFallback,
+  enumerationFailureNote,
+  type MacJxaCommand,
+  parseMacWindowEnumeration,
+  pickWindowBelow,
+  readWindowBelow
+} from './window-below'
 
 const win = (pid: number, x = 0, y = 0, width = 800, height = 600, app = `app-${pid}`): EnumeratedWindow => ({
   app,
@@ -12,6 +21,16 @@ const win = (pid: number, x = 0, y = 0, width = 800, height = 600, app = `app-${
 
 const SELF_PID = 42
 const SELF_BOUNDS = { x: 100, y: 100, width: 800, height: 600 }
+
+const MAC_WINDOW_JSON = JSON.stringify([
+  {
+    app: 'Google Chrome',
+    bounds: { x: 20, y: 30, width: 1440, height: 900 },
+    id: 123,
+    pid: 456,
+    title: 'Inbox'
+  }
+])
 
 describe('pickWindowBelow', () => {
   it('picks the first overlapping window behind ours in z-order', () => {
@@ -123,6 +142,151 @@ describe('enumerationFailureNote', () => {
 
       expect(note).not.toMatch(/xprop|Wayland/)
       expect(note.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('enumerateWindowsWithFallback', () => {
+  it('uses the built-in macOS fallback when get-windows cannot run', async () => {
+    const chrome = win(1, 120, 120, 800, 600, 'Google Chrome')
+    const primary = vi.fn(async () => null)
+    const macFallback = vi.fn(async () => [chrome])
+
+    const windows = await enumerateWindowsWithFallback(false, {
+      platform: 'darwin',
+      primary,
+      macFallback
+    })
+
+    expect(windows).toEqual([chrome])
+    expect(primary).toHaveBeenCalledWith(false)
+    expect(macFallback).toHaveBeenCalledWith(false)
+  })
+
+  it('does not run the fallback when the primary enumerator succeeds', async () => {
+    const safari = win(2, 120, 120, 800, 600, 'Safari')
+    const primary = vi.fn(async () => [safari])
+    const macFallback = vi.fn(async () => [win(3)])
+
+    const windows = await enumerateWindowsWithFallback(true, {
+      platform: 'darwin',
+      primary,
+      macFallback
+    })
+
+    expect(windows).toEqual([safari])
+    expect(macFallback).not.toHaveBeenCalled()
+  })
+
+  it('treats an empty primary enumeration as a successful result', async () => {
+    const primary = vi.fn(async () => [])
+    const macFallback = vi.fn(async () => [win(3)])
+
+    const windows = await enumerateWindowsWithFallback(false, {
+      platform: 'darwin',
+      primary,
+      macFallback
+    })
+
+    expect(windows).toEqual([])
+    expect(macFallback).not.toHaveBeenCalled()
+  })
+
+  it('propagates null when both macOS enumerators fail', async () => {
+    const primary = vi.fn(async () => null)
+    const macFallback = vi.fn(async () => null)
+
+    const windows = await enumerateWindowsWithFallback(false, {
+      platform: 'darwin',
+      primary,
+      macFallback
+    })
+
+    expect(windows).toBeNull()
+    expect(macFallback).toHaveBeenCalledWith(false)
+  })
+
+  it('does not run the macOS fallback on another platform', async () => {
+    const primary = vi.fn(async () => null)
+    const macFallback = vi.fn(async () => [win(3)])
+
+    const windows = await enumerateWindowsWithFallback(false, {
+      platform: 'win32',
+      primary,
+      macFallback
+    })
+
+    expect(windows).toBeNull()
+    expect(macFallback).not.toHaveBeenCalled()
+  })
+})
+
+describe('enumerateViaMacJxa', () => {
+  it('executes the built-in CoreGraphics script and parses its response', async () => {
+    let command: MacJxaCommand | null = null
+
+    const execute = vi.fn(async (nextCommand: MacJxaCommand) => {
+      command = nextCommand
+
+      return MAC_WINDOW_JSON
+    })
+
+    const windows = await enumerateViaMacJxa(false, execute)
+
+    expect(command).toEqual({
+      args: ['-l', 'JavaScript', '-e', expect.stringContaining('CGWindowListCopyWindowInfo')],
+      file: '/usr/bin/osascript',
+      options: { encoding: 'utf8', maxBuffer: 2 * 1024 * 1024, timeout: 3000 }
+    })
+    expect(windows?.[0]).toMatchObject({ app: 'Google Chrome', title: '' })
+  })
+
+  it('fails closed when the built-in subprocess rejects', async () => {
+    const execute = vi.fn(async () => {
+      throw new Error('osascript unavailable')
+    })
+
+    await expect(enumerateViaMacJxa(false, execute)).resolves.toBeNull()
+  })
+})
+
+describe('parseMacWindowEnumeration', () => {
+  it('normalizes the CoreGraphics response', () => {
+    expect(parseMacWindowEnumeration(MAC_WINDOW_JSON, true)).toEqual([
+      {
+        app: 'Google Chrome',
+        bounds: { x: 20, y: 30, width: 1440, height: 900 },
+        id: 123,
+        pid: 456,
+        title: 'Inbox'
+      }
+    ])
+  })
+
+  it('drops titles unless Screen Recording was already granted', () => {
+    expect(parseMacWindowEnumeration(MAC_WINDOW_JSON, false)?.[0]?.title).toBe('')
+  })
+
+  it('fails closed on malformed helper output', () => {
+    expect(parseMacWindowEnumeration('not json', true)).toBeNull()
+    expect(parseMacWindowEnumeration('{}', true)).toBeNull()
+  })
+})
+
+describe('readWindowBelow', () => {
+  it('uses the fallback-aware enumerator when Hyprland is unavailable', async () => {
+    const target = win(7, 120, 120, 800, 600, 'Google Chrome')
+    const readHyprland = vi.fn(async () => null)
+    const enumerate = vi.fn(async () => [win(SELF_PID, 100, 100), target])
+
+    const result = await readWindowBelow(SELF_PID, SELF_BOUNDS, false, { enumerate, readHyprland })
+
+    expect(readHyprland).toHaveBeenCalledWith(SELF_PID)
+    expect(enumerate).toHaveBeenCalledWith(false)
+    expect('error' in result).toBe(false)
+
+    if (!('error' in result)) {
+      expect(result.window?.app).toBe('Google Chrome')
     }
   })
 })

--- a/apps/desktop/electron/window-below.ts
+++ b/apps/desktop/electron/window-below.ts
@@ -12,6 +12,9 @@
 // permission; we pass titles through only when that permission is ALREADY
 // granted and never trigger the prompt for it.
 
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
 import { readHyprlandWindows } from './hyprland'
 
 export interface EnumeratedWindow {
@@ -124,10 +127,151 @@ type GetWindowsModule = {
 
 let getWindowsModule: Promise<GetWindowsModule> | null = null
 
+const execFileAsync = promisify(execFile)
+
 const loadGetWindows = (): Promise<GetWindowsModule> => {
   getWindowsModule ??= import('get-windows')
 
   return getWindowsModule
+}
+
+// `get-windows` uses a bundled Swift executable on macOS. If that helper is
+// absent or cannot launch from a packaged app, use the same CoreGraphics API
+// through macOS' built-in JavaScript bridge. `/usr/bin/osascript` is part of the
+// OS, needs no bundled native payload, and CGWindowListCopyWindowInfo exposes
+// app/bounds/z-order without an Accessibility or Screen Recording prompt.
+// Window titles are still stripped below unless Screen Recording was already
+// granted to Hermes.
+const MAC_WINDOW_ENUMERATION_JXA = `
+ObjC.import("CoreGraphics");
+
+function run() {
+  var raw = $.CGWindowListCopyWindowInfo(
+    $.kCGWindowListOptionOnScreenOnly | $.kCGWindowListExcludeDesktopElements,
+    $.kCGNullWindowID
+  );
+  var bridged = ObjC.castRefToObject(raw);
+  var windows = [];
+
+  function unwrap(dictionary, key, fallback) {
+    var value = dictionary && dictionary.objectForKey(key);
+    if (!value) return fallback;
+    var unwrapped = ObjC.unwrap(value);
+    return unwrapped === undefined || unwrapped === null ? fallback : unwrapped;
+  }
+
+  for (var index = 0; index < bridged.count; index += 1) {
+    var window = bridged.objectAtIndex(index);
+    var bounds = window.objectForKey("kCGWindowBounds");
+    var layer = Number(unwrap(window, "kCGWindowLayer", 0));
+    var alpha = Number(unwrap(window, "kCGWindowAlpha", 0));
+    var width = Number(unwrap(bounds, "Width", 0));
+    var height = Number(unwrap(bounds, "Height", 0));
+
+    // Layer zero is an ordinary application window. Excluding menu bar,
+    // notification, and desktop layers keeps those system surfaces from being
+    // mistaken for the app underneath the HUD.
+    if (layer !== 0 || alpha <= 0 || width <= 0 || height <= 0) continue;
+
+    windows.push({
+      app: String(unwrap(window, "kCGWindowOwnerName", "")),
+      bounds: {
+        x: Number(unwrap(bounds, "X", 0)),
+        y: Number(unwrap(bounds, "Y", 0)),
+        width: width,
+        height: height
+      },
+      id: Number(unwrap(window, "kCGWindowNumber", 0)),
+      pid: Number(unwrap(window, "kCGWindowOwnerPID", 0)),
+      title: String(unwrap(window, "kCGWindowName", ""))
+    });
+  }
+
+  return JSON.stringify(windows);
+}
+`
+
+export interface MacJxaCommand {
+  args: string[]
+  file: string
+  options: { encoding: 'utf8'; maxBuffer: number; timeout: number }
+}
+
+export type MacJxaExecutor = (command: MacJxaCommand) => Promise<string>
+
+const executeMacJxa: MacJxaExecutor = async command => {
+  const result = await execFileAsync(command.file, command.args, command.options)
+
+  return String(result.stdout ?? '')
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === 'object' && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+
+const finiteNumber = (value: unknown): number => (typeof value === 'number' && Number.isFinite(value) ? value : 0)
+
+export function parseMacWindowEnumeration(stdout: string, titlesAvailable: boolean): EnumeratedWindow[] | null {
+  let parsed: unknown
+
+  try {
+    parsed = JSON.parse(stdout)
+  } catch {
+    return null
+  }
+
+  if (!Array.isArray(parsed)) {
+    return null
+  }
+
+  const windows: EnumeratedWindow[] = []
+
+  for (const value of parsed) {
+    const window = asRecord(value)
+    const bounds = asRecord(window?.bounds)
+
+    if (!window || !bounds) {
+      continue
+    }
+
+    const width = finiteNumber(bounds.width)
+    const height = finiteNumber(bounds.height)
+
+    if (width <= 0 || height <= 0) {
+      continue
+    }
+
+    windows.push({
+      app: typeof window.app === 'string' ? window.app : '',
+      bounds: {
+        x: finiteNumber(bounds.x),
+        y: finiteNumber(bounds.y),
+        width,
+        height
+      },
+      id: finiteNumber(window.id),
+      pid: finiteNumber(window.pid),
+      title: titlesAvailable && typeof window.title === 'string' ? window.title : ''
+    })
+  }
+
+  return windows
+}
+
+export async function enumerateViaMacJxa(
+  titlesAvailable: boolean,
+  execute: MacJxaExecutor = executeMacJxa
+): Promise<EnumeratedWindow[] | null> {
+  try {
+    const stdout = await execute({
+      args: ['-l', 'JavaScript', '-e', MAC_WINDOW_ENUMERATION_JXA],
+      file: '/usr/bin/osascript',
+      options: { encoding: 'utf8', maxBuffer: 2 * 1024 * 1024, timeout: 3000 }
+    })
+
+    return parseMacWindowEnumeration(stdout, titlesAvailable)
+  } catch {
+    return null
+  }
 }
 
 /**
@@ -178,15 +322,45 @@ async function enumerateViaGetWindows(titlesAvailable: boolean): Promise<Enumera
   }))
 }
 
+type WindowEnumerator = (titlesAvailable: boolean) => Promise<EnumeratedWindow[] | null>
+
+export async function enumerateWindowsWithFallback(
+  titlesAvailable: boolean,
+  {
+    platform = process.platform,
+    primary = enumerateViaGetWindows,
+    macFallback = enumerateViaMacJxa
+  }: {
+    platform?: NodeJS.Platform
+    primary?: WindowEnumerator
+    macFallback?: WindowEnumerator
+  } = {}
+): Promise<EnumeratedWindow[] | null> {
+  const windows = await primary(titlesAvailable)
+
+  if (windows !== null || platform !== 'darwin') {
+    return windows
+  }
+
+  return macFallback(titlesAvailable)
+}
+
 export async function readWindowBelow(
   selfPid: number,
   selfBounds: EnumeratedWindow['bounds'],
-  titlesAvailable: boolean
+  titlesAvailable: boolean,
+  {
+    enumerate = enumerateWindowsWithFallback,
+    readHyprland = readHyprlandWindows
+  }: {
+    enumerate?: typeof enumerateWindowsWithFallback
+    readHyprland?: typeof readHyprlandWindows
+  } = {}
 ): Promise<WindowBelowResult | WindowBelowUnavailable> {
   // Hyprland first, and only ever on Hyprland — its own IPC sees native Wayland
   // windows, which the X11 enumerator below cannot, and it answers null
   // everywhere else so the established path stays the default.
-  const windows = (await readHyprlandWindows(selfPid)) ?? (await enumerateViaGetWindows(titlesAvailable))
+  const windows = (await readHyprland(selfPid)) ?? (await enumerate(titlesAvailable))
 
   if (!windows) {
     return {


### PR DESCRIPTION
## Summary

`read_window_below` currently depends on the native helper bundled by `get-windows`. If that helper is missing or cannot launch from a packaged macOS app, window enumeration fails completely.

This change:

- Keeps `get-windows` as the primary enumerator.
- Falls back to macOS CoreGraphics through the built-in `/usr/bin/osascript` JavaScript bridge when the primary enumerator returns `null`.
- Preserves the existing privacy behavior. Window titles stay blank unless Screen Recording permission was already granted, and Hermes does not request a new permission.
- Leaves Windows and Linux behavior unchanged.
- Adds subprocess, parser, fallback, null sentinel, and caller wiring coverage.

The fallback script is static. No window data is interpolated into the command. It has a 3 second timeout, a 2 MB output limit, and returns `null` on any execution or parsing failure.

## Verification

- `npm run test:desktop:platforms --workspace apps/desktop` (88 files passed, 1 skipped; 1,046 tests passed, 2 skipped)
- `npm run typecheck --workspace apps/desktop`
- ESLint and Prettier on both changed files
- `npm run build --workspace apps/desktop`
- Live macOS smoke test against the real CoreGraphics fallback. It enumerated two windows and confirmed titles were stripped without Screen Recording permission.
