### PR TITLE
fix(desktop): keep reasoning settings label on one line

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -838,7 +838,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
             <span className="text-xs text-muted-foreground">{m.defaultsLabel}</span>
             {reasoningSupported && (
               <div className="flex items-center gap-2 text-xs">
-                {m.reasoning}
+                <span className="shrink-0 whitespace-nowrap">{m.reasoning}</span>
                 <Select
                   onValueChange={value => void writeAgentDefault('agent.reasoning_effort', value)}
                   value={effortValue}


### PR DESCRIPTION
## Summary

Short CJK labels like 推理 wrapped awkwardly next to the reasoning effort select. Keep the label on one line with `whitespace-nowrap` + `shrink-0`.

## Testing

- Diff review of `apps/desktop/src/app/settings/model-settings.tsx`

Closes #83118