### PR TITLE
fix(repo): protect workflow paths with codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require maintainer review for workflow and composite action changes.
+.github/workflows/ @NousResearch/hermes-maintainers
+.github/actions/ @NousResearch/hermes-maintainers

--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Historical Axl Ibiza, MBA commit identity

--- a/repro_codeowners.py
+++ b/repro_codeowners.py
@@ -18,10 +18,12 @@ if not codeowners.exists():
     sys.exit(1)
 
 text = codeowners.read_text(encoding="utf-8")
-workflow_covered = any(
-    line.strip() and not line.strip().startswith("#") and "workflow" in line
+lines = {
+    line.strip()
     for line in text.splitlines()
-)
+    if line.strip() and not line.lstrip().startswith("#")
+}
+workflow_covered = ".github/workflows/ @NousResearch/hermes-maintainers" in lines
 if workflow_covered:
     print("PASS: workflow paths covered by CODEOWNERS")
     sys.exit(0)

--- a/repro_codeowners.py
+++ b/repro_codeowners.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Repro: workflow files lack mandatory review protection (no CODEOWNERS).
+
+Bug class: #23632 / #31935 — no .github/CODEOWNERS means workflow files
+(.github/workflows/*.yml) can be modified without mandatory review,
+a supply-chain risk for a repo whose CI runs arbitrary code.
+
+On main: FAILS (no CODEOWNERS entry for workflows). With the fix: PASSES.
+"""
+import sys
+from pathlib import Path
+
+repo = Path(__file__).resolve().parent
+codeowners = repo / ".github" / "CODEOWNERS"
+
+if not codeowners.exists():
+    print("FAIL: .github/CODEOWNERS does not exist")
+    sys.exit(1)
+
+text = codeowners.read_text(encoding="utf-8")
+workflow_covered = any(
+    line.strip() and not line.strip().startswith("#") and "workflow" in line
+    for line in text.splitlines()
+)
+if workflow_covered:
+    print("PASS: workflow paths covered by CODEOWNERS")
+    sys.exit(0)
+print("FAIL: no CODEOWNERS rule covers .github/workflows/")
+sys.exit(1)

--- a/tests/test_codeowners.py
+++ b/tests/test_codeowners.py
@@ -1,0 +1,24 @@
+"""Regression tests for workflow ownership protections."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_github_codeowners_exists():
+    codeowners_path = REPO_ROOT / ".github" / "CODEOWNERS"
+
+    assert codeowners_path.exists()
+
+
+def test_workflows_and_actions_require_maintainer_review():
+    codeowners_path = REPO_ROOT / ".github" / "CODEOWNERS"
+    lines = {
+        line.strip()
+        for line in codeowners_path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    assert ".github/workflows/ @NousResearch/hermes-maintainers" in lines
+    assert ".github/actions/ @NousResearch/hermes-maintainers" in lines


### PR DESCRIPTION
<!-- native-links:v1 -->
Related #23632 #31935 #23751

## What does this PR do?

Closes the **missing CODEOWNERS** security defect class (#23632, #31935): the repo had no `.github/CODEOWNERS`, so workflow files (`.github/workflows/*.yml`) could be modified without mandatory review — a supply-chain risk for a repo whose CI runs arbitrary code.

**Fix:** add `.github/CODEOWNERS` with a rule covering workflow paths, plus a conformance test. This is the fix from #23751 (author: **LeonSGP43**, cherry-picked with authorship preserved), which was closed unmerged.

## Repro receipt (sha256)

`repro_codeowners.py` — sha256 `87b9d8cb619f1225966457a1fdbdede723f60974aa7be6f0b5633c47b128a87a`

```bash
# baseline (origin/main @ 9d6c5a920c7)
python repro_codeowners.py
# FAIL: .github/CODEOWNERS does not exist   (exit 1)

# this branch
python repro_codeowners.py
# PASS: workflow paths covered by CODEOWNERS   (exit 0)
```

## How to test

```bash
pytest tests/test_codeowners.py -q
# 2 passed
```

## What platforms were tested?

- Windows 11 native: `2 passed`, `git diff --check` clean.

## Why this matters to users

Workflow files are the highest-trust files in the repo — they execute on every push. Without CODEOWNERS, a single-approver change to CI can ship without review.

Closes #23632
Closes #31935

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Code follows repo style
- [x] Self-review complete
- [x] Tests added (CODEOWNERS conformance)
- [x] Suite green: `2 passed` on current main
- [x] `git diff --check` clean
- [x] Repro receipt: baseline FAIL / fixed PASS (sha256 above)
- [x] Credit: implementation from #23751 by @LeonSGP43, cherry-picked with authorship preserved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added ownership rules requiring designated maintainers to review changes to workflow and automation configurations.
  - Recorded contributor identity information for consistent historical attribution.

- **Tests**
  - Added automated checks confirming that ownership rules exist and cover workflow and action paths.
  - Added a standalone validation check that reports whether the required ownership configuration is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->