### PR TITLE
fix(hindsight): add local_embedded to mode options in declared config schema

### DIFF
--- a/plugins/memory/hindsight/config_schema.py
+++ b/plugins/memory/hindsight/config_schema.py
@@ -21,6 +21,11 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             description="How Hermes connects to Hindsight.",
             options=(
                 ProviderFieldOption(
+                    "local_embedded",
+                    "Local Embedded",
+                    "Run Hindsight locally with embedded PostgreSQL",
+                ),
+                ProviderFieldOption(
                     "cloud",
                     "Cloud",
                     "Hindsight Cloud API (lightweight, just needs an API key)",


### PR DESCRIPTION
## Problem

The Hindsight config schema in `plugins/memory/hindsight/config_schema.py` only lists `cloud` and `local_external` as mode options. When a user's config has `mode: local_embedded`, the backend's `_declared_provider_payload` coerces the unknown value to the default (`cloud`), causing the desktop Memory settings page to show 'Cloud' with a 'missing API key' badge — even though the actual config is correct and Hindsight is working fine.

## Root Cause

In `web_server.py:1117-1118`:
```python
if field.kind == "select" and value not in field.allowed_values():
    value = field.default
```

`local_embedded` is a valid Hindsight mode (runs its own embedded PostgreSQL and embedding model) but wasn't in the declared options, so it gets coerced to `cloud` in the display payload.

## Fix

Add `local_embedded` as a valid option in the mode select field. Five lines.

## Testing

- Verified `allowed_values()` now includes `local_embedded`
- Confirmed the desktop Memory settings page now shows 'Local Embedded' correctly
- No regressions — the save path was never affected (only the display was wrong)