### PR TITLE
fix(kanban): keep distinct input blockers from false triage

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5897,7 +5897,11 @@ def edit_completed_task_result(
 
 
 def _block_reason_fingerprint(reason: Optional[str]) -> str:
-    """Return a privacy-safe identity for normalized-equivalent reason text."""
+    """Hash NFKC-, whitespace-, and case-normalized reason text.
+
+    Whitespace and case-only changes share an identity. Distinct ASCII
+    punctuation remains distinct; NFKC-equivalent punctuation does not.
+    """
     normalized = unicodedata.normalize("NFKC", reason or "")
     normalized = re.sub(r"\s+", " ", normalized).strip().casefold()
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
@@ -6050,6 +6054,12 @@ def block_task(
         cause_fingerprint = _block_reason_fingerprint(reason)
         if prev_fingerprint is None and prev_recurrences:
             prev_fingerprint = _legacy_block_reason_fingerprint(conn, task_id)
+            if prev_fingerprint is None:
+                _log.warning(
+                    "Could not recover legacy block reason fingerprint for task %s; "
+                    "resetting recurrence lineage",
+                    task_id,
+                )
         same_cause = (
             prev_kind == kind
             and prev_fingerprint is not None
@@ -6951,7 +6961,7 @@ def specify_triage_task(
             sets.append("assignee = ?")
             params.append(assignee)
             changed_fields.append("assignee")
-        if changed_fields:
+        if any(field in changed_fields for field in ("title", "body")):
             # A materially revised specification represents fresh human input,
             # so an earlier unresolved blocker must not consume the new task's
             # recurrence budget.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4248,7 +4248,7 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
     ).fetchone()
     try:
         payload = json.loads(row["payload"]) if row and row["payload"] else {}
-    except (json.JSONDecodeError, TypeError):
+    except (TypeError, ValueError, RecursionError):
         payload = {}
     if not isinstance(payload, dict):
         payload = {}
@@ -4606,7 +4606,7 @@ def _retry_status_for_run(
     ).fetchone()
     try:
         payload = json.loads(event["payload"]) if event and event["payload"] else {}
-    except (json.JSONDecodeError, TypeError):
+    except (TypeError, ValueError, RecursionError):
         payload = {}
     if not isinstance(payload, dict):
         payload = {}
@@ -5918,7 +5918,7 @@ def _legacy_block_reason_fingerprint(
         return None
     try:
         payload = json.loads(row["payload"])
-    except (json.JSONDecodeError, TypeError):
+    except (TypeError, ValueError, RecursionError):
         return None
     if not isinstance(payload, dict) or "reason" not in payload:
         return None
@@ -6282,7 +6282,7 @@ def request_review(
                     if changes_event and changes_event["payload"]
                     else {}
                 )
-            except (json.JSONDecodeError, TypeError):
+            except (TypeError, ValueError, RecursionError):
                 changes_payload = {}
             prior_reviewer = (
                 changes_payload.get("reviewer")
@@ -6406,7 +6406,7 @@ def request_changes(
                 if claimed_event and claimed_event["payload"]
                 else {}
             )
-        except (json.JSONDecodeError, TypeError):
+        except (TypeError, ValueError, RecursionError):
             claimed_payload = {}
         if not isinstance(claimed_payload, dict):
             claimed_payload = {}
@@ -6427,7 +6427,7 @@ def request_changes(
                 if requested_event["payload"]
                 else {}
             )
-        except (json.JSONDecodeError, TypeError):
+        except (TypeError, ValueError, RecursionError):
             requested_payload = {}
         if not isinstance(requested_payload, dict):
             requested_payload = {}
@@ -6696,7 +6696,7 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
                 if review_event and review_event["payload"]
                 else {}
             )
-        except (json.JSONDecodeError, TypeError):
+        except (TypeError, ValueError, RecursionError):
             handoff = {}
         implementer = handoff.get("implementer")
         if not isinstance(implementer, str) or not implementer.strip():

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -988,11 +988,11 @@ class Task:
     # relying on tenant + time-window heuristics.
     session_id: Optional[str] = None
     # Typed block reason (one of VALID_BLOCK_KINDS) or None for legacy/un-typed
-    # blocks. Set by ``block_task``; preserved across unblock so a re-block for
-    # the same kind is recognisable as an unblock↔re-block loop.
+    # blocks. Set by ``block_task``; preserved across unblock and paired with
+    # the reason fingerprint so a same-cause re-block is recognisable.
     block_kind: Optional[str] = None
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
-    # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
+    # ``BLOCK_RECURRENCE_LIMIT``. Reset on completion or material specification.
     block_recurrences: int = 0
 
     @classmethod
@@ -1276,9 +1276,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- Unblock-loop counter. Incremented each time a task is re-blocked for the
     -- same truly-blocked reason after having been unblocked. When it reaches
     -- BLOCK_RECURRENCE_LIMIT the task is routed to ``triage`` instead of
-    -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
-    -- successful completion — NOT on unblock (resetting on unblock is exactly
-    -- the amnesia that let the loop run unbounded).
+    -- ``blocked`` so a cron can't spin it forever. Reset to 0 on successful
+    -- completion or material human specification — NOT on a bare unblock
+    -- (that amnesia let the loop run unbounded).
     block_recurrences    INTEGER NOT NULL DEFAULT 0
 );
 
@@ -5948,8 +5948,9 @@ def block_task(
 
     * ``needs_input`` / ``capability`` / ``None`` — "truly blocked" (Dale's
       "Type 1"). Lands in ``blocked`` for a human. BUT: each time such a task
-      is re-blocked for the SAME kind after having been unblocked, the
-      unblock-loop counter (``block_recurrences``) increments. When it reaches
+      is re-blocked for the same normalized cause after having been unblocked,
+      the unblock-loop counter (``block_recurrences``) increments. When it
+      reaches
       :data:`BLOCK_RECURRENCE_LIMIT`, the task is routed to ``triage`` instead
       of ``blocked`` — breaking the cron-unblock ↔ worker-re-block loop and
       forcing a human-in-the-loop triage decision.
@@ -6631,8 +6632,9 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             if landing_status == "ready" and resume_status == "review"
             else landing_status
         )
-        # NOTE: deliberately does NOT touch ``block_recurrences`` or
-        # ``block_kind``. Resetting the recurrence counter on unblock is exactly
+        # NOTE: deliberately does NOT touch ``block_recurrences``,
+        # ``block_kind``, or ``block_reason_fingerprint``. Resetting recurrence
+        # identity on a bare unblock is exactly
         # the amnesia that let a cron unblock → worker re-block loop run
         # unbounded (Dale's report). The counter survives the unblock so that a
         # subsequent same-cause ``block_task`` can detect the loop and route to
@@ -6671,9 +6673,9 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
     ``review_reopened`` event.
 
     Deliberately does NOT touch ``block_recurrences``/``block_kind``: review is
-    not a block, so there is no loop counter to reset. (A stale counter from a
-    genuine block *before* review is left intact — only :func:`complete_task`
-    clears it.) Returns False when the task is missing or not in ``review``.
+    not a block, so there is no loop counter to reset. A stale counter from a
+    genuine block *before* review is left intact until completion or material
+    specification. Returns False when the task is missing or not in ``review``.
     """
     now = int(time.time())
     with write_txn(conn):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -78,6 +78,7 @@ import re
 import random
 import secrets
 import shutil
+import unicodedata
 import sqlite3
 import subprocess
 import sys
@@ -1265,9 +1266,13 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- Typed block reason set by ``block_task`` (one of VALID_BLOCK_KINDS, or
     -- NULL for legacy/un-typed blocks). Drives routing: ``dependency`` never
     -- sits in ``blocked`` (goes to ``todo`` for parent-gating); the others go
-    -- to ``blocked`` for a human. Preserved across unblock so a re-block for
-    -- the SAME kind can be recognised as a loop.
+    -- to ``blocked`` for a human. Preserved across unblock and paired with the
+    -- reason fingerprint so a re-block for the SAME cause can be recognised.
     block_kind           TEXT,
+    -- SHA-256 of the normalized human-facing block reason. Preserved across
+    -- unblock with block_kind so recurrence accounting distinguishes causes
+    -- without duplicating potentially sensitive reason text on the task row.
+    block_reason_fingerprint TEXT,
     -- Unblock-loop counter. Incremented each time a task is re-blocked for the
     -- same truly-blocked reason after having been unblocked. When it reaches
     -- BLOCK_RECURRENCE_LIMIT the task is routed to ``triage`` instead of
@@ -2472,6 +2477,16 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "tasks",
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+
+    if "block_reason_fingerprint" not in cols:
+        # Existing recurrence rows are resolved lazily from their latest block
+        # event by block_task(), avoiding raw reason text on the task row.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "block_reason_fingerprint",
+            "block_reason_fingerprint TEXT",
         )
 
     # Indexes over additive ``tasks`` columns must be created after the
@@ -5167,6 +5182,7 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL,
                        block_kind   = NULL,
+                       block_reason_fingerprint = NULL,
                        block_recurrences = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked', 'review')
@@ -5184,6 +5200,7 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL,
                        block_kind   = NULL,
+                       block_reason_fingerprint = NULL,
                        block_recurrences = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked', 'review')
@@ -5879,6 +5896,36 @@ def edit_completed_task_result(
     return True
 
 
+def _block_reason_fingerprint(reason: Optional[str]) -> str:
+    """Return a privacy-safe identity for normalized-equivalent reason text."""
+    normalized = unicodedata.normalize("NFKC", reason or "")
+    normalized = re.sub(r"\s+", " ", normalized).strip().casefold()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _legacy_block_reason_fingerprint(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> Optional[str]:
+    """Recover cause identity for rows created before the fingerprint column."""
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('blocked', 'block_loop_detected') "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if not row or not row["payload"]:
+        return None
+    try:
+        payload = json.loads(row["payload"])
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict) or "reason" not in payload:
+        return None
+    reason = payload["reason"]
+    return _block_reason_fingerprint(reason if isinstance(reason, str) else None)
+
+
 def block_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5921,7 +5968,8 @@ def block_task(
     recurrences = 0
     with write_txn(conn):
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            "SELECT status, block_kind, block_reason_fingerprint, "
+            "block_recurrences FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
@@ -5932,6 +5980,7 @@ def block_task(
             else "ready"
         )
         prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
+        prev_fingerprint = cur_row["block_reason_fingerprint"]
         prev_recurrences = (
             int(cur_row["block_recurrences"])
             if "block_recurrences" in cur_row.keys()
@@ -5993,9 +6042,18 @@ def block_task(
         # re-block for the SAME reason after a prior unblock. block_task only
         # fires from running/ready (i.e. AFTER an unblock returned the task to
         # the work pool), so a stored block_kind that matches the incoming kind
-        # means: blocked → unblocked → about-to-re-block for the same cause.
+        # means: blocked → unblocked → about-to-re-block for the same kind.
+        # The normalized reason fingerprint distinguishes separate causes while
+        # avoiding potentially sensitive reason text on the task row.
         # An un-typed (None) block compares as "same" to a prior un-typed block.
-        same_cause = prev_kind == kind
+        cause_fingerprint = _block_reason_fingerprint(reason)
+        if prev_fingerprint is None and prev_recurrences:
+            prev_fingerprint = _legacy_block_reason_fingerprint(conn, task_id)
+        same_cause = (
+            prev_kind == kind
+            and prev_fingerprint is not None
+            and prev_fingerprint == cause_fingerprint
+        )
         recurrences = prev_recurrences + 1 if same_cause else 1
 
         if recurrences >= BLOCK_RECURRENCE_LIMIT:
@@ -6009,12 +6067,20 @@ def block_task(
                        claim_expires = NULL,
                        worker_pid    = NULL,
                        block_kind    = ?,
+                       block_reason_fingerprint = ?,
                        block_recurrences = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
-                else (kind, recurrences, task_id, int(expected_run_id)),
+                (kind, cause_fingerprint, recurrences, task_id)
+                if expected_run_id is None
+                else (
+                    kind,
+                    cause_fingerprint,
+                    recurrences,
+                    task_id,
+                    int(expected_run_id),
+                ),
             )
             if cur.rowcount != 1:
                 return False
@@ -6031,6 +6097,7 @@ def block_task(
                 conn, task_id, "block_loop_detected",
                 {
                     "reason": reason,
+                    "reason_fingerprint": cause_fingerprint,
                     "kind": kind,
                     "recurrences": recurrences,
                     "limit": BLOCK_RECURRENCE_LIMIT,
@@ -6048,11 +6115,12 @@ def block_task(
                            claim_expires = NULL,
                            worker_pid    = NULL,
                            block_kind    = ?,
+                           block_reason_fingerprint = ?,
                            block_recurrences = ?
                      WHERE id = ?
                        AND status IN ('running', 'ready')
                     """,
-                    (kind, recurrences, task_id),
+                    (kind, cause_fingerprint, recurrences, task_id),
                 )
             else:
                 cur = conn.execute(
@@ -6063,12 +6131,19 @@ def block_task(
                            claim_expires = NULL,
                            worker_pid    = NULL,
                            block_kind    = ?,
+                           block_reason_fingerprint = ?,
                            block_recurrences = ?
                      WHERE id = ?
                        AND status IN ('running', 'ready')
                        AND current_run_id = ?
                     """,
-                    (kind, recurrences, task_id, int(expected_run_id)),
+                    (
+                        kind,
+                        cause_fingerprint,
+                        recurrences,
+                        task_id,
+                        int(expected_run_id),
+                    ),
                 )
             if cur.rowcount != 1:
                 return False
@@ -6089,6 +6164,7 @@ def block_task(
                 conn, task_id, "blocked",
                 {
                     "reason": reason,
+                    "reason_fingerprint": cause_fingerprint,
                     "kind": kind,
                     "recurrences": recurrences,
                     "source_status": source_status,
@@ -6561,7 +6637,8 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # unbounded (Dale's report). The counter survives the unblock so that a
         # subsequent same-cause ``block_task`` can detect the loop and route to
         # triage at ``BLOCK_RECURRENCE_LIMIT``. It is reset to 0 only on a
-        # successful completion (see ``complete_task``). ``consecutive_failures``
+        # successful completion or a material human specification (see
+        # ``complete_task`` and ``specify_triage_task``). ``consecutive_failures``
         # (the *dispatcher* spawn/crash/timeout counter — a different signal) is
         # still reset here, which is correct: a deliberate unblock is a fresh
         # start for the dispatcher's retry budget.
@@ -6872,6 +6949,17 @@ def specify_triage_task(
             sets.append("assignee = ?")
             params.append(assignee)
             changed_fields.append("assignee")
+        if changed_fields:
+            # A materially revised specification represents fresh human input,
+            # so an earlier unresolved blocker must not consume the new task's
+            # recurrence budget.
+            sets.extend(
+                [
+                    "block_kind = NULL",
+                    "block_reason_fingerprint = NULL",
+                    "block_recurrences = 0",
+                ]
+            )
         params.append(task_id)
         cur = conn.execute(
             f"UPDATE tasks SET {', '.join(sets)} "

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -203,6 +203,32 @@ def test_legacy_recurrence_row_recovers_cause_from_latest_event(
         assert kb.get_task(conn, tid).status == "triage"
 
 
+def test_legacy_fingerprint_tolerates_invalid_utf8_block_payload(
+    kanban_home: Path,
+) -> None:
+    """Corrupt BLOB payloads must not crash the legacy cause reader."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        reason = "Waiting for the same credential"
+        kb.block_task(conn, tid, reason=reason, kind="capability")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET block_reason_fingerprint = NULL WHERE id = ?",
+                (tid,),
+            )
+            conn.execute(
+                "UPDATE task_events SET payload = ? "
+                "WHERE task_id = ? AND kind = 'blocked'",
+                (b"\x80", tid),
+            )
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason=reason, kind="capability")
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_recurrences == 1
+
+
 # ---------------------------------------------------------------------------
 # Dependency routing
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -165,6 +165,22 @@ def test_block_cause_fingerprint_is_normalized_and_privacy_safe(
         assert kb.get_task(conn, tid).status == "triage"
 
 
+def test_punctuation_change_starts_distinct_recurrence_lineage(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="Use the saved card?", kind="needs_input")
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+
+        kb.block_task(conn, tid, reason="Use the saved card!", kind="needs_input")
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_recurrences == 1
+
+
 def test_status_only_specification_preserves_same_cause_lineage(
     kanban_home: Path,
 ) -> None:
@@ -178,6 +194,26 @@ def test_status_only_specification_preserves_same_cause_lineage(
         assert kb.get_task(conn, tid).status == "triage"
 
         assert kb.specify_triage_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        task = kb.get_task(conn, tid)
+        assert task.status == "triage"
+        assert task.block_recurrences == 3
+
+
+def test_assignee_only_specification_preserves_same_cause_lineage(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        reason = "Still waiting for the payment method"
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        assert kb.get_task(conn, tid).status == "triage"
+
+        assert kb.specify_triage_task(conn, tid, assignee="reviewer")
         assert kb.claim_task(conn, tid, claimer="worker") is not None
         kb.block_task(conn, tid, reason=reason, kind="needs_input")
         task = kb.get_task(conn, tid)
@@ -205,6 +241,7 @@ def test_legacy_recurrence_row_recovers_cause_from_latest_event(
 
 def test_legacy_fingerprint_tolerates_invalid_utf8_block_payload(
     kanban_home: Path,
+    caplog,
 ) -> None:
     """Corrupt BLOB payloads must not crash the legacy cause reader."""
     with kb.connect_closing() as conn:
@@ -227,6 +264,8 @@ def test_legacy_fingerprint_tolerates_invalid_utf8_block_payload(
         task = kb.get_task(conn, tid)
         assert task.status == "blocked"
         assert task.block_recurrences == 1
+        assert "Could not recover legacy block reason fingerprint" in caplog.text
+        assert reason not in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -78,6 +78,131 @@ def test_block_loop_detected_event_emitted(kanban_home: Path) -> None:
         assert payload.get("kind") == "capability"
 
 
+def test_distinct_reasons_do_not_share_recurrence_lineage(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(
+            conn,
+            tid,
+            reason="Which saved payment method?",
+            kind="needs_input",
+        )
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+
+        kb.block_task(
+            conn,
+            tid,
+            reason="Which controlled QA email?",
+            kind="needs_input",
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_recurrences == 1
+        assert not [
+            event
+            for event in kb.list_events(conn, tid)
+            if event.kind == "block_loop_detected"
+        ]
+
+
+def test_material_specification_resets_block_recurrence_lineage(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        reason = "Which saved payment method?"
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        assert kb.get_task(conn, tid).status == "triage"
+
+        assert kb.specify_triage_task(
+            conn,
+            tid,
+            body="Owner selected the corporate card.",
+            author="owner",
+        )
+        specified = kb.get_task(conn, tid)
+        assert specified.block_kind is None
+        assert specified.block_recurrences == 0
+
+        claimed = kb.claim_task(conn, tid, claimer="worker")
+        assert claimed is not None
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_recurrences == 1
+
+
+def test_block_cause_fingerprint_is_normalized_and_privacy_safe(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        reason = "  Which   Controlled QA Email?  "
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        row = conn.execute(
+            "SELECT block_reason_fingerprint FROM tasks WHERE id = ?",
+            (tid,),
+        ).fetchone()
+        fingerprint = row["block_reason_fingerprint"]
+        assert fingerprint
+        assert reason.strip().casefold() not in fingerprint
+
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(
+            conn,
+            tid,
+            reason="which controlled qa email?",
+            kind="needs_input",
+        )
+        assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_status_only_specification_preserves_same_cause_lineage(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        reason = "Still waiting for the payment method"
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        assert kb.get_task(conn, tid).status == "triage"
+
+        assert kb.specify_triage_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        kb.block_task(conn, tid, reason=reason, kind="needs_input")
+        task = kb.get_task(conn, tid)
+        assert task.status == "triage"
+        assert task.block_recurrences == 3
+
+
+def test_legacy_recurrence_row_recovers_cause_from_latest_event(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        reason = "Waiting for the same credential"
+        kb.block_task(conn, tid, reason=reason, kind="capability")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET block_reason_fingerprint = NULL WHERE id = ?",
+                (tid,),
+            )
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason=reason, kind="capability")
+        assert kb.get_task(conn, tid).status == "triage"
+
+
 # ---------------------------------------------------------------------------
 # Dependency routing
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -12,7 +12,7 @@ forever. The fix gives ``block_task`` a typed ``kind`` and a persistent
   and at ``BLOCK_RECURRENCE_LIMIT`` the task routes to ``triage`` for a human.
 * ``unblock_task`` deliberately does NOT reset ``block_recurrences`` (the
   amnesia that let the loop run unbounded).
-* A successful ``complete_task`` resets the loop memory.
+* A successful ``complete_task`` or material specification resets loop memory.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What does this PR do?

Kanban tasks that are unblocked after one `needs_input` question no longer jump to triage when they later block on a different question. The recurrence guard now identifies a cause by block kind plus a normalized SHA-256 reason fingerprint, preserving same-cause loop protection without duplicating potentially sensitive reason text on the task row.

### Symptom

After a human answers one input request and unblocks a task, a later, unrelated `needs_input` request is counted as recurrence 2 and routes the task to triage instead of blocking for the new input.

### Impact

Affected Kanban workflows can be falsely escalated and stop dispatching even though the worker encountered a new question rather than repeating an unresolved blocker.

### Bug Cause

**Trigger:** `hermes_cli/kanban_db.py` / `block_task()` / a task re-blocks with the same block kind after an unblock.

**Causal chain:**
1. A task blocks with `needs_input`, is unblocked after a human response, and later asks a different question.
2. `block_task()` compares only the previous and incoming block kinds, so both questions are treated as the same cause.
3. The recurrence counter reaches its limit and routes the task to triage.

**Why it is wrong:** A block kind identifies the routing class, not the specific unresolved cause. Distinct human questions can legitimately share `needs_input`.

**Working sibling / contrast:** First-class review transitions bypass `block_task()` and therefore do not contribute to block recurrence accounting; that behavior remains unchanged.

**Ruled out:** The recurrence threshold itself is not the defect. Repeating the same normalized reason must still escalate at the existing threshold, and the regression tests preserve that contract.

### Fix

- Persist a normalized reason fingerprint alongside the block kind and require both to match before incrementing a recurrence lineage.
- Recover cause identity lazily from the latest block event for legacy rows with an existing recurrence count.
- Reset block lineage when `specify_triage_task()` applies a material human specification, while preserving it for a bare unblock.
- Clear the fingerprint on completion and cover same-cause, distinct-cause, specification-reset, migration, privacy, and review lifecycle behavior.

## Related Issue

Closes #83624

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` - track privacy-safe cause identity, migrate existing boards, and reset lineage on material specification.
- `tests/hermes_cli/test_kanban_block_kinds.py` - add state-machine regressions for recurrence identity and lifecycle boundaries.

## How to Test

1. Run the focused Kanban block-kind suite.
2. Confirm all seven tests pass, including distinct-cause and same-cause recurrence paths.

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_block_kinds.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - schema comments and docstrings updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
