### PR TITLE
fix(gateway): treat non-ASCII chars as MEDIA tag boundary

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1939,11 +1939,17 @@ _MEDIA_EXT_ALTERNATION = "|".join(
 # guard keeps multi-part extensions intact — for ``archive.tar.gz`` the
 # ``.`` after ``tar`` is followed by ``g``, so the match must extend to
 # ``.gz`` instead of stopping early at ``.tar``.
+#
+# Non-ASCII boundary: the trailing lookahead also accepts any non-ASCII
+# character (``[^\x00-\x7F]``) as a boundary, so a tag whose path is
+# followed directly by CJK text without whitespace (e.g.
+# ``MEDIA:/x/a.xlsx已生成``) still extracts cleanly instead of leaking the
+# literal ``MEDIA:`` text to the user.
 MEDIA_TAG_CLEANUP_RE = re.compile(
     r'''[`"'*_]{0,3}MEDIA:\s*'''
     r'''(?P<path>`[^`\n]+?`|"[^"\n]+?"|'[^'\n]+?'|'''
     r'''(?:~/|/|[A-Za-z]:[/\\])\S+?(?:[^\S\n]+\S+?)*?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
-    r'''(?=[\s`"'*_,;:)\]}\[]|MEDIA:|\.(?:\s|$)|$)[`"'*_]{0,3}\.?''',
+    r'''(?=[\s`"'*_,;:)\]}\[]|MEDIA:|\.(?:\s|$)|$|[^\x00-\x7F])[`"'*_]{0,3}\.?''',
     re.IGNORECASE,
 )
 

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -383,5 +383,40 @@ class TestStaleToolMediaLeak:
         )
 
 
+class TestMediaTagCleanupReNonAsciiBoundary:
+    """MEDIA_TAG_CLEANUP_RE must treat non-ASCII characters (e.g. CJK) as a
+    valid trailing boundary so a MEDIA: path followed directly by Chinese
+    text without whitespace is still extracted instead of leaking the
+    literal ``MEDIA:`` text to the user.
+    """
+
+    @pytest.mark.parametrize("text, expected_path", [
+        # CJK glued directly after the path (the regression)
+        ("已生成并验证成功。MEDIA:/opt/data/cache/excel-send-test.xlsx为啥会发送个",
+         "/opt/data/cache/excel-send-test.xlsx"),
+        ("文件在 MEDIA:/tmp/photo.png请下载", "/tmp/photo.png"),
+        ("报告已生成:MEDIA:/tmp/report.pdf请注意查收", "/tmp/report.pdf"),
+        ("MEDIA:C:\\Users\\me\\a.xlsx中文", "C:\\Users\\me\\a.xlsx"),
+        # CJK with existing separator still works
+        ("文件在 MEDIA:/tmp/photo.png 请下载", "/tmp/photo.png"),
+    ])
+    def test_non_ascii_boundary_extracts_path(self, text, expected_path):
+        from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
+
+        match = MEDIA_TAG_CLEANUP_RE.search(text)
+        assert match is not None, f"Should match: {text}"
+        assert match.group("path") == expected_path
+
+    @pytest.mark.parametrize("text", [
+        "just a sentence without media",
+        "MEDIA:/nope.py",  # .py not in the deliverable extension list
+        "MEDIA:/nope.log",  # .log not in the deliverable extension list
+    ])
+    def test_no_media_no_match(self, text):
+        from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
+
+        assert MEDIA_TAG_CLEANUP_RE.search(text) is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What does this PR do?

Fixes a `MEDIA_TAG_CLEANUP_RE` boundary bug: when a `MEDIA:` tag's path is **followed directly by non-ASCII (CJK) characters without whitespace**, the trailing lookahead fails, the tag is not extracted, and the literal `MEDIA:/path/to/file.xlsx` text leaks through to the user instead of being delivered as an attachment.

Example that broke (real case from WeChat gateway):

```
已生成并验证成功。MEDIA:/opt/data/cache/excel-send-test.xlsx为啥会发送个
```

The user saw the raw `MEDIA:` text instead of the Excel attachment. This is not WeChat-specific — it hits any platform whose agent replies in Chinese/CJK, where paths are frequently glued to CJK text with no separating space.

**Why this approach is the right one:** the path token pattern itself is unchanged. Only the *trailing boundary* lookahead is extended to accept any non-ASCII character as a valid boundary. Since every character a file path can legally contain is ASCII, a non-ASCII character appearing after a path is *by definition* the end of the path — so `[^\x00-\x7F]` is semantically correct, not a heuristic.

## Related Issue

Related: #68773 (closed) — *"Agent fails to append separators after MEDIA tags, URLs, and file paths, causing cascading delivery and truncation failures"*. That fix handled punctuation/whitespace-separated tags; this PR fixes the remaining **non-ASCII-glued** variant of the same MEDIA-tag boundary family. No open issue exists for the CJK-glued case.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` — `MEDIA_TAG_CLEANUP_RE` trailing lookahead: add `[^\x00-\x7F]` to the boundary class (`(?=[\s`"'*_,;:)\]}\[]|MEDIA:|\.(?:\s|$)|$|[^\x00-\x7F])`). One-line regex change + explanatory comment.
- `tests/gateway/test_media_extraction.py` — new `TestMediaTagCleanupReNonAsciiBoundary` class: 8 parametrized cases (5 positive: unix + Windows paths with CJK glued directly, CJK with existing separator; 3 negative: plain text, non-deliverable extensions).

## How to Test

**Reproduction (before fix):**

```bash
cd hermes-agent
python - <<'EOF'
from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
text = "已生成并验证成功。MEDIA:/opt/data/cache/excel-send-test.xlsx为啥会发送个"
m = MEDIA_TAG_CLEANUP_RE.search(text)
print("MATCH:" , m.group("path") if m else None)
EOF
```

On `main` this prints `MATCH: None` — the tag is not recognized, so the gateway's cleanup passes the message through with the literal `MEDIA:...` text intact.

**Verification (after fix):**

```bash
cd hermes-agent
python - <<'EOF'
from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
cases = [
    ("已生成并验证成功。MEDIA:/opt/data/cache/excel-send-test.xlsx为啥会发送个", "/opt/data/cache/excel-send-test.xlsx"),
    ("文件在 MEDIA:/tmp/photo.png请下载", "/tmp/photo.png"),
    ("MEDIA:C:\\Users\\me\\a.xlsx中文", "C:\\Users\\me\\a.xlsx"),
]
for text, want in cases:
    m = MEDIA_TAG_CLEANUP_RE.search(text)
    got = m.group("path") if m else None
    print("OK " if got == want else "FAIL", repr(got), "==", repr(want))
EOF
```

Expected: all `OK` — path extracted, `MEDIA:` prefix stripped, message delivered as an attachment.

**Regression suite:**

```bash
uv run --extra dev pytest tests/gateway/test_media_extraction.py tests/gateway/test_run_tool_media_re.py -q
```

Result: **31 passed** (23 existing + 8 new). Also verified at runtime: real file send through the gateway after applying the fix delivered the attachment correctly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): treat non-ASCII chars as MEDIA tag boundary`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: 31 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 12 (Docker) + WeChat/Photon gateways

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: in-code comment added at the regex
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — regex-only change, platform-neutral; Windows drive-path case covered in tests
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ uv run --extra dev pytest tests/gateway/test_media_extraction.py tests/gateway/test_run_tool_media_re.py -q
...............................                                          [100%]
31 passed in 0.88s
```
