### PR TITLE
fix(kanban): fire kanban_task_claimed on review-lane claims

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4835,7 +4835,18 @@ def claim_review_task(
              "source_status": "review"},
             run_id=run_id,
         )
-        return get_task(conn, task_id)
+        claimed = get_task(conn, task_id)
+    # Same post-commit contract as claim_task: the review lane is dispatched
+    # from the dispatcher process too, so a plugin registered there must see
+    # reviewer spawns as well as implementation spawns.
+    _fire_kanban_lifecycle_hook(
+        "kanban_task_claimed",
+        task_id,
+        board=get_current_board(),
+        assignee=claimed.assignee if claimed else None,
+        run_id=run_id,
+    )
+    return claimed
 
 
 def _retry_status_for_run(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4560,7 +4560,18 @@ def claim_review_task(
              "source_status": "review"},
             run_id=run_id,
         )
-        return get_task(conn, task_id)
+        claimed = get_task(conn, task_id)
+    # Same post-commit contract as claim_task: the review lane is dispatched
+    # from the dispatcher process too, so a plugin registered there must see
+    # reviewer spawns as well as implementation spawns.
+    _fire_kanban_lifecycle_hook(
+        "kanban_task_claimed",
+        task_id,
+        board=get_current_board(),
+        assignee=claimed.assignee if claimed else None,
+        run_id=run_id,
+    )
+    return claimed
 
 
 def _retry_status_for_run(

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -67,6 +67,113 @@ def test_claim_fires_hook(kanban_home, captured_hooks):
 
 
 
+def test_review_claim_fires_hook(kanban_home, captured_hooks):
+    """The review lane is dispatched from the same process as the ready lane.
+
+    ``kanban_task_claimed`` is documented as firing "after claim commit, in
+    dispatcher process before worker spawn" so a plugin registered in the
+    dispatcher observes every transition centrally. ``claim_review_task`` is
+    a dispatcher-side claim too, so a reviewer spawn must be observable the
+    same way an implementation spawn is.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t", assignee="worker")
+        implementation = kb.claim_task(conn, tid)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            tid,
+            reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        review = kb.claim_review_task(conn, tid, claimer="reviewer:1")
+        assert review is not None
+    finally:
+        conn.close()
+
+    fired = [e for e in captured_hooks if e[0] == "kanban_task_claimed"]
+    # One for the implementation claim, one for the review claim.
+    assert len(fired) == 2
+    kw = fired[1][1]
+    assert kw["task_id"] == tid
+    assert kw["assignee"] == "reviewer"
+    assert "profile_name" in kw
+    assert kw["run_id"] == review.current_run_id
+
+
+def test_failed_review_claim_does_not_fire_hook(kanban_home, captured_hooks):
+    """A refused claim is not a spawn, so it must stay silent.
+
+    The second claim loses the race (the task is already ``running`` under
+    the first reviewer's lock) and returns None — firing the hook there
+    would tell an observer a reviewer started when none did.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t", assignee="worker")
+        implementation = kb.claim_task(conn, tid)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            tid,
+            reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        assert kb.claim_review_task(conn, tid, claimer="reviewer:1") is not None
+        assert kb.claim_review_task(conn, tid, claimer="reviewer:2") is None
+    finally:
+        conn.close()
+
+    fired = [e for e in captured_hooks if e[0] == "kanban_task_claimed"]
+    # Implementation claim + the one review claim that actually won.
+    assert len(fired) == 2
+
+
+def test_review_claim_demoted_by_reopened_parent_does_not_fire_hook(
+    kanban_home, captured_hooks
+):
+    """The dependency-guard exit is a demotion, not a spawn.
+
+    When a parent is reopened while the child waits in review,
+    ``claim_review_task`` sends the child back to ``todo`` and returns None.
+    That path writes to the board, so it is easy to mistake for a
+    transition worth announcing — but no reviewer process starts, and
+    ``claim_task``'s matching ``parents_not_done`` exit is silent too.
+    """
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="planner")
+        assert kb.complete_task(conn, parent)
+        tid = kb.create_task(
+            conn, title="t", assignee="worker", parents=[parent]
+        )
+        implementation = kb.claim_task(conn, tid)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            tid,
+            reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        # Reopen the parent behind the child's back.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'ready' WHERE id = ?", (parent,)
+            )
+        assert kb.claim_review_task(conn, tid, claimer="reviewer:1") is None
+        demoted = kb.get_task(conn, tid)
+        assert demoted is not None
+        assert demoted.status == "todo"
+    finally:
+        conn.close()
+
+    fired = [e for e in captured_hooks if e[0] == "kanban_task_claimed"]
+    # Only the implementation claim; the refused review claim stays silent.
+    assert len(fired) == 1
+    assert fired[0][1]["task_id"] == tid
+
+
 def test_misbehaving_hook_does_not_break_transition(kanban_home, monkeypatch):
     """A hook callback that raises must not break the board transition."""
     mgr = get_plugin_manager()


### PR DESCRIPTION
## What does this PR do?

`claim_review_task` transitions a task `review -> running` and the dispatcher then spawns a reviewer worker, but it never fired the `kanban_task_claimed` plugin lifecycle hook. Its sibling `claim_task` (`ready -> running`) does. A plugin registered in the dispatcher therefore observed implementation-worker spawns and silently missed every reviewer spawn.

The documented contract for the hook is in `website/docs/user-guide/features/hooks.md`:

| Hook | Kind | When | Kwargs |
|---|---|---|---|
| `kanban_task_claimed` | Observer | After claim commit, in dispatcher process before worker spawn; return ignored. | `task_id`, `profile_name`, `board`, `assignee`, `run_id` |

and `website/docs/developer-guide/plugins/index.md` tells plugin authors to register it "in the dispatcher to observe every transition centrally". Both dispatcher lanes claim from `_dispatch_once_locked` — the ready lane through `claim_task` (`hermes_cli/kanban_db.py:9553`) and the review lane through `claim_review_task` (`hermes_cli/kanban_db.py:9673`) — so a reviewer spawn is one of the transitions that description covers.

The fix fires the hook from `claim_review_task` with the same call shape and the same placement as `claim_task`: after the write transaction commits, so the callback sees durable board state and never runs while the SQLite write lock is held. `profile_name` is resolved inside `_fire_kanban_lifecycle_hook`, so the kwargs match the ready lane without the caller plumbing anything through. `invoke_hook` wraps each callback in its own `try/except` and the return value is discarded, so a raising observer cannot break the claim.

The three exits that return `None` stay silent, matching `claim_task`:

- parent reopened while the task waited in review — the task is demoted to `todo`, no reviewer starts;
- the `review -> running` CAS loses to another claimer;
- the row is not in `review`.

## Related Issue

Related: #64178 (hook delivery parity across surfaces), #56008 (reports `kanban_task_claimed` as the dispatcher-context hook).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py` — `claim_review_task` records `source_status: "review"` on the `claimed` event and fires `kanban_task_claimed` after the write transaction commits, mirroring `claim_task`.
- `tests/hermes_cli/test_kanban_lifecycle_hooks.py` — three tests: the review claim fires the hook with the documented kwargs; a claim that loses the lock race does not fire; a claim refused by the parent-dependency guard does not fire.

## How to Test

1. Without the change, `python -m pytest tests/hermes_cli/test_kanban_lifecycle_hooks.py` gives `2 failed, 3 passed` — `test_review_claim_fires_hook` and `test_failed_review_claim_does_not_fire_hook` both report `AssertionError: assert 1 == 2`, one `kanban_task_claimed` for the implementation claim and none for the review claim.
2. With the change, `scripts/run_tests.sh --files 'tests/hermes_cli/test_kanban_lifecycle_hooks.py'` gives `5 tests passed, 0 failed`.
3. Kanban review surfaces and dashboard plugin, run together: `scripts/run_tests.sh --files 'tests/hermes_cli/test_kanban_lifecycle_hooks.py:tests/hermes_cli/test_kanban_review_lifecycle.py:tests/hermes_cli/test_kanban_review_lifecycle_complete.py:tests/hermes_cli/test_kanban_review_surfaces.py:tests/hermes_cli/test_kanban_db.py:tests/hermes_cli/test_kanban_core_functionality.py:tests/plugins/test_kanban_dashboard_plugin.py'` gives `132 tests passed, 0 failed, 2 skipped` (the 2 skips are `windows_only`, which run on the `tests-os` lane).
4. End to end: register a plugin with a `kanban_task_claimed` callback, move a task through `request_review`, and let the dispatcher pick it up from the review column. The callback now fires with `assignee` set to the reviewer and `run_id` set to the review run.

`ruff check .` passes. `ty check` reports the same diagnostic counts on both touched files as on `main` (6 for `kanban_db.py`, 1 for the test file).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.6.0), Python 3.11.9, deps from `uv sync --locked`. Not run on Linux or Windows; the change is pure Python with no platform-specific calls.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — N/A: the change makes the code match the existing hooks table rather than changing it.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — no filesystem, process or terminal calls added; `scripts/check-windows-footguns.py --all` passes.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — N/A

## Screenshots / Logs

Before the change:

```
FAILED tests/hermes_cli/test_kanban_lifecycle_hooks.py::test_review_claim_fires_hook
FAILED tests/hermes_cli/test_kanban_lifecycle_hooks.py::test_failed_review_claim_does_not_fire_hook
E       AssertionError: assert 1 == 2
========================= 2 failed, 3 passed in 1.09s ==========================
```

After:

```
=== Summary: 1 files, 5 tests passed, 0 failed (100% complete) in 1.5s (20 workers) ===
```
