### PR TITLE
fix(todo): preserve items without explicit id during deduplication

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -30,6 +30,16 @@ class TestWriteAndRead:
             {"id": "1", "content": "Latest version", "status": "in_progress"},
         ]
 
+    def test_write_preserves_items_without_ids(self):
+        store = TodoStore()
+        result = store.write([
+            {"content": "Task 1", "status": "pending"},
+            {"content": "Task 2", "status": "pending"},
+        ])
+        assert len(result) == 2
+        assert result[0]["content"] == "Task 1"
+        assert result[1]["content"] == "Task 2"
+
 
 class TestHasItems:
     def test_empty_store(self):

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -196,8 +196,12 @@ class TodoStore:
                 # Non-dict items get a synthetic key so _validate can handle them
                 last_index[f"__invalid_{i}"] = i
                 continue
-            item_id = str(item.get("id", "")).strip() or "?"
-            last_index[item_id] = i
+            raw_id = item.get("id", "")
+            item_id = str(raw_id).strip() if raw_id is not None else ""
+            if not item_id:
+                last_index[f"__missing_id_{i}"] = i
+            else:
+                last_index[item_id] = i
         return [todos[i] for i in sorted(last_index.values())]
 
 


### PR DESCRIPTION
## Summary

Items missing `id` collapsed to one dedupe key. Use per-index synthetic keys until validation assigns fallback ids.

## Testing

- `python3 -m pytest tests/tools/test_todo_tool.py -q` — 15 passed

Closes #83389