### PR TITLE
fix(desktop): correct Quick Entry shadow artifacts on macOS

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9692,7 +9692,13 @@ function spawnQuickEntryWindow() {
     // of the taskbar/alt-tab list; on macOS use an NSPanel so the frameless
     // capture window never becomes the app's cmd-tab anchor.
     skipTaskbar: !IS_MAC,
-    hasShadow: true,
+    // macOS derives a transparent window's native shadow from its alpha
+    // content, but the boot HTML paints an OPAQUE background before the
+    // renderer forces transparency (quick-entry-root.tsx) — the OS then
+    // caches a full-frame shadow that renders as a huge detached blur blob
+    // behind the card. The card draws its own CSS box-shadow already, so
+    // the native one only double-paints. Other platforms keep it.
+    hasShadow: !IS_MAC,
     alwaysOnTop: true,
     type: IS_MAC ? 'panel' : undefined,
     hiddenInMissionControl: IS_MAC,

--- a/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
+++ b/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
@@ -88,7 +88,11 @@ export function QuickEntryApp() {
           background: 'var(--ui-bg-elevated, var(--background))',
           border: '1px solid var(--ui-stroke-secondary, rgba(127,127,127,0.35))',
           borderRadius: 12,
-          boxShadow: '0 18px 48px rgba(0,0,0,0.38)',
+          // Shadow budget is capped by the 12px transparent padding around the
+          // card: extent (offset + blur) beyond 12px gets clipped by the fixed
+          // 640x168 window bounds, slicing the gradient into a hard edge.
+          // 2 + 8 = 10px stays inside the padding and fades out cleanly.
+          boxShadow: '0 2px 8px rgba(0,0,0,0.22)',
           display: 'flex',
           flexDirection: 'column',
           gap: 8,


### PR DESCRIPTION
## Bug Description

On macOS, the Quick Entry floating composer (global hotkey, default Cmd+Shift+Space) renders with visible shadow artifacts: a huge soft blur blob extending far below the card, and — after the native window shadow is removed — a hard, sliced edge at the outer boundary of the CSS shadow. Screenshots from an affected build show the pill card floating above a wide fog-like halo that makes the overlay look broken.

## Root Cause

Two independent shadow layers were stacking on the transparent, frameless NSPanel:

1. **Native macOS window shadow (`hasShadow: true`).** For transparent windows, AppKit derives the shadow shape from the window's alpha content. However, `index.html`'s boot script paints an *opaque* themed background first (a deliberate anti-flash measure for normal windows), and the Quick Entry renderer only forces `html/body/#root` transparent afterwards (`quick-entry-root.tsx`). The OS can therefore compute/cache a full-frame shadow for a window whose visible content is only the small floating card — producing the oversized detached blob.
2. **Card CSS `box-shadow: 0 18px 48px rgba(0,0,0,0.38)`.** Shadow extent (offset + blur ≈ 66px) vastly exceeds the 12px transparent padding between the card and the fixed 640×168 window bounds, so the blur gradient is clipped by the window edge into a visibly harsh cutoff. Even at moderate values, any extent > 12px clips.

## Fix

- `electron/main.ts`: `hasShadow: !IS_MAC` for the Quick Entry window — drop the native shadow on macOS only (the card already draws its own; other platforms are unchanged).
- `src/app/quick-entry/quick-entry-app.tsx`: tighten the card shadow to `0 2px 8px rgba(0,0,0,0.22)` — total extent 10px stays inside the 12px padding budget, so the gradient fades to fully transparent before reaching the window bounds. Comments in both files document the constraint.

## How to Verify

1. On macOS, enable **Settings → Advanced → Quick Entry** and press the hotkey (default Cmd+Shift+Space).
2. Before: a large fog-like blob surrounds the card / shadow edges look sliced.
3. After: a clean Spotlight-style pill with a subtle, evenly fading drop shadow.

Verified on macOS (arm64) with a local `npm run pack` build: artifacts gone, composer appearance unchanged otherwise.

## Test Plan

- [x] Existing tests still pass (`npx vitest run --project electron --project ui quick-entry` — 40/40)
- [x] Manual verification of the fix on macOS arm64
- [ ] Added regression test for this bug (visual shadow rendering is not covered by the existing unit surface; the constraint is documented in code comments instead)

## Risk Assessment

Low — visual-only change scoped to the Quick Entry window. No behavioral, IPC, or sizing changes; non-macOS platforms keep the native shadow exactly as before.
