### PR TITLE
fix(desktop): isolate messaging settings by profile

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -142,6 +142,7 @@ import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
+import { requireMessagingRequestProfile } from './messaging-request-routing'
 import {
   oauthGuardMayHardFail,
   oauthSessionIsLive,
@@ -10966,9 +10967,8 @@ ipcMain.handle('hermes:api', async (_event, request) => {
     return rerouted
   }
 
+  const profile = requireMessagingRequestProfile(request?.path, request?.profile)
   const tornDownProfile = await prepareProfileDeleteRequest(request)
-
-  const profile = request?.profile
   // After tearing down a backend for profile deletion, route to the primary
   // backend instead of spawning a fresh pool backend.  A freshly spawned
   // backend calls ensure_hermes_home() which recreates the profile directory,

--- a/apps/desktop/electron/messaging-request-routing.test.ts
+++ b/apps/desktop/electron/messaging-request-routing.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { requireMessagingRequestProfile } from './messaging-request-routing'
+
+test('rejects a messaging settings request without a profile', () => {
+  assert.throws(
+    () => requireMessagingRequestProfile('/api/messaging/platforms/telegram', undefined),
+    /explicit profile/i
+  )
+})
+
+test('normalizes an explicit messaging settings profile', () => {
+  assert.equal(requireMessagingRequestProfile('/api/messaging/platforms/telegram', ' specialist '), 'specialist')
+})
+
+test('keeps unrelated primary requests backward compatible', () => {
+  assert.equal(requireMessagingRequestProfile('/api/status', undefined), undefined)
+})

--- a/apps/desktop/electron/messaging-request-routing.ts
+++ b/apps/desktop/electron/messaging-request-routing.ts
@@ -1,0 +1,11 @@
+const MESSAGING_SETTINGS_PATH = /^\/api\/messaging\/platforms(?:\/|$)/
+
+export function requireMessagingRequestProfile(path: unknown, profile: unknown): string | undefined {
+  const normalizedProfile = typeof profile === 'string' ? profile.trim() : ''
+
+  if (typeof path === 'string' && MESSAGING_SETTINGS_PATH.test(path.split(/[?#]/, 1)[0]) && !normalizedProfile) {
+    throw new Error('Messaging settings requests require an explicit profile; refusing to use the primary profile.')
+  }
+
+  return normalizedProfile || undefined
+}

--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -5,13 +5,16 @@ import {
   getActionStatus,
   getElevenLabsVoices,
   getMemoryProviderConfig,
+  getMessagingPlatforms,
   getStatus,
   restartGateway,
   saveMemoryProviderConfig,
   setApiRequestProfile,
   speakText,
+  testMessagingPlatform,
   transcribeAudio,
-  updateHermes
+  updateHermes,
+  updateMessagingPlatform
 } from './hermes'
 
 // Contract: every backend-targeted action helper must carry the active gateway
@@ -78,6 +81,18 @@ describe('backend action helpers are profile-scoped', () => {
 
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBe('jarvis')
+    }
+  })
+
+  it('forwards the active profile to every messaging action', () => {
+    setApiRequestProfile('specialist')
+
+    void getMessagingPlatforms()
+    void updateMessagingPlatform('telegram', { enabled: true })
+    void testMessagingPlatform('telegram')
+
+    for (const call of api.mock.calls) {
+      expect(call[0].profile).toBe('specialist')
     }
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1268,6 +1268,7 @@ export function grantComputerUsePermissions(): Promise<ActionResponse> {
 
 export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
   return window.hermesDesktop.api<MessagingPlatformsResponse>({
+    ...profileScoped(),
     path: '/api/messaging/platforms'
   })
 }
@@ -1277,6 +1278,7 @@ export function updateMessagingPlatform(
   body: MessagingPlatformUpdate
 ): Promise<{ ok: boolean; platform: string }> {
   return window.hermesDesktop.api<{ ok: boolean; platform: string }>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}`,
     method: 'PUT',
     body
@@ -1285,6 +1287,7 @@ export function updateMessagingPlatform(
 
 export function testMessagingPlatform(platformId: string): Promise<MessagingPlatformTestResponse> {
   return window.hermesDesktop.api<MessagingPlatformTestResponse>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
     method: 'POST'
   })


### PR DESCRIPTION
## Problem
In a multi-profile Desktop session, the Messaging page's list, update, and connection-test helpers omitted the active profile. Electron therefore routed those requests to the primary backend. Opening a secondary profile could display the primary profile's messaging values, and saving from that screen could overwrite the primary profile's .env.

## Fix
- forward profileScoped() from all three Messaging helpers
- fail closed in Electron when a /api/messaging/platforms request has no explicit profile, instead of silently falling back to primary
- keep unrelated primary requests backward compatible

## Verification
- profile-scope UI tests: 5 passed
- Electron routing tests: 3 passed
- focused ESLint: passed
- Desktop TypeScript typecheck (renderer, Electron, E2E): passed