### PR TITLE
fix(todo): reject empty content instead of silent placeholder

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from tools.todo_tool import TodoStore, todo_tool
 
 
@@ -90,6 +92,66 @@ class TestMergeMode:
         )
         items = store.read()
         assert len(items) == 2
+
+
+class TestEmptyContentValidation:
+    """Issue #44496 — empty/missing content must fail, not silently substitute."""
+
+    def test_validate_raises_on_empty_content(self):
+        with pytest.raises(ValueError, match="missing required 'content'"):
+            TodoStore._validate({"id": "x", "content": "", "status": "pending"})
+
+    def test_validate_raises_on_missing_content(self):
+        with pytest.raises(ValueError, match="missing required 'content'"):
+            TodoStore._validate({"id": "x", "status": "pending"})
+
+    def test_validate_raises_on_whitespace_content(self):
+        with pytest.raises(ValueError, match="missing required 'content'"):
+            TodoStore._validate({"id": "x", "content": "   ", "status": "pending"})
+
+    def test_replace_leaves_list_unchanged_on_empty_content(self):
+        store = TodoStore()
+        store.write([{"id": "1", "content": "Keep me", "status": "pending"}])
+        with pytest.raises(ValueError):
+            store.write([{"id": "2", "content": "", "status": "pending"}])
+        items = store.read()
+        assert len(items) == 1
+        assert items[0]["content"] == "Keep me"
+        assert not any("(no description)" in t["content"] for t in items)
+
+    def test_replace_via_todo_tool_returns_error(self):
+        store = TodoStore()
+        store.write([{"id": "1", "content": "Keep me", "status": "pending"}])
+        result = json.loads(
+            todo_tool(
+                todos=[{"id": "2", "content": "", "status": "pending"}],
+                store=store,
+            )
+        )
+        assert "error" in result
+        assert "content" in result["error"]
+        items = store.read()
+        assert len(items) == 1
+        assert items[0]["content"] == "Keep me"
+
+    def test_merge_status_only_preserves_content(self):
+        store = TodoStore()
+        store.write([{"id": "1", "content": "Original", "status": "pending"}])
+        store.write([{"id": "1", "status": "completed"}], merge=True)
+        items = store.read()
+        assert items[0]["content"] == "Original"
+        assert items[0]["status"] == "completed"
+
+    def test_merge_new_item_without_content_returns_error(self):
+        store = TodoStore()
+        store.write([{"id": "1", "content": "Keep me", "status": "pending"}])
+        result = json.loads(
+            todo_tool(todos=[{"id": "2", "status": "pending"}], merge=True, store=store)
+        )
+        assert "error" in result
+        items = store.read()
+        assert len(items) == 1
+        assert items[0]["content"] == "Keep me"
 
 
 class TestTodoToolFunction:

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -71,7 +71,16 @@ class TodoStore:
         else:
             # Merge mode: update existing items by id, append new ones
             existing = {item["id"]: item for item in self._items}
-            for t in self._dedupe_by_id(todos):
+            existing_ids = set(existing.keys())
+            deduped = self._dedupe_by_id(todos)
+            # Validate new items before mutating so a bad call is transactional
+            new_items = {}
+            for t in deduped:
+                item_id = str(t.get("id", "")).strip()
+                if item_id and item_id not in existing_ids:
+                    validated = self._validate(t)
+                    new_items[item_id] = validated
+            for t in deduped:
                 item_id = str(t.get("id", "")).strip()
                 if not item_id:
                     continue  # Can't merge without an id
@@ -85,8 +94,8 @@ class TodoStore:
                         if status in VALID_STATUSES:
                             existing[item_id]["status"] = status
                 else:
-                    # New item -- validate fully and append to end
-                    validated = self._validate(t)
+                    # New item -- already validated above
+                    validated = new_items[item_id]
                     existing[validated["id"]] = validated
                     self._items.append(validated)
             # Rebuild _items preserving order for existing items
@@ -177,9 +186,10 @@ class TodoStore:
 
         content = str(item.get("content", "")).strip()
         if not content:
-            content = "(no description)"
-        else:
-            content = TodoStore._cap_content(content)
+            raise ValueError(
+                f"todo item {item_id!r} is missing required 'content' field"
+            )
+        content = TodoStore._cap_content(content)
 
         status = str(item.get("status", "pending")).strip().lower()
         if status not in VALID_STATUSES:
@@ -231,7 +241,10 @@ def todo_tool(
             return tool_error(
                 f"todos must be a list, got {type(todos).__name__}"
             )
-        items = store.write(todos, merge)
+        try:
+            items = store.write(todos, merge)
+        except ValueError as exc:
+            return tool_error(str(exc))
     else:
         items = store.read()
 


### PR DESCRIPTION
## Summary

Empty todo `content` was replaced with `(no description)`. Raise instead, return a tool error, and leave the list unchanged.

## Testing

- `python3 -m pytest tests/tools/test_todo_tool.py -q` — 21 passed

Closes #44496