### PR TITLE
fix(agent): honor image_input_mode=native when vision metadata is unknown

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6719,7 +6719,38 @@ class AIAgent:
             cfg = load_config()
             provider = (getattr(self, "provider", "") or "").strip()
             model = (getattr(self, "model", "") or "").strip()
-            return _lookup_supports_vision(provider, model, cfg) is True
+            requested_provider = (getattr(self, "requested_provider", "") or "").strip()
+            return _lookup_supports_vision(
+                provider,
+                model,
+                cfg,
+                requested_provider=requested_provider,
+            ) is True
+        except Exception:
+            return False
+
+    def _should_preserve_native_image_parts(self) -> bool:
+        """Return True when explicit ``image_input_mode: native`` is active.
+
+        User-attached image preprocessing must honor the routing policy even
+        when capability metadata is unknown (``None``). Provider rejection
+        and retry/fallback remain the recovery path for models that truly
+        lack vision support.
+        """
+        try:
+            from hermes_cli.config import load_config
+            from agent.image_routing import decide_image_input_mode
+
+            cfg = load_config()
+            provider = (getattr(self, "provider", "") or "").strip()
+            model = (getattr(self, "model", "") or "").strip()
+            requested_provider = (getattr(self, "requested_provider", "") or "").strip()
+            return decide_image_input_mode(
+                provider,
+                model,
+                cfg,
+                requested_provider=requested_provider,
+            ) == "native"
         except Exception:
             return False
 
@@ -6815,7 +6846,7 @@ class AIAgent:
         # native Anthropic ``{"type": "image", "source": ...}`` blocks. When
         # the active model supports vision we let the adapter do its job and
         # skip this legacy text-fallback preprocessor entirely.
-        if self._model_supports_vision():
+        if self._model_supports_vision() or self._should_preserve_native_image_parts():
             return api_messages
 
         # Non-vision Anthropic model (rare today, but keep the fallback for
@@ -6845,7 +6876,7 @@ class AIAgent:
         ):
             return api_messages
 
-        if self._model_supports_vision():
+        if self._model_supports_vision() or self._should_preserve_native_image_parts():
             return api_messages
 
         transformed = copy.deepcopy(api_messages)

--- a/tests/run_agent/test_vision_aware_preprocessing.py
+++ b/tests/run_agent/test_vision_aware_preprocessing.py
@@ -188,3 +188,84 @@ class TestModelSupportsVision:
              patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert agent._model_supports_vision() is True
 
+
+class TestNativeImageInputModePreservation:
+    """Explicit ``image_input_mode: native`` must not preflight-strip images."""
+
+    _NATIVE_UNKNOWN_CFG = {
+        "model": {"provider": "custom:private", "default": "private-vlm"},
+        "agent": {"image_input_mode": "native"},
+    }
+
+    def test_native_unknown_model_preserves_images_non_vision_path(self):
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.requested_provider = "custom:private"
+        agent.model = "private-vlm"
+        with patch("hermes_cli.config.load_config", return_value=self._NATIVE_UNKNOWN_CFG), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch.object(
+                 agent,
+                 "_describe_image_for_anthropic_fallback",
+                 return_value="[fallback description]",
+             ) as describe:
+            out = agent._prepare_messages_for_non_vision_model([IMG_PARTS_USER_MSG])
+        assert out[0]["content"][1]["type"] == "image_url"
+        describe.assert_not_called()
+
+    def test_native_unknown_model_preserves_images_anthropic_path(self):
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.requested_provider = "custom:private"
+        agent.model = "private-vlm"
+        with patch("hermes_cli.config.load_config", return_value=self._NATIVE_UNKNOWN_CFG), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch.object(
+                 agent,
+                 "_describe_image_for_anthropic_fallback",
+                 return_value="[fallback description]",
+             ) as describe:
+            out = agent._prepare_anthropic_messages_for_api([IMG_PARTS_USER_MSG])
+        assert out[0]["content"][1]["type"] == "image_url"
+        describe.assert_not_called()
+
+    def test_auto_unknown_model_still_strips_images(self):
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.requested_provider = "custom:private"
+        agent.model = "private-vlm"
+        cfg = {
+            "model": {"provider": "custom:private", "default": "private-vlm"},
+            "agent": {"image_input_mode": "auto"},
+        }
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch.object(
+                 agent,
+                 "_describe_image_for_anthropic_fallback",
+                 return_value="[fallback description]",
+             ):
+            out = agent._prepare_messages_for_non_vision_model([IMG_PARTS_USER_MSG])
+        assert isinstance(out[0]["content"], str)
+        assert "image_url" not in out[0]["content"]
+
+    def test_text_mode_still_strips_images(self):
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.requested_provider = "custom:private"
+        agent.model = "private-vlm"
+        cfg = {
+            "model": {"provider": "custom:private", "default": "private-vlm"},
+            "agent": {"image_input_mode": "text"},
+        }
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch.object(
+                 agent,
+                 "_describe_image_for_anthropic_fallback",
+                 return_value="[text mode description]",
+             ):
+            out = agent._prepare_messages_for_non_vision_model([IMG_PARTS_USER_MSG])
+        assert isinstance(out[0]["content"], str)
+        assert "[text mode description]" in out[0]["content"]
+


### PR DESCRIPTION
## What does this PR do?

When `agent.image_input_mode` is set to `native`, user-attached image parts are now preserved in API-bound messages even when models.dev capability lookup returns `None` (custom providers, private models, uncatalogued aliases). Previously, `decide_image_input_mode()` correctly returned `"native"`, but `_prepare_anthropic_messages_for_api` and `_prepare_messages_for_non_vision_model` still downgraded images via `_model_supports_vision()` treating unknown capability as non-vision.

The fix adds `_should_preserve_native_image_parts()` that consults the routing policy and skips preflight image stripping when explicit native mode is active. `auto` and `text` modes retain existing capability-gated behavior; provider rejection recovery is unchanged.

## Related Issue

Fixes #83666

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: add `_should_preserve_native_image_parts()`; gate both user-message image preprocessors on native policy; pass `requested_provider` through `_model_supports_vision()` for custom provider overrides
- `tests/run_agent/test_vision_aware_preprocessing.py`: add regression tests for native/auto/text modes with unknown capability

## How to Test

1. Configure a synthetic custom provider with `agent.image_input_mode: native` and no `supports_vision` override (model absent from models.dev).
2. Build an in-memory user message with `image_url` content and call `_prepare_messages_for_non_vision_model`.
3. Confirm `image_url` parts remain in the prepared message and `_describe_image_for_anthropic_fallback` is not called before the provider request.
4. Run `pytest tests/run_agent/test_vision_aware_preprocessing.py -q` — all tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Cloud Agent)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix (repro script output):

```
decision: native
lookup: None
final_gate: False
describe.called: True
prepared content: [fallback description] ... (text only)
```

After fix:

```
decision: native
lookup: None
final_gate: False
describe.called: False
prepared content: [{'type': 'text', ...}, {'type': 'image_url', ...}]
```