### PR TITLE
fix(file-ops): recover Windows auth writes after locked rename (#83607)

### DIFF
--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -61,6 +61,24 @@ def test_atomic_replace_preserves_symlink(tmp_path: Path) -> None:
     assert link.read_text(encoding="utf-8") == "updated\n"
 
 
+def test_atomic_replace_permission_denied_falls_back_to_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "locked.json"
+    target.write_text("old", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "fresh")
+
+    def deny_replace(src: str, dst: str) -> None:
+        raise OSError(errno.EACCES, "Permission denied", src, dst)
+
+    monkeypatch.setattr(os, "replace", deny_replace)
+    atomic_replace(tmp, target)
+
+    assert target.read_text(encoding="utf-8") == "fresh"
+    assert not tmp.exists()
+
+
+
 def test_atomic_replace_regular_file(tmp_path: Path) -> None:
     target = tmp_path / "plain.yaml"
     target.write_text("old\n", encoding="utf-8")

--- a/utils.py
+++ b/utils.py
@@ -114,7 +114,7 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     try:
         os.replace(tmp_str, real_path)
     except OSError as exc:
-        if exc.errno not in (errno.EXDEV, errno.EBUSY):
+        if exc.errno not in (errno.EXDEV, errno.EBUSY, errno.EACCES, errno.EPERM):
             raise
         logger.debug(
             "atomic_replace: %s -> %s failed with %s; falling back to copy",


### PR DESCRIPTION
## Summary
- fall back to copy/fsync/unlink when Windows denies an atomic rename because auth.json is temporarily locked
- add a regression test for the EACCES fallback path

Closes #83607

## Verification
- `python3 -m py_compile utils.py tests/test_atomic_replace_symlinks.py`
- direct EACCES fallback smoke test passed
- targeted pytest invocation was blocked by the live Hermes process guard; the focused helper behavior was exercised directly