### PR TITLE
fix(cron): reject canonical git checkout as agent job workdir

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -33,6 +33,7 @@ except ImportError:  # pragma: no cover - non-Windows
     msvcrt = None
 from datetime import datetime, timedelta
 from pathlib import Path
+import subprocess
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Set, Tuple, Union, Collection
 
@@ -1395,6 +1396,56 @@ def save_jobs(
         _save_jobs_unlocked(jobs, removed_ids=removed_ids, replace=replace)
 
 
+def _is_canonical_git_checkout(path: Path) -> bool:
+    """Return True when *path* is a canonical (primary) git working tree.
+
+    A cron job workdir may point at a git **linked worktree** (the ``.git``
+    entry is a file whose value names a separate common git dir) or at a plain
+    non-repo directory, but never at a canonical checkout — the repo's real
+    working tree (``.git`` is a directory, and ``--git-dir`` equals
+    ``--git-common-dir``). Running agent terminal/file/code-exec inside a
+    canonical checkout risks parallel-agent collision on a dirty shared tree
+    and re-opens the project-context (AGENTS.md) injection surface.
+
+    Mirrors the atlas-side ``hermes-workdir-check.py`` classification: a
+    linked worktree is told apart from a canonical checkout by ``--git-dir``
+    differing from ``--git-common-dir``, NOT by whether ``.git`` is a file (an
+    initialised submodule also has a ``.git`` file yet is a committable
+    primary tree). Ambiguous cases (git refuses to answer) are treated as
+    False — fail-open so an unknown directory is not spuriously rejected.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    if out.returncode != 0 or out.stdout.strip() != "true":
+        return False
+    try:
+        gitdir = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--path-format=absolute", "--git-dir"],
+            capture_output=True, text=True, timeout=10,
+        )
+        common = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    if gitdir.returncode != 0 or common.returncode != 0:
+        return False
+    gitdir_path = gitdir.stdout.strip() or ""
+    common_path = common.stdout.strip() or ""
+    if not gitdir_path or not common_path:
+        return False
+    try:
+        return os.path.realpath(gitdir_path) == os.path.realpath(common_path)
+    except OSError:
+        return False
+
+
 def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     """Normalize and validate a cron job workdir.
 
@@ -1405,6 +1456,8 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
       - The path must exist and be a directory at create/update time.  We do
         NOT re-check at run time (a user might briefly unmount the dir; the
         scheduler will just fall back to old behaviour with a logged warning).
+      - A canonical (primary) git checkout is rejected — agent runs must use a
+        linked worktree or a plain non-repo directory.
 
     Returns the absolute path string, or None when disabled.
     Raises ValueError on invalid input.
@@ -1425,6 +1478,14 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
         raise ValueError(f"Cron workdir does not exist: {resolved}")
     if not resolved.is_dir():
         raise ValueError(f"Cron workdir is not a directory: {resolved}")
+    if _is_canonical_git_checkout(resolved):
+        raise ValueError(
+            f"Cron workdir must not be a canonical git checkout: {resolved}. "
+            f"Agent runs must use their own linked worktree (e.g. a git worktree "
+            f"or a plain non-repo directory) so parallel agents never collide on "
+            f"a dirty shared tree. Use `git worktree add` for a repo-driven job, "
+            f"or point workdir at a plain directory."
+        )
     return str(resolved)
 
 

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -13,8 +13,17 @@ Covers:
 from __future__ import annotations
 
 import json
+import subprocess
 
 import pytest
+
+
+def _git(repo, *args):
+    """Run a git command in *repo* (behave a path, not a callable)."""
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True,
+    )
 
 
 @pytest.fixture()
@@ -68,6 +77,37 @@ class TestNormalizeWorkdir:
         f.write_text("hi")
         with pytest.raises(ValueError, match="not a directory"):
             _normalize_workdir(str(f))
+
+    def test_canonical_git_checkout_rejected(self, tmp_path):
+        from cron.jobs import _normalize_workdir
+        repo = tmp_path / "canonical"
+        repo.mkdir()
+        _git(repo, "init", "-q")
+        with pytest.raises(ValueError, match="canonical git checkout"):
+            _normalize_workdir(str(repo))
+
+    def test_linked_worktree_accepted(self, tmp_path):
+        from cron.jobs import _normalize_workdir
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q")
+        _git(repo, "config", "user.email", "test@example.com")
+        _git(repo, "config", "user.name", "Test")
+        (repo / "f.txt").write_text("x")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-q", "-m", "init")
+        branch = _git(repo, "symbolic-ref", "--short", "HEAD").stdout.strip()
+        wt = tmp_path / "wt"
+        _git(repo, "worktree", "add", "-q", "-b", "wt-branch", str(wt), branch)
+        result = _normalize_workdir(str(wt))
+        assert result == str(wt.resolve())
+
+    def test_plain_non_repo_accepted(self, tmp_path):
+        from cron.jobs import _normalize_workdir
+        plain = tmp_path / "plain-dir"
+        plain.mkdir()
+        result = _normalize_workdir(str(plain))
+        assert result == str(plain.resolve())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Prevents an agent cron job from being scheduled with a `workdir` pointing at a
repo's **canonical (primary) git checkout**. `_normalize_workdir` now rejects a
workdir whose git-dir equals git-common-dir (the primary working tree), while
still accepting **linked worktrees** (`.git` is a file) and **plain non-repo
directories**.

## Why

An agent cron job with `workdir` runs terminal/file/code_exec in that tree and
loads its AGENTS.md/CLAUDE.md/.cursorrules as project context. Pointing it
at a canonical checkout (e.g. a source checkout) means the agent runs against
the real shared tree — a parallel-agent collision on a dirty tree, and a
re-opened instruction-injection surface. This is the structural (create-time)
half of enforcing that agent work never runs in a canonical checkout; the
complementary runtime work lives separately.

## Approach

- `_is_canonical_git_checkout(path)`: classify via `git rev-parse
  --path-format=absolute --git-dir` vs `--git-common-dir`. A linked worktree has
  `--git-dir` differing from `--git-common-dir`; a canonical checkout has them
  equal. Told apart by the dirs, **not** by whether `.git` is a file (an
  initialised submodule also has a `.git` file yet is a committable primary
  tree). Unknown/ambiguous cases (git refuses to answer) fail open.
- Wired into `_normalize_workdir`, so it applies at `create_job` and
  `update_job` (the same path that rejects relative/missing/non-dir workdirs).
  The refusal message names the pass: use `git worktree add` or a plain dir.

## Tests

Three new tests in `tests/cron/test_cron_workdir.py`:
- canonical checkout -> rejected
- linked worktree -> accepted
- plain non-repo dir -> accepted

Verified:
- `scripts/run_tests.sh tests/cron/test_cron_workdir.py` — 17/17 pass
- full `tests/cron/` — 518 passed, 1 skipped
- sabotage: canonical-reject test fails (DID NOT RAISE) without the fix
- `ruff check` + `git diff --check` clean

## Related

Complementary to open PR #64211 (`require trusted agent workdirs`, a
trust-allowlist approach) — this is a distinct structural guard, not a
duplicate.
