### PR TITLE
fix(agent): extract session titles from reasoning fields

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -23,7 +23,7 @@ import re
 import threading
 from typing import Any, Callable, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 from agent.context_compressor import LEGACY_SUMMARY_PREFIX
 from agent.message_content import flatten_message_text
 
@@ -403,7 +403,7 @@ def generate_title(
             main_runtime=main_runtime,
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
         )
-        content = response.choices[0].message.content or ""
+        content = extract_content_or_reasoning(response) or ""
         return _clean_title(_extract_title_text(content))
     except Exception as e:
         # Log at WARNING so this shows up in agent.log without debug mode.

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -64,6 +64,36 @@ class TestGenerateTitle:
             assert "<think>" not in title
             assert "summarize" not in title
 
+    def test_falls_back_to_reasoning_content(self):
+        """A reasoning model that returns the structured JSON only in
+        ``reasoning_content`` with an empty ``content`` (e.g. opencode-go's
+        glm-5 aux tier) must still produce a title instead of silently
+        dropping back to the derived placeholder."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+        mock_response.choices[0].message.reasoning_content = (
+            '{"title": "Debugging Python Import Errors"}'
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("help me fix this import")
+            assert title == "Debugging Python Import Errors"
+
+    def test_falls_back_to_reasoning_field(self):
+        """Same fallback via the ``reasoning`` field used by other reasoning
+        providers (DeepSeek, Moonshot, ...)."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+        mock_response.choices[0].message.reasoning = (
+            '{"title": "Debugging Python Import Errors"}'
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("help me fix this import")
+            assert title == "Debugging Python Import Errors"
+
     def test_strips_unterminated_think_block(self):
         """An unterminated <think> block (no close tag) must still be
         stripped so the leaked reasoning doesn't become the title."""


### PR DESCRIPTION
## Summary

`generate_title()` in `agent/title_generator.py` read only `message.content` when extracting the LLM-generated session title. On reasoning models — e.g. opencode-go's auxiliary `glm-5` tier, which is the auto-detected default for that provider — the provider returns the structured JSON title inside `reasoning_content` while `content` comes back empty. The empty content made title extraction fail silently, and every session's title stayed at the deterministic "derived" placeholder (first line of the opening message) forever; no error was logged and no `llm`-provenance title was ever persisted.

## Fix

Use the existing shared helper `extract_content_or_reasoning()` (already used by `agent/oneshot.py`) instead of reading `message.content` alone. It falls back to `message.reasoning` / `message.reasoning_content` / `reasoning_details` when content is empty or reasoning-only, matching the main agent loop's behavior for reasoning models.

## Validation

- Added regression tests: a response with empty `content` + JSON in `reasoning_content`, and the same via the `reasoning` field, both now yield the model title.
- `scripts/run_tests.sh tests/agent/test_title_generator.py tests/agent/test_turn_context.py tests/hermes_cli/test_aux_config.py`: **54 passed, 0 failed**.
- Reproduced against the live provider: opencode-go `glm-5` returns `content=''` + `reasoning='{"title": "..."}'`; after the fix the title is extracted correctly.

## Related

- #83390 (different failure mode: DeepSeek HTTP 400 on `response_format`) — same fragile spot in title extraction, not addressed by this PR.
