### PR TITLE
fix(cli): pass the configured fallback chain to AIAgent in oneshot mode

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -302,7 +302,14 @@ def _run_agent(
 
     session_db = _create_session_db_for_oneshot()
 
+    # AIAgent builds its fallback chain solely from this argument, so omitting
+    # it leaves the chain empty and no failover can ever happen in oneshot mode,
+    # regardless of what fallback_providers says. Same resolution as
+    # cron/scheduler.py.
+    fallback_model = cfg.get("fallback_providers") or cfg.get("fallback_model") or None
+
     agent = AIAgent(
+        fallback_model=fallback_model,
         api_key=runtime.get("api_key"),
         base_url=runtime.get("base_url"),
         provider=runtime.get("provider"),

--- a/tests/hermes_cli/test_oneshot_fallback_chain.py
+++ b/tests/hermes_cli/test_oneshot_fallback_chain.py
@@ -1,0 +1,81 @@
+"""Regression test: oneshot mode must hand the fallback chain to AIAgent.
+
+AIAgent derives ``_fallback_chain`` exclusively from its ``fallback_model``
+argument.  ``_run_agent`` used to omit it, so ``hermes -z`` (and every daemon
+answering through it) ran with an empty chain and could never fail over, no
+matter what ``fallback_providers`` held in the config.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+CHAIN = [
+    {
+        "provider": "openrouter",
+        "model": "google/gemma-4-26b-a4b-it:free",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+]
+
+
+def _run_and_capture(config):
+    """Invoke _run_agent with all heavy collaborators stubbed out.
+
+    Returns the kwargs AIAgent was constructed with.
+    """
+    from hermes_cli import oneshot
+
+    fake_agent = MagicMock()
+    fake_agent.chat.return_value = "ok"
+    agent_cls = MagicMock(return_value=fake_agent)
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("run_agent.AIAgent", agent_cls),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "test-key-1234567890",
+                "base_url": "https://api.groq.com/openai/v1",
+                "provider": "groq",
+                "api_mode": None,
+                "credential_pool": None,
+            },
+        ),
+        patch("hermes_cli.tools_config._get_platform_tools", return_value=set()),
+        patch.object(oneshot, "_create_session_db_for_oneshot", return_value=None),
+    ):
+        oneshot._run_agent("hello", model="llama-3.3-70b-versatile")
+
+    assert agent_cls.call_count == 1
+    return agent_cls.call_args.kwargs
+
+
+def test_fallback_providers_reach_the_agent():
+    kwargs = _run_and_capture(
+        {
+            "model": {"default": "llama-3.3-70b-versatile", "provider": "groq"},
+            "fallback_providers": CHAIN,
+        }
+    )
+    assert kwargs.get("fallback_model") == CHAIN
+
+
+def test_legacy_fallback_model_key_still_honoured():
+    legacy = {"provider": "openrouter", "model": "google/gemma-4-26b-a4b-it:free"}
+    kwargs = _run_and_capture(
+        {
+            "model": {"default": "llama-3.3-70b-versatile", "provider": "groq"},
+            "fallback_model": legacy,
+        }
+    )
+    assert kwargs.get("fallback_model") == legacy
+
+
+def test_absent_config_yields_none_not_missing_kwarg():
+    kwargs = _run_and_capture(
+        {"model": {"default": "llama-3.3-70b-versatile", "provider": "groq"}}
+    )
+    assert kwargs.get("fallback_model", "MISSING") is None


### PR DESCRIPTION
## What

`AIAgent` builds `_fallback_chain` exclusively from its `fallback_model` constructor argument. `hermes_cli/oneshot.py` never passed it, so **every `hermes -z` run started with an empty chain** and could not fail over — regardless of what `fallback_providers` held in the config.

`cron/scheduler.py` already resolves the value correctly; this brings oneshot in line with it (one line, same expression).

## Why it is easy to miss

`hermes fallback list` reads the config file directly, so it happily prints a chain that does not exist at runtime:

```
Fallback chain (1 entry):
  1. google/gemma-4-26b-a4b-it:free  (via openrouter)
```

...while the live agent reports `len(self._fallback_chain) == 0`. The display is not evidence — only the constructed agent is.

This hits every headless caller, which in practice means bot/daemon setups that answer through `hermes -z`. Those are exactly the deployments where nobody is watching a terminal to notice that failover silently never happens.

## How to test

Configure a profile whose primary provider fails and give it a working fallback:

```yaml
model:
  default: llama-3.3-70b-versatile
  provider: groq
  base_url: https://api.groq.com/openai/v1
fallback_providers:
  - provider: openrouter
    model: google/gemma-4-26b-a4b-it:free
    base_url: https://openrouter.ai/api/v1
    key_env: OPENROUTER_API_KEY
```

Before: the run dies on the primary provider. After: it answers via the fallback.

Automated coverage in `tests/hermes_cli/test_oneshot_fallback_chain.py` — three cases (new list format, legacy single-dict `fallback_model`, absent config). All three fail without the change and pass with it.

## Platforms

Tested on Linux (Debian arm64, Python 3.11).

## Related

Companion PR #83703 fixes the agent-side half of the same user-visible symptom: a 413 that cannot be compressed aborts instead of failing over.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian arm64, Python 3.11

> Note on the suite: `tests/hermes_cli/` and `tests/run_agent/` pass in full, which is where this change lives.
>
> The complete `pytest tests/` run is not clean on this machine, and I'd rather be precise than just tick the box: an unmodified `main` checkout already fails 129 tests here (LSP end-to-end, ACP registry manifest, Discord, zombie-process reaping — all environment-dependent). The suite also has order-dependent tests under parallel distribution: two runs of the same tree differ by ~3 failures in each direction, mostly tests that manipulate environment variables and dotenv state, each of which passes in isolation.
>
> If you have a known-clean reference environment, I'm happy to re-run there.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing surface change)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config keys; this makes an existing key work in one more code path)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure config plumbing, no OS-specific calls)
- [x] I've updated tool descriptions/schemas — N/A
