### PR TITLE
fix(slack): drain orphaned socket tasks after close_async

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1211,6 +1211,10 @@ class SlackAdapter(BasePlatformAdapter):
         awaits inside ``close()``. Cancelling from a snapshot taken partway
         through that would race a moving target. See
         slackapi/python-slack-sdk#1913.
+
+        After ``close_async()`` we re-read the client task attributes one more
+        time and cancel anything that was rebound during the close.  A bounded
+        pass count prevents indefinite spinning if the client keeps rebinding.
         """
         handler = self._handler
         task = self._socket_mode_task
@@ -1231,6 +1235,33 @@ class SlackAdapter(BasePlatformAdapter):
                     e,
                     exc_info=True,
                 )
+
+        # Drain pass: re-read client task attributes after close_async() and
+        # cancel anything rebound during the close.  connect() can rebind
+        # current_session_monitor / message_processor / message_receiver on
+        # success, so a single pre-close snapshot is not enough.
+        if client is not None:
+            seen: set[int] = set()
+            if task is not None:
+                seen.add(id(task))
+            for _drain_pass in range(3):
+                fresh = [
+                    t
+                    for attr in _SOCKET_CLIENT_TASK_ATTRS
+                    for t in [getattr(client, attr, None)]
+                    if t is not None
+                    and callable(getattr(t, "cancel", None))
+                    and id(t) not in seen
+                ]
+                if not fresh:
+                    break
+                seen.update(id(t) for t in fresh)
+                logger.debug(
+                    "[Slack] drain pass %d: cancelling %d orphaned task(s)",
+                    _drain_pass + 1,
+                    len(fresh),
+                )
+                await _cancel_socket_tasks(fresh)
 
     async def _socket_transport_connected(self) -> Optional[bool]:
         """Best-effort check of current Socket Mode transport state."""


### PR DESCRIPTION
## Summary

After a Socket Mode reconnect, `_stop_socket_mode_handler()` cancels a single snapshot of client tasks taken before any `await`. But `connect()` rebinds the client's task attributes (`current_session_monitor`, `message_processor`, `message_receiver`) on success, so tasks rebound *during* `close_async()` are never cancelled. They keep retrying `SocketModeClient.connect()` against a closed aiohttp session, producing ~25k "Session is closed" log lines per day until process restart.

## Root cause

The docstring already identifies the hazard:

> `connect()` rebinds the client's task attributes on success, so the set of live tasks changes across the awaits inside `close()`.

The current code snapshots the task set once before `_cancel_socket_tasks` and `close_async()`. Any task rebound onto those attributes after that read is orphaned.

This is the upstream SDK behaviour tracked in slackapi/python-slack-sdk#1913.

## Fix

After `close_async()`, re-read the client task attributes up to 3 passes and cancel anything not yet seen in the `id()`-based `seen` set. This drains orphaned tasks that were rebound during the close sequence.

- Bounded to 3 passes so teardown never spins indefinitely
- `seen` set prevents re-cancelling already-cancelled tasks
- Debug logging on each drain pass for observability

## Changes

- `plugins/platforms/slack/adapter.py`: Added drain loop after `close_async()` in `_stop_socket_mode_handler()`

Fixes #83662