### PR TITLE
fix(supermemory): show billing usage in runtime footer

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -780,9 +780,9 @@ def _fetch_anthropic_account_usage(
                 "custom and proxy routes are not queried."
             ),
         )
-    token = str(api_key or "").strip() if has_live_context else (
-        resolve_anthropic_token() or ""
-    ).strip()
+    token = str(api_key or "").strip()
+    if not token:
+        token = (resolve_anthropic_token() or "").strip()
     if not token:
         return None
     if not _is_oauth_token(token):
@@ -955,7 +955,7 @@ def _fetch_supermemory_account_usage() -> AccountUsageSnapshot:
         used_value = float(used)
         included_value = float(included)
         remaining = (
-            float(balance)
+            max(0.0, float(balance))
             if _is_finite_num(balance)
             else max(0.0, included_value - used_value)
         )
@@ -976,7 +976,7 @@ def _fetch_supermemory_account_usage() -> AccountUsageSnapshot:
             f"Supermemory credits used: ${used_value:.2f} of ${included_value:.2f}"
         )
     elif _is_finite_num(balance):
-        details.append(f"Supermemory credits balance: ${float(balance):.2f}")
+        details.append(f"Supermemory credits balance: ${max(0.0, float(balance)):.2f}")
 
     return AccountUsageSnapshot(
         provider="supermemory",

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -5,6 +5,7 @@ import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import urlparse
 
 import httpx
 
@@ -748,8 +749,40 @@ def redeem_codex_reset_credit(
     )
 
 
-def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
-    token = (resolve_anthropic_token() or "").strip()
+def _anthropic_official_usage_route(base_url: Optional[str]) -> bool:
+    """Return whether live credentials may be used on Anthropic's usage API."""
+    if not base_url:
+        return True
+    try:
+        parsed = urlparse(str(base_url).strip())
+        return (
+            parsed.scheme.lower() == "https"
+            and (parsed.hostname or "").lower() == "api.anthropic.com"
+            and parsed.port in {None, 443}
+        )
+    except (TypeError, ValueError):
+        return False
+
+
+def _fetch_anthropic_account_usage(
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[AccountUsageSnapshot]:
+    has_live_context = base_url is not None or api_key is not None
+    if has_live_context and not _anthropic_official_usage_route(base_url):
+        return AccountUsageSnapshot(
+            provider="anthropic",
+            source="oauth_usage_api",
+            fetched_at=_utc_now(),
+            unavailable_reason=(
+                "Anthropic account limits require the official Anthropic endpoint; "
+                "custom and proxy routes are not queried."
+            ),
+        )
+    token = str(api_key or "").strip() if has_live_context else (
+        resolve_anthropic_token() or ""
+    ).strip()
     if not token:
         return None
     if not _is_oauth_token(token):
@@ -881,6 +914,80 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def _fetch_supermemory_account_usage() -> AccountUsageSnapshot:
+    """Fetch billing usage from one atomically resolved Supermemory connection."""
+    from plugins.memory.supermemory import resolve_supermemory_connection_settings
+
+    connection = resolve_supermemory_connection_settings()
+    resolved_key = str(connection.get("api_key") or "").strip()
+    resolved_base = str(connection.get("base_url") or "").strip().rstrip("/")
+    timeout = connection.get("api_timeout", 10.0)
+    if not resolved_key:
+        return AccountUsageSnapshot(
+            provider="supermemory",
+            source="billing_usage_api",
+            fetched_at=_utc_now(),
+            unavailable_reason="SUPERMEMORY_API_KEY not set",
+        )
+
+    endpoint = f"{resolved_base}/v3/auth/billing/usage"
+    with httpx.Client(timeout=timeout) as client:
+        response = client.get(
+            endpoint,
+            headers={"Authorization": f"Bearer {resolved_key}", "Accept": "application/json"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+    features = payload.get("features") if isinstance(payload, dict) else None
+    credits = features.get("usd_credits") if isinstance(features, dict) else None
+    if not isinstance(credits, dict):
+        credits = {}
+
+    used = credits.get("usage")
+    included = credits.get("included_usage")
+    balance = credits.get("balance")
+    reset = credits.get("next_reset_at")
+
+    windows: list[AccountUsageWindow] = []
+    details: list[str] = []
+    if _is_finite_num(used) and _is_finite_num(included) and float(included) > 0:
+        used_value = float(used)
+        included_value = float(included)
+        remaining = (
+            float(balance)
+            if _is_finite_num(balance)
+            else max(0.0, included_value - used_value)
+        )
+        reset_at = (
+            _parse_dt(float(reset) / 1000)
+            if _is_finite_num(reset)
+            else _parse_dt(reset)
+        )
+        windows.append(
+            AccountUsageWindow(
+                label="Supermemory credits",
+                used_percent=(used_value / included_value) * 100,
+                reset_at=reset_at,
+                detail=f"${remaining:.2f} of ${included_value:.2f} remaining",
+            )
+        )
+        details.append(
+            f"Supermemory credits used: ${used_value:.2f} of ${included_value:.2f}"
+        )
+    elif _is_finite_num(balance):
+        details.append(f"Supermemory credits balance: ${float(balance):.2f}")
+
+    return AccountUsageSnapshot(
+        provider="supermemory",
+        source="billing_usage_api",
+        fetched_at=_utc_now(),
+        title="Supermemory limits",
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
@@ -894,9 +1001,13 @@ def fetch_account_usage(
         if normalized == "openai-codex":
             return _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
         if normalized == "anthropic":
-            return _fetch_anthropic_account_usage()
+            return _fetch_anthropic_account_usage(base_url=base_url, api_key=api_key)
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized == "supermemory":
+            # Supermemory's key/base/timeout form one authority unit. Never
+            # combine generic model-provider overrides with that connection.
+            return _fetch_supermemory_account_usage()
     except Exception:
         return None
     return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1961,7 +1961,7 @@ def _current_max_iterations() -> int:
         return 500
 
 
-from contextlib import contextmanager as _contextmanager
+from contextlib import contextmanager as _contextmanager, nullcontext as _nullcontext
 
 
 # Platforms that bind a host TCP port (HTTP/webhook listeners). In a profile
@@ -2025,6 +2025,75 @@ def _profile_runtime_scope(profile_home: "Path"):
     finally:
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
+
+
+def _runtime_footer_context_from_agent(agent: Any) -> Dict[str, Any]:
+    """Capture the actual runtime used by one agent turn for footer billing.
+
+    The API key lives only in the internal ``agent_result`` long enough for the
+    outer gateway path to consume it.  ``_build_runtime_footer_for_result``
+    removes the context before hooks or platform sends run.
+    """
+    if agent is None:
+        return {}
+    return {
+        "provider": getattr(agent, "provider", None),
+        "base_url": getattr(agent, "base_url", None),
+        "api_key": getattr(agent, "api_key", None),
+    }
+
+
+async def _build_runtime_footer_for_result(
+    runner: Any,
+    *,
+    source: Any,
+    session_key: str | None,
+    agent_result: Dict[str, Any],
+    turn_seconds: float | None,
+) -> str:
+    """Build the footer under the same profile/secret scope as the agent turn."""
+    runtime_context = agent_result.pop("_runtime_footer_context", None)
+    if not isinstance(runtime_context, dict):
+        runtime_context = {}
+
+    config = getattr(runner, "config", None)
+    if getattr(config, "multiplex_profiles", False):
+        profile_home = runner._resolve_profile_home_for_source(source)
+        scope = _profile_runtime_scope(profile_home)
+    else:
+        scope = _nullcontext()
+
+    with scope:
+        user_config = _load_gateway_config()
+        if not runtime_context.get("provider"):
+            try:
+                _model, resolved_runtime = runner._resolve_session_agent_runtime(
+                    source=source,
+                    session_key=session_key,
+                    user_config=user_config,
+                )
+                runtime_context = {
+                    "provider": resolved_runtime.get("provider"),
+                    "base_url": resolved_runtime.get("base_url"),
+                    "api_key": resolved_runtime.get("api_key"),
+                }
+            except Exception:
+                logger.debug("runtime footer provider resolution failed", exc_info=True)
+
+        from gateway.runtime_footer import build_footer_line_async
+
+        return await build_footer_line_async(
+            user_config=user_config,
+            platform_key=_platform_config_key(source.platform),
+            provider=runtime_context.get("provider"),
+            base_url=runtime_context.get("base_url"),
+            api_key=runtime_context.get("api_key"),
+            model=agent_result.get("model"),
+            context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
+            context_length=agent_result.get("context_length") or None,
+            cwd=os.environ.get("TERMINAL_CWD", ""),
+            turn_seconds=turn_seconds,
+        )
 
 
 def load_gateway_config_for_runner() -> "GatewayConfig":
@@ -5646,6 +5715,7 @@ class TurnRunner:
             _output_toks = getattr(_agent, "session_completion_tokens", 0)
             _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
         _resolved_model = getattr(_agent, "model", None) if _agent else None
+        _runtime_footer_context = _runtime_footer_context_from_agent(_agent)
 
         # Sync session_id immediately after run_conversation(). Compression
         # can rotate before a follow-up model call fails; the failure return
@@ -5781,6 +5851,8 @@ class TurnRunner:
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": _runtime_footer_context.get("provider"),
+                "_runtime_footer_context": _runtime_footer_context,
                 "context_length": _context_length,
             }
 
@@ -5858,6 +5930,8 @@ class TurnRunner:
             "input_tokens": _input_toks,
             "output_tokens": _output_toks,
             "model": _resolved_model,
+            "provider": _runtime_footer_context.get("provider"),
+            "_runtime_footer_context": _runtime_footer_context,
             "context_length": _context_length,
             "session_id": effective_session_id,
             "response_previewed": result.get("response_previewed", False),
@@ -18303,14 +18377,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
-                _footer_line = _bfl(
-                    user_config=_load_gateway_config(),
-                    platform_key=_platform_config_key(source.platform),
-                    model=agent_result.get("model"),
-                    context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
-                    context_length=agent_result.get("context_length") or None,
-                    cwd=os.environ.get("TERMINAL_CWD", ""),
+                _footer_line = await _build_runtime_footer_for_result(
+                    self,
+                    source=source,
+                    session_key=session_key,
+                    agent_result=agent_result,
                     turn_seconds=_turn_seconds,
                 )
             except Exception as _footer_err:

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -60,10 +60,6 @@ async def fetch_runtime_footer_quota_snapshot(
     requests: list[tuple[str, str | None, str | None]] = []
     if normalized in {"anthropic", "openai-codex", "openrouter"}:
         requests.append((normalized, base_url, api_key))
-    # With no Supermemory key this returns an unavailable snapshot without a
-    # request. asyncio.to_thread also preserves profile-scoped contextvars.
-    requests.append(("supermemory", None, None))
-
     async def _fetch(
         one_provider: str,
         one_base_url: str | None,
@@ -76,6 +72,14 @@ async def fetch_runtime_footer_quota_snapshot(
             api_key=one_api_key,
         )
 
+    def _fetch_supermemory_if_configured():
+        """Resolve connection + fetch in one worker so footer rendering never blocks."""
+        from plugins.memory.supermemory import resolve_supermemory_connection_settings
+
+        if not str(resolve_supermemory_connection_settings().get("api_key") or "").strip():
+            return None
+        return fetch_account_usage("supermemory")
+
     try:
         results = await asyncio.wait_for(
             asyncio.gather(
@@ -83,6 +87,7 @@ async def fetch_runtime_footer_quota_snapshot(
                     _fetch(name, request_base, request_key)
                     for name, request_base, request_key in requests
                 ),
+                asyncio.to_thread(_fetch_supermemory_if_configured),
                 return_exceptions=True,
             ),
             timeout=max(0.001, float(timeout_seconds)),

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,6 +1,6 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
+Renders a compact footer showing runtime state (model, context %, quota, cwd) and
 appends it to the FINAL message of an agent turn when enabled.  Off by default
 to keep replies minimal.
 
@@ -9,16 +9,17 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        fields: [model, context_pct, quota, cwd]   # order shown; drop any to hide
 
 Available fields:
     model        — bare model id, vendor prefix dropped (``gpt-5.4``)
     context_pct  — last-call context occupancy as a percent (``5%``)
+    quota        — available model/Supermemory usage windows (best-effort)
     latency      — wall-clock duration of the turn (``22s``, ``1m05s``)
     cwd          — home-relative working dir (``~``)
 
-``latency`` is opt-in: it is NOT in the default field set, so a footer whose
-``fields`` are unset renders exactly as before.
+``latency`` is opt-in: it is NOT in the default field set. A footer whose
+``fields`` are unset uses ``model``, ``context_pct``, ``quota``, and ``cwd``.
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -34,11 +35,82 @@ piecemeal, the footer is sent as a separate trailing message via
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import math
 import os
 from typing import Any, Iterable, Optional
 
-_DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+_DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "quota", "cwd")
 _SEP = " · "
+logger = logging.getLogger(__name__)
+
+
+async def fetch_runtime_footer_quota_snapshot(
+    provider: str | None,
+    *,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    timeout_seconds: float = 5.0,
+):
+    """Fetch model and Supermemory quota snapshots without blocking the loop."""
+    from agent.account_usage import AccountUsageSnapshot, fetch_account_usage
+
+    normalized = str(provider or "").strip().lower()
+    requests: list[tuple[str, str | None, str | None]] = []
+    if normalized in {"anthropic", "openai-codex", "openrouter"}:
+        requests.append((normalized, base_url, api_key))
+    # With no Supermemory key this returns an unavailable snapshot without a
+    # request. asyncio.to_thread also preserves profile-scoped contextvars.
+    requests.append(("supermemory", None, None))
+
+    async def _fetch(
+        one_provider: str,
+        one_base_url: str | None,
+        one_api_key: str | None,
+    ):
+        return await asyncio.to_thread(
+            fetch_account_usage,
+            one_provider,
+            base_url=one_base_url,
+            api_key=one_api_key,
+        )
+
+    try:
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                *(
+                    _fetch(name, request_base, request_key)
+                    for name, request_base, request_key in requests
+                ),
+                return_exceptions=True,
+            ),
+            timeout=max(0.001, float(timeout_seconds)),
+        )
+    except (asyncio.TimeoutError, ValueError, TypeError):
+        logger.debug("runtime footer quota fetch timed out", exc_info=True)
+        return None
+
+    snapshots = [
+        result
+        for result in results
+        if isinstance(result, AccountUsageSnapshot)
+        and result.available
+        and not result.unavailable_reason
+    ]
+    if not snapshots:
+        return None
+    if len(snapshots) == 1:
+        return snapshots[0]
+
+    return AccountUsageSnapshot(
+        provider="combined",
+        source="runtime_footer",
+        fetched_at=snapshots[0].fetched_at,
+        title="Account limits",
+        windows=tuple(window for snapshot in snapshots for window in snapshot.windows),
+        details=tuple(detail for snapshot in snapshots for detail in snapshot.details),
+    )
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -108,11 +180,42 @@ def _format_latency(seconds: float) -> str:
     return f"{m}m{sec:02d}s"
 
 
+def _quota_block(snapshot: Any) -> str:
+    """Render up to three available quota windows using provider labels."""
+    if not snapshot or getattr(snapshot, "unavailable_reason", None):
+        return ""
+    lines: list[str] = []
+    for window in list(getattr(snapshot, "windows", ()) or ()):
+        try:
+            label = str(getattr(window, "label", "") or "").strip()
+            raw_used = getattr(window, "used_percent", None)
+            if raw_used is None:
+                continue
+            used = float(raw_used)
+            if not label or not math.isfinite(used):
+                continue
+            line = f"{label[:40]} - {max(0, min(100, round(used)))}%"
+            detail = str(getattr(window, "detail", "") or "").strip()
+            if detail:
+                line += f" - {detail}"
+            reset_at = getattr(window, "reset_at", None)
+            if reset_at is not None:
+                reset_text = reset_at.astimezone().strftime("%b %d %H:%M %Z").replace(" 0", " ")
+                line += f" - Reset {reset_text}"
+            lines.append(line)
+        except (AttributeError, TypeError, ValueError, OverflowError):
+            continue
+        if len(lines) >= 3:
+            break
+    return "Quota Used:\n" + "\n".join(lines) if lines else ""
+
+
 def format_runtime_footer(
     *,
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    quota_snapshot: Any = None,
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
@@ -121,8 +224,11 @@ def format_runtime_footer(
 
     Fields are skipped silently when their underlying data is missing — a
     partially-populated footer is better than a line with ``?%`` or empty slots.
+    Multiline fields such as quota are rendered beneath the compact inline
+    metadata so later fields cannot be joined onto a quota detail line.
     """
     parts: list[str] = []
+    blocks: list[str] = []
     for field in fields:
         if field == "model":
             m = _model_short(model)
@@ -137,15 +243,19 @@ def format_runtime_footer(
             # timing (call sites that don't measure) or the value is negative.
             if turn_seconds is not None and turn_seconds >= 0:
                 parts.append(_format_latency(turn_seconds))
+        elif field == "quota":
+            quota = _quota_block(quota_snapshot)
+            if quota:
+                blocks.append(quota)
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
         # Unknown field names are silently ignored.
 
-    if not parts:
+    if not parts and not blocks:
         return ""
-    return _SEP.join(parts)
+    return "\n".join(part for part in (_SEP.join(parts), *blocks) if part)
 
 
 def build_footer_line(
@@ -155,6 +265,7 @@ def build_footer_line(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    quota_snapshot: Any = None,
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
 ) -> str:
@@ -175,7 +286,44 @@ def build_footer_line(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
+        quota_snapshot=quota_snapshot,
         cwd=cwd,
         turn_seconds=turn_seconds,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+    )
+
+
+async def build_footer_line_async(
+    *,
+    user_config: dict[str, Any] | None,
+    platform_key: str | None,
+    provider: str | None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    model: Optional[str],
+    context_tokens: int,
+    context_length: Optional[int],
+    cwd: Optional[str] = None,
+    turn_seconds: Optional[float] = None,
+) -> str:
+    """Build the footer and fetch quota only when the effective config shows it."""
+    cfg = resolve_footer_config(user_config, platform_key)
+    if not cfg.get("enabled"):
+        return ""
+    fields = cfg.get("fields") or _DEFAULT_FIELDS
+    quota_snapshot = None
+    if "quota" in fields:
+        quota_snapshot = await fetch_runtime_footer_quota_snapshot(
+            provider,
+            base_url=base_url,
+            api_key=api_key,
+        )
+    return format_runtime_footer(
+        model=model,
+        context_tokens=context_tokens,
+        context_length=context_length,
+        quota_snapshot=quota_snapshot,
+        cwd=cwd,
+        turn_seconds=turn_seconds,
+        fields=fields,
     )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3943,7 +3943,7 @@ class GatewaySlashCommandsMixin:
                 model=_resolve_gateway_model(user_config) or None,
                 context_tokens=0,
                 context_length=None,
-                fields=effective.get("fields") or ["model", "context_pct", "cwd"],
+                fields=effective.get("fields") or ["model", "context_pct", "quota", "cwd"],
             )
             if preview:
                 example = t("gateway.footer.example_line", preview=preview)

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -3180,7 +3180,7 @@ class CLICommandsMixin:
         cfg = load_config() or {}
         footer_cfg = ((cfg.get("display") or {}).get("runtime_footer") or {})
         current = bool(footer_cfg.get("enabled", False))
-        fields = footer_cfg.get("fields") or ["model", "context_pct", "cwd"]
+        fields = footer_cfg.get("fields") or ["model", "context_pct", "quota", "cwd"]
 
         if arg in {"status", "?"}:
             state = "ON" if current else "OFF"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1335,7 +1335,7 @@ DEFAULT_CONFIG = {
         # display.platforms.<platform>.runtime_footer.
         "runtime_footer": {
             "enabled": False,
-            "fields": ["model", "context_pct", "cwd"],  # Order shown; drop any to hide
+            "fields": ["model", "context_pct", "quota", "cwd"],  # Order shown; drop any to hide
         },
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
         # Petdex animated mascot (https://github.com/crafter-station/petdex).

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -157,6 +157,24 @@ def _load_supermemory_config(hermes_home: str) -> dict:
     return config
 
 
+def resolve_supermemory_connection_settings(
+    hermes_home: str | None = None,
+    *,
+    config: dict | None = None,
+) -> dict[str, Any]:
+    """Resolve the authoritative Supermemory key, base URL, and timeout."""
+    if hermes_home is None:
+        from hermes_constants import get_hermes_home
+
+        hermes_home = str(get_hermes_home())
+    resolved_config = config if config is not None else _load_supermemory_config(hermes_home)
+    return {
+        "api_key": get_secret("SUPERMEMORY_API_KEY", "") or "",
+        "base_url": _resolve_base_url(resolved_config.get("base_url", "")),
+        "api_timeout": resolved_config.get("api_timeout", _DEFAULT_API_TIMEOUT),
+    }
+
+
 def _save_supermemory_config(values: dict, hermes_home: str) -> None:
     config_path = Path(hermes_home) / "supermemory.json"
     existing = {}
@@ -656,7 +674,11 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._session_id = session_id
         self._turn_count = 0
         self._config = _load_supermemory_config(self._hermes_home)
-        self._api_key = get_secret("SUPERMEMORY_API_KEY", "") or ""
+        connection = resolve_supermemory_connection_settings(
+            self._hermes_home,
+            config=self._config,
+        )
+        self._api_key = connection["api_key"]
 
         # Resolve container tag: env var > config > default.
         # Supports {identity} template for profile-scoped containers.
@@ -672,10 +694,10 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._capture_mode = self._config["capture_mode"]
         self._search_mode = self._config["search_mode"]
         self._entity_context = self._config["entity_context"]
-        self._api_timeout = self._config["api_timeout"]
+        self._api_timeout = connection["api_timeout"]
         # Base URL: config > SUPERMEMORY_BASE_URL env var > api.supermemory.ai.
         # Supports self-hosted Supermemory servers.
-        self._base_url = _resolve_base_url(self._config["base_url"])
+        self._base_url = connection["base_url"]
         self._enable_custom_containers = self._config["enable_custom_container_tags"]
         self._custom_containers = self._config["custom_containers"]
         self._custom_container_instructions = self._config["custom_container_instructions"]

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -4,9 +4,11 @@ appended to final gateway replies."""
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 
 import pytest
 
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 from gateway.runtime_footer import (
     _home_relative_cwd,
     _model_short,
@@ -79,6 +81,17 @@ def test_format_footer_skips_missing_context_length():
 # ---------------------------------------------------------------------------
 
 
+def test_resolve_defaults_include_quota_field():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    default_fields = DEFAULT_CONFIG["display"]["runtime_footer"]["fields"]
+    assert "quota" in default_fields
+    assert resolve_footer_config({}, "telegram") == {
+        "enabled": False,
+        "fields": default_fields,
+    }
+
+
 def test_resolve_platform_override_wins():
     user = {
         "display": {
@@ -105,7 +118,7 @@ def test_resolve_platform_can_add_fields_only():
     }
     tg = resolve_footer_config(user, "telegram")
     assert tg["enabled"] is True
-    assert tg["fields"] == ["model", "context_pct", "cwd"]
+    assert tg["fields"] == ["model", "context_pct", "quota", "cwd"]
     dc = resolve_footer_config(user, "discord")
     assert dc["enabled"] is True
     assert dc["fields"] == ["context_pct"]
@@ -131,6 +144,56 @@ def test_build_footer_per_platform_off_suppresses():
         cwd="/tmp",
     )
     assert out == ""
+
+
+def test_format_footer_quota_uses_provider_window_labels():
+    snapshot = AccountUsageSnapshot(
+        provider="combined",
+        source="test",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(label="Session", used_percent=25),
+            AccountUsageWindow(
+                label="Supermemory credits",
+                used_percent=80,
+                detail="$10.00 of $50.00 remaining",
+            ),
+        ),
+    )
+
+    out = format_runtime_footer(
+        model=None,
+        context_tokens=0,
+        context_length=None,
+        quota_snapshot=snapshot,
+        cwd="",
+        fields=("quota",),
+    )
+
+    assert out == (
+        "Quota Used:\n"
+        "Session - 25%\n"
+        "Supermemory credits - 80% - $10.00 of $50.00 remaining"
+    )
+
+
+def test_format_footer_keeps_inline_fields_above_multiline_quota():
+    snapshot = AccountUsageSnapshot(
+        provider="combined",
+        source="test",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(AccountUsageWindow(label="Session", used_percent=25),),
+    )
+
+    out = format_runtime_footer(
+        model="openai/gpt-5.6",
+        context_tokens=50,
+        context_length=100,
+        quota_snapshot=snapshot,
+        cwd="/tmp/project",
+    )
+
+    assert out == "gpt-5.6 · 50% · /tmp/project\nQuota Used:\nSession - 25%"
 
 
 
@@ -247,29 +310,29 @@ def test_build_footer_line_threads_turn_seconds(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Byte-stability: `latency` is opt-in, so the DEFAULT footer is unchanged.
+# Byte-stability: `latency` is opt-in; unavailable quota adds no output bytes.
 #
 # Upstream doctrine: a system prompt / rendered surface must be byte-stable for
 # the life of a conversation.  Adding a field to _DEFAULT_FIELDS would silently
-# change the footer text of every user who already enabled it.  These tests pin
-# the default set and the exact default-config output strings.
+# change the footer text of every user who already enabled it. These tests pin
+# latency exclusion and exact output when quota data is unavailable.
 # ---------------------------------------------------------------------------
 
-_LEGACY_DEFAULT_FIELDS = ["model", "context_pct", "cwd"]
+_DEFAULT_FIELDS_WITH_QUOTA = ["model", "context_pct", "quota", "cwd"]
 
 
 def test_latency_not_in_default_fields():
     from gateway.runtime_footer import _DEFAULT_FIELDS
 
     assert "latency" not in _DEFAULT_FIELDS
-    assert list(_DEFAULT_FIELDS) == _LEGACY_DEFAULT_FIELDS
+    assert list(_DEFAULT_FIELDS) == _DEFAULT_FIELDS_WITH_QUOTA
 
 
 def test_resolve_footer_config_default_fields_exclude_latency():
-    assert resolve_footer_config({}, "telegram")["fields"] == _LEGACY_DEFAULT_FIELDS
+    assert resolve_footer_config({}, "telegram")["fields"] == _DEFAULT_FIELDS_WITH_QUOTA
     assert resolve_footer_config(
         {"display": {"runtime_footer": {"enabled": True}}}, "discord"
-    )["fields"] == _LEGACY_DEFAULT_FIELDS
+    )["fields"] == _DEFAULT_FIELDS_WITH_QUOTA
 
 
 @pytest.mark.parametrize(

--- a/tests/gateway/test_runtime_footer_live_integration.py
+++ b/tests/gateway/test_runtime_footer_live_integration.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import agent.account_usage as account_usage
+import gateway.run as gateway_run
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+from gateway.config import Platform
+from plugins.memory.supermemory import resolve_supermemory_connection_settings
+
+
+def _snapshot(provider: str, label: str) -> AccountUsageSnapshot:
+    return AccountUsageSnapshot(
+        provider=provider,
+        source="test",
+        fetched_at=datetime(2026, 8, 11, tzinfo=timezone.utc),
+        windows=(AccountUsageWindow(label=label, used_percent=25),),
+    )
+
+
+def test_runtime_footer_context_uses_actual_agent_runtime():
+    agent = SimpleNamespace(
+        provider="openai-codex",
+        base_url="https://chatgpt.example/codex",
+        api_key="model-secret",
+    )
+
+    assert gateway_run._runtime_footer_context_from_agent(agent) == {
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.example/codex",
+        "api_key": "model-secret",
+    }
+
+
+@pytest.mark.asyncio
+async def test_live_footer_consumes_active_runtime_and_reenters_profile_scope(
+    tmp_path,
+    monkeypatch,
+):
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    (profile_home / ".env").write_text("SUPERMEMORY_API_KEY=profile-sm-secret\n")
+    (profile_home / "supermemory.json").write_text(
+        json.dumps({"base_url": "https://self-hosted.example/root"})
+    )
+
+    runner = SimpleNamespace(
+        config=SimpleNamespace(multiplex_profiles=True),
+        _resolve_profile_home_for_source=lambda source: profile_home,
+    )
+    source = SimpleNamespace(platform=Platform.TELEGRAM)
+    agent_result = {
+        "model": "openai/gpt-5.6",
+        "last_prompt_tokens": 50,
+        "context_length": 100,
+        "_runtime_footer_context": {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.example/codex",
+            "api_key": "model-secret",
+        },
+    }
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["model", "quota"],
+                }
+            }
+        },
+    )
+
+    calls = []
+
+    def fake_fetch(provider, base_url=None, api_key=None):
+        calls.append((provider, base_url, api_key))
+        if provider == "supermemory":
+            settings = resolve_supermemory_connection_settings()
+            assert settings["api_key"] == "profile-sm-secret"
+            assert settings["base_url"] == "https://self-hosted.example/root"
+            assert base_url is None
+            assert api_key is None
+            return _snapshot("supermemory", "Supermemory credits")
+        assert (provider, base_url, api_key) == (
+            "openai-codex",
+            "https://chatgpt.example/codex",
+            "model-secret",
+        )
+        return _snapshot("openai-codex", "7d")
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fake_fetch)
+
+    line = await gateway_run._build_runtime_footer_for_result(
+        runner,
+        source=source,
+        session_key="telegram:123",
+        agent_result=agent_result,
+        turn_seconds=1.0,
+    )
+
+    assert line == "gpt-5.6\nQuota Used:\n7d - 25%\nSupermemory credits - 25%"
+    assert set(calls) == {
+        ("openai-codex", "https://chatgpt.example/codex", "model-secret"),
+        ("supermemory", None, None),
+    }
+    assert "_runtime_footer_context" not in agent_result

--- a/tests/gateway/test_runtime_footer_quota_fetch.py
+++ b/tests/gateway/test_runtime_footer_quota_fetch.py
@@ -16,6 +16,11 @@ async def test_quota_fetch_yields_event_loop_during_delayed_request(monkeypatch)
     ticked = asyncio.Event()
     saw_tick_from_worker: list[bool] = []
 
+    monkeypatch.setattr(
+        "plugins.memory.supermemory.resolve_supermemory_connection_settings",
+        lambda: {"api_key": "test-key", "base_url": "https://api.supermemory.ai", "api_timeout": 10},
+    )
+
     def delayed_fetch(provider, *, base_url=None, api_key=None):
         assert provider == "supermemory"
         time.sleep(0.05)
@@ -65,6 +70,11 @@ async def test_quota_fetch_combines_model_and_supermemory_snapshots(monkeypatch)
     now = datetime(2026, 8, 11, tzinfo=timezone.utc)
     fetched = []
 
+    monkeypatch.setattr(
+        "plugins.memory.supermemory.resolve_supermemory_connection_settings",
+        lambda: {"api_key": "test-key", "base_url": "https://api.supermemory.ai", "api_timeout": 10},
+    )
+
     def fake_fetch(provider, *, base_url=None, api_key=None):
         fetched.append((provider, base_url, api_key))
         if provider == "openai-codex":
@@ -107,6 +117,49 @@ async def test_quota_fetch_combines_model_and_supermemory_snapshots(monkeypatch)
         ("openai-codex", "https://chatgpt.example/codex", "codex-token"),
         ("supermemory", None, None),
     ]
+
+
+@pytest.mark.asyncio
+async def test_quota_fetch_skips_supermemory_without_a_configured_key(monkeypatch):
+    fetched = []
+
+    monkeypatch.setattr(
+        "plugins.memory.supermemory.resolve_supermemory_connection_settings",
+        lambda: {"api_key": "", "base_url": "https://api.supermemory.ai", "api_timeout": 10},
+    )
+
+    def fake_fetch(provider, *, base_url=None, api_key=None):
+        fetched.append((provider, base_url, api_key))
+        return None
+
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", fake_fetch)
+
+    snapshot = await runtime_footer.fetch_runtime_footer_quota_snapshot("custom-local")
+
+    assert snapshot is None
+    assert fetched == []
+
+
+@pytest.mark.asyncio
+async def test_quota_fetch_timeout_includes_supermemory_config_resolution(monkeypatch):
+    def slow_resolver():
+        time.sleep(0.1)
+        return {"api_key": "", "base_url": "https://api.supermemory.ai", "api_timeout": 10}
+
+    monkeypatch.setattr(
+        "plugins.memory.supermemory.resolve_supermemory_connection_settings",
+        slow_resolver,
+    )
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    snapshot = await runtime_footer.fetch_runtime_footer_quota_snapshot(
+        "custom-local",
+        timeout_seconds=0.01,
+    )
+
+    assert snapshot is None
+    assert loop.time() - started < 0.05
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_runtime_footer_quota_fetch.py
+++ b/tests/gateway/test_runtime_footer_quota_fetch.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+import gateway.runtime_footer as runtime_footer
+
+
+@pytest.mark.asyncio
+async def test_quota_fetch_yields_event_loop_during_delayed_request(monkeypatch):
+    ticked = asyncio.Event()
+    saw_tick_from_worker: list[bool] = []
+
+    def delayed_fetch(provider, *, base_url=None, api_key=None):
+        assert provider == "supermemory"
+        time.sleep(0.05)
+        saw_tick_from_worker.append(ticked.is_set())
+        return None
+
+    async def tick_while_fetching():
+        await asyncio.sleep(0.01)
+        ticked.set()
+
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", delayed_fetch)
+
+    snapshot, _ = await asyncio.gather(
+        runtime_footer.fetch_runtime_footer_quota_snapshot("custom-local"),
+        tick_while_fetching(),
+    )
+
+    assert snapshot is None
+    assert saw_tick_from_worker == [True]
+
+
+@pytest.mark.asyncio
+async def test_quota_fetch_timeout_is_bounded_and_fail_open(monkeypatch):
+    release_worker = threading.Event()
+
+    def blocked_fetch(provider, *, base_url=None, api_key=None):
+        release_worker.wait(timeout=1)
+        return None
+
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", blocked_fetch)
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    try:
+        snapshot = await runtime_footer.fetch_runtime_footer_quota_snapshot(
+            "custom-local",
+            timeout_seconds=0.01,
+        )
+    finally:
+        release_worker.set()
+
+    assert snapshot is None
+    assert loop.time() - started < 0.2
+
+
+@pytest.mark.asyncio
+async def test_quota_fetch_combines_model_and_supermemory_snapshots(monkeypatch):
+    now = datetime(2026, 8, 11, tzinfo=timezone.utc)
+    fetched = []
+
+    def fake_fetch(provider, *, base_url=None, api_key=None):
+        fetched.append((provider, base_url, api_key))
+        if provider == "openai-codex":
+            return AccountUsageSnapshot(
+                provider=provider,
+                source="test",
+                fetched_at=now,
+                windows=(AccountUsageWindow(label="Session", used_percent=25),),
+            )
+        if provider == "supermemory":
+            return AccountUsageSnapshot(
+                provider=provider,
+                source="test",
+                fetched_at=now,
+                windows=(
+                    AccountUsageWindow(
+                        label="Supermemory credits",
+                        used_percent=80,
+                        detail="$10.00 of $50.00 remaining",
+                    ),
+                ),
+            )
+        raise AssertionError(provider)
+
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", fake_fetch)
+
+    snapshot = await runtime_footer.fetch_runtime_footer_quota_snapshot(
+        "openai-codex",
+        base_url="https://chatgpt.example/codex",
+        api_key="codex-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.provider == "combined"
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Session", 25),
+        ("Supermemory credits", 80),
+    ]
+    assert fetched == [
+        ("openai-codex", "https://chatgpt.example/codex", "codex-token"),
+        ("supermemory", None, None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_footer_builder_skips_fetch_when_footer_disabled(monkeypatch):
+    called = False
+
+    async def forbidden_fetch(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("quota fetch must stay disabled")
+
+    monkeypatch.setattr(
+        runtime_footer,
+        "fetch_runtime_footer_quota_snapshot",
+        forbidden_fetch,
+    )
+
+    line = await runtime_footer.build_footer_line_async(
+        user_config={"display": {"runtime_footer": {"enabled": False}}},
+        platform_key="telegram",
+        provider="openai-codex",
+        base_url="https://chatgpt.example/codex",
+        api_key="codex-token",
+        model="openai/gpt-5.6",
+        context_tokens=50,
+        context_length=100,
+    )
+
+    assert line == ""
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_async_footer_builder_skips_fetch_when_quota_field_is_omitted(monkeypatch):
+    called = False
+
+    async def forbidden_fetch(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("quota fetch must stay hidden")
+
+    monkeypatch.setattr(
+        runtime_footer,
+        "fetch_runtime_footer_quota_snapshot",
+        forbidden_fetch,
+    )
+
+    line = await runtime_footer.build_footer_line_async(
+        user_config={
+            "display": {
+                "runtime_footer": {"enabled": True, "fields": ["model"]}
+            }
+        },
+        platform_key="telegram",
+        provider="openai-codex",
+        model="openai/gpt-5.6",
+        context_tokens=50,
+        context_length=100,
+    )
+
+    assert line == "gpt-5.6"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_async_footer_builder_fetches_and_renders_enabled_quota(monkeypatch):
+    snapshot = AccountUsageSnapshot(
+        provider="supermemory",
+        source="test",
+        fetched_at=datetime(2026, 8, 11, tzinfo=timezone.utc),
+        windows=(AccountUsageWindow(label="Supermemory credits", used_percent=80),),
+    )
+
+    async def fake_fetch(provider, *, base_url=None, api_key=None, timeout_seconds=5.0):
+        assert (provider, base_url, api_key) == (
+            "openai-codex",
+            "https://chatgpt.example/codex",
+            "codex-token",
+        )
+        return snapshot
+
+    monkeypatch.setattr(
+        runtime_footer,
+        "fetch_runtime_footer_quota_snapshot",
+        fake_fetch,
+    )
+
+    line = await runtime_footer.build_footer_line_async(
+        user_config={
+            "display": {
+                "runtime_footer": {"enabled": True, "fields": ["model", "quota"]}
+            }
+        },
+        platform_key="telegram",
+        provider="openai-codex",
+        base_url="https://chatgpt.example/codex",
+        api_key="codex-token",
+        model="openai/gpt-5.6",
+        context_tokens=50,
+        context_length=100,
+    )
+
+    assert line == "gpt-5.6\nQuota Used:\nSupermemory credits - 80%"

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -5,6 +5,8 @@ import threading
 
 import pytest
 
+import plugins.memory.supermemory as supermemory_module
+
 from plugins.memory.supermemory import (
     SupermemoryMemoryProvider,
     _clean_text_for_capture,
@@ -80,6 +82,24 @@ def test_load_and_save_config_round_trip(tmp_path):
     assert cfg["container_tag"] == "demo-tag"
     assert cfg["auto_capture"] is False
     assert cfg["auto_recall"] is True
+
+
+def test_resolve_connection_settings_reuses_configured_self_hosted_base(tmp_path, monkeypatch):
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "self-hosted-key")
+    monkeypatch.setenv("SUPERMEMORY_BASE_URL", "https://env.example.invalid")
+    _save_supermemory_config(
+        {"base_url": "https://memory.internal.example/root", "api_timeout": 2.5},
+        str(tmp_path),
+    )
+
+    assert hasattr(supermemory_module, "resolve_supermemory_connection_settings")
+    settings = supermemory_module.resolve_supermemory_connection_settings(str(tmp_path))
+
+    assert settings == {
+        "api_key": "self-hosted-key",
+        "base_url": "https://memory.internal.example/root",
+        "api_timeout": 2.5,
+    }
 
 
 def test_clean_text_for_capture_strips_injected_context():

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -250,6 +250,26 @@ def test_anthropic_usage_uses_live_oauth_token_on_official_route(monkeypatch):
     ]
 
 
+def test_anthropic_usage_falls_back_to_profile_token_when_live_key_is_empty(monkeypatch):
+    """A runtime URL without a key must not suppress the configured OAuth token."""
+    client = _RecordingClient({"five_hour": {"utilization": 0.25}})
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token",
+        lambda: "cc-profile-oauth-token",
+    )
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout: client)
+
+    snapshot = fetch_account_usage(
+        "anthropic",
+        base_url="https://api.anthropic.com/v1",
+        api_key=None,
+    )
+
+    assert snapshot is not None
+    assert snapshot.available
+    assert client.calls[0][1]["Authorization"] == "Bearer cc-profile-oauth-token"
+
+
 def test_anthropic_usage_omits_custom_route_instead_of_cross_hosting_key(monkeypatch):
     monkeypatch.setattr(
         "agent.account_usage.resolve_anthropic_token",
@@ -358,3 +378,51 @@ def test_supermemory_billing_rejects_split_model_credentials_and_cloud_override(
             {"Authorization": "Bearer self-hosted-key", "Accept": "application/json"},
         )
     ]
+
+
+def test_supermemory_billing_clamps_negative_remaining_credit(monkeypatch):
+    """Overages are rendered as exhausted credit, never a negative remainder."""
+    monkeypatch.setattr(
+        "plugins.memory.supermemory.resolve_supermemory_connection_settings",
+        lambda: {
+            "api_key": "test-key",
+            "base_url": "https://memory.example",
+            "api_timeout": 2.5,
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout: _RecordingClient(
+            {
+                "features": {
+                    "usd_credits": {
+                        "usage": 60,
+                        "included_usage": 50,
+                        "balance": -10,
+                    }
+                }
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("supermemory")
+
+    assert snapshot is not None
+    assert snapshot.windows[0].used_percent == 120
+    assert snapshot.windows[0].detail == "$0.00 of $50.00 remaining"
+
+
+def test_supermemory_billing_clamps_negative_balance_without_usage_window(monkeypatch):
+    monkeypatch.setattr(
+        "plugins.memory.supermemory.resolve_supermemory_connection_settings",
+        lambda: {"api_key": "test-key", "base_url": "https://memory.example", "api_timeout": 2.5},
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout: _RecordingClient({"features": {"usd_credits": {"balance": -10}}}),
+    )
+
+    snapshot = fetch_account_usage("supermemory")
+
+    assert snapshot is not None
+    assert snapshot.details == ("Supermemory credits balance: $0.00",)

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 
 from agent.account_usage import (
@@ -47,6 +48,22 @@ class _RoutingClient:
 
     def get(self, url, headers=None):
         return _Response(self._payloads[url])
+
+
+class _RecordingClient:
+    def __init__(self, payload):
+        self._payload = payload
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, headers=None):
+        self.calls.append((url, headers))
+        return _Response(self._payload)
 
 
 def test_fetch_account_usage_codex(monkeypatch):
@@ -201,3 +218,143 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+def test_anthropic_usage_uses_live_oauth_token_on_official_route(monkeypatch):
+    client = _RecordingClient({"five_hour": {"utilization": 0.25}})
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token",
+        lambda: "sk-ant-profile-token",
+    )
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout: client)
+
+    snapshot = fetch_account_usage(
+        "anthropic",
+        base_url="https://api.anthropic.com/v1",
+        api_key="sk-ant-live-oauth-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.available
+    assert client.calls == [
+        (
+            "https://api.anthropic.com/api/oauth/usage",
+            {
+                "Authorization": "Bearer sk-ant-live-oauth-token",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "anthropic-beta": "oauth-2025-04-20",
+                "User-Agent": "claude-code/2.1.0",
+            },
+        )
+    ]
+
+
+def test_anthropic_usage_omits_custom_route_instead_of_cross_hosting_key(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token",
+        lambda: "sk-ant-profile-token",
+    )
+
+    def fail_client(*args, **kwargs):
+        raise AssertionError("custom-route Anthropic quota must not make a request")
+
+    monkeypatch.setattr("agent.account_usage.httpx.Client", fail_client)
+
+    snapshot = fetch_account_usage(
+        "anthropic",
+        base_url="https://anthropic-proxy.example/v1",
+        api_key="sk-ant-live-oauth-token",
+    )
+
+    assert snapshot is not None
+    assert not snapshot.available
+    assert "official Anthropic endpoint" in (snapshot.unavailable_reason or "")
+
+
+def test_fetch_account_usage_supermemory_uses_resolved_self_hosted_endpoint(monkeypatch):
+    client = _RecordingClient(
+        {
+            "features": {
+                "usd_credits": {
+                    "usage": 44.25,
+                    "included_usage": 55,
+                    "balance": 10.75,
+                    "next_reset_at": 1785391522227,
+                }
+            }
+        }
+    )
+    monkeypatch.setattr(
+        "plugins.memory.supermemory.resolve_supermemory_connection_settings",
+        lambda: {
+            "api_key": "self-hosted-key",
+            "base_url": "https://memory.internal.example/root",
+            "api_timeout": 2.5,
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout: client,
+    )
+
+    snapshot = fetch_account_usage("supermemory")
+
+    assert snapshot is not None
+    assert snapshot.provider == "supermemory"
+    assert snapshot.windows == (
+        AccountUsageWindow(
+            label="Supermemory credits",
+            used_percent=80.45454545454545,
+            reset_at=datetime.fromtimestamp(1785391522227 / 1000, tz=timezone.utc),
+            detail="$10.75 of $55.00 remaining",
+        ),
+    )
+    assert client.calls == [
+        (
+            "https://memory.internal.example/root/v3/auth/billing/usage",
+            {"Authorization": "Bearer self-hosted-key", "Accept": "application/json"},
+        )
+    ]
+
+
+def test_supermemory_billing_rejects_split_model_credentials_and_cloud_override(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    (tmp_path / "supermemory.json").write_text(
+        json.dumps({"base_url": "https://self-hosted.example/root"})
+    )
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "self-hosted-key")
+    client = _RecordingClient(
+        {
+            "features": {
+                "usd_credits": {
+                    "usage": 1,
+                    "included_usage": 9,
+                    "balance": 8,
+                }
+            }
+        }
+    )
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout: client)
+
+    token = set_hermes_home_override(str(tmp_path))
+    try:
+        snapshot = fetch_account_usage(
+            "supermemory",
+            base_url="https://api.supermemory.ai",
+            api_key="model-provider-key",
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    assert snapshot is not None
+    assert client.calls == [
+        (
+            "https://self-hosted.example/root/v3/auth/billing/usage",
+            {"Authorization": "Bearer self-hosted-key", "Accept": "application/json"},
+        )
+    ]

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -87,7 +87,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/voice [on\|off\|tts\|status]` | Toggle CLI voice mode and spoken playback. Recording uses `voice.record_key` (default: `Ctrl+B`). |
 | `/yolo` | Toggle YOLO mode — skip all dangerous command approval prompts. |
 | `/approvals [manual\|smart\|off]` | Show or set the persistent dangerous-command approval mode. |
-| `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (shows model, context %, and cwd). |
+| `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (shows model, context %, available quota, and cwd). |
 | `/busy [queue\|steer\|interrupt\|status]` | CLI-only: control what pressing Enter does while Hermes is working — queue the new message, steer mid-turn, or interrupt immediately. |
 | `/indicator [kaomoji\|emoji\|unicode\|ascii]` | CLI-only: pick the TUI busy-indicator style. |
 | `/timestamps [on\|off\|status]` | CLI-only: toggle `[HH:MM]` timestamps on messages and in `/history`. |
@@ -263,7 +263,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/learn <what to learn from>` | Distill a reusable skill from anything you describe. |
 | `/bundles` | List configured skill bundles (`/<name>` aliases that preload several skills). |
 | `/reload-skills` (alias: `/reload_skills`) | Re-scan `~/.hermes/skills/` for newly installed or removed skills. |
-| `/footer [on\|off\|status]` | Toggle the runtime-metadata footer on final replies (shows model, context %, and cwd). |
+| `/footer [on\|off\|status]` | Toggle the runtime-metadata footer on final replies (shows model, context %, available quota, and cwd). |
 | `/curator [status\|run\|pin\|archive]` | Background skill maintenance controls. |
 | `/suggestions [accept\|dismiss N\|catalog\|clear]` | Review suggested automations right in chat. `/suggestions` lists pending suggestions, `catalog` adds curated starter automations, and `clear` prunes resolved suggestion records. Accepted suggestions keep this chat/thread as the job delivery origin. |
 | `/blueprint [name] [slot=value ...]` | Browse cron blueprints, start a guided slot-filling conversation, or create a blueprint job directly. Directly created jobs deliver back to the current chat/thread. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1720,7 +1720,7 @@ display:
   spinner_token_flow: true # CLI only: append live cumulative turn tokens to the spinner timer
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    fields: ["model", "context_pct", "quota", "cwd"]
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
@@ -1822,13 +1822,13 @@ Focus view is **display-only**. It never edits conversation history, the system 
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The footer can show the model, context-window percentage, available model/Supermemory quota windows, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance. Quota fetching is best-effort, timeout-bounded, and skipped when the footer is disabled or the `quota` field is omitted.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # order shown; drop any to hide
+    fields: ["model", "context_pct", "quota", "cwd"]   # order shown; drop any to hide
 ```
 
 Supported fields:
@@ -1837,17 +1837,21 @@ Supported fields:
 | --- | --- | --- |
 | `model` | Bare model id, vendor prefix dropped | `gpt-5.4` |
 | `context_pct` | Last-call context occupancy as a percent | `5%` |
+| `quota` | Available provider and Supermemory usage windows | `Session - 25%` |
 | `latency` | Wall-clock duration of the turn | `22s`, `1m05s` |
 | `cwd` | Home-relative working directory | `~` |
 
-The default field set is `["model", "context_pct", "cwd"]`. `latency` is opt-in — add it to `fields` to use it. Fields whose data is unavailable are skipped silently rather than rendering an empty slot.
+The default field set is `["model", "context_pct", "quota", "cwd"]`. `latency` is opt-in — add it to `fields` to use it. Fields whose data is unavailable are skipped silently rather than rendering an empty slot. Supermemory billing uses the same configured base URL and API key as the memory provider, including self-hosted installations.
 
 The `/footer` slash command toggles this at runtime in any session.
 
 Example footer appended to a Telegram/Discord/Slack reply:
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+claude-opus-4.7 · 5% · ~/project
+Quota Used:
+Session - 25%
+Supermemory credits - 80% - $10.00 of $50.00 remaining
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/slash-commands.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/slash-commands.md
@@ -75,7 +75,7 @@ Hermes 有两个斜杠命令入口，均由 `hermes_cli/commands.py` 中的中�
 | `/statusbar`（别名：`/sb`） | 切换上下文/模型状态栏的显示与隐藏 |
 | `/voice [on\|off\|tts\|status]` | 切换 CLI 语音模式和语音播放。录音使用 `voice.record_key`（默认：`Ctrl+B`）。 |
 | `/yolo` | 切换 YOLO 模式——跳过所有危险命令审批提示。 |
-| `/footer [on\|off\|status]` | 切换最终回复中的 gateway 运行时元数据页脚（显示模型、工具调用次数、耗时）。 |
+| `/footer [on\|off\|status]` | 切换最终回复中的 gateway 运行时元数据页脚（显示模型、上下文百分比、可用配额和当前工作目录）。 |
 | `/busy [queue\|steer\|interrupt\|status]` | 仅限 CLI：控制 Hermes 工作时按下 Enter 的行为——将新消息加入队列、中途引导，或立即中断。 |
 | `/indicator [kaomoji\|emoji\|unicode\|ascii]` | 仅限 CLI：选择 TUI 忙碌指示器样式。 |
 
@@ -224,7 +224,7 @@ hermes config set model.aliases.grok x-ai/grok-4
 | `/queue <prompt>`（别名：`/q`） | 将 prompt 加入队列等待下一轮处理，不中断当前轮次。 |
 | `/steer <prompt>` | 在下一次工具调用后注入一条消息，不中断——模型在下一次迭代时获取，而非作为新轮次。 |
 | `/goal <text>` | 设置一个持续目标，Hermes 将跨轮次持续推进——这是我们对 Ralph loop 的实现。裁判模型在每轮后检查；若未完成，Hermes 自动继续，直到完成、你暂停/清除，或达到轮次预算（默认 20）。子命令：`/goal status`、`/goal pause`、`/goal resume`、`/goal clear`。agent 运行中可安全执行 status/pause/clear；设置新目标需先执行 `/stop`。见 [持续目标](/user-guide/features/goals)。 |
-| `/footer [on\|off\|status]` | 切换最终回复中的运行时元数据页脚（显示模型、工具调用次数、耗时）。 |
+| `/footer [on\|off\|status]` | 切换最终回复中的运行时元数据页脚（显示模型、上下文百分比、可用配额和当前工作目录）。 |
 | `/curator [status\|run\|pin\|archive]` | 后台 skill 维护控制。 |
 | `/suggestions [accept\|dismiss N\|catalog\|clear]` | 直接在聊天中审核建议的自动化。`/suggestions` 列出待处理建议，`catalog` 添加精选起步自动化，`clear` 清理已解决的建议记录。被接受的建议会保留当前聊天/线程作为任务投递来源。 |
 | `/blueprint [name] [slot=value ...]` | 浏览 cron blueprint、启动引导式填槽对话，或直接创建 blueprint 任务。直接创建的任务会回投到当前聊天/线程。 |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1228,7 +1228,7 @@ display:
   tool_preview_length: 0  # 工具调用预览的最大字符数（0 = 无限制，显示完整路径/命令）
   runtime_footer:         # Gateway：在最终回复中附加运行时上下文页脚
     enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    fields: ["model", "context_pct", "quota", "cwd"]
   file_mutation_verifier: true    # 当本轮 write_file/patch 调用失败时附加建议性页脚
   language: en            # 静态消息的 UI 语言（审批提示、部分 gateway 回复）。en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
@@ -1272,13 +1272,15 @@ display:
 
 ### 运行时元数据页脚（仅限 gateway）
 
-当 `display.runtime_footer.enabled: true` 时，Hermes 在每个 gateway 轮次的**最终**消息中附加一个小型运行时上下文页脚。目前页脚可显示模型、上下文窗口百分比和当前工作目录。默认关闭；如果您的团队希望每个回复都包含这些来源信息，请按 gateway 选择加入。
+当 `display.runtime_footer.enabled: true` 时，Hermes 在每个 gateway 轮次的**最终**消息中附加一个小型运行时上下文页脚。页脚可显示模型、上下文窗口百分比、可用的模型/Supermemory 配额窗口和当前工作目录。默认关闭；配额查询为尽力而为且受超时限制，页脚关闭或省略 `quota` 字段时不会查询。
+
+Supermemory 账单查询会复用 memory provider 已配置的 API 密钥和 base URL，包括自托管安装，不会将自托管密钥改发到云端 API。
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # 支持字段：model、context_pct、cwd
+    fields: ["model", "context_pct", "quota", "cwd"]   # 支持字段：model、context_pct、quota、cwd
 ```
 
 `/footer` 斜杠命令在任何会话中运行时切换此功能。
@@ -1286,7 +1288,10 @@ display:
 附加到 Telegram/Discord/Slack 回复的示例页脚：
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+claude-opus-4.7 · 5% · ~/project
+Quota Used:
+Session - 25%
+Supermemory credits - 80% - $10.00 of $50.00 remaining
 ```
 
 只有轮次的**最终**消息获得页脚；中间更新保持干净。


### PR DESCRIPTION
Replaces #69621, which GitHub would not allow to be reopened after its closed head branch was force-pushed to the current-main reconstruction.

## Summary

- add Supermemory billing usage snapshots through the existing account-usage path
- render Supermemory credit usage in the runtime footer alongside model/provider quota windows
- resolve Supermemory API key, base URL, and timeout as one authority unit so self-hosted credentials cannot be redirected to the hosted cloud API
- run final-footer usage requests off the gateway event loop with a bounded, fail-open timeout
- retain multiplexed profile scope during Supermemory quota resolution while consuming internal credential context before hooks or delivery
- avoid usage requests when the footer is disabled or `quota` is omitted
- render compact metadata on the first line and quota details in a separate multiline block
- align defaults, CLI/gateway field listings, and English/Chinese documentation

## Validation

Validated at exact head `3f70b90ef363527e3fcd98bf29d92b1ad147b3b4` on current `NousResearch/hermes-agent` main `2cdb30a474d76cca9eb61714d889c18f493aa7fc`:

- 138 focused/adjacent account-usage, Supermemory, footer, credential-scope, proxy, and result-path tests passed
- 294 full memory/account-usage tests passed
- broad gateway shards: 5,073 passed, 8 skipped, 2 xfailed
  - one untouched order-dependent `HERMES_HOME` test failed identically on clean main under the exact candidate shard manifest and passed isolated on the candidate
- Ruff, `py_compile`, `git diff --check`, clean-tree, one-commit, secret/path, and conflict-marker checks passed
- independent exact-head review: **PASS** (`gpt-5.6-sol` via `openai-codex`)

The prior public head and discussion remain preserved in #69621; this draft contains the current-main reconstruction rather than a mechanical rebase of the stale implementation.
