### PR TITLE
fix(desktop): scope messaging to active remote profile

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -212,6 +212,7 @@ import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-bac
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import {
+  buildSidebarSessionSliceParams,
   fetchPrimaryProfileSessions,
   fetchRemoteProfileSessions,
   mergeProfileSessionWindow
@@ -12314,36 +12315,7 @@ async function interceptSessionRequestForRemote(request) {
       return undefined // local fast path → batched endpoint's single DB open
     }
 
-    const recentsProfile = (searchParams.get('recents_profile') || 'all').trim() || 'all'
-
-    const sliceParams = (limitKey, defaultLimit, extra) => {
-      const sp = new URLSearchParams({
-        limit: searchParams.get(limitKey) || defaultLimit,
-        offset: '0',
-        min_messages: '1',
-        archived: 'exclude',
-        order: 'recent',
-        ...extra
-      })
-
-      return sp
-    }
-
-    const recentsSp = sliceParams('recents_limit', '20', { profile: recentsProfile })
-    const recentsExclude = searchParams.get('recents_exclude')
-
-    if (recentsExclude) {
-      recentsSp.set('exclude_sources', recentsExclude)
-    }
-
-    const cronSp = sliceParams('cron_limit', '50', { profile: 'all', source: 'cron' })
-
-    const messagingSp = sliceParams('messaging_limit', '100', { profile: 'all' })
-    const messagingExclude = searchParams.get('messaging_exclude')
-
-    if (messagingExclude) {
-      messagingSp.set('exclude_sources', messagingExclude)
-    }
+    const { recents: recentsSp, cron: cronSp, messaging: messagingSp } = buildSidebarSessionSliceParams(searchParams)
 
     const [recents, cron, messaging] = await Promise.all([
       fetchProfilesSessionSlice(recentsSp, remoteProfiles),

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -3,10 +3,40 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
+  buildSidebarSessionSliceParams,
   fetchPrimaryProfileSessions,
   fetchRemoteProfileSessions,
   mergeProfileSessionWindow
 } from './profile-session-routing'
+
+test('remote sidebar slices all follow the selected profile', () => {
+  const slices = buildSidebarSessionSliceParams(
+    new URLSearchParams({
+      recents_profile: 'work-vps',
+      recents_limit: '30',
+      cron_limit: '40',
+      messaging_limit: '50',
+      recents_exclude: 'cron,signal',
+      messaging_exclude: 'desktop,cron'
+    })
+  )
+
+  assert.equal(slices.recents.get('profile'), 'work-vps')
+  assert.equal(slices.cron.get('profile'), 'work-vps')
+  assert.equal(slices.messaging.get('profile'), 'work-vps')
+  assert.equal(slices.recents.get('exclude_sources'), 'cron,signal')
+  assert.equal(slices.cron.get('source'), 'cron')
+  assert.equal(slices.messaging.get('exclude_sources'), 'desktop,cron')
+})
+
+test('remote sidebar slices preserve the explicit all-profiles scope', () => {
+  const slices = buildSidebarSessionSliceParams(new URLSearchParams({ recents_profile: 'all' }))
+
+  assert.deepEqual(
+    Object.values(slices).map(params => params.get('profile')),
+    ['all', 'all', 'all']
+  )
+})
 
 test('primary session reads use the profile-aware request path', async () => {
   const calls: Array<{ profile: string | null; path: string }> = []

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -38,6 +38,20 @@ test('remote sidebar slices preserve the explicit all-profiles scope', () => {
   )
 })
 
+test('remote sidebar slices fall back to the all-profiles scope and default limits', () => {
+  for (const searchParams of [new URLSearchParams(), new URLSearchParams({ recents_profile: '   ' })]) {
+    const slices = buildSidebarSessionSliceParams(searchParams)
+
+    assert.deepEqual(
+      Object.values(slices).map(params => params.get('profile')),
+      ['all', 'all', 'all']
+    )
+    assert.equal(slices.recents.get('limit'), '20')
+    assert.equal(slices.cron.get('limit'), '50')
+    assert.equal(slices.messaging.get('limit'), '100')
+  }
+})
+
 test('primary session reads use the profile-aware request path', async () => {
   const calls: Array<{ profile: string | null; path: string }> = []
   const expected = { sessions: [{ id: 'session-1' }], total: 1, profile_totals: { default: 1 } }

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -77,6 +77,47 @@ export function mergeProfileSessionWindow(rows: unknown[], offset: number, limit
   return window
 }
 
+export interface SidebarSessionSliceParams {
+  cron: URLSearchParams
+  messaging: URLSearchParams
+  recents: URLSearchParams
+}
+
+/** Build the three remote-profile sidebar reads from one workspace scope. */
+export function buildSidebarSessionSliceParams(searchParams: URLSearchParams): SidebarSessionSliceParams {
+  const profile = (searchParams.get('recents_profile') || 'all').trim() || 'all'
+
+  const slice = (limitKey: string, defaultLimit: string, extra: Record<string, string>) =>
+    new URLSearchParams({
+      limit: searchParams.get(limitKey) || defaultLimit,
+      offset: '0',
+      min_messages: '1',
+      archived: 'exclude',
+      order: 'recent',
+      ...extra
+    })
+
+  const recents = slice('recents_limit', '20', { profile })
+  const recentsExclude = searchParams.get('recents_exclude')
+
+  if (recentsExclude) {
+    recents.set('exclude_sources', recentsExclude)
+  }
+
+  const messaging = slice('messaging_limit', '100', { profile })
+  const messagingExclude = searchParams.get('messaging_exclude')
+
+  if (messagingExclude) {
+    messaging.set('exclude_sources', messagingExclude)
+  }
+
+  return {
+    cron: slice('cron_limit', '50', { profile, source: 'cron' }),
+    messaging,
+    recents
+  }
+}
+
 export async function fetchPrimaryProfileSessions(
   searchParams: URLSearchParams,
   fetchJsonForProfile: FetchJsonForProfile

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -118,6 +118,7 @@ export function buildSidebarSessionSliceParams(searchParams: URLSearchParams): S
   }
 }
 
+/** Fetch the primary backend's profile-aware session slice, falling back to an empty result when unavailable. */
 export async function fetchPrimaryProfileSessions(
   searchParams: URLSearchParams,
   fetchJsonForProfile: FetchJsonForProfile

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -144,6 +144,7 @@ import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarFilterMenu } from './filter-menu'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
+import { filterSessionsByProfileScope } from './profile-scope'
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import {
@@ -523,11 +524,21 @@ export function ChatSidebar({
     [visibleSessions]
   )
 
+  const visibleCronSessions = useMemo(
+    () => filterSessionsByProfileScope(cronSessions, profileScope),
+    [cronSessions, profileScope]
+  )
+
+  const visibleMessagingSessions = useMemo(
+    () => filterSessionsByProfileScope(messagingSessions, profileScope),
+    [messagingSessions, profileScope]
+  )
+
   // Index sessions by every id a pin might be stored under — recents, cron,
   // AND messaging, since all three can be pinned (see session-index.ts).
   const sessionByAnyId = useMemo(
-    () => buildSessionByAnyId(visibleSessions, cronSessions, messagingSessions),
-    [visibleSessions, cronSessions, messagingSessions]
+    () => buildSessionByAnyId(visibleSessions, visibleCronSessions, visibleMessagingSessions),
+    [visibleSessions, visibleCronSessions, visibleMessagingSessions]
   )
 
   // Local pin ids first (hand-picked order), then server-flagged pins the
@@ -1160,7 +1171,7 @@ export function ChatSidebar({
   // within a platform by recency. Per-platform totals (when a "load more" has
   // resolved them) drive the count + whether more remain on disk.
   const messagingGroups = useMemo<MessagingSection[]>(() => {
-    if (!messagingSessions.length) {
+    if (!visibleMessagingSessions.length) {
       return []
     }
 
@@ -1170,7 +1181,7 @@ export function ChatSidebar({
     // promises rows that will never appear.
     const pinnedBySource = new Map<string, number>()
 
-    for (const session of messagingSessions) {
+    for (const session of visibleMessagingSessions) {
       const sourceId = normalizeSessionSource(session.source)
 
       if (!sourceId) {
@@ -1207,7 +1218,7 @@ export function ChatSidebar({
         }
       })
       .sort((a, b) => sessionTime(b.sessions[0]) - sessionTime(a.sessions[0]))
-  }, [messagingSessions, messagingPlatformTotals, messagingTruncated, isPinnedSession])
+  }, [visibleMessagingSessions, messagingPlatformTotals, messagingTruncated, isPinnedSession])
 
   // Grouping by profile: one collapsible group per profile, color on the header
   // (not on every row). Default profile floats to the top, the rest alpha.

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -78,6 +78,8 @@ import {
   $profiles,
   $profileScope,
   ALL_PROFILES,
+  messagingProfileFor,
+  messagingTotalsKey,
   normalizeProfileKey
 } from '@/store/profile'
 import {
@@ -396,6 +398,7 @@ export function ChatSidebar({
   // profile while scope is still ALL (persisted), the rail is hidden and they'd
   // otherwise be stuck in the grouped view with no way out.
   const showAllProfiles = multiProfile && profileScope === ALL_PROFILES
+  const messagingProfile = messagingProfileFor(profileScope)
   const agentOrderIds = useStore($sidebarSessionOrderIds)
   const agentOrderManual = useStore($sidebarSessionOrderManual)
   const workspaceOrderIds = useStore($sidebarWorkspaceOrderIds)
@@ -1202,7 +1205,7 @@ export function ChatSidebar({
     return [...bySource.entries()]
       .map(([sourceId, list]) => {
         const ordered = [...list].sort((a, b) => sessionTime(b) - sessionTime(a))
-        const known = messagingPlatformTotals[sourceId]
+        const known = messagingPlatformTotals[messagingTotalsKey(messagingProfile, sourceId)]
         const unpinnedKnown = known == null ? null : Math.max(0, known - (pinnedBySource.get(sourceId) ?? 0))
         const total = Math.max(ordered.length, unpinnedKnown ?? 0)
 
@@ -1218,7 +1221,7 @@ export function ChatSidebar({
         }
       })
       .sort((a, b) => sessionTime(b.sessions[0]) - sessionTime(a.sessions[0]))
-  }, [visibleMessagingSessions, messagingPlatformTotals, messagingTruncated, isPinnedSession])
+  }, [visibleMessagingSessions, messagingPlatformTotals, messagingTruncated, isPinnedSession, messagingProfile])
 
   // Grouping by profile: one collapsible group per profile, color on the header
   // (not on every row). Default profile floats to the top, the rest alpha.

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -78,9 +78,9 @@ import {
   $profiles,
   $profileScope,
   ALL_PROFILES,
-  messagingProfileFor,
   messagingTotalsKey,
-  normalizeProfileKey
+  normalizeProfileKey,
+  sidebarProfileForScope
 } from '@/store/profile'
 import {
   $activeProjectId,
@@ -398,7 +398,7 @@ export function ChatSidebar({
   // profile while scope is still ALL (persisted), the rail is hidden and they'd
   // otherwise be stuck in the grouped view with no way out.
   const showAllProfiles = multiProfile && profileScope === ALL_PROFILES
-  const messagingProfile = messagingProfileFor(profileScope)
+  const messagingProfile = sidebarProfileForScope(profileScope)
   const agentOrderIds = useStore($sidebarSessionOrderIds)
   const agentOrderManual = useStore($sidebarSessionOrderManual)
   const workspaceOrderIds = useStore($sidebarWorkspaceOrderIds)

--- a/apps/desktop/src/app/chat/sidebar/profile-scope.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-scope.test.ts
@@ -5,6 +5,7 @@ import type { SessionInfo } from '@/types/hermes'
 
 import { filterSessionsByProfileScope } from './profile-scope'
 
+/** Build the smallest session row needed by the profile-scope tests. */
 const row = (id: string, profile?: string): SessionInfo =>
   ({ id, message_count: 1, profile, source: 'signal', started_at: 0, title: id }) as SessionInfo
 

--- a/apps/desktop/src/app/chat/sidebar/profile-scope.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-scope.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { ALL_PROFILES } from '@/store/profile'
+import type { SessionInfo } from '@/types/hermes'
+
+import { filterSessionsByProfileScope } from './profile-scope'
+
+const row = (id: string, profile?: string): SessionInfo =>
+  ({ id, message_count: 1, profile, source: 'signal', started_at: 0, title: id }) as SessionInfo
+
+describe('filterSessionsByProfileScope', () => {
+  it('keeps only rows from the selected profile', () => {
+    const rows = [row('default-row', 'default'), row('work-row', 'work')]
+
+    expect(filterSessionsByProfileScope(rows, 'work').map(session => session.id)).toEqual(['work-row'])
+  })
+
+  it('treats legacy rows without a profile as default', () => {
+    const rows = [row('legacy-row'), row('work-row', 'work')]
+
+    expect(filterSessionsByProfileScope(rows, 'default').map(session => session.id)).toEqual(['legacy-row'])
+  })
+
+  it('preserves every row in the canonical all-profiles scope', () => {
+    const rows = [row('default-row', 'default'), row('work-row', 'work')]
+
+    expect(filterSessionsByProfileScope(rows, ALL_PROFILES)).toBe(rows)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/profile-scope.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-scope.ts
@@ -1,0 +1,12 @@
+import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
+import type { SessionInfo } from '@/types/hermes'
+
+export function filterSessionsByProfileScope(sessions: SessionInfo[], profileScope: string): SessionInfo[] {
+  if (profileScope === ALL_PROFILES) {
+    return sessions
+  }
+
+  const scope = normalizeProfileKey(profileScope)
+
+  return sessions.filter(session => normalizeProfileKey(session.profile) === scope)
+}

--- a/apps/desktop/src/app/chat/sidebar/profile-scope.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-scope.ts
@@ -1,6 +1,7 @@
 import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import type { SessionInfo } from '@/types/hermes'
 
+/** Return the sessions visible in one sidebar profile scope, or the original unified list for All profiles. */
 export function filterSessionsByProfileScope(sessions: SessionInfo[], profileScope: string): SessionInfo[] {
   if (profileScope === ALL_PROFILES) {
     return sessions

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as HermesModule from '@/hermes'
 import { getSession } from '@/hermes'
 import { $activeGatewayProfile, $profiles } from '@/store/profile'
-import { $sessions } from '@/store/session'
+import { $cronSessions, $messagingSessions, $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import { resolveSessionProfile, resolveStoredSession } from './utils'
@@ -21,6 +21,8 @@ const profiles = (...names: string[]) => names.map(name => ({ name }) as never)
 
 describe('resolveStoredSession profile ownership', () => {
   beforeEach(() => {
+    $cronSessions.set([])
+    $messagingSessions.set([])
     $sessions.set([])
     $profiles.set(profiles('default', 'meta'))
     $activeGatewayProfile.set('meta')
@@ -28,6 +30,8 @@ describe('resolveStoredSession profile ownership', () => {
   })
 
   afterEach(() => {
+    $cronSessions.set([])
+    $messagingSessions.set([])
     $sessions.set([])
     $profiles.set([])
     $activeGatewayProfile.set('default')
@@ -40,6 +44,19 @@ describe('resolveStoredSession profile ownership', () => {
 
     expect(resolved?.profile).toBe('default')
     expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['cron', $cronSessions],
+    ['messaging', $messagingSessions]
+  ])('resolves a %s sidebar row without duplicating it into regular sessions', async (_source, store) => {
+    store.set([session({ id: 's1', profile: 'default' })])
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('default')
+    expect(mockGetSession).not.toHaveBeenCalled()
+    expect($sessions.get()).toEqual([])
   })
 
   it('treats a profile-less cache hit as unresolved when multiple profiles exist', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -7,7 +7,9 @@ import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import {
+  $cronSessions,
   $currentCwd,
+  $messagingSessions,
   $sessions,
   commitWorkspaceCwdForSelectedSession,
   releaseWorkspaceCwdOwner,
@@ -1291,7 +1293,9 @@ function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
 }
 
 export async function resolveStoredSession(storedSessionId: string): Promise<SessionInfo | undefined> {
-  const cached = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+  const cached = [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()].find(session =>
+    sessionMatchesStoredId(session, storedSessionId)
+  )
 
   // A row with no owning profile can't route a resume when more than one
   // profile exists — a resume without a profile lands on whichever gateway is

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -4,11 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SessionInfo, SidebarSessionsResponse } from '@/hermes'
 import {
   $cronSessions,
+  $messagingPlatformTotals,
   $messagingSessions,
   $sessions,
   $sessionsLoading,
   setCronSessions,
+  setMessagingPlatformTotals,
   setMessagingSessions,
+  setMessagingTruncated,
   setSessions,
   setSessionsLoading
 } from '@/store/session'
@@ -55,6 +58,21 @@ const sidebar = (
 const listSidebarSessions = vi.fn()
 const listAllProfileSessions = vi.fn()
 
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
   getCronJobs: vi.fn(async () => []),
@@ -77,6 +95,8 @@ beforeEach(() => {
   setSessions([])
   setCronSessions([])
   setMessagingSessions([])
+  setMessagingPlatformTotals({})
+  setMessagingTruncated(false)
   setSessionsLoading(false)
 })
 
@@ -84,6 +104,8 @@ afterEach(() => {
   setSessions([])
   setCronSessions([])
   setMessagingSessions([])
+  setMessagingPlatformTotals({})
+  setMessagingTruncated(false)
   setSessionsLoading(false)
 })
 
@@ -281,5 +303,106 @@ describe('refreshSessions batches slices into one request', () => {
     })
 
     expect(getCronJobs).toHaveBeenLastCalledWith('all')
+  })
+})
+
+describe('messaging profile scope', () => {
+  it('refreshes messaging sessions only for the active profile', async () => {
+    listAllProfileSessions.mockResolvedValue({
+      sessions: [row('m1', { profile: 'work', source: 'signal' })],
+      total: 1
+    })
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'work' }))
+
+    await act(async () => {
+      await result.current.refreshMessagingSessions()
+    })
+
+    expect(listAllProfileSessions).toHaveBeenCalledWith(
+      expect.any(Number),
+      1,
+      'exclude',
+      'recent',
+      'work',
+      expect.objectContaining({ excludeSources: expect.any(Array) })
+    )
+    expect($messagingSessions.get().map(s => s.id)).toEqual(['m1'])
+  })
+
+  it('keeps the explicit all-profiles view unified', async () => {
+    listAllProfileSessions.mockResolvedValue({ sessions: [], total: 0 })
+    const { result } = renderHook(() => useSessionListActions({ profileScope: '__all__' }))
+
+    await act(async () => {
+      await result.current.refreshMessagingSessions()
+    })
+
+    expect(listAllProfileSessions.mock.calls[0][4]).toBe('all')
+  })
+
+  it('keeps per-platform pagination on the active profile', async () => {
+    setMessagingSessions([row('m1', { profile: 'work', source: 'signal' })])
+    listAllProfileSessions.mockResolvedValue({
+      sessions: [row('m1', { profile: 'work', source: 'signal' }), row('m2', { profile: 'work', source: 'signal' })],
+      total: 2
+    })
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'work' }))
+
+    await act(async () => {
+      await result.current.loadMoreMessagingForPlatform('signal')
+    })
+
+    expect(listAllProfileSessions.mock.calls[0][4]).toBe('work')
+    expect($messagingSessions.get().map(s => s.id)).toEqual(['m1', 'm2'])
+  })
+
+  it('ignores an in-flight response after the active profile changes', async () => {
+    const work = deferred<{ sessions: SessionInfo[]; total: number }>()
+    const personal = deferred<{ sessions: SessionInfo[]; total: number }>()
+
+    listAllProfileSessions.mockImplementation((_limit, _min, _archived, _order, profile) =>
+      profile === 'work' ? work.promise : personal.promise
+    )
+
+    const { rerender, result } = renderHook(({ profileScope }) => useSessionListActions({ profileScope }), {
+      initialProps: { profileScope: 'work' }
+    })
+
+    const workRefresh = result.current.refreshMessagingSessions()
+    rerender({ profileScope: 'personal' })
+    const personalRefresh = result.current.refreshMessagingSessions()
+
+    await act(async () => {
+      personal.resolve({
+        sessions: [row('personal-message', { profile: 'personal', source: 'telegram' })],
+        total: 1
+      })
+      await personalRefresh
+      work.resolve({ sessions: [row('work-message', { profile: 'work', source: 'signal' })], total: 1 })
+      await workRefresh
+    })
+
+    expect(listAllProfileSessions.mock.calls.map(call => call[4])).toEqual(['work', 'personal'])
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['personal-message'])
+  })
+
+  it('does not let a callback captured before a profile switch clear current totals', async () => {
+    listAllProfileSessions.mockResolvedValue({ sessions: [], total: 0 })
+    setMessagingPlatformTotals({ signal: 12 })
+
+    const { rerender, result } = renderHook(({ profileScope }) => useSessionListActions({ profileScope }), {
+      initialProps: { profileScope: 'work' }
+    })
+
+    const staleRefresh = result.current.refreshMessagingSessions
+
+    rerender({ profileScope: 'personal' })
+
+    await act(async () => {
+      await staleRefresh()
+    })
+
+    expect(listAllProfileSessions).not.toHaveBeenCalled()
+    expect($messagingPlatformTotals.get()).toEqual({ signal: 12 })
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo, SidebarSessionsResponse } from '@/hermes'
+import { $cronJobs, setCronJobs } from '@/store/cron'
 import {
   $cronSessions,
   $messagingPlatformTotals,
@@ -57,12 +58,14 @@ const sidebar = (
 
 const listSidebarSessions = vi.fn()
 const listAllProfileSessions = vi.fn()
+const getCronJobs = vi.fn()
 
 interface Deferred<T> {
   promise: Promise<T>
   resolve: (value: T) => void
 }
 
+/** Create a promise whose completion order the stale-response tests control. */
 function deferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void
 
@@ -75,7 +78,7 @@ function deferred<T>(): Deferred<T> {
 
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  getCronJobs: vi.fn(async () => []),
+  getCronJobs: (...args: unknown[]) => getCronJobs(...args),
   listAllProfileSessions: (...args: unknown[]) => listAllProfileSessions(...args),
   listSidebarSessions: (...args: unknown[]) => listSidebarSessions(...args)
 }))
@@ -89,9 +92,12 @@ vi.mock('@/store/projects', () => ({
 }))
 
 beforeEach(() => {
+  getCronJobs.mockReset()
+  getCronJobs.mockResolvedValue([])
   listSidebarSessions.mockReset()
   listAllProfileSessions.mockReset()
   removed.ids = new Set()
+  setCronJobs([])
   setSessions([])
   setCronSessions([])
   setMessagingSessions([])
@@ -101,6 +107,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  setCronJobs([])
   setSessions([])
   setCronSessions([])
   setMessagingSessions([])
@@ -284,8 +291,67 @@ describe('refreshSessions batches slices into one request', () => {
     )
   })
 
+  it('does not start a refresh callback captured before a profile switch', async () => {
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+
+    const { rerender, result } = renderHook(({ profileScope }) => useSessionListActions({ profileScope }), {
+      initialProps: { profileScope: 'work' }
+    })
+
+    const staleRefresh = result.current.refreshSessions
+
+    rerender({ profileScope: 'personal' })
+
+    await act(async () => {
+      await staleRefresh()
+    })
+
+    expect(listSidebarSessions).not.toHaveBeenCalled()
+  })
+
+  it('ignores an in-flight sidebar response after the active profile changes', async () => {
+    const work = deferred<SidebarSessionsResponse>()
+    const personal = deferred<SidebarSessionsResponse>()
+
+    listSidebarSessions.mockImplementation(({ recentsProfile }) =>
+      recentsProfile === 'work' ? work.promise : personal.promise
+    )
+
+    const { rerender, result } = renderHook(({ profileScope }) => useSessionListActions({ profileScope }), {
+      initialProps: { profileScope: 'work' }
+    })
+
+    const workRefresh = result.current.refreshSessions()
+
+    rerender({ profileScope: 'personal' })
+    const personalRefresh = result.current.refreshSessions()
+
+    await act(async () => {
+      personal.resolve(
+        sidebar(
+          { sessions: [row('personal-session', { profile: 'personal' })] },
+          [row('personal-cron', { profile: 'personal', source: 'cron' })],
+          [row('personal-signal', { profile: 'personal', source: 'signal' })]
+        )
+      )
+      await personalRefresh
+
+      work.resolve(
+        sidebar(
+          { sessions: [row('work-session', { profile: 'work' })] },
+          [row('work-cron', { profile: 'work', source: 'cron' })],
+          [row('work-telegram', { profile: 'work', source: 'telegram' })]
+        )
+      )
+      await workRefresh
+    })
+
+    expect($sessions.get().map(session => session.id)).toEqual(['personal-session'])
+    expect($cronSessions.get().map(session => session.id)).toEqual(['personal-cron'])
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['personal-signal'])
+  })
+
   it('scopes the cron-jobs fetch to the active profile (all → unified view)', async () => {
-    const { getCronJobs } = await import('@/hermes')
     listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
 
     const scoped = renderHook(() => useSessionListActions({ profileScope: 'work' }))
@@ -303,6 +369,33 @@ describe('refreshSessions batches slices into one request', () => {
     })
 
     expect(getCronJobs).toHaveBeenLastCalledWith('all')
+  })
+
+  it('ignores an out-of-order cron-jobs response from the previous profile', async () => {
+    const work = deferred<Array<{ enabled: boolean; id: string }>>()
+    const personal = deferred<Array<{ enabled: boolean; id: string }>>()
+
+    getCronJobs.mockImplementation((profile: string) => (profile === 'work' ? work.promise : personal.promise))
+
+    const { rerender, result } = renderHook(({ profileScope }) => useSessionListActions({ profileScope }), {
+      initialProps: { profileScope: 'work' }
+    })
+
+    const workRefresh = result.current.refreshCronJobs()
+
+    rerender({ profileScope: 'personal' })
+    const personalRefresh = result.current.refreshCronJobs()
+
+    await act(async () => {
+      personal.resolve([{ enabled: true, id: 'personal-job' }])
+      await personalRefresh
+
+      work.resolve([{ enabled: true, id: 'work-job' }])
+      await workRefresh
+    })
+
+    expect(getCronJobs.mock.calls.map(call => call[0])).toEqual(['work', 'personal'])
+    expect($cronJobs.get().map(job => job.id)).toEqual(['personal-job'])
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -354,6 +354,44 @@ describe('messaging profile scope', () => {
 
     expect(listAllProfileSessions.mock.calls[0][4]).toBe('work')
     expect($messagingSessions.get().map(s => s.id)).toEqual(['m1', 'm2'])
+    expect($messagingPlatformTotals.get()).toEqual({ 'work:signal': 2 })
+  })
+
+  it('keeps resolved platform totals separate across profile switches', async () => {
+    listAllProfileSessions.mockResolvedValue({
+      sessions: [row('work-signal', { profile: 'work', source: 'signal' })],
+      total: 42
+    })
+
+    const { rerender, result } = renderHook(({ profileScope }) => useSessionListActions({ profileScope }), {
+      initialProps: { profileScope: 'work' }
+    })
+
+    await act(async () => {
+      await result.current.loadMoreMessagingForPlatform('signal')
+    })
+
+    expect($messagingPlatformTotals.get()).toEqual({ 'work:signal': 42 })
+
+    rerender({ profileScope: 'personal' })
+
+    expect($messagingPlatformTotals.get()['personal:signal']).toBeUndefined()
+    expect($messagingPlatformTotals.get()['work:signal']).toBe(42)
+
+    listAllProfileSessions.mockResolvedValue({
+      sessions: [row('personal-signal', { profile: 'personal', source: 'signal' })],
+      total: 3
+    })
+
+    await act(async () => {
+      await result.current.loadMoreMessagingForPlatform('signal')
+    })
+
+    expect($messagingPlatformTotals.get()).toEqual({ 'personal:signal': 3, 'work:signal': 42 })
+
+    rerender({ profileScope: 'work' })
+
+    expect($messagingPlatformTotals.get()['work:signal']).toBe(42)
   })
 
   it('ignores an in-flight response after the active profile changes', async () => {
@@ -386,9 +424,9 @@ describe('messaging profile scope', () => {
     expect($messagingSessions.get().map(session => session.id)).toEqual(['personal-message'])
   })
 
-  it('does not let a callback captured before a profile switch clear current totals', async () => {
+  it('does not let a callback captured before a profile switch disturb current totals', async () => {
     listAllProfileSessions.mockResolvedValue({ sessions: [], total: 0 })
-    setMessagingPlatformTotals({ signal: 12 })
+    setMessagingPlatformTotals({ 'work:signal': 12 })
 
     const { rerender, result } = renderHook(({ profileScope }) => useSessionListActions({ profileScope }), {
       initialProps: { profileScope: 'work' }
@@ -403,6 +441,6 @@ describe('messaging profile scope', () => {
     })
 
     expect(listAllProfileSessions).not.toHaveBeenCalled()
-    expect($messagingPlatformTotals.get()).toEqual({ signal: 12 })
+    expect($messagingPlatformTotals.get()).toEqual({ 'work:signal': 12 })
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -394,6 +394,47 @@ describe('messaging profile scope', () => {
     expect($messagingPlatformTotals.get()['work:signal']).toBe(42)
   })
 
+  it('ignores an older overlapping load-more response for the same profile and platform', async () => {
+    const older = deferred<{ sessions: SessionInfo[]; total: number }>()
+    const newer = deferred<{ sessions: SessionInfo[]; total: number }>()
+
+    setMessagingSessions([row('m1', { profile: 'work', source: 'signal' })])
+    listAllProfileSessions.mockImplementationOnce(() => older.promise).mockImplementationOnce(() => newer.promise)
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'work' }))
+    const olderLoad = result.current.loadMoreMessagingForPlatform('signal')
+
+    setMessagingSessions([
+      row('m1', { profile: 'work', source: 'signal' }),
+      row('m2', { profile: 'work', source: 'signal' })
+    ])
+    const newerLoad = result.current.loadMoreMessagingForPlatform('signal')
+
+    await act(async () => {
+      newer.resolve({
+        sessions: [
+          row('m1', { profile: 'work', source: 'signal' }),
+          row('m2', { profile: 'work', source: 'signal' }),
+          row('m3', { profile: 'work', source: 'signal' })
+        ],
+        total: 3
+      })
+      await newerLoad
+
+      older.resolve({
+        sessions: [
+          row('m1', { profile: 'work', source: 'signal' }),
+          row('m2', { profile: 'work', source: 'signal' })
+        ],
+        total: 2
+      })
+      await olderLoad
+    })
+
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['m1', 'm2', 'm3'])
+    expect($messagingPlatformTotals.get()).toEqual({ 'work:signal': 3 })
+  })
+
   it('ignores an in-flight response after the active profile changes', async () => {
     const work = deferred<{ sessions: SessionInfo[]; total: number }>()
     const personal = deferred<{ sessions: SessionInfo[]; total: number }>()

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, render, renderHook } from '@testing-library/react'
+import { Suspense } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo, SidebarSessionsResponse } from '@/hermes'
@@ -309,6 +310,46 @@ describe('refreshSessions batches slices into one request', () => {
     expect(listSidebarSessions).not.toHaveBeenCalled()
   })
 
+  it('keeps the committed profile active when a later render is discarded', async () => {
+    const never = new Promise<never>(() => undefined)
+    let committedRefresh: (() => Promise<void>) | undefined
+
+    /** Expose only callbacks from committed renders; suspended renders are discarded. */
+    function Harness({ profileScope, suspend }: { profileScope: string; suspend: boolean }) {
+      const actions = useSessionListActions({ profileScope })
+
+      if (suspend) {
+        throw never
+      }
+
+      committedRefresh = actions.refreshSessions
+
+      return null
+    }
+
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+
+    const view = render(
+      <Suspense fallback={null}>
+        <Harness profileScope="work" suspend={false} />
+      </Suspense>
+    )
+
+    const workRefresh = committedRefresh!
+
+    view.rerender(
+      <Suspense fallback={null}>
+        <Harness profileScope="personal" suspend />
+      </Suspense>
+    )
+
+    await act(async () => {
+      await workRefresh()
+    })
+
+    expect(listSidebarSessions).toHaveBeenCalledWith(expect.objectContaining({ recentsProfile: 'work' }))
+  })
+
   it('ignores an in-flight sidebar response after the active profile changes', async () => {
     const work = deferred<SidebarSessionsResponse>()
     const personal = deferred<SidebarSessionsResponse>()
@@ -351,7 +392,7 @@ describe('refreshSessions batches slices into one request', () => {
     expect($messagingSessions.get().map(session => session.id)).toEqual(['personal-signal'])
   })
 
-  it('scopes the cron-jobs fetch to the active profile (all → unified view)', async () => {
+  it('scopes the cron-jobs fetch to the active profile', async () => {
     listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
 
     const scoped = renderHook(() => useSessionListActions({ profileScope: 'work' }))
@@ -361,7 +402,9 @@ describe('refreshSessions batches slices into one request', () => {
     })
 
     expect(getCronJobs).toHaveBeenLastCalledWith('work')
+  })
 
+  it('requests cron jobs for the unified scope', async () => {
     const unified = renderHook(() => useSessionListActions({ profileScope: '__all__' }))
 
     await act(async () => {
@@ -450,6 +493,43 @@ describe('messaging profile scope', () => {
     expect($messagingPlatformTotals.get()).toEqual({ 'work:signal': 2 })
   })
 
+  it('keeps rows from every profile when paginating the unified scope', async () => {
+    setMessagingSessions([row('work-signal', { profile: 'work', source: 'signal' })])
+    listAllProfileSessions.mockResolvedValue({
+      sessions: [
+        row('work-signal', { profile: 'work', source: 'signal' }),
+        row('personal-signal', { profile: 'personal', source: 'signal' })
+      ],
+      total: 2
+    })
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: '__all__' }))
+
+    await act(async () => {
+      await result.current.loadMoreMessagingForPlatform('signal')
+    })
+
+    expect(listAllProfileSessions.mock.calls[0][4]).toBe('all')
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['work-signal', 'personal-signal'])
+    expect($messagingPlatformTotals.get()).toEqual({ 'all:signal': 2 })
+  })
+
+  it('keeps loaded platform rows when pagination fails', async () => {
+    const loaded = [row('work-signal', { profile: 'work', source: 'signal' })]
+    setMessagingSessions(loaded)
+    setMessagingPlatformTotals({ 'work:signal': 12 })
+    listAllProfileSessions.mockRejectedValue(new Error('request failed'))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'work' }))
+
+    await act(async () => {
+      await expect(result.current.loadMoreMessagingForPlatform('signal')).resolves.toBeUndefined()
+    })
+
+    expect($messagingSessions.get()).toEqual(loaded)
+    expect($messagingPlatformTotals.get()).toEqual({ 'work:signal': 12 })
+  })
+
   it('keeps resolved platform totals separate across profile switches', async () => {
     listAllProfileSessions.mockResolvedValue({
       sessions: [row('work-signal', { profile: 'work', source: 'signal' })],
@@ -515,10 +595,7 @@ describe('messaging profile scope', () => {
       await newerLoad
 
       older.resolve({
-        sessions: [
-          row('m1', { profile: 'work', source: 'signal' }),
-          row('m2', { profile: 'work', source: 'signal' })
-        ],
+        sessions: [row('m1', { profile: 'work', source: 'signal' }), row('m2', { profile: 'work', source: 'signal' })],
         total: 2
       })
       await olderLoad

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -96,21 +96,47 @@ interface UseSessionListActionsArgs {
   profileScope: string
 }
 
+const sessionProfileForScope = (profileScope: string): string =>
+  profileScope === ALL_PROFILES ? 'all' : normalizeProfileKey(profileScope)
+
 /** Owns the sidebar's session-list fetching + paging: recents, cron runs/jobs,
  *  and the per-platform messaging slices. Returns the callbacks the controller
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
+  const profileScopeRef = useRef(profileScope)
+  const refreshMessagingSessionsRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
+  profileScopeRef.current = profileScope
 
   // Messaging-platform sessions as their own slice, fetched separately from
   // local recents so each platform renders a self-managed section and never
-  // competes with local chats for the recents page budget. One combined fetch
-  // seeds every platform; the sidebar splits the rows per source.
+  // competes with local chats for the recents page budget. Keep the fetch on
+  // the sidebar's profile scope; otherwise a remote-profile switch leaks one
+  // instance's Telegram/Signal sections into another instance's workspace.
   const refreshMessagingSessions = useCallback(async () => {
+    const sessionProfile = sessionProfileForScope(profileScope)
+
+    // A callback captured before a profile switch may still be queued by an
+    // event subscription. Do not let it start a request or clear current totals.
+    if (sessionProfileForScope(profileScopeRef.current) !== sessionProfile) {
+      return
+    }
+
+    const requestId = refreshMessagingSessionsRequestRef.current + 1
+    refreshMessagingSessionsRequestRef.current = requestId
+    setMessagingPlatformTotals({})
+
     try {
-      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
+      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', sessionProfile, {
         excludeSources: MESSAGING_EXCLUDED_SOURCES
       })
+
+      if (
+        refreshMessagingSessionsRequestRef.current !== requestId ||
+        sessionProfileForScope(profileScopeRef.current) !== sessionProfile
+      ) {
+        return
+      }
 
       // Drop any non-messaging source the broad exclude didn't catch (custom
       // sources) — those stay in local recents, not a platform section.
@@ -123,29 +149,50 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     } catch {
       // Non-fatal: the messaging sections just stay empty/stale.
     }
-  }, [])
+  }, [profileScope])
 
   // Page a single platform's section independently (mirrors the per-profile
   // pager): fetch that source's next window and merge it back in place, leaving
   // every other platform's rows untouched. Resolves the platform's exact total.
-  const loadMoreMessagingForPlatform = useCallback(async (platform: string) => {
-    const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform
-    const loaded = $messagingSessions.get().filter(inPlatform).length
+  const loadMoreMessagingForPlatform = useCallback(
+    async (platform: string) => {
+      const sessionProfile = sessionProfileForScope(profileScope)
 
-    const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', 'all', {
-      source: platform
-    })
+      if (sessionProfileForScope(profileScopeRef.current) !== sessionProfile) {
+        return
+      }
 
-    const incoming = dropTombstoned(result.sessions.filter(s => normalizeSessionSource(s.source) === platform))
+      const inProfile = (s: SessionInfo) =>
+        sessionProfile === 'all' || normalizeProfileKey(s.profile) === sessionProfile
 
-    setMessagingSessions(prev => [
-      ...prev.filter(s => !inPlatform(s)),
-      ...mergeSessionPage(prev.filter(inPlatform), incoming, sessionsToKeep())
-    ])
+      const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform && inProfile(s)
+      const loaded = $messagingSessions.get().filter(inPlatform).length
 
-    const total = result.total ?? incoming.length
-    setMessagingPlatformTotals(prev => ({ ...prev, [platform]: Math.max(total, incoming.length) }))
-  }, [])
+      const result = await listAllProfileSessions(
+        loaded + SIDEBAR_SESSIONS_PAGE_SIZE,
+        1,
+        'exclude',
+        'recent',
+        sessionProfile,
+        { source: platform }
+      )
+
+      if (sessionProfileForScope(profileScopeRef.current) !== sessionProfile) {
+        return
+      }
+
+      const incoming = dropTombstoned(result.sessions.filter(inPlatform))
+
+      setMessagingSessions(prev => [
+        ...prev.filter(s => !inPlatform(s)),
+        ...mergeSessionPage(prev.filter(inPlatform), incoming, sessionsToKeep())
+      ])
+
+      const total = result.total ?? incoming.length
+      setMessagingPlatformTotals(prev => ({ ...prev, [platform]: Math.max(total, incoming.length) }))
+    },
+    [profileScope]
+  )
 
   // Cron *jobs* drive the sidebar "Cron jobs" section. Jobs are created
   // synchronously (agent tool call or the cron UI), so refreshing here right
@@ -156,7 +203,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // own jobs; ALL_PROFILES keeps the unified view.
   const refreshCronJobs = useCallback(async () => {
     try {
-      await refreshCronJobsStore(profileScope === ALL_PROFILES ? 'all' : profileScope)
+      await refreshCronJobsStore(sessionProfileForScope(profileScope))
     } catch {
       // Non-fatal: the cron section just keeps its last-known jobs.
     }
@@ -184,11 +231,11 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       // Unified cross-profile list (served read-only off each profile's
       // state.db; no per-profile backend is spawned). Single-profile users get
       // the same rows tagged profile="default".
-      // Scope recents to the active profile (not always 'all') so a profile
+      // Scope every sidebar slice to the active profile (not always 'all') so a profile
       // with few recent sessions isn't windowed out of the cross-profile
-      // recency page — the empty-history-on-profile-switch bug. Cron + messaging
-      // stay cross-profile.
-      const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+      // recency page and never inherits another profile's cron or messaging
+      // sections. ALL_PROFILES remains the explicit unified view.
+      const sessionProfile = sessionProfileForScope(profileScope)
 
       // Batched: one request opens each profile DB once and returns all three
       // source-scoped slices, instead of three separate listAllProfileSessions

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -102,15 +102,12 @@ interface UseSessionListActionsArgs {
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
   const profileScopeRef = useRef(profileScope)
   const loadMoreMessagingRequestRef = useRef<Record<string, number>>({})
+  const refreshCronJobsRequestRef = useRef(0)
   const refreshMessagingSessionsRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
   profileScopeRef.current = profileScope
 
-  // Messaging-platform sessions as their own slice, fetched separately from
-  // local recents so each platform renders a self-managed section and never
-  // competes with local chats for the recents page budget. Keep the fetch on
-  // the sidebar's profile scope; otherwise a remote-profile switch leaks one
-  // instance's Telegram/Signal sections into another instance's workspace.
+  /** Refresh the active profile's messaging-platform sidebar slice. */
   const refreshMessagingSessions = useCallback(async () => {
     const sessionProfile = messagingProfileFor(profileScope)
 
@@ -148,9 +145,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     }
   }, [profileScope])
 
-  // Page a single platform's section independently (mirrors the per-profile
-  // pager): fetch that source's next window and merge it back in place, leaving
-  // every other platform's rows untouched. Resolves the platform's exact total.
+  /** Page one messaging platform without replacing another platform's rows. */
   const loadMoreMessagingForPlatform = useCallback(
     async (platform: string) => {
       const sessionProfile = messagingProfileFor(profileScope)
@@ -199,22 +194,32 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     [profileScope]
   )
 
-  // Cron *jobs* drive the sidebar "Cron jobs" section. Jobs are created
-  // synchronously (agent tool call or the cron UI), so refreshing here right
-  // after an agent turn surfaces a new job immediately; the interval poll keeps
-  // next-run/state fresh as the scheduler advances them. Jobs live per-profile
-  // on disk and the list endpoint aggregates 'all' by default, so scope the
-  // fetch to the sidebar's profile scope — a concrete profile sees only its
-  // own jobs; ALL_PROFILES keeps the unified view.
+  /** Refresh cron jobs only while the profile that requested them remains active. */
   const refreshCronJobs = useCallback(async () => {
+    const sessionProfile = messagingProfileFor(profileScope)
+
+    if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
+      return
+    }
+
+    const requestId = refreshCronJobsRequestRef.current + 1
+    refreshCronJobsRequestRef.current = requestId
+
     try {
-      await refreshCronJobsStore(messagingProfileFor(profileScope))
+      await refreshCronJobsStore(sessionProfile)
     } catch {
       // Non-fatal: the cron section just keeps its last-known jobs.
     }
   }, [profileScope])
 
+  /** Refresh every sidebar session slice without committing an obsolete profile response. */
   const refreshSessions = useCallback(async () => {
+    const sessionProfile = messagingProfileFor(profileScope)
+
+    if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
+      return
+    }
+
     const requestId = refreshSessionsRequestRef.current + 1
     refreshSessionsRequestRef.current = requestId
     // The loading flag exists to drive the initial skeletons (they only render
@@ -240,8 +245,6 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       // with few recent sessions isn't windowed out of the cross-profile
       // recency page and never inherits another profile's cron or messaging
       // sections. ALL_PROFILES remains the explicit unified view.
-      const sessionProfile = messagingProfileFor(profileScope)
-
       // Batched: one request opens each profile DB once and returns all three
       // source-scoped slices, instead of three separate listAllProfileSessions
       // calls that each reopened + re-counted every profile DB per refresh.
@@ -254,7 +257,10 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         messagingExclude: MESSAGING_EXCLUDED_SOURCES
       })
 
-      if (refreshSessionsRequestRef.current === requestId) {
+      if (
+        refreshSessionsRequestRef.current === requestId &&
+        messagingProfileFor(profileScopeRef.current) === sessionProfile
+      ) {
         const recents = result.recents
 
         // Drop rows the user just deleted/archived: a refresh can race an
@@ -319,7 +325,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     }
 
     // Cron *jobs* are a distinct API (getCronJobs), not a session slice.
-    void refreshCronJobs()
+    if (messagingProfileFor(profileScopeRef.current) === sessionProfile) {
+      void refreshCronJobs()
+    }
   }, [profileScope, refreshCronJobs])
 
   const loadMoreSessions = useCallback(async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -17,7 +17,7 @@ import {
   SIDEBAR_FILTERED_PAGE_SIZE,
   SIDEBAR_SESSIONS_PAGE_SIZE
 } from '@/store/layout'
-import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
+import { messagingProfileFor, messagingTotalsKey, normalizeProfileKey } from '@/store/profile'
 import { $removedSessionIds } from '@/store/projects'
 import {
   $messagingSessions,
@@ -96,9 +96,6 @@ interface UseSessionListActionsArgs {
   profileScope: string
 }
 
-const sessionProfileForScope = (profileScope: string): string =>
-  profileScope === ALL_PROFILES ? 'all' : normalizeProfileKey(profileScope)
-
 /** Owns the sidebar's session-list fetching + paging: recents, cron runs/jobs,
  *  and the per-platform messaging slices. Returns the callbacks the controller
  *  wires into the sidebar and refresh effects. */
@@ -114,17 +111,16 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // the sidebar's profile scope; otherwise a remote-profile switch leaks one
   // instance's Telegram/Signal sections into another instance's workspace.
   const refreshMessagingSessions = useCallback(async () => {
-    const sessionProfile = sessionProfileForScope(profileScope)
+    const sessionProfile = messagingProfileFor(profileScope)
 
     // A callback captured before a profile switch may still be queued by an
-    // event subscription. Do not let it start a request or clear current totals.
-    if (sessionProfileForScope(profileScopeRef.current) !== sessionProfile) {
+    // event subscription. Do not let it start a request against the old scope.
+    if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
       return
     }
 
     const requestId = refreshMessagingSessionsRequestRef.current + 1
     refreshMessagingSessionsRequestRef.current = requestId
-    setMessagingPlatformTotals({})
 
     try {
       const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', sessionProfile, {
@@ -133,7 +129,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       if (
         refreshMessagingSessionsRequestRef.current !== requestId ||
-        sessionProfileForScope(profileScopeRef.current) !== sessionProfile
+        messagingProfileFor(profileScopeRef.current) !== sessionProfile
       ) {
         return
       }
@@ -156,9 +152,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // every other platform's rows untouched. Resolves the platform's exact total.
   const loadMoreMessagingForPlatform = useCallback(
     async (platform: string) => {
-      const sessionProfile = sessionProfileForScope(profileScope)
+      const sessionProfile = messagingProfileFor(profileScope)
 
-      if (sessionProfileForScope(profileScopeRef.current) !== sessionProfile) {
+      if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
         return
       }
 
@@ -177,7 +173,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         { source: platform }
       )
 
-      if (sessionProfileForScope(profileScopeRef.current) !== sessionProfile) {
+      if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
         return
       }
 
@@ -189,7 +185,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       ])
 
       const total = result.total ?? incoming.length
-      setMessagingPlatformTotals(prev => ({ ...prev, [platform]: Math.max(total, incoming.length) }))
+      const totalsKey = messagingTotalsKey(sessionProfile, platform)
+
+      setMessagingPlatformTotals(prev => ({ ...prev, [totalsKey]: Math.max(total, incoming.length) }))
     },
     [profileScope]
   )
@@ -203,7 +201,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // own jobs; ALL_PROFILES keeps the unified view.
   const refreshCronJobs = useCallback(async () => {
     try {
-      await refreshCronJobsStore(sessionProfileForScope(profileScope))
+      await refreshCronJobsStore(messagingProfileFor(profileScope))
     } catch {
       // Non-fatal: the cron section just keeps its last-known jobs.
     }
@@ -235,7 +233,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       // with few recent sessions isn't windowed out of the cross-profile
       // recency page and never inherits another profile's cron or messaging
       // sections. ALL_PROFILES remains the explicit unified view.
-      const sessionProfile = sessionProfileForScope(profileScope)
+      const sessionProfile = messagingProfileFor(profileScope)
 
       // Batched: one request opens each profile DB once and returns all three
       // source-scoped slices, instead of three separate listAllProfileSessions

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -101,6 +101,7 @@ interface UseSessionListActionsArgs {
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
   const profileScopeRef = useRef(profileScope)
+  const loadMoreMessagingRequestRef = useRef<Record<string, number>>({})
   const refreshMessagingSessionsRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
   profileScopeRef.current = profileScope
@@ -158,6 +159,10 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         return
       }
 
+      const requestKey = messagingTotalsKey(sessionProfile, platform)
+      const requestId = (loadMoreMessagingRequestRef.current[requestKey] ?? 0) + 1
+      loadMoreMessagingRequestRef.current[requestKey] = requestId
+
       const inProfile = (s: SessionInfo) =>
         sessionProfile === 'all' || normalizeProfileKey(s.profile) === sessionProfile
 
@@ -173,7 +178,10 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         { source: platform }
       )
 
-      if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
+      if (
+        loadMoreMessagingRequestRef.current[requestKey] !== requestId ||
+        messagingProfileFor(profileScopeRef.current) !== sessionProfile
+      ) {
         return
       }
 
@@ -185,9 +193,8 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       ])
 
       const total = result.total ?? incoming.length
-      const totalsKey = messagingTotalsKey(sessionProfile, platform)
 
-      setMessagingPlatformTotals(prev => ({ ...prev, [totalsKey]: Math.max(total, incoming.length) }))
+      setMessagingPlatformTotals(prev => ({ ...prev, [requestKey]: Math.max(total, incoming.length) }))
     },
     [profileScope]
   )

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 
 import { listAllProfileSessions, listSidebarSessions, type SessionInfo } from '@/hermes'
 import { sameCronSignature } from '@/lib/session-signatures'
@@ -102,10 +102,12 @@ interface UseSessionListActionsArgs {
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
   const profileScopeRef = useRef(profileScope)
   const loadMoreMessagingRequestRef = useRef<Record<string, number>>({})
-  const refreshCronJobsRequestRef = useRef(0)
   const refreshMessagingSessionsRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
-  profileScopeRef.current = profileScope
+
+  useLayoutEffect(() => {
+    profileScopeRef.current = profileScope
+  }, [profileScope])
 
   /** Refresh the active profile's messaging-platform sidebar slice. */
   const refreshMessagingSessions = useCallback(async () => {
@@ -164,14 +166,21 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform && inProfile(s)
       const loaded = $messagingSessions.get().filter(inPlatform).length
 
-      const result = await listAllProfileSessions(
-        loaded + SIDEBAR_SESSIONS_PAGE_SIZE,
-        1,
-        'exclude',
-        'recent',
-        sessionProfile,
-        { source: platform }
-      )
+      let result
+
+      try {
+        result = await listAllProfileSessions(
+          loaded + SIDEBAR_SESSIONS_PAGE_SIZE,
+          1,
+          'exclude',
+          'recent',
+          sessionProfile,
+          { source: platform }
+        )
+      } catch {
+        // Non-fatal: leave the platform's loaded rows and total unchanged.
+        return
+      }
 
       if (
         loadMoreMessagingRequestRef.current[requestKey] !== requestId ||
@@ -201,9 +210,6 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
       return
     }
-
-    const requestId = refreshCronJobsRequestRef.current + 1
-    refreshCronJobsRequestRef.current = requestId
 
     try {
       await refreshCronJobsStore(sessionProfile)

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -17,7 +17,7 @@ import {
   SIDEBAR_FILTERED_PAGE_SIZE,
   SIDEBAR_SESSIONS_PAGE_SIZE
 } from '@/store/layout'
-import { messagingProfileFor, messagingTotalsKey, normalizeProfileKey } from '@/store/profile'
+import { messagingTotalsKey, normalizeProfileKey, sidebarProfileForScope } from '@/store/profile'
 import { $removedSessionIds } from '@/store/projects'
 import {
   $messagingSessions,
@@ -111,11 +111,11 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
   /** Refresh the active profile's messaging-platform sidebar slice. */
   const refreshMessagingSessions = useCallback(async () => {
-    const sessionProfile = messagingProfileFor(profileScope)
+    const sessionProfile = sidebarProfileForScope(profileScope)
 
     // A callback captured before a profile switch may still be queued by an
     // event subscription. Do not let it start a request against the old scope.
-    if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
+    if (sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
       return
     }
 
@@ -129,7 +129,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       if (
         refreshMessagingSessionsRequestRef.current !== requestId ||
-        messagingProfileFor(profileScopeRef.current) !== sessionProfile
+        sidebarProfileForScope(profileScopeRef.current) !== sessionProfile
       ) {
         return
       }
@@ -150,9 +150,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   /** Page one messaging platform without replacing another platform's rows. */
   const loadMoreMessagingForPlatform = useCallback(
     async (platform: string) => {
-      const sessionProfile = messagingProfileFor(profileScope)
+      const sessionProfile = sidebarProfileForScope(profileScope)
 
-      if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
+      if (sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
         return
       }
 
@@ -184,7 +184,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       if (
         loadMoreMessagingRequestRef.current[requestKey] !== requestId ||
-        messagingProfileFor(profileScopeRef.current) !== sessionProfile
+        sidebarProfileForScope(profileScopeRef.current) !== sessionProfile
       ) {
         return
       }
@@ -205,9 +205,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
   /** Refresh cron jobs only while the profile that requested them remains active. */
   const refreshCronJobs = useCallback(async () => {
-    const sessionProfile = messagingProfileFor(profileScope)
+    const sessionProfile = sidebarProfileForScope(profileScope)
 
-    if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
+    if (sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
       return
     }
 
@@ -220,9 +220,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
   /** Refresh every sidebar session slice without committing an obsolete profile response. */
   const refreshSessions = useCallback(async () => {
-    const sessionProfile = messagingProfileFor(profileScope)
+    const sessionProfile = sidebarProfileForScope(profileScope)
 
-    if (messagingProfileFor(profileScopeRef.current) !== sessionProfile) {
+    if (sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
       return
     }
 
@@ -265,7 +265,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       if (
         refreshSessionsRequestRef.current === requestId &&
-        messagingProfileFor(profileScopeRef.current) === sessionProfile
+        sidebarProfileForScope(profileScopeRef.current) === sessionProfile
       ) {
         const recents = result.recents
 
@@ -331,7 +331,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     }
 
     // Cron *jobs* are a distinct API (getCronJobs), not a session slice.
-    if (messagingProfileFor(profileScopeRef.current) === sessionProfile) {
+    if (sidebarProfileForScope(profileScopeRef.current) === sessionProfile) {
       void refreshCronJobs()
     }
   }, [profileScope, refreshCronJobs])

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -152,7 +152,7 @@ describe('Hermes REST helpers', () => {
     })
 
     // Slices reassembled from the legacy per-slice route with the same
-    // scoping: recents on the caller's profile, cron + messaging cross-profile.
+    // scoping: every section follows the caller's profile.
     expect(result.recents.sessions.map(s => s.id)).toEqual(['recent-1'])
     // One row back against a 30-row window: the profile is fully loaded, so
     // the legacy path must not claim there's another page.
@@ -163,7 +163,10 @@ describe('Hermes REST helpers', () => {
     const paths = api.mock.calls.map(call => (call[0] as { path: string }).path)
     expect(paths.filter(p => p.startsWith('/api/profiles/sessions/sidebar'))).toHaveLength(1)
     expect(paths.filter(p => p.startsWith('/api/profiles/sessions?'))).toHaveLength(3)
-    expect(paths).toContainEqual(expect.stringContaining('profile=work'))
+    expect(
+      paths.filter(path => path.startsWith('/api/profiles/sessions?') && path.includes('profile=work'))
+    ).toHaveLength(3)
+    expect(paths.some(path => path.includes('profile=all'))).toBe(false)
     expect(paths).toContainEqual(expect.stringContaining('source=cron'))
     expect(paths).toContainEqual(expect.stringContaining('exclude_sources=cron%2Ctool'))
   })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -542,16 +542,16 @@ function isEndpointMissingError(err: unknown): boolean {
 
 // Compatibility fallback: reassemble the three sidebar slices from the
 // per-slice endpoint, mirroring the batched route's semantics (min_messages=1,
-// archived excluded, recency order; recents scoped to the caller's profile,
-// cron + messaging cross-profile). Rides the same Electron remote-splice
+// archived excluded, recency order; every slice scoped to the caller's profile).
+// Rides the same Electron remote-splice
 // interception as the pre-batching desktop, so remote profiles stay correct.
 async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<SidebarSessionsResponse> {
   const [recents, cron, messaging] = await Promise.all([
     listAllProfileSessions(req.recentsLimit, 1, 'exclude', 'recent', req.recentsProfile, {
       excludeSources: req.recentsExclude
     }),
-    listAllProfileSessions(req.cronLimit, 1, 'exclude', 'recent', 'all', { source: 'cron' }),
-    listAllProfileSessions(req.messagingLimit, 1, 'exclude', 'recent', 'all', {
+    listAllProfileSessions(req.cronLimit, 1, 'exclude', 'recent', req.recentsProfile, { source: 'cron' }),
+    listAllProfileSessions(req.messagingLimit, 1, 'exclude', 'recent', req.recentsProfile, {
       excludeSources: req.messagingExclude
     })
   ])

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -315,11 +315,11 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
 
 export const ALL_PROFILES = '__all__'
 
-// Messaging totals belong to the Desktop profile route as well as the source.
-// Shared by the fetcher and sidebar so neither can read another profile's count.
+/** Normalize a sidebar scope to the profile key used by messaging session queries. */
 export const messagingProfileFor = (profileScope: string): string =>
   profileScope === ALL_PROFILES ? 'all' : normalizeProfileKey(profileScope)
 
+/** Key a platform total by its Desktop profile route so counts cannot leak across profiles. */
 export const messagingTotalsKey = (messagingProfile: string, sourceId: string): string =>
   `${messagingProfile}:${sourceId}`
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -315,8 +315,8 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
 
 export const ALL_PROFILES = '__all__'
 
-/** Normalize a sidebar scope to the profile key used by messaging session queries. */
-export const messagingProfileFor = (profileScope: string): string =>
+/** Normalize a sidebar scope to the profile key used by session and cron queries. */
+export const sidebarProfileForScope = (profileScope: string): string =>
   profileScope === ALL_PROFILES ? 'all' : normalizeProfileKey(profileScope)
 
 /** Key a platform total by its Desktop profile route so counts cannot leak across profiles. */

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -315,6 +315,14 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
 
 export const ALL_PROFILES = '__all__'
 
+// Messaging totals belong to the Desktop profile route as well as the source.
+// Shared by the fetcher and sidebar so neither can read another profile's count.
+export const messagingProfileFor = (profileScope: string): string =>
+  profileScope === ALL_PROFILES ? 'all' : normalizeProfileKey(profileScope)
+
+export const messagingTotalsKey = (messagingProfile: string, sourceId: string): string =>
+  `${messagingProfile}:${sourceId}`
+
 const SHOW_ALL_PROFILES_STORAGE_KEY = 'hermes.desktop.showAllProfiles'
 
 // Opt-in unified view. When false, scope follows the live gateway profile, so


### PR DESCRIPTION
## What does this PR do?

Completes profile isolation in Hermes Desktop for existing installations that map named profiles to different remote backends.

The backend now scopes the batched sidebar endpoint, but several Desktop-only paths could still bypass that contract:

- Electron rebuilt remote-profile sidebar slices with cron and messaging forced to `profile=all`;
- the older-backend fallback and standalone messaging refresh/pagination paths also forced `all`;
- responses and callbacks captured before a profile switch could later overwrite the active profile;
- messaging totals and stored-session lookup could reuse state from another profile.

The result was that one remote instance's messaging sections could appear inside another instance's workspace. This PR makes the selected profile authoritative across recents, cron, messaging, pagination, totals, and stored-session resolution. The explicit **All profiles** view remains the only unified view.

## Relationship to recent upstream work

- **#83052** added the server-side batched profile-scope contract. This PR covers Electron's per-profile remote fan-out, older-backend compatibility, renderer filtering, pagination/totals, and async race guards that remain client-side.
- **#86325** fixed the complementary transport problem: distinct profile backends must not accidentally reuse the primary socket. This PR fixes the data shown after the correct socket/backend is selected. Both pieces are required for an A → B → A Desktop switch to stay isolated.
- **#86272** substantially overlaps the socket-routing side now covered by #86325; it does not replace the sidebar/data-isolation changes here.
- The new connection-registry/agent-roster path does not remove the existing per-profile override path. Existing Desktop configurations and compatibility fallbacks still exercise the code changed here.

Fixes #42915.
Fixes #56631.
Fixes #60678.

Partially addresses #63593: this fixes its cross-profile messaging leakage; its independent empty-profile sidebar visibility behavior is unchanged.

This consolidates the remaining profile-scope work from #42934, #44157, #56635, #60688, and #71526, with relevant contributors credited in commit trailers. #63618 contains separate sidebar-visibility work and is only partially overlapped.

## Changes made

- Centralize Electron's remote sidebar slice parameters so recents, cron, and messaging share the selected scope.
- Match that scope in the legacy fallback and standalone messaging polling/pagination paths.
- Reject stale profile callbacks, out-of-order responses, and obsolete overlapping pagination requests before shared-store writes.
- Key resolved messaging totals by `profile:source`, preserving A's count across A → B → A without leaking it into B.
- Apply the canonical scope filter before messaging groups and the pinned-session index, including the persisted single-profile edge case.
- Resolve stored rows from regular, cron, and messaging caches before the by-ID fallback so opening a messaging row does not duplicate it into regular Sessions.
- Add regression coverage for concrete/all scopes, defaults, pagination, totals, remote routing, fallback behavior, stale callbacks, discarded renders, and overlapping requests.

Project/worktree-grouped presentation is unchanged: messaging sections remain hidden there, matching current `main`.

## How to test

1. Keep the Desktop default connection local and configure two named profiles with different remote URL overrides and messaging integrations.
2. Select profile A and verify only A's messaging sections/sessions appear; repeat for profile B.
3. Switch profiles while a refresh is in flight and verify the old profile never reappears.
4. Select **All profiles** and verify both sets are visible.
5. Load more within a messaging platform, switch A → B → A, and verify A's exact count/load-more state is restored without leaking into B.

### Automated validation

Current head `b4633a5af`, based on upstream `951ae62ff`:

- Focused changed-path Vitest suites: **5 files / 68 tests passed** (58 renderer + 10 Electron).
- `npm --prefix apps/desktop run typecheck` passed.
- Full Desktop ESLint passed with **0 errors** (107 warnings already present in the current tree).
- `npm --prefix apps/desktop run build` passed.
- The packaged Windows build (`electron-builder --dir`) completed successfully.
- Broader Windows UI run: 4,333 passed; the four failures that remain when rerun in isolation are locale-sensitive number/currency assertions and reproduce on a clean upstream worktree. The additional failures seen only under the concurrent full run disappear in isolation.
- Broader Windows Electron run: 1,183 passed; 26 failures are existing POSIX-only assumptions around Unix modes/sockets/symlink permissions, outside this platform-neutral diff.

### Manual validation

- **Windows 11 packaged app:** built and launched the current PR head, started with a ready local/default gateway, and displayed `barry`, `bertha`, and `claude-martin` in the profile rail. Switching to Claude Martin connected to its HTTPS backend and showed **Signal + API**, with no Telegram/WhatsApp. Switching to Barry connected to its different HTTPS backend and showed **Telegram + WhatsApp + API**, with no Signal. Switching back restored Claude Martin's Signal-only messaging view with the gateway ready. Both remotes reported client/backend `v0.20.1`.
- **macOS packaged app:** previously validated the same two-live-remote A → B → A flow, including exact-response chat smoke tests and opening a cached Messaging row without duplicating it into regular Sessions.

## Checklist

### Code

- [x] Read the Contributing Guide and Desktop Engineering Guide
- [x] Conventional commit messages
- [x] Searched related open/closed issues and PRs
- [x] Preserved credit for overlapping prior work
- [x] Scoped to the Desktop profile-isolation bug class
- [x] Added behavior-level regression tests
- [x] Tested on Windows 11 and macOS

### Documentation & housekeeping

- [x] Documentation/config examples are not required for this behavioral fix
- [x] Cross-platform impact considered; routing and renderer state are platform-neutral
- [x] No tool-schema changes
