### PR TITLE
fix(desktop): stop landing bare new chats in a stale remote workspace…

### DIFF
--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -25,6 +25,7 @@ import {
   _resetLegacyDiscardForTests,
   applyConfiguredDefaultProjectDir,
   commitWorkspaceCwdForSelectedSession,
+  ensureDefaultWorkspaceCwd,
   getRememberedRoute,
   getRememberedSessionId,
   getRememberedWorkspaceCwd,
@@ -501,6 +502,35 @@ describe('workspaceCwdForNewSession', () => {
     applyConfiguredDefaultProjectDir('/home/user/configured')
 
     expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
+  })
+
+  it('seeds the remote remembered cwd for resume while bare new chats stay detached (#57911)', async () => {
+    const desktopWindow = window as { hermesDesktop?: unknown }
+    const previousDesktop = desktopWindow.hermesDesktop
+    const sanitizeWorkspaceCwd = vi.fn(async (cwd: string) => ({ cwd }))
+    desktopWindow.hermesDesktop = { sanitizeWorkspaceCwd }
+
+    try {
+      window.localStorage.setItem(
+        'hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-a.default',
+        '/tradingview'
+      )
+      $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
+      $currentCwd.set('')
+      $activeSessionId.set(null)
+
+      // Boot/resume must still restore the remote-keyed remembered workspace.
+      await ensureDefaultWorkspaceCwd()
+
+      expect($currentCwd.get()).toBe('/tradingview')
+      expect(sanitizeWorkspaceCwd).not.toHaveBeenCalled()
+
+      // Cmd+N is a different contract: without an explicit default, it must not
+      // inherit the restored workspace.
+      expect(workspaceCwdForNewSession()).toBe('')
+    } finally {
+      desktopWindow.hermesDesktop = previousDesktop
+    }
   })
 
   it('remembers only the workspace the user picked, not the one they looked at', () => {

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -27,6 +27,7 @@ import {
   commitWorkspaceCwdForSelectedSession,
   getRememberedRoute,
   getRememberedSessionId,
+  getRememberedWorkspaceCwd,
   mergeSessionPage,
   rememberedSessionProfile,
   resolveComposerSessionKey,
@@ -446,21 +447,60 @@ describe('workspaceCwdForNewSession', () => {
     $currentCwd.set('/live/session/path')
     $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
 
+    // Remote remembered memory lives under its own key: backend-a's pick is
+    // invisible to backend-b and to local. But a bare new session must stay
+    // DETACHED in every mode when no default project dir is configured
+    // (#57911) — the remembered pick only feeds resume/restore, never a bare
+    // Cmd+N.
     expect(workspaceCwdForNewSession()).toBe('')
 
     setCurrentCwd('/backend/project-a')
-    expect(workspaceCwdForNewSession()).toBe('/backend/project-a')
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/project-a')
+    expect(workspaceCwdForNewSession()).toBe('')
 
     $connection.set({ baseUrl: 'http://backend-b', mode: 'remote' } as never)
+    expect(getRememberedWorkspaceCwd()).toBe('')
     expect(workspaceCwdForNewSession()).toBe('')
 
     setCurrentCwd('/backend/project-b')
-    expect(workspaceCwdForNewSession()).toBe('/backend/project-b')
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/project-b')
+    expect(workspaceCwdForNewSession()).toBe('')
 
     // Back on local with no configured default: a bare new chat is detached and
     // never reads the remote keys (nor inherits the sticky local workspace).
     $connection.set(null)
     expect(workspaceCwdForNewSession()).toBe('')
+  })
+
+  it('does not stick a previous remote workspace onto a bare new session (#57911)', () => {
+    // Repro: in remote mode the user attaches to project-A so the renderer
+    // persists /tradingview as the remembered cwd under the remote key. The
+    // user then presses Cmd+N *without* being scoped into any project. A bare
+    // new session must NOT inherit /tradingview — pre-fix this returned the
+    // sticky remembered cwd and the gateway mapped it back to the wrong
+    // project via project_tree.py.
+    window.localStorage.setItem(
+      'hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-a.default',
+      '/tradingview'
+    )
+    $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
+    applyConfiguredDefaultProjectDir(null)
+
+    expect(workspaceCwdForNewSession()).toBe('')
+  })
+
+  it('respects an explicit configured default in remote mode (#57911)', () => {
+    // Symmetric guard: removing the remote branch must NOT regress users who
+    // *did* set a configured default — the explicit default pre-attaches
+    // identically across local and remote mode.
+    $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
+    window.localStorage.setItem(
+      'hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-a.default',
+      '/tradingview'
+    )
+    applyConfiguredDefaultProjectDir('/home/user/configured')
+
+    expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
   })
 
   it('remembers only the workspace the user picked, not the one they looked at', () => {
@@ -474,7 +514,10 @@ describe('workspaceCwdForNewSession', () => {
     setCurrentCwdTransient('/backend/some-other-project')
 
     expect($currentCwd.get()).toBe('/backend/some-other-project')
-    expect(workspaceCwdForNewSession()).toBe('/backend/picked')
+    // The remembered key keeps the user's pick; a bare new chat still starts
+    // detached in remote mode (#57911) unless a default is configured.
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/picked')
+    expect(workspaceCwdForNewSession()).toBe('')
   })
 
   it('settling a resumed session does not move where the next new chat starts', () => {
@@ -488,7 +531,10 @@ describe('workspaceCwdForNewSession', () => {
     setSelectedStoredSessionId('sess-in-project')
     commitWorkspaceCwdForSelectedSession('/backend/last-project')
 
-    expect(workspaceCwdForNewSession()).toBe('/backend/picked')
+    // Settling must not claim the followed folder as the user's pick — and a
+    // bare new chat stays detached in remote mode (#57911).
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/picked')
+    expect(workspaceCwdForNewSession()).toBe('')
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -910,16 +910,19 @@ export const setNewChatWorkspaceTarget = (next: NewChatWorkspaceTarget): number 
 }
 
 export const workspaceCwdForNewSession = (): string => {
-  if ($connection.get()?.mode === 'remote') {
-    return getRememberedWorkspaceCwd()
-  }
-
   // A bare new chat starts DETACHED — no inherited cwd, so the composer's coding
   // rail (which keys off $currentCwd) shows no branch and the first message runs
   // in the gateway's default rather than silently in the last repo you touched.
   // Only an explicit default-project-dir setting pre-attaches. Entering a
   // project/worktree attaches its cwd directly (startSessionInWorkspace), so the
   // "remember where I was when I'm in a project" case is unaffected.
+  //
+  // This must behave identically in local and remote mode: the remembered CWD
+  // under the remote-keyed workspaceCwdKey() can come from a *different* project
+  // than the one the user is currently scoped into, and a bare new session in
+  // the wrong workspace was the #57911 symptom. Resume/restore still reads the
+  // remembered cwd via ensureDefaultWorkspaceCwd (remote-keyed and
+  // intentionally sticky).
   return getConfiguredDefaultProjectDir()
 }
 


### PR DESCRIPTION
Summary
workspaceCwdForNewSession() in apps/desktop/src/store/session.ts special-cased remote mode and returned the remembered (connection-keyed) workspace cwd. After the user worked in a project, a bare Cmd+N / "New Session" outside any project scope inherited that folder, and the gateway mapped it back to the wrong project via project_tree.py — file/terminal operations could run in the wrong repository without the user noticing.

This removes the remote branch so a bare new chat starts detached in every mode:

only an explicit configured default project dir pre-attaches,
entering a project/worktree still attaches its cwd directly (startSessionInWorkspace),
resume/restore keeps reading the remembered cwd via ensureDefaultWorkspaceCwd (still remote-keyed and intentionally sticky).
Pick-up of #57926 (original author Ahmett101), rebased onto current main and reworked per the maintainer review: the remote-memory isolation test now validates separate stored keys without asserting a bare new session inherits either key, and the #77496/#80213 picked-workspace tests assert the remembered key (not bare-session inheritance).

Verification
npx vitest run --project ui src/store src/app/chat/sidebar — 805/805 passing (includes 2 new #57911 regression tests)

tsc -p . --noEmit — clean

eslint src/store/session.ts src/store/session.test.ts — clean

 I've read the Contributing Guide

 My commit messages follow Conventional Commits (fix(desktop):)

 I searched for existing PRs to make sure this isn't a duplicate

 My PR contains only changes related to this fix (single commit)

 Desktop-only change (no Python touched) — desktop UI suite passed: vitest 805/805, tsc clean, eslint clean

 I've added tests for my changes

Closes #57911