### PR TITLE
feat(gateway): combine interim activity with progress

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -33,6 +33,8 @@ from typing import Any
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
     "tool_progress_grouping": "accumulate",  # "accumulate" = edit one bubble; "separate" = one msg per tool
+    "tool_progress_collapsible": False,
+    "tool_progress_max_chars": 0,  # 0 = existing platform-sized rollover behavior
     "show_reasoning": False,
     # How a reasoning/thinking summary is rendered when show_reasoning is on.
     #   "code"      -> 💭 **Reasoning:** + fenced code block (legacy default)
@@ -266,10 +268,16 @@ def _normalise(setting: str, value: Any) -> Any:
         if val in {"true", "1", "yes", "on"}:
             return "all"
         return val if val in {"off", "new", "all", "verbose", "log"} else "all"
+    if setting == "interim_assistant_messages":
+        if isinstance(value, str):
+            val = value.strip().lower()
+            if val == "progress":
+                return "progress"
+            return val in {"true", "1", "yes", "on", "raw", "verbose"}
+        return bool(value)
     if setting in {
         "show_reasoning",
         "streaming",
-        "interim_assistant_messages",
         "long_running_notifications",
         "busy_ack_detail",
         "busy_steer_ack_enabled",
@@ -281,7 +289,7 @@ def _normalise(setting: str, value: Any) -> Any:
                 return "generic"
             return val in {"true", "1", "yes", "on", "raw", "verbose"}
         return bool(value)
-    if setting == "cleanup_progress":
+    if setting in {"cleanup_progress", "tool_progress_collapsible"}:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)
@@ -306,6 +314,11 @@ def _normalise(setting: str, value: Any) -> Any:
     if setting == "tool_preview_length":
         try:
             return int(value)
+        except (TypeError, ValueError):
+            return 0
+    if setting == "tool_progress_max_chars":
+        try:
+            return max(0, int(value))
         except (TypeError, ValueError):
             return 0
     return value

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3374,6 +3374,18 @@ class BasePlatformAdapter(ABC):
         """
         return preview.text
 
+    def render_progress_message(
+        self, entries: list[str], *, collapsible: bool = False
+    ) -> str:
+        """Render one editable gateway activity/progress message.
+
+        The base rendering preserves the existing plain newline-separated
+        bubble. Adapters with a native disclosure primitive may override the
+        opt-in ``collapsible`` form without moving message ownership out of the
+        gateway.
+        """
+        return "\n".join(str(entry) for entry in entries)
+
     @property
     def has_fatal_error(self) -> bool:
         return self._fatal_error_message is not None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4121,6 +4121,13 @@ class TurnRunner:
                 _progress_len_fn = adapter.message_len_fn_for_chat(ctx.source.chat_id)
             except Exception:
                 pass
+        if ctx.progress_collapsible:
+            try:
+                _rich_limit = adapter.streaming_overflow_limit()
+                if _rich_limit:
+                    _raw_progress_limit = max(_raw_progress_limit, int(_rich_limit))
+            except Exception:
+                pass
         # Leave a little room for platform quirks / formatting.  For tiny
         # test adapters keep the limit usable instead of clamping to 500+.
         _PROGRESS_TEXT_LIMIT = max(
@@ -4157,7 +4164,58 @@ class TurnRunner:
             return await adapter.edit_message(**kwargs)
 
         def _progress_text(lines: list) -> str:
+            renderer = getattr(adapter, "render_progress_message", None)
+            if callable(renderer):
+                return renderer(
+                    [str(line) for line in lines],
+                    collapsible=ctx.progress_collapsible,
+                )
             return "\n".join(str(line) for line in lines)
+
+        def _trim_progress_tail() -> None:
+            """Keep newest whole activity events within configured/platform caps."""
+            nonlocal progress_lines
+            configured_limit = max(0, int(ctx.progress_max_chars or 0))
+
+            def _body_text() -> str:
+                return "\n".join(str(line) for line in progress_lines)
+
+            if configured_limit:
+                while len(progress_lines) > 1 and len(_body_text()) > configured_limit:
+                    progress_lines.pop(0)
+                if progress_lines and len(_body_text()) > configured_limit:
+                    text = str(progress_lines[0])
+                    progress_lines[0] = (
+                        "…" + text[-(configured_limit - 1):]
+                        if configured_limit > 1
+                        else "…"
+                    )
+            else:
+                # Zero preserves the legacy platform-sized split/rollover path.
+                return
+
+            while (
+                len(progress_lines) > 1
+                and _progress_len_fn(_progress_text(progress_lines)) > _PROGRESS_TEXT_LIMIT
+            ):
+                progress_lines.pop(0)
+
+            # A single unusually large event must still remain one editable
+            # message. Trim from its oldest edge until the rendered wrapper fits.
+            while (
+                progress_lines
+                and _progress_len_fn(_progress_text(progress_lines)) > _PROGRESS_TEXT_LIMIT
+            ):
+                text = str(progress_lines[0])
+                if len(text) <= 1:
+                    break
+                excess = max(
+                    1,
+                    _progress_len_fn(_progress_text(progress_lines))
+                    - _PROGRESS_TEXT_LIMIT,
+                )
+                keep = max(1, len(text) - excess - 1)
+                progress_lines[0] = "…" + text[-keep:]
 
         def _split_progress_groups(lines: list) -> list[list]:
             """Partition progress lines into platform-sized editable bubbles."""
@@ -4202,6 +4260,11 @@ class TurnRunner:
                 """
             nonlocal progress_msg_id, progress_lines, can_edit
             if not progress_lines or not can_edit:
+                return False
+            _trim_progress_tail()
+            if ctx.progress_max_chars:
+                # A bounded rolling feed edits one stable message and evicts
+                # old entries instead of creating overflow continuations.
                 return False
             groups = _split_progress_groups(progress_lines)
             if len(groups) <= 1:
@@ -4284,6 +4347,9 @@ class TurnRunner:
                     ctx.last_progress_msg[0] = None
                     ctx.repeat_count[0] = 0
                     continue
+                elif isinstance(raw, tuple) and len(raw) == 2 and raw[0] == "__interim__":
+                    msg = str(raw[1])
+                    progress_lines.append(msg)
                 else:
                     msg = raw
                     progress_lines.append(msg)
@@ -4313,7 +4379,7 @@ class TurnRunner:
 
                 if can_edit and progress_msg_id is not None:
                     # Try to edit the existing progress message
-                    full_text = "\n".join(progress_lines)
+                    full_text = _progress_text(progress_lines)
                     result = await _edit_progress_message(progress_msg_id, full_text)
                     if not result.success:
                         _err = (getattr(result, "error", "") or "").lower()
@@ -4353,7 +4419,7 @@ class TurnRunner:
                 else:
                     if can_edit:
                         # First tool: send all accumulated text as new message
-                        full_text = "\n".join(progress_lines)
+                        full_text = _progress_text(progress_lines)
                         result = await adapter.send(
                             chat_id=ctx.source.chat_id,
                             content=full_text,
@@ -4407,6 +4473,9 @@ class TurnRunner:
                             progress_lines = []
                             ctx.last_progress_msg[0] = None
                             ctx.repeat_count[0] = 0
+                        elif isinstance(raw, tuple) and len(raw) == 2 and raw[0] == "__interim__":
+                            progress_lines.append(str(raw[1]))
+                            await _roll_progress_overflow_if_needed()
                         else:
                             progress_lines.append(raw)
                             await _roll_progress_overflow_if_needed()
@@ -4678,9 +4747,20 @@ class TurnRunner:
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
-        _want_stream_deltas = _streaming_enabled
+        # A combined activity feed must own interim commentary before any
+        # visible content bubble is created. The provider delta callback does
+        # not identify commentary vs. final-answer tokens, so progress mode
+        # deliberately disables visible text streaming for this turn. The final
+        # answer is delivered normally after the activity message.
+        _want_stream_deltas = (
+            _streaming_enabled
+            and ctx.interim_assistant_messages_mode != "progress"
+        )
         _want_interim_messages = ctx.interim_assistant_messages_enabled
-        _want_interim_consumer = _want_interim_messages
+        _want_interim_consumer = (
+            _want_interim_messages
+            and ctx.interim_assistant_messages_mode != "progress"
+        )
         if _want_stream_deltas or _want_interim_consumer:
             try:
                 from gateway.stream_consumer import GatewayStreamConsumer
@@ -4729,6 +4809,13 @@ class TurnRunner:
             if not ctx._run_still_current():
                 return
             display_text = text
+            if ctx.interim_assistant_messages_mode == "progress":
+                if (
+                    ctx.progress_queue is not None
+                    and str(display_text or "").strip()
+                ):
+                    ctx.progress_queue.put(("__interim__", str(display_text)))
+                return
             if _stream_consumer is not None:
                 if already_streamed:
                     _stream_consumer.on_segment_break()
@@ -25432,6 +25519,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
+        progress_collapsible = bool(
+            resolve_display_setting(user_config, platform_key, "tool_progress_collapsible")
+        )
+        progress_max_chars = int(
+            resolve_display_setting(user_config, platform_key, "tool_progress_max_chars") or 0
+        )
         from gateway.status_phrases import choose_status_phrase, resolve_status_phrase_catalog
         _generic_status_recent: List[str] = []
         _generic_status_catalog = resolve_status_phrase_catalog(user_config, platform_key)
@@ -25443,7 +25536,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             require_platform_override_for: set[Any] | None = None,
             allow_generic: bool = False,
         ) -> str:
-            """Return off|raw|generic for a gateway visibility surface."""
+            """Return off|raw|generic|progress for a visibility surface."""
             if require_platform_override_for:
                 current_platform = _gateway_platform_value(source.platform)
                 platform_only = {
@@ -25456,8 +25549,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ):
                     return "off"
             value = resolve_display_setting(user_config, platform_key, setting, default)
-            if isinstance(value, str) and value.strip().lower() == "generic":
-                return "generic" if allow_generic else "off"
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                if normalized == "generic":
+                    return "generic" if allow_generic else "off"
+                if normalized == "progress" and setting == "interim_assistant_messages":
+                    return "progress"
             return "raw" if bool(value) else "off"
 
         def _generic_status_phrase(kind: str, *, tool_name: str | None = None, preview: str | None = None, args: Any = None) -> str:
@@ -25518,7 +25615,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             require_platform_override_for={Platform.MATTERMOST},
         )
         _thinking_enabled = _thinking_mode != "off"
-        needs_progress_queue = tool_progress_enabled or _thinking_enabled
+        needs_progress_queue = (
+            tool_progress_enabled
+            or _thinking_enabled
+            or interim_assistant_messages_mode == "progress"
+        )
 
 
         # Queue for progress messages (thread-safe)
@@ -25590,6 +25691,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _thinking_enabled=_thinking_enabled,
             progress_mode=progress_mode,
             progress_grouping=progress_grouping,
+            progress_collapsible=progress_collapsible,
+            progress_max_chars=progress_max_chars,
             tool_progress_enabled=tool_progress_enabled,
             progress_queue=progress_queue,
             log_queue=log_queue,
@@ -25609,6 +25712,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             disabled_toolsets=disabled_toolsets,
             log_mode_enabled=log_mode_enabled,
             interim_assistant_messages_enabled=interim_assistant_messages_enabled,
+            interim_assistant_messages_mode=interim_assistant_messages_mode,
             needs_progress_queue=needs_progress_queue,
             _voice_ack_fired=_voice_ack_fired,
             _voice_ack_guild=_voice_ack_guild,

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -41,6 +41,8 @@ class TurnContext:
     _thinking_enabled: bool = False
     progress_mode: str = "off"
     progress_grouping: str = "grouped"
+    progress_collapsible: bool = False
+    progress_max_chars: int = 0
     tool_progress_enabled: bool = False
 
     # --- queues ----------------------------------------------------------
@@ -96,6 +98,7 @@ class TurnContext:
     disabled_toolsets: Any = None
     log_mode_enabled: bool = False
     interim_assistant_messages_enabled: bool = False
+    interim_assistant_messages_mode: str = "off"
     needs_progress_queue: bool = False
 
     # --- lazy-imported callables captured from the outer body -------------

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1250,12 +1250,16 @@ DEFAULT_CONFIG = {
             "first_lines": 2,
             "last_lines": 2,
         },
-        "interim_assistant_messages": True,  # Gateway: send natural mid-turn assistant status messages. Desktop: keep mid-turn narration between tool calls instead of collapsing to the final message.
+        # Gateway: true sends natural mid-turn assistant status messages;
+        # "progress" appends them to the editable tool/activity bubble instead.
+        # Desktop: true keeps mid-turn narration between tool calls instead of
+        # collapsing to the final message.
+        "interim_assistant_messages": True,
         # Codex Responses models narrate progress in a dedicated commentary
-        # channel. When true (default), completed commentary messages are
-        # delivered as visible mid-turn updates via the interim message path.
-        # When false, commentary falls back to the reasoning channel and is
-        # only visible when show_reasoning is enabled.
+        # channel. When enabled (default: true), completed commentary messages
+        # are delivered through the configured interim message path. When false,
+        # commentary falls back to the reasoning channel and is only visible
+        # when show_reasoning is enabled.
         "show_commentary": True,
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         # NOTE: display.tool_progress_overrides is deprecated and no longer
@@ -1284,6 +1288,12 @@ DEFAULT_CONFIG = {
         # applies where tool_progress is already enabled. Per-platform override
         # via display.platforms.<platform>.tool_progress_grouping.
         "tool_progress_grouping": "accumulate",
+        # Render the editable activity bubble through a platform-native
+        # disclosure primitive where supported (Telegram Rich Messages).
+        "tool_progress_collapsible": False,
+        # Rolling character budget for one editable activity bubble. Zero keeps
+        # the legacy platform-sized split/rollover behavior.
+        "tool_progress_max_chars": 0,
         # Optional custom phrases for generic long-running status messages.
         # Built-in defaults live in gateway/assets/status_phrases.yaml. Users
         # can set `path`/`paths` to HERMES_HOME-relative YAML files/directories

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1775,6 +1775,18 @@ class TelegramAdapter(BasePlatformAdapter):
             payload["skip_entity_detection"] = True
         return payload
 
+    def render_progress_message(
+        self, entries: list[str], *, collapsible: bool = False
+    ) -> str:
+        """Render opt-in activity as one native Rich Message details block."""
+        if not collapsible:
+            return super().render_progress_message(entries, collapsible=False)
+        safe_entries = [_html.escape(str(entry), quote=False) for entry in entries]
+        latest = " ".join(str(entries[-1]).split()) if entries else "Working"
+        latest = _html.escape(latest[:120], quote=False)
+        body = "\n\n".join(safe_entries)
+        return f"<details><summary>{latest}</summary>\n\n{body}\n\n</details>"
+
     def _is_rich_capability_error(self, exc: Exception) -> bool:
         """True ⇒ the rich endpoint itself is unavailable (old PTB/server).
 

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -114,6 +114,37 @@ class TestYAMLNormalisation:
         config = {"display": {"platforms": {"whatsapp": {"thinking_progress": "false"}}}}
         assert resolve_display_setting(config, "whatsapp", "thinking_progress") is False
 
+    def test_interim_progress_and_activity_limits_are_preserved(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "interim_assistant_messages": "progress",
+                        "tool_progress_collapsible": "true",
+                        "tool_progress_max_chars": "6000",
+                    }
+                }
+            }
+        }
+        assert resolve_display_setting(
+            config, "telegram", "interim_assistant_messages"
+        ) == "progress"
+        assert resolve_display_setting(
+            config, "telegram", "tool_progress_collapsible"
+        ) is True
+        assert resolve_display_setting(
+            config, "telegram", "tool_progress_max_chars"
+        ) == 6000
+
+    def test_activity_feed_config_defaults_preserve_legacy_behavior(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        display = DEFAULT_CONFIG["display"]
+        assert display["tool_progress_collapsible"] is False
+        assert display["tool_progress_max_chars"] == 0
+
 
 # ---------------------------------------------------------------------------
 # Built-in platform defaults (tier system)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -376,6 +376,56 @@ class DelayedInterimAgent:
         }
 
 
+class MixedActivityFeedAgent:
+    """Emits tools and commentary into one bounded activity feed."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        assert self.tool_progress_callback is not None
+        assert self.interim_assistant_callback is not None
+        self.tool_progress_callback("tool.started", "terminal", "oldest-command", {})
+        time.sleep(0.35)
+        self.interim_assistant_callback("I found the relevant gateway seam.")
+        self.tool_progress_callback("tool.started", "terminal", "newest-command", {})
+        time.sleep(0.1)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class AlreadyStreamedActivityFeedAgent(MixedActivityFeedAgent):
+    """Models providers that mark pre-tool narration as already streamed."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        assert self.interim_assistant_callback is not None
+        assert self.tool_progress_callback is not None
+        # Progress mode must decline visible stream deltas, then still accept
+        # the provider's already_streamed marker into the activity feed.
+        assert self.stream_delta_callback is None
+        self.interim_assistant_callback(
+            "Provider-marked streamed commentary.", already_streamed=True
+        )
+        self.tool_progress_callback("tool.started", "terminal", "verify-command", {})
+        time.sleep(0.35)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class CollapsibleProgressCaptureAdapter(ProgressCaptureAdapter):
+    """Expose the platform progress renderer expected by the gateway."""
+
+    def render_progress_message(self, entries, *, collapsible=False):
+        body = "\n".join(entries)
+        if not collapsible:
+            return body
+        return f"<details><summary>{entries[-1]}</summary>\n{body}\n</details>"
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -1024,6 +1074,73 @@ async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, 
     assert result.get("already_sent") is not True
     assert adapter.edits == []
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+
+
+@pytest.mark.asyncio
+async def test_interim_progress_mode_shares_one_bounded_collapsible_tool_bubble(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        MixedActivityFeedAgent,
+        session_id="sess-collapsible-activity-feed",
+        config_data={
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "all",
+                        "tool_progress_grouping": "accumulate",
+                        "interim_assistant_messages": "progress",
+                        "tool_progress_collapsible": True,
+                        "tool_progress_max_chars": 70,
+                    }
+                }
+            }
+        },
+        adapter_cls=CollapsibleProgressCaptureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"].startswith("<details>")
+    rendered = adapter.edits[-1]["content"]
+    assert rendered.startswith("<details>")
+    assert "I found the relevant gateway seam." in rendered
+    assert "newest-command" in rendered
+    assert "oldest-command" not in rendered
+    assert all(call["content"] != "I found the relevant gateway seam." for call in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_interim_progress_mode_owns_provider_already_streamed_commentary(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        AlreadyStreamedActivityFeedAgent,
+        session_id="sess-progress-already-streamed-commentary",
+        config_data={
+            "streaming": {"enabled": True},
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "off",
+                        "interim_assistant_messages": "progress",
+                        "tool_progress_collapsible": True,
+                        "tool_progress_max_chars": 6000,
+                    }
+                }
+            },
+        },
+        adapter_cls=CollapsibleProgressCaptureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert "Provider-marked streamed commentary." in adapter.sent[0]["content"]
+    assert adapter.sent[0]["content"].startswith("<details>")
 
 
 class TransformedStreamAgent:

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -448,6 +448,41 @@ def test_streaming_overflow_limit_none_when_rich_latched_off():
     assert adapter.streaming_overflow_limit() is None
 
 
+def test_collapsible_progress_renderer_produces_rich_details_with_latest_summary():
+    adapter = _make_adapter()
+
+    rendered = adapter.render_progress_message(
+        ["💻 terminal: pytest", "I found the gateway seam."],
+        collapsible=True,
+    )
+
+    assert rendered.startswith("<details>")
+    assert "<summary>I found the gateway seam.</summary>" in rendered
+    assert "💻 terminal: pytest" in rendered
+    assert rendered.endswith("</details>")
+    assert adapter._rich_eligible(rendered) is True
+
+
+@pytest.mark.asyncio
+async def test_collapsible_progress_over_legacy_limit_edits_in_place_as_rich():
+    adapter = _make_adapter()
+    rendered = adapter.render_progress_message(["x" * 5000], collapsible=True)
+
+    assert len(rendered) > 4096
+    rich_limit = adapter.streaming_overflow_limit()
+    assert rich_limit is not None
+    assert len(rendered) < rich_limit
+
+    result = await adapter.edit_message("12345", "555", rendered, finalize=True)
+
+    assert result.success is True
+    assert result.message_id == "555"
+    api_kwargs = _rich_edit_kwargs(adapter)
+    assert api_kwargs["rich_message"]["markdown"] == rendered
+    assert adapter._bot is not None
+    adapter._bot.edit_message_text.assert_not_called()
+
+
 # ----------------------------------------------------------------------------
 # Rich finalize via editMessageText (Bot API 10.1 rich_message edit param).
 # Streamed previews finalize by editing the existing message IN PLACE as rich,

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -770,6 +770,40 @@ display:
 
 Defaults to `false`. Only platforms whose adapter implements `delete_message` honor the setting (currently Telegram and Discord). Failed runs **skip** cleanup so the bubbles remain as breadcrumbs.
 
+### Combined activity feed (opt-in)
+
+Interim assistant commentary can share the editable tool-progress bubble instead
+of creating separate messages. Telegram can additionally render that bubble as a
+native Rich Message disclosure (`Show more`):
+
+```yaml
+display:
+  platforms:
+    telegram:
+      tool_progress: all
+      tool_progress_grouping: accumulate
+      interim_assistant_messages: progress
+      tool_progress_collapsible: true
+      tool_progress_max_chars: 6000
+      cleanup_progress: true
+
+telegram:
+  extra:
+    rich_messages: true
+```
+
+`tool_progress_max_chars` is a rolling character budget for the activity body.
+When it is exceeded, Hermes removes the oldest complete events while keeping the
+same editable message. A single overlong event is trimmed from its oldest edge.
+The default is `0`, which preserves the existing platform-sized rollover
+behavior. `cleanup_progress` deletes the entire combined activity message after
+a successful final reply, including commentary hidden inside the disclosure.
+Telegram's native disclosure and 32,768-character Rich Message limit require
+`telegram.extra.rich_messages: true`; without it, Telegram
+uses the legacy MarkdownV2 fallback. Progress-mode commentary also owns the
+visible mid-turn surface, so text token streaming is disabled for that turn and
+the completed final answer is sent separately.
+
 ## Next Steps
 
 - [Telegram Setup](telegram.md)


### PR DESCRIPTION
## What changed

- adds `interim_assistant_messages: progress` so commentary can share the editable tool-progress message
- adds a character-bounded rolling activity feed with `tool_progress_max_chars`; oldest complete events are removed first
- adds `tool_progress_collapsible` and renders Telegram activity as a native Rich Message `<details>` block
- routes both the initial send and later edits through the same platform renderer
- keeps cleanup tied to the original progress message ID, so the combined disclosure is deleted after a successful final reply

## Why

Interim commentary currently creates a separate chat message. That also resets the accumulated tool-progress bubble, so a single agent turn can leave several progress messages behind. Telegram Rich Messages support editable disclosure blocks and a 32,768-character payload, which is a better fit for this temporary activity log.

Example:

```yaml
display:
  platforms:
    telegram:
      tool_progress: all
      tool_progress_grouping: accumulate
      interim_assistant_messages: progress
      tool_progress_collapsible: true
      tool_progress_max_chars: 6000
      cleanup_progress: true

telegram:
  extra:
    rich_messages: true
```

## Compatibility

The new behavior is opt-in. Defaults remain `tool_progress_collapsible: false` and `tool_progress_max_chars: 0`, which preserves the existing plain rendering and platform-sized rollover behavior. Boolean `interim_assistant_messages` values keep their current meaning. Progress mode owns the visible mid-turn surface, so it disables text token streaming for that turn and sends the completed final answer separately. Telegram native disclosure rendering also requires the existing `rich_messages` opt-in.

## Verification

- 83 focused gateway/config/Telegram Rich Message/cleanup tests
- Ruff on all changed Python files
- `git diff --check`
- Rich in-place edit test with a 5,000-character activity message
