### PR TITLE
fix(context): read oMLX admin context window

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -606,6 +606,7 @@ _CONTEXT_LENGTH_KEYS = (
     "context_window",
     "context_size",
     "max_context_length",
+    "max_context_window",
     "max_position_embeddings",
     "max_model_len",
     "max_input_tokens",
@@ -1134,6 +1135,40 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         if pricing:
             return pricing
     return {}
+
+
+def _query_omlx_admin_context_length(
+    client: Any,
+    model: str,
+    server_url: str,
+) -> Optional[int]:
+    """Read oMLX's loaded runtime context window from the admin API."""
+    try:
+        resp = client.get(f"{server_url}/admin/api/models")
+        if resp.status_code != 200:
+            return None
+        payload = resp.json()
+    except Exception:
+        return None
+
+    entries: list[Dict[str, Any]] = []
+    if isinstance(payload, dict):
+        models = payload.get("models")
+        if isinstance(models, list):
+            entries = [entry for entry in models if isinstance(entry, dict)]
+        else:
+            entries = [payload]
+
+    if not entries:
+        return None
+
+    for entry in entries:
+        if _model_id_matches(entry.get("id", ""), model):
+            return _extract_context_length(entry)
+
+    if len(entries) == 1:
+        return _extract_context_length(entries[0])
+    return None
 
 
 def _add_model_aliases(cache: Dict[str, Dict[str, Any]], model_id: str, entry: Dict[str, Any]) -> None:
@@ -2138,7 +2173,10 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                 # configured name rarely equals the reported id (a GGUF path),
                 # so fall back to the sole model when nothing matches.
                 matched = None
+                is_omlx = False
                 for m in models_list:
+                    if m.get("owned_by") == "omlx":
+                        is_omlx = True
                     if _model_id_matches(m.get("id", ""), model):
                         matched = m
                         break
@@ -2164,6 +2202,10 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                             val = source.get(key)
                             if isinstance(val, (int, float)) and val:
                                 return int(val)
+                if is_omlx:
+                    ctx = _query_omlx_admin_context_length(client, model, server_url)
+                    if ctx is not None:
+                        return ctx
     except Exception as exc:
         if _is_connect_timeout(exc):
             _note_endpoint_blackholed(server_url)

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -272,6 +272,67 @@ class TestQueryLocalContextLengthModelsList:
         assert result == 256000
 
 
+class TestQueryLocalContextLengthOMLX:
+    """oMLX keeps runtime context in the admin API, not the OpenAI /v1/models list."""
+
+    def _make_resp(self, status_code, body):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = body
+        return resp
+
+    def test_omlx_admin_models_fallback_reads_max_context_window(self):
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {"id": "MiniMax-M2.7-4bit-mxfp4", "owned_by": "omlx"},
+            ]
+        })
+        admin_resp = self._make_resp(200, {
+            "models": [
+                {
+                    "id": "MiniMax-M2.7-4bit-mxfp4",
+                    "settings": {"max_context_window": 120000},
+                }
+            ]
+        })
+
+        call_count = [0]
+
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp
+            if call_count[0] == 2:
+                return list_resp
+            if call_count[0] == 3:
+                return admin_resp
+            return self._make_resp(404, {})
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "MiniMax-M2.7-4bit-mxfp4",
+                "http://192.168.5.125:8098/v1",
+                api_key="secret",
+            )
+
+        assert result == 120000
+        assert [call.args[0] for call in client_mock.get.call_args_list] == [
+            "http://192.168.5.125:8098/v1/models/MiniMax-M2.7-4bit-mxfp4",
+            "http://192.168.5.125:8098/v1/models",
+            "http://192.168.5.125:8098/admin/api/models",
+        ]
+
+
 class TestQueryLocalContextLengthLmStudio:
     """_query_local_context_length with LM Studio native /api/v1/models response."""
 


### PR DESCRIPTION
<!-- native-links:v1 -->
Related #24640 #31272 #25675

## What does this PR do?

Closes the **oMLX context-length auto-detection** defect class (#24640, #31272): `_query_local_context_length()` could not read the runtime context window from oMLX servers — the OpenAI-compat `/v1/models` response doesn't carry the loaded context, so auto-detect fell back to a wrong default and conversations were truncated or overgrown.

**Fix:** detect oMLX servers (`owned_by == "omlx"`) in the `/v1/models` scan and query the oMLX admin API (`/admin/api/models`) for the loaded runtime context window, falling back to the sole-model entry when no id matches. Also adds `max_context_window` to the context-length key set.

This is the fix from #25675 (author: **LeonSGP43**, cherry-picked with authorship preserved), merged onto the current `_query_local_context_length_uncached` structure (which gained the llama.cpp `meta.n_ctx` fallback since the PR was written).

## How to test

```bash
pytest tests/agent/test_model_metadata_local_ctx.py -q
# 24 passed
```

## What platforms were tested?

- Windows 11 native: `24 passed`, `git diff --check` clean.

## Why this matters to users

oMLX users get correct auto-detected context instead of a wrong default — the exact report filed twice (#24640, #31272).

Closes #24640
Closes #31272

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Code follows repo style
- [x] Self-review complete
- [x] Tests added (oMLX admin context resolution)
- [x] Suite green: `24 passed` on current main
- [x] `git diff --check` clean
- [x] Credit: implementation from #25675 by @LeonSGP43, cherry-picked with authorship preserved
