### PR TITLE
feat(todo): persist durable task timing across resume

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2059,7 +2059,8 @@ def _append_durable_todo_snapshot(agent: Any, messages: list) -> None:
     if callable(has_durable_state):
         should_preserve = bool(has_durable_state())
     else:
-        should_preserve = bool(store.has_items())
+        has_items = getattr(store, "has_items", None)
+        should_preserve = bool(has_items()) if callable(has_items) else False
     if not should_preserve:
         return
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1988,6 +1988,113 @@ def _strip_stale_todo_snapshot(content: Any) -> Any:
     return content
 
 
+_DURABLE_TODO_SNAPSHOT_CALL_ID = "hermes_durable_todo_snapshot_v1"
+_DURABLE_TODO_SNAPSHOT_FLAG = "_durable_todo_snapshot"
+
+
+def _todo_call_id(tool_call: Any) -> Optional[str]:
+    if not isinstance(tool_call, dict):
+        return None
+    function = tool_call.get("function")
+    if not isinstance(function, dict) or function.get("name") != "todo":
+        return None
+    call_id = tool_call.get("id")
+    return str(call_id) if call_id else None
+
+
+def _strip_todo_tool_pairs(messages: list) -> None:
+    """Remove Todo call/result pairs before inserting one current snapshot."""
+    todo_call_ids = {
+        call_id
+        for message in messages
+        if isinstance(message, dict) and message.get("role") == "assistant"
+        for call_id in [
+            _todo_call_id(tool_call)
+            for tool_call in (message.get("tool_calls") or [])
+        ]
+        if call_id
+    }
+    normalized = []
+    for message in messages:
+        if not isinstance(message, dict):
+            normalized.append(message)
+            continue
+        if message.get(_DURABLE_TODO_SNAPSHOT_FLAG):
+            continue
+        if (
+            message.get("role") == "tool"
+            and message.get("tool_call_id") in todo_call_ids
+        ):
+            continue
+        if message.get("role") != "assistant" or not isinstance(
+            message.get("tool_calls"), list
+        ):
+            normalized.append(message)
+            continue
+        retained_calls = [
+            call
+            for call in message["tool_calls"]
+            if _todo_call_id(call) is None
+        ]
+        if len(retained_calls) == len(message["tool_calls"]):
+            normalized.append(message)
+            continue
+        retained = dict(message)
+        if retained_calls:
+            retained["tool_calls"] = retained_calls
+        else:
+            retained.pop("tool_calls", None)
+        if retained_calls or _message_text(retained).strip():
+            normalized.append(retained)
+    messages[:] = normalized
+
+
+def _append_durable_todo_snapshot(agent: Any, messages: list) -> None:
+    """Persist one bounded TodoStore snapshot as a valid tool-call pair."""
+    _strip_todo_tool_pairs(messages)
+    store = getattr(agent, "_todo_store", None)
+    if store is None:
+        return
+    has_durable_state = getattr(store, "has_durable_state", None)
+    if callable(has_durable_state):
+        should_preserve = bool(has_durable_state())
+    else:
+        should_preserve = bool(store.has_items())
+    if not should_preserve:
+        return
+
+    from tools.todo_tool import MAX_TODO_RESULT_CHARS, todo_tool
+
+    result = todo_tool(store=store)
+    if not isinstance(result, str) or len(result) > MAX_TODO_RESULT_CHARS:
+        logger.warning(
+            "Skipping oversized durable todo snapshot during compression: "
+            "session=%s chars=%d",
+            getattr(agent, "session_id", None) or "none",
+            len(result) if isinstance(result, str) else -1,
+        )
+        return
+    messages.extend([
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": _DURABLE_TODO_SNAPSHOT_CALL_ID,
+                "type": "function",
+                "function": {"name": "todo", "arguments": "{}"},
+            }],
+            _DURABLE_TODO_SNAPSHOT_FLAG: True,
+        },
+        {
+            "role": "tool",
+            "tool_call_id": _DURABLE_TODO_SNAPSHOT_CALL_ID,
+            "name": "todo",
+            "content": result,
+            _DURABLE_TODO_SNAPSHOT_FLAG: True,
+        },
+    ])
+
+
 def _merge_anchor_into_user_message(target: dict, anchor: dict) -> None:
     """Fold the human anchor into an existing user-role scaffolding turn.
 
@@ -3154,6 +3261,7 @@ def compress_context(
                         "check auxiliary.compression.model in config.yaml."
                     )
 
+        _strip_todo_tool_pairs(compressed)
         todo_snapshot = agent._todo_store.format_for_injection()
         if todo_snapshot:
             # Fold the snapshot into a trailing REAL user message so
@@ -3205,6 +3313,7 @@ def compress_context(
                     "_todo_snapshot_synthetic": True,
                 })
         _ensure_compressed_has_user_turn(messages, compressed)
+        _append_durable_todo_snapshot(agent, compressed)
 
         cached_system_prompt = agent._cached_system_prompt
         agent._invalidate_system_prompt()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1153,6 +1153,20 @@ def build_turn_context(
     plugin_user_context = ""
     try:
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+        _snapshot_todos = getattr(agent._todo_store, "snapshot", None)
+        if callable(_snapshot_todos):
+            _snapshot_value = _snapshot_todos()
+            _todo_snapshot = (
+                _snapshot_value
+                if isinstance(_snapshot_value, dict)
+                else {"todos": [], "timing": None}
+            )
+        else:
+            _read_todos = getattr(agent._todo_store, "read", None)
+            _todo_snapshot = {
+                "todos": _read_todos() if callable(_read_todos) else [],
+                "timing": None,
+            }
         _pre_results = _invoke_hook(
             "pre_llm_call",
             session_id=agent.session_id,
@@ -1160,6 +1174,8 @@ def build_turn_context(
             turn_id=turn_id,
             user_message=original_user_message,
             conversation_history=list(messages),
+            todos=_todo_snapshot["todos"],
+            todo_snapshot=_todo_snapshot,
             is_first_turn=(not bool(conversation_history)),
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -112,8 +112,39 @@ These hooks frame the user turn, not individual provider API attempts:
 | `post_llm_call` | After the turn completes with final assistant output. |
 
 Common `pre_llm_call` fields include `session_id`, `turn_id`,
-`user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`,
-and `sender_id`.
+`user_message`, `conversation_history`, `todos`, `todo_snapshot`,
+`is_first_turn`, `model`, `platform`, and `sender_id`. `todos` preserves the
+existing list-only shape. `todo_snapshot` contains the same list plus the
+machine-owned timing envelope returned by the todo tool.
+
+Todo timing is additive and versioned. `todo_snapshot["timing"]` records the
+current cycle and per-item timing under `schema_version = 1`. Hermes, not the
+model, owns these values: cycle elapsed time is wall time from cycle start to
+completion (or now), while item `active_seconds` accumulates only while the
+item status is `in_progress`. Each item also carries a machine-owned `cycle_id`.
+Terminal items retained in a later full todo list keep their prior cycle ID, so
+observers can exclude them from the new cycle without mutating the model-owned
+todo list. The timing envelope is serialized in canonical todo tool results,
+preserved as one bounded paired call/result across repeated context compression,
+and restored on resume. A cleared list still preserves a closed cycle snapshot,
+so post-restart work advances to a new cycle ID. `source = "live_runtime"`
+identifies timing generated in
+the current process; `source = "paired_history"` identifies structurally
+validated replay. Pairing is not authentication because API callers can supply
+history, so this timing is UI/observability data and must not drive billing,
+security, or SLA enforcement. Legacy results without the envelope hydrate with
+`known = false`; consumers must display an unknown value rather than fabricating
+zero. `finished_at` covers both `completed` and `cancelled`. `active_seconds`
+and cycle `elapsed_seconds` are convenience values derived at `observed_at`;
+hydration ignores them and restores only timestamps plus
+`accumulated_active_seconds`. Timestamps are Unix seconds in UTC.
+
+Todo inputs are bounded to 256 items, 128 characters per ID, and 4,000
+characters per description. Hermes normalizes long-form JSON control escapes
+and derives the result limit from those accepted maxima, so compression never
+drops an otherwise valid store solely because its serialized timing envelope is
+large. Hydration degrades cycle/status, cycle-membership, or active-window
+contradictions to unknown.
 
 Common `post_llm_call` fields include `session_id`, `turn_id`,
 `user_message`, `assistant_response`, `conversation_history`, `model`, and

--- a/run_agent.py
+++ b/run_agent.py
@@ -4459,7 +4459,7 @@ class AIAgent:
         from tools.todo_tool import MAX_TODO_RESULT_CHARS
 
         # Walk history backwards to find the most recent todo tool response
-        last_todo_response = None
+        last_todo_snapshot = None
         for idx in range(len(history) - 1, -1, -1):
             msg = history[idx]
             if msg.get("role") != "tool":
@@ -4484,16 +4484,19 @@ class AIAgent:
             try:
                 data = json.loads(content)
                 if "todos" in data and isinstance(data["todos"], list):
-                    last_todo_response = data["todos"]
+                    last_todo_snapshot = data
                     break
             except (json.JSONDecodeError, TypeError):
                 continue
 
-        if last_todo_response:
-            # Replay the items into the store (replace mode)
-            self._todo_store.write(last_todo_response, merge=False)
+        if last_todo_snapshot is not None:
+            # Restore the canonical list and its machine-owned timing envelope.
+            self._todo_store.hydrate(last_todo_snapshot)
             if not self.quiet_mode:
-                self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
+                self._vprint(
+                    f"{self.log_prefix}📋 Restored "
+                    f"{len(last_todo_snapshot['todos'])} todo item(s) from history"
+                )
         _set_interrupt(False)
 
     @classmethod

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -26,6 +26,12 @@ import pytest
 
 from agent.context_compressor import ContextCompressor
 from hermes_state import SessionDB
+from tools.todo_tool import (
+    MAX_TODO_CONTENT_CHARS,
+    MAX_TODO_ITEMS,
+    MAX_TODO_RESULT_CHARS,
+    TodoStore,
+)
 
 
 def _build_agent_with_db(db: SessionDB, session_id: str, platform: str = "telegram"):
@@ -66,6 +72,22 @@ def _build_agent_with_db(db: SessionDB, session_id: str, platform: str = "telegr
 
 def _msgs(n=20):
     return [{"role": "user", "content": f"m{i}"} for i in range(n)]
+
+
+class _FakeClock:
+    def __init__(self, value: float):
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+
+def _durable_todo_pair_count(messages: list[dict]) -> int:
+    return sum(
+        message.get("role") == "tool"
+        and message.get("tool_call_id") == "hermes_durable_todo_snapshot_v1"
+        for message in messages
+    )
 
 
 def _bound_context_compressor(db: SessionDB, session_id: str) -> ContextCompressor:
@@ -508,6 +530,121 @@ class TestCooldownPersistFailureIsNotAClearedRow:
         assert compressor._ineffective_compression_count == 0
 
 
+class TestDurableTodoTimingCompression:
+    def test_maximum_valid_store_keeps_durable_pair(self):
+        from agent.conversation_compression import _append_durable_todo_snapshot
+
+        agent = MagicMock()
+        agent.session_id = "TODO_TIMING_MAXIMUM"
+        agent._todo_store = TodoStore(clock=lambda: 100.0)
+        agent._todo_store.write([
+            {
+                "id": f"{index}:" + "\\" * 400,
+                "content": "\\" * MAX_TODO_CONTENT_CHARS,
+                "status": "pending",
+            }
+            for index in range(MAX_TODO_ITEMS)
+        ])
+        messages = []
+
+        _append_durable_todo_snapshot(agent, messages)
+
+        assert _durable_todo_pair_count(messages) == 1
+        assert len(messages[-1]["content"]) <= MAX_TODO_RESULT_CHARS
+
+    def test_in_place_compression_restart_and_repeated_compression(self, tmp_path: Path):
+        from agent.conversation_compression import compress_context
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        session_id = "TODO_TIMING_COMPRESSION"
+        db.create_session(session_id, source="cli")
+        agent = _build_agent_with_db(db, session_id, platform="cli")
+        agent.compression_in_place = True
+        clock = _FakeClock(100)
+        agent._todo_store = TodoStore(clock=clock)
+        agent._todo_store.write([
+            {"id": "task", "content": "durable work", "status": "pending"}
+        ])
+        clock.value = 120
+        agent._todo_store.write([
+            {"id": "task", "content": "durable work", "status": "in_progress"}
+        ])
+
+        clock.value = 150
+        compressed, _ = compress_context(
+            agent, _msgs(), "sys", approx_tokens=120_000
+        )
+        active = db.get_messages_as_conversation(session_id)
+        assert _durable_todo_pair_count(active) == 1
+
+        restarted = _build_agent_with_db(db, session_id, platform="cli")
+        restarted._todo_store = TodoStore(clock=_FakeClock(200))
+        restarted._hydrate_todo_store(active)
+        restored = restarted._todo_store.snapshot()
+        assert restored["todos"][0]["status"] == "in_progress"
+        assert restored["timing"]["cycle"]["id"] == 1
+        assert restored["timing"]["cycle"]["elapsed_seconds"] == 100
+        assert restored["timing"]["items"]["task"]["active_seconds"] == 80
+
+        clock.value = 160
+        agent.context_compressor.compress.return_value = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] latest"},
+            {"role": "user", "content": "tail"},
+        ]
+        compress_context(agent, compressed, "sys", approx_tokens=120_000)
+        latest = db.get_messages_as_conversation(session_id)
+        assert _durable_todo_pair_count(latest) == 1
+
+        restarted_again = _build_agent_with_db(db, session_id, platform="cli")
+        restarted_again._todo_store = TodoStore(clock=_FakeClock(200))
+        restarted_again._hydrate_todo_store(latest)
+        restored_again = restarted_again._todo_store.snapshot()
+        assert restored_again["timing"]["items"]["task"]["active_seconds"] == 80
+        db.close()
+
+    def test_clear_compression_restart_advances_cycle(self, tmp_path: Path):
+        from agent.conversation_compression import compress_context
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        session_id = "TODO_TIMING_CLEAR_COMPRESSION"
+        db.create_session(session_id, source="cli")
+        agent = _build_agent_with_db(db, session_id, platform="cli")
+        agent.compression_in_place = True
+        clock = _FakeClock(100)
+        agent._todo_store = TodoStore(clock=clock)
+        agent._todo_store.write([
+            {"id": "old", "content": "old work", "status": "in_progress"}
+        ])
+        clock.value = 120
+        agent._todo_store.write([
+            {"id": "old", "content": "old work", "status": "completed"}
+        ])
+        clock.value = 130
+        agent._todo_store.write([])
+        assert not agent._todo_store.has_items()
+        assert agent._todo_store.has_durable_state()
+
+        compress_context(agent, _msgs(), "sys", approx_tokens=120_000)
+        active = db.get_messages_as_conversation(session_id)
+        assert _durable_todo_pair_count(active) == 1
+
+        restarted = _build_agent_with_db(db, session_id, platform="cli")
+        restarted._todo_store = TodoStore(clock=_FakeClock(200))
+        restarted._hydrate_todo_store(active)
+        restored = restarted._todo_store.snapshot()
+        assert restored["todos"] == []
+        assert restored["timing"]["cycle"]["id"] == 1
+        assert restored["timing"]["cycle"]["finished_at"] == 120
+
+        restarted._todo_store.write([
+            {"id": "new", "content": "new work", "status": "pending"}
+        ])
+        next_cycle = restarted._todo_store.snapshot()
+        assert next_cycle["timing"]["cycle"]["id"] == 2
+        assert next_cycle["timing"]["cycle"]["started_at"] == 200
+        db.close()
+
+
 class TestTodoSnapshotMergedNotDuplicated:
     """Todo snapshots preserve tail content without duplicate user turns."""
 
@@ -644,18 +781,19 @@ class TestTodoSnapshotScaffoldingTails:
             _msgs(), "sys", approx_tokens=120_000
         )
 
-        tail = compressed[-1]
+        tail = compressed[-3]
         assert tail["role"] == "user"
         assert "please fix the login bug" in tail["content"]
         assert "task A" in tail["content"]
         assert "old finished task" not in tail["content"]
         assert tail["content"].count(TODO_INJECTION_HEADER) == 1
+        assert _durable_todo_pair_count(compressed) == 1
         assert not any(
             previous.get("role") == current.get("role") == "user"
             for previous, current in zip(compressed, compressed[1:])
         )
 
-    def test_empty_todo_store_injects_nothing(self, tmp_path: Path):
+    def test_terminal_todo_has_no_user_snapshot_but_keeps_durable_pair(self, tmp_path: Path):
         from tools.todo_tool import TODO_INJECTION_HEADER
 
         db = SessionDB(db_path=tmp_path / "state.db")
@@ -678,7 +816,8 @@ class TestTodoSnapshotScaffoldingTails:
             _msgs(), "sys", approx_tokens=120_000
         )
 
-        assert compressed == expected
+        assert compressed[:3] == expected
+        assert _durable_todo_pair_count(compressed) == 1
         assert not any(
             TODO_INJECTION_HEADER in str(message.get("content") or "")
             for message in compressed

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -531,6 +531,17 @@ class TestCooldownPersistFailureIsNotAClearedRow:
 
 
 class TestDurableTodoTimingCompression:
+    def test_store_without_durable_capability_is_ignored(self):
+        from agent.conversation_compression import _append_durable_todo_snapshot
+
+        agent = MagicMock()
+        agent._todo_store = object()
+        messages = []
+
+        _append_durable_todo_snapshot(agent, messages)
+
+        assert messages == []
+
     def test_maximum_valid_store_keeps_durable_pair(self):
         from agent.conversation_compression import _append_durable_todo_snapshot
 

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -23,6 +23,15 @@ class _FakeTodoStore:
     def has_items(self):
         return True
 
+    def read(self):
+        return [{"id": "task", "content": "work", "status": "in_progress"}]
+
+    def snapshot(self):
+        return {
+            "todos": self.read(),
+            "timing": {"schema_version": 1, "cycle": {"id": 3}, "items": {}},
+        }
+
     def _hydrate(self, *_a, **_k):
         pass
 
@@ -206,6 +215,16 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.messages[-1] == {"role": "user", "content": "hello"}
     assert ctx.current_turn_user_idx == len(ctx.messages) - 1
     assert ctx.active_system_prompt == "SYSTEM"
+
+
+def test_pre_llm_hook_receives_atomic_todo_snapshot() -> None:
+    agent = _FakeAgent()
+    with patch("hermes_cli.lifecycle.invoke_hook", return_value=[]) as invoke:
+        _build(agent)
+
+    pre_llm = next(call for call in invoke.call_args_list if call.args == ("pre_llm_call",))
+    assert pre_llm.kwargs["todos"] == agent._todo_store.read()
+    assert pre_llm.kwargs["todo_snapshot"] == agent._todo_store.snapshot()
 
 
 # ── Trivial-prompt prefetch gate (PR #25350 salvage) ─────────────────────────

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -873,6 +873,51 @@ class TestHydrateTodoStore:
             agent._hydrate_todo_store(history)
         assert not agent._todo_store.has_items()
 
+    def test_paired_todo_result_restores_durable_timing(self, agent):
+        snapshot = {
+            "todos": [
+                {"id": "task", "content": "work", "status": "completed"}
+            ],
+            "timing": {
+                "schema_version": 1,
+                "cycle": {
+                    "id": 4,
+                    "known": True,
+                    "started_at": 100.0,
+                    "finished_at": 130.0,
+                    "elapsed_seconds": 30,
+                },
+                "items": {
+                    "task": {
+                        "known": True,
+                        "cycle_id": 4,
+                        "created_at": 100.0,
+                        "started_at": 110.0,
+                        "finished_at": 130.0,
+                        "accumulated_active_seconds": 20,
+                        "active_seconds": 20,
+                        "active_since": None,
+                    }
+                },
+            },
+        }
+        history = [
+            self._assistant_todo_call("c1"),
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": json.dumps(snapshot),
+            },
+        ]
+
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+
+        restored = agent._todo_store.snapshot()["timing"]
+        assert restored["cycle"]["id"] == 4
+        assert restored["cycle"]["elapsed_seconds"] == 30
+        assert restored["items"]["task"]["active_seconds"] == 20
+
 
 
 

--- a/tests/tools/test_todo_timing.py
+++ b/tests/tools/test_todo_timing.py
@@ -1,0 +1,393 @@
+"""Deterministic tests for durable TodoStore timing."""
+
+import json
+
+from tools.todo_tool import (
+    MAX_TODO_CONTENT_CHARS,
+    MAX_TODO_ITEMS,
+    MAX_TODO_RESULT_CHARS,
+    TodoStore,
+    todo_tool,
+)
+
+
+class FakeClock:
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+
+def _item(status: str, task_id: str = "task") -> dict:
+    return {"id": task_id, "content": "work", "status": status}
+
+
+def test_active_time_accumulates_only_while_in_progress() -> None:
+    clock = FakeClock(100)
+    store = TodoStore(clock=clock)
+    store.write([_item("pending")])
+
+    clock.value = 110
+    store.write([_item("in_progress")])
+    clock.value = 130
+    store.write([_item("pending")])
+    clock.value = 135
+    store.write([_item("in_progress")])
+    clock.value = 150
+    store.write([_item("completed")])
+
+    timing = store.snapshot()["timing"]
+    assert timing["items"]["task"]["active_seconds"] == 35
+    assert timing["items"]["task"]["finished_at"] == 150
+    assert timing["cycle"]["elapsed_seconds"] == 50
+
+    clock.value = 200
+    frozen = store.snapshot()["timing"]
+    assert frozen["items"]["task"]["active_seconds"] == 35
+    assert frozen["cycle"]["elapsed_seconds"] == 50
+
+
+def test_timing_survives_tool_result_hydration_and_keeps_running() -> None:
+    first_clock = FakeClock(100)
+    first = TodoStore(clock=first_clock)
+    first.write([_item("in_progress")])
+    first_clock.value = 130
+    persisted = json.loads(todo_tool(store=first))
+
+    resumed_clock = FakeClock(150)
+    resumed = TodoStore(clock=resumed_clock)
+    resumed.hydrate(persisted)
+    restored = resumed.snapshot()["timing"]
+    assert restored["cycle"]["id"] == 1
+    assert restored["cycle"]["elapsed_seconds"] == 50
+    assert restored["items"]["task"]["active_seconds"] == 50
+
+    resumed_clock.value = 160
+    resumed.write([_item("completed")])
+    completed = resumed.snapshot()["timing"]
+    assert completed["cycle"]["elapsed_seconds"] == 60
+    assert completed["items"]["task"]["active_seconds"] == 60
+
+
+def test_repeated_hydration_preserves_fractional_closed_interval() -> None:
+    clock = FakeClock(100.25)
+    store = TodoStore(clock=clock)
+    store.write([_item("in_progress")])
+    clock.value = 101.10
+    store.write([_item("pending")])
+    expected = store.snapshot()["timing"]["items"]["task"][
+        "accumulated_active_seconds"
+    ]
+
+    for value in (150.0, 200.0, 250.0):
+        resumed = TodoStore(clock=FakeClock(value))
+        resumed.hydrate(store.snapshot())
+        actual = resumed.snapshot()["timing"]["items"]["task"][
+            "accumulated_active_seconds"
+        ]
+        assert actual == expected
+        store = resumed
+
+
+def test_legacy_hydration_is_unknown_instead_of_fabricating_zero() -> None:
+    clock = FakeClock(500)
+    store = TodoStore(clock=clock)
+    store.hydrate({"todos": [_item("completed")]})
+
+    timing = store.snapshot()["timing"]
+    assert timing["cycle"]["known"] is False
+    assert timing["cycle"]["elapsed_seconds"] is None
+    assert timing["items"]["task"]["known"] is False
+    assert timing["items"]["task"]["active_seconds"] is None
+
+
+def test_terminal_cycle_rotates_only_when_new_active_work_arrives() -> None:
+    clock = FakeClock(10)
+    store = TodoStore(clock=clock)
+    store.write([_item("in_progress")])
+    clock.value = 20
+    store.write([_item("completed")])
+    completed = store.snapshot()["timing"]
+    assert completed["cycle"]["id"] == 1
+    assert completed["cycle"]["elapsed_seconds"] == 10
+
+    clock.value = 50
+    store.write([_item("completed")])
+    still_completed = store.snapshot()["timing"]
+    assert still_completed["cycle"]["id"] == 1
+    assert still_completed["cycle"]["elapsed_seconds"] == 10
+
+    clock.value = 80
+    store.write([_item("in_progress")])
+    next_cycle = store.snapshot()["timing"]
+    assert next_cycle["cycle"]["id"] == 2
+    assert next_cycle["cycle"]["started_at"] == 80
+    assert next_cycle["cycle"]["elapsed_seconds"] == 0
+    assert next_cycle["items"]["task"]["active_seconds"] == 0
+
+
+def test_cleared_list_closes_cycle_and_next_list_starts_another() -> None:
+    clock = FakeClock(10)
+    store = TodoStore(clock=clock)
+    store.write([_item("in_progress")])
+    clock.value = 20
+    store.write([])
+    clock.value = 40
+    store.write([_item("pending", "next")])
+
+    timing = store.snapshot()["timing"]
+    assert timing["cycle"]["id"] == 2
+    assert timing["cycle"]["started_at"] == 40
+
+
+def test_new_cycle_preserves_carried_terminal_membership() -> None:
+    clock = FakeClock(100)
+    store = TodoStore(clock=clock)
+    old = {"id": "old", "content": "old", "status": "pending"}
+    store.write([old])
+    clock.value = 110
+    store.write([{**old, "status": "in_progress"}])
+    clock.value = 120
+    store.write([{**old, "status": "completed"}])
+    clock.value = 130
+    store.write([
+        {**old, "status": "completed"},
+        {"id": "new", "content": "new", "status": "pending"},
+    ])
+
+    timing = store.snapshot()["timing"]
+    assert timing["cycle"]["id"] == 2
+    assert timing["items"]["old"]["cycle_id"] == 1
+    assert timing["items"]["old"]["active_seconds"] == 10
+    assert timing["items"]["new"]["cycle_id"] == 2
+
+
+def test_first_observation_of_terminal_item_has_unknown_duration() -> None:
+    store = TodoStore(clock=FakeClock(100))
+    store.write([_item("completed")])
+    timing = store.snapshot()["timing"]
+    assert timing["cycle"]["known"] is False
+    assert timing["items"]["task"]["known"] is False
+
+
+def test_model_supplied_timing_fields_are_ignored() -> None:
+    clock = FakeClock(100)
+    store = TodoStore(clock=clock)
+    store.write([{**_item("in_progress"), "timing": {"active_seconds": 999999}}])
+    timing = store.snapshot()["timing"]
+    assert timing["items"]["task"]["active_seconds"] == 0
+    assert timing["items"]["task"]["created_at"] == 100
+
+
+def test_hydration_rejects_impossible_timestamp_order() -> None:
+    snapshot = {
+        "todos": [_item("completed")],
+        "timing": {
+            "schema_version": 1,
+            "cycle": {
+                "id": 1,
+                "known": True,
+                "started_at": 100.0,
+                "finished_at": 90.0,
+            },
+            "items": {
+                "task": {
+                    "known": True,
+                    "cycle_id": 1,
+                    "created_at": 100.0,
+                    "started_at": 110.0,
+                    "finished_at": 90.0,
+                    "accumulated_active_seconds": 5.0,
+                    "active_since": None,
+                }
+            },
+        },
+    }
+    store = TodoStore(clock=FakeClock(200))
+    store.hydrate(snapshot)
+    timing = store.snapshot()["timing"]
+    assert timing["cycle"]["known"] is False
+    assert timing["items"]["task"]["known"] is False
+
+
+def test_hydration_marks_forged_excessive_item_timing_unknown() -> None:
+    snapshot = {
+        "todos": [_item("in_progress")],
+        "timing": {
+            "schema_version": 1,
+            "source": "live_runtime",
+            "cycle": {
+                "id": 1,
+                "known": True,
+                "started_at": 100.0,
+                "finished_at": None,
+            },
+            "items": {
+                "task": {
+                    "known": True,
+                    "cycle_id": 1,
+                    "created_at": 100.0,
+                    "started_at": 110.0,
+                    "finished_at": None,
+                    "accumulated_active_seconds": 1_000_000_000.0,
+                    "active_since": 110.0,
+                }
+            },
+        },
+    }
+    store = TodoStore(clock=FakeClock(200))
+    store.hydrate(snapshot)
+    timing = store.snapshot()["timing"]
+    assert timing["source"] == "paired_history"
+    assert timing["cycle"]["known"] is True
+    assert timing["items"]["task"]["known"] is False
+
+
+def test_hydration_rejects_future_cycle_timestamp() -> None:
+    snapshot = {
+        "todos": [_item("pending")],
+        "timing": {
+            "schema_version": 1,
+            "cycle": {
+                "id": 1,
+                "known": True,
+                "started_at": 1000.0,
+                "finished_at": None,
+            },
+            "items": {},
+        },
+    }
+    store = TodoStore(clock=FakeClock(200))
+    store.hydrate(snapshot)
+    assert store.snapshot()["timing"]["cycle"]["known"] is False
+
+
+def test_hydration_rejects_finished_cycle_with_active_item() -> None:
+    source_clock = FakeClock(100)
+    source = TodoStore(clock=source_clock)
+    source.write([_item("in_progress")])
+    snapshot = source.snapshot()
+    snapshot["timing"]["cycle"]["finished_at"] = 120.0
+
+    restored = TodoStore(clock=FakeClock(130))
+    restored.hydrate(snapshot)
+    timing = restored.snapshot()["timing"]
+    assert timing["cycle"]["known"] is False
+    assert timing["items"]["task"]["known"] is False
+
+
+def test_hydration_rejects_terminal_list_without_finished_cycle() -> None:
+    clock = FakeClock(100)
+    source = TodoStore(clock=clock)
+    source.write([_item("in_progress")])
+    clock.value = 120
+    source.write([_item("completed")])
+    snapshot = source.snapshot()
+    snapshot["timing"]["cycle"]["finished_at"] = None
+
+    restored = TodoStore(clock=FakeClock(200))
+    restored.hydrate(snapshot)
+    timing = restored.snapshot()["timing"]
+    assert timing["cycle"]["known"] is False
+    assert timing["items"]["task"]["known"] is False
+
+
+def test_hydration_rejects_active_item_from_prior_cycle() -> None:
+    source = TodoStore(clock=FakeClock(100))
+    source.write([_item("pending")])
+    snapshot = source.snapshot()
+    snapshot["timing"]["cycle"]["id"] = 2
+
+    restored = TodoStore(clock=FakeClock(200))
+    restored.hydrate(snapshot)
+    timing = restored.snapshot()["timing"]
+    assert timing["cycle"]["known"] is True
+    assert timing["items"]["task"]["known"] is False
+
+
+def test_hydration_rejects_active_time_beyond_terminal_window() -> None:
+    clock = FakeClock(100)
+    source = TodoStore(clock=clock)
+    source.write([_item("in_progress")])
+    clock.value = 110
+    source.write([_item("completed")])
+    snapshot = source.snapshot()
+    snapshot["timing"]["items"]["task"]["accumulated_active_seconds"] = 90.0
+
+    restored = TodoStore(clock=FakeClock(200))
+    restored.hydrate(snapshot)
+    timing = restored.snapshot()["timing"]
+    assert timing["cycle"]["known"] is True
+    assert timing["items"]["task"]["known"] is False
+
+
+def test_legacy_unknown_cycle_never_emits_partially_known_items() -> None:
+    clock = FakeClock(500)
+    store = TodoStore(clock=clock)
+    store.hydrate({"todos": [_item("pending")]})
+    clock.value = 510
+    store.write([
+        _item("pending"),
+        {"id": "new", "content": "new", "status": "pending"},
+    ])
+    persisted = store.snapshot()
+    assert persisted["timing"]["cycle"]["id"] is None
+    assert persisted["timing"]["items"]["new"]["known"] is False
+
+    resumed = TodoStore(clock=FakeClock(520))
+    resumed.hydrate(persisted)
+    assert resumed.snapshot()["timing"]["items"]["new"]["known"] is False
+
+
+def test_cancelled_item_records_terminal_timestamp_and_active_time() -> None:
+    clock = FakeClock(100)
+    store = TodoStore(clock=clock)
+    store.write([_item("pending")])
+    clock.value = 110
+    store.write([_item("in_progress")])
+    clock.value = 120
+    store.write([_item("cancelled")])
+    item = store.snapshot()["timing"]["items"]["task"]
+    assert item["finished_at"] == 120
+    assert item["active_seconds"] == 10
+
+
+def test_todo_result_keeps_item_shape_and_adds_timing_envelope() -> None:
+    store = TodoStore(clock=FakeClock(100))
+    result = json.loads(todo_tool(todos=[_item("pending")], store=store))
+    assert result["todos"] == [_item("pending")]
+    assert result["timing"]["schema_version"] == 1
+    assert result["timing"]["cycle"]["known"] is True
+
+
+def test_timing_envelope_has_bounded_result_overhead() -> None:
+    items = [
+        {"id": str(index), "content": "task", "status": "pending"}
+        for index in range(MAX_TODO_ITEMS)
+    ]
+    store = TodoStore(clock=FakeClock(100))
+    result = json.loads(todo_tool(todos=items, store=store))
+    full = len(json.dumps(result))
+    legacy_shape = len(
+        json.dumps({"todos": result["todos"], "summary": result["summary"]})
+    )
+    assert full - legacy_shape <= 64_000
+
+
+def test_maximum_valid_todo_result_fits_durable_snapshot_bound() -> None:
+    items = [
+        {
+            "id": f"{index}:" + "\\" * 400,
+            "content": "\\" * MAX_TODO_CONTENT_CHARS,
+            "status": "pending",
+        }
+        for index in range(MAX_TODO_ITEMS)
+    ]
+    result = todo_tool(todos=items, store=TodoStore(clock=FakeClock(100)))
+    assert len(result) <= MAX_TODO_RESULT_CHARS
+    parsed = json.loads(result)
+    ids = [item["id"] for item in parsed["todos"]]
+    assert len(ids) == MAX_TODO_ITEMS
+    assert len(set(ids)) == MAX_TODO_ITEMS
+    assert all(len(item_id) <= 128 for item_id in ids)

--- a/tests/tools/test_todo_timing.py
+++ b/tests/tools/test_todo_timing.py
@@ -171,6 +171,23 @@ def test_first_observation_of_terminal_item_has_unknown_duration() -> None:
     assert timing["items"]["task"]["known"] is False
 
 
+def test_terminal_first_clear_restart_rotates_cycle_for_new_work() -> None:
+    first = TodoStore(clock=FakeClock(100))
+    first.write([_item("completed")])
+    assert first.snapshot()["timing"]["cycle"]["id"] == 1
+    first.write([])
+
+    resumed = TodoStore(clock=FakeClock(200))
+    resumed.hydrate(first.snapshot())
+    resumed.write([_item("pending", "next")])
+
+    timing = resumed.snapshot()["timing"]
+    assert timing["cycle"]["id"] == 2
+    assert timing["cycle"]["known"] is True
+    assert timing["cycle"]["started_at"] == 200
+    assert timing["items"]["next"]["cycle_id"] == 2
+
+
 def test_model_supplied_timing_fields_are_ignored() -> None:
     clock = FakeClock(100)
     store = TodoStore(clock=clock)

--- a/tools/todo_timing.py
+++ b/tools/todo_timing.py
@@ -1,0 +1,387 @@
+"""Durable, machine-owned timing state for the todo tool.
+
+The model owns todo identifiers, text, and statuses. Hermes owns all timestamps.
+Timing is serialized into the existing todo tool result so a fresh AIAgent can
+restore it from canonical paired tool history without a second persistence
+surface.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+
+TODO_TIMING_SCHEMA_VERSION = 1
+_ACTIVE_STATUSES = {"pending", "in_progress"}
+_TERMINAL_STATUSES = {"completed", "cancelled"}
+_MAX_SAFE_CYCLE_ID = (1 << 53) - 1
+_MAX_FUTURE_SKEW_SECONDS = 300.0
+_TIMING_EPSILON_SECONDS = 1e-6
+
+
+def _number(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) and parsed >= 0 else None
+
+
+class TodoTimingState:
+    """Track task-active time and task-cycle wall time across todo writes."""
+
+    def __init__(self, clock: Optional[Callable[[], float]] = None) -> None:
+        self._clock = clock or time.time
+        self._cycle_id = 0
+        self._cycle_known = False
+        self._cycle_started_at: Optional[float] = None
+        self._cycle_completed_at: Optional[float] = None
+        self._items: Dict[str, Dict[str, Any]] = {}
+        self._source = "live_runtime"
+
+    def has_state(self) -> bool:
+        """Return whether timing has durable cycle or item state to preserve."""
+        return self._cycle_id > 0 or bool(self._items)
+
+    def apply(
+        self,
+        previous: List[Dict[str, str]],
+        current: List[Dict[str, str]],
+    ) -> None:
+        """Apply one validated todo-list transition at the current clock time."""
+        now = float(self._clock())
+        previous_by_id = {item["id"]: item for item in previous}
+        previous_terminal = bool(previous) and all(
+            item["status"] in _TERMINAL_STATUSES for item in previous
+        )
+        current_active = any(item["status"] in _ACTIVE_STATUSES for item in current)
+        rotate = previous_terminal and current_active
+
+        started_cycle = False
+        if rotate:
+            self._start_cycle(current, now)
+            started_cycle = True
+        elif not previous and current and (
+            self._cycle_id == 0 or self._cycle_completed_at is not None
+        ):
+            self._start_cycle(current, now)
+            started_cycle = True
+
+        updated: Dict[str, Dict[str, Any]] = {}
+        for item in current:
+            task_id = item["id"]
+            previous_item = previous_by_id.get(task_id)
+            timing = self._items.get(task_id)
+            carried_terminal = (
+                started_cycle
+                and previous_item is not None
+                and previous_item["status"] in _TERMINAL_STATUSES
+                and item["status"] in _TERMINAL_STATUSES
+                and timing is not None
+            )
+            if started_cycle and not carried_terminal:
+                timing = None
+            if (
+                timing is not None
+                and timing.get("cycle_id") != self._cycle_id
+                and item["status"] in _ACTIVE_STATUSES
+            ):
+                timing = None
+            if timing is None:
+                timing = self._new_item(item["status"], now, self._cycle_id)
+            elif previous_item is not None:
+                self._transition(
+                    timing,
+                    previous_item["status"],
+                    item["status"],
+                    now,
+                )
+            updated[task_id] = timing
+        self._items = updated
+
+        if not current:
+            if previous and self._cycle_completed_at is None:
+                self._cycle_completed_at = now
+            return
+        if all(item["status"] in _TERMINAL_STATUSES for item in current):
+            if self._cycle_completed_at is None:
+                self._cycle_completed_at = now
+        else:
+            self._cycle_completed_at = None
+
+    def hydrate(self, todos: List[Dict[str, str]], payload: Any) -> None:
+        """Restore a validated timing envelope or mark legacy state unknown."""
+        self._reset_unknown(todos)
+        if not isinstance(payload, dict) or payload.get("schema_version") != TODO_TIMING_SCHEMA_VERSION:
+            return
+
+        cycle = payload.get("cycle")
+        item_payloads = payload.get("items")
+        if not isinstance(cycle, dict) or not isinstance(item_payloads, dict):
+            return
+
+        now = float(self._clock())
+        cycle_id = cycle.get("id")
+        cycle_known = cycle.get("known") is True
+        cycle_started_at = _number(cycle.get("started_at"))
+        cycle_completed_at = _number(cycle.get("finished_at"))
+        if (
+            not isinstance(cycle_id, int)
+            or isinstance(cycle_id, bool)
+            or cycle_id < 1
+            or cycle_id > _MAX_SAFE_CYCLE_ID
+        ):
+            return
+        if cycle_started_at is not None and cycle_started_at > now + _MAX_FUTURE_SKEW_SECONDS:
+            return
+        if cycle_completed_at is not None and cycle_completed_at > now + _MAX_FUTURE_SKEW_SECONDS:
+            return
+        if cycle_known and cycle_started_at is None:
+            return
+        if (
+            cycle_known
+            and cycle_started_at is not None
+            and cycle_completed_at is not None
+            and cycle_completed_at < cycle_started_at
+        ):
+            return
+        if cycle_completed_at is not None and any(
+            item["status"] in _ACTIVE_STATUSES for item in todos
+        ):
+            return
+        if (
+            cycle_known
+            and todos
+            and all(item["status"] in _TERMINAL_STATUSES for item in todos)
+            and cycle_completed_at is None
+        ):
+            return
+
+        restored: Dict[str, Dict[str, Any]] = {}
+        for item in todos:
+            task_id = item["id"]
+            raw = item_payloads.get(task_id)
+            timing = self._hydrate_item(
+                item["status"], raw, now=now, current_cycle_id=cycle_id
+            )
+            if not cycle_known:
+                timing = self._unknown_item(timing.get("cycle_id"))
+            restored[task_id] = timing
+
+        self._cycle_id = cycle_id
+        self._cycle_known = cycle_known
+        self._cycle_started_at = cycle_started_at if cycle_known else None
+        self._cycle_completed_at = cycle_completed_at if cycle_known else None
+        self._items = restored
+        self._source = "paired_history"
+
+    def snapshot(self, todos: List[Dict[str, str]]) -> Dict[str, Any]:
+        """Return a JSON-safe timing envelope for tool results and hooks."""
+        now = float(self._clock())
+        items: Dict[str, Dict[str, Any]] = {}
+        for item in todos:
+            timing = self._items.get(item["id"])
+            if timing is None or not timing.get("known"):
+                cycle_id = timing.get("cycle_id") if timing is not None else None
+                items[item["id"]] = self._unknown_snapshot_item(cycle_id)
+                continue
+            active_seconds = float(timing["active_seconds"])
+            active_since = timing.get("active_since")
+            if active_since is not None:
+                active_seconds += max(0.0, now - float(active_since))
+            items[item["id"]] = {
+                "known": True,
+                "cycle_id": timing.get("cycle_id"),
+                "created_at": timing.get("created_at"),
+                "started_at": timing.get("started_at"),
+                "finished_at": timing.get("completed_at"),
+                "accumulated_active_seconds": max(
+                    0.0,
+                    float(timing["active_seconds"]),
+                ),
+                "active_seconds": max(0, round(active_seconds)),
+                "active_since": active_since,
+            }
+
+        cycle_elapsed: Optional[int] = None
+        if self._cycle_known and self._cycle_started_at is not None:
+            cycle_end = self._cycle_completed_at if self._cycle_completed_at is not None else now
+            cycle_elapsed = max(0, round(cycle_end - self._cycle_started_at))
+        return {
+            "schema_version": TODO_TIMING_SCHEMA_VERSION,
+            "source": self._source,
+            "observed_at": now,
+            "cycle": {
+                "id": self._cycle_id if self._cycle_id > 0 else None,
+                "known": self._cycle_known,
+                "started_at": self._cycle_started_at if self._cycle_known else None,
+                "finished_at": self._cycle_completed_at if self._cycle_known else None,
+                "elapsed_seconds": cycle_elapsed,
+            },
+            "items": items,
+        }
+
+    def _start_cycle(self, todos: List[Dict[str, str]], now: float) -> None:
+        self._cycle_id += 1
+        if any(item["status"] in _ACTIVE_STATUSES for item in todos):
+            self._cycle_known = True
+            self._cycle_started_at = now
+            self._cycle_completed_at = None
+        else:
+            self._cycle_known = False
+            self._cycle_started_at = None
+            self._cycle_completed_at = None
+
+    def _reset_unknown(self, todos: List[Dict[str, str]]) -> None:
+        self._cycle_id = 0
+        self._cycle_known = False
+        self._cycle_started_at = None
+        self._cycle_completed_at = None
+        self._items = {item["id"]: self._unknown_item() for item in todos}
+        self._source = "paired_history"
+
+    @staticmethod
+    def _unknown_item(cycle_id: int | None = None) -> Dict[str, Any]:
+        return {
+            "known": False,
+            "cycle_id": cycle_id,
+            "created_at": None,
+            "started_at": None,
+            "completed_at": None,
+            "active_since": None,
+            "accumulated_active_seconds": None,
+            "active_seconds": None,
+        }
+
+    @classmethod
+    def _unknown_snapshot_item(cls, cycle_id: int | None = None) -> Dict[str, Any]:
+        item = cls._unknown_item(cycle_id)
+        item["finished_at"] = item.pop("completed_at")
+        return item
+
+    @classmethod
+    def _new_item(cls, status: str, now: float, cycle_id: int) -> Dict[str, Any]:
+        if cycle_id < 1:
+            return cls._unknown_item()
+        if status in _TERMINAL_STATUSES:
+            return cls._unknown_item(cycle_id)
+        started_at = now if status == "in_progress" else None
+        return {
+            "known": True,
+            "cycle_id": cycle_id,
+            "created_at": now,
+            "started_at": started_at,
+            "completed_at": None,
+            "active_since": started_at,
+            "active_seconds": 0.0,
+        }
+
+    @staticmethod
+    def _transition(
+        timing: Dict[str, Any],
+        previous_status: str,
+        current_status: str,
+        now: float,
+    ) -> None:
+        if not timing.get("known"):
+            return
+        active_since = timing.get("active_since")
+        if previous_status == "in_progress" and current_status != "in_progress":
+            if active_since is not None:
+                timing["active_seconds"] = float(timing["active_seconds"]) + max(
+                    0.0, now - float(active_since)
+                )
+            timing["active_since"] = None
+        if current_status == "in_progress" and previous_status != "in_progress":
+            if timing.get("started_at") is None:
+                timing["started_at"] = now
+            timing["active_since"] = now
+        if current_status in _TERMINAL_STATUSES and previous_status not in _TERMINAL_STATUSES:
+            timing["completed_at"] = now
+        elif current_status not in _TERMINAL_STATUSES:
+            timing["completed_at"] = None
+
+    @classmethod
+    def _hydrate_item(
+        cls,
+        status: str,
+        raw: Any,
+        *,
+        now: float,
+        current_cycle_id: int,
+    ) -> Dict[str, Any]:
+        if not isinstance(raw, dict):
+            return cls._unknown_item()
+        cycle_id = raw.get("cycle_id")
+        if (
+            isinstance(cycle_id, bool)
+            or not isinstance(cycle_id, int)
+            or cycle_id < 1
+            or cycle_id > current_cycle_id
+        ):
+            cycle_id = None
+        if raw.get("known") is not True:
+            return cls._unknown_item(cycle_id)
+        if cycle_id is None:
+            return cls._unknown_item()
+        if status in _ACTIVE_STATUSES and cycle_id != current_cycle_id:
+            return cls._unknown_item(cycle_id)
+        created_at = _number(raw.get("created_at"))
+        started_at = _number(raw.get("started_at"))
+        completed_at = _number(raw.get("finished_at"))
+        active_since = _number(raw.get("active_since"))
+        accumulated = _number(raw.get("accumulated_active_seconds"))
+        if created_at is None or accumulated is None:
+            return cls._unknown_item(cycle_id)
+        if any(
+            value is not None and value > now + _MAX_FUTURE_SKEW_SECONDS
+            for value in (created_at, started_at, completed_at, active_since)
+        ):
+            return cls._unknown_item(cycle_id)
+        if started_at is not None and started_at < created_at:
+            return cls._unknown_item(cycle_id)
+        if completed_at is not None and completed_at < (started_at or created_at):
+            return cls._unknown_item(cycle_id)
+        if status in _TERMINAL_STATUSES and completed_at is None:
+            return cls._unknown_item(cycle_id)
+        if status not in _TERMINAL_STATUSES and completed_at is not None:
+            return cls._unknown_item(cycle_id)
+        if status == "in_progress" and (
+            started_at is None
+            or active_since is None
+            or active_since < started_at
+        ):
+            return cls._unknown_item(cycle_id)
+        if status != "in_progress" and active_since is not None:
+            return cls._unknown_item(cycle_id)
+        active_end = completed_at if completed_at is not None else now
+        if accumulated > 0 and started_at is None:
+            return cls._unknown_item(cycle_id)
+        if (
+            started_at is not None
+            and accumulated
+            > max(0.0, active_end - started_at) + _TIMING_EPSILON_SECONDS
+        ):
+            return cls._unknown_item(cycle_id)
+        if accumulated > max(0.0, active_end - created_at) + _TIMING_EPSILON_SECONDS:
+            return cls._unknown_item(cycle_id)
+        total_active = accumulated
+        if active_since is not None:
+            total_active += max(0.0, now - active_since)
+        if total_active > max(0.0, now - created_at) + _TIMING_EPSILON_SECONDS:
+            return cls._unknown_item(cycle_id)
+        if status != "in_progress":
+            active_since = None
+        return {
+            "known": True,
+            "cycle_id": cycle_id,
+            "created_at": created_at,
+            "started_at": started_at,
+            "completed_at": completed_at,
+            "active_since": active_since,
+            "active_seconds": accumulated,
+        }

--- a/tools/todo_timing.py
+++ b/tools/todo_timing.py
@@ -65,9 +65,7 @@ class TodoTimingState:
         if rotate:
             self._start_cycle(current, now)
             started_cycle = True
-        elif not previous and current and (
-            self._cycle_id == 0 or self._cycle_completed_at is not None
-        ):
+        elif not previous and current:
             self._start_cycle(current, now)
             started_cycle = True
 

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -14,8 +14,11 @@ Design:
 - Behavioral guidance lives entirely in the tool schema description
 """
 
+import hashlib
 import json
-from typing import Dict, Any, List, Optional
+from typing import Callable, Dict, Any, List, Optional
+
+from tools.todo_timing import TodoTimingState
 
 
 # Valid status values for todo items
@@ -30,12 +33,24 @@ VALID_STATUSES = {"pending", "in_progress", "completed", "cancelled"}
 # task description, and active lists are a handful of items, not hundreds.
 MAX_TODO_CONTENT_CHARS = 4000
 MAX_TODO_ITEMS = 256
+MAX_TODO_ID_CHARS = 128
 # Upper bound on a single todo tool-result payload accepted during history
 # hydration. The gateway/API server replays caller-supplied conversation
 # history to rebuild the store, so an oversized forged result is dropped
 # before it is parsed and re-injected (see AIAgent._hydrate_todo_store).
-MAX_TODO_RESULT_CHARS = 512_000
+# Covers the maximum validated 256 x 4000-character todo list plus the
+# bounded timing envelope. Hydration and compression both enforce this cap
+# before parsing or replaying caller-supplied content.
+# Validated text contains no long-form JSON control escapes, so each input
+# character expands to at most two output characters (quote/backslash and the
+# short control escapes). Reserve 2 KiB per item for timing and JSON structure.
+MAX_TODO_RESULT_CHARS = (
+    MAX_TODO_ITEMS
+    * (2 * MAX_TODO_CONTENT_CHARS + 4 * MAX_TODO_ID_CHARS + 2048)
+    + 4096
+)
 _TRUNCATION_MARKER = "… [truncated]"
+_SHORT_JSON_CONTROLS = {"\b", "\f", "\n", "\r", "\t"}
 # Persisted as ordinary message content. ContextCompressor uses this stable
 # header to distinguish the synthetic post-compaction row from a real user.
 TODO_INJECTION_HEADER = (
@@ -53,8 +68,9 @@ class TodoStore:
       - status: pending | in_progress | completed | cancelled
     """
 
-    def __init__(self):
+    def __init__(self, clock: Optional[Callable[[], float]] = None):
         self._items: List[Dict[str, str]] = []
+        self._timing = TodoTimingState(clock=clock)
 
     def write(self, todos: List[Dict[str, Any]], merge: bool = False) -> List[Dict[str, str]]:
         """
@@ -65,6 +81,7 @@ class TodoStore:
             merge: if False, replace the entire list. If True, update
                    existing items by id and append new ones.
         """
+        previous = self.read()
         if not merge:
             # Replace mode: new list entirely
             self._items = [self._validate(t) for t in self._dedupe_by_id(todos)]
@@ -72,7 +89,7 @@ class TodoStore:
             # Merge mode: update existing items by id, append new ones
             existing = {item["id"]: item for item in self._items}
             for t in self._dedupe_by_id(todos):
-                item_id = str(t.get("id", "")).strip()
+                item_id = self._cap_id(str(t.get("id", "")).strip())
                 if not item_id:
                     continue  # Can't merge without an id
 
@@ -103,15 +120,37 @@ class TodoStore:
         # (list order is priority).
         if len(self._items) > MAX_TODO_ITEMS:
             self._items = self._items[:MAX_TODO_ITEMS]
+        self._timing.apply(previous, self._items)
         return self.read()
 
     def read(self) -> List[Dict[str, str]]:
         """Return a copy of the current list."""
         return [item.copy() for item in self._items]
 
+    def snapshot(self) -> Dict[str, Any]:
+        """Return todos plus machine-owned durable timing metadata."""
+        items = self.read()
+        return {"todos": items, "timing": self._timing.snapshot(items)}
+
+    def hydrate(self, snapshot: Dict[str, Any]) -> List[Dict[str, str]]:
+        """Restore state from a canonical paired todo tool result."""
+        raw_items = snapshot.get("todos") if isinstance(snapshot, dict) else None
+        if not isinstance(raw_items, list):
+            return self.read()
+        self._items = [self._validate(t) for t in self._dedupe_by_id(raw_items)]
+        if len(self._items) > MAX_TODO_ITEMS:
+            self._items = self._items[:MAX_TODO_ITEMS]
+        timing = snapshot.get("timing") if isinstance(snapshot, dict) else None
+        self._timing.hydrate(self._items, timing)
+        return self.read()
+
     def has_items(self) -> bool:
         """Check if there are any items in the list."""
         return bool(self._items)
+
+    def has_durable_state(self) -> bool:
+        """Return whether compression must preserve Todo items or cycle timing."""
+        return self.has_items() or self._timing.has_state()
 
     def format_for_injection(self) -> Optional[str]:
         """
@@ -155,10 +194,29 @@ class TodoStore:
         re-injection block (format_for_injection) without bound. Keep the
         head — the actionable part of a task description — plus a marker.
         """
+        content = TodoStore._sanitize_text(content)
         if len(content) > MAX_TODO_CONTENT_CHARS:
             keep = MAX_TODO_CONTENT_CHARS - len(_TRUNCATION_MARKER)
             return content[:keep] + _TRUNCATION_MARKER
         return content
+
+    @staticmethod
+    def _sanitize_text(value: str) -> str:
+        """Replace control characters that JSON expands to six-character escapes."""
+        return "".join(
+            char if ord(char) >= 32 or char in _SHORT_JSON_CONTROLS else " "
+            for char in value
+        )
+
+    @staticmethod
+    def _cap_id(item_id: str) -> str:
+        """Bound identifiers while retaining a deterministic uniqueness suffix."""
+        item_id = TodoStore._sanitize_text(item_id)
+        if len(item_id) <= MAX_TODO_ID_CHARS:
+            return item_id
+        digest = hashlib.sha256(item_id.encode("utf-8", "surrogatepass")).hexdigest()[:16]
+        keep = MAX_TODO_ID_CHARS - len(digest) - 1
+        return f"{item_id[:keep]}#{digest}"
 
     @staticmethod
     def _validate(item: Dict[str, Any]) -> Dict[str, str]:
@@ -171,7 +229,7 @@ class TodoStore:
         if not isinstance(item, dict):
             return {"id": "?", "content": "(invalid item)", "status": "pending"}
 
-        item_id = str(item.get("id", "")).strip()
+        item_id = TodoStore._cap_id(str(item.get("id", "")).strip())
         if not item_id:
             item_id = "?"
 
@@ -196,7 +254,7 @@ class TodoStore:
                 # Non-dict items get a synthetic key so _validate can handle them
                 last_index[f"__invalid_{i}"] = i
                 continue
-            item_id = str(item.get("id", "")).strip() or "?"
+            item_id = TodoStore._cap_id(str(item.get("id", "")).strip()) or "?"
             last_index[item_id] = i
         return [todos[i] for i in sorted(last_index.values())]
 
@@ -241,8 +299,10 @@ def todo_tool(
     completed = sum(1 for i in items if i["status"] == "completed")
     cancelled = sum(1 for i in items if i["status"] == "cancelled")
 
+    snapshot = store.snapshot()
     return json.dumps({
-        "todos": items,
+        "todos": snapshot["todos"],
+        "timing": snapshot["timing"],
         "summary": {
             "total": len(items),
             "pending": pending,
@@ -287,15 +347,18 @@ TODO_SCHEMA = {
             "todos": {
                 "type": "array",
                 "description": "Task items to write. Omit to read current list.",
+                "maxItems": MAX_TODO_ITEMS,
                 "items": {
                     "type": "object",
                     "properties": {
                         "id": {
                             "type": "string",
+                            "maxLength": MAX_TODO_ID_CHARS,
                             "description": "Unique item identifier"
                         },
                         "content": {
                             "type": "string",
+                            "maxLength": MAX_TODO_CONTENT_CHARS,
                             "description": "Task description"
                         },
                         "status": {


### PR DESCRIPTION
## What does this PR do?

Todo timing currently exists only in observer memory, so process restart resets elapsed time and context compression drops the paired Todo result that resume hydration trusts.

This change makes `TodoStore` own a versioned timing envelope while keeping the model-facing todo item schema unchanged. The envelope records cycle/item timestamps and closed `in_progress` intervals, survives ordinary resume and repeated in-place compression, and exposes bootstrap state to `pre_llm_call`. Existing `post_tool_call` remains the real-time mutation stream.

Legacy or malformed history restores todo content with unknown timing rather than fabricating zero. Paired history is structurally validated but explicitly documented as observability data, not authenticated billing/security evidence.

This supersedes #79370 with the complete durable producer contract rather than only exposing the resumed list.

## Related Issue

No separate issue. Supersedes #79370.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- Add `TodoTimingState` with machine-generated cycle/item timing and cycle membership.
- Keep todo input and `todos` output item shapes unchanged; add a versioned top-level `timing` envelope.
- Restore timing only from structurally paired Todo results and reject future, impossible, excessive, or status-inconsistent values.
- Preserve exactly one bounded paired Todo snapshot across repeated context compression.
- Preserve a closed cycle even when the current Todo list is empty, so restart cannot reuse its cycle ID.
- Rotate `terminal-first → clear → restart → active` into the next cycle even though the first cycle's elapsed timing is unknown.
- Expose `todo_snapshot` on `pre_llm_call` for restart bootstrap; retain `post_tool_call` as the immediate update path.
- Mark legacy data unknown and distinguish `live_runtime` from `paired_history` provenance.
- Document UI/observability semantics and trust limits.

## How to Test

1. Apply `tests/tools/test_todo_timing.py` without the production patch and observe the expected RED failures.
2. Run:
   ```bash
   scripts/run_tests.sh -j 1 tests/tools/test_todo_timing.py tests/tools/test_todo_tool.py
   scripts/run_tests.sh -j 1 tests/run_agent/test_run_agent.py -k TestHydrateTodoStore
   scripts/run_tests.sh -j 1 tests/agent/test_turn_context.py
   scripts/run_tests.sh -j 1 tests/agent/test_compression_rotation_state.py -k TestDurableTodoTimingCompression
   ```
3. Verify the compression regressions execute real `compress_context()` + `archive_and_compact()`, reload active DB history into a fresh agent, preserve active timing across repeated compression, and advance the cycle after both known and terminal-first unknown `clear → restart → new work` sequences.

Focused candidate results:

- Official todo timing/tool: `36 passed`
- Official runner hydrate: `2 passed`; turn context: `17 passed`
- Official runner compression durability/max-payload/legacy-store: `4 passed`
- Python 3.11 upstream-like runner: compression telemetry and worker isolation `5 passed`
- Official runner + test-only Python 3.14 progress-executor bypass for changed legacy snapshot classes: `4 passed`; real `compress_context` and `SessionDB` still ran
- Broader direct Todo/read-loop tools: `50 passed`
- Ruff, compileall, and `git diff --check`: pass

The local default Python is 3.14 and upstream's progress executor currently hangs there. Only the four pre-existing wrapper-based snapshot tests used an external test plugin that bypasses that progress wrapper; the new DB roundtrip ran through the repository wrapper without the plugin. Repository CI remains the authoritative full-suite check.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository `AGENTS.md`.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs; this intentionally supersedes #79370.
- [x] My PR contains only changes related to durable Todo timing.
- [ ] I've run `pytest tests/ -q` and all tests pass locally — focused suites pass; full-suite authority is CI because of the local Python 3.14 upstream executor incompatibility.
- [x] I've added tests for the change.
- [x] I've tested on Fedora Linux.

### Documentation & Housekeeping

- [x] Updated relevant observability documentation.
- [x] Config examples: N/A, no config keys changed.
- [x] CONTRIBUTING/AGENTS: N/A, no contributor workflow changed.
- [x] Considered cross-platform impact: stdlib Python and JSON-only contract.
- [x] Tool input shape is unchanged; accepted limits are now explicit and additive output/hook fields are documented.

## Screenshots / Logs

Source-to-consumer canary after resume:

```json
{"status":"PASS","total":100,"active":80,"source":"paired_history"}
```
