### PR TITLE
fix(desktop): keep cron, messaging and search inside the active profi…

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -600,10 +600,19 @@ export function ChatSidebar({
 
   // Full-text search across *all* sessions (not just the loaded page) so 699
   // sessions stay findable. Debounced; loaded sessions are matched instantly
-  // client-side and merged ahead of the server hits.
+  // and merged ahead of the server hits. Server hits are scoped to the current
+  // profile scope: a concrete profile searches only its own state.db, and All
+  // Profiles searches everything.
+  const searchScope = showAllProfiles ? ALL_PROFILES : profileScope
+
+  // A profile switch must not briefly render the previous profile's FTS hits
+  // while this scoped request is pending (or if it fails).
+  const [serverMatchesScope, setServerMatchesScope] = useState('')
+
   useEffect(() => {
     if (!trimmedQuery) {
       setServerMatches([])
+      setServerMatchesScope('')
       setSearchPending(false)
 
       return
@@ -611,13 +620,16 @@ export function ChatSidebar({
 
     let cancelled = false
 
+    setServerMatches([])
+    setServerMatchesScope(searchScope)
     setSearchPending(true)
 
     const id = window.setTimeout(() => {
-      void searchSessions(trimmedQuery)
+      void searchSessions(trimmedQuery, showAllProfiles ? undefined : profileScope)
         .then(res => {
           if (!cancelled) {
             setServerMatches(res.results)
+            setServerMatchesScope(searchScope)
           }
         })
         .catch(() => undefined)
@@ -632,7 +644,7 @@ export function ChatSidebar({
       cancelled = true
       window.clearTimeout(id)
     }
-  }, [trimmedQuery])
+  }, [trimmedQuery, searchScope, showAllProfiles, profileScope])
 
   const searchResults = useMemo(() => {
     if (!trimmedQuery) {
@@ -647,7 +659,9 @@ export function ChatSidebar({
       }
     }
 
-    for (const match of serverMatches) {
+    const matchesForCurrentScope = serverMatchesScope === searchScope ? serverMatches : []
+
+    for (const match of matchesForCurrentScope) {
       if (out.has(match.session_id)) {
         continue
       }
@@ -657,7 +671,7 @@ export function ChatSidebar({
     }
 
     return [...out.values()]
-  }, [trimmedQuery, sortedSessions, serverMatches, sessionByAnyId])
+  }, [trimmedQuery, sortedSessions, serverMatches, serverMatchesScope, searchScope, sessionByAnyId])
 
   const unpinnedAgentSessions = useMemo(
     () => sortedSessions.filter(s => !isPinnedSession(s)),

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -24,6 +24,7 @@ import {
   listSidebarSessions,
   pluginSocket,
   resetSidebarBatchCapability,
+  searchSessions,
   setApiRequestConnection,
   setApiRequestProfile,
   speakText,
@@ -79,6 +80,17 @@ describe('Hermes REST helpers', () => {
         timeoutMs: 60_000
       })
     )
+  })
+
+  it('routes a session search to the selected profile backend', async () => {
+    api.mockResolvedValue({ results: [] })
+
+    await searchSessions('attendance audit', 'sabby')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/sessions/search?q=attendance+audit&profile=sabby',
+      profile: 'sabby'
+    })
   })
 
   it('batches the sidebar slices into a single request with per-slice limits + excludes', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -770,9 +770,16 @@ export function setSessionUnreadRemote(id: string, unread: boolean, profile?: st
   })
 }
 
-export function searchSessions(query: string): Promise<SessionSearchResponse> {
+export function searchSessions(query: string, profile?: string): Promise<SessionSearchResponse> {
+  const params = new URLSearchParams({ q: query })
+
+  if (profile) {
+    params.set('profile', profile)
+  }
+
   return hermesApi<SessionSearchResponse>({
-    path: `/api/sessions/search?q=${encodeURIComponent(query)}`
+    ...(profile ? { profile } : {}),
+    path: `/api/sessions/search?${params.toString()}`
   })
 }
 


### PR DESCRIPTION
## Summary

The sidebar keeps cron and messaging session caches warm by fetching them cross-profile, but in a concrete profile view those caches were rendered unfiltered: a profile like `sabby` showed another profile's Telegram threads in the messaging platform sections, and Pinned resolution could surface cron/messaging rows from other profiles. Session search also hit every profile's DB regardless of scope, and the per-slice messaging fetches (seed + per-platform pager) always asked for `profile=all`, bypassing the batched endpoint's single-scope behavior.

This PR makes every sidebar surface answer to the same profile scope as Recents:

- **`filterByProfile()`** — display-side filter applied to the cron and messaging caches before they feed Pinned resolution and the messaging platform sections. No-op reference passthrough in explicit All Profiles mode; untagged sessions normalize to `default`, so single-profile users are unaffected.
- **Scoped fetches** — the messaging seed fetch and per-platform pager now request the active profile, matching what the batched `/api/profiles/sessions/sidebar` endpoint already does for every slice (the #65710/#42651/#70629 single-scope contract).
- **Scoped search** — `searchSessions()` takes an optional profile and routes `/api/sessions/search?profile=...`; the sidebar clears FTS hits on scope change and ignores stale-scope responses while a scoped request is in flight.
- **Remote correctness** — the Electron remote fan-out for the batched sidebar endpoint scopes the cron and messaging slices to the same `recents_profile` as recents (previously hardcoded to `all`), keeping remote-profile setups consistent with the local endpoint.

## Notes

- No new endpoint parameters: the change follows the backend's existing single-scope semantics.
- Preserves the reference-identity invariant: `filterByProfile` returns the input array unchanged when nothing is filtered, so sidebar memos don't recompute on no-ops.

## Verification

- `npm run check:lint` — clean (typecheck ×3, eslint 0 errors)
- `npm run test:ui` — 3683 passed (413 files)
- `npm run test:desktop:platforms` — skipped: needs packaged `release/` artifacts from a full build (exercises installer boot, not store logic)