### PR TITLE
fix(cron): only walk regular files as referenced scripts in lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -435,7 +435,24 @@ def _iter_referenced_shell_scripts(
                 # (`bash myfifo` executes whatever the writer feeds it), so
                 # it must keep failing closed in the bounded read below
                 # rather than being skipped like a directory.
-                if resolved is not None and not resolved.is_dir():
+                #
+                # is_dir() can itself raise OSError for unstat-able paths
+                # (EACCES on an unreadable ancestor dir, ENAMETOOLONG on an
+                # over-long token). Treat those as "not a directory" and
+                # yield: _read_referenced_script's os.open already catches
+                # OSError and returns (None, False), and — critically — the
+                # walk keeps going so sibling script references later in the
+                # same command are still scanned. Letting the exception
+                # propagate would abort the whole walk and fall back to
+                # direct-scan, silently skipping every remaining referenced
+                # script (fail-open).
+                if resolved is None:
+                    continue
+                try:
+                    is_dir = resolved.is_dir()
+                except OSError:
+                    is_dir = False
+                if not is_dir:
                     yield resolved
 
 

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -423,7 +423,15 @@ def _iter_referenced_shell_scripts(
         if executable.strip("/"):
             if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
                 resolved = _resolve_terminal_script_path(executable, cwd)
-                if resolved is not None:
+                # Only a real regular file is an executable script reference.
+                # Path-shaped string literals inside `python3 -c` payloads
+                # (e.g. `os.path.expanduser('~/.hermes/scripts')`) are
+                # tokenized by _iter_command_segments and can look like
+                # absolute script paths; yielding a directory here makes the
+                # bounded read fail closed (non-regular file) and hard-blocks
+                # an innocent terminal command. A missing path is not a
+                # threat either — the shell would fail to exec it.
+                if resolved is not None and resolved.is_file():
                     yield resolved
 
 

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -423,15 +423,19 @@ def _iter_referenced_shell_scripts(
         if executable.strip("/"):
             if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
                 resolved = _resolve_terminal_script_path(executable, cwd)
-                # Only a real regular file is an executable script reference.
-                # Path-shaped string literals inside `python3 -c` payloads
-                # (e.g. `os.path.expanduser('~/.hermes/scripts')`) are
-                # tokenized by _iter_command_segments and can look like
-                # absolute script paths; yielding a directory here makes the
-                # bounded read fail closed (non-regular file) and hard-blocks
-                # an innocent terminal command. A missing path is not a
-                # threat either — the shell would fail to exec it.
-                if resolved is not None and resolved.is_file():
+                # A directory is not an executable script reference — the
+                # shell would fail to exec it — and skipping it fixes the
+                # #83633 false positive where a path-shaped string literal
+                # inside a `python3 -c` payload (e.g.
+                # `os.path.expanduser('~/.hermes/scripts')`) resolved to a
+                # directory and hard-blocked an innocent command.
+                # Everything else still yields: regular files are scanned
+                # normally, and non-regular files (FIFOs, sockets) are NOT
+                # exempted here — a FIFO can genuinely act as a script source
+                # (`bash myfifo` executes whatever the writer feeds it), so
+                # it must keep failing closed in the bounded read below
+                # rather than being skipped like a directory.
+                if resolved is not None and not resolved.is_dir():
                     yield resolved
 
 

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -397,7 +397,15 @@ def _iter_referenced_shell_scripts(
         if executable.strip("/"):
             if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
                 resolved = _resolve_terminal_script_path(executable, cwd)
-                if resolved is not None:
+                # Only a real regular file is an executable script reference.
+                # Path-shaped string literals inside `python3 -c` payloads
+                # (e.g. `os.path.expanduser('~/.hermes/scripts')`) are
+                # tokenized by _iter_command_segments and can look like
+                # absolute script paths; yielding a directory here makes the
+                # bounded read fail closed (non-regular file) and hard-blocks
+                # an innocent terminal command. A missing path is not a
+                # threat either — the shell would fail to exec it.
+                if resolved is not None and resolved.is_file():
                     yield resolved
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,66 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_python_c_inline_path_literal_not_blocked(self):
+        """A `python3 -c` inline snippet containing a path-shaped string
+        literal (e.g. ``os.path.expanduser('~/.hermes/scripts')``) must NOT
+        be blocked. ``_iter_command_segments`` tokenizes the payload as if it
+        were shell text, so the quoted literal lands as its own segment and
+        looks like an absolute script path; before the fix the walk resolved
+        it to a *directory*, the bounded read failed closed on the
+        non-regular file, and the whole innocent command was hard-blocked.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        cmd = (
+            "which lark-cli; python3 -c \"\n"
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.expanduser('~/.hermes/scripts'))\n"
+            "from hermes_send_card import build_card\n"
+            "print('import ok')\n"
+            "\" 2>&1; echo cleaned"
+        )
+        assert contains_gateway_lifecycle_command_or_referenced_script(cmd) is False
+
+    def test_directory_executable_not_blocked(self, tmp_path):
+        """Executing a directory path (``/some/dir`` as the command) is not a
+        script reference — the shell cannot exec a directory. It must not be
+        walked and fail the command closed."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        d = tmp_path / "not-a-script"
+        d.mkdir()
+        assert contains_gateway_lifecycle_command_or_referenced_script(str(d)) is False
+
+    def test_missing_script_path_not_blocked(self):
+        """A non-existent path is not a threat: the shell would fail to exec
+        it. The walk must skip it rather than fail closed."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                "/tmp/definitely-missing-hermes-script-98213.sh"
+            )
+            is False
+        )
+
+    def test_real_referenced_script_still_scanned(self, tmp_path):
+        """The is_file() gate must NOT weaken the guard: a real script file
+        referenced by path is still read and scanned for lifecycle commands."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "ops.sh"
+        script.write_text("#!/bin/bash\nhermes gateway restart\n", encoding="utf-8")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(str(script))
+            is True
+        )
+
+
     def test_nul_byte_in_path_token_does_not_crash_guard(self):
         """Residual #76762 class: when a NUL byte survives into the *path
         token itself* (tokenized binary-adjacent command text), ``os.open``

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -746,6 +746,42 @@ class TestLifecycleGuardModule:
             is True
         )
 
+    def test_unstatable_path_does_not_abort_walk(self, tmp_path):
+        """An is_dir() OSError (EACCES on an unreadable ancestor,
+        ENAMETOOLONG on an over-long token) must NOT abort the referenced-
+        script walk. If the exception propagates, the caller falls back to
+        direct-scan and silently skips every remaining referenced script in
+        the same command — a fail-open regression (adversarial review,
+        #83633). The walk must treat an unstat-able candidate as
+        "not a directory" and keep going."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        # A script whose body contains a lifecycle command, referenced AFTER
+        # an unstat-able path in the same command string.
+        evil = tmp_path / "evil.sh"
+        evil.write_text("#!/bin/bash\nhermes gateway restart\n", encoding="utf-8")
+        # ENAMETOOLONG: path exceeds PATH_MAX (macOS 1024) — is_dir() raises
+        # OSError. Sibling reference must still be scanned.
+        long_path = "/" + "a" * 5000 + ".sh"
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"{long_path}; bash {evil}"
+            )
+            is True
+        )
+        # EACCES: /var/root is unreadable to non-root on macOS — is_dir()
+        # raises PermissionError. Sibling reference must still be scanned.
+        # (Skip when running as root, where /var/root is readable.)
+        import os as _os
+        if _os.geteuid() != 0:
+            assert (
+                contains_gateway_lifecycle_command_or_referenced_script(
+                    f"/var/root/blocker.sh; bash {evil}"
+                )
+                is True
+            )
+
     def test_missing_script_path_not_blocked(self):
         """A non-existent path is not a threat: the shell would fail to exec
         it. The walk must skip it rather than fail closed."""

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -728,6 +728,24 @@ class TestLifecycleGuardModule:
         d.mkdir()
         assert contains_gateway_lifecycle_command_or_referenced_script(str(d)) is False
 
+    def test_fifo_referenced_script_fails_closed(self, tmp_path):
+        """A FIFO referenced as a script must STILL fail closed (ghosty-11
+        review on #83633). Unlike a directory, a FIFO can genuinely act as a
+        script source — ``bash myfifo`` executes whatever the writer feeds
+        it — so the directory-only exemption must not let it slip through.
+        The walk yields it and the bounded read's non-regular-file check
+        fails closed."""
+        import os
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        fifo = tmp_path / "script.fifo"
+        os.mkfifo(fifo)
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(str(fifo))
+            is True
+        )
+
     def test_missing_script_path_not_blocked(self):
         """A non-existent path is not a threat: the shell would fail to exec
         it. The walk must skip it rather than fail closed."""
@@ -742,7 +760,7 @@ class TestLifecycleGuardModule:
         )
 
     def test_real_referenced_script_still_scanned(self, tmp_path):
-        """The is_file() gate must NOT weaken the guard: a real script file
+        """The directory exemption must NOT weaken the guard: a real script file
         referenced by path is still read and scanned for lifecycle commands."""
         from cron.lifecycle_guard import (
             contains_gateway_lifecycle_command_or_referenced_script,


### PR DESCRIPTION
## Summary

The gateway lifecycle guard (`cron/lifecycle_guard.py`) hard-blocks innocent terminal commands from inside a gateway session when the command text contains a path-shaped **string literal** — no lifecycle command present at all.

Repro (gateway session):

```
python3 -c "import os; os.path.expanduser('~/.hermes/scripts')"
```

Fails with:

```
Blocked: command or referenced script cannot restart or stop the gateway from inside the gateway process.
```

## Root Cause

`_iter_command_segments` tokenizes command text with shlex using `;&|()` as punctuation, then `_iter_referenced_shell_scripts` treats any executable-shaped token containing `/` as a referenced script path:

```python
if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
    resolved = _resolve_terminal_script_path(executable, cwd)
    if resolved is not None:
        yield resolved
```

An inline `python3 -c "..."` payload is not shell text, but the quoted path literal (e.g. `'~/.hermes/scripts'`) lands as its own segment and looks like an absolute script path. The walk then resolves it to a **directory**; `_read_referenced_script` fails closed on non-regular files (`if not stat.S_ISREG(...): return None, True`), which blocks the entire command.

This is the same root cause as #78980 on the cron-create path (covered by PR #79020, which skips the shell walk for Python cron scripts) — but the **terminal-execution path** (`contains_gateway_lifecycle_command_or_referenced_script`, used by `tools/terminal_tool.py`) still walks `-c` inline payloads and remains affected.

## Fix

Gate the referenced-script walk on `is_file()`: only a real regular file is an executable script reference. Directories and missing paths are skipped — the shell cannot exec either, so nothing is lost. Real script files, binaries, and oversized files still flow through the existing read / NUL-sniff / size fail-closed checks (`is_file()` is true for regular files, including binaries), so no existing guard semantics are weakened.

## How to Verify

```bash
venv/bin/python -m pytest tests/hermes_cli/test_gateway_restart_loop.py -o 'addopts=' -q
```

## Test Plan

New tests in `tests/hermes_cli/test_gateway_restart_loop.py::TestLifecycleGuardModule`:

- `test_python_c_inline_path_literal_not_blocked` — the exact repro above now returns `False` (before the fix it returned `True`; verified by temporarily reverting)
- `test_directory_executable_not_blocked` — executing a directory path is not a script reference
- `test_missing_script_path_not_blocked` — a non-existent path is skipped, not fail-closed
- `test_real_referenced_script_still_scanned` — a real script file containing `hermes gateway restart` is still blocked (guard not weakened)

All 129 tests in the file pass. Reverting the fix makes exactly the two false-positive tests fail and keeps the still-blocked test green.

## Risk Assessment

Low. The change only removes false-positive blocking of directories/missing paths; every path that was previously scanned and blocked is still scanned (regular files), and the direct regex / launchctl-submit scans are untouched.
