### PR TITLE
fix(gateway): expose trusted tool invocation context to plugins

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22002,6 +22002,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,
             cron_session="",
+            is_bot=bool(getattr(context.source, "is_bot", False)),
         )
 
     def _clear_session_env(self, tokens: list) -> None:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -38,7 +38,7 @@ needs to replace the import + call site:
 
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any, Iterator
+from typing import Any, Iterator, Optional
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
 # When a contextvar holds _UNSET, we fall back to os.environ (CLI/cron compat).
@@ -88,6 +88,15 @@ _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=
 _SESSION_SCOPE_ID: ContextVar = ContextVar("HERMES_SESSION_SCOPE_ID", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
 _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
+# True when the current turn's inbound sender is a bot/webhook rather than a
+# human (mirrors SessionSource.is_bot). Kept out of _VAR_MAP like
+# _SESSION_ASYNC_DELIVERY below: it is a trust-relevant capability flag read
+# via session_is_bot(), not a legacy HERMES_SESSION_* string read via
+# get_session_env(), and it must default to "untrusted" rather than fall back
+# to os.environ. Consumed by gateway/tool_context.py to fail closed on a
+# bot-authored inbound message before any trusted actor is derived from it.
+_SESSION_IS_BOT: ContextVar = ContextVar("HERMES_SESSION_IS_BOT", default=_UNSET)
+
 # In-process UI session/window id for multi-session desktop/TUI hosts. This is
 # intentionally separate from HERMES_SESSION_ID: the latter is the durable
 # conversation/session-db id, while the UI id is the live frontend tab/window
@@ -229,6 +238,7 @@ def set_session_vars(
     async_delivery: bool = True,
     ui_session_id: str = "",
     cron_session: Any = _UNSET,
+    is_bot: bool = False,
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -248,6 +258,12 @@ def set_session_vars(
     ``cron_session`` is tri-state: ``_UNSET`` preserves legacy
     ``os.environ["HERMES_CRON_SESSION"]`` fallback, ``"1"`` marks a cron job,
     and ``""`` explicitly marks a non-cron session while masking leaked env.
+
+    ``is_bot`` mirrors ``SessionSource.is_bot`` — True when the inbound
+    message's author is a bot/webhook rather than a human. See
+    ``_SESSION_IS_BOT`` / ``session_is_bot`` for why this defaults to
+    "untrusted" when unset rather than falling back to this parameter's
+    default.
     """
     # Mark the session-context machinery engaged for this process. The
     # subprocess-env bridge uses this to switch from "os.environ fallback" to
@@ -271,6 +287,7 @@ def set_session_vars(
         _SESSION_PROFILE.set(profile),
         _CRON_SESSION.set(cron_session),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
+        _SESSION_IS_BOT.set(bool(is_bot)),
     ]
     try:
         from agent.runtime_cwd import set_session_cwd
@@ -315,6 +332,10 @@ def clear_session_vars(tokens: list) -> None:
     # behavior (CLI / unaware paths), not be mistaken for an opted-out
     # stateless adapter.
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    # Reset is_bot to the "never set" sentinel, which session_is_bot() treats
+    # as untrusted — a handler that has exited must not leave behind a
+    # human-sender signal a later, unrelated read could pick up.
+    _SESSION_IS_BOT.set(_UNSET)
     try:
         from agent.runtime_cwd import clear_session_cwd
 
@@ -363,12 +384,49 @@ def reset_session_vars() -> None:
     # same inheritance-leak reason as the mapped vars above — see clear_session_vars,
     # which resets this var on the handler-exit path for the symmetric concern.
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    # Same inheritance-leak reason: an inherited is_bot=False from a sibling
+    # task's session must not survive into this task before it binds its own.
+    _SESSION_IS_BOT.set(_UNSET)
     try:
         from agent.runtime_cwd import clear_session_cwd
 
         clear_session_cwd()
     except Exception:
         pass
+
+
+def get_session_var_strict(name: str) -> Optional[str]:
+    """Read a ``HERMES_SESSION_*`` ContextVar with NO ``os.environ`` fallback.
+
+    Unlike :func:`get_session_env`, this returns ``None`` — never a value
+    borrowed from process-global environment — when the variable was never
+    bound in the current task-local context. Use this instead of
+    ``get_session_env`` wherever a same-process, differently-scoped
+    ``os.environ`` value must not be mistaken for this task's own session
+    state — e.g. deriving an authenticated identity in
+    ``gateway/tool_context.py``, where an env fallback would let a
+    CLI/cron/test process's leftover env vars masquerade as a real inbound
+    gateway message.
+    """
+    var = _VAR_MAP.get(name)
+    if var is None:
+        return None
+    value = var.get()
+    return None if value is _UNSET else value
+
+
+def session_is_bot() -> bool:
+    """Whether the current session's inbound sender is a bot/webhook.
+
+    Defaults to ``True`` (untrusted) when never explicitly bound via
+    ``set_session_vars(is_bot=...)``, so a context that hasn't been through
+    the trusted inbound-message pipeline is never mistaken for a verified
+    human sender. Never falls back to ``os.environ``.
+    """
+    value = _SESSION_IS_BOT.get()
+    if value is _UNSET:
+        return True
+    return bool(value)
 
 
 def get_session_env(name: str, default: str = "") -> str:

--- a/gateway/tool_context.py
+++ b/gateway/tool_context.py
@@ -1,0 +1,116 @@
+"""Narrow, read-only proof of an authenticated inbound gateway message.
+
+``TrustedToolInvocationContext`` is built exclusively from the gateway's own
+task-local ``ContextVar``-bound session state (see
+:mod:`gateway.session_context`) — never from model tool-call arguments, a
+plain mapping, or an environment variable. A plugin that must discover a
+sender's identity for a security-sensitive action (e.g. picking a message
+delivery target) should accept this typed object as a tool-handler kwarg and
+reject anything else with a nominal ``isinstance`` check, so a model can never
+forge one through tool-call arguments or a duck-typed lookalike.
+
+This is the seam a standalone plugin imports as
+``gateway.tool_context.TrustedToolInvocationContext``; core has no plugin-
+specific branch here — the type and its builder are generic to any tool
+handler that needs proof of the authenticated sender behind the current turn.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from gateway.session import Platform, SessionSource
+
+# Platforms this seam currently vouches for. Extend deliberately: every entry
+# here is a platform whose adapter has been audited to set `is_bot` correctly
+# and to bind session vars only after the inbound message is authenticated.
+_TRUSTED_PLATFORMS = frozenset({Platform.FEISHU.value})
+
+
+@dataclass(frozen=True)
+class TrustedToolInvocationContext:
+    """Typed, post-auth proof of who sent the message driving this tool call.
+
+    ``source`` carries the authenticated sender's platform/user_id/is_bot.
+    ``context_id`` and ``anchor_id`` tie the proof to one authenticated
+    inbound turn — a consumer keys any state it derives on both so a stale or
+    cross-session context can't be replayed.
+    """
+
+    source: SessionSource
+    context_id: str
+    anchor_id: str
+    authenticated: bool = True
+
+    def require_valid(self) -> "TrustedToolInvocationContext":
+        """Raise if this is not a usable, authenticated proof.
+
+        Defense in depth: :func:`build_trusted_tool_invocation_context`
+        already refuses to construct an instance unless every field below is
+        present, so this should never raise for a builder-constructed
+        context. It exists so a consumer's own ``value.require_valid()``
+        check has real validation behind it rather than a no-op.
+        """
+        if not self.authenticated:
+            raise PermissionError("trusted tool invocation context is not authenticated")
+        if not self.anchor_id:
+            raise ValueError("trusted tool invocation context is missing an inbound message anchor")
+        if not self.context_id:
+            raise ValueError("trusted tool invocation context is missing a context id")
+        if self.source.is_bot:
+            raise PermissionError("trusted tool invocation context sender is a bot")
+        return self
+
+
+def build_trusted_tool_invocation_context() -> Optional[TrustedToolInvocationContext]:
+    """Build a context strictly from the current task's bound session state.
+
+    Returns ``None`` (fail-closed) unless ALL of the following hold for the
+    CURRENT task-local session:
+
+    - the platform is one of ``_TRUSTED_PLATFORMS`` (Feishu today);
+    - the sender is not a bot/webhook;
+    - the inbound message id (the reply/callback anchor) is present;
+    - the sender's user id and a stable context id (session key, falling
+      back to session id) are present.
+
+    Reads ONLY task-local ContextVars via
+    ``gateway.session_context.get_session_var_strict`` / ``session_is_bot`` —
+    never model tool-call arguments, a plain mapping, or ``os.environ`` (that
+    fallback exists in ``get_session_env`` for CLI/cron compatibility and is
+    deliberately not used here, since it would let a same-process CLI/cron/
+    test env var masquerade as a real inbound gateway message). CLI, the API
+    server, cron, and any other surface that never called
+    ``set_session_vars`` for this task always resolve to ``None`` here.
+    """
+    from gateway.session_context import get_session_var_strict, session_is_bot
+
+    if session_is_bot():
+        return None
+
+    platform = (get_session_var_strict("HERMES_SESSION_PLATFORM") or "").strip().lower()
+    if platform not in _TRUSTED_PLATFORMS:
+        return None
+
+    user_id = (get_session_var_strict("HERMES_SESSION_USER_ID") or "").strip()
+    anchor_id = (get_session_var_strict("HERMES_SESSION_MESSAGE_ID") or "").strip()
+    context_id = (
+        (get_session_var_strict("HERMES_SESSION_KEY") or "").strip()
+        or (get_session_var_strict("HERMES_SESSION_ID") or "").strip()
+    )
+    if not user_id or not anchor_id or not context_id:
+        return None
+
+    source = SessionSource(
+        platform=Platform(platform),
+        chat_id=(get_session_var_strict("HERMES_SESSION_CHAT_ID") or "").strip(),
+        user_id=user_id,
+        message_id=anchor_id,
+        is_bot=False,
+    )
+    return TrustedToolInvocationContext(
+        source=source,
+        context_id=context_id,
+        anchor_id=anchor_id,
+    )

--- a/model_tools.py
+++ b/model_tools.py
@@ -1455,6 +1455,17 @@ def handle_function_call(
         except Exception:
             reset_current_observability_context = None
         try:
+            # Built fresh from the current task's ContextVar-bound session
+            # state (never from function_args or an env var) so a handler can
+            # accept a typed, unforgeable proof of the authenticated inbound
+            # sender. None on any non-gateway surface (CLI, API server, cron)
+            # and on any gateway session that isn't a real, non-bot Feishu
+            # inbound message. See gateway/tool_context.py.
+            try:
+                from gateway.tool_context import build_trusted_tool_invocation_context
+                _trusted_tool_context = build_trusted_tool_invocation_context()
+            except Exception:
+                _trusted_tool_context = None
             if function_name == "execute_code":
                 # Prefer the caller-provided list so subagents can't overwrite
                 # the parent's tool set via the process-global.
@@ -1465,6 +1476,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         enabled_tools=sandbox_enabled,
+                        tool_context=_trusted_tool_context,
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
@@ -1473,6 +1485,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         user_task=user_task,
+                        tool_context=_trusted_tool_context,
                     )
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)

--- a/tests/gateway/test_tool_context.py
+++ b/tests/gateway/test_tool_context.py
@@ -1,0 +1,177 @@
+"""Tests for gateway/tool_context.py — the trusted tool invocation context seam.
+
+``build_trusted_tool_invocation_context()`` is the ONLY supported way to
+derive a typed proof of "who authenticated-sent the message driving this
+tool call". It must construct that proof strictly from the current task's
+``ContextVar``-bound gateway session state (see ``gateway/session_context.py``)
+and fail closed (return ``None``) whenever that state isn't a fully-bound,
+non-bot Feishu inbound message — never from model tool-call arguments, a
+plain mapping, or an environment variable.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from gateway.session_context import (
+    clear_session_vars,
+    reset_session_vars,
+    set_session_vars,
+)
+from gateway.tool_context import (
+    TrustedToolInvocationContext,
+    build_trusted_tool_invocation_context,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_session_context():
+    """Every test starts and ends with no session bound in this task."""
+    reset_session_vars()
+    yield
+    reset_session_vars()
+
+
+def _bind_feishu_human(**overrides):
+    defaults = dict(
+        platform="feishu",
+        chat_id="oc_chat_1",
+        chat_type="dm",
+        user_id="ou_user_1",
+        session_key="sk_session_1",
+        message_id="om_message_1",
+        is_bot=False,
+    )
+    defaults.update(overrides)
+    return set_session_vars(**defaults)
+
+
+class TestAuthenticatedFeishuHuman:
+    def test_builds_typed_context_with_correct_fields(self):
+        tokens = _bind_feishu_human()
+        try:
+            ctx = build_trusted_tool_invocation_context()
+            assert isinstance(ctx, TrustedToolInvocationContext)
+            assert ctx.source.platform.value == "feishu"
+            assert ctx.source.user_id == "ou_user_1"
+            assert ctx.source.is_bot is False
+            assert ctx.anchor_id == "om_message_1"
+            assert ctx.context_id == "sk_session_1"
+            assert ctx.authenticated is True
+        finally:
+            clear_session_vars(tokens)
+
+    def test_require_valid_does_not_raise(self):
+        tokens = _bind_feishu_human()
+        try:
+            ctx = build_trusted_tool_invocation_context()
+            assert ctx.require_valid() is ctx
+        finally:
+            clear_session_vars(tokens)
+
+    def test_context_id_falls_back_to_session_id_when_session_key_empty(self):
+        tokens = _bind_feishu_human(session_key="", session_id="sid_fallback")
+        try:
+            ctx = build_trusted_tool_invocation_context()
+            assert ctx is not None
+            assert ctx.context_id == "sid_fallback"
+        finally:
+            clear_session_vars(tokens)
+
+
+class TestFailClosed:
+    def test_unbound_session_returns_none(self):
+        assert build_trusted_tool_invocation_context() is None
+
+    def test_bot_sender_returns_none(self):
+        tokens = _bind_feishu_human(is_bot=True)
+        try:
+            assert build_trusted_tool_invocation_context() is None
+        finally:
+            clear_session_vars(tokens)
+
+    def test_non_feishu_platform_returns_none(self):
+        tokens = _bind_feishu_human(platform="telegram")
+        try:
+            assert build_trusted_tool_invocation_context() is None
+        finally:
+            clear_session_vars(tokens)
+
+    def test_missing_message_anchor_returns_none(self):
+        tokens = _bind_feishu_human(message_id="")
+        try:
+            assert build_trusted_tool_invocation_context() is None
+        finally:
+            clear_session_vars(tokens)
+
+    def test_missing_user_id_returns_none(self):
+        tokens = _bind_feishu_human(user_id="")
+        try:
+            assert build_trusted_tool_invocation_context() is None
+        finally:
+            clear_session_vars(tokens)
+
+    def test_missing_context_id_returns_none(self):
+        tokens = _bind_feishu_human(session_key="", session_id="")
+        try:
+            assert build_trusted_tool_invocation_context() is None
+        finally:
+            clear_session_vars(tokens)
+
+    def test_cleared_session_returns_none(self):
+        tokens = _bind_feishu_human()
+        clear_session_vars(tokens)
+        assert build_trusted_tool_invocation_context() is None
+
+    def test_require_valid_raises_on_bot_source(self):
+        ctx = build_trusted_tool_invocation_context()  # unbound -> None first
+        assert ctx is None
+        tokens = _bind_feishu_human()
+        try:
+            ctx = build_trusted_tool_invocation_context()
+            assert ctx is not None
+            # Hand-construct an invalid instance (a builder never would) to
+            # prove require_valid() is real validation, not a rubber stamp.
+            forged = TrustedToolInvocationContext(
+                source=ctx.source.__class__(**{**ctx.source.__dict__, "is_bot": True}),
+                context_id=ctx.context_id,
+                anchor_id=ctx.anchor_id,
+            )
+            with pytest.raises(PermissionError):
+                forged.require_valid()
+        finally:
+            clear_session_vars(tokens)
+
+
+class TestCannotBeForgedFromEnvOrArgs:
+    def test_os_environ_alone_does_not_produce_a_context(self, monkeypatch):
+        """A same-process env var must never masquerade as a bound session.
+
+        This is exactly the leak get_session_var_strict is designed to
+        block: os.environ fallback is fine for legacy get_session_env
+        (CLI/cron compatibility) but must never feed an authenticated-actor
+        derivation.
+        """
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "feishu")
+        monkeypatch.setenv("HERMES_SESSION_USER_ID", "ou_attacker")
+        monkeypatch.setenv("HERMES_SESSION_MESSAGE_ID", "om_attacker")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "sk_attacker")
+        try:
+            assert build_trusted_tool_invocation_context() is None
+        finally:
+            for name in (
+                "HERMES_SESSION_PLATFORM",
+                "HERMES_SESSION_USER_ID",
+                "HERMES_SESSION_MESSAGE_ID",
+                "HERMES_SESSION_KEY",
+            ):
+                os.environ.pop(name, None)
+
+    def test_builder_takes_no_arguments(self):
+        """The builder cannot read model tool-call arguments: it has none."""
+        import inspect
+
+        sig = inspect.signature(build_trusted_tool_invocation_context)
+        assert len(sig.parameters) == 0

--- a/tests/test_dispatch_trusted_tool_context.py
+++ b/tests/test_dispatch_trusted_tool_context.py
@@ -1,0 +1,206 @@
+"""Tests that handle_function_call forwards a trusted tool invocation context
+into registry.dispatch — and only when one legitimately exists.
+
+Companion to test_dispatch_session_id.py, which established this
+mock-the-registry pattern for asserting exactly what kwargs
+``handle_function_call`` forwards to ``registry.dispatch`` without exercising
+every real tool handler.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from gateway.session_context import clear_session_vars, reset_session_vars, set_session_vars
+from gateway.tool_context import TrustedToolInvocationContext
+
+
+def _make_registry(captured: dict):
+    """Return a mock registry whose dispatch records the kwargs it receives."""
+    registry = MagicMock()
+
+    def _dispatch(name, args, **kwargs):
+        captured.update(kwargs)
+        return json.dumps({"result": "ok"})
+
+    registry.dispatch.side_effect = _dispatch
+    return registry
+
+
+def _bind_feishu_human(**overrides):
+    defaults = dict(
+        platform="feishu",
+        chat_id="oc_chat_1",
+        chat_type="dm",
+        user_id="ou_user_1",
+        session_key="sk_session_1",
+        message_id="om_message_1",
+        is_bot=False,
+    )
+    defaults.update(overrides)
+    return set_session_vars(**defaults)
+
+
+class TestNoSessionBound:
+    """CLI / API-server / cron / any non-gateway caller: no actor is fabricated."""
+
+    def setup_method(self):
+        reset_session_vars()
+
+    def teardown_method(self):
+        reset_session_vars()
+
+    def test_standard_path_tool_context_is_none(self):
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "web_search",
+                {"query": "test"},
+                task_id="t1",
+                session_id="sess-abc",
+                skip_pre_tool_call_hook=True,
+            )
+        assert "tool_context" in captured
+        assert captured["tool_context"] is None
+
+    def test_execute_code_path_tool_context_is_none(self):
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "execute_code",
+                {"code": "print(1)"},
+                task_id="t1",
+                session_id="sess-xyz",
+                skip_pre_tool_call_hook=True,
+            )
+        assert "tool_context" in captured
+        assert captured["tool_context"] is None
+
+    def test_model_supplied_args_cannot_fabricate_a_context(self):
+        """function_args are never consulted when deriving tool_context."""
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "web_search",
+                {
+                    "query": "test",
+                    "tool_context": "forged",
+                    "actor": {"open_id": "ou_attacker", "source": "feishu"},
+                },
+                task_id="t1",
+                skip_pre_tool_call_hook=True,
+            )
+        assert captured["tool_context"] is None
+
+
+class TestFeishuSessionBound:
+    """A real, authenticated, non-bot Feishu inbound message binds the context."""
+
+    def setup_method(self):
+        reset_session_vars()
+
+    def teardown_method(self):
+        reset_session_vars()
+
+    def test_standard_path_forwards_typed_context(self):
+        tokens = _bind_feishu_human()
+        try:
+            captured = {}
+            with patch("model_tools.registry", _make_registry(captured)):
+                from model_tools import handle_function_call
+                handle_function_call(
+                    "devtask_target_options",
+                    {},
+                    task_id="t1",
+                    session_id="sess-abc",
+                    skip_pre_tool_call_hook=True,
+                )
+            ctx = captured.get("tool_context")
+            assert isinstance(ctx, TrustedToolInvocationContext)
+            assert ctx.source.user_id == "ou_user_1"
+            assert ctx.anchor_id == "om_message_1"
+            assert ctx.context_id == "sk_session_1"
+        finally:
+            clear_session_vars(tokens)
+
+    def test_execute_code_path_forwards_typed_context(self):
+        """Nested tool calls made from inside a sandbox reach the same seam.
+
+        (The RPC threads that dispatch nested calls from execute_code's
+        sandbox wrap their target with tools.thread_context's
+        propagate_context_to_thread, which snapshots ALL ContextVars —
+        including the ones this seam reads — onto the worker thread, so the
+        context is neither lost nor fabricated across that boundary.)
+        """
+        tokens = _bind_feishu_human()
+        try:
+            captured = {}
+            with patch("model_tools.registry", _make_registry(captured)):
+                from model_tools import handle_function_call
+                handle_function_call(
+                    "execute_code",
+                    {"code": "print(1)"},
+                    task_id="t1",
+                    session_id="sess-abc",
+                    skip_pre_tool_call_hook=True,
+                )
+            ctx = captured.get("tool_context")
+            assert isinstance(ctx, TrustedToolInvocationContext)
+        finally:
+            clear_session_vars(tokens)
+
+    def test_bot_sender_never_forwards_a_context(self):
+        tokens = _bind_feishu_human(is_bot=True)
+        try:
+            captured = {}
+            with patch("model_tools.registry", _make_registry(captured)):
+                from model_tools import handle_function_call
+                handle_function_call(
+                    "devtask_target_options",
+                    {},
+                    task_id="t1",
+                    skip_pre_tool_call_hook=True,
+                )
+            assert captured.get("tool_context") is None
+        finally:
+            clear_session_vars(tokens)
+
+    def test_non_feishu_platform_never_forwards_a_context(self):
+        tokens = _bind_feishu_human(platform="telegram")
+        try:
+            captured = {}
+            with patch("model_tools.registry", _make_registry(captured)):
+                from model_tools import handle_function_call
+                handle_function_call(
+                    "devtask_target_options",
+                    {},
+                    task_id="t1",
+                    skip_pre_tool_call_hook=True,
+                )
+            assert captured.get("tool_context") is None
+        finally:
+            clear_session_vars(tokens)
+
+    def test_existing_kwargs_still_forwarded_unchanged(self):
+        """Regression guard: adding tool_context must not disturb task_id/
+        session_id/user_task forwarding for ordinary tool dispatch."""
+        tokens = _bind_feishu_human()
+        try:
+            captured = {}
+            with patch("model_tools.registry", _make_registry(captured)):
+                from model_tools import handle_function_call
+                handle_function_call(
+                    "web_search",
+                    {"query": "test"},
+                    task_id="task-999",
+                    session_id="sess-1",
+                    user_task="find the bug",
+                    skip_pre_tool_call_hook=True,
+                )
+            assert captured.get("task_id") == "task-999"
+            assert captured.get("session_id") == "sess-1"
+            assert captured.get("user_task") == "find the bug"
+        finally:
+            clear_session_vars(tokens)


### PR DESCRIPTION
## Summary

- Add a generic typed `TrustedToolInvocationContext` seam for gateway plugins.
- Build it only from task-local authenticated Feishu session context; fail closed for unbound, bot, non-Feishu, missing-anchor, mapping, and environment-only inputs.
- Forward the context through normal and `execute_code` tool dispatch without adding a devtask-specific core branch.

## Validation

- `env -u PYTHONPATH /Users/dou/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_tool_context.py tests/test_dispatch_trusted_tool_context.py -q` — 21 passed.
- `compileall` — passed.
- `git diff --check` — passed.
- Full gateway suite: 5222 passed / 7 environment or test-order failures / 14 skipped; the failures are unrelated to this change.
