### PR TITLE
fix(memory): make mixed CJK memories searchable

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -46,7 +46,10 @@ CREATE INDEX IF NOT EXISTS idx_facts_category ON facts(category);
 CREATE INDEX IF NOT EXISTS idx_entities_name  ON entities(name);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts
-    USING fts5(content, tags, content=facts, content_rowid=fact_id);
+    USING fts5(
+        content, tags, content=facts, content_rowid=fact_id,
+        tokenize='trigram'
+    );
 
 CREATE TRIGGER IF NOT EXISTS facts_ai AFTER INSERT ON facts BEGIN
     INSERT INTO facts_fts(rowid, content, tags)
@@ -175,11 +178,40 @@ class MemoryStore:
         from hermes_state import apply_wal_with_fallback
         apply_wal_with_fallback(self._conn, db_label="memory_store.db (holographic)")
         self._conn.executescript(_SCHEMA)
+        self._migrate_fts_tokenizer()
         # Migrate: add hrr_vector column if missing (safe for existing databases)
         columns = {row[1] for row in self._conn.execute("PRAGMA table_info(facts)").fetchall()}
         if "hrr_vector" not in columns:
             self._conn.execute("ALTER TABLE facts ADD COLUMN hrr_vector BLOB")
         self._conn.commit()
+
+    def _migrate_fts_tokenizer(self) -> None:
+        """Rebuild legacy unicode61 indexes with the CJK-safe trigram tokenizer."""
+        row = self._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'facts_fts'"
+        ).fetchone()
+        if row is None or "trigram" in row["sql"].lower():
+            return
+
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+            self._conn.execute("DROP TABLE facts_fts")
+            self._conn.execute(
+                """
+                CREATE VIRTUAL TABLE facts_fts USING fts5(
+                    content, tags, content=facts, content_rowid=fact_id,
+                    tokenize='trigram'
+                )
+                """
+            )
+            self._conn.execute(
+                "INSERT INTO facts_fts(facts_fts) VALUES('rebuild')"
+            )
+            self._conn.execute("COMMIT")
+        except Exception:
+            if self._conn.in_transaction:
+                self._conn.execute("ROLLBACK")
+            raise
 
     # ------------------------------------------------------------------
     # Public API

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -48,7 +48,7 @@ CREATE INDEX IF NOT EXISTS idx_entities_name  ON entities(name);
 CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts
     USING fts5(
         content, tags, content=facts, content_rowid=fact_id,
-        tokenize='trigram'
+        tokenize='trigram remove_diacritics 1'
     );
 
 CREATE TRIGGER IF NOT EXISTS facts_ai AFTER INSERT ON facts BEGIN
@@ -200,7 +200,7 @@ class MemoryStore:
                 """
                 CREATE VIRTUAL TABLE facts_fts USING fts5(
                     content, tags, content=facts, content_rowid=fact_id,
-                    tokenize='trigram'
+                    tokenize='trigram remove_diacritics 1'
                 )
                 """
             )

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -130,6 +130,14 @@ class TestSharedConnection:
 
         assert [result["fact_id"] for result in results] == [fact_id]
 
+    def test_trigram_search_preserves_diacritic_folding(self, db_path):
+        with MemoryStore(db_path) as store:
+            fact_id = store.add_fact("café deployment notes")
+
+            results = store.search_facts("cafe")
+
+        assert [result["fact_id"] for result in results] == [fact_id]
+
 
 class TestCloseSemantics:
     def test_closing_one_instance_keeps_sibling_alive(self, db_path):

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -107,6 +107,29 @@ class TestSharedConnection:
             a.close()
             b.close()
 
+    @pytest.mark.parametrize("query", ["watchdog", "ppid", "桌面后端"])
+    def test_existing_store_migrates_mixed_cjk_content_index(self, db_path, query):
+        content = (
+            "桌面后端秒退根因:web_server的HERMES_PARENT_PID父进程"
+            "watchdog单层ppid比较会误杀健康后端。"
+        )
+        with MemoryStore(db_path) as store:
+            fact_id = store.add_fact(content)
+            store._conn.executescript(
+                """
+                DROP TABLE facts_fts;
+                CREATE VIRTUAL TABLE facts_fts USING fts5(
+                    content, tags, content=facts, content_rowid=fact_id
+                );
+                INSERT INTO facts_fts(facts_fts) VALUES('rebuild');
+                """
+            )
+
+        with MemoryStore(db_path) as migrated_store:
+            results = migrated_store.search_facts(query)
+
+        assert [result["fact_id"] for result in results] == [fact_id]
+
 
 class TestCloseSemantics:
     def test_closing_one_instance_keeps_sibling_alive(self, db_path):


### PR DESCRIPTION
## What does this PR do?

Holographic memory searches now find ASCII terms and three-or-more-character CJK phrases embedded in mixed-content facts. Existing stores are upgraded automatically, avoiding silent zero-result searches without discarding stored facts, and accent-insensitive Latin searches remain supported.

### Symptom

A fact containing adjacent CJK and ASCII text is stored successfully, but searches for an embedded ASCII term or a CJK phrase return no results. Whitespace-delimited English content remains searchable.

### Impact

Users of the local holographic SQLite memory provider cannot retrieve affected mixed-content memories through full-text search even though the facts remain in the database. The measured blast radius is limited to FTS lookups for mixed-content runs; two-character queries remain outside this change because SQLite trigram indexes require at least three characters.

### Bug Cause

**Trigger:** `plugins/memory/holographic/store.py:48` / creation of `facts_fts` with the default FTS5 tokenizer

**Causal chain:**
1. A user stores a fact containing adjacent CJK and ASCII text.
2. The default `unicode61` tokenizer indexes the unseparated run as a token that does not match the later exact phrase query.
3. `MemoryStore.search_facts()` receives no FTS candidate and returns an empty result set for content that exists.

**Why it is wrong:** The index tokenization does not preserve the substring-search behavior required for mixed CJK content, so valid search terms are absent from the MATCH index.

**Working sibling / contrast:** Whitespace-delimited English text creates separate `unicode61` tokens and remains searchable.

**Ruled out:** Query sanitization preserves the tested ASCII terms. A live SQLite comparison reproduced the miss with `unicode61` and matched the same stored content with `trigram`, locating the failure in index tokenization rather than ranking or query cleanup.

### Fix

Create `facts_fts` with SQLite's trigram tokenizer and retain Latin diacritic folding. On startup, detect a legacy non-trigram virtual table, rebuild it transactionally from the existing `facts` content, and leave already-upgraded stores unchanged.

## Related Issue

Closes #83593

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/store.py` - use a diacritic-folding trigram FTS index and migrate legacy indexes transactionally.
- `tests/plugins/memory/test_holographic_store.py` - cover legacy-store migration, embedded ASCII and CJK retrieval, and diacritic folding.

## How to Test

1. Create a legacy holographic SQLite store whose fact contains adjacent CJK and ASCII content.
2. Confirm the legacy index returns no matches, then open it with the patched `MemoryStore` and repeat the same ASCII and CJK searches.
3. Run the focused holographic memory suite:

```bash
scripts/run_tests.sh tests/plugins/memory/test_holographic_auto_extract.py tests/plugins/memory/test_holographic_retrieval.py tests/plugins/memory/test_holographic_shutdown_closes_db.py tests/plugins/memory/test_holographic_store.py tests/plugins/test_holographic_vector_storage.py
```

The focused suite completed with 31 passed and 2 skipped. REAL_ENV verification on Windows 11 with SQLite 3.50.4 reproduced the legacy misses and verified migrated and trigger-maintained searches.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - behavior and migration are covered by code, docstrings, and tests
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the migration uses SQLite FTS5 APIs exercised by the cross-platform Python test suite
- [x] Tool descriptions or schemas update: N/A - no model tool schema changed

## Screenshots / Logs

The focused test result and REAL_ENV verification summary are included in How to Test.
