### PR TITLE
fix(terminal): keep foreground Windows payloads out of argv

### DIFF
--- a/tests/tools/test_local_env_windows_command_payload.py
+++ b/tests/tools/test_local_env_windows_command_payload.py
@@ -1,0 +1,231 @@
+"""Windows command payload transport tests for ``LocalEnvironment``."""
+
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments import local as local_mod
+from tools.environments.local import LocalEnvironment, _bash_safe_path
+
+
+@pytest.fixture
+def local_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    with patch.object(
+        LocalEnvironment, "init_session", autospec=True, return_value=None
+    ):
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=5)
+    yield env
+    env.cleanup()
+
+
+@pytest.mark.windows_only
+def test_generated_script_body_is_not_in_windows_process_argv(local_env, monkeypatch):
+    marker = "HERMES_ARGV_PAYLOAD_MARKER_7f2d"
+    script = f"printf '%s' '{marker}'\n" + ("# padding\n" * 1200)
+    captured = {}
+
+    def fake_popen(args, **kwargs):
+        captured["args"] = list(args)
+        argv_text = "\0".join(args)
+        if marker not in argv_text:
+            script_path = Path(local_mod._msys_to_windows_path(args[-1]))
+            captured["bytes"] = script_path.read_bytes()
+        return SimpleNamespace(pid=12345, stdin=None, stdout=None)
+
+    monkeypatch.setattr(
+        local_mod,
+        "_find_bash",
+        lambda: r"C:\Program Files\Git\bin\bash.exe",
+    )
+    monkeypatch.setattr(local_mod.subprocess, "Popen", fake_popen)
+
+    proc = local_env._run_bash(script)
+
+    argv_text = "\0".join(captured["args"])
+    assert marker not in argv_text
+    assert script not in argv_text
+    assert captured["bytes"] == script.encode("utf-8")
+    local_env._discard_staged_command_script(
+        getattr(proc, "_hermes_staged_command_script")
+    )
+
+
+@pytest.mark.windows_only
+def test_real_git_bash_executes_payload_larger_than_cmd_limit(local_env, tmp_path):
+    destination = tmp_path / "payload.bin"
+    payload = "第一行 Ω\n'quoted' \"double\" C:\\path\\file\n\n末行"
+    padding = "\n".join(f"# padding-{i:04d}-{'x' * 32}" for i in range(400))
+    command = (
+        f"{padding}\n"
+        f"printf %s {shlex.quote(payload)} > "
+        f"{shlex.quote(_bash_safe_path(str(destination)))}"
+    )
+    assert len(command) > 8191
+
+    result = local_env.execute(command, timeout=20)
+
+    assert result["returncode"] == 0, result
+    assert destination.read_bytes() == payload.encode("utf-8")
+
+
+@pytest.mark.windows_only
+def test_stdin_remains_byte_exact_and_closes_with_large_staged_program(
+    local_env, tmp_path
+):
+    destination = tmp_path / "stdin.bin"
+    stdin_data = "αβγ\nquotes ' \"\nC:\\temp\\x\n\nfinal"
+    padding = "\n".join(f"# stdin-padding-{i:04d}" for i in range(700))
+    command = f"{padding}\ncat > {shlex.quote(_bash_safe_path(str(destination)))}"
+    assert len(command) > 8191
+
+    result = local_env.execute(command, timeout=20, stdin_data=stdin_data)
+
+    assert result["returncode"] == 0, result
+    assert destination.read_bytes() == stdin_data.encode("utf-8")
+
+
+def _staged_files(env):
+    return set(Path(env.get_temp_dir()).glob("hermes-command-*.sh"))
+
+
+@pytest.mark.windows_only
+def test_process_start_failure_removes_staged_script(local_env, monkeypatch):
+    before = _staged_files(local_env)
+    monkeypatch.setattr(
+        local_mod,
+        "_find_bash",
+        lambda: r"C:\Program Files\Git\bin\bash.exe",
+    )
+
+    def fail_start(*args, **kwargs):
+        raise OSError("synthetic process start failure")
+
+    monkeypatch.setattr(local_mod.subprocess, "Popen", fail_start)
+
+    with pytest.raises(OSError, match="synthetic process start failure"):
+        local_env._run_bash("printf start")
+
+    assert _staged_files(local_env) == before
+
+
+@pytest.mark.windows_only
+@pytest.mark.parametrize("command", ["printf normal", "exit 7"])
+def test_normal_and_nonzero_completion_remove_staged_script(local_env, command):
+    before = _staged_files(local_env)
+
+    local_env.execute(command, timeout=10)
+
+    assert _staged_files(local_env) == before
+
+
+@pytest.mark.windows_only
+def test_wait_exception_removes_staged_script(local_env, monkeypatch):
+    path = local_env._stage_command_script("printf interrupted")
+    proc = SimpleNamespace(_hermes_staged_command_script=path)
+
+    def interrupted(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(local_mod.BaseEnvironment, "_wait_for_process", interrupted)
+
+    with pytest.raises(KeyboardInterrupt):
+        local_env._wait_for_process(proc, timeout=1)
+
+    assert not Path(path).exists()
+
+
+@pytest.mark.windows_only
+def test_environment_cleanup_removes_abandoned_staged_script(local_env):
+    path = local_env._stage_command_script("printf abandoned")
+
+    local_env.cleanup()
+
+    assert not Path(path).exists()
+
+
+@pytest.mark.windows_only
+def test_failed_unlink_remains_owned_for_cleanup_retry(local_env, monkeypatch):
+    path = local_env._stage_command_script("printf retry-cleanup")
+    real_unlink = local_mod.os.unlink
+    failed_once = False
+
+    def transient_failure(candidate):
+        nonlocal failed_once
+        if candidate == path and not failed_once:
+            failed_once = True
+            raise PermissionError("script is still open")
+        return real_unlink(candidate)
+
+    monkeypatch.setattr(local_mod.os, "unlink", transient_failure)
+
+    local_env._discard_staged_command_script(path)
+
+    assert Path(path).exists()
+    assert path in local_env._staged_command_scripts
+
+    local_env.cleanup()
+
+    assert not Path(path).exists()
+    assert path not in local_env._staged_command_scripts
+
+
+@pytest.mark.windows_only
+def test_timeout_removes_staged_script(local_env):
+    before = _staged_files(local_env)
+
+    result = local_env.execute("sleep 5", timeout=1)
+
+    assert result.get("timed_out") or result["returncode"] != 0
+    assert _staged_files(local_env) == before
+
+
+@pytest.mark.windows_only
+def test_large_remote_script_reaches_fake_ssh_via_stdin_not_argv(local_env, tmp_path):
+    argv_file = tmp_path / "ssh-argv.json"
+    stdin_file = tmp_path / "ssh-stdin.bin"
+    shim = tmp_path / "ssh"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        '"$SSH_TEST_PYTHON" -c \'import json,os,sys; '
+        'open(os.environ["SSH_ARGV_FILE"],"w",encoding="utf-8").write('
+        "json.dumps(sys.argv[1:])); "
+        'open(os.environ["SSH_STDIN_FILE"],"wb").write(sys.stdin.buffer.read())\' '
+        '"$@"\n',
+        encoding="utf-8",
+        newline="\n",
+    )
+    os.chmod(shim, 0o755)
+
+    remote_script = "Write-Output '开始'\n" + (
+        "# remote-padding-xxxxxxxxxxxxxxxx\n" * 400
+    )
+    assert len(remote_script) > 8191
+    local_env.env.update({
+        "SSH_ARGV_FILE": str(argv_file),
+        "SSH_STDIN_FILE": str(stdin_file),
+        "SSH_TEST_PYTHON": sys.executable.replace("\\", "/"),
+    })
+    command = (
+        f"{shlex.quote(_bash_safe_path(str(shim)))} "
+        "example.invalid powershell.exe -NoProfile -NonInteractive "
+        "-Command - <<'HERMES_REMOTE_SCRIPT'\n"
+        f"{remote_script}"
+        "HERMES_REMOTE_SCRIPT"
+    )
+
+    result = local_env.execute(command, timeout=20)
+
+    assert result["returncode"] == 0, result
+    argv = json.loads(argv_file.read_text(encoding="utf-8"))
+    argv_text = "\0".join(argv)
+    assert len(argv_text) < 8191
+    assert "Write-Output" not in argv_text
+    assert "EncodedCommand" not in argv
+    assert stdin_file.read_bytes() == remote_script.encode("utf-8")

--- a/tests/tools/test_local_env_windows_command_payload.py
+++ b/tests/tools/test_local_env_windows_command_payload.py
@@ -1,0 +1,299 @@
+"""Windows command payload transport tests for ``LocalEnvironment``."""
+
+import json
+import os
+import shlex
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments import base as base_mod
+from tools.environments import local as local_mod
+from tools.environments.local import LocalEnvironment, _bash_safe_path
+
+
+@pytest.fixture
+def local_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    with patch.object(
+        LocalEnvironment, "init_session", autospec=True, return_value=None
+    ):
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=5)
+    yield env
+    env.cleanup()
+
+
+@pytest.mark.windows_only
+def test_generated_script_body_is_not_in_windows_process_argv(local_env, monkeypatch):
+    marker = "HERMES_ARGV_PAYLOAD_MARKER_7f2d"
+    script = f"printf '%s' '{marker}'\n" + ("# padding\n" * 1200)
+    captured = {}
+
+    def fake_popen(args, **kwargs):
+        captured["args"] = list(args)
+        argv_text = "\0".join(args)
+        if marker not in argv_text:
+            script_path = Path(local_mod._msys_to_windows_path(args[-1]))
+            captured["bytes"] = script_path.read_bytes()
+        return SimpleNamespace(pid=12345, stdin=None, stdout=None)
+
+    monkeypatch.setattr(
+        local_mod,
+        "_find_bash",
+        lambda: r"C:\Program Files\Git\bin\bash.exe",
+    )
+    monkeypatch.setattr(local_mod.subprocess, "Popen", fake_popen)
+
+    proc = local_env._run_bash(script)
+
+    argv_text = "\0".join(captured["args"])
+    assert marker not in argv_text
+    assert script not in argv_text
+    assert captured["bytes"] == script.encode("utf-8")
+    local_env._discard_staged_command_script(
+        getattr(proc, "_hermes_staged_command_script")
+    )
+
+
+@pytest.mark.windows_only
+def test_staged_script_preserves_surrogateescaped_bytes(local_env):
+    script = "printf byte-transparent-\udc80\udcff\n"
+
+    path = local_env._stage_command_script(script)
+
+    assert Path(path).read_bytes() == script.encode("utf-8", errors="surrogateescape")
+    local_env._discard_staged_command_script(path)
+
+
+@pytest.mark.windows_only
+def test_real_git_bash_executes_payload_larger_than_cmd_limit(local_env, tmp_path):
+    destination = tmp_path / "payload.bin"
+    payload = "第一行 Ω\n'quoted' \"double\" C:\\path\\file\n\n末行"
+    padding = "\n".join(f"# padding-{i:04d}-{'x' * 32}" for i in range(400))
+    command = (
+        f"{padding}\n"
+        f"printf %s {shlex.quote(payload)} > "
+        f"{shlex.quote(_bash_safe_path(str(destination)))}"
+    )
+    assert len(command) > 8191
+
+    result = local_env.execute(command, timeout=20)
+
+    assert result["returncode"] == 0, result
+    assert destination.read_bytes() == payload.encode("utf-8")
+
+
+@pytest.mark.windows_only
+def test_stdin_remains_byte_exact_and_closes_with_large_staged_program(
+    local_env, tmp_path
+):
+    destination = tmp_path / "stdin.bin"
+    stdin_data = "αβγ\nquotes ' \"\nC:\\temp\\x\n\nfinal"
+    padding = "\n".join(f"# stdin-padding-{i:04d}" for i in range(700))
+    command = f"{padding}\ncat > {shlex.quote(_bash_safe_path(str(destination)))}"
+    assert len(command) > 8191
+
+    result = local_env.execute(command, timeout=20, stdin_data=stdin_data)
+
+    assert result["returncode"] == 0, result
+    assert destination.read_bytes() == stdin_data.encode("utf-8")
+
+
+def _staged_files(env):
+    return set(Path(env.get_temp_dir()).glob("hermes-command-*.sh"))
+
+
+@pytest.mark.windows_only
+def test_process_start_failure_removes_staged_script(local_env, monkeypatch):
+    before = _staged_files(local_env)
+    monkeypatch.setattr(
+        local_mod,
+        "_find_bash",
+        lambda: r"C:\Program Files\Git\bin\bash.exe",
+    )
+
+    def fail_start(*args, **kwargs):
+        raise OSError("synthetic process start failure")
+
+    monkeypatch.setattr(local_mod.subprocess, "Popen", fail_start)
+
+    with pytest.raises(OSError, match="synthetic process start failure"):
+        local_env._run_bash("printf start")
+
+    assert _staged_files(local_env) == before
+
+
+@pytest.mark.windows_only
+@pytest.mark.parametrize("command", ["printf normal", "exit 7"])
+def test_normal_and_nonzero_completion_remove_staged_script(local_env, command):
+    before = _staged_files(local_env)
+
+    local_env.execute(command, timeout=10)
+
+    assert _staged_files(local_env) == before
+
+
+@pytest.mark.windows_only
+def test_wait_exception_removes_staged_script(local_env, monkeypatch):
+    path = local_env._stage_command_script("printf interrupted")
+    proc = SimpleNamespace(_hermes_staged_command_script=path)
+
+    def interrupted(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(local_mod.BaseEnvironment, "_wait_for_process", interrupted)
+
+    with pytest.raises(KeyboardInterrupt):
+        local_env._wait_for_process(proc, timeout=1)
+
+    assert not Path(path).exists()
+
+
+@pytest.mark.windows_only
+def test_yielded_process_keeps_script_until_process_exits(local_env, monkeypatch):
+    path = local_env._stage_command_script("sleep 1\nprintf complete")
+    exited = False
+
+    class YieldedProcess:
+        _hermes_staged_command_script = path
+
+        def poll(self):
+            return 0 if exited else None
+
+    proc = YieldedProcess()
+    monkeypatch.setattr(
+        local_mod.BaseEnvironment,
+        "_wait_for_process",
+        lambda *args, **kwargs: {"yielded_session_id": "proc_test"},
+    )
+
+    result = local_env._wait_for_process(
+        proc,
+        timeout=1,
+        watch_interrupt_tid=123,
+        yield_handler=lambda *_: None,
+    )
+
+    assert result["yielded_session_id"] == "proc_test"
+    assert Path(path).exists()
+    local_env.cleanup()
+    assert Path(path).exists()
+    exited = True
+    deadline = time.monotonic() + 2
+    while Path(path).exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not Path(path).exists()
+
+
+@pytest.mark.windows_only
+def test_environment_cleanup_removes_abandoned_staged_script(local_env):
+    path = local_env._stage_command_script("printf abandoned")
+
+    local_env.cleanup()
+
+    assert not Path(path).exists()
+
+
+@pytest.mark.windows_only
+def test_failed_unlink_remains_owned_for_cleanup_retry(local_env, monkeypatch):
+    path = local_env._stage_command_script("printf retry-cleanup")
+    real_unlink = local_mod.os.unlink
+    failed_once = False
+
+    def transient_failure(candidate):
+        nonlocal failed_once
+        if candidate == path and not failed_once:
+            failed_once = True
+            raise PermissionError("script is still open")
+        return real_unlink(candidate)
+
+    monkeypatch.setattr(local_mod.os, "unlink", transient_failure)
+
+    local_env._discard_staged_command_script(path)
+
+    assert Path(path).exists()
+    assert path in local_env._staged_command_scripts
+
+    local_env.cleanup()
+
+    assert not Path(path).exists()
+    assert path not in local_env._staged_command_scripts
+
+
+@pytest.mark.windows_only
+def test_timeout_removes_staged_script(local_env):
+    before = _staged_files(local_env)
+
+    result = local_env.execute("sleep 5", timeout=1)
+
+    assert result.get("timed_out") or result["returncode"] != 0
+    assert _staged_files(local_env) == before
+
+
+@pytest.mark.windows_only
+def test_hard_wait_backstop_removes_staged_script(local_env, monkeypatch):
+    before = _staged_files(local_env)
+    monkeypatch.setattr(base_mod, "_EXECUTE_WAIT_BOUND_GRACE_S", 0.05)
+
+    def wedged_wait(*args, **kwargs):
+        time.sleep(3)
+        return {"output": "late", "returncode": 0}
+
+    monkeypatch.setattr(base_mod.BaseEnvironment, "_wait_for_process", wedged_wait)
+    monkeypatch.setattr(
+        "agent.deadline.kill_process_tree", lambda *args, **kwargs: None
+    )
+
+    result = local_env.execute("sleep 30", timeout=1)
+
+    assert result["returncode"] == 124
+    assert _staged_files(local_env) == before
+
+
+@pytest.mark.windows_only
+def test_large_remote_script_reaches_fake_ssh_via_stdin_not_argv(local_env, tmp_path):
+    argv_file = tmp_path / "ssh-argv.json"
+    stdin_file = tmp_path / "ssh-stdin.bin"
+    shim = tmp_path / "ssh"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        '"$SSH_TEST_PYTHON" -c \'import json,os,sys; '
+        'open(os.environ["SSH_ARGV_FILE"],"w",encoding="utf-8").write('
+        "json.dumps(sys.argv[1:])); "
+        'open(os.environ["SSH_STDIN_FILE"],"wb").write(sys.stdin.buffer.read())\' '
+        '"$@"\n',
+        encoding="utf-8",
+        newline="\n",
+    )
+    os.chmod(shim, 0o755)
+
+    remote_script = "Write-Output '开始'\n" + (
+        "# remote-padding-xxxxxxxxxxxxxxxx\n" * 400
+    )
+    assert len(remote_script) > 8191
+    local_env.env.update({
+        "SSH_ARGV_FILE": str(argv_file),
+        "SSH_STDIN_FILE": str(stdin_file),
+        "SSH_TEST_PYTHON": sys.executable.replace("\\", "/"),
+    })
+    command = (
+        f"{shlex.quote(_bash_safe_path(str(shim)))} "
+        "example.invalid powershell.exe -NoProfile -NonInteractive "
+        "-Command - <<'HERMES_REMOTE_SCRIPT'\n"
+        f"{remote_script}"
+        "HERMES_REMOTE_SCRIPT"
+    )
+
+    result = local_env.execute(command, timeout=20)
+
+    assert result["returncode"] == 0, result
+    argv = json.loads(argv_file.read_text(encoding="utf-8"))
+    argv_text = "\0".join(argv)
+    assert len(argv_text) < 8191
+    assert "Write-Output" not in argv_text
+    assert "EncodedCommand" not in argv
+    assert stdin_file.read_bytes() == remote_script.encode("utf-8")

--- a/tests/tools/test_terminal_command_payload_security.py
+++ b/tests/tools/test_terminal_command_payload_security.py
@@ -1,0 +1,110 @@
+"""Security invariants for large terminal command payloads."""
+
+import json
+import logging
+
+import tools.terminal_tool as terminal_tool
+
+
+def _config(cwd):
+    return {
+        "env_type": "local",
+        "cwd": cwd,
+        "timeout": 1,
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+
+
+def _patch_terminal(monkeypatch, tmp_path, env):
+    monkeypatch.setattr(terminal_tool, "_active_environments", {"default": env})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {"default": 0})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(
+        terminal_tool, "_get_env_config", lambda: _config(str(tmp_path))
+    )
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_resolve_container_task_id",
+        lambda value: value or "default",
+    )
+
+
+def test_original_command_is_guarded_before_environment_execution(
+    monkeypatch, tmp_path
+):
+    command = "rm -rf guarded-marker\n" + ("# payload\n" * 1200)
+    observed = []
+
+    class Env:
+        env = {}
+
+        def execute(self, command, **kwargs):
+            raise AssertionError("denied command reached environment execution")
+
+    _patch_terminal(monkeypatch, tmp_path, Env())
+
+    def deny(candidate, env_type, **kwargs):
+        observed.append(candidate)
+        return {"approved": False, "description": "dangerous command"}
+
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", deny)
+
+    result = json.loads(terminal_tool.terminal_tool(command))
+
+    assert observed == [command]
+    assert result["status"] == "blocked"
+
+
+def test_short_command_preview_force_redacts_secret():
+    secret = "sk-proj-PreviewSecret123456789012345"
+
+    preview = terminal_tool._safe_command_preview(
+        f"curl -H 'Authorization: Bearer {secret}' https://example.invalid"
+    )
+
+    assert secret not in preview
+    assert "***" in preview
+
+
+def test_long_multiline_command_preview_contains_only_metadata():
+    marker = "FULL_SCRIPT_BODY_MUST_NOT_BE_LOGGED_4ca1"
+    command = marker + "\n" + ("echo payload\n" * 100)
+
+    preview = terminal_tool._safe_command_preview(command)
+
+    assert marker not in preview
+    assert "echo payload" not in preview
+    assert f"chars={len(command)}" in preview
+    assert f"lines={command.count(chr(10)) + 1}" in preview
+
+
+def test_retry_log_omits_long_command_body(monkeypatch, tmp_path, caplog):
+    marker = "RETRY_LOG_SCRIPT_BODY_916e"
+    command = marker + "\n" + ("echo payload\n" * 100)
+
+    class FailingEnv:
+        env = {}
+
+        def execute(self, command, **kwargs):
+            raise RuntimeError("backend unavailable")
+
+    _patch_terminal(monkeypatch, tmp_path, FailingEnv())
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda *args, **kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(terminal_tool.time, "sleep", lambda seconds: None)
+
+    with caplog.at_level(logging.WARNING, logger="tools.terminal_tool"):
+        terminal_tool.terminal_tool(command)
+
+    assert marker not in caplog.text
+    assert "echo payload" not in caplog.text
+    assert f"chars={len(command)}" in caplog.text

--- a/tests/tools/test_terminal_command_payload_security.py
+++ b/tests/tools/test_terminal_command_payload_security.py
@@ -1,0 +1,112 @@
+"""Security invariants for large terminal command payloads."""
+
+import json
+import logging
+
+import tools.terminal_tool as terminal_tool
+
+
+def _config(cwd):
+    return {
+        "env_type": "local",
+        "cwd": cwd,
+        "timeout": 1,
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+
+
+def _patch_terminal(monkeypatch, tmp_path, env):
+    monkeypatch.setattr(terminal_tool, "_active_environments", {"default": env})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {"default": 0})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(
+        terminal_tool, "_get_env_config", lambda: _config(str(tmp_path))
+    )
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_resolve_container_task_id",
+        lambda value: value or "default",
+    )
+
+
+def test_original_command_is_guarded_before_environment_execution(
+    monkeypatch, tmp_path
+):
+    command = "rm -rf guarded-marker\n" + ("# payload\n" * 1200)
+    observed = []
+
+    class Env:
+        env = {}
+
+        def execute(self, command, **kwargs):
+            raise AssertionError("denied command reached environment execution")
+
+    _patch_terminal(monkeypatch, tmp_path, Env())
+
+    def deny(candidate, env_type, **kwargs):
+        observed.append(candidate)
+        return {"approved": False, "description": "dangerous command"}
+
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", deny)
+
+    result = json.loads(terminal_tool.terminal_tool(command))
+
+    assert observed == [command]
+    assert result["status"] == "blocked"
+
+
+def test_short_command_preview_force_redacts_secret():
+    secret = "sk-proj-PreviewSecret123456789012345"
+
+    preview = terminal_tool._safe_command_preview(
+        f"curl -H 'Authorization: Bearer {secret}' https://example.invalid"
+    )
+
+    assert secret not in preview
+    assert "***" in preview
+
+
+def test_long_multiline_command_preview_contains_only_metadata():
+    marker = "FULL_SCRIPT_BODY_MUST_NOT_BE_LOGGED_4ca1"
+    command = marker + "\n" + ("echo payload\n" * 100)
+
+    preview = terminal_tool._safe_command_preview(command)
+
+    assert marker not in preview
+    assert "echo payload" not in preview
+    assert f"chars={len(command)}" in preview
+    assert f"lines={command.count(chr(10)) + 1}" in preview
+
+
+def test_retry_log_omits_long_command_body(monkeypatch, tmp_path, caplog):
+    marker = "RETRY_LOG_SCRIPT_BODY_916e"
+    command = marker + "\n" + ("echo payload\n" * 100)
+
+    class FailingEnv:
+        env = {}
+
+        def execute(self, command, **kwargs):
+            raise RuntimeError(f"backend unavailable for:\n{command}")
+
+    _patch_terminal(monkeypatch, tmp_path, FailingEnv())
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda *args, **kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(terminal_tool.time, "sleep", lambda seconds: None)
+
+    with caplog.at_level(logging.WARNING, logger="tools.terminal_tool"):
+        result = terminal_tool.terminal_tool(command)
+
+    assert marker not in caplog.text
+    assert "echo payload" not in caplog.text
+    assert f"chars={len(command)}" in caplog.text
+    assert marker not in result
+    assert "echo payload" not in result

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1424,6 +1424,7 @@ class LocalEnvironment(BaseEnvironment):
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         cwd = _resolve_local_initial_cwd(cwd)
         super().__init__(cwd=cwd, timeout=timeout, env=env)
+        self._staged_command_scripts: set[str] = set()
         self.init_session()
 
     def get_temp_dir(self) -> str:
@@ -1483,6 +1484,52 @@ class LocalEnvironment(BaseEnvironment):
         """Rewrite native/mixed Windows paths before quoting for Git Bash."""
         return _quote_bash_path(path)
 
+    def _stage_command_script(self, cmd_string: str) -> str:
+        """Write a generated Bash program without putting it in Windows argv."""
+        fd, path = tempfile.mkstemp(
+            prefix="hermes-command-",
+            suffix=".sh",
+            dir=self.get_temp_dir(),
+        )
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(cmd_string.encode("utf-8", "surrogateescape"))
+        except BaseException:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            raise
+
+        scripts = getattr(self, "_staged_command_scripts", None)
+        if scripts is None:
+            scripts = self._staged_command_scripts = set()
+        scripts.add(path)
+        return path
+
+    def _discard_staged_command_script(self, path: str | None) -> None:
+        """Release one staged command script owned by this environment."""
+        if not path:
+            return
+        scripts = getattr(self, "_staged_command_scripts", None)
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logger.debug(
+                "Failed to remove staged terminal script %s",
+                os.path.basename(path),
+                exc_info=True,
+            )
+            return
+        if scripts is not None:
+            scripts.discard(path)
+
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
@@ -1497,7 +1544,6 @@ class LocalEnvironment(BaseEnvironment):
             init_files = _resolve_shell_init_files()
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
-        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
         # Recover when the cwd has been deleted out from under us — usually by
@@ -1529,19 +1575,34 @@ class LocalEnvironment(BaseEnvironment):
 
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
-        proc = subprocess.Popen(
-            args,
-            text=True,
-            env=run_env,
-            encoding="utf-8",
-            errors="replace",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
-            start_new_session=True,
-            cwd=_popen_cwd,
-            **_popen_kwargs,
-        )
+        staged_script = None
+        if _IS_WINDOWS:
+            staged_script = self._stage_command_script(cmd_string)
+            script_arg = _bash_safe_path(staged_script)
+            args = [bash, "-l", script_arg] if login else [bash, script_arg]
+        else:
+            args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
+
+        try:
+            proc = subprocess.Popen(
+                args,
+                text=True,
+                env=run_env,
+                encoding="utf-8",
+                errors="replace",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+                start_new_session=True,
+                cwd=_popen_cwd,
+                **_popen_kwargs,
+            )
+        except BaseException:
+            self._discard_staged_command_script(staged_script)
+            raise
+
+        if staged_script is not None:
+            proc._hermes_staged_command_script = staged_script
         if not _IS_WINDOWS:
             try:
                 proc._hermes_pgid = os.getpgid(proc.pid)
@@ -1552,6 +1613,21 @@ class LocalEnvironment(BaseEnvironment):
             _pipe_stdin(proc, stdin_data)
 
         return proc
+
+    def _wait_for_process(
+        self, proc, timeout: int = 120, *, bounded_capture: bool = False
+    ) -> dict:
+        """Wait for a command and always release its staged Windows script."""
+        try:
+            return super()._wait_for_process(
+                proc,
+                timeout=timeout,
+                bounded_capture=bounded_capture,
+            )
+        finally:
+            self._discard_staged_command_script(
+                getattr(proc, "_hermes_staged_command_script", None)
+            )
 
     def _kill_process(self, proc):
         """Kill the entire process group (all children)."""
@@ -1685,3 +1761,5 @@ class LocalEnvironment(BaseEnvironment):
                     pass
         except Exception:
             pass
+        for path in tuple(getattr(self, "_staged_command_scripts", ())):
+            self._discard_staged_command_script(path)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -729,6 +729,8 @@ class LocalEnvironment(BaseEnvironment):
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         super().__init__(cwd=_resolve_local_initial_cwd(cwd), timeout=timeout, env=env)
+        self._staged_command_scripts: set[str] = set()
+        self._staged_command_processes: dict[str, object] = {}
         self.init_session()
 
     def get_temp_dir(self) -> str:
@@ -774,6 +776,68 @@ class LocalEnvironment(BaseEnvironment):
         """Rewrite native/mixed Windows paths before quoting for Git Bash."""
         return _quote_bash_path(path)
 
+    def _stage_command_script(self, cmd_string: str) -> str:
+        """Write a generated Bash program without putting it in Windows argv."""
+        fd, path = tempfile.mkstemp(
+            prefix="hermes-command-",
+            suffix=".sh",
+            dir=self.get_temp_dir(),
+        )
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                # Preserve surrogateescaped bytes inherited from decoded
+                # filesystem or subprocess data instead of replacing them.
+                handle.write(cmd_string.encode("utf-8", "surrogateescape"))
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            with contextlib.suppress(OSError):
+                os.unlink(path)
+            raise
+
+        self._staged_command_scripts.add(path)
+        return path
+
+    def _discard_staged_command_script(self, path: str | None) -> None:
+        """Release one staged command script owned by this environment."""
+        if not path:
+            return
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logger.debug(
+                "Failed to remove staged terminal script %s",
+                os.path.basename(path),
+                exc_info=True,
+            )
+            return
+        self._staged_command_scripts.discard(path)
+        self._staged_command_processes.pop(path, None)
+
+    def _discard_staged_command_script_after_exit(self, proc, path: str) -> None:
+        """Keep a yielded script until its adopted background process exits."""
+        if getattr(proc, "_hermes_staged_cleanup_started", False):
+            return
+        proc._hermes_staged_cleanup_started = True
+
+        def _cleanup_when_exited() -> None:
+            while True:
+                try:
+                    if proc.poll() is not None:
+                        break
+                except Exception:
+                    return
+                time.sleep(0.05)
+            self._discard_staged_command_script(path)
+
+        threading.Thread(
+            target=_cleanup_when_exited,
+            name=f"terminal-script-cleanup-{getattr(proc, 'pid', 'unknown')}",
+            daemon=True,
+        ).start()
+
     def _recover_cwd(self) -> None:
         """Swap ``self.cwd`` for a usable directory if it vanished or is inaccessible
         (e.g. a command ``rm -rf``'d its own cwd) — otherwise Popen raises before bash
@@ -801,20 +865,63 @@ class LocalEnvironment(BaseEnvironment):
         # custom init files so nvm/asdf/pyenv land on PATH in the snapshot.
         if login:
             cmd_string = _prepend_shell_init(cmd_string, _resolve_shell_init_files())
-        args = [bash, *(["-l"] if login else []), "-c", cmd_string]
+        staged_script = None
+        if _IS_WINDOWS:
+            staged_script = self._stage_command_script(cmd_string)
+            args = [bash, *(["-l"] if login else []), _bash_safe_path(staged_script)]
+        else:
+            args = [bash, *(["-l"] if login else []), "-c", cmd_string]
         self._recover_cwd()
-        proc = subprocess.Popen(
-            args, text=True, env=_make_run_env(self.env), encoding="utf-8", errors="replace",
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
-            start_new_session=True, cwd=self.cwd,
-            **({"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}))
+        try:
+            proc = subprocess.Popen(
+                args, text=True, env=_make_run_env(self.env), encoding="utf-8", errors="replace",
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+                start_new_session=True, cwd=self.cwd,
+                **({"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}))
+        except BaseException:
+            self._discard_staged_command_script(staged_script)
+            raise
+        if staged_script is not None:
+            proc._hermes_staged_command_script = staged_script
+            self._staged_command_processes[staged_script] = proc
         if not _IS_WINDOWS:
             with contextlib.suppress(ProcessLookupError):
                 proc._hermes_pgid = os.getpgid(proc.pid)
         if stdin_data is not None:
             _pipe_stdin(proc, stdin_data)
         return proc
+
+    def _wait_for_process(
+        self, proc, timeout: int = 120, *, bounded_capture: bool = False,
+        watch_interrupt_tid: int | None = None, yield_handler=None,
+    ) -> dict:
+        """Wait for a command and release its staged Windows script safely."""
+        path = getattr(proc, "_hermes_staged_command_script", None)
+        if path:
+            self._staged_command_processes[path] = proc
+        try:
+            result = super()._wait_for_process(
+                proc,
+                timeout=timeout,
+                bounded_capture=bounded_capture,
+                watch_interrupt_tid=watch_interrupt_tid,
+                yield_handler=yield_handler,
+            )
+        except BaseException:
+            self._discard_staged_command_script(path)
+            raise
+
+        if path:
+            try:
+                still_running = proc.poll() is None
+            except Exception:
+                still_running = False
+            if still_running:
+                self._discard_staged_command_script_after_exit(proc, path)
+            else:
+                self._discard_staged_command_script(path)
+        return result
 
     def _kill_process(self, proc):
         """Kill the entire process group (all children)."""
@@ -823,6 +930,10 @@ class LocalEnvironment(BaseEnvironment):
         except OSError:  # ProcessLookupError / PermissionError included
             with contextlib.suppress(Exception):
                 proc.kill()
+        finally:
+            self._discard_staged_command_script(
+                getattr(proc, "_hermes_staged_command_script", None)
+            )
 
     def _extract_cwd_from_output(self, result: dict):
         """Base semantics plus: Git Bash ``pwd -P`` emits MSYS form on Windows —
@@ -853,3 +964,16 @@ class LocalEnvironment(BaseEnvironment):
         for f in (self._snapshot_path, self._cwd_file, *stale):
             with contextlib.suppress(OSError):
                 os.unlink(f)
+        for path in tuple(self._staged_command_scripts):
+            proc = self._staged_command_processes.get(path)
+            if proc is not None:
+                try:
+                    if proc.poll() is None:
+                        self._discard_staged_command_script_after_exit(proc, path)
+                        continue
+                except Exception:
+                    # Unknown liveness is not permission to remove a script a
+                    # child may still be reading. The temp-cache pruner remains
+                    # the crash-recovery backstop.
+                    continue
+            self._discard_staged_command_script(path)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -608,15 +608,21 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
             del os.environ["HERMES_SPINNER_PAUSE"]
 
 def _safe_command_preview(command: Any, limit: int = 200) -> str:
-    """Return a log-safe preview for possibly-invalid command values."""
+    """Return a force-redacted, bounded description for command logs."""
     if command is None:
         return "<None>"
     if isinstance(command, str):
-        return command[:limit]
+        if "\n" in command or len(command) > limit:
+            return (
+                f"<command chars={len(command)} "
+                f"lines={command.count(chr(10)) + 1}>"
+            )
+        return _redact_terminal_error_text(command)[:limit]
     try:
-        return repr(command)[:limit]
+        rendered = repr(command)
     except Exception:
         return f"<{type(command).__name__}>"
+    return _redact_terminal_error_text(rendered)[:limit]
 
 def _looks_like_env_assignment(token: str) -> bool:
     """Return True when *token* is a leading shell environment assignment."""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1101,16 +1101,17 @@ def _run_foreground(
         except Exception as e:
             if "timeout" in str(e).lower():
                 return _error_json(f"Command timed out after {effective_timeout} seconds", exit_code=124)
+            error_preview = _safe_command_preview(str(e))
             # Retry on transient errors
             if retry_count < max_retries:
                 wait_time = 2 ** (retry_count + 1)
                 logger.warning("Execution error, retrying in %ds (attempt %d/%d) - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
-                               wait_time, retry_count + 1, max_retries, _safe_command_preview(command), type(e).__name__, e, eff, env_type)
+                               wait_time, retry_count + 1, max_retries, _safe_command_preview(command), type(e).__name__, error_preview, eff, env_type)
                 time.sleep(wait_time)
                 continue
             logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
-                         max_retries, _safe_command_preview(command), type(e).__name__, e, eff, env_type)
-            return _error_json(_redact_terminal_error_text(f"Command execution failed: {type(e).__name__}: {e}"))
+                         max_retries, _safe_command_preview(command), type(e).__name__, error_preview, eff, env_type)
+            return _error_json(f"Command execution failed: {type(e).__name__}: {error_preview}")
 
     if result.get("yielded_session_id"):
         return json.dumps({

--- a/tools/terminal_tool_guards.py
+++ b/tools/terminal_tool_guards.py
@@ -48,15 +48,25 @@ def _validate_workdir(workdir: str) -> str | None:
 
 
 def _safe_command_preview(command: Any, limit: int = 200) -> str:
-    """Return a log-safe preview for possibly-invalid command values."""
+    """Return a force-redacted, bounded description for command logs."""
+    # Lazy import keeps the companion module's import cycle benign while
+    # preserving terminal_tool as the canonical redaction implementation.
+    from tools.terminal_tool import _redact_terminal_error_text
+
     if command is None:
         return "<None>"
     if isinstance(command, str):
-        return command[:limit]
+        if "\n" in command or len(command) > limit:
+            return (
+                f"<command chars={len(command)} "
+                f"lines={command.count(chr(10)) + 1}>"
+            )
+        return _redact_terminal_error_text(command)[:limit]
     try:
-        return repr(command)[:limit]
+        rendered = repr(command)
     except Exception:
         return f"<{type(command).__name__}>"
+    return _redact_terminal_error_text(rendered)[:limit]
 
 
 def _blocked_json(error: str, status: str) -> str:


### PR DESCRIPTION
## Summary

- stage generated Bash programs in a private temporary file for native-Windows `LocalEnvironment` foreground execution instead of placing the full program in process arguments
- keep ordinary command stdin on its existing independent pipe and remove staged scripts across completion, timeout, interruption, startup failure, outer wall-clock backstop, yield completion, and environment cleanup
- redact both command previews and backend exception text; long or multiline values become character/line metadata
- leave Linux, macOS, Docker, POSIX SSH, and the public terminal schema unchanged

## Root cause

`LocalEnvironment._run_bash()` passed the complete generated wrapper as the argument after `bash -c`. On native Windows that made script fidelity depend on the Windows/MSYS process-argument transport. The regression reproduces a generated wrapper larger than 8191 characters being truncated before Bash parsing, ending in an unmatched-quote error.

The existing `stdin_data` path cannot safely carry that wrapper because stdin belongs to the command being executed: programs such as `ssh`, `cat`, and `read` must continue to receive it and observe EOF independently.

This change stages only the already-authorized generated wrapper after the existing terminal guard has inspected the original command. It does not add a model-facing stdin or script-file input.

## User impact

Complex Windows foreground commands can execute without embedding their full generated Bash wrapper in the child process command line. UTF-8, Unicode, LF newlines, quotes, backslashes, empty lines, surrogateescaped bytes, and separate stdin/EOF behavior are preserved. Long or multiline script bodies are no longer copied into retry logs or terminal error responses, including when a backend exception echoes its attempted command.

## Rebase and review follow-up

- Rebased the candidate onto current `origin/main` and resolved the `LocalEnvironment` refactor plus the move of `_safe_command_preview()` into `terminal_tool_guards.py`.
- Preserved current-main `yield_handler` and interrupt forwarding. A yielded foreground process keeps its staged script until the adopted process exits.
- Added a direct regression for cleanup when the outer `run_bounded_sync` wall-clock backstop fires.
- Retained `surrogateescape` as a byte-transparent boundary; replacing undecodable bytes would silently mutate an already-authorized command.

## Validation

Rebased onto `origin/main` at `284d220ba4`; candidate head `ea6507d1dc`.

- focused payload/security tests: 18 passed, 0 failed
- complete repository Windows-marked lane (64 files): 190 passed, 0 failed, 2 skipped
- Ruff lint: passed for all five changed files
- Ruff format check: both new test files already formatted
- `git diff --check`: passed

An additional related-file comparison produced the same five failures on the candidate and a clean detached `origin/main` baseline: three local Git Bash tests require an unavailable `python3`, one Windows cwd assertion assumes a POSIX root, and the current-main hard timeout test loses partial output. They are not introduced by this diff.

## Scope

This PR addresses the native-Windows `LocalEnvironment` foreground path, including a foreground process later yielded to background, plus log-safe previews. Direct `background=true` and PTY execution route through `ProcessRegistry.spawn_local()` and still pass their command through `bash -lic` argv; changing that separate lifecycle/registry path is intentionally not included here.

This PR does not change SSH disconnect/result semantics, add Windows OpenSSH support, modify the public terminal schema, or alter the local default shell.
