### PR TITLE
improve(hermes): sanitize cron context payloads

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -59,6 +59,37 @@ from agent.delegation_context import (
 logger = logging.getLogger(__name__)
 
 
+def _extract_cron_context_payload(text: str) -> str:
+    """Return the useful payload from a saved cron artifact.
+
+    Scheduler-generated cron outputs include the full assembled prompt for
+    provenance. Passing that whole file through ``context_from`` leaks upstream
+    instructions into downstream jobs. Preserve raw outputs that are not in the
+    scheduler artifact format, but for cron artifacts inject only the final
+    Response section, or the final Error section when the source job failed.
+    """
+    artifact = (text or "").strip()
+    if not artifact:
+        return ""
+
+    markers: list[tuple[int, str]] = []
+    for match in re.finditer(r"(?m)^## (Response|Error)\s*$", artifact):
+        markers.append((match.start(), match.group(1)))
+    if not markers:
+        return artifact
+
+    marker_start, marker_name = markers[-1]
+    marker_end = artifact.find("\n", marker_start)
+    if marker_end == -1:
+        return ""
+    payload = artifact[marker_end + 1 :].strip()
+    if not payload or payload == "(No response generated)":
+        return ""
+    if marker_name == "Error":
+        return f"## Error\n\n{payload}".strip()
+    return payload
+
+
 def _set_cron_session_title(session_db, session_id, base_title):
     """Robustly title a finished cron session before it is closed.
 
@@ -2687,6 +2718,7 @@ def _build_job_prompt(
                 if not output_files:
                     continue  # silent skip — no output yet
                 latest_output = output_files[0].read_text(encoding="utf-8").strip()
+                latest_output = _extract_cron_context_payload(latest_output)
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -78,6 +78,72 @@ class TestBuildJobPromptContextFrom:
         assert "Today's top story: AI is everywhere." in prompt
         assert f"Output from job '{job_a['id']}'" in prompt
 
+    def test_extracts_response_only_from_saved_cron_artifact(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            """# Cron Job: upstream
+
+## Prompt
+
+UPSTREAM PROMPT SHOULD NOT LEAK
+
+## Response
+
+Useful upstream answer.
+""",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Summarize the news",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Useful upstream answer." in prompt
+        assert "UPSTREAM PROMPT SHOULD NOT LEAK" not in prompt
+        assert "## Prompt" not in prompt
+
+    def test_extracts_error_only_from_failed_cron_artifact(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Validate", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            """# Cron Job: validation (FAILED)
+
+## Prompt
+
+Nested prompt that should not reach the next job.
+
+## Error
+
+```
+RuntimeError: provider timeout
+```
+""",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Queue actions",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "RuntimeError: provider timeout" in prompt
+        assert "Nested prompt that should not reach the next job." not in prompt
+        assert "## Prompt" not in prompt
+
     def test_uses_most_recent_output(self, cron_env):
         from cron.jobs import create_job, OUTPUT_DIR
         from cron.scheduler import _build_job_prompt
@@ -215,5 +281,4 @@ class TestUpdateContextFrom:
 
         reloaded = get_job(job_b["id"])
         assert reloaded["context_from"] == [job_a["id"]]
-
 


### PR DESCRIPTION
## Summary
- sanitize cron context_from artifacts down to the final Response or Error section before prompt injection
- prevent downstream cron jobs from receiving nested upstream Prompt sections
- add regressions for successful and failed saved cron artifacts

## Verification
- uv run --active --with pytest --with pytest-asyncio python -m pytest tests/cron/test_cron_context_from.py -q => 12 passed
- uv run --active --with pytest --with pytest-asyncio python -m pytest tests/cron/test_cron_context_from.py tests/cron/test_scheduler.py tests/cron/test_cron_no_agent.py -q => 87 passed, 1 existing coroutine warning
- live artifact smoke: failed validation output now extracts Error with has_prompt=False

## Safety
No order-placement, broker-auth, credential, sandbox, kill-switch, or trading-parameter behavior changed.