### PR TITLE
fix(tools): close SessionDB handle in trace_upload after use

### DIFF
--- a/agent/trace_upload.py
+++ b/agent/trace_upload.py
@@ -336,10 +336,19 @@ def load_session_messages(
     """
     from hermes_state import SessionDB
     db = SessionDB(db_path=db_path) if db_path else SessionDB()
-    resolved = db.resolve_session_id(session_id) or session_id
-    meta = db.get_session(resolved) or {}
-    messages = db.get_messages_as_conversation(resolved)
-    return messages, meta
+    try:
+        resolved = db.resolve_session_id(session_id) or session_id
+        meta = db.get_session(resolved) or {}
+        messages = db.get_messages_as_conversation(resolved)
+        return messages, meta
+    finally:
+        try:
+            db.close()
+        except Exception:
+            import logging
+            logging.getLogger(__name__).debug(
+                "trace_upload: closing owned SessionDB failed", exc_info=True
+            )
 
 
 def upload_session_trace(


### PR DESCRIPTION
## Summary

`load_session_for_upload()` in `agent/trace_upload.py` creates a `SessionDB()` on every call but never closes it. On a long-lived gateway this leaks SQLite handles per trace upload, contributing to the fd/memory growth tracked in #83092.

Same bug class as #83027 (session_search) and #83072 (react_to_message).

## Fix

Wrap the post-open body in `try/finally`, close the dedicated DB in the `finally`, and log cleanup failures at debug level. Matches the established pattern from #83027/#83034 and the proposed fix in #83079.

## Evidence

Posted reproduction data and full audit of `SessionDB()` call sites on [#83092](https://github.com/NousResearch/hermes-agent/issues/83092#issuecomment-5249198898). This leak site is called per trace upload — each call opens a fresh handle with no owner to close it.

## Test plan

- [x] Existing `tests/agent/test_trace_upload.py` — 5 passed, 1 skipped
- [x] No new tests needed (same pattern as #83034 which was accepted without dedicated tests)

Part of #83092.