### PR TITLE
feat(desktop): rich web progress UI for the Windows update hand-off

### DIFF
--- a/scripts/desktop-update-ui.html
+++ b/scripts/desktop-update-ui.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<!--
+  Hermes Desktop update progress UI.
+
+  Served by scripts/desktop-update.ps1's in-process loopback HTTP server and
+  displayed in an Edge app-mode window (chromeless). The page polls
+  /progress (JSON) and renders phase state + the live hand-off log.
+
+  Contract with desktop-update.ps1 (keep in sync):
+    GET /          -> this file
+    GET /progress  -> {"status":"running|done|error","phase":"<id>",
+                       "message":"...","lines":["..."]}
+  Phase ids: prepare, wait-desktop, wait-venv, update, rebuild.
+
+  Single self-contained file on purpose: no external assets, no CDN, works
+  from a cold checkout with no network beyond the loopback socket.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Hermes Update</title>
+    <style>
+      :root {
+        --bg: #0f1115;
+        --panel: #161a21;
+        --panel-edge: #232a35;
+        --text: #e6e1d6;
+        --dim: #8a8577;
+        --gold: #d7a94b;
+        --gold-soft: rgba(215, 169, 75, 0.14);
+        --ok: #7dc383;
+        --err: #e07a6a;
+        --mono: 'Cascadia Mono', Consolas, 'Courier New', monospace;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        background: var(--bg);
+        color: var(--text);
+        font-family: 'Segoe UI', system-ui, sans-serif;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        user-select: none;
+      }
+
+      header {
+        padding: 18px 22px 14px;
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+      }
+      .caduceus {
+        color: var(--gold);
+        font-size: 22px;
+      }
+      h1 {
+        font-size: 17px;
+        font-weight: 600;
+        letter-spacing: 0.2px;
+      }
+      .sub {
+        color: var(--dim);
+        font-size: 12px;
+        margin-left: auto;
+      }
+
+      .bar {
+        height: 2px;
+        background: var(--panel-edge);
+        position: relative;
+        overflow: hidden;
+      }
+      .bar::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: -35%;
+        width: 35%;
+        height: 100%;
+        background: linear-gradient(90deg, transparent, var(--gold), transparent);
+        animation: sweep 1.6s ease-in-out infinite;
+      }
+      @keyframes sweep {
+        to {
+          left: 100%;
+        }
+      }
+      body.done .bar::after,
+      body.error .bar::after {
+        animation: none;
+        content: none;
+      }
+      body.done .bar {
+        background: var(--ok);
+      }
+      body.error .bar {
+        background: var(--err);
+      }
+
+      main {
+        flex: 1;
+        display: flex;
+        min-height: 0;
+        gap: 14px;
+        padding: 16px 22px;
+      }
+
+      .phases {
+        width: 240px;
+        flex-shrink: 0;
+      }
+      .phase {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 7px 10px;
+        border-radius: 6px;
+        font-size: 13px;
+        color: var(--dim);
+      }
+      .phase .dot {
+        width: 16px;
+        text-align: center;
+        font-family: var(--mono);
+        font-size: 13px;
+      }
+      .phase.active {
+        color: var(--text);
+        background: var(--gold-soft);
+      }
+      .phase.active .dot {
+        color: var(--gold);
+        animation: pulse 1.2s ease-in-out infinite;
+      }
+      .phase.done {
+        color: var(--text);
+      }
+      .phase.done .dot {
+        color: var(--ok);
+      }
+      .phase.failed .dot {
+        color: var(--err);
+      }
+      @keyframes pulse {
+        50% {
+          opacity: 0.35;
+        }
+      }
+
+      .log {
+        flex: 1;
+        background: var(--panel);
+        border: 1px solid var(--panel-edge);
+        border-radius: 8px;
+        padding: 10px 12px;
+        overflow-y: auto;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        line-height: 1.55;
+        color: var(--dim);
+        white-space: pre-wrap;
+        word-break: break-all;
+        user-select: text;
+      }
+      .log .ln.err {
+        color: var(--err);
+      }
+
+      footer {
+        padding: 12px 22px 14px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        border-top: 1px solid var(--panel-edge);
+      }
+      #status {
+        font-size: 13px;
+        color: var(--dim);
+        flex: 1;
+      }
+      body.done #status {
+        color: var(--ok);
+      }
+      body.error #status {
+        color: var(--err);
+      }
+      .brand {
+        font-size: 11px;
+        color: var(--dim);
+        letter-spacing: 0.4px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <span class="caduceus">&#9764;</span>
+      <h1>Updating Hermes</h1>
+      <span class="sub">Hermes restarts automatically when this finishes</span>
+    </header>
+    <div class="bar"></div>
+    <main>
+      <div class="phases" id="phases"></div>
+      <div class="log" id="log"></div>
+    </main>
+    <footer>
+      <span id="status">Starting&hellip;</span>
+      <span class="brand">Nous Research</span>
+    </footer>
+
+    <script>
+      ;(function () {
+        'use strict'
+
+        var PHASES = [
+          { id: 'prepare', label: 'Preparing update' },
+          { id: 'wait-desktop', label: 'Closing Hermes' },
+          { id: 'wait-venv', label: 'Releasing install lock' },
+          { id: 'update', label: 'Installing update' },
+          { id: 'rebuild', label: 'Rebuilding desktop app' }
+        ]
+
+        var phasesEl = document.getElementById('phases')
+        var logEl = document.getElementById('log')
+        var statusEl = document.getElementById('status')
+
+        PHASES.forEach(function (p) {
+          var row = document.createElement('div')
+          row.className = 'phase'
+          row.id = 'phase-' + p.id
+          row.innerHTML = '<span class="dot">&#9675;</span><span>' + p.label + '</span>'
+          phasesEl.appendChild(row)
+        })
+
+        var renderedLines = 0
+        var lastStatus = 'running'
+        var failures = 0
+
+        function setPhaseStates(activeId, status) {
+          var reached = true
+          PHASES.forEach(function (p) {
+            var el = document.getElementById('phase-' + p.id)
+            var dot = el.querySelector('.dot')
+            el.className = 'phase'
+            if (p.id === activeId) {
+              reached = false
+              if (status === 'error') {
+                el.className = 'phase failed'
+                dot.innerHTML = '&#10007;'
+              } else if (status === 'done') {
+                el.className = 'phase done'
+                dot.innerHTML = '&#10003;'
+              } else {
+                el.className = 'phase active'
+                dot.innerHTML = '&#9684;'
+              }
+            } else if (reached) {
+              el.className = 'phase done'
+              dot.innerHTML = '&#10003;'
+            } else {
+              dot.innerHTML = '&#9675;'
+            }
+          })
+        }
+
+        function appendLines(lines) {
+          if (!lines || lines.length <= renderedLines) {
+            return
+          }
+          var atBottom = logEl.scrollTop + logEl.clientHeight >= logEl.scrollHeight - 8
+          for (var i = renderedLines; i < lines.length; i++) {
+            var ln = document.createElement('div')
+            ln.className = /(!\||error|failed|aborted)/i.test(lines[i]) ? 'ln err' : 'ln'
+            ln.textContent = lines[i]
+            logEl.appendChild(ln)
+          }
+          renderedLines = lines.length
+          if (atBottom) {
+            logEl.scrollTop = logEl.scrollHeight
+          }
+        }
+
+        function apply(state) {
+          lastStatus = state.status || 'running'
+          document.body.className = lastStatus === 'done' ? 'done' : lastStatus === 'error' ? 'error' : ''
+          setPhaseStates(state.phase || 'prepare', lastStatus)
+          appendLines(state.lines)
+          if (lastStatus === 'done') {
+            statusEl.textContent = state.message || 'Update complete — restarting Hermes…'
+          } else if (lastStatus === 'error') {
+            statusEl.textContent = state.message || 'Update failed. Hermes will restart on the previous version.'
+          } else {
+            statusEl.textContent = state.message || 'Working…'
+          }
+        }
+
+        function poll() {
+          fetch('/progress?ts=' + Date.now(), { cache: 'no-store' })
+            .then(function (r) {
+              return r.json()
+            })
+            .then(function (state) {
+              failures = 0
+              apply(state)
+            })
+            .catch(function () {
+              failures += 1
+              // The server dies when the hand-off script exits. That is the normal
+              // end of life for this page: surface what the last known state implied
+              // instead of an alarming network error.
+              if (failures >= 5) {
+                if (lastStatus === 'done') {
+                  statusEl.textContent = 'Restarting Hermes…'
+                } else if (lastStatus !== 'error') {
+                  statusEl.textContent = 'Updater closed. If Hermes does not restart, reopen it manually.'
+                }
+              }
+            })
+        }
+
+        poll()
+        setInterval(poll, 400)
+      })()
+    </script>
+  </body>
+</html>

--- a/scripts/desktop-update.ps1
+++ b/scripts/desktop-update.ps1
@@ -25,6 +25,15 @@
 #     [-RelaunchExe <path>] Hermes.exe to start when done (omit = no relaunch)
 #     [-NoUi]               headless (tests); default shows a progress window
 #     [-NoMarkerCleanup]    leave .hermes-update-in-progress in place (tests)
+#     [-SelfTestUi]         serve the progress UI with simulated phases and
+#                           exit (manual QA / CI smoke; no update is run)
+#
+# PROGRESS UI: the primary surface is scripts/desktop-update-ui.html rendered
+# in an Edge app-mode window (chromeless; msedge ships on every Win10/11 box,
+# so no WebView2 SDK DLLs and no frozen binary). The script serves the page
+# plus a /progress JSON endpoint from an in-process loopback TCP listener.
+# When Edge or the listener is unavailable it degrades to the previous
+# WinForms window, then to log-only — the update itself never depends on UI.
 #
 # SAFETY POSTURE: both preflight gates FAIL CLOSED. A Desktop that never
 # exits, or a venv shim that never unlocks, aborts the hand-off without
@@ -41,13 +50,20 @@
 # own it (a handoff partner that rewrote it keeps its claim).
 
 param(
-    [Parameter(Mandatory = $true)][string]$InstallRoot,
+    [string]$InstallRoot = "",
     [string]$Branch = "main",
     [int]$DesktopPid = 0,
     [string]$RelaunchExe = "",
     [switch]$NoUi,
-    [switch]$NoMarkerCleanup
+    [switch]$NoMarkerCleanup,
+    [switch]$SelfTestUi
 )
+
+if (-not $SelfTestUi -and -not $InstallRoot) {
+    # Mandatory in spirit; relaxed in the signature only so -SelfTestUi can run
+    # without a checkout (the UI smoke test needs no install to point at).
+    throw "-InstallRoot is required"
+}
 
 $ErrorActionPreference = "Continue"
 # Foreground helpers: the script is spawned via `cmd start /min`, so its
@@ -69,17 +85,135 @@ try {
     [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
     $OutputEncoding = [System.Text.Encoding]::UTF8
 } catch {}
-$HermesHome = Split-Path -Parent $InstallRoot
+$HermesHome = if ($InstallRoot) { Split-Path -Parent $InstallRoot } else { $env:TEMP }
 $MarkerPath = Join-Path $HermesHome ".hermes-update-in-progress"
 $LogDir = Join-Path $HermesHome "logs"
 $LogPath = Join-Path $LogDir "desktop-update-handoff.log"
 $ResultPath = Join-Path $HermesHome ".hermes-update-result.json"
 $script:Ui = $null
 
+# ── Progress UI: loopback server + Edge app-mode shell ─────────────────────
+# State shared with the poller thread. Synchronized so the listener thread
+# reads a consistent snapshot while the main thread appends lines.
+$script:UiState = [hashtable]::Synchronized(@{
+    status  = "running"      # running | done | error
+    phase   = "prepare"      # prepare | wait-desktop | wait-venv | update | rebuild
+    message = "Starting update..."
+    lines   = [System.Collections.ArrayList]::Synchronized([System.Collections.ArrayList]::new())
+})
+$script:UiServer = $null     # @{ Listener; Runspace; PowerShell; Port; EdgeProc }
+
+function Set-UiPhase([string]$Phase, [string]$Message) {
+    $script:UiState.phase = $Phase
+    if ($Message) { $script:UiState.message = $Message }
+}
+
+function Get-UiHtmlPath {
+    # Lives next to this script in the checkout. Missing file = fall back to
+    # WinForms (old checkouts mid-update, partial syncs).
+    $p = Join-Path $PSScriptRoot "desktop-update-ui.html"
+    if (Test-Path -LiteralPath $p) { return $p }
+    return $null
+}
+
+function Find-EdgeExe {
+    foreach ($root in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:LOCALAPPDATA)) {
+        if (-not $root) { continue }
+        $p = Join-Path $root "Microsoft\Edge\Application\msedge.exe"
+        if (Test-Path -LiteralPath $p) { return $p }
+    }
+    return $null
+}
+
+function Start-UiServer([string]$HtmlPath) {
+    # In-process HTTP on a loopback ephemeral port, served from a dedicated
+    # runspace so the main thread never blocks on Accept. Plain TcpListener
+    # instead of HttpListener: no URL ACL / netsh reservation semantics to
+    # trip over, and two GET routes don't need more.
+    try {
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+        $listener.Start()
+        $port = ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
+
+        $rs = [runspacefactory]::CreateRunspace()
+        $rs.Open()
+        $rs.SessionStateProxy.SetVariable("Listener", $listener)
+        $rs.SessionStateProxy.SetVariable("State", $script:UiState)
+        $rs.SessionStateProxy.SetVariable("HtmlBytes", [System.IO.File]::ReadAllBytes($HtmlPath))
+
+        $ps = [powershell]::Create()
+        $ps.Runspace = $rs
+        [void]$ps.AddScript({
+            function Send-Response($Stream, [string]$Status, [string]$ContentType, [byte[]]$Body) {
+                $head = "HTTP/1.1 $Status`r`nContent-Type: $ContentType`r`nContent-Length: $($Body.Length)`r`nCache-Control: no-store`r`nConnection: close`r`n`r`n"
+                $headBytes = [System.Text.Encoding]::ASCII.GetBytes($head)
+                $Stream.Write($headBytes, 0, $headBytes.Length)
+                $Stream.Write($Body, 0, $Body.Length)
+                $Stream.Flush()
+            }
+            while ($true) {
+                try { $client = $Listener.AcceptTcpClient() } catch { break }  # Stop() ends the loop
+                try {
+                    $client.ReceiveTimeout = 2000
+                    $stream = $client.GetStream()
+                    $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::ASCII, $false, 1024, $true)
+                    $request = $reader.ReadLine()
+                    # Drain headers so the client doesn't see a reset mid-send.
+                    while ($true) { $h = $reader.ReadLine(); if ($null -eq $h -or $h -eq "") { break } }
+                    if ($request -match "^GET /progress") {
+                        $snapshot = @{
+                            status  = $State.status
+                            phase   = $State.phase
+                            message = $State.message
+                            lines   = @($State.lines.ToArray())
+                        } | ConvertTo-Json -Compress
+                        Send-Response $stream "200 OK" "application/json; charset=utf-8" ([System.Text.Encoding]::UTF8.GetBytes($snapshot))
+                    } elseif ($request -match "^GET / ") {
+                        Send-Response $stream "200 OK" "text/html; charset=utf-8" $HtmlBytes
+                    } else {
+                        Send-Response $stream "404 Not Found" "text/plain" ([System.Text.Encoding]::ASCII.GetBytes("not found"))
+                    }
+                } catch {
+                    # Per-connection failure: drop it, keep serving.
+                } finally {
+                    try { $client.Close() } catch {}
+                }
+            }
+        })
+        [void]$ps.BeginInvoke()
+
+        return @{ Listener = $listener; Runspace = $rs; PowerShell = $ps; Port = $port; EdgeProc = $null }
+    } catch {
+        try { if ($listener) { $listener.Stop() } } catch {}
+        return $null
+    }
+}
+
+function Stop-UiServer {
+    if (-not $script:UiServer) { return }
+    try { $script:UiServer.Listener.Stop() } catch {}
+    try { $script:UiServer.PowerShell.Stop() } catch {}
+    try { $script:UiServer.Runspace.Close() } catch {}
+    # Closing Edge is cosmetic; if the user closed it already this is a no-op,
+    # and if it lingers the page shows the terminal state until they close it.
+    try {
+        if ($script:UiServer.EdgeProc -and -not $script:UiServer.EdgeProc.HasExited) {
+            $script:UiServer.EdgeProc.CloseMainWindow() | Out-Null
+        }
+    } catch {}
+    $script:UiServer = $null
+}
+
 function Write-HandoffLog([string]$Message) {
     $line = "{0:yyyy-MM-ddTHH:mm:ssK} {1}" -f (Get-Date), $Message
     try { Add-Content -LiteralPath $LogPath -Value $line -Encoding UTF8 } catch {}
     Write-Host $line
+    # Feed the web UI regardless of which shell rendered (Edge polls /progress;
+    # cap retained lines so a huge pip install can't grow the JSON unboundedly).
+    try {
+        [void]$script:UiState.lines.Add($Message)
+        while ($script:UiState.lines.Count -gt 400) { $script:UiState.lines.RemoveAt(0) }
+    } catch {}
     if ($script:Ui) {
         try {
             $script:Ui.Box.AppendText($Message + "`r`n")
@@ -90,6 +224,41 @@ function Write-HandoffLog([string]$Message) {
 
 function Show-ProgressWindow {
     if ($NoUi) { return }
+
+    # ── Primary: repo-owned HTML in an Edge app-mode window ────────────────
+    # Chromeless (--app), so it reads as a native progress dialog, not a
+    # browser. Serving over loopback HTTP (not file://) keeps fetch() inside
+    # the page's origin without any browser flag overrides.
+    $htmlPath = Get-UiHtmlPath
+    $edge = Find-EdgeExe
+    if ($htmlPath -and $edge) {
+        $server = Start-UiServer $htmlPath
+        if ($server) {
+            try {
+                # Dedicated tiny profile dir: guarantees a NEW WINDOW + process
+                # we own (a default-profile launch delegates to an existing
+                # Edge and returns instantly, leaving nothing to close), and
+                # avoids touching the user's real browser profile.
+                $edgeProfile = Join-Path $env:TEMP ("hermes-update-ui-{0}" -f $PID)
+                $edgeArgs = @(
+                    "--app=http://127.0.0.1:$($server.Port)/",
+                    "--user-data-dir=$edgeProfile",
+                    "--no-first-run", "--no-default-browser-check",
+                    "--disable-features=msImplicitSignin",
+                    "--window-size=760,480"
+                )
+                $server.EdgeProc = Start-Process -FilePath $edge -ArgumentList $edgeArgs -PassThru
+                $script:UiServer = $server
+                Write-HandoffLog "progress UI: Edge app window on 127.0.0.1:$($server.Port)"
+                return
+            } catch {
+                try { $server.Listener.Stop() } catch {}
+                # fall through to WinForms
+            }
+        }
+    }
+
+    # ── Fallback: legacy WinForms window (Edge missing/failed) ─────────────
     try {
         Add-Type -AssemblyName System.Windows.Forms | Out-Null
         Add-Type -AssemblyName System.Drawing | Out-Null
@@ -135,6 +304,13 @@ function Show-ProgressWindow {
 }
 
 function Close-ProgressWindow {
+    if ($script:UiServer) {
+        # Let the page render the terminal state before the server dies: the
+        # poller runs every 400ms, so two beats is enough. The page also
+        # handles the server vanishing gracefully (shows last known state).
+        Start-Sleep -Milliseconds 900
+        Stop-UiServer
+    }
     if ($script:Ui) {
         try { $script:Ui.Form.Close() } catch {}
         $script:Ui = $null
@@ -308,6 +484,35 @@ function Invoke-StreamedHermes([string]$Exe, [string[]]$HermesArgs, [string]$Tag
 
 $finalCode = 1
 $finalMsg = "update did not complete"
+
+# ── -SelfTestUi: drive the progress UI through simulated phases ────────────
+# Manual QA / smoke for the Edge shell without running a real update. Exits
+# before the marker/desktop/venv machinery — touches nothing.
+if ($SelfTestUi) {
+    Show-ProgressWindow
+    Write-HandoffLog "SELF-TEST: progress UI simulation (no update will run)"
+    $simPhases = @(
+        @{ id = "prepare";      msg = "Preparing update..." },
+        @{ id = "wait-desktop"; msg = "Waiting for Hermes to close..." },
+        @{ id = "wait-venv";    msg = "Waiting for the install lock..." },
+        @{ id = "update";       msg = "Running hermes update..." },
+        @{ id = "rebuild";      msg = "Rebuilding the desktop app..." }
+    )
+    foreach ($p in $simPhases) {
+        Set-UiPhase $p.id $p.msg
+        for ($i = 1; $i -le 6; $i++) {
+            Write-HandoffLog ("{0}| simulated output line {1}" -f $p.id, $i)
+            Start-Sleep -Milliseconds 500
+        }
+    }
+    $script:UiState.status = "done"
+    $script:UiState.message = "Self-test complete."
+    Write-HandoffLog "SELF-TEST: terminal state rendered; closing in 5s"
+    Start-Sleep -Seconds 5
+    Stop-UiServer
+    exit 0
+}
+
 try {
     New-Item -ItemType Directory -Path $LogDir -Force -ErrorAction SilentlyContinue | Out-Null
     Remove-Item -LiteralPath $ResultPath -Force -ErrorAction SilentlyContinue
@@ -327,6 +532,7 @@ try {
 
     # -- 1. Wait for the Desktop to exit (FAIL CLOSED) ----------------------
     if ($DesktopPid -gt 0) {
+        Set-UiPhase "wait-desktop" "Waiting for Hermes to close..."
         $deadline = (Get-Date).AddSeconds(30)
         while ((Get-Date) -lt $deadline) {
             $proc = Get-Process -Id $DesktopPid -ErrorAction SilentlyContinue
@@ -346,6 +552,7 @@ try {
     }
 
     # -- 2. Wait for the venv shim to unlock (FAIL CLOSED) ------------------
+    Set-UiPhase "wait-venv" "Waiting for the install lock to release..."
     $shim = Join-Path $InstallRoot "venv\Scripts\hermes.exe"
     if (Test-Path -LiteralPath $shim) {
         $unlocked = $false
@@ -385,6 +592,7 @@ try {
         exit $finalCode
     }
     $updateArgs = @("update", "--yes", "--gateway", "--force", "--branch", $Branch)
+    Set-UiPhase "update" "Installing update (this can take a few minutes)..."
     Write-HandoffLog ("running: hermes " + ($updateArgs -join " "))
     $res = Invoke-StreamedHermes $hermesExe $updateArgs "update"
     Write-HandoffLog "hermes update exit code: $($res.Code)"
@@ -405,6 +613,7 @@ try {
     $desktopBuildFailed = $false
     if ($res.Code -eq 0 -and $res.Output -match "Desktop build failed") {
         Write-HandoffLog "hermes update reported a desktop build failure (non-fatal there, fatal here); retrying build"
+        Set-UiPhase "rebuild" "Rebuilding the desktop app..."
         $rebuild = Invoke-StreamedHermes $hermesExe @("desktop", "--force-build", "--build-only") "rebuild"
         Write-HandoffLog "desktop rebuild exit code: $($rebuild.Code)"
         if ($rebuild.Code -ne 0) { $desktopBuildFailed = $true }
@@ -422,6 +631,10 @@ try {
     }
     exit $finalCode
 } finally {
+    # Push the terminal state to the web UI before tearing it down so the
+    # user sees "complete"/"failed", not a page that just vanishes.
+    $script:UiState.status = if ($finalCode -eq 0) { "done" } else { "error" }
+    $script:UiState.message = $finalMsg
     Write-Result ($finalCode -eq 0) $finalCode $finalMsg
     Remove-MarkerIfOwned
     Close-ProgressWindow


### PR DESCRIPTION
# Summary

The Windows update hand-off now shows a polished, Hermes-branded progress window instead of the bare WinForms box — phases with checkmarks, an animated progress sweep, and a live log tail, rendered from a repo-owned HTML page in a chromeless Edge app-mode window.

This closes the UX gap that was the last argument for handing updates back to the frozen `hermes-setup.exe` binary: the pretty UI now ships with the checkout and iterates at repo speed, same as the update logic itself. No rust rebuild / signing / R2 upload in the loop.

## Changes

- `scripts/desktop-update-ui.html` (new): self-contained dark-theme progress page — phase checklist (prepare → closing Hermes → install lock → update → rebuild), animated sweep bar, streaming log pane, terminal success/failure states, graceful handling of the server vanishing at hand-off end
- `scripts/desktop-update.ps1`: serves the page + a `/progress` JSON endpoint from an in-process loopback `TcpListener` (ephemeral port, runspace thread, no HttpListener URL-ACL semantics); launches `msedge --app` with a throwaway `--user-data-dir` (owned window, user's browser profile untouched); phase transitions pushed at each hand-off gate; `Write-HandoffLog` feeds the log pane (400-line cap); `-SelfTestUi` drives all phases without running an update
- Degradation ladder: Edge/HTML/listener unavailable → existing WinForms window → log-only. The update itself never depends on any UI surface. No Electron-side changes; spawn contract untouched.

## Validation

| Check | Result |
|---|---|
| PowerShell AST parse (pwsh 7.4) | 0 errors |
| E2E vs live loopback server (real HTTP): serves HTML, /progress reflects phase/message/lines, terminal state stable, 404 route, clean teardown + port release, log cap | 6/6 |
| Rendered UI (headless Chromium): done-state — all phases checkmarked, no layout breakage | pass |
| Rendered UI: active-state DOM probe — earlier phases `done`, active phase gold bg `rgba(215,169,75,0.14)` + `pulse` dot animation, later phases pending, 38 log lines streamed | pass |
| prettier | clean |

Windows-box visual QA available via `powershell -File scripts\desktop-update.ps1 -SelfTestUi`.

## Infographic

![Update UI infographic](https://v3b.fal.media/files/b/0aa5db07/tbqcKWuSvRfgtKW5E9Jvq_8A4z43DU.png)
