### PR TITLE
fix(openviking): bind identity to the initialized profile

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -30,7 +30,7 @@ import time
 import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Dict, Any, Optional, List, Tuple, Set, Mapping
 
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
@@ -234,6 +234,18 @@ def _reject_denylisted_env_var(key: str) -> None:
         )
 
 _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
+# Explicit env snapshots are profile-scoped and must not share the process-wide
+# last-known-good value. Keep only referenced values for the latest load per
+# config path; a different mapping falls back safely instead of serving another
+# profile's data.
+_LAST_EXPANDED_CONFIG_BY_EXPLICIT_ENV: Dict[
+    str,
+    Tuple[
+        Dict[str, Optional[str]],
+        Dict[str, Optional[str]],
+        Dict[str, Any],
+    ],
+] = {}
 # (path, mtime_ns, size) -> cached expanded config dict.
 # load_config() returns a deepcopy of the cached value when the file
 # hasn't changed since the last load, skipping yaml.safe_load +
@@ -2588,7 +2600,7 @@ def _strip_dotted_keys(cfg: dict, dotted_keys: set) -> Tuple[dict, set]:
     return cfg, stripped
 
 
-def _env_expand_match(m: re.Match) -> str:
+def _env_expand_match(m: re.Match, *, env: Optional[Mapping[str, str]] = None) -> str:
     """Expand one ``${...}`` config reference.
 
     Two accepted shapes, matching what MCP server config already resolves
@@ -2606,13 +2618,14 @@ def _env_expand_match(m: re.Match) -> str:
     ref only ever needs the env shape.  Unknown prefixes warn once and stay
     verbatim so callers can detect them.
     """
+    source = os.environ if env is None else env
     raw = m.group(0)
     inner = m.group(1).strip()
     if inner.startswith("env:"):
         name = inner[len("env:"):].strip()
         if not name:
             return raw
-        val = os.environ.get(name)
+        val = source.get(name)
         if val is not None:
             return val
         logger.warning(
@@ -2633,7 +2646,7 @@ def _env_expand_match(m: re.Match) -> str:
         )
         return raw
     # Legacy ``${VAR}`` — bare name.
-    return os.environ.get(inner, raw)
+    return source.get(inner, raw)
 
 
 def _env_ref_var_name(ref: str) -> Optional[str]:
@@ -2648,24 +2661,30 @@ def _env_ref_var_name(ref: str) -> Optional[str]:
     return ref
 
 
-def _expand_env_vars(obj):
+def _expand_env_vars(obj, *, env: Optional[Mapping[str, str]] = None):
     """Recursively expand ``${VAR}`` / ``${env:VAR}`` references in config
     values.
 
     Only string values are processed; dict keys, numbers, booleans, and
     None are left untouched.  Unresolved references (variable not in
-    ``os.environ``) are kept verbatim so callers can detect them.
+    the selected environment) are kept verbatim so callers can detect them.
     """
     if isinstance(obj, str):
-        return re.sub(r"\${([^}]+)}", _env_expand_match, obj)
+        return re.sub(
+            r"\${([^}]+)}",
+            lambda match: _env_expand_match(match, env=env),
+            obj,
+        )
     if isinstance(obj, dict):
-        return {k: _expand_env_vars(v) for k, v in obj.items()}
+        return {k: _expand_env_vars(v, env=env) for k, v in obj.items()}
     if isinstance(obj, list):
-        return [_expand_env_vars(item) for item in obj]
+        return [_expand_env_vars(item, env=env) for item in obj]
     return obj
 
 
-def _env_ref_snapshot(obj, snapshot=None):
+def _env_ref_snapshot(
+    obj, snapshot=None, *, env: Optional[Mapping[str, str]] = None
+):
     """Map every ``${VAR}`` / ``${env:VAR}`` name referenced in config values
     to its current ``os.environ`` value (``None`` when unset).
 
@@ -2686,13 +2705,14 @@ def _env_ref_snapshot(obj, snapshot=None):
         for raw in re.findall(r"\${([^}]+)}", obj):
             name = _env_ref_var_name(raw)
             if name is not None:
-                snapshot[name] = os.environ.get(name)
+                source = os.environ if env is None else env
+                snapshot[name] = source.get(name)
     elif isinstance(obj, dict):
         for value in obj.values():
-            _env_ref_snapshot(value, snapshot)
+            _env_ref_snapshot(value, snapshot, env=env)
     elif isinstance(obj, list):
         for item in obj:
-            _env_ref_snapshot(item, snapshot)
+            _env_ref_snapshot(item, snapshot, env=env)
     return snapshot
 
 
@@ -3302,7 +3322,7 @@ def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
     atomic_yaml_write(config_path, data, **kwargs)
 
 
-def load_config() -> Dict[str, Any]:
+def load_config(*, env: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
     """Load configuration from ~/.hermes/config.yaml.
 
     Cached on the config file's (mtime_ns, size). Returns a deepcopy of
@@ -3312,14 +3332,19 @@ def load_config() -> Dict[str, Any]:
     (which change ``HERMES_HOME`` and therefore ``get_config_path()``)
     don't collide.
 
+    ``env=`` supplies user-config expansion values and bypasses the shared
+    process expansion cache; managed refs remain process-global.
+
     Read-only callers should use ``load_config_readonly()`` to skip the
     defensive deepcopy — that path matters in agent-loop hot spots like
     ``get_provider_request_timeout`` which is called once per API turn.
     """
-    return _load_config_impl(want_deepcopy=True)
+    return _load_config_impl(want_deepcopy=True, env=env)
 
 
-def load_config_readonly() -> Dict[str, Any]:
+def load_config_readonly(
+    *, env: Optional[Mapping[str, str]] = None
+) -> Dict[str, Any]:
     """Fast-path variant of ``load_config()`` for callers that ONLY READ.
 
     Returns the cached config dict directly without the defensive deepcopy
@@ -3328,6 +3353,9 @@ def load_config_readonly() -> Dict[str, Any]:
     caller** — only use this when you are absolutely sure your code path
     will not write to the result. If you need to mutate or pass to
     ``save_config``, call ``load_config()`` instead.
+
+    ``env=`` supplies user-config expansion values and bypasses the shared
+    process expansion cache; managed refs remain process-global.
 
     Why this exists: ``load_config()`` cache-hit cost is ~265us per call,
     half of which (~135us) is the defensive deepcopy. The agent loop calls
@@ -3339,7 +3367,7 @@ def load_config_readonly() -> Dict[str, Any]:
     existing ``isinstance(x, dict)`` guards downstream keep working. The
     safety guarantee is purely documented, not enforced — be careful.
     """
-    return _load_config_impl(want_deepcopy=False)
+    return _load_config_impl(want_deepcopy=False, env=env)
 
 
 def write_platform_config_field(
@@ -3494,8 +3522,11 @@ def apply_terminal_config_to_env(
     return target
 
 
-def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
+def _load_config_impl(
+    *, want_deepcopy: bool, env: Optional[Mapping[str, str]] = None
+) -> Dict[str, Any]:
     with _CONFIG_LOCK:
+        explicit_env = env is not None
         ensure_hermes_home()
         config_path = get_config_path()
         path_key = str(config_path)
@@ -3533,7 +3564,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         else:
             cache_sig = None
 
-        cached = _LOAD_CONFIG_CACHE.get(path_key)
+        cached = _LOAD_CONFIG_CACHE.get(path_key) if not explicit_env else None
         if cached is not None and cache_sig is not None and cached[:4] == cache_sig:
             # File signatures match, but the cached expansion is only valid if
             # every ${VAR} it was expanded against still has the same value.
@@ -3572,22 +3603,41 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                 # loaded config — keep serving it until the file is fixed.
                 # Fresh processes with no last-known-good keep the existing
                 # DEFAULT_CONFIG fallback.
-                lkg = _LAST_EXPANDED_CONFIG_BY_PATH.get(path_key)
+                if explicit_env:
+                    explicit_lkg = _LAST_EXPANDED_CONFIG_BY_EXPLICIT_ENV.get(path_key)
+                    if explicit_lkg is None:
+                        lkg = None
+                    else:
+                        user_ref_snapshot, managed_ref_snapshot, expanded_lkg = (
+                            explicit_lkg
+                        )
+                        lkg = (
+                            expanded_lkg
+                            if all(
+                                env.get(name) == value
+                                for name, value in user_ref_snapshot.items()
+                            )
+                            and all(
+                                os.environ.get(name) == value
+                                for name, value in managed_ref_snapshot.items()
+                            )
+                            else None
+                        )
+                else:
+                    lkg = _LAST_EXPANDED_CONFIG_BY_PATH.get(path_key)
                 _warn_config_parse_failure(
                     config_path,
                     e,
                     fallback="last-known-good" if lkg is not None else "defaults",
                 )
                 if lkg is not None:
-                    # save_config() stores the pre-expansion normalized dict
-                    # (env-ref templates preserved); the load path stores the
-                    # expanded one. Expand defensively — idempotent when the
-                    # stored value is already expanded.
-                    from typing import cast as _cast
-                    lkg_copy: Dict[str, Any] = _cast(
-                        Dict[str, Any], _expand_env_vars(copy.deepcopy(lkg))
-                    )
-                    if cache_sig is not None:
+                    # Explicit-env LKG values are already fully expanded;
+                    # preserve unresolved managed refs exactly as loaded.
+                    lkg_copy: Dict[str, Any] = copy.deepcopy(lkg)
+                    if not explicit_env:
+                        # Preserve the legacy process-env recovery behavior.
+                        lkg_copy = _expand_env_vars(lkg_copy)
+                    if cache_sig is not None and not explicit_env:
                         # Cache under the corrupt file's signature (empty env
                         # snapshot: always valid) so repeated loads don't
                         # re-parse the broken file; fixing the file changes the
@@ -3601,29 +3651,38 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
 
         normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
-        expanded = _expand_env_vars(normalized)
+        explicit_env_refs = (
+            _env_ref_snapshot(normalized, env=env) if explicit_env else None
+        )
+        expanded = _expand_env_vars(normalized, env=env)
         # Managed scope wins at the leaf. Applied AFTER user expansion so a user
         # ${VAR} cannot shadow a managed literal: managed values are expanded only
         # against the process environment, never against user-config-defined refs.
         # This deliberately inverts the usual env-over-config precedence for the
         # keys the managed layer pins — see docs/design/managed-scope.md §4.1.
         managed_config = managed_scope.load_managed_config()
+        managed_env_refs = None
         if managed_config:
-            # Normalize the managed overlay through the same canonicalization as
-            # the user config BEFORE merging (parity with
-            # managed_scope.apply_managed_overlay): a dict-valued
-            # ``model.default`` (``{provider: ..., model: ...}``) or a bare
-            # ``model: <string>`` must be flattened to a string ``default``
-            # paired with ``provider`` so the merged result never exposes a
-            # nested dict to status/fallback/runtime readers.
+            # Canonicalize managed model keys before merging; refs expand against
+            # process env because managed config is global, even for profile env.
             managed_normalized = _normalize_root_model_keys(managed_config)
             if isinstance(managed_normalized.get("model"), str):
                 managed_normalized = dict(managed_normalized)
                 managed_normalized["model"] = {"default": managed_normalized["model"]}
+            managed_env_refs = (
+                _env_ref_snapshot(managed_normalized) if explicit_env else None
+            )
             managed_expanded = _expand_env_vars(managed_normalized)
             expanded = _deep_merge(expanded, managed_expanded)
-        _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
-        if cache_sig is not None:
+        if explicit_env:
+            _LAST_EXPANDED_CONFIG_BY_EXPLICIT_ENV[path_key] = (
+                explicit_env_refs or {},
+                managed_env_refs or {},
+                copy.deepcopy(expanded),
+            )
+        else:
+            _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
+        if cache_sig is not None and not explicit_env:
             # Cache stores a separate deepcopy so subsequent ``load_config()``
             # (deepcopy=True) callers can mutate freely without affecting the
             # cached value, and ``load_config_readonly()`` (deepcopy=False)
@@ -3633,7 +3692,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             # this expansion was made against so later loads can detect env
             # drift (late .env load, in-process rotation) — see cache hit above.
             cached_copy = copy.deepcopy(expanded)
-            env_snapshot = _env_ref_snapshot(normalized)
+            env_snapshot = _env_ref_snapshot(normalized, env=env)
             if managed_config:
                 _env_ref_snapshot(managed_config, env_snapshot)
             _LOAD_CONFIG_CACHE[path_key] = (*cache_sig, cached_copy, env_snapshot)
@@ -3642,7 +3701,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             # object" invariant that callers may rely on for identity checks.
             if not want_deepcopy:
                 return cached_copy
-        else:
+        elif not explicit_env:
             _LOAD_CONFIG_CACHE.pop(path_key, None)
         # First-load result is a fresh dict (not aliased to the cache); safe
         # to return directly. For the deepcopy=True path this is the

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -235,6 +235,7 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
         values[name] = value
     if values:
         _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
+    _report_secret_source_outcomes(report, cfg, scope=home_key)
     return dict(values)
 
 
@@ -614,6 +615,47 @@ def _apply_managed_env() -> None:
     _load_dotenv_with_fallback(managed_env, override=True)
 
 
+def _report_secret_source_outcomes(
+    report, secrets_cfg: dict, *, scope: str | None = None
+) -> None:
+    """Print source outcomes without exposing any applied secret values."""
+    for src in report.sources:
+        if src.applied:
+            print(
+                f"  {src.label}: applied {len(src.applied)} "
+                f"secret{'s' if len(src.applied) != 1 else ''}",
+                file=sys.stderr,
+            )
+        if src.result.error:
+            try:
+                from agent.secret_sources.base import ErrorKind
+
+                error_kind = (
+                    ErrorKind(src.result.error_kind).value
+                    if src.result.error_kind is not None
+                    else None
+                )
+            except (TypeError, ValueError):
+                error_kind = None
+            summary = "source failed"
+            if error_kind:
+                summary += f" (error_kind={error_kind})"
+            print(f"  {src.label}: {summary}", file=sys.stderr)
+            hint = _remediation_hint(
+                src.name, src.result.error_kind, secrets_cfg, scope=scope
+            )
+            if hint:
+                print(f"  {src.label}: → {hint}", file=sys.stderr)
+        if src.result.warnings:
+            count = len(src.result.warnings)
+            print(
+                f"  {src.label}: {count} warning{'s' if count != 1 else ''}",
+                file=sys.stderr,
+            )
+    for conflict in report.conflicts:
+        print(f"  Secret sources: {conflict}", file=sys.stderr)
+
+
 def _apply_external_secret_sources(home_path: Path) -> None:
     """Pull secrets from every enabled external source into env.
 
@@ -711,24 +753,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
                 values[name] = os.environ[name]
         _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
 
-    for src in report.sources:
-        if src.applied:
-            print(
-                f"  {src.label}: applied {len(src.applied)} "
-                f"secret{'s' if len(src.applied) != 1 else ''}",
-                file=sys.stderr,
-            )
-        if src.result.error:
-            print(f"  {src.label}: {src.result.error}", file=sys.stderr)
-            hint = _remediation_hint(
-                src.name, src.result.error_kind, cfg, scope=home_key
-            )
-            if hint:
-                print(f"  {src.label}: → {hint}", file=sys.stderr)
-        for warn in src.result.warnings:
-            print(f"  {src.label}: {warn}", file=sys.stderr)
-    for conflict in report.conflicts:
-        print(f"  Secret sources: {conflict}", file=sys.stderr)
+    _report_secret_source_outcomes(report, cfg, scope=home_key)
 
 
 def _remediation_hint(

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -32,8 +32,8 @@ hermes memory setup    # select "openviking"
 ```
 
 The setup can link to an existing `~/.openviking/ovcli.conf`, copy its current
-connection values into Hermes, or create a minimal `ovcli.conf` when one does
-not exist.
+connection values into the active profile's `.env`, or create a minimal
+`ovcli.conf` when one does not exist.
 
 Or manually:
 
@@ -41,16 +41,12 @@ Or manually:
 hermes config set memory.provider openviking
 ```
 
-Add the connection settings to the active profile's `.env` file. For the
-default profile that is `~/.hermes/.env`; for a named profile use
-`~/.hermes/profiles/<profile>/.env`.
+If the server requires authentication, add only the API key to the active
+profile's `.env` file. For the default profile that is `~/.hermes/.env`; for a
+named profile use `~/.hermes/profiles/<profile>/.env`.
 
 ```text
-OPENVIKING_ENDPOINT=http://127.0.0.1:1933
-# OPENVIKING_API_KEY=...
-# OPENVIKING_ACCOUNT=default
-# OPENVIKING_USER=default
-# OPENVIKING_AGENT=hermes
+OPENVIKING_API_KEY=...
 ```
 
 ## Config
@@ -64,16 +60,26 @@ OpenViking's server config is separate from Hermes:
   `account`, and `user`. It is read from `OPENVIKING_CLI_CONFIG_FILE` or
   `~/.openviking/ovcli.conf`.
 
-Hermes-side provider config is read from environment variables in the active
-profile's `.env`:
+For manual configuration, store the optional API key in the active profile's
+`.env` and put the endpoint and local/trusted identity settings in that
+profile's `config.yaml`:
 
-| Env Var | Default | Description |
-|---------|---------|-------------|
-| `OPENVIKING_ENDPOINT` | `http://127.0.0.1:1933` | Server URL |
-| `OPENVIKING_API_KEY` | (none) | User/admin API key for authenticated servers |
-| `OPENVIKING_ACCOUNT` | `default` | Tenant account for local/trusted mode |
-| `OPENVIKING_USER` | `default` | Tenant user for local/trusted mode |
-| `OPENVIKING_AGENT` | `hermes` | Hermes peer ID in OpenViking, used for peer-scoped memories |
+```yaml
+memory:
+  provider: openviking
+  openviking:
+    endpoint: http://127.0.0.1:1933
+    account: default
+    user: default
+    agent: hermes
+```
+
+The setup command may store all selected connection values in the profile's
+`.env`. The legacy `OPENVIKING_ENDPOINT`, `OPENVIKING_ACCOUNT`,
+`OPENVIKING_USER`, and `OPENVIKING_AGENT` overrides remain supported. Bound
+profiles resolve identity from their own secret scope; the process-level
+`OPENVIKING_ENDPOINT` remains a non-secret fallback when the profile supplies
+none.
 
 When `OPENVIKING_API_KEY` is set, Hermes lets OpenViking derive account/user
 identity from the key. In local or trusted deployments without an API key,
@@ -93,10 +99,10 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 ## Memory Writes And Deletes
 
 `viking_remember` writes directly to OpenViking with `POST /api/v1/content/write`
-and `mode=create`. It creates peer-scoped memory files under
-`viking://user/peers/${OPENVIKING_AGENT}/memories/...`; OpenViking may return a
-canonical user-scoped form such as
-`viking://user/default/peers/${OPENVIKING_AGENT}/memories/...` in API-key mode.
+and `mode=create`, using the current-user shorthand
+`viking://user/memories/...`. Hermes sends `OPENVIKING_AGENT` as the peer
+identity through the `X-OpenViking-Actor-Peer` header. OpenViking applies the
+authenticated account's namespace policy and may return a canonical URI.
 Explicit remembers do not depend on session commit extraction.
 
 Hermes built-in `memory` tool additions are mirrored to OpenViking after the
@@ -104,7 +110,7 @@ local memory operation succeeds:
 
 | Hermes action | OpenViking operation |
 |---------------|----------------------|
-| `add` | `content/write` with `mode=create` under the configured peer memory namespace |
+| `add` | `content/write` with `mode=create` under the current-user shorthand namespace |
 
 Built-in `replace` and `remove` operations are not mirrored because Hermes
 native memory entries do not yet carry stable OpenViking file URIs. Use
@@ -113,10 +119,8 @@ memory URI.
 
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as
-`viking://user/peers/hermes/memories/preferences/mem_abc123.md` or the canonical
-`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md`. Files
-directly under `memories/`, such as `viking://user/default/memories/profile.md`,
-are also allowed because OpenViking supports them. The tool rejects directories,
-resources, skills, sessions, generated summary files, and URIs with query
-strings or fragments. Use OpenViking's MCP, CLI, or admin APIs for broader
-resource and directory cleanup.
+`viking://user/memories/preferences/mem_abc123.md` or a canonical URI returned
+by OpenViking. The tool rejects directories, resources, skills, sessions,
+generated summary files, and URIs with query strings or fragments. Use
+OpenViking's MCP, CLI, or admin APIs for broader resource and directory
+cleanup.

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -14,6 +14,8 @@ Hermes can identify older servers that expose the legacy status-only health
 response, but only when anonymous OpenAPI metadata also identifies the service
 as OpenViking. OpenViking 0.2.6 and earlier are deprecated for this integration;
 upgrade them to receive the current health contract and compatibility fixes.
+Selecting a peer with `X-OpenViking-Actor-Peer` requires OpenViking 0.4.0 or
+newer; older 0.3.x servers retain their legacy agent-filtering limitation.
 
 ## Setup
 
@@ -31,9 +33,11 @@ Then configure Hermes:
 hermes memory setup    # select "openviking"
 ```
 
-The setup can link to an existing `~/.openviking/ovcli.conf`, copy its current
-connection values into the active profile's `.env`, or create a minimal
-`ovcli.conf` when one does not exist.
+The setup can link an existing `~/.openviking/ovcli.conf` profile. Linking is
+an explicit shared-file choice: the selected external file is read at runtime
+and its values are not copied into `.env`. To isolate credentials, use
+separate saved ovcli profiles or manual split profile configuration. Setup can
+also create a minimal `ovcli.conf` when one does not exist.
 
 Or manually:
 
@@ -74,9 +78,13 @@ memory:
     agent: hermes
 ```
 
-The setup command may store all selected connection values in the profile's
-`.env`. The legacy `OPENVIKING_ENDPOINT`, `OPENVIKING_ACCOUNT`,
-`OPENVIKING_USER`, and `OPENVIKING_AGENT` overrides remain supported. Bound
+Manual configuration keeps only `OPENVIKING_API_KEY` in the active profile's
+`.env`; put `endpoint`, `account`, `user`, and `agent` under
+`memory.openviking` in the active profile's `config.yaml`. The wizard's legacy
+`Keep in Hermes only` option still stores selected connection values in `.env`;
+users who want non-secrets out of `.env` should use the default `Mirror to
+OpenViking store` option or manual split configuration. Legacy
+`OPENVIKING_*` environment overrides remain supported. Bound
 profiles resolve identity from their own secret scope; the process-level
 `OPENVIKING_ENDPOINT` remains a non-secret fallback when the profile supplies
 none.
@@ -103,6 +111,8 @@ and `mode=create`, using the current-user shorthand
 `viking://user/memories/...`. Hermes sends `OPENVIKING_AGENT` as the peer
 identity through the `X-OpenViking-Actor-Peer` header. OpenViking applies the
 authenticated account's namespace policy and may return a canonical URI.
+Peer selection requires OpenViking 0.4.0+; 0.3.x servers retain their legacy
+agent-filtering limitation.
 Explicit remembers do not depend on session commit extraction.
 
 Hermes built-in `memory` tool additions are mirrored to OpenViking after the

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -7,13 +7,15 @@ automatic memory extraction, and session management.
 Original PR #3369 by Mibayy, rewritten to use the full OpenViking session
 lifecycle instead of read-only search endpoints.
 
-Config via environment variables (profile-scoped via each profile's .env)
-or a linked OpenViking CLI config:
+Connection settings prefer ``memory.openviking`` in the active profile's
+config.yaml, with ``OPENVIKING_API_KEY`` in its .env, or a linked OpenViking
+CLI config. Legacy ``OPENVIKING_*`` environment overrides remain supported:
   OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
   OPENVIKING_ACCOUNT   — Tenant account for local/trusted mode (default: default)
   OPENVIKING_USER      — Tenant user for local/trusted mode (default: default)
-  OPENVIKING_AGENT     — Hermes peer ID in OpenViking (default: hermes)
+  OPENVIKING_AGENT     — peer identity sent through X-OpenViking-Actor-Peer
+                         (default: hermes)
 
 Capabilities:
   - Automatic memory extraction on session commit (6 categories)
@@ -65,7 +67,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _OPENVIKING_SERVICE_ENDPOINT = "https://api.vikingdb.cn-beijing.volces.com/openviking"
 _DEFAULT_AGENT = "hermes"
-_AGENT_PROMPT_LABEL = "Hermes peer ID in OpenViking"
+_AGENT_PROMPT_LABEL = "Peer identity sent through X-OpenViking-Actor-Peer"
 _OVCLI_CONFIG_ENV = "OPENVIKING_CLI_CONFIG_FILE"
 _OVCLI_DEFAULT_RELATIVE_PATH = ".openviking/ovcli.conf"
 _OVCLI_SAVED_PREFIX = "ovcli.conf."
@@ -102,6 +104,7 @@ _SESSION_START_LIST_PARAMS = {
     "abs_limit": 512,
     "node_limit": 512,
 }
+_IDENTITY_UNSET = object()
 
 # Maps the viking_remember `category` enum to a viking:// subdirectory.
 # Keep in sync with REMEMBER_SCHEMA.parameters.properties.category.enum.
@@ -287,17 +290,34 @@ def _get_httpx():
 class _VikingClient:
     """Thin HTTP client for the OpenViking REST API."""
 
-    def __init__(self, endpoint: str, api_key: str = "",
-                 account: Optional[str] = None, user: Optional[str] = None,
-                 agent: Optional[str] = None):
+    def __init__(
+        self,
+        endpoint: str,
+        api_key: str = "",
+        account: Optional[str] | object = _IDENTITY_UNSET,
+        user: Optional[str] | object = _IDENTITY_UNSET,
+        agent: Optional[str] | object = _IDENTITY_UNSET,
+    ):
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
         # Account/user are local/trusted-mode tenant identity. API-key requests
         # omit these headers by default; trusted-mode retry may send them only
         # after OpenViking explicitly asks for asserted tenant identity.
-        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
-        self._user = user or os.environ.get("OPENVIKING_USER", "default")
-        self._agent = agent if agent is not None else os.environ.get("OPENVIKING_AGENT", _DEFAULT_AGENT)
+        self._account = (
+            os.environ.get("OPENVIKING_ACCOUNT", "default")
+            if account is _IDENTITY_UNSET or account is None
+            else account
+        )
+        self._user = (
+            os.environ.get("OPENVIKING_USER", "default")
+            if user is _IDENTITY_UNSET or user is None
+            else user
+        )
+        self._agent = (
+            os.environ.get("OPENVIKING_AGENT", _DEFAULT_AGENT)
+            if agent is _IDENTITY_UNSET or agent is None
+            else agent
+        )
         self._httpx = _get_httpx()
         if self._httpx is None:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
@@ -810,8 +830,11 @@ def _default_ovcli_config_path() -> Path:
     return Path.home() / _OVCLI_DEFAULT_RELATIVE_PATH
 
 
-def _resolve_ovcli_config_path(config_path: str = "") -> Path:
-    env_path = os.environ.get(_OVCLI_CONFIG_ENV, "").strip()
+def _resolve_ovcli_config_path(
+    config_path: str = "", *, env: Optional[dict] = None
+) -> Path:
+    env_path = _env_value(_OVCLI_CONFIG_ENV, env)
+    env_path = env_path.strip() if env_path else ""
     if env_path:
         return Path(env_path).expanduser()
     if config_path:
@@ -1094,11 +1117,23 @@ def _is_local_openviking_url(value: str) -> bool:
     return scheme == "http" and (parsed.hostname or "").lower() in _LOCAL_OPENVIKING_HOSTS
 
 
-def _load_hermes_openviking_config() -> dict:
+def _load_hermes_openviking_config(hermes_home: Optional[str] = None) -> dict:
     try:
         from hermes_cli.config import load_config_readonly
 
-        config = load_config_readonly()
+        if hermes_home:
+            from hermes_constants import (
+                reset_hermes_home_override,
+                set_hermes_home_override,
+            )
+
+            home_token = set_hermes_home_override(hermes_home)
+            try:
+                config = load_config_readonly()
+            finally:
+                reset_hermes_home_override(home_token)
+        else:
+            config = load_config_readonly()
         memory_config = config.get("memory", {}) if isinstance(config, dict) else {}
         provider_config = memory_config.get("openviking", {}) if isinstance(memory_config, dict) else {}
         return dict(provider_config) if isinstance(provider_config, dict) else {}
@@ -1106,8 +1141,34 @@ def _load_hermes_openviking_config() -> dict:
         return {}
 
 
-def _env_value(name: str) -> Optional[str]:
-    return os.environ[name].strip() if name in os.environ else None
+def _env_value(name: str, env: Optional[dict] = None) -> Optional[str]:
+    source = os.environ if env is None else env
+    if name in source:
+        return source[name].strip()
+    return None
+
+
+def _profile_openviking_env(hermes_home: Optional[str]) -> Optional[dict]:
+    if not hermes_home:
+        return None
+    home = Path(hermes_home)
+    try:
+        from hermes_cli.env_loader import hydrate_profile_secret_sources
+        from agent.secret_scope import build_profile_secret_scope
+
+        # The shared hydrator is cached once per profile home. Calling it here
+        # is safe for reloads and covers provider initialization paths that do
+        # not enter the gateway's broader profile runtime scope.
+        hydrate_profile_secret_sources(home)
+        return build_profile_secret_scope(home)
+    except Exception as exc:
+        logger.warning(
+            "OpenViking profile secret-source hydration failed for %s (%s); "
+            "continuing without profile secrets.",
+            home,
+            type(exc).__name__,
+        )
+        return {}
 
 
 def _first_nonempty(*values: Optional[str], default: str = "") -> str:
@@ -1117,38 +1178,54 @@ def _first_nonempty(*values: Optional[str], default: str = "") -> str:
     return default
 
 
-def _resolve_connection_settings(provider_config: Optional[dict] = None) -> dict:
+def _resolve_connection_settings(
+    provider_config: Optional[dict] = None, *, env: Optional[dict] = None
+) -> dict:
     provider_config = dict(provider_config or {})
     ovcli_values: dict = {}
     if provider_config.get("use_ovcli_config"):
-        ovcli_path = _resolve_ovcli_config_path(str(provider_config.get("ovcli_config_path") or ""))
+        ovcli_path = _resolve_ovcli_config_path(
+            str(provider_config.get("ovcli_config_path") or ""), env=env
+        )
         ovcli_values = _connection_values_from_ovcli(_load_ovcli_config(ovcli_path))
 
-    endpoint_env = _env_value("OPENVIKING_ENDPOINT")
-    api_key_env = _env_value("OPENVIKING_API_KEY")
-    account_env = _env_value("OPENVIKING_ACCOUNT")
-    user_env = _env_value("OPENVIKING_USER")
-    agent_env = _env_value("OPENVIKING_AGENT")
+    endpoint_env = _env_value("OPENVIKING_ENDPOINT", env)
+    process_endpoint = None
+    if env is not None and "OPENVIKING_ENDPOINT" not in env:
+        process_endpoint = _env_value("OPENVIKING_ENDPOINT")
+    api_key_env = _env_value("OPENVIKING_API_KEY", env)
+    account_env = _env_value("OPENVIKING_ACCOUNT", env)
+    user_env = _env_value("OPENVIKING_USER", env)
+    agent_env = _env_value("OPENVIKING_AGENT", env)
 
     # Non-secret fields fall back to config.yaml (e.g. the Dashboard writes
-    # ``memory.openviking.endpoint`` there) before the built-in default, so the
-    # full chain is env -> ovcli -> config.yaml -> default. The secret api_key is
+    # ``memory.openviking.endpoint`` there) before the built-in default. Bound
+    # profiles add the legacy process endpoint only after profile-owned config;
+    # credentials never use that process fallback. The secret api_key is
     # sourced from the environment (synced from .env), never from config.yaml.
     endpoint = _first_nonempty(
         endpoint_env,
         ovcli_values.get("endpoint"),
         _clean_config_value(provider_config.get("endpoint")),
+        process_endpoint,
         default=_DEFAULT_ENDPOINT,
     )
+    api_key = api_key_env if api_key_env is not None else ovcli_values.get("api_key", "")
+    account = account_env if account_env is not None else _first_nonempty(
+        ovcli_values.get("account"), _clean_config_value(provider_config.get("account"))
+    )
+    user = user_env if user_env is not None else _first_nonempty(
+        ovcli_values.get("user"), _clean_config_value(provider_config.get("user"))
+    )
+    if env is not None and not api_key:
+        account = account or "default"
+        user = user or "default"
+
     return {
         "endpoint": _normalize_openviking_url(endpoint),
-        "api_key": api_key_env if api_key_env is not None else ovcli_values.get("api_key", ""),
-        "account": account_env if account_env is not None else _first_nonempty(
-            ovcli_values.get("account"), _clean_config_value(provider_config.get("account"))
-        ),
-        "user": user_env if user_env is not None else _first_nonempty(
-            ovcli_values.get("user"), _clean_config_value(provider_config.get("user"))
-        ),
+        "api_key": api_key,
+        "account": account,
+        "user": user,
         "agent": _first_nonempty(
             agent_env,
             ovcli_values.get("agent"),
@@ -2213,6 +2290,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._session_id = ""
         self._turn_count = 0
         self._hermes_home = ""
+        self._hermes_home_bound = False
         self._run_id = uuid.uuid4().hex
         self._run_lock_file: Optional[Any] = None
         self._run_lock_path: Optional[Path] = None
@@ -2267,7 +2345,42 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return "openviking"
 
     def is_available(self) -> bool:
-        """Check if OpenViking endpoint is configured. No network calls."""
+        """Check if OpenViking is configured without probing the server."""
+        try:
+            from hermes_constants import get_hermes_home_override
+
+            active_home = get_hermes_home_override()
+        except Exception:
+            active_home = None
+        if active_home:
+            from agent.secret_scope import load_env_file
+
+            profile_env = load_env_file(Path(active_home) / ".env")
+            provider_config = _load_hermes_openviking_config(active_home)
+            if profile_env and profile_env.get("OPENVIKING_ENDPOINT", "").strip():
+                return True
+            if (
+                profile_env is not None
+                and "OPENVIKING_ENDPOINT" not in profile_env
+                and os.environ.get("OPENVIKING_ENDPOINT", "").strip()
+            ):
+                return True
+            if _clean_config_value(provider_config.get("endpoint")):
+                return True
+            if not provider_config.get("use_ovcli_config"):
+                return False
+            try:
+                ovcli_path = _resolve_ovcli_config_path(
+                    str(provider_config.get("ovcli_config_path") or ""),
+                    env=profile_env,
+                )
+                return bool(
+                    _connection_values_from_ovcli(_load_ovcli_config(ovcli_path)).get(
+                        "endpoint"
+                    )
+                )
+            except Exception:
+                return False
         if os.environ.get("OPENVIKING_ENDPOINT"):
             return True
         provider_config = _load_hermes_openviking_config()
@@ -2314,8 +2427,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
             {
                 "key": "agent",
                 "description": (
-                    "Hermes peer ID in OpenViking, sent as the actor peer and "
-                    "used for peer-scoped memories"
+                    "Peer identity sent through X-OpenViking-Actor-Peer; OpenViking "
+                    "applies its account namespace policy"
                 ),
                 "default": "hermes",
                 "env_var": "OPENVIKING_AGENT",
@@ -2698,9 +2811,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if kwargs.get("platform") == "cli"
             else None
         )
+        requested_home = str(kwargs.get("hermes_home") or "").strip()
+        hermes_home = requested_home
+        if not hermes_home:
+            try:
+                from hermes_constants import get_hermes_home
+                hermes_home = str(get_hermes_home())
+            except Exception:
+                hermes_home = str(Path.home() / ".hermes")
+        self._hermes_home = hermes_home
+        self._hermes_home_bound = bool(requested_home)
         connection_error = ""
         try:
-            settings = _resolve_connection_settings(_load_hermes_openviking_config())
+            settings = self._resolve_bound_connection_settings()
         except _OpenVikingEndpointError as exc:
             connection_error = str(exc)
             settings = {
@@ -2722,14 +2845,6 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._env_refresh_enabled = True
         self._session_id = session_id
         self._turn_count = 0
-        hermes_home = str(kwargs.get("hermes_home") or "").strip()
-        if not hermes_home:
-            try:
-                from hermes_constants import get_hermes_home
-                hermes_home = str(get_hermes_home())
-            except Exception:
-                hermes_home = str(Path.home() / ".hermes")
-        self._hermes_home = hermes_home
         self._acquire_run_lock()
         self._profile_prefetched_sessions.clear()
 
@@ -2801,6 +2916,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
         with self._client_refresh_lock:
             return self._ensure_client_locked()
 
+    def _resolve_bound_connection_settings(self) -> dict:
+        provider_config, profile_env = self._profile_config_and_env()
+        return _resolve_connection_settings(provider_config, env=profile_env)
+
+    def _profile_config_and_env(self) -> tuple[dict, Optional[dict]]:
+        home = self._hermes_home if self._hermes_home_bound else None
+        provider_config = (
+            _load_hermes_openviking_config(home)
+            if home
+            else _load_hermes_openviking_config()
+        )
+        return provider_config, _profile_openviking_env(home)
+
     def _ensure_client_locked(self) -> Optional["_VikingClient"]:
         """Resolve and publish one client/config state under the refresh lock."""
         if self._shutting_down:
@@ -2808,7 +2936,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             return None
 
         try:
-            settings = _resolve_connection_settings(_load_hermes_openviking_config())
+            settings = self._resolve_bound_connection_settings()
         except _OpenVikingEndpointError as exc:
             failed_key = ("invalid-endpoint", str(exc))
             failed = self._failed_refresh
@@ -3613,8 +3741,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
         logger.warning("Invalid %s value %r; using default %r.", source, value, default)
 
     @staticmethod
-    def _setting_value(env_name: str, config_value: Any) -> tuple[Any, str]:
-        env_value = os.environ.get(env_name)
+    def _setting_value(
+        env_name: str,
+        config_value: Any,
+        *,
+        env: Optional[dict] = None,
+    ) -> tuple[Any, str]:
+        env_value = _env_value(env_name, env)
         if env_value is not None and env_value.strip():
             return env_value, env_name
         config_key = env_name.removeprefix("OPENVIKING_").lower()
@@ -3627,8 +3760,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
         config_value: Any,
         *,
         default: bool,
+        env: Optional[dict] = None,
     ) -> bool:
-        value, source = cls._setting_value(env_name, config_value)
+        value, source = cls._setting_value(env_name, config_value, env=env)
         if isinstance(value, bool):
             return value
         if isinstance(value, str):
@@ -3649,8 +3783,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
         default: int,
         minimum: int,
         maximum: int,
+        env: Optional[dict] = None,
     ) -> int:
-        value, source = cls._setting_value(env_name, config_value)
+        value, source = cls._setting_value(env_name, config_value, env=env)
         try:
             if isinstance(value, bool):
                 raise ValueError
@@ -3672,8 +3807,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
         default: float,
         minimum: float,
         maximum: float,
+        env: Optional[dict] = None,
     ) -> float:
-        value, source = cls._setting_value(env_name, config_value)
+        value, source = cls._setting_value(env_name, config_value, env=env)
         try:
             if isinstance(value, bool):
                 raise ValueError
@@ -3688,7 +3824,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _recall_config(self) -> Dict[str, Any]:
         # Read from config.yaml → memory.openviking as primary source, env vars
         # as override. Behavioural settings belong in config.yaml (AGENTS.md).
-        provider_config = _load_hermes_openviking_config()
+        provider_config, profile_env = self._profile_config_and_env()
         cfg = provider_config
 
         return {
@@ -3697,57 +3833,66 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 cfg.get("recall_limit", _DEFAULT_RECALL_LIMIT),
                 default=_DEFAULT_RECALL_LIMIT,
                 minimum=1, maximum=100,
+                env=profile_env,
             ),
             "score_threshold": self._setting_float(
                 "OPENVIKING_RECALL_SCORE_THRESHOLD",
                 cfg.get("recall_score_threshold", _DEFAULT_RECALL_SCORE_THRESHOLD),
                 default=_DEFAULT_RECALL_SCORE_THRESHOLD,
                 minimum=0.0, maximum=1.0,
+                env=profile_env,
             ),
             "max_injected_chars": self._setting_int(
                 "OPENVIKING_RECALL_MAX_INJECTED_CHARS",
                 cfg.get("recall_max_injected_chars", _DEFAULT_RECALL_MAX_INJECTED_CHARS),
                 default=_DEFAULT_RECALL_MAX_INJECTED_CHARS,
                 minimum=100, maximum=50000,
+                env=profile_env,
             ),
             "timeout_seconds": self._setting_float(
                 "OPENVIKING_RECALL_TIMEOUT_SECONDS",
                 cfg.get("recall_timeout_seconds", _DEFAULT_RECALL_TIMEOUT_SECONDS),
                 default=_DEFAULT_RECALL_TIMEOUT_SECONDS,
                 minimum=0.25, maximum=60.0,
+                env=profile_env,
             ),
             "request_timeout_seconds": self._setting_float(
                 "OPENVIKING_RECALL_REQUEST_TIMEOUT_SECONDS",
                 cfg.get("recall_request_timeout_seconds", _DEFAULT_RECALL_REQUEST_TIMEOUT_SECONDS),
                 default=_DEFAULT_RECALL_REQUEST_TIMEOUT_SECONDS,
                 minimum=0.25, maximum=60.0,
+                env=profile_env,
             ),
             "full_read_limit": self._setting_int(
                 "OPENVIKING_RECALL_FULL_READ_LIMIT",
                 cfg.get("recall_full_read_limit", _DEFAULT_RECALL_FULL_READ_LIMIT),
                 default=_DEFAULT_RECALL_FULL_READ_LIMIT,
                 minimum=0, maximum=100,
+                env=profile_env,
             ),
             "prefer_abstract": self._setting_bool(
                 "OPENVIKING_RECALL_PREFER_ABSTRACT",
                 cfg.get("recall_prefer_abstract", False),
                 default=False,
+                env=profile_env,
             ),
             "resources": self._setting_bool(
                 "OPENVIKING_RECALL_RESOURCES",
                 cfg.get("recall_resources", False),
                 default=False,
+                env=profile_env,
             ),
         }
 
     def _profile_token_budget(self) -> int:
-        cfg = _load_hermes_openviking_config()
+        cfg, profile_env = self._profile_config_and_env()
         return self._setting_int(
             "OPENVIKING_PROFILE_TOKEN_BUDGET",
             cfg.get("profile_token_budget", _DEFAULT_PROFILE_TOKEN_BUDGET),
             default=_DEFAULT_PROFILE_TOKEN_BUDGET,
             minimum=500,
             maximum=50000,
+            env=profile_env,
         )
 
     @staticmethod
@@ -4752,9 +4897,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
         )
 
     def _build_memory_uri(self, subdir: str) -> str:
-        """Build a viking:// memory URI under the configured peer namespace."""
+        """Build a current-user shorthand memory URI."""
         slug = uuid.uuid4().hex[:12]
-        return f"viking://user/peers/{self._agent}/memories/{subdir}/mem_{slug}.md"
+        return f"viking://user/memories/{subdir}/mem_{slug}.md"
 
     def on_memory_write(
         self,
@@ -4957,7 +5102,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
     ) -> Dict[str, Any]:
         summary_level = level in {"abstract", "overview"}
         # OpenViking expects directory URIs for pseudo summary files
-        # (e.g. viking://user/hermes/.overview.md).
+        # (e.g. viking://user/memories/preferences/.overview.md).
         resolved_uri = self._normalize_summary_uri(uri) if summary_level else uri
         used_fallback = False
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1117,7 +1117,9 @@ def _is_local_openviking_url(value: str) -> bool:
     return scheme == "http" and (parsed.hostname or "").lower() in _LOCAL_OPENVIKING_HOSTS
 
 
-def _load_hermes_openviking_config(hermes_home: Optional[str] = None) -> dict:
+def _load_hermes_openviking_config(
+    hermes_home: Optional[str] = None, *, env: Optional[dict] = None
+) -> dict:
     try:
         from hermes_cli.config import load_config_readonly
 
@@ -1129,11 +1131,19 @@ def _load_hermes_openviking_config(hermes_home: Optional[str] = None) -> dict:
 
             home_token = set_hermes_home_override(hermes_home)
             try:
-                config = load_config_readonly()
+                config = (
+                    load_config_readonly(env=env)
+                    if env is not None
+                    else load_config_readonly()
+                )
             finally:
                 reset_hermes_home_override(home_token)
         else:
-            config = load_config_readonly()
+            config = (
+                load_config_readonly(env=env)
+                if env is not None
+                else load_config_readonly()
+            )
         memory_config = config.get("memory", {}) if isinstance(config, dict) else {}
         provider_config = memory_config.get("openviking", {}) if isinstance(memory_config, dict) else {}
         return dict(provider_config) if isinstance(provider_config, dict) else {}
@@ -1217,7 +1227,10 @@ def _resolve_connection_settings(
     user = user_env if user_env is not None else _first_nonempty(
         ovcli_values.get("user"), _clean_config_value(provider_config.get("user"))
     )
-    if env is not None and not api_key:
+    if not api_key:
+        # Intentional local/trusted-mode normalization at this settings boundary.
+        # _VikingClient preserves an explicit "" for the separate purpose of
+        # preventing ambient-process fallback when callers bypass this resolver.
         account = account or "default"
         user = user or "default"
 
@@ -1373,47 +1386,6 @@ def _validate_openviking_reachability(endpoint: str) -> tuple[bool, str]:
     return False, f"OpenViking server is not reachable at {endpoint}."
 
 
-def _validate_openviking_auth(values: dict) -> tuple[bool, str]:
-    try:
-        endpoint = _normalize_openviking_url(values.get("endpoint"))
-        client = _VikingClient(
-            endpoint,
-            _clean_config_value(values.get("api_key")),
-            account=_clean_config_value(values.get("account")),
-            user=_clean_config_value(values.get("user")),
-            agent=_clean_config_value(values.get("agent")) or _DEFAULT_AGENT,
-        )
-        client.validate_auth()
-    except Exception as e:
-        return False, f"OpenViking authentication validation failed: {_format_openviking_exception(e)}"
-    return True, ""
-
-
-def _validate_openviking_root_access(values: dict) -> tuple[bool, str]:
-    try:
-        endpoint = _normalize_openviking_url(values.get("endpoint"))
-        client = _VikingClient(
-            endpoint,
-            _clean_config_value(values.get("api_key")),
-            agent=_clean_config_value(values.get("agent")) or _DEFAULT_AGENT,
-        )
-        client.validate_root_access()
-    except Exception as e:
-        return False, f"OpenViking root API key validation failed: {_format_openviking_exception(e)}"
-    return True, ""
-
-
-def _validate_openviking_user_key_scope(values: dict) -> tuple[bool, str]:
-    root_ok, _message = _validate_openviking_root_access(values)
-    if not root_ok:
-        return True, ""
-    return (
-        False,
-        "That key has ROOT access. Choose Root API key and provide account/user, "
-        "or enter a user API key.",
-    )
-
-
 def _status_code_from_error(error: Exception) -> Optional[int]:
     if isinstance(error, _OpenVikingHTTPError):
         return error.status_code
@@ -1448,13 +1420,18 @@ def _validate_openviking_setup_values(
     api_key = _clean_config_value(values.get("api_key"))
     if require_api_key and not api_key:
         return False, "Remote OpenViking configs require an API key.", None
+    account = _clean_config_value(values.get("account"))
+    user = _clean_config_value(values.get("user"))
+    if not api_key:
+        account = account or "default"
+        user = user or "default"
 
     try:
         client = _VikingClient(
             endpoint,
             api_key,
-            account=_clean_config_value(values.get("account")),
-            user=_clean_config_value(values.get("user")),
+            account=account,
+            user=user,
             agent=_clean_config_value(values.get("agent")) or _DEFAULT_AGENT,
         )
         identity, health = _probe_openviking_identity(client)
@@ -2356,7 +2333,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
             from agent.secret_scope import load_env_file
 
             profile_env = load_env_file(Path(active_home) / ".env")
-            provider_config = _load_hermes_openviking_config(active_home)
+            provider_config = _load_hermes_openviking_config(
+                active_home, env=profile_env
+            )
             if profile_env and profile_env.get("OPENVIKING_ENDPOINT", "").strip():
                 return True
             if (
@@ -2922,12 +2901,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     def _profile_config_and_env(self) -> tuple[dict, Optional[dict]]:
         home = self._hermes_home if self._hermes_home_bound else None
+        profile_env = _profile_openviking_env(home)
         provider_config = (
-            _load_hermes_openviking_config(home)
+            _load_hermes_openviking_config(home, env=profile_env)
             if home
             else _load_hermes_openviking_config()
         )
-        return provider_config, _profile_openviking_env(home)
+        return provider_config, profile_env
 
     def _ensure_client_locked(self) -> Optional["_VikingClient"]:
         """Resolve and publish one client/config state under the refresh lock."""

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -89,6 +89,174 @@ class TestLoadConfigCacheEnvStaleness:
         assert first is second
         assert first["providers"]["mistral"]["api_key"] == "key-stable"
 
+    def test_explicit_environment_is_isolated_from_process_cache(
+        self, tmp_path, monkeypatch
+    ):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "values:\n"
+            "  bare: ${PROFILE_REF_83647}\n"
+            "  prefixed: ${env:PROFILE_REF_83647}\n"
+        )
+        monkeypatch.setenv("PROFILE_REF_83647", "process-b")
+        monkeypatch.setitem(load_config.__globals__, "get_config_path", lambda: config_file)
+
+        assert load_config(env={"PROFILE_REF_83647": "profile-a"})["values"] == {
+            "bare": "profile-a",
+            "prefixed": "profile-a",
+        }
+        assert load_config(env={})["values"] == {
+            "bare": "${PROFILE_REF_83647}",
+            "prefixed": "${env:PROFILE_REF_83647}",
+        }
+        assert load_config()["values"] == {
+            "bare": "process-b",
+            "prefixed": "process-b",
+        }
+
+    def test_explicit_environment_lkg_does_not_cross_profiles(
+        self, tmp_path, monkeypatch
+    ):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("model:\n  default: ${PROFILE_LKG_83647}\n")
+        monkeypatch.setenv("PROFILE_LKG_83647", "process-b")
+        monkeypatch.setitem(load_config.__globals__, "get_config_path", lambda: config_file)
+
+        assert load_config(env={"PROFILE_LKG_83647": "profile-a"})["model"]["default"] == (
+            "profile-a"
+        )
+        config_file.write_text("model: [broken")
+
+        assert load_config(env={"PROFILE_LKG_83647": "profile-a"})["model"]["default"] == (
+            "profile-a"
+        )
+        assert "profile-a" not in str(
+            load_config(env={"PROFILE_LKG_83647": "profile-b"})
+        )
+
+    def test_explicit_environment_keeps_managed_overlay_global(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        managed = tmp_path / "managed"
+        home.mkdir()
+        managed.mkdir()
+        config_file = home / "config.yaml"
+        config_file.write_text(
+            "model:\n"
+            "  default: user-${SHARED_CONFIG_REF}\n"
+            "auxiliary:\n"
+            "  vision:\n"
+            "    api_key: ${SHARED_CONFIG_REF}\n"
+        )
+        (managed / "config.yaml").write_text(
+            "model:\n  default: managed-${SHARED_CONFIG_REF}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+        monkeypatch.setenv("SHARED_CONFIG_REF", "process-b")
+        monkeypatch.setitem(load_config.__globals__, "get_config_path", lambda: config_file)
+
+        from hermes_cli import config as config_module, managed_scope
+
+        config_module._LOAD_CONFIG_CACHE.clear()
+        managed_scope.invalidate_managed_cache()
+        loaded = load_config(env={"SHARED_CONFIG_REF": "profile-a"})
+
+        assert loaded["model"]["default"] == "managed-process-b"
+        assert loaded["auxiliary"]["vision"]["api_key"] == "profile-a"
+
+    def test_explicit_environment_lkg_keeps_unresolved_managed_ref(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        managed = tmp_path / "managed"
+        home.mkdir()
+        managed.mkdir()
+        config_file = home / "config.yaml"
+        config_file.write_text("model:\n  default: user-${MANAGED_LKG_REF_83647}\n")
+        (managed / "config.yaml").write_text(
+            "model:\n  default: managed-${MANAGED_LKG_REF_83647}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+        monkeypatch.delenv("MANAGED_LKG_REF_83647", raising=False)
+        monkeypatch.setitem(load_config.__globals__, "get_config_path", lambda: config_file)
+
+        from hermes_cli import config as config_module, managed_scope
+
+        config_module._LOAD_CONFIG_CACHE.clear()
+        managed_scope.invalidate_managed_cache()
+        profile_env = {"MANAGED_LKG_REF_83647": "profile-a"}
+
+        assert load_config(env=profile_env)["model"]["default"] == (
+            "managed-${MANAGED_LKG_REF_83647}"
+        )
+        config_file.write_text("model: [broken")
+
+        assert load_config(env=profile_env)["model"]["default"] == (
+            "managed-${MANAGED_LKG_REF_83647}"
+        )
+
+    def test_explicit_environment_lkg_refreshes_rotated_managed_ref(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        managed = tmp_path / "managed"
+        home.mkdir()
+        managed.mkdir()
+        config_file = home / "config.yaml"
+        config_file.write_text(
+            "model:\n  default: user-${MANAGED_LKG_ROTATE_REF_83647}\n"
+        )
+        (managed / "config.yaml").write_text(
+            "model:\n  default: managed-${MANAGED_LKG_ROTATE_REF_83647}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+        monkeypatch.setenv("MANAGED_LKG_ROTATE_REF_83647", "process-a")
+        monkeypatch.setitem(load_config.__globals__, "get_config_path", lambda: config_file)
+
+        from hermes_cli import config as config_module, managed_scope
+
+        config_module._LOAD_CONFIG_CACHE.clear()
+        managed_scope.invalidate_managed_cache()
+        profile_env = {"MANAGED_LKG_ROTATE_REF_83647": "profile-value"}
+
+        assert load_config(env=profile_env)["model"]["default"] == "managed-process-a"
+        monkeypatch.setenv("MANAGED_LKG_ROTATE_REF_83647", "process-b")
+        config_file.write_text("model: [broken")
+
+        loaded = load_config(env=profile_env)
+        assert loaded["model"]["default"] == "managed-process-b"
+        assert "process-a" not in str(loaded)
+        assert "profile-value" not in str(loaded)
+
+    def test_explicit_environment_lkg_tracks_only_referenced_values(
+        self, tmp_path, monkeypatch
+    ):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("model:\n  default: ${PROFILE_REF_83647}\n")
+        monkeypatch.setitem(load_config.__globals__, "get_config_path", lambda: config_file)
+
+        from hermes_cli import config as config_module
+
+        env = {
+            "PROFILE_REF_83647": "profile-a",
+            "OPENVIKING_API_KEY": "unreferenced-openviking-sentinel",
+        }
+        load_config(env=env)
+
+        user_snapshot, managed_snapshot, expanded = (
+            config_module._LAST_EXPANDED_CONFIG_BY_EXPLICIT_ENV[str(config_file)]
+        )
+        assert user_snapshot == {"PROFILE_REF_83647": "profile-a"}
+        assert managed_snapshot == {}
+        assert "OPENVIKING_API_KEY" not in user_snapshot
+        assert "unreferenced-openviking-sentinel" not in repr(
+            (user_snapshot, managed_snapshot, expanded)
+        )
+
 
 class TestLoadCliConfigExpansion:
     """Verify that load_cli_config() also expands ${VAR} references."""

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -8,6 +8,8 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
 
+import pytest
+
 import plugins.memory.openviking as openviking_plugin
 from plugins.memory.openviking import OpenVikingMemoryProvider
 
@@ -339,6 +341,43 @@ memory:
         assert cfg["prefer_abstract"] is True
         assert cfg["resources"] is True
         assert provider._profile_token_budget() == 7000
+
+    def test_bound_recall_config_uses_initialized_home_outside_active_context(
+        self, monkeypatch, tmp_path
+    ):
+        hermes_home = tmp_path / "profile"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            """\
+memory:
+  openviking:
+    recall_limit: 11
+    profile_token_budget: 7100
+""",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("OPENVIKING_RECALL_LIMIT", "99")
+        monkeypatch.setenv("OPENVIKING_PROFILE_TOKEN_BUDGET", "9000")
+
+        provider = OpenVikingMemoryProvider()
+        provider._hermes_home = str(hermes_home)
+        provider._hermes_home_bound = True
+
+        assert provider._recall_config()["limit"] == 11
+        assert provider._profile_token_budget() == 7100
+
+        (hermes_home / "config.yaml").write_text(
+            """\
+memory:
+  openviking:
+    recall_limit: 12
+    profile_token_budget: 7200
+""",
+            encoding="utf-8",
+        )
+
+        assert provider._recall_config()["limit"] == 12
+        assert provider._profile_token_budget() == 7200
 
     def test_recall_config_env_overrides_config_yaml(self, monkeypatch, tmp_path):
         """Env vars OPENVIKING_RECALL_* take precedence over config.yaml values
@@ -778,6 +817,7 @@ class TestOpenVikingAutoRecallPrefetch:
             for headers in records["headers"]
         ]
         assert all(headers.get("x-openviking-actor-peer") == "hermes" for headers in normalized_headers)
+        assert all("x-openviking-agent" not in headers for headers in normalized_headers)
         assert all(headers.get("x-openviking-account") == "acct" for headers in normalized_headers)
         assert all(headers.get("x-openviking-user") == "user" for headers in normalized_headers)
 
@@ -815,11 +855,7 @@ class TestOpenVikingBrowse:
 
 
 class TestOpenVikingMemoryUriBuilder:
-    """Regression tests for _build_memory_uri — fixes #36969.
-
-    OpenViking's current memory layout stores peer-scoped memories under
-    viking://user/peers/{peer_id}/...
-    """
+    """Regression tests for current-user shorthand explicit memory writes."""
 
     def _make_provider(self, user="alice", agent="coder"):
         p = OpenVikingMemoryProvider.__new__(OpenVikingMemoryProvider)
@@ -827,13 +863,14 @@ class TestOpenVikingMemoryUriBuilder:
         p._agent = agent
         return p
 
-    def test_uri_layout_includes_peer_segment(self):
-        """URI must contain /peers/{peer_id}/ between user and memories."""
+    def test_uri_layout_uses_current_user_shorthand(self):
+        """URI must leave user and agent resolution to OpenViking."""
         p = self._make_provider(user="alice", agent="coder")
         uri = p._build_memory_uri("preferences")
-        assert uri.startswith("viking://user/peers/coder/memories/preferences/mem_")
+        assert uri.startswith("viking://user/memories/preferences/mem_")
+        assert "/alice/" not in uri
+        assert "/coder/" not in uri
         assert uri.endswith(".md")
-
 
 # ===================================================================
 # Issue #21130 — OPENVIKING_* not reloaded after /reload
@@ -842,6 +879,199 @@ class TestOpenVikingMemoryUriBuilder:
 
 class TestEnsureClientReloadsEnv:
     """Verify /reload picks up new OPENVIKING_* values without a restart (#21130)."""
+
+    def test_bound_profiles_keep_write_identity_when_global_env_interleaves(
+        self, monkeypatch, tmp_path
+    ):
+        instances = []
+
+        class _RecordingClient:
+            def __init__(self, endpoint, api_key="", account="", user="", agent="hermes"):
+                self.endpoint = endpoint
+                self.api_key = api_key
+                self.account = account
+                self.user = user
+                self.agent = agent
+                self.posts = []
+                instances.append(self)
+
+            def health(self):
+                return True
+
+            def post(self, path, payload=None, **kwargs):
+                self.posts.append((path, payload or {}))
+                return {"result": {"written_bytes": 7}}
+
+        def write_profile(home, endpoint, key, account, user, agent):
+            home.mkdir(exist_ok=True)
+            (home / ".env").write_text(
+                f"OPENVIKING_API_KEY={key}\n"
+                f"OPENVIKING_ACCOUNT={account}\n"
+                f"OPENVIKING_USER={user}\n"
+                f"OPENVIKING_AGENT={agent}\n",
+                encoding="utf-8",
+            )
+            (home / "config.yaml").write_text(
+                f"memory:\n  openviking:\n    endpoint: {endpoint}\n",
+                encoding="utf-8",
+            )
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        write_profile(home_a, "https://a.example", "key-a", "acct-a", "user-a", "agent-a")
+        write_profile(home_b, "https://b.example", "key-b", "acct-b", "user-b", "agent-b")
+
+        monkeypatch.setattr(openviking_plugin, "_VikingClient", _RecordingClient)
+        monkeypatch.setenv("HERMES_HOME", str(home_b))
+        for key, value in {
+            "OPENVIKING_ENDPOINT": "https://global.example",
+            "OPENVIKING_API_KEY": "key-global",
+            "OPENVIKING_ACCOUNT": "acct-global",
+            "OPENVIKING_USER": "user-global",
+            "OPENVIKING_AGENT": "agent-global",
+        }.items():
+            monkeypatch.setenv(key, value)
+
+        provider_a = OpenVikingMemoryProvider()
+        provider_b = OpenVikingMemoryProvider()
+        provider_a.initialize("session-a", hermes_home=str(home_a))
+        provider_b.initialize("session-b", hermes_home=str(home_b))
+
+        for key, value in {
+            "OPENVIKING_ENDPOINT": "https://interleaved.example",
+            "OPENVIKING_API_KEY": "key-interleaved",
+            "OPENVIKING_ACCOUNT": "acct-interleaved",
+            "OPENVIKING_USER": "user-interleaved",
+            "OPENVIKING_AGENT": "agent-interleaved",
+        }.items():
+            monkeypatch.setenv(key, value)
+
+        for provider, expected, content in (
+            (provider_a, ("https://a.example", "key-a", "acct-a", "user-a", "agent-a"), "fact-a"),
+            (provider_b, ("https://b.example", "key-b", "acct-b", "user-b", "agent-b"), "fact-b"),
+        ):
+            result = json.loads(provider.handle_tool_call(
+                "viking_remember", {"content": content, "category": "preference"}
+            ))
+            assert result["status"] == "stored"
+            client = provider._client
+            assert (client.endpoint, client.api_key, client.account, client.user, client.agent) == expected
+            assert client.posts[-1][0] == "/api/v1/content/write"
+            assert client.posts[-1][1]["uri"].startswith(
+                "viking://user/memories/preferences/mem_"
+            )
+
+        assert len(instances) == 2
+
+        write_profile(home_a, "https://a-reloaded.example", "key-a2", "acct-a2", "user-a2", "agent-a2")
+        result = json.loads(provider_a.handle_tool_call(
+            "viking_remember", {"content": "fact-a2", "category": "entity"}
+        ))
+        assert result["status"] == "stored"
+        assert len(instances) == 3
+        assert provider_a._client.endpoint == "https://a-reloaded.example"
+        assert provider_a._client.api_key == "key-a2"
+        assert provider_a._client.posts[-1][1]["uri"].startswith(
+            "viking://user/memories/entities/mem_"
+        )
+        assert provider_b._ensure_client() is instances[1]
+        assert len(instances) == 3
+
+        provider_a.shutdown()
+        provider_b.shutdown()
+
+    @pytest.mark.parametrize(
+        ("profile_env", "expected_api_key", "expected_account", "expected_user"),
+        [
+            ("", "", "default", "default"),
+            ("OPENVIKING_API_KEY=profile-key\n", "profile-key", "", ""),
+        ],
+    )
+    def test_bound_profile_identity_does_not_use_ambient_values(
+        self,
+        monkeypatch,
+        tmp_path,
+        profile_env,
+        expected_api_key,
+        expected_account,
+        expected_user,
+    ):
+        class _RecordingClient:
+            def __init__(self, endpoint, api_key="", account="", user="", agent="hermes"):
+                self.endpoint = endpoint
+                self.api_key = api_key
+                self.account = account
+                self.user = user
+                self.agent = agent
+
+            def health(self):
+                return True
+
+        home = tmp_path / "profile"
+        home.mkdir()
+        if profile_env:
+            (home / ".env").write_text(profile_env, encoding="utf-8")
+        (home / "config.yaml").write_text(
+            "memory:\n  openviking:\n    endpoint: https://profile.example\n",
+            encoding="utf-8",
+        )
+        client_class = openviking_plugin._VikingClient
+        monkeypatch.setattr(openviking_plugin, "_VikingClient", _RecordingClient)
+        for key, value in {
+            "OPENVIKING_ENDPOINT": "https://ambient.example",
+            "OPENVIKING_API_KEY": "ambient-key",
+            "OPENVIKING_ACCOUNT": "ambient-account",
+            "OPENVIKING_USER": "ambient-user",
+            "OPENVIKING_AGENT": "ambient-agent",
+        }.items():
+            monkeypatch.setenv(key, value)
+
+        provider = OpenVikingMemoryProvider()
+        provider.initialize("session", hermes_home=str(home))
+
+        assert provider._client.endpoint == "https://profile.example"
+        assert provider._client.api_key == expected_api_key
+        assert provider._client.account == expected_account
+        assert provider._client.user == expected_user
+        assert provider._client.agent == "hermes"
+        headers = client_class(
+            provider._endpoint,
+            provider._api_key,
+            account=provider._account,
+            user=provider._user,
+            agent=provider._agent,
+        )._headers()
+        if expected_api_key:
+            assert "X-OpenViking-Account" not in headers
+            assert "X-OpenViking-User" not in headers
+        else:
+            assert headers["X-OpenViking-Account"] == "default"
+            assert headers["X-OpenViking-User"] == "default"
+        provider.shutdown()
+
+    def test_explicit_empty_identity_does_not_fall_back_to_process_env(self, monkeypatch):
+        for key, value in {
+            "OPENVIKING_ACCOUNT": "ambient-account",
+            "OPENVIKING_USER": "ambient-user",
+            "OPENVIKING_AGENT": "ambient-agent",
+        }.items():
+            monkeypatch.setenv(key, value)
+
+        client = openviking_plugin._VikingClient(
+            "https://openviking.example",
+            account="",
+            user="",
+            agent="",
+        )
+
+        assert client._account == ""
+        assert client._user == ""
+        assert client._agent == ""
+
+        legacy = openviking_plugin._VikingClient("https://openviking.example")
+        assert legacy._account == "ambient-account"
+        assert legacy._user == "ambient-user"
+        assert legacy._agent == "ambient-agent"
 
     def test_ensure_client_rebuilds_when_api_key_changes(self, monkeypatch):
         constructions = []
@@ -904,6 +1134,8 @@ class TestEnsureClientReloadsEnv:
         monkeypatch.setattr("plugins.memory.openviking._VikingClient", _StubClient)
         monkeypatch.setenv("OPENVIKING_ENDPOINT", "https://openviking.example")
         monkeypatch.setenv("OPENVIKING_API_KEY", "sk-test")
+        monkeypatch.setenv("OPENVIKING_USER", "justin")
+        monkeypatch.setenv("OPENVIKING_AGENT", "hermes")
 
         provider = OpenVikingMemoryProvider()
         provider.initialize("session-1")
@@ -921,7 +1153,7 @@ class TestEnsureClientReloadsEnv:
         assert instances[1].posts[0][1]["content"] == "stable fact"
         assert instances[1].posts[0][1]["mode"] == "create"
         assert instances[1].posts[0][1]["uri"].startswith(
-            "viking://user/peers/hermes/memories/"
+            "viking://user/memories/"
         )
 
     def test_concurrent_refresh_does_not_return_stale_client(self, monkeypatch):

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -5,6 +5,7 @@ import stat
 import threading
 import time
 import zipfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -84,37 +85,132 @@ def _allow_setup_validation(monkeypatch, *, root_access: bool = False):
     )
 
 
-def test_openviking_provider_config_loader_uses_readonly_config(monkeypatch):
-    import hermes_cli.config as config_mod
+def test_openviking_provider_config_loader_keeps_full_home_semantics(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    ambient_home = tmp_path / "ambient"
+    ambient_home.mkdir()
+    managed_home = tmp_path / "managed"
+    managed_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        """\
+memory:
+  openviking:
+    endpoint: ${OPENVIKING_TEST_ENDPOINT}
+    recall_limit: 3
+""",
+        encoding="utf-8",
+    )
+    (managed_home / "config.yaml").write_text(
+        """\
+memory:
+  openviking:
+    recall_limit: 9
+""",
+        encoding="utf-8",
+    )
+    (ambient_home / "config.yaml").write_text(
+        "memory:\n  openviking:\n    endpoint: https://ambient.test\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENVIKING_TEST_ENDPOINT", "https://expanded.test")
+    monkeypatch.setenv("HERMES_HOME", str(ambient_home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_home))
 
-    calls = []
-    backing_config = {
-        "memory": {
-            "openviking": {
-                "endpoint": "http://127.0.0.1:19472",
-                "api_key": "test-key",
-            }
-        }
-    }
+    config = openviking_module._load_hermes_openviking_config(str(hermes_home))
 
-    def load_config_readonly():
-        calls.append("readonly")
-        return backing_config
+    assert config["endpoint"] == "https://expanded.test"
+    assert config["recall_limit"] == 9
 
-    def load_config():
-        raise AssertionError("OpenViking config loader should use readonly config")
+    (hermes_home / "config.yaml").write_text(
+        """\
+memory:
+  openviking:
+    endpoint: https://reloaded.test
+    recall_limit: 4
+""",
+        encoding="utf-8",
+    )
+    reloaded = openviking_module._load_hermes_openviking_config(str(hermes_home))
 
-    monkeypatch.setattr(config_mod, "load_config_readonly", load_config_readonly)
-    monkeypatch.setattr(config_mod, "load_config", load_config)
+    assert reloaded["endpoint"] == "https://reloaded.test"
+    assert reloaded["recall_limit"] == 9
 
-    config = openviking_module._load_hermes_openviking_config()
 
-    assert calls == ["readonly"]
-    assert config == {
-        "endpoint": "http://127.0.0.1:19472",
-        "api_key": "test-key",
-    }
-    assert config is not backing_config["memory"]["openviking"]
+def test_profile_openviking_env_hydrates_external_secrets_once(tmp_path, monkeypatch):
+    from hermes_cli import env_loader
+
+    import agent.secret_sources.bitwarden as bitwarden_module
+    from agent.secret_sources import registry as registry_module
+
+    monkeypatch.delenv("BWS_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("OPENVIKING_API_KEY", raising=False)
+    (tmp_path / ".env").write_text("BWS_ACCESS_TOKEN=profile-bootstrap\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        "memory:\n"
+        "  openviking:\n"
+        "    endpoint: https://profile.test\n"
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    fetches = []
+    monkeypatch.setattr(bitwarden_module, "find_bws", lambda **_kwargs: Path("/fake/bws"))
+
+    def _fake_fetch(**kwargs):
+        fetches.append(kwargs)
+        return {"OPENVIKING_API_KEY": "profile-provider-key"}, []
+
+    monkeypatch.setattr(bitwarden_module, "fetch_bitwarden_secrets", _fake_fetch)
+    registry_module._reset_registry_for_tests()
+    env_loader.reset_secret_source_cache()
+
+    class _HealthyClient:
+        def __init__(self, endpoint, api_key="", **_kwargs):
+            self.endpoint = endpoint
+            self.api_key = api_key
+
+        def health(self):
+            return True
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", _HealthyClient)
+    provider = OpenVikingMemoryProvider()
+    try:
+        provider.initialize("session", hermes_home=str(tmp_path))
+        assert provider._endpoint == "https://profile.test"
+        assert provider._api_key == "profile-provider-key"
+        assert openviking_module._profile_openviking_env(str(tmp_path))["OPENVIKING_API_KEY"] == (
+            "profile-provider-key"
+        )
+        assert len(fetches) == 1
+    finally:
+        provider.shutdown()
+        env_loader.reset_secret_source_cache()
+        registry_module._reset_registry_for_tests()
+
+
+def test_profile_openviking_env_warns_without_secret_values(tmp_path, monkeypatch, caplog):
+    from hermes_cli import env_loader
+
+    secret_value = "do-not-log-this"
+
+    def _fail(_home):
+        raise RuntimeError(secret_value)
+
+    monkeypatch.setattr(env_loader, "hydrate_profile_secret_sources", _fail)
+
+    with caplog.at_level("WARNING", logger=openviking_module.__name__):
+        assert openviking_module._profile_openviking_env(str(tmp_path)) == {}
+
+    assert str(tmp_path) in caplog.text
+    assert "RuntimeError" in caplog.text
+    assert secret_value not in caplog.text
 
 
 def test_connection_settings_read_dashboard_config_file(tmp_path, monkeypatch):
@@ -738,6 +834,7 @@ def test_viking_client_delete_uses_identity_headers(monkeypatch):
     assert captured["kwargs"]["params"] == {"uri": "viking://user/memories/x.md"}
     assert captured["kwargs"]["headers"]["Authorization"] == "Bearer test-key"
     assert captured["kwargs"]["headers"]["X-OpenViking-Actor-Peer"] == "hermes"
+    assert "X-OpenViking-Agent" not in captured["kwargs"]["headers"]
 
 
 def test_openviking_identity_probes_are_anonymous_before_authenticated_requests(monkeypatch):
@@ -1631,6 +1728,26 @@ def test_blocked_endpoint_does_not_fall_back_or_construct_client(monkeypatch, tm
     assert openviking_module._DEFAULT_ENDPOINT not in warnings[0]
 
 
+def test_bound_profile_keeps_safe_process_endpoint_fallback(monkeypatch, tmp_path):
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "https://legacy-endpoint.example")
+
+    class _HealthyClient:
+        def __init__(self, endpoint, *args, **kwargs):
+            self.endpoint = endpoint
+
+        def health(self):
+            return True
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", _HealthyClient)
+    provider = OpenVikingMemoryProvider()
+
+    provider.initialize("session-1", hermes_home=str(tmp_path))
+
+    assert provider._endpoint == "https://legacy-endpoint.example"
+    provider.shutdown()
+
+
 @pytest.mark.parametrize(
     "health_payload",
     [
@@ -1692,6 +1809,33 @@ def test_is_available_true_for_config_yaml_endpoint(monkeypatch):
         lambda: {"endpoint": "http://saved.test:1933"},
     )
     assert OpenVikingMemoryProvider().is_available() is True
+
+
+def test_is_available_reads_active_profile_env_without_global_mutation(
+    monkeypatch, tmp_path
+):
+    _clear_openviking_env(monkeypatch)
+    from hermes_cli import env_loader
+
+    hydrate_calls = []
+    monkeypatch.setattr(
+        env_loader,
+        "hydrate_profile_secret_sources",
+        lambda home: hydrate_calls.append(home),
+    )
+    (tmp_path / ".env").write_text(
+        "OPENVIKING_ENDPOINT=https://profile.test\n", encoding="utf-8"
+    )
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    home_token = set_hermes_home_override(tmp_path)
+    try:
+        assert OpenVikingMemoryProvider().is_available() is True
+    finally:
+        reset_hermes_home_override(home_token)
+    assert os.environ.get("OPENVIKING_ENDPOINT") is None
+    assert hydrate_calls == []
 
 
 def test_is_available_false_without_any_endpoint(monkeypatch):

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -19,11 +19,6 @@ from plugins.memory.openviking import (
 )
 
 
-def _clear_openviking_tenant_env(monkeypatch):
-    for name in ("OPENVIKING_ACCOUNT", "OPENVIKING_USER", "OPENVIKING_AGENT"):
-        monkeypatch.delenv(name, raising=False)
-
-
 @pytest.fixture(autouse=True)
 def _isolate_openviking_home(tmp_path, monkeypatch):
     home = tmp_path / "home"
@@ -41,48 +36,6 @@ def _clear_openviking_env(monkeypatch):
         "OPENVIKING_PROFILE_TOKEN_BUDGET",
     ):
         monkeypatch.delenv(key, raising=False)
-
-
-def _prompt_from_values(values: dict[str, str], *, forbidden: set[str] | None = None):
-    forbidden = forbidden or set()
-
-    def _prompt(label, default=None, secret=False):
-        if label in forbidden:
-            raise AssertionError(f"{label} should not be prompted")
-        return values.get(label, default or "")
-
-    return _prompt
-
-
-def _allow_setup_validation(monkeypatch, *, root_access: bool = False):
-    monkeypatch.setattr(
-        openviking_module,
-        "_validate_openviking_reachability",
-        lambda endpoint: (True, ""),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        openviking_module,
-        "_validate_openviking_auth",
-        lambda values: (True, ""),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        openviking_module,
-        "_validate_openviking_root_access",
-        lambda values: (root_access, "" if root_access else "Requires role: root"),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        openviking_module,
-        "_validate_openviking_setup_values",
-        lambda values, *, require_api_key=False: (
-            True,
-            "",
-            "root" if root_access else ("user" if values.get("api_key") else None),
-        ),
-        raising=False,
-    )
 
 
 def test_openviking_provider_config_loader_keeps_full_home_semantics(
@@ -213,6 +166,70 @@ def test_profile_openviking_env_warns_without_secret_values(tmp_path, monkeypatc
     assert secret_value not in caplog.text
 
 
+def test_bound_profile_config_expands_against_its_profile_env(tmp_path, monkeypatch):
+    home = tmp_path / "profile-a"
+    home.mkdir()
+    (home / ".env").write_text(
+        "OPENVIKING_PROFILE_ENDPOINT=https://profile-a.example\n"
+        "OPENVIKING_PROFILE_AGENT=agent-a\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "memory:\n"
+        "  openviking:\n"
+        "    endpoint: ${env:OPENVIKING_PROFILE_ENDPOINT}\n"
+        "    agent: ${OPENVIKING_PROFILE_AGENT}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENVIKING_PROFILE_ENDPOINT", "https://process-b.example")
+    monkeypatch.setenv("OPENVIKING_PROFILE_AGENT", "agent-b")
+
+    class _HealthyClient:
+        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+            self.endpoint = endpoint
+            self.agent = agent
+
+        def health(self):
+            return True
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", _HealthyClient)
+    provider = OpenVikingMemoryProvider()
+    provider.initialize("session", hermes_home=str(home))
+    try:
+        assert provider._endpoint == "https://profile-a.example"
+        assert provider._agent == "agent-a"
+    finally:
+        provider.shutdown()
+
+
+def test_bound_profile_config_does_not_fall_back_to_process_env(tmp_path, monkeypatch):
+    home = tmp_path / "profile-a"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "memory:\n"
+        "  openviking:\n"
+        "    endpoint: https://profile-a.example\n"
+        "    agent: ${env:OPENVIKING_MISSING_REF}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENVIKING_MISSING_REF", "agent-b")
+
+    class _HealthyClient:
+        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+            self.agent = agent
+
+        def health(self):
+            return True
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", _HealthyClient)
+    provider = OpenVikingMemoryProvider()
+    provider.initialize("session", hermes_home=str(home))
+    try:
+        assert provider._agent == "${env:OPENVIKING_MISSING_REF}"
+    finally:
+        provider.shutdown()
+
+
 def test_connection_settings_read_dashboard_config_file(tmp_path, monkeypatch):
     _clear_openviking_env(monkeypatch)
     hermes_home = tmp_path / "hermes"
@@ -240,6 +257,20 @@ memory:
     assert settings["user"] == "saved-user"
     assert settings["agent"] == "saved-agent"
     assert settings["api_key"] == ""
+
+
+def test_unbound_no_key_settings_keep_trusted_identity_defaults(monkeypatch):
+    _clear_openviking_env(monkeypatch)
+
+    settings = openviking_module._resolve_connection_settings(
+        {"endpoint": "http://127.0.0.1:1933"}
+    )
+    headers = _VikingClient(**settings)._headers()
+
+    assert settings["account"] == "default"
+    assert settings["user"] == "default"
+    assert headers["X-OpenViking-Account"] == "default"
+    assert headers["X-OpenViking-User"] == "default"
 
 
 def test_linked_ovcli_config_is_read_at_runtime(tmp_path, monkeypatch):
@@ -881,6 +912,47 @@ def test_openviking_identity_probes_are_anonymous_before_authenticated_requests(
     for _url, headers in calls[2:]:
         assert headers["X-API-Key"] == "secret-key"
         assert headers["Authorization"] == "Bearer secret-key"
+        assert "X-OpenViking-Account" not in headers
+        assert "X-OpenViking-User" not in headers
+
+
+def test_openviking_setup_validation_defaults_trusted_identity(monkeypatch):
+    captured = {}
+
+    class RecordingVikingClient:
+        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+            captured.update(
+                endpoint=endpoint,
+                api_key=api_key,
+                account=account,
+                user=user,
+                agent=agent,
+            )
+
+        def health_payload(self):
+            return {"status": "ok", "healthy": True, "version": "0.2.10"}
+
+        def validate_auth(self):
+            return {}
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", RecordingVikingClient)
+
+    valid, message, role = openviking_module._validate_openviking_setup_values({
+        "endpoint": "https://openviking.example",
+        "api_key": "",
+        "account": "",
+        "user": "",
+        "agent": "hermes",
+    })
+
+    assert (valid, message, role) == (True, "", None)
+    assert captured == {
+        "endpoint": "https://openviking.example",
+        "api_key": "",
+        "account": "default",
+        "user": "default",
+        "agent": "hermes",
+    }
 
 
 def test_repeated_openviking_health_probes_never_send_identity_headers(monkeypatch):
@@ -1187,16 +1259,6 @@ def test_sync_turn_captures_session_id_before_worker_runs():
             {"role": "assistant", "parts": [{"type": "text", "text": "a"}], "peer_id": "hermes"},
         ]
     }]
-
-
-def _long_structured_turn(assistant_count=204):
-    return [
-        {"role": "user", "content": "u"},
-        *[
-            {"role": "assistant", "content": f"assistant-{index}"}
-            for index in range(assistant_count)
-        ],
-    ]
 
 
 def test_end_then_switch_does_not_double_commit():

--- a/tests/secret_sources/test_error_remediation.py
+++ b/tests/secret_sources/test_error_remediation.py
@@ -145,8 +145,9 @@ def test_env_loader_prints_remediation_hint(tmp_path, monkeypatch, capsys):
         env_loader.reset_secret_source_cache()
 
     err = capsys.readouterr().err
-    assert "rejected the machine-account access token" in err
+    assert "Bitwarden Secrets Manager: source failed (error_kind=auth_failed)" in err
     assert "hermes secrets bitwarden token" in err
+    assert "invalid_client" not in err
 
 
 def test_remediation_hint_uses_explicit_profile_scope(tmp_path, monkeypatch):

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -213,6 +213,63 @@ def test_cold_profile_hydration_seeds_op_env_bootstrap(tmp_path, monkeypatch):
     assert os.environ.get("OP_SERVICE_ACCOUNT_TOKEN") is None
 
 
+def test_cold_profile_hydration_reports_returned_source_outcomes_once(
+    tmp_path, monkeypatch, capsys
+):
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n  external:\n    enabled: true\n", encoding="utf-8"
+    )
+
+    from agent.secret_sources.base import ErrorKind, FetchResult
+    from agent.secret_sources.registry import ApplyReport, SourceReport
+    from agent.secret_sources import registry as reg_module
+
+    secret_value = "arbitrary-sentinel-secret"
+    remediation_calls = []
+
+    def _remediation_hint(name, error_kind, _cfg, *, scope=None):
+        remediation_calls.append((name, error_kind, scope))
+        return "check the source credentials"
+
+    monkeypatch.setattr(env_loader, "_remediation_hint", _remediation_hint)
+
+    def _fake_apply_all(_cfg, _home, environ=None):
+        return ApplyReport(
+            sources=[
+                SourceReport(
+                    name="external",
+                    label="External Source",
+                    result=FetchResult(
+                        secrets={"UNSAFE_API_KEY": secret_value},
+                        error=f"source unavailable: {secret_value}",
+                        error_kind=ErrorKind.NETWORK,
+                        warnings=[f"retry later: {secret_value}"],
+                    ),
+                    applied=["UNSAFE_API_KEY"],
+                )
+            ],
+            provenance={},
+            conflicts=["UNSAFE_API_KEY: conflict"],
+        )
+
+    monkeypatch.setattr(reg_module, "apply_all", _fake_apply_all)
+
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {}
+    output = capsys.readouterr().err
+    assert "External Source: applied 1 secret" in output
+    assert "External Source: source failed (error_kind=network)" in output
+    assert "check the source credentials" in output
+    assert "External Source: 1 warning" in output
+    assert "UNSAFE_API_KEY: conflict" in output
+    assert secret_value not in output
+    assert remediation_calls == [
+        ("external", ErrorKind.NETWORK, str(tmp_path.resolve()))
+    ]
+
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {}
+    assert capsys.readouterr().err == ""
+
+
 def test_cold_profile_hydration_dotenv_wins_over_op_env(tmp_path, monkeypatch):
     """.env takes precedence over .op.env for the same key (setdefault)."""
     monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -305,18 +305,33 @@ hermes memory setup    # select "openviking"
 hermes config set memory.provider openviking
 ```
 
-`hermes memory setup` can reuse or copy connection values from
-`~/.openviking/ovcli.conf`. Manual setup uses the active profile's `.env` file;
-for the default profile that is `~/.hermes/.env`, and for named profiles use
-`~/.hermes/profiles/<profile>/.env`.
+`hermes memory setup` can reuse an `~/.openviking/ovcli.conf` or copy selected
+connection values into the active profile's `.env`. For manual configuration,
+put only the API key there; for the default profile that is `~/.hermes/.env`,
+and for named profiles use `~/.hermes/profiles/<profile>/.env`.
 
 ```text
-OPENVIKING_ENDPOINT=http://127.0.0.1:1933
-# OPENVIKING_API_KEY=...
-# OPENVIKING_ACCOUNT=default
-# OPENVIKING_USER=default
-# OPENVIKING_AGENT=hermes
+OPENVIKING_API_KEY=...
 ```
+
+Put the endpoint and local/trusted identity settings in the active profile's
+`config.yaml`:
+
+```yaml
+memory:
+  provider: openviking
+  openviking:
+    endpoint: http://127.0.0.1:1933
+    account: default
+    user: default
+    agent: hermes
+```
+
+The setup command may store all selected connection values in the profile's
+`.env`. Legacy `OPENVIKING_ENDPOINT`, `OPENVIKING_ACCOUNT`, `OPENVIKING_USER`,
+and `OPENVIKING_AGENT` overrides remain supported. Bound profiles resolve
+identity from their own secret scope; the process-level `OPENVIKING_ENDPOINT`
+remains a non-secret fallback when the profile supplies none.
 
 OpenViking server settings live in `ov.conf` (`--config`,
 `OPENVIKING_CONFIG_FILE`, or `~/.openviking/ov.conf`). Client connection values
@@ -329,7 +344,10 @@ live in `ovcli.conf` (`OPENVIKING_CLI_CONFIG_FILE` or
 - `viking://` URI scheme for hierarchical knowledge browsing
 
 `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` are used for local/trusted mode.
-`OPENVIKING_AGENT` is Hermes' peer ID in OpenViking for peer-scoped memories.
+`OPENVIKING_AGENT` is the peer identity sent through the
+`X-OpenViking-Actor-Peer` header. For current-user shorthand memory writes,
+OpenViking uses that identity together with the authenticated account and
+applies its own namespace policy when resolving the canonical URI.
 
 ---
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -305,10 +305,13 @@ hermes memory setup    # select "openviking"
 hermes config set memory.provider openviking
 ```
 
-`hermes memory setup` can reuse an `~/.openviking/ovcli.conf` or copy selected
-connection values into the active profile's `.env`. For manual configuration,
-put only the API key there; for the default profile that is `~/.hermes/.env`,
-and for named profiles use `~/.hermes/profiles/<profile>/.env`.
+`hermes memory setup` can link an existing `~/.openviking/ovcli.conf` profile;
+existing profiles are linked, not copied into the active profile's `.env`.
+Linking is an explicit shared-file choice: the selected external file is read
+at runtime. To isolate credentials, use separate saved ovcli profiles or
+manual split profile configuration. For manual configuration, put only the
+API key in the profile `.env`; for the default profile that is
+`~/.hermes/.env`, and for named profiles use `~/.hermes/profiles/<profile>/.env`.
 
 ```text
 OPENVIKING_API_KEY=...
@@ -327,9 +330,13 @@ memory:
     agent: hermes
 ```
 
-The setup command may store all selected connection values in the profile's
-`.env`. Legacy `OPENVIKING_ENDPOINT`, `OPENVIKING_ACCOUNT`, `OPENVIKING_USER`,
-and `OPENVIKING_AGENT` overrides remain supported. Bound profiles resolve
+Manual configuration keeps only `OPENVIKING_API_KEY` in the active profile's
+`.env`; put `endpoint`, `account`, `user`, and `agent` under
+`memory.openviking` in the active profile's `config.yaml`. The wizard's legacy
+`Keep in Hermes only` option still stores selected connection values in `.env`;
+users who want non-secrets out of `.env` should use the default `Mirror to
+OpenViking store` option or manual split configuration. Legacy
+`OPENVIKING_*` environment overrides remain supported. Bound profiles resolve
 identity from their own secret scope; the process-level `OPENVIKING_ENDPOINT`
 remains a non-secret fallback when the profile supplies none.
 
@@ -347,7 +354,9 @@ live in `ovcli.conf` (`OPENVIKING_CLI_CONFIG_FILE` or
 `OPENVIKING_AGENT` is the peer identity sent through the
 `X-OpenViking-Actor-Peer` header. For current-user shorthand memory writes,
 OpenViking uses that identity together with the authenticated account and
-applies its own namespace policy when resolving the canonical URI.
+applies its own namespace policy when resolving the canonical URI. Selecting a
+peer requires OpenViking 0.4.0+; older 0.3.x servers retain their legacy
+agent-filtering limitation.
 
 ---
 
@@ -693,7 +702,10 @@ Each provider's data is isolated per [profile](/user-guide/profiles):
 - **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
 - **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
-- **Env var providers** (OpenViking) are configured via each profile's `.env` file
+- **OpenViking** uses each profile's `config.yaml` for connection settings and
+  `.env` for secrets; an explicitly linked ovcli profile intentionally shares
+  the selected external file. Use separate saved ovcli profiles or manual
+  split profile configuration when credentials must be isolated.
 
 ## Building a Memory Provider
 


### PR DESCRIPTION
## What does this PR do?

OpenViking identity currently comes from three places:

1. provider configuration and credentials,
2. HTTP request headers, and
3. the `viking://` path used for explicit memories.

In a single-profile process those sources usually agree by accident. In a multiplexed gateway or TUI, a provider can outlive the profile context that created it. A reload or background memory operation can then resolve process-global `OPENVIKING_*` values from another profile.

There is also an internal read/write mismatch. The existing profile, preference, and entity recall paths already read from `viking://user/memories/...`, but `viking_remember` writes under `viking://user/peers/{agent}/memories/...`. An explicit memory can therefore land outside the tree the same plugin reads at session start.

This PR enforces one invariant: **the profile that initialized an OpenViking provider supplies its configuration and identity; Hermes sends that identity through `X-OpenViking-Actor-Peer`; OpenViking chooses the canonical namespace allowed by the authenticated account.**

It binds the provider to its initialized `hermes_home` and uses OpenViking's current-user shorthand for explicit writes. URI and profile binding belong together: splitting them would leave intermediate states where the shorthand is paired with another profile's credential or peer identity.

### Prior work and why this approach differs

This builds on useful prior investigation rather than duplicating it:

- [#82119](https://github.com/NousResearch/hermes-agent/pull/82119) correctly identifies profile `.env` lookup as a problem. Its lookup remains context-based and can fall back to process-global values. This PR binds each provider instance to the `hermes_home` passed to `initialize()`, then uses Hermes' full read-only config loader and external-secret machinery for that home during initialization and reloads.
- [#51231](https://github.com/NousResearch/hermes-agent/pull/51231) writes to `viking://user/{agent}/memories/...`. [#54399](https://github.com/NousResearch/hermes-agent/pull/54399), among other unrelated fixes, includes the same URI approach. That embeds an agent-isolated server namespace in Hermes and cannot also represent an account configured with a shared user namespace.
- [#57879](https://github.com/NousResearch/hermes-agent/pull/57879) resolves and constructs a canonical peer path, with a fallback to the shorthand peer namespace when status resolution fails. It still makes the client choose a canonical layout before the authenticated server applies its namespace policy.

This PR instead sends `viking://user/memories/...`, the authenticated credential, and the peer identity through `X-OpenViking-Actor-Peer`. OpenViking then resolves the canonical path according to the account's namespace policy. This does not assume the earlier changes were wrong for every OpenViking version; it avoids freezing one server policy into Hermes' path builder and aligns explicit writes with Hermes' existing recall tree.

No inspected open PR combines peer identity with profile-bound resolution and policy-neutral writes.

## Related Issue

Fixes #82117
Fixes #50701

This is intended as a consolidated replacement for the overlapping OpenViking portions of #82119, #51231, #54399, and #57879, not as a change that must merge alongside them. #54399's unrelated fixes remain independent. Maintainers can choose the preferred implementation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/openviking/__init__.py`
  - bind config, secret, reload, recall, and token-budget resolution to the initialized profile;
  - prevent bound providers from inheriting another profile's process-global API key, account, user, or agent;
  - preserve local/trusted `default/default` identity when no API key is configured;
  - preserve legacy unbound environment behavior and the non-secret process endpoint fallback;
  - send the peer identity through `X-OpenViking-Actor-Peer`;
  - write explicit memories through `viking://user/memories/...`.
- `tests/openviking_plugin/test_openviking.py`
  - cover interleaved profile identity, reload behavior, trusted defaults, headers, and shorthand writes.
- `tests/plugins/memory/test_openviking_provider.py`
  - cover full profile config semantics, external secret hydration, safe warnings, discovery, and endpoint compatibility.
- `plugins/memory/openviking/README.md` and `website/docs/user-guide/features/memory-providers.md`
  - document profile-scoped configuration, request identity, and server-owned namespace resolution.

### Compatibility details

Profile-scoped configuration and current-user memory writes are compatible with OpenViking 0.3.24 and 0.4.x. Peer selection through `X-OpenViking-Actor-Peer` requires OpenViking 0.4.0 or later. On 0.3.x, peer/agent filtering remains unchanged from current Hermes and is not fixed by this PR because those servers use the retired `X-OpenViking-Agent` contract.

| Case | Behavior |
|---|---|
| Bound profile with API key | Uses only that profile's secret scope; OpenViking derives account/user unless the profile explicitly supplies supported identity values |
| Bound profile without API key | Uses profile values or local/trusted defaults `default/default`; never borrows another profile's identity |
| Legacy caller without explicit `hermes_home` | Retains existing process-environment behavior |
| Process-level endpoint | Remains a non-secret compatibility fallback after profile-owned endpoint sources |
| `OPENVIKING_CLI_CONFIG_FILE` | Bound providers resolve it from their profile scope; setup persists linked paths in profile config; legacy unbound callers retain process-environment behavior |
| External secret sources | Initialization hydrates them through the existing per-profile cache; discovery does not fetch external providers |
| OpenViking peer selection | Receives `X-OpenViking-Actor-Peer` |
| Shared-user namespace policy | Server canonicalizes shorthand without an agent segment |
| Agent-isolated namespace policy | Server canonicalizes the same shorthand with the authorized agent segment |
| Secret-source failure | Memory remains optional; the warning includes profile path and exception type but no exception text or secret values |

## How to Test

1. Run the affected provider suites:

   `scripts/run_tests.sh tests/openviking_plugin/test_openviking.py tests/plugins/memory/test_openviking_provider.py -q`

2. Run the supporting isolation suites:

   `scripts/run_tests.sh tests/test_env_loader_secret_sources.py tests/agent/test_secret_scope.py tests/gateway/test_multiplex_credential_isolation.py -q`

3. Configure two Hermes profiles with different OpenViking credentials and agent identities. Interleave `viking_remember` calls and change one profile's `.env`; verify each provider keeps its own endpoint, credential, agent headers, and reload state.

4. Against OpenViking 0.4.0 or later, send `X-OpenViking-Actor-Peer` without `X-OpenViking-Agent`. Write, read, and delete a `viking://user/memories/...` file, then verify that the file is absent. This was verified with OpenViking v0.4.13.

5. Against OpenViking v0.3.24, test the same `viking://user/memories/...` write under both `isolate_user_scope_by_agent=false` and `true`. Verify write, read, delete, and the policy-selected canonical storage layout.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — path handling uses `pathlib` and existing profile helpers
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, the existing tool schema is unchanged

## Screenshots / Logs

No UI change.

Verified locally before publication:

- canonical OpenViking provider/plugin suites: **96 passed**;
- secret-source, secret-scope, and multiplex-isolation suites: **44 passed**;
- Ruff, Python compilation, and `git diff --check`: passed;
- live OpenViking v0.4.13 Actor-Peer-only write/read/delete: passed; deletion and absence verified;
- live OpenViking v0.3.24 write/read/delete: passed under both shared-user and agent-isolated namespace policies;
- temporary live-test memories: deleted and absence verified.
