### PR TITLE
fix(agent): fail over instead of aborting when compression is exhausted

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -14381,6 +14381,17 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error.", force=True)
                             self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logging.error(f"{self.log_prefix}413 compression failed after {max_compression_attempts} attempts.")
+                            # Compression is exhausted, but the fallback chain may still have a
+                            # provider with a larger context window. Returning here skipped the
+                            # failover guard further down, which handles every other error class.
+                            if self._try_activate_fallback():
+                                self._emit_status(
+                                    f"Switched to fallback provider {self.provider}/{self.model} "
+                                    f"after compression was exhausted"
+                                )
+                                compression_attempts = 0
+                                restart_with_compressed_messages = True
+                                break
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
@@ -14412,6 +14423,17 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}❌ Payload too large and cannot compress further.", force=True)
                             self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logging.error(f"{self.log_prefix}413 payload too large. Cannot compress further.")
+                            # Compression is exhausted, but the fallback chain may still have a
+                            # provider with a larger context window. Returning here skipped the
+                            # failover guard further down, which handles every other error class.
+                            if self._try_activate_fallback():
+                                self._emit_status(
+                                    f"Switched to fallback provider {self.provider}/{self.model} "
+                                    f"after compression was exhausted"
+                                )
+                                compression_attempts = 0
+                                restart_with_compressed_messages = True
+                                break
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
@@ -14465,6 +14487,17 @@ class AIAgent:
                                 self._vprint(f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
                                 self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                                 logging.error(f"{self.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+                                # Compression is exhausted, but the fallback chain may still have a
+                                # provider with a larger context window. Returning here skipped the
+                                # failover guard further down, which handles every other error class.
+                                if self._try_activate_fallback():
+                                    self._emit_status(
+                                        f"Switched to fallback provider {self.provider}/{self.model} "
+                                        f"after compression was exhausted"
+                                    )
+                                    compression_attempts = 0
+                                    restart_with_compressed_messages = True
+                                    break
                                 self._persist_session(messages, conversation_history)
                                 return {
                                     "messages": messages,
@@ -14538,6 +14571,17 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
                             self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logging.error(f"{self.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
+                            # Compression is exhausted, but the fallback chain may still have a
+                            # provider with a larger context window. Returning here skipped the
+                            # failover guard further down, which handles every other error class.
+                            if self._try_activate_fallback():
+                                self._emit_status(
+                                    f"Switched to fallback provider {self.provider}/{self.model} "
+                                    f"after compression was exhausted"
+                                )
+                                compression_attempts = 0
+                                restart_with_compressed_messages = True
+                                break
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
@@ -14571,6 +14615,17 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}❌ Context length exceeded and cannot compress further.", force=True)
                             self._vprint(f"{self.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
                             logging.error(f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
+                            # Compression is exhausted, but the fallback chain may still have a
+                            # provider with a larger context window. Returning here skipped the
+                            # failover guard further down, which handles every other error class.
+                            if self._try_activate_fallback():
+                                self._emit_status(
+                                    f"Switched to fallback provider {self.provider}/{self.model} "
+                                    f"after compression was exhausted"
+                                )
+                                compression_attempts = 0
+                                restart_with_compressed_messages = True
+                                break
                             self._persist_session(messages, conversation_history)
                             return {
                                 "messages": messages,
@@ -16039,7 +16094,16 @@ class AIAgent:
             str: Final assistant response
         """
         result = self.run_conversation(message, stream_callback=stream_callback)
-        return result["final_response"]
+        if not isinstance(result, dict):
+            return ""
+        # Failure paths (failed/partial/compression_exhausted) return no
+        # "final_response" at all. Subscripting raised KeyError:
+        # final_response, which hid the actual cause carried in "error".
+        response = result.get("final_response")
+        if response is not None:
+            return response
+        detail = str(result.get("error") or "").strip()
+        raise RuntimeError(detail or "Agent produced no response.")
 
     def _run_codex_app_server_turn(
         self,

--- a/tests/run_agent/test_failover_on_compression_exhausted.py
+++ b/tests/run_agent/test_failover_on_compression_exhausted.py
@@ -1,0 +1,152 @@
+"""Failover must be attempted before giving up on an uncompressible payload.
+
+Two defects made a 413 look like a crash instead of a provider switch:
+
+* the compression dead-ends returned straight out of ``run_conversation``,
+  bypassing the failover guard that handles every other error class;
+* ``chat()`` subscripted ``result["final_response"]``, a key those failure
+  results never carry, so the caller saw ``KeyError: final_response``
+  instead of the real cause sitting in ``result["error"]``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+import run_agent
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(run_agent, "jittered_backoff", lambda *a, **k: 0.0)
+
+
+def _tool_defs():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "web_search tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def _make_agent(fallback_model=None):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://api.groq.com/openai/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _413():
+    err = Exception("Request entity too large")
+    err.status_code = 413
+    return err
+
+
+def _ok_response(text="Hello"):
+    msg = SimpleNamespace(content=text, tool_calls=None, reasoning_content=None, reasoning=None)
+    resp = SimpleNamespace(choices=[SimpleNamespace(message=msg, finish_reason="stop")], model="fb/model")
+    resp.usage = None
+    return resp
+
+
+CHAIN = [
+    {
+        "provider": "openrouter",
+        "model": "google/gemma-4-26b-a4b-it:free",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+]
+
+
+class TestFailoverOnCompressionExhausted:
+
+    def test_uncompressible_payload_switches_provider_and_answers(self):
+        """A 413 that cannot be compressed should move to the next provider."""
+        agent = _make_agent(fallback_model=CHAIN)
+        agent.client.chat.completions.create.side_effect = [_413(), _ok_response("Hello")]
+
+        def _activate():
+            agent.provider = "openrouter"
+            agent.model = "google/gemma-4-26b-a4b-it:free"
+            agent._fallback_index = 1
+            return True
+
+        with (
+            patch.object(agent, "_compress_context") as compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_try_activate_fallback", side_effect=_activate) as activate,
+        ):
+            # Same message count back -> nothing left to compress.
+            compress.return_value = ([{"role": "user", "content": "hello"}], "same prompt")
+            result = agent.run_conversation("hello")
+
+        assert activate.called, "failover was never attempted"
+        assert result.get("final_response") == "Hello"
+        assert result["completed"] is True
+
+    def test_gives_up_only_after_the_chain_is_exhausted(self):
+        """With no fallback left, the original partial-failure result stands."""
+        agent = _make_agent(fallback_model=None)
+        agent.client.chat.completions.create.side_effect = [_413()]
+
+        with (
+            patch.object(agent, "_compress_context") as compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            compress.return_value = ([{"role": "user", "content": "hello"}], "same prompt")
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result.get("partial") is True
+        assert "413" in result["error"]
+
+
+class TestChatSurfacesTheRealError:
+
+    def test_failure_without_final_response_reports_the_cause(self):
+        agent = _make_agent()
+        failure = {
+            "messages": [],
+            "completed": False,
+            "partial": True,
+            "failed": True,
+            "compression_exhausted": True,
+            "error": "Request payload too large (413). Cannot compress further.",
+        }
+        with patch.object(agent, "run_conversation", return_value=failure):
+            with pytest.raises(RuntimeError, match="Cannot compress further"):
+                agent.chat("hello")
+
+    def test_successful_result_is_returned_unchanged(self):
+        agent = _make_agent()
+        with patch.object(agent, "run_conversation", return_value={"final_response": "Hi"}):
+            assert agent.chat("hello") == "Hi"


### PR DESCRIPTION
## What

A 413 whose payload cannot be compressed any further surfaced to the user as `KeyError: 'final_response'` instead of a provider switch. Two defects stacked on top of each other:

**1. The compression dead-ends skip the failover guard.**

`run_conversation()` has five exit points that give up on compression (`compression_exhausted`). All five `return` straight out of the function, which bypasses the guard further down that calls `_try_activate_fallback()` for every other error class. A configured fallback provider — possibly one with a much larger context window, i.e. exactly what a payload-size problem needs — was never tried.

The 429 path in the same function already documents the intended pattern (*"skip straight to max_retries — the top-of-loop guard will handle fallback or bail cleanly"*). The compression paths just never adopted it.

**2. `chat()` masked the cause.**

```python
result = self.run_conversation(message, stream_callback=stream_callback)
return result["final_response"]
```

Failure results carry `failed` / `partial` / `error` but **no** `final_response`. So the subscript replaced the real diagnosis —

```
Request payload too large (413). Cannot compress further.
```

— with a key name. Debugging this from the outside is genuinely hard: the message names a dict key that has nothing to do with the actual problem, and the classifier only marks 413 as `should_compress`, never `should_fallback`, so nothing else rescued the run either.

## After

The chain is tried first; only an exhausted chain produces the original partial-failure result. `chat()` returns the response when there is one and otherwise raises with the underlying error text.

## How to test

Reproduced with a profile whose primary provider reliably 413s (a large toolset against a provider with a tight request-size limit) plus an OpenRouter fallback:

| | before | after |
|---|---|---|
| result | `KeyError: 'final_response'` | the model's answer |
| runtime trace | no failover attempted | switch to `openrouter/gemma-4-26b` |

Automated coverage in `tests/run_agent/test_failover_on_compression_exhausted.py`:

- uncompressible payload with a chain → switches provider and answers
- uncompressible payload without a chain → keeps the existing partial-failure result
- `chat()` on a failure result → raises with the real error, not a `KeyError`
- `chat()` on a normal result → unchanged

The two behavioural tests fail without the change.

`tests/run_agent/test_413_compression.py` passes unchanged, including `test_413_cannot_compress_further` — its agent fixture is built without a fallback chain, so `_try_activate_fallback()` returns `False` and the dead-end path stays exactly as it was. That was the intended compatibility property, not a coincidence.

## Platforms

Tested on Linux (Debian arm64, Python 3.11). No OS-specific code paths touched.

## Related

Companion PR #83702 fixes the other half of the same symptom: `hermes -z` never received the configured fallback chain at all.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian arm64, Python 3.11

> Note on the suite: `tests/run_agent/` passes in full (1382 passed, 3 skipped), which is where this change lives.
>
> The complete `pytest tests/` run is not clean on this machine, and I want to be precise about why rather than just ticking the box. An unmodified `main` checkout fails 129 tests here (LSP end-to-end, ACP registry manifest, Discord, zombie-process reaping — all environment-dependent). This branch fails 134. That difference is **not** attributable to the change: two runs of this same branch differ by 3 failures in each direction, and the set that differs from `main` is composed of entirely different tests between runs (`test_gmi_provider` / `test_transcription_dotenv_fallback` in one, `test_goal_command` in the next). Each of those passes when run in isolation. The suite has order-dependent tests under parallel distribution — mostly ones that manipulate environment variables and dotenv state.
>
> If you have a known-clean reference environment, I'm happy to re-run there.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behaviour now matches what the fallback docs already promise)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (no OS-specific calls)
- [x] I've updated tool descriptions/schemas — N/A
