### PR TITLE
fix(tools): keep execute_code read_file results stable (#82711)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -31,6 +31,27 @@ class TestReadFileHandler:
         assert result["total_lines"] == 2
         mock_ops.read_file.assert_called_once_with("/tmp/test.txt", 1, 2000)
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_deduplicate_false_preserves_content_schema_after_prior_read(self, mock_get):
+        """execute_code reads must not receive a schema-changing dedup stub."""
+        from tools.file_tools import read_file_tool, _read_tracker
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "line1\nline2"
+        result_obj.to_dict.return_value = {"content": "line1\nline2", "total_lines": 2}
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        task_id = "stable-schema-dedup-test"
+        _read_tracker.pop(task_id, None)
+
+        first = json.loads(read_file_tool("/tmp/test.txt", task_id=task_id))
+        second = json.loads(read_file_tool("/tmp/test.txt", task_id=task_id, deduplicate=False))
+
+        assert first["content"] == second["content"] == "line1\nline2"
+        assert mock_ops.read_file.call_count == 2
+        _read_tracker.pop(task_id, None)
+
 
     @patch("tools.file_tools._get_file_ops")
     def test_exception_returns_error_json(self, mock_get):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -343,9 +343,9 @@ _TOOL_STUBS = {
     ),
     "read_file": (
         "read_file",
-        "path: str, offset: int = 1, limit: int = 2000",
-        '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines"."""',
-        '{"path": path, "offset": offset, "limit": limit}',
+        "path: str, offset: int = 1, limit: int = 2000, deduplicate: bool = False",
+        '"""Read a file with a stable content-bearing result. Deduplication is disabled by default so prior native reads cannot change the return schema."""',
+        '{"path": path, "offset": offset, "limit": limit, "deduplicate": deduplicate}',
     ),
     "write_file": (
         "write_file",

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1547,7 +1547,7 @@ def _special_file_kind(path) -> str | None:
     return "a special (non-regular) file"
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
+def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default", deduplicate: bool = True) -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -1713,9 +1713,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
             return cached_not_found
 
         # ── Dedup check ───────────────────────────────────────────────
-        # If we already read this exact (path, offset, limit) and the
-        # file hasn't been modified since, return a lightweight stub
-        # instead of re-sending the same content.  Saves context tokens.
+        # Native reads deduplicate unchanged content to save context tokens.
+        # RPC callers may disable this when they need a stable content-bearing
+        # return contract (for example, hermes_tools.read_file in execute_code).
         resolved_str = str(_resolved)
         dedup_key = (resolved_str, offset, limit)
         with _read_tracker_lock:
@@ -1731,8 +1731,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 task_data["dedup_hits"] = {}
             if "read_timestamps" not in task_data:
                 task_data["read_timestamps"] = {}
-            cached_mtime = task_data.get("dedup", {}).get(dedup_key)
-
+            cached_mtime = task_data.get("dedup", {}).get(dedup_key) if deduplicate else None
         if cached_mtime is not None:
             try:
                 current_mtime = os.path.getmtime(resolved_str)
@@ -2615,7 +2614,7 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid, deduplicate=args.get("deduplicate", True))
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## Summary

- keep native `read_file` deduplication unchanged for normal tool calls
- disable deduplication for `hermes_tools.read_file()` by default so execute_code always receives the documented content-bearing schema
- add a regression test for a prior native read followed by an execute_code-style read

Fixes #82711.

## Tests

- `python3 -m py_compile tools/file_tools.py tools/code_execution_tool.py tests/tools/test_file_tools.py`
- `pytest -q tests/tools/test_file_tools.py::TestReadFileHandler tests/tools/test_code_execution.py::TestHermesToolsGeneration` (8 passed)
