### PR TITLE
fix(config): recognize platform hint override keys

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4759,6 +4759,11 @@ _DYNAMIC_TOP_LEVEL_KEYS = frozenset({
 # accepted because ``PlatformConfig`` carries an open ``extra`` mapping.
 _PLATFORM_CONTAINER_KEYS = frozenset({"platforms"})
 
+# ``platform_hints`` has dynamic platform names but a closed override shape.
+# Keep it separate from open dictionaries so typos in ``append`` / ``replace``
+# still receive the unknown-key warning instead of being silently accepted.
+_PLATFORM_HINT_OVERRIDE_FIELDS = frozenset({"append", "replace"})
+
 
 def _known_top_level_keys() -> set[str]:
     """Return the union of known top-level config keys for validation.
@@ -4842,6 +4847,29 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
             suggested_full = f"{suggestion}.{rest}" if rest else suggestion
             return False, suggested_full
 
+        return False, None
+
+    # ``platform_hints`` accepts any platform name, either as the documented
+    # string shorthand or followed by exactly one ``append`` / ``replace``
+    # field.  It is not an open dict: deeper or misspelled fields are ignored
+    # by prompt assembly and should keep the validator's warning.
+    if top == "platform_hints":
+        if len(segments) == 1:
+            return True, None
+        platform_name = segments[1]
+        if not platform_name:
+            return False, None
+        if len(segments) == 2:
+            return True, None
+        if len(segments) == 3:
+            field = segments[2]
+            if field in _PLATFORM_HINT_OVERRIDE_FIELDS:
+                return True, None
+            suggestion = _suggest_closest_key(
+                field, set(_PLATFORM_HINT_OVERRIDE_FIELDS)
+            )
+            if suggestion is not None:
+                return False, f"platform_hints.{platform_name}.{suggestion}"
         return False, None
 
     # ── Deeper validation ────────────────────────────────────────────

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3193,6 +3193,17 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
         rest = ".".join(segments[1:])
         return False, f"{suggestion}.{rest}" if rest else suggestion
 
+    if top == "platform_hints":
+        # Platform names are dynamic; each override is a string or append/replace mapping.
+        if not all(segments) or len(segments) > 3:
+            return False, None
+        modes = {"append", "replace"}
+        if len(segments) <= 2 or segments[2] in modes:
+            return True, None
+        sibling = _suggest_closest_key(segments[2], modes)
+        prefix = ".".join(seg.replace(".", r"\.") for seg in segments[:2])
+        return False, f"{prefix}.{sibling}" if sibling is not None else None
+
     if top in _OPEN_SUBKEY_TOP_LEVEL_KEYS:
         return True, None
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -465,6 +465,17 @@ class TestSchemaValidation:
         assert saved["desktop"]["macos_signing_identity"] == "Hermes Local Signing"
         assert "not a recognized config key" not in capsys.readouterr().out
 
+    def test_platform_hint_override_is_accepted(self, _isolated_hermes_home, capsys):
+        """Documented per-platform overrides must not emit a false warning."""
+        value = "Use short paragraphs."
+        set_config_value("platform_hints.plugin_platform.append", value)
+
+        import yaml
+
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["platform_hints"]["plugin_platform"]["append"] == value
+        assert "not a recognized config key" not in capsys.readouterr().out
+
 
 
     def test_force_suppresses_notice(self, _isolated_hermes_home, capsys):
@@ -493,6 +504,10 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "platform_hints",
+        "platform_hints.plugin_platform",
+        "platform_hints.plugin_platform.append",
+        "platform_hints.plugin_platform.replace",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key
@@ -503,6 +518,8 @@ class TestValidateConfigKey:
         ("gateway.discord.gateway_restart_notification", None),  # no close suggestion
         ("disco", "discord"),
         ("agent.max_turn", "agent.max_turns"),
+        ("platform_hints.telegram.append.extra", None),
+        ("platform_hints..append", None),
     ])
     def test_unknown_keys_with_suggestion(self, key, expected_in_suggestion):
         from hermes_cli.config import _validate_config_key
@@ -511,6 +528,14 @@ class TestValidateConfigKey:
         if expected_in_suggestion is not None:
             assert suggestion is not None and expected_in_suggestion in suggestion, \
                 f"Expected suggestion to contain {expected_in_suggestion!r}, got {suggestion!r}"
+
+    def test_platform_hint_typo_suggests_fully_qualified_key(self):
+        from hermes_cli.config import _validate_config_key
+
+        assert _validate_config_key("platform_hints.telegram.apend") == (
+            False,
+            "platform_hints.telegram.append",
+        )
 
 
     def test_underscore_only_first_segment_escapes(self):

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -486,6 +486,70 @@ class TestSchemaValidation:
         assert "brand_new_future_key" in content
 
 
+class TestPlatformHintValidation:
+    @pytest.mark.parametrize("key", [
+        "platform_hints",
+        "platform_hints.plugin_platform",
+        "platform_hints.plugin_platform.append",
+        "platform_hints.plugin_platform.replace",
+        r"platform_hints.plugin\.platform.append",
+    ])
+    def test_supported_paths(self, key):
+        from hermes_cli.config import _validate_config_key
+
+        assert _validate_config_key(key) == (True, None)
+
+    @pytest.mark.parametrize("key,value,expected", [
+        ("platform_hints", '{"plugin_platform": "Use short paragraphs."}',
+         {"plugin_platform": "Use short paragraphs."}),
+        ("platform_hints.plugin_platform", "Use short paragraphs.",
+         {"plugin_platform": "Use short paragraphs."}),
+        ("platform_hints.plugin_platform", '{"replace": "Use short paragraphs."}',
+         {"plugin_platform": {"replace": "Use short paragraphs."}}),
+        ("platform_hints.plugin_platform.append", "Use short paragraphs.",
+         {"plugin_platform": {"append": "Use short paragraphs."}}),
+    ])
+    def test_supported_values_persist_without_warning(
+        self, _isolated_hermes_home, capsys, key, value, expected,
+    ):
+        import yaml
+
+        set_config_value(key, value)
+
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["platform_hints"] == expected
+        assert "not a recognized config key" not in capsys.readouterr().out
+
+    @pytest.mark.parametrize("key", [
+        "platform_hints.telegram.append.extra",
+        "platform_hints.telegram.unknown",
+        "platform_hints..append",
+        "platform_hints.",
+        "platform_hints.telegram.",
+    ])
+    def test_unsupported_paths(self, key):
+        from hermes_cli.config import _validate_config_key
+
+        assert _validate_config_key(key)[0] is False
+
+    @pytest.mark.parametrize("platform", ["telegram", r"plugin\.platform"])
+    def test_typo_suggests_fully_qualified_path(self, platform):
+        from hermes_cli.config import _validate_config_key
+
+        assert _validate_config_key(f"platform_hints.{platform}.apend") == (
+            False, f"platform_hints.{platform}.append",
+        )
+
+    @pytest.mark.parametrize("key", [
+        "platform_hints.telegram.append.extra",
+        "platform_hints.telegram.apend",
+    ])
+    def test_unknown_paths_still_warn(self, _isolated_hermes_home, capsys, key):
+        set_config_value(key, "Use short paragraphs.")
+
+        assert "not a recognized config key" in capsys.readouterr().out
+
+
 class TestValidateConfigKey:
     """Unit tests for the validator itself."""
 


### PR DESCRIPTION
`hermes config set` stores documented platform hint overrides but warns that their keys are unknown. Accept the runtime-supported root, dynamic platform names, string shorthand, `append`, and `replace`; retain warnings and fully qualified suggestions for misspelled or over-deep keys. Follow-up to #48630.

Validation: 122 tests passed across `tests/hermes_cli/test_set_config_value.py` and `tests/agent/test_platform_hint_overrides.py`; scoped Ruff and `git diff --check` passed.
