### PR TITLE
fix(cli): scope status bar aliases by provider

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -136,7 +136,7 @@ def _normalize_provider_for_alias_display(provider: str | None) -> str:
         from hermes_cli.models import normalize_provider
 
         return normalize_provider(provider_key)
-    except Exception:
+    except ImportError:
         return provider_key
 
 
@@ -164,14 +164,21 @@ def _reverse_alias_for_display(model_name: str, provider: str | None = None) -> 
         try:
             from hermes_cli.config import load_config
             cfg = load_config() or {}
+            mdl = cfg.get("model", {}) or {}
             ma = cfg.get("model_aliases")
             if isinstance(ma, dict):
                 for alias, entry in ma.items():
                     if isinstance(alias, str) and isinstance(entry, dict):
                         m = str(entry.get("model", "") or "").strip()
                         if m:
-                            remember(alias, m, entry.get("provider", "custom"))
-            mdl = cfg.get("model", {}) or {}
+                            # Fall back to the same default as the string-form
+                            # aliases below so both config shapes behave
+                            # identically for provider-less entries.
+                            remember(
+                                alias,
+                                m,
+                                entry.get("provider") or mdl.get("provider", ""),
+                            )
             if isinstance(mdl, dict):
                 simple = mdl.get("aliases")
                 if isinstance(simple, dict):

--- a/cli.py
+++ b/cli.py
@@ -120,50 +120,82 @@ def format_duration_compact(*args, **kwargs):
     return f"{days:.1f}d"
 
 
-# Cached reverse map of config.yaml ``model_aliases:`` so the TUI can show
-# friendly names instead of full Palantir RIDs / long catalog IDs. Built
-# lazily on first call; cache is process-lifetime (config is read once at
-# session start, so further invalidation is unnecessary).
-_REVERSE_ALIAS_CACHE: dict[str, str] | None = None
+# Cached reverse maps of config.yaml model aliases so the TUI can show friendly
+# names instead of full Palantir RIDs / long catalog IDs. ``None`` provider keys
+# retain the legacy model-only fallback for callers without runtime provider
+# information. Built lazily on first call; cache is process-lifetime (config is
+# read once at session start, so further invalidation is unnecessary).
+_REVERSE_ALIAS_CACHE: dict[tuple[str | None, str], str] | None = None
 
 
-def _reverse_alias_for_display(model_name: str) -> str:
-    """Return the shortest configured alias for ``model_name``, or ``model_name``.
+def _normalize_provider_for_alias_display(provider: str | None) -> str:
+    provider_key = str(provider or "").strip().lower()
+    if not provider_key or provider_key == "auto":
+        return provider_key
+    try:
+        from hermes_cli.models import normalize_provider
+
+        return normalize_provider(provider_key)
+    except Exception:
+        return provider_key
+
+
+def _reverse_alias_for_display(model_name: str, provider: str | None = None) -> str:
+    """Return the shortest configured alias for ``provider``/``model_name``.
 
     Looks up both ``model_aliases:`` (dict-based, full DirectAlias entries)
     and ``model.aliases:`` (string-based, set via ``hermes config set``)
     from config.yaml. Multiple aliases pointing at the same model — the
-    shortest wins, so ``opus47`` beats ``palantir-claude47``.
+    shortest wins, so ``opus47`` beats ``palantir-claude47``. When provider
+    information is unavailable, preserve the historical model-only lookup.
     """
     global _REVERSE_ALIAS_CACHE
     if not model_name:
         return model_name
     if _REVERSE_ALIAS_CACHE is None:
-        rmap: dict[str, str] = {}
+        rmap: dict[tuple[str | None, str], str] = {}
+
+        def remember(alias: str, model: str, alias_provider: str | None) -> None:
+            provider_key = _normalize_provider_for_alias_display(alias_provider)
+            for key in ((provider_key, model), (None, model)):
+                if key not in rmap or len(alias) < len(rmap[key]):
+                    rmap[key] = alias
+
         try:
             from hermes_cli.config import load_config
             cfg = load_config() or {}
             ma = cfg.get("model_aliases")
             if isinstance(ma, dict):
                 for alias, entry in ma.items():
-                    if isinstance(entry, dict):
+                    if isinstance(alias, str) and isinstance(entry, dict):
                         m = str(entry.get("model", "") or "").strip()
-                        if m and (m not in rmap or len(alias) < len(rmap[m])):
-                            rmap[m] = alias
+                        if m:
+                            remember(alias, m, entry.get("provider", "custom"))
             mdl = cfg.get("model", {}) or {}
             if isinstance(mdl, dict):
                 simple = mdl.get("aliases")
                 if isinstance(simple, dict):
                     for alias, val in simple.items():
-                        if isinstance(val, str) and val.strip():
+                        if isinstance(alias, str) and isinstance(val, str) and val.strip():
                             v = val.strip()
-                            m = v.split("/", 1)[1] if "/" in v else v
-                            if m and (m not in rmap or len(alias) < len(rmap[m])):
-                                rmap[m] = alias
+                            if "/" in v:
+                                alias_provider, m = v.split("/", 1)
+                            else:
+                                alias_provider = mdl.get("provider", "")
+                                m = v
+                            m = m.strip()
+                            if m:
+                                remember(alias, m, alias_provider)
         except Exception:
             pass
         _REVERSE_ALIAS_CACHE = rmap
-    return _REVERSE_ALIAS_CACHE.get(model_name, model_name)
+    provider_key = _normalize_provider_for_alias_display(provider)
+    lookup_key = (
+        (provider_key, model_name)
+        if provider_key and provider_key != "auto"
+        else (None, model_name)
+    )
+    return _REVERSE_ALIAS_CACHE.get(lookup_key, model_name)
 
 
 def format_token_count_compact(*args, **kwargs):
@@ -5297,17 +5329,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         return f"✓ {format_duration_compact(idle)}"
 
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
-        # Prefer the agent's model name — it updates on fallback.
-        # self.model reflects the originally configured model and never
-        # changes mid-session, so the TUI would show a stale name after
-        # _try_activate_fallback() switches provider/model.
+        # Prefer the agent's live route — its model and provider update on
+        # fallback. The CLI fields retain the primary route, so using them
+        # while an agent is active would leave the TUI label stale.
         agent = getattr(self, "agent", None)
         model_name = (getattr(agent, "model", None) or self.model or "unknown")
+        active_provider = (
+            getattr(agent, "provider", None)
+            or getattr(self, "provider", None)
+        )
         # Friendly display: prefer reverse-alias from config.yaml ``model_aliases:``
         # before slash/length truncation. This turns long Palantir RIDs like
         # ``ri.language-model-service..language-model.anthropic-claude-4-7-opus``
         # into the user's chosen short name (e.g. ``opus-4.7``) in the status bar.
-        model_short = _reverse_alias_for_display(model_name)
+        model_short = _reverse_alias_for_display(model_name, active_provider)
         if model_short == model_name:
             model_short = model_name.split("/")[-1] if "/" in model_name else model_name
             # Strip Palantir RID prefixes via the shared display formatter so

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -152,6 +152,66 @@ class TestCLIStatusBar:
 
         assert cli_mod._reverse_alias_for_display("gpt-5.6-sol") == "local-gpt56"
 
+    def test_reverse_alias_auto_provider_falls_back_to_model_only(self, monkeypatch):
+        _set_alias_config(
+            monkeypatch,
+            {
+                "model": {
+                    "aliases": {
+                        "local-gpt56": "local-sub2api/gpt-5.6-sol",
+                        "any-gpt56": "gpt-5.6-sol",
+                    }
+                }
+            },
+        )
+
+        assert (
+            cli_mod._reverse_alias_for_display("gpt-5.6-sol", "auto")
+            == "any-gpt56"
+        )
+
+    def test_reverse_alias_dict_form_without_provider_uses_model_default(
+        self, monkeypatch
+    ):
+        _set_alias_config(
+            monkeypatch,
+            {
+                "model_aliases": {
+                    "top-level": {
+                        "model": "gpt-5.6-sol",
+                    }
+                },
+                "model": {
+                    "provider": "local-sub2api",
+                },
+            },
+        )
+
+        assert (
+            cli_mod._reverse_alias_for_display("gpt-5.6-sol", "local-sub2api")
+            == "top-level"
+        )
+
+    def test_reverse_alias_dict_form_without_provider_stays_scoped(
+        self, monkeypatch
+    ):
+        _set_alias_config(
+            monkeypatch,
+            {
+                "model_aliases": {
+                    "top-level": {
+                        "model": "gpt-5.6-sol",
+                    }
+                }
+            },
+        )
+
+        assert (
+            cli_mod._reverse_alias_for_display("gpt-5.6-sol", "openai-codex")
+            == "gpt-5.6-sol"
+        )
+        assert cli_mod._reverse_alias_for_display("gpt-5.6-sol") == "top-level"
+
     def test_status_bar_prefers_live_agent_provider(self, monkeypatch):
         _set_alias_config(
             monkeypatch,

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -7,6 +7,15 @@ import cli as cli_mod
 from cli import HermesCLI
 
 
+_LOCAL_GPT56_ALIAS_CONFIG = {
+    "model": {
+        "aliases": {
+            "local-gpt56": "local-sub2api/gpt-5.6-sol",
+        }
+    }
+}
+
+
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj = HermesCLI.__new__(HermesCLI)
     cli_obj.model = model
@@ -14,6 +23,18 @@ def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
     return cli_obj
+
+
+def _set_alias_config(monkeypatch, config):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr(cli_mod, "_REVERSE_ALIAS_CACHE", None)
+
+
+def _status_bar_model_short(provider: str, *, cli_provider: str | None = None) -> str:
+    cli_obj = _make_cli("gpt-5.6-sol")
+    cli_obj.provider = cli_provider or provider
+    cli_obj.agent = SimpleNamespace(model="gpt-5.6-sol", provider=provider)
+    return cli_obj._get_status_bar_snapshot()["model_short"]
 
 
 def _attach_agent(
@@ -54,6 +75,107 @@ def _attach_agent(
 
 
 class TestCLIStatusBar:
+    def test_status_bar_does_not_use_alias_from_another_provider(self, monkeypatch):
+        _set_alias_config(monkeypatch, _LOCAL_GPT56_ALIAS_CONFIG)
+
+        assert _status_bar_model_short("openai-codex") == "gpt-5.6-sol"
+
+    def test_status_bar_uses_alias_from_active_provider(self, monkeypatch):
+        _set_alias_config(monkeypatch, _LOCAL_GPT56_ALIAS_CONFIG)
+
+        assert _status_bar_model_short("local-sub2api") == "local-gpt56"
+
+    def test_reverse_alias_supports_both_config_forms(self, monkeypatch):
+        _set_alias_config(
+            monkeypatch,
+            {
+                "model_aliases": {
+                    "top-level": {
+                        "model": "claude-opus-4-6",
+                        "provider": "anthropic",
+                    }
+                },
+                "model": {
+                    "aliases": {
+                        "string-form": "openai-codex/gpt-5.6-sol",
+                    }
+                },
+            },
+        )
+
+        assert (
+            cli_mod._reverse_alias_for_display("claude-opus-4-6", "anthropic")
+            == "top-level"
+        )
+        assert (
+            cli_mod._reverse_alias_for_display("gpt-5.6-sol", "openai-codex")
+            == "string-form"
+        )
+
+    def test_reverse_alias_matches_canonical_provider_alias(self, monkeypatch):
+        _set_alias_config(
+            monkeypatch,
+            {
+                "model": {
+                    "aliases": {
+                        "opus": "claude/claude-opus-4-6",
+                    }
+                }
+            },
+        )
+
+        assert (
+            cli_mod._reverse_alias_for_display("claude-opus-4-6", "anthropic")
+            == "opus"
+        )
+
+    def test_reverse_alias_uses_shortest_provider_match(self, monkeypatch):
+        _set_alias_config(
+            monkeypatch,
+            {
+                "model": {
+                    "aliases": {
+                        "long-local-gpt56": "local-sub2api/gpt-5.6-sol",
+                        "gpt56": "local-sub2api/gpt-5.6-sol",
+                    }
+                }
+            },
+        )
+
+        assert (
+            cli_mod._reverse_alias_for_display("gpt-5.6-sol", "local-sub2api")
+            == "gpt56"
+        )
+
+    def test_reverse_alias_falls_back_when_provider_is_unavailable(self, monkeypatch):
+        _set_alias_config(monkeypatch, _LOCAL_GPT56_ALIAS_CONFIG)
+
+        assert cli_mod._reverse_alias_for_display("gpt-5.6-sol") == "local-gpt56"
+
+    def test_status_bar_prefers_live_agent_provider(self, monkeypatch):
+        _set_alias_config(
+            monkeypatch,
+            {
+                "model_aliases": {
+                    "codex": {
+                        "model": "gpt-5.6-sol",
+                        "provider": "openai-codex",
+                    },
+                    "local-gpt56": {
+                        "model": "gpt-5.6-sol",
+                        "provider": "local-sub2api",
+                    },
+                }
+            },
+        )
+        assert (
+            _status_bar_model_short(
+                "local-sub2api",
+                cli_provider="openai-codex",
+            )
+            == "local-gpt56"
+        )
+
     def test_session_title_is_right_aligned_after_it_is_queued(self):
         cli_obj = _make_cli()
         cli_obj._pending_title = "weekly-digest"
@@ -350,5 +472,3 @@ class TestIdleSinceLastTurn:
         cli_obj._prompt_duration = 5.0
         snapshot = cli_obj._get_status_bar_snapshot()
         assert snapshot["idle_since"].startswith("✓ ")
-
-


### PR DESCRIPTION
## Summary

- key classic CLI reverse-alias display by canonical `(provider, model)` instead of model alone
- prefer the live agent provider so fallback routes display the correct alias
- preserve both documented alias config forms, shortest-alias selection, and the legacy model-only fallback when provider information is unavailable

## Problem

A session routed through `openai-codex / gpt-5.6-sol` could display `local-gpt56` when that alias was configured for `local-sub2api / gpt-5.6-sol`. Routing was correct; only the status-bar label was wrong.

This patch does not add an always-visible provider prefix and does not change model routing.

## Test plan

- `scripts/run_tests.sh tests/cli/test_cli_status_bar.py -- -q` — 27 passed
- `python -m py_compile cli.py tests/cli/test_cli_status_bar.py`
- `python scripts/check-windows-footguns.py cli.py tests/cli/test_cli_status_bar.py`
- sabotage check: the new cross-provider regression test fails under the old model-only lookup (`local-gpt56` instead of `gpt-5.6-sol`)

Fixes #83665

Related: #72777 and #72798 cover the adjacent same-provider/generated-alias display contract, not this cross-provider collision.
