### PR TITLE
fix(plugins): declare E.164 platform targets

### DIFF
--- a/contributors/emails/steven.d.spencer@gmail.com
+++ b/contributors/emails/steven.d.spencer@gmail.com
@@ -1,0 +1,2 @@
+indybones
+# PR #83672

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -114,6 +114,11 @@ class PlatformEntry:
     # Max message length for smart-chunking.  0 = no limit.
     max_message_length: int = 0
 
+    # True when direct recipients may be addressed as E.164 phone numbers.
+    # The shared send_message parser uses this to keep ``platform:+1555...``
+    # on the explicit-target path instead of consulting the channel directory.
+    accepts_e164_targets: bool = False
+
     # ── Privacy ──
     # If True, session descriptions redact PII (phone numbers, etc.)
     pii_safe: bool = False

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from gateway.config import Platform
+from gateway.platform_registry import PlatformEntry, platform_registry
 from tools.send_message_tool import _parse_target_ref, send_message_tool
 
 
@@ -27,6 +28,89 @@ def test_photon_e164_target_is_explicit() -> None:
 
 def test_e164_target_still_requires_phone_platform() -> None:
     assert _parse_target_ref("matrix", "+15551234567")[2] is False
+
+
+def _register_phone_plugin(name: str, *, accepts_e164_targets: bool) -> None:
+    platform_registry.register(
+        PlatformEntry(
+            name=name,
+            label="Community Phone",
+            adapter_factory=lambda _cfg: None,
+            check_fn=lambda: True,
+            accepts_e164_targets=accepts_e164_targets,
+        )
+    )
+
+
+def test_plugin_must_opt_in_to_e164_targets() -> None:
+    platform_name = "phone_target_disabled"
+    _register_phone_plugin(platform_name, accepts_e164_targets=False)
+    try:
+        assert _parse_target_ref(platform_name, "+15555550100") == (
+            None,
+            None,
+            False,
+        )
+    finally:
+        platform_registry.unregister(platform_name)
+
+
+def test_plugin_e164_target_bypasses_directory_and_home_fallback() -> None:
+    platform_name = "phone_target_enabled"
+    _register_phone_plugin(platform_name, accepts_e164_targets=True)
+    try:
+        platform = Platform(platform_name)
+        platform_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+        config = SimpleNamespace(
+            platforms={platform: platform_cfg},
+            get_home_channel=lambda _platform: (_ for _ in ()).throw(
+                AssertionError("explicit E.164 target must not use home channel")
+            ),
+        )
+
+        with (
+            patch("hermes_cli.plugins.discover_plugins") as discover_plugins,
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("tools.interrupt.is_interrupted", return_value=False),
+            patch(
+                "gateway.channel_directory.resolve_channel_name",
+                side_effect=AssertionError(
+                    "explicit E.164 target must not use channel directory"
+                ),
+            ),
+            patch(
+                "model_tools._run_async", side_effect=_run_async_immediately
+            ),
+            patch(
+                "tools.send_message_tool._send_to_platform",
+                new=AsyncMock(return_value={"success": True}),
+            ) as send_mock,
+            patch("gateway.mirror.mirror_to_session", return_value=True),
+        ):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": f"{platform_name}:+15555550100",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert "note" not in result
+        discover_plugins.assert_called_with()
+        send_mock.assert_awaited_once_with(
+            platform,
+            platform_cfg,
+            "+15555550100",
+            "hello",
+            thread_id=None,
+            media_files=[],
+            force_document=False,
+        )
+    finally:
+        platform_registry.unregister(platform_name)
 
 
 def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
@@ -63,4 +147,3 @@ def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
         media_files=[],
         force_document=False,
     )
-

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -597,12 +597,11 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if group_id:
             return f"group:{group_id}", None, True
         return None, None, False
-    if platform_name in _PHONE_PLATFORMS:
-        match = _E164_TARGET_RE.fullmatch(target_ref)
-        if match:
-            # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
-            # expect E.164 format for direct recipients.
-            return target_ref.strip(), None, True
+    match = _E164_TARGET_RE.fullmatch(target_ref)
+    if match and _accepts_e164_targets(platform_name):
+        # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
+        # expect E.164 format for direct recipients.
+        return target_ref.strip(), None, True
     if platform_name == "photon":
         # Photon DM chat GUIDs ('any;-;+1555...') are platform-native ids the
         # adapter resolves itself — pass through verbatim instead of bouncing
@@ -618,6 +617,24 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     if platform_name == "xmpp" and "@" in target_ref:
         return target_ref, None, True
     return None, None, False
+
+
+def _accepts_e164_targets(platform_name: str) -> bool:
+    """Return whether a built-in or registered plugin accepts phone targets."""
+    if platform_name in _PHONE_PLATFORMS:
+        return True
+    try:
+        from hermes_cli.plugins import discover_plugins
+        from gateway.platform_registry import platform_registry
+
+        # ``hermes send`` parses its target before loading gateway config, so
+        # make sure standalone platform plugins have registered their lazy
+        # PlatformEntry before consulting the capability.
+        discover_plugins()
+        entry = platform_registry.get(platform_name)
+    except Exception:
+        return False
+    return bool(entry and entry.accepts_e164_targets)
 
 
 def _describe_media_for_mirror(media_files):

--- a/website/docs/developer-guide/adding-platform-adapters.md
+++ b/website/docs/developer-guide/adding-platform-adapters.md
@@ -300,6 +300,20 @@ ctx.register_platform(
 )
 ```
 
+If the adapter accepts direct recipients in E.164 form, declare that on the
+platform registration:
+
+```python
+ctx.register_platform(
+    # ...
+    accepts_e164_targets=True,
+)
+```
+
+This makes targets such as `my_platform:+15555550100` explicit. The shared
+send parser passes the phone number directly to the adapter instead of trying
+to resolve it as a channel name or consulting the platform's home channel.
+
 The scheduler reads this env var when resolving the home target for `deliver=my_platform` jobs, and also treats the platform as a valid cron target in `_KNOWN_DELIVERY_PLATFORMS`-style checks. If your `env_enablement_fn` seeds a `home_channel` dict (see above), that takes precedence — `cron_deliver_env_var` is the fallback for cron jobs that run before env seeding.
 
 ### Out-of-process cron delivery


### PR DESCRIPTION
## What does this PR do?

Lets a platform plugin declare that it accepts direct E.164 recipient targets.

`send_message` currently recognizes `platform:+E164` only for names in the hardcoded `_PHONE_PLATFORMS` set. A standalone phone-addressed plugin therefore sends an explicit recipient through channel-directory resolution instead of passing it to its adapter.

This change adds an opt-in `PlatformEntry.accepts_e164_targets` capability. The parser keeps the existing built-in set and unions it with the capability declared through `ctx.register_platform(...)`. The standalone `hermes send` path performs plugin discovery before consulting the entry, since target parsing happens before gateway config loading there.

## Related Issue

Fixes #83671

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add the default-off `accepts_e164_targets` capability to `gateway.platform_registry.PlatformEntry`.
- Resolve E.164 explicit-target behavior from the existing built-in set or an opted-in plugin entry.
- Prove the opted-in send path never consults the channel directory or home channel, while an unopted plugin remains unchanged.
- Document the registration flag for platform authors.

## How to Test

1. Run `HERMES_PYTHON=/path/to/dev/python scripts/run_tests.sh tests/tools/test_send_message_target_parse.py tests/gateway/test_plugin_platform_interface.py tests/hermes_cli/test_plugin_scanner_recursion.py -q`.
2. Confirm 17 tests pass (2 platform-interface tests skip when optional platform dependencies are absent).
3. Run `ruff check gateway/platform_registry.py tools/send_message_tool.py tests/tools/test_send_message_target_parse.py` and `git diff --check`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched open and closed issues/PRs; #23409/#23434 address the built-in BlueBubbles surface, not plugin-declared phone addressing.
- [x] My PR contains only changes related to this fix.
- [ ] I've run the full `pytest tests/ -q` suite.
- [x] I've added tests for my changes.
- [x] I've tested on macOS (darwin-arm64).

### Documentation & Housekeeping

- [x] I've updated the platform-adapter developer documentation.
- [x] `cli-config.yaml.example` is N/A; this adds no config key.
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A; the existing plugin registration surface is extended in place.
- [x] Cross-platform impact considered: Python-only registry/parser behavior with no OS-specific path.
- [x] Tool descriptions/schemas are N/A; target syntax is unchanged.
