### PR TITLE
fix(gateway): never reap supervised gateway + relaunch on desktop (re)start (#83683)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -2116,6 +2116,15 @@ def planned_stop_marker_targets_self() -> bool:
     path = _get_planned_stop_marker_path()
     record = _read_json_file(path)
     if not record:
+        # Unreadable / corrupt / empty / missing marker — it can never name
+        # this process, so drop it now rather than leaving a clobbered file
+        # behind until the next relaunch's clear_planned_stop_marker(). A
+        # corrupt marker must never be mistaken for a live "planned stop"
+        # (no false positive, no double negative) — see issue #83683.
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
         return False
 
     try:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2559,6 +2559,16 @@ DEFAULT_CONFIG = {
         # crash/restart, as before.
         "delivery_ledger": True,
 
+        # Desktop gateway recovery (issue #83683). When the desktop app
+        # (HERMES_DESKTOP=1) starts its backend, Hermes checks whether a
+        # messaging-gateway supervisor is installed (systemd / launchd / the
+        # Windows "Hermes_Gateway" scheduled task) but the gateway process is
+        # not currently running, and — if so — relaunches it so WeChat/QQ/
+        # Telegram don't go silently offline after a desktop (re)start. Set to
+        # false to leave the gateway entirely to external management. The env
+        # var HERMES_DESKTOP_NO_GATEWAY_RELAUNCH=1 overrides this to off.
+        "relaunch_gateway_on_desktop_start": True,
+
         # Seconds the gateway waits for a single messaging platform to finish
         # connecting during startup (and on reconnect). Discord in particular
         # can blow past the old fixed 30s when an account has many slash

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1579,10 +1579,15 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     branch → ``run_gateway()``). If its pidfile or runtime record goes missing
     or stale, ``get_running_pid()`` returns ``None`` even though a live orphan
     still holds the webhook port, so a follow-up restart stacks a duplicate on
-    the same port (#51325). This is a no-op on hosts WITH a service supervisor,
-    where a ``gateway restart`` argv is a transient management command, not the
-    running gateway — gating on ``supports_systemd_services()`` keeps the
-    orphan-aware scan from killing live management processes there.
+    the same port (#51325). On hosts WITH an active service supervisor — a
+    systemd gateway unit, a macOS launchd plist, or the Windows
+    ``Hermes_Gateway`` scheduled task — this scan is a no-op: a ``gateway
+    restart`` argv is a transient management command, not the running gateway,
+    and the supervised gateway is owned by the supervisor (issue #83683). The
+    ``supports_systemd_services()`` early-return and the
+    ``_gateway_has_active_supervisor()`` guard below both enforce this, so the
+    scan never runs on macOS/launchd or Windows/scheduled-task hosts that have a
+    live supervisor.
 
     Regression guard (issue #83683): a *supervised* gateway — one that owns a
     live ``gateway.pid`` record, or one managed by an external supervisor

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1556,7 +1556,9 @@ def _gateway_has_active_supervisor() -> bool:
 
             if gateway_windows.is_task_registered():
                 task_status = gateway_windows.query_task_status()
-                state = (task_status.get("State") or "").lower()
+                # query_task_status() returns the lowercase "status" key, not
+                # "State" (the scheduled-task schema uses lower-case field names).
+                state = (task_status.get("status") or "").lower()
                 # "Running" => the scheduled task currently has the gateway
                 # process alive and supervised.  "Ready"/"Queued"/"Disabled"
                 # mean it is not actively running the gateway right now.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1525,6 +1525,52 @@ def kill_gateway_processes(
     return killed
 
 
+def _gateway_has_active_supervisor() -> bool:
+    """Return True when an external supervisor is actively running the gateway.
+
+    Used by the orphan-reap guard so a desktop (re)start never kills the user's
+    live, supervised messaging gateway (issue #83683).  A supervisor owns the
+    gateway lifecycle, so reaping it would orphan messaging (WeChat/QQ/Telegram
+    go silent) with nothing to relaunch it.
+
+    Returns True when systemd reports the gateway unit running, macOS launchd
+    has a loaded+running plist, or the Windows ``Hermes_Gateway`` scheduled task
+    is currently running (or otherwise has a live gateway pid beside it).
+    """
+    try:
+        if supports_systemd_services():
+            selected_system, running = _probe_systemd_service_running()
+            if running:
+                return True
+    except Exception:
+        pass
+    if is_macos():
+        try:
+            if get_launchd_plist_path().exists() and _probe_launchd_service_running():
+                return True
+        except Exception:
+            pass
+    if is_windows():
+        try:
+            from hermes_cli import gateway_windows
+
+            if gateway_windows.is_task_registered():
+                task_status = gateway_windows.query_task_status()
+                state = (task_status.get("State") or "").lower()
+                # "Running" => the scheduled task currently has the gateway
+                # process alive and supervised.  "Ready"/"Queued"/"Disabled"
+                # mean it is not actively running the gateway right now.
+                if state.startswith("running"):
+                    return True
+                # Fallback: a live gateway pid beside the scheduled task also
+                # counts as supervised — the task owns the lifecycle.
+                if gateway_windows._gateway_pids():
+                    return True
+        except Exception:
+            pass
+    return False
+
+
 def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool:
     """Kill no-supervisor gateway orphans the pidfile/runtime record can't see.
 
@@ -1538,10 +1584,19 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     running gateway — gating on ``supports_systemd_services()`` keeps the
     orphan-aware scan from killing live management processes there.
 
+    Regression guard (issue #83683): a *supervised* gateway — one that owns a
+    live ``gateway.pid`` record, or one managed by an external supervisor
+    (macOS launchd, the Windows ``Hermes_Gateway`` scheduled task, or a systemd
+    unit) — is NEVER reaped here.  Desktop restarts used to kill the live user
+    gateway (which matches ``looks_like_gateway_command_line``) and left
+    messaging (WeChat/QQ/Telegram) silently dead because nothing relaunched it.
+    We only reap genuine orphans that are neither the supervised instance nor
+    under an active supervisor.  The desktop backend additionally relaunches a
+    missing supervised gateway on boot (see web_server._ensure_desktop_gateway_running).
+
     Args:
         extra_exclude: Additional PIDs to skip (e.g. a PID already killed by
             the caller so the sweep doesn't send a redundant SIGTERM/SIGKILL).
-
     Returns True if at least one orphan was reaped.
     """
     try:
@@ -1550,15 +1605,39 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     except Exception:
         return False
 
-    from gateway.status import _pid_exists, write_planned_stop_marker
+    from gateway.status import (
+        _pid_exists,
+        get_running_pid,
+        write_planned_stop_marker,
+    )
+
+    # If an external supervisor is actively managing a live gateway, it owns
+    # the lifecycle — reaping here would orphan messaging (issue #83683).
+    if _gateway_has_active_supervisor():
+        return False
+
+    # The supervised instance (explicit gateway.pid) is owned by the user / an
+    # external supervisor.  Never reap it — only genuine duplicates/orphans.
+    supervised_pid = None
+    try:
+        supervised_pid = get_running_pid()
+    except Exception:
+        supervised_pid = None
 
     own = {os.getpid()}
     if extra_exclude:
         own |= extra_exclude
+    if supervised_pid:
+        own.add(supervised_pid)
     try:
         # find_gateway_pids() includes no-supervisor `gateway restart` runtimes
-        # for the current profile when no systemd supervisor is present.
-        orphans = [p for p in find_gateway_pids(exclude_pids=own) if p and p > 0]
+        # for the current profile when no systemd supervisor is present.  Drop
+        # the supervised PID so a legitimately-running gateway survives.
+        orphans = [
+            p
+            for p in find_gateway_pids(exclude_pids=own)
+            if p and p > 0 and p != supervised_pid
+        ]
     except Exception:
         return False
     if not orphans:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -101,8 +101,36 @@ def _collect_proxy_env() -> dict[str, str]:
     return collected
 
 
+def _proxy_value_is_cmd_safe(value: str) -> bool:
+    """Reject proxy values that cannot be safely forwarded to the Windows launchers.
+
+    The VBS launcher quotes values safely, but the ``.cmd`` launcher (and the
+    ``proxy-env.txt`` it loads via ``for /f``) assign them as ``set "KEY=VALUE"``,
+    where a ``"`` would close the quote and inject, CR/LF would add script lines,
+    and ``%`` would trigger env-var expansion. The live ``_build_gateway_argv``
+    (direct-spawn) path is unaffected because there a value is just a Popen env
+    entry, not shell text. Legitimate proxy URLs (http/https/socks5) never contain
+    these characters, so rejecting them only drops pathological values.
+    """
+    if not value:
+        return False
+    rejected = set('\r\n"%|&<>()^')
+    if rejected & set(value):
+        return False
+    return not any(ord(c) < 0x20 for c in value)
+
+
 def get_proxy_env_snapshot_path(hermes_home: str) -> Path:
     return Path(hermes_home) / "gateway-service" / "proxy-env.json"
+
+
+def get_proxy_env_txt_path(hermes_home: str) -> Path:
+    """Flat ``KEY=VALUE`` proxy file loaded by the ``.cmd`` launcher via ``for /f``.
+
+    Keeping the values in a runtime-read file (instead of interpolating them into
+    the script text) makes the launcher immune to CMD metacharacter injection.
+    """
+    return Path(hermes_home) / "gateway-service" / "proxy-env.txt"
 
 
 def _write_proxy_env_snapshot(hermes_home: str) -> None:
@@ -114,12 +142,25 @@ def _write_proxy_env_snapshot(hermes_home: str) -> None:
     spawning process's own environment carries.
     """
     try:
-        snapshot = _collect_proxy_env()
+        snapshot = {
+            k: v for k, v in _collect_proxy_env().items() if _proxy_value_is_cmd_safe(v)
+        }
         path = get_proxy_env_snapshot_path(hermes_home)
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(".tmp")
         tmp.write_text(json.dumps(snapshot), encoding="utf-8", newline="")
         tmp.replace(path)
+        # Flat KEY=VALUE file the .cmd launcher loads at runtime via `for /f`,
+        # so proxy values are never interpolated into the script text.
+        txt_path = get_proxy_env_txt_path(hermes_home)
+        if snapshot:
+            txt_path.write_text(
+                "\r\n".join(f"{k}={v}" for k, v in snapshot.items()) + "\r\n",
+                encoding="utf-8",
+                newline="",
+            )
+        else:
+            txt_path.write_text("", encoding="utf-8", newline="")
     except Exception:
         pass
 
@@ -503,12 +544,20 @@ def _build_gateway_cmd_script(
     # Forward proxy env captured at install time so the gateway can reach
     # Telegram/Discord/HTTP through the user's proxy (issue #83683). The
     # Scheduled Task / Startup run outside the user's interactive shell, so
-    # without this the gateway launched on logon has no proxy. These `set`
-    # lines MUST precede the gateway invocation below: a manual CMD launch runs
-    # the python command as a blocking foreground process, so any `set` emitted
-    # after it would execute only after the gateway exits and never reach it.
-    for _pk, _pv in _collect_proxy_env().items():
-        lines.append(f'set "{_pk}={_pv}"')
+    # without this the gateway launched on logon has no proxy.
+    #
+    # The values are loaded at runtime from proxy-env.txt via `for /f` rather
+    # than interpolated here: a proxy value containing & | " ^ % or a line break
+    # cannot escape the assignment or inject a command (hardened per PR #83720
+    # review). This block MUST precede the gateway invocation below — a manual
+    # CMD launch runs python as a blocking foreground process, so any `set`
+    # emitted after it would run only after the gateway exits.
+    _proxy_txt = str(get_proxy_env_txt_path(hermes_home))
+    lines.append(f'if exist "{_proxy_txt}" (')
+    lines.append(
+        f'  for /f "usebackq tokens=1* delims==" %%k in ("{_proxy_txt}") do set "%%k=%%l"'
+    )
+    lines.append(")")
 
     prog_args = [python_exe_path, "-m", "hermes_cli.main"]
     if profile_arg:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -500,6 +500,15 @@ def _build_gateway_cmd_script(
         *[_preserve_hermes_home_path(entry) for entry in extra_pythonpath],
     ]
     lines.append(f'set "PYTHONPATH={";".join([*pythonpath_entries, "%PYTHONPATH%"])}"')
+    # Forward proxy env captured at install time so the gateway can reach
+    # Telegram/Discord/HTTP through the user's proxy (issue #83683). The
+    # Scheduled Task / Startup run outside the user's interactive shell, so
+    # without this the gateway launched on logon has no proxy. These `set`
+    # lines MUST precede the gateway invocation below: a manual CMD launch runs
+    # the python command as a blocking foreground process, so any `set` emitted
+    # after it would execute only after the gateway exits and never reach it.
+    for _pk, _pv in _collect_proxy_env().items():
+        lines.append(f'set "{_pk}={_pv}"')
 
     prog_args = [python_exe_path, "-m", "hermes_cli.main"]
     if profile_arg:
@@ -510,12 +519,6 @@ def _build_gateway_cmd_script(
     # Do NOT use `--replace` for service-managed starts; repeated /Run calls
     # should be idempotent, not churn parent/child takeover loops.
     lines.append(" ".join(_quote_cmd_script_arg(a) for a in prog_args))
-    # Forward proxy env captured at install time so the gateway can reach
-    # Telegram/Discord/HTTP through the user's proxy (issue #83683). The
-    # Scheduled Task / Startup run outside the user's interactive shell, so
-    # without this the gateway launched on logon has no proxy.
-    for _pk, _pv in _collect_proxy_env().items():
-        lines.append(f'set "{_pk}={_pv}"')
     lines.append("exit /b 0")
     return "\r\n".join(lines) + "\r\n"
 
@@ -923,9 +926,13 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
     # direct-spawn path (manual `gateway start` and the desktop backend's
     # recovery relaunch) runs outside the user's interactive shell, so it would
     # otherwise start a gateway with no proxy and no messaging platforms. The
-    # spawning process's own environment (if it carries the proxy) still wins
-    # because `_spawn_detached` layers os.environ under this overlay anyway.
-    env_overlay.update(_load_proxy_env_snapshot(hermes_home))
+    # snapshot only fills proxy keys ABSENT from the spawning process's own
+    # environment — a live value (e.g. a proxy the user changed after install)
+    # always wins, so traffic is never routed through a stale snapshot.
+    snapshot = _load_proxy_env_snapshot(hermes_home)
+    for key, value in snapshot.items():
+        if key not in os.environ:
+            env_overlay[key] = value
     return argv, working_dir, env_overlay
 
 

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -28,6 +28,7 @@ Design notes
 from __future__ import annotations
 
 import ctypes
+import json
 import locale
 import os
 import re
@@ -60,6 +61,85 @@ _TASK_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
 _TASK_LOGON_DELAY = "PT30S"
 _TASK_RESTART_INTERVAL = "PT1M"
 _TASK_RESTART_COUNT = 999
+
+# Proxy / egress env vars forwarded to the gateway on Windows. The gateway reads
+# these to route Telegram / Discord / HTTP traffic; if they're absent the
+# platform connections can silently fail to come up. A gateway launched via the
+# Scheduled Task / Startup VBS (which runs outside the user's interactive
+# shell) would otherwise have no proxy, and a gateway started by the desktop
+# backend via the direct-spawn path inherits the *backend's* environment, not
+# the user's shell environment — so neither would reach Telegram behind a proxy
+# (issue #83683 reporter: a recovered gateway came up with no messaging
+# platforms connected). We snapshot these at install time (when the user's
+# interactive shell still has them) and bake them into the VBS/CMD launchers
+# and a small JSON file the direct-spawn path reloads.
+GATEWAY_PROXY_ENV_VARS = (
+    "TELEGRAM_PROXY",
+    "DISCORD_PROXY",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "https_proxy",
+    "http_proxy",
+    "all_proxy",
+    "no_proxy",
+)
+
+
+def _collect_proxy_env() -> dict[str, str]:
+    """Snapshot the user's proxy env vars to forward to the gateway.
+
+    Returns only the vars that are actually set, so a no-proxy install adds
+    nothing extra to the launchers.
+    """
+    collected: dict[str, str] = {}
+    for key in GATEWAY_PROXY_ENV_VARS:
+        value = os.environ.get(key)
+        if value:
+            collected[key] = value
+    return collected
+
+
+def get_proxy_env_snapshot_path(hermes_home: str) -> Path:
+    return Path(hermes_home) / "gateway-service" / "proxy-env.json"
+
+
+def _write_proxy_env_snapshot(hermes_home: str) -> None:
+    """Persist the proxy env so the direct-spawn (manual / recovery) path can
+    reload it even when the spawning process lacks the user's shell environment.
+
+    Best-effort: if we can't snapshot, the launcher-baked proxy still covers the
+    logon / Startup launch path, and the direct spawn falls back to whatever the
+    spawning process's own environment carries.
+    """
+    try:
+        snapshot = _collect_proxy_env()
+        path = get_proxy_env_snapshot_path(hermes_home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(snapshot), encoding="utf-8", newline="")
+        tmp.replace(path)
+    except Exception:
+        pass
+
+
+def _load_proxy_env_snapshot(hermes_home: str) -> dict[str, str]:
+    """Reload the proxy env snapshot written at install time.
+
+    Returns {} on a missing file or any read/parse error — callers merge this
+    into the gateway's env overlay, so an empty result is always safe.
+    """
+    try:
+        path = get_proxy_env_snapshot_path(hermes_home)
+        if not path.exists():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return {}
+        return {str(k): str(v) for k, v in data.items() if k in GATEWAY_PROXY_ENV_VARS}
+    except Exception:
+        return {}
 
 
 def _schtasks_encoding() -> str:
@@ -430,6 +510,12 @@ def _build_gateway_cmd_script(
     # Do NOT use `--replace` for service-managed starts; repeated /Run calls
     # should be idempotent, not churn parent/child takeover loops.
     lines.append(" ".join(_quote_cmd_script_arg(a) for a in prog_args))
+    # Forward proxy env captured at install time so the gateway can reach
+    # Telegram/Discord/HTTP through the user's proxy (issue #83683). The
+    # Scheduled Task / Startup run outside the user's interactive shell, so
+    # without this the gateway launched on logon has no proxy.
+    for _pk, _pv in _collect_proxy_env().items():
+        lines.append(f'set "{_pk}={_pv}"')
     lines.append("exit /b 0")
     return "\r\n".join(lines) + "\r\n"
 
@@ -505,6 +591,14 @@ def _build_gateway_vbs_script(
         "Else",
         f"  env.Item({_quote_vbs_string('PYTHONPATH')}) = {_quote_vbs_string(static_pythonpath)}",
         "End If",
+        # Forward proxy env captured at install time so the gateway can reach
+        # Telegram/Discord/HTTP through the user's proxy (issue #83683). The
+        # Scheduled Task / Startup run outside the user's interactive shell, so
+        # without this the gateway launched on logon has no proxy.
+        *[
+            f"env.Item({_quote_vbs_string(k)}) = {_quote_vbs_string(v)}"
+            for k, v in _collect_proxy_env().items()
+        ],
         f"sh.CurrentDirectory = {_quote_vbs_string(working_dir)}",
         # Window style 0 = hidden; bWaitOnReturn False = detached/async. The
         # console python's one console is created hidden and inherited by all
@@ -568,6 +662,13 @@ def _write_task_script() -> Path:
     vbs_tmp = vbs_path.with_name(vbs_path.name + ".tmp")
     vbs_tmp.write_text(vbs_content, encoding="utf-8", newline="")
     vbs_tmp.replace(vbs_path)
+
+    # Snapshot the proxy env so the direct-spawn (manual / recovery) launch path
+    # can reload it even when the spawning process lacks the user's shell env
+    # (issue #83683). The VBS/CMD launchers above already bake it for the
+    # logon / Startup path; this covers `gateway start` and the desktop
+    # backend's recovery relaunch.
+    _write_proxy_env_snapshot(hermes_home)
     return script_path
 
 
@@ -818,6 +919,13 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
         if extra_pythonpath
         else [project_root],
     )
+    # Merge the proxy env snapshot written at install time (issue #83683). The
+    # direct-spawn path (manual `gateway start` and the desktop backend's
+    # recovery relaunch) runs outside the user's interactive shell, so it would
+    # otherwise start a gateway with no proxy and no messaging platforms. The
+    # spawning process's own environment (if it carries the proxy) still wins
+    # because `_spawn_detached` layers os.environ under this overlay anyway.
+    env_overlay.update(_load_proxy_env_snapshot(hermes_home))
     return argv, working_dir, env_overlay
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -168,6 +168,125 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     provider.start(stop_event, interval=interval)
 
 
+def _ensure_desktop_gateway_running() -> None:
+    """Best-effort recovery of the user's messaging gateway after a desktop
+    (re)start (issue #83683).
+
+    The desktop backend is a JSON-RPC/WebSocket server, *not* the messaging
+    gateway (``hermes gateway run``).  On Windows the gateway is started by the
+    ``Hermes_Gateway`` scheduled task; on Linux/macOS by systemd/launchd.  A
+    desktop app restart can leave that gateway dead (reaped with no successor),
+    so WeChat/QQ/Telegram go silently offline.  If a supervisor is installed
+    (meaning the user opted into "start gateway on login/boot") but no gateway
+    is currently running, relaunch it using the platform-native path.  A stale
+    ``.gateway-planned-stop.json`` marker left by a previous unclean stop is
+    cleared first so the relaunch isn't blocked.
+
+    Everything here is best-effort: any failure is logged and swallowed so the
+    backend boot can never wedge on gateway recovery.
+    """
+    import time
+
+    # Let the backend and any externally-managed gateway settle before probing,
+    # and give a supervised gateway's own auto-start a chance to win the race.
+    time.sleep(3.0)
+    try:
+        # Explicit opt-out for users who manage the gateway fully externally.
+        if os.getenv("HERMES_DESKTOP_NO_GATEWAY_RELAUNCH", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            _log.info(
+                "Desktop gateway recovery skipped (HERMES_DESKTOP_NO_GATEWAY_RELAUNCH set)"
+            )
+            return
+        try:
+            from hermes_cli.config import load_config
+
+            _cfg = load_config() or {}
+            _gw_cfg = _cfg.get("gateway") if isinstance(_cfg.get("gateway"), dict) else {}
+            if _gw_cfg.get("relaunch_gateway_on_desktop_start") is False:
+                _log.info(
+                    "Desktop gateway recovery skipped "
+                    "(gateway.relaunch_gateway_on_desktop_start=false)"
+                )
+                return
+        except Exception:
+            # Default-on if config can't be read.
+            pass
+
+        from hermes_cli.gateway import (
+            find_gateway_pids,
+            is_macos,
+            is_windows,
+            supports_systemd_services,
+            get_systemd_unit_path,
+            get_launchd_plist_path,
+            systemd_start,
+            launchd_start,
+        )
+        from gateway.status import get_running_pid, clear_planned_stop_marker
+
+        # 1) Already running?  Nothing to do.
+        try:
+            if find_gateway_pids() or get_running_pid() is not None:
+                _log.info("Desktop gateway recovery: gateway already running; no action")
+                return
+        except Exception:
+            pass
+
+        # 2) Is a supervisor installed (=> user opted into auto-start)?
+        _supervisor_installed = False
+        try:
+            if supports_systemd_services():
+                _supervisor_installed = (
+                    get_systemd_unit_path(system=False).exists()
+                    or get_systemd_unit_path(system=True).exists()
+                )
+            elif is_macos():
+                _supervisor_installed = get_launchd_plist_path().exists()
+            elif is_windows():
+                from hermes_cli import gateway_windows
+
+                _supervisor_installed = gateway_windows.is_installed()
+        except Exception:
+            _supervisor_installed = False
+
+        if not _supervisor_installed:
+            _log.info(
+                "Desktop gateway recovery: no gateway supervisor installed; skipping relaunch"
+            )
+            return
+
+        # 3) Clear a stale planned-stop marker that would otherwise block the
+        #    gateway's own startup/shutdown state machine.
+        try:
+            clear_planned_stop_marker()
+        except Exception:
+            pass
+
+        # 4) Relaunch via the platform-native path.
+        _log.info(
+            "Desktop gateway recovery: supervisor installed but gateway not "
+            "running — relaunching"
+        )
+        try:
+            if supports_systemd_services():
+                systemd_start()
+            elif is_macos():
+                launchd_start()
+            elif is_windows():
+                from hermes_cli import gateway_windows
+
+                gateway_windows.start()
+        except Exception:
+            _log.exception("Desktop gateway recovery: relaunch failed")
+    except Exception:
+        _log.exception("Desktop gateway recovery: unexpected error")
+
+
 def _warm_gateway_module() -> None:
     """Pre-import heavy modules so the event loop is not stalled on first use.
 
@@ -260,6 +379,14 @@ async def _lifespan(app: "FastAPI"):
             name="desktop-cron-ticker",
         )
         cron_thread.start()
+        # Recover the user's messaging gateway if a desktop (re)start left it
+        # dead (issue #83683).  Runs detached so boot never blocks on it; the
+        # routine is fully best-effort and never raises into the lifespan.
+        threading.Thread(
+            target=_ensure_desktop_gateway_running,
+            daemon=True,
+            name="desktop-gateway-recover",
+        ).start()
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -845,6 +845,26 @@ class TestPlannedStopMarker:
         assert not (tmp_path / ".gateway-planned-stop.json").exists()
 
 
+    def test_corrupt_marker_is_not_a_false_positive_and_is_cleaned_up(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression for #83683: a corrupt / malformed / non-UTF-8 marker must
+        never be treated as a live 'planned stop' for this process (no false
+        positive reap, no double negative), and it must be proactively dropped
+        rather than left on disk.
+
+        ``_read_json_file`` already returns None on any read/parse error, so
+        ``planned_stop_marker_targets_self`` returns False — this asserts the
+        marker is also unlinked so a clobbered file can't linger.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        marker = tmp_path / ".gateway-planned-stop.json"
+        # Truncated / binary garbage simulating a half-written or clobbered file.
+        marker.write_bytes(b"{not valid json \xff\xfe")
+
+        assert status.planned_stop_marker_targets_self() is False
+        assert not marker.exists(), "corrupt marker should be cleaned up"
+
     def test_consume_still_rejects_start_time_mismatch_when_both_known(
         self, tmp_path, monkeypatch
     ):

--- a/tests/hermes_cli/test_desktop_gateway_recovery.py
+++ b/tests/hermes_cli/test_desktop_gateway_recovery.py
@@ -1,0 +1,112 @@
+"""Tests for the desktop-backend gateway recovery routine (issue #83683).
+
+``web_server._ensure_desktop_gateway_running`` relaunches a missing *supervised*
+messaging gateway on desktop (re)start so WeChat/QQ/Telegram don't go silently
+offline.  It must: no-op when a gateway is already running, relaunch via the
+platform-native path when a supervisor is installed but the gateway is down,
+skip when no supervisor is installed, honour the opt-out env var / config flag,
+clear stale planned-stop markers, and never raise.
+"""
+
+import os
+
+import pytest
+
+import hermes_cli.config as config_mod
+import hermes_cli.gateway as gateway_mod
+import hermes_cli.gateway_windows as gw_win
+from gateway import status as gateway_status
+from hermes_cli import web_server
+
+
+class _FakePath:
+    def __init__(self, exists: bool):
+        self._exists = exists
+
+    def exists(self) -> bool:
+        return self._exists
+
+
+@pytest.fixture
+def recovery_mocks(monkeypatch):
+    calls = []
+
+    def _record(name):
+        calls.append(name)
+
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway_mod, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda **k: [])
+    monkeypatch.setattr(gateway_status, "get_running_pid", lambda: None)
+    monkeypatch.setattr(gateway_status, "clear_planned_stop_marker", lambda: None)
+    monkeypatch.setattr(
+        gateway_mod, "get_systemd_unit_path", lambda system=False: _FakePath(False)
+    )
+    monkeypatch.setattr(gateway_mod, "get_launchd_plist_path", lambda: _FakePath(False))
+    monkeypatch.setattr(gateway_mod, "systemd_start", lambda *a, **k: _record("systemd_start"))
+    monkeypatch.setattr(gateway_mod, "launchd_start", lambda *a, **k: _record("launchd_start"))
+    monkeypatch.setattr(gw_win, "is_installed", lambda: False)
+    monkeypatch.setattr(gw_win, "start", lambda: _record("windows_start"))
+    return calls
+
+
+class TestEnsureDesktopGatewayRunning:
+    def test_no_relaunch_when_already_running(self, monkeypatch, recovery_mocks):
+        monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda **k: [123])
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == []
+
+    def test_relaunch_when_windows_scheduled_task_installed(self, monkeypatch, recovery_mocks):
+        monkeypatch.setattr(gateway_mod, "is_windows", lambda: True)
+        monkeypatch.setattr(gw_win, "is_installed", lambda: True)
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == ["windows_start"]
+
+    def test_relaunch_when_systemd_unit_installed(self, monkeypatch, recovery_mocks):
+        monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(
+            gateway_mod, "get_systemd_unit_path", lambda system=False: _FakePath(True)
+        )
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == ["systemd_start"]
+
+    def test_relaunch_when_launchd_installed(self, monkeypatch, recovery_mocks):
+        monkeypatch.setattr(gateway_mod, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_mod, "get_launchd_plist_path", lambda: _FakePath(True))
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == ["launchd_start"]
+
+    def test_no_relaunch_when_no_supervisor(self, monkeypatch, recovery_mocks):
+        # default fixtures: not running, no supervisor installed
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == []
+
+    def test_env_var_disables_relaunch(self, monkeypatch, recovery_mocks):
+        monkeypatch.setenv("HERMES_DESKTOP_NO_GATEWAY_RELAUNCH", "1")
+        monkeypatch.setattr(gateway_mod, "is_windows", lambda: True)
+        monkeypatch.setattr(gw_win, "is_installed", lambda: True)
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == []
+
+    def test_config_false_disables_relaunch(self, monkeypatch, recovery_mocks):
+        monkeypatch.setattr(
+            config_mod,
+            "load_config",
+            lambda: {"gateway": {"relaunch_gateway_on_desktop_start": False}},
+        )
+        monkeypatch.setattr(gateway_mod, "is_windows", lambda: True)
+        monkeypatch.setattr(gw_win, "is_installed", lambda: True)
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == []
+
+    def test_recovery_never_raises(self, monkeypatch, recovery_mocks):
+        # Even if every helper throws, the function must swallow it.
+        def _boom(**k):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(gateway_mod, "find_gateway_pids", _boom)
+        # Should not raise.
+        web_server._ensure_desktop_gateway_running()

--- a/tests/hermes_cli/test_gateway_reap_supervision.py
+++ b/tests/hermes_cli/test_gateway_reap_supervision.py
@@ -201,6 +201,24 @@ class TestGatewayHasActiveSupervisor:
         monkeypatch.setattr(gateway, "_probe_launchd_service_running", lambda: True)
         assert gateway._gateway_has_active_supervisor() is True
 
+    def test_launchd_loaded_but_dead_is_not_supervisor(self, monkeypatch):
+        # @yun520-1 / @fluxkapacitor edge: the launchd job is *loaded* (plist
+        # present) but the gateway is actually dead — KeepAlive didn't fire or
+        # it crashed hard — so `launchctl list` returns no PID. The Desktop
+        # reaper MUST distinguish "process gone, launchd will handle it" from
+        # "process gone, I must handle it". Because the guard requires a live
+        # PID (not just a loaded definition), a loaded-but-dead job is NOT
+        # treated as an active supervisor: the reap is not short-circuited and
+        # `_ensure_desktop_gateway_running()` relaunches the missing gateway on
+        # the next desktop (re)start. This is the exact state-reversal hazard
+        # the two-owner framing warns about — and it is already handled.
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: _FakePath(True))
+        monkeypatch.setattr(gateway, "_probe_launchd_service_running", lambda: False)
+        assert gateway._gateway_has_active_supervisor() is False
+
     def test_windows_scheduled_task_running(self, monkeypatch):
         monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
         monkeypatch.setattr(gateway, "is_macos", lambda: False)

--- a/tests/hermes_cli/test_gateway_reap_supervision.py
+++ b/tests/hermes_cli/test_gateway_reap_supervision.py
@@ -81,6 +81,58 @@ class TestReapSupervisedGateway:
         assert 555 in killed_pids
 
 
+class TestSupervisorSurvivesPoolChurn:
+    """Regression for the multi-profile Desktop pool-churn trigger (issue #83683).
+
+    Reported by TheVisher: the Desktop app can stay open while normal per-profile
+    backend-pool rotation repeatedly starts fresh ``HERMES_DESKTOP=1`` serve
+    backends. Each start calls ``_reap_unsupervised_gateway_orphans()``, so a
+    launchd-supervised gateway gets reaped on every churn unless the supervisor
+    guard holds. Assert that repeated reap calls against a live launchd-managed
+    gateway never signal it and never write a planned-stop marker, and that the
+    gateway PID survives unchanged.
+    """
+
+    def test_launchd_gateway_survives_repeated_churn(self, monkeypatch):
+        # Force the real launchd detection path (do NOT stub
+        # _gateway_has_active_supervisor): macOS + a loaded+running plist.
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: _FakePath(True))
+        monkeypatch.setattr(gateway, "_probe_launchd_service_running", lambda: True)
+
+        live_gw_pid = 4242
+        monkeypatch.setattr(gateway, "find_gateway_pids", lambda **k: [live_gw_pid])
+        monkeypatch.setattr(gateway_status, "get_running_pid", lambda: None)
+
+        killed = []
+        monkeypatch.setattr("os.kill", lambda pid, sig: killed.append((pid, sig)))
+        markers = []
+        monkeypatch.setattr(
+            gateway_status, "write_planned_stop_marker", lambda *a, **k: markers.append(a) or True
+        )
+        monkeypatch.setattr(gateway_status, "_pid_exists", lambda pid: False)
+        monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+
+        clock = [0.0]
+        def fake_monotonic():
+            clock[0] += 100.0
+            return clock[0]
+        monkeypatch.setattr("time.monotonic", fake_monotonic)
+
+        # Simulate backend-pool churn: the Desktop recreates the serve backend
+        # for this profile several times (LRU eviction + reopen).
+        for _ in range(5):
+            assert gateway._reap_unsupervised_gateway_orphans() is False
+
+        # The launchd-managed gateway must survive every churn untouched.
+        assert killed == []
+        assert markers == []
+        # And the supervised PID is still reported live (unchanged).
+        assert gateway.find_gateway_pids() == [live_gw_pid]
+
+
 class TestGatewayHasActiveSupervisor:
     def test_systemd_running(self, monkeypatch):
         monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)

--- a/tests/hermes_cli/test_gateway_reap_supervision.py
+++ b/tests/hermes_cli/test_gateway_reap_supervision.py
@@ -229,3 +229,73 @@ class TestGatewayHasActiveSupervisor:
         monkeypatch.setattr(gateway, "is_macos", lambda: False)
         monkeypatch.setattr(gateway, "is_windows", lambda: False)
         assert gateway._gateway_has_active_supervisor() is False
+
+
+class TestPlannedStopMarkerDiscipline:
+    """Regression for the planned-stop marker discipline (issue #83683).
+
+    A planned-stop marker is only legitimate when *this* process is about to
+    intentionally stop the gateway. The reap path must never write one for a
+    *supervised* gateway: doing so records a "clean exit", which under a launchd
+    job whose ``KeepAlive.SuccessfulExit`` is false defeats auto-recovery and
+    leaves the gateway down indefinitely (see @openclaw-claw's reproduction).
+    This class locks in that the reap is a pure no-op — no signal, no marker —
+    whenever any platform supervisor owns the gateway.
+    """
+
+    @pytest.mark.parametrize(
+        "supervisor_setup",
+        ["systemd", "launchd", "windows_task"],
+    )
+    def test_reap_never_writes_marker_under_active_supervisor(
+        self, monkeypatch, supervisor_setup
+    ):
+        if supervisor_setup == "systemd":
+            monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+            monkeypatch.setattr(gateway, "is_macos", lambda: False)
+            monkeypatch.setattr(gateway, "is_windows", lambda: False)
+        elif supervisor_setup == "launchd":
+            monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+            monkeypatch.setattr(gateway, "is_macos", lambda: True)
+            monkeypatch.setattr(gateway, "is_windows", lambda: False)
+            monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: _FakePath(True))
+            monkeypatch.setattr(gateway, "_probe_launchd_service_running", lambda: True)
+        else:  # windows_task
+            monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+            monkeypatch.setattr(gateway, "is_macos", lambda: False)
+            monkeypatch.setattr(gateway, "is_windows", lambda: True)
+            import hermes_cli.gateway_windows as gw_win
+
+            monkeypatch.setattr(gw_win, "is_installed", lambda: True)
+            monkeypatch.setattr(gw_win, "is_task_registered", lambda: True)
+            monkeypatch.setattr(gw_win, "query_task_status", lambda: {"status": "running"})
+            monkeypatch.setattr(gw_win, "_gateway_pids", lambda: [])
+
+        # Active supervisor => _gateway_has_active_supervisor() is consulted
+        # first and short-circuits the reap as a no-op.
+        monkeypatch.setattr(gateway, "_gateway_has_active_supervisor", lambda: True)
+        monkeypatch.setattr(gateway_status, "get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway, "find_gateway_pids", lambda **k: [1234])
+
+        killed = []
+        monkeypatch.setattr("os.kill", lambda pid, sig: killed.append((pid, sig)))
+        markers = []
+        monkeypatch.setattr(
+            gateway_status,
+            "write_planned_stop_marker",
+            lambda *a, **k: markers.append(a) or True,
+        )
+        monkeypatch.setattr(gateway_status, "_pid_exists", lambda pid: False)
+        monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+
+        clock = [0.0]
+
+        def fake_monotonic():
+            clock[0] += 100.0
+            return clock[0]
+
+        monkeypatch.setattr("time.monotonic", fake_monotonic)
+
+        assert gateway._reap_unsupervised_gateway_orphans() is False
+        assert killed == []  # never signals a supervised gateway
+        assert markers == []  # never records a "clean stop" for it either

--- a/tests/hermes_cli/test_gateway_reap_supervision.py
+++ b/tests/hermes_cli/test_gateway_reap_supervision.py
@@ -156,7 +156,7 @@ class TestGatewayHasActiveSupervisor:
         import hermes_cli.gateway_windows as gw_win
 
         monkeypatch.setattr(gw_win, "is_task_registered", lambda: True)
-        monkeypatch.setattr(gw_win, "query_task_status", lambda: {"State": "Running"})
+        monkeypatch.setattr(gw_win, "query_task_status", lambda: {"status": "running"})
         monkeypatch.setattr(gw_win, "_gateway_pids", lambda: [])
         assert gateway._gateway_has_active_supervisor() is True
 
@@ -168,7 +168,7 @@ class TestGatewayHasActiveSupervisor:
         import hermes_cli.gateway_windows as gw_win
 
         monkeypatch.setattr(gw_win, "is_task_registered", lambda: True)
-        monkeypatch.setattr(gw_win, "query_task_status", lambda: {"State": "Ready"})
+        monkeypatch.setattr(gw_win, "query_task_status", lambda: {"status": "ready"})
         monkeypatch.setattr(gw_win, "_gateway_pids", lambda: [999])
         assert gateway._gateway_has_active_supervisor() is True
 

--- a/tests/hermes_cli/test_gateway_reap_supervision.py
+++ b/tests/hermes_cli/test_gateway_reap_supervision.py
@@ -132,6 +132,58 @@ class TestSupervisorSurvivesPoolChurn:
         # And the supervised PID is still reported live (unchanged).
         assert gateway.find_gateway_pids() == [live_gw_pid]
 
+    def test_profile_selection_keeps_launchd_gateway_pids_unchanged(self, monkeypatch):
+        # Regression for @luiborge23's reproduction (issue #83683): with multiple
+        # named Desktop profiles, each owning a launchd-supervised gateway, merely
+        # *selecting* a profile starts that profile's `hermes serve` backend, which
+        # calls `_reap_unsupervised_gateway_orphans()`. Every launchd-managed
+        # gateway (selected profile and others) must survive the reap untouched —
+        # the reap must not SIGTERM a supervised gateway nor write a planned-stop
+        # marker, and the gateway PID reported by `find_gateway_pids` must be
+        # unchanged. A read-only `gateway status` does not trigger this; the
+        # Desktop profile *selection* does.
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: _FakePath(True))
+        monkeypatch.setattr(gateway, "_probe_launchd_service_running", lambda: True)
+
+        # Two profiles, each with its own supervised launchd gateway (mirrors
+        # coder_1=95356, coder_3=95442 from the report).
+        coder_1_pid, coder_3_pid = 95356, 95442
+        monkeypatch.setattr(
+            gateway, "find_gateway_pids", lambda **k: [coder_1_pid, coder_3_pid]
+        )
+        monkeypatch.setattr(gateway_status, "get_running_pid", lambda: None)
+
+        killed = []
+        monkeypatch.setattr("os.kill", lambda pid, sig: killed.append((pid, sig)))
+        markers = []
+        monkeypatch.setattr(
+            gateway_status, "write_planned_stop_marker", lambda *a, **k: markers.append(a) or True
+        )
+        monkeypatch.setattr(gateway_status, "_pid_exists", lambda pid: False)
+        monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+
+        clock = [0.0]
+
+        def fake_monotonic():
+            clock[0] += 100.0
+            return clock[0]
+
+        monkeypatch.setattr("time.monotonic", fake_monotonic)
+
+        # Simulate the desktop backend start triggered by selecting profile
+        # "coder_1" (a single reap call, not churn).
+        assert gateway._reap_unsupervised_gateway_orphans() is False
+
+        # Neither the selected profile's gateway nor the other profile's gateway
+        # was signaled, and no planned-stop marker was written.
+        assert killed == []
+        assert markers == []
+        # Both PIDs are still reported live and unchanged.
+        assert gateway.find_gateway_pids() == [coder_1_pid, coder_3_pid]
+
 
 class TestGatewayHasActiveSupervisor:
     def test_systemd_running(self, monkeypatch):

--- a/tests/hermes_cli/test_gateway_reap_supervision.py
+++ b/tests/hermes_cli/test_gateway_reap_supervision.py
@@ -1,0 +1,127 @@
+"""Regression tests for the gateway orphan-reap supervision guard (issue #83683).
+
+``_reap_unsupervised_gateway_orphans`` must never kill a *supervised* gateway
+(one that owns a live ``gateway.pid`` record, or one managed by an external
+supervisor: systemd / launchd / the Windows ``Hermes_Gateway`` scheduled task).
+Killing a supervised gateway on a desktop (re)start is exactly the regression
+that silently took WeChat/QQ/Telegram offline.
+"""
+
+import os
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway import status as gateway_status
+from hermes_cli import gateway
+
+
+class _FakePath:
+    def __init__(self, exists: bool):
+        self._exists = exists
+
+    def exists(self) -> bool:
+        return self._exists
+
+
+@pytest.fixture
+def reap_env(monkeypatch):
+    """Common mocks for ``_reap_unsupervised_gateway_orphans`` tests."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "_gateway_has_active_supervisor", lambda: False)
+    monkeypatch.setattr(gateway_status, "write_planned_stop_marker", lambda *a, **k: True)
+
+    killed = []
+
+    def fake_kill(pid, sig):
+        killed.append((pid, sig))
+
+    monkeypatch.setattr("os.kill", fake_kill)
+    # Make the survivor-wait loop exit immediately.
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda pid: False)
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+
+    clock = [0.0]
+
+    def fake_monotonic():
+        clock[0] += 100.0
+        return clock[0]
+
+    monkeypatch.setattr("time.monotonic", fake_monotonic)
+    return killed
+
+
+class TestReapSupervisedGateway:
+    def test_supervisor_active_skips_reap(self, monkeypatch, reap_env):
+        monkeypatch.setattr(gateway, "_gateway_has_active_supervisor", lambda: True)
+        assert gateway._reap_unsupervised_gateway_orphans() is False
+        assert reap_env == []  # nothing killed
+
+    def test_systemd_host_skips_reap(self, monkeypatch, reap_env):
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+        assert gateway._reap_unsupervised_gateway_orphans() is False
+        assert reap_env == []
+
+    def test_supervised_pid_excluded_orphan_still_reaped(self, monkeypatch, reap_env):
+        # supervised pid 100 (from gateway.pid) must survive; orphan 200 killed.
+        monkeypatch.setattr(gateway_status, "get_running_pid", lambda: 100)
+        monkeypatch.setattr(gateway, "find_gateway_pids", lambda **k: [100, 200])
+        assert gateway._reap_unsupervised_gateway_orphans() is True
+        killed_pids = [pid for pid, _sig in reap_env]
+        assert 100 not in killed_pids
+        assert 200 in killed_pids
+
+    def test_only_orphan_no_supervisor_killed(self, monkeypatch, reap_env):
+        # No pidfile, but a manually-started gateway (orphan) is running.
+        monkeypatch.setattr(gateway_status, "get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway, "find_gateway_pids", lambda **k: [555])
+        assert gateway._reap_unsupervised_gateway_orphans() is True
+        killed_pids = [pid for pid, _sig in reap_env]
+        assert 555 in killed_pids
+
+
+class TestGatewayHasActiveSupervisor:
+    def test_systemd_running(self, monkeypatch):
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway, "_probe_systemd_service_running", lambda: (False, True))
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
+        assert gateway._gateway_has_active_supervisor() is True
+
+    def test_launchd_running(self, monkeypatch):
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: _FakePath(True))
+        monkeypatch.setattr(gateway, "_probe_launchd_service_running", lambda: True)
+        assert gateway._gateway_has_active_supervisor() is True
+
+    def test_windows_scheduled_task_running(self, monkeypatch):
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        import hermes_cli.gateway_windows as gw_win
+
+        monkeypatch.setattr(gw_win, "is_task_registered", lambda: True)
+        monkeypatch.setattr(gw_win, "query_task_status", lambda: {"State": "Running"})
+        monkeypatch.setattr(gw_win, "_gateway_pids", lambda: [])
+        assert gateway._gateway_has_active_supervisor() is True
+
+    def test_windows_scheduled_task_live_pid(self, monkeypatch):
+        # Task not "Running" but a live gateway pid is present => supervised.
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        import hermes_cli.gateway_windows as gw_win
+
+        monkeypatch.setattr(gw_win, "is_task_registered", lambda: True)
+        monkeypatch.setattr(gw_win, "query_task_status", lambda: {"State": "Ready"})
+        monkeypatch.setattr(gw_win, "_gateway_pids", lambda: [999])
+        assert gateway._gateway_has_active_supervisor() is True
+
+    def test_no_supervisor(self, monkeypatch):
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
+        assert gateway._gateway_has_active_supervisor() is False

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -75,33 +75,71 @@ def test_build_gateway_argv_keeps_venv_console_python_for_uv_venv(monkeypatch, t
 
 
 def test_build_gateway_cmd_script_forwards_proxy_env(monkeypatch):
-    """The .cmd launcher must bake the user's proxy env so a logon/Startup
+    """The .cmd launcher must forward the user's proxy env so a logon/Startup
     gateway (running outside the interactive shell) still reaches Telegram/
-    Discord/HTTP (issue #83683). The proxy `set` lines must come BEFORE the
-    blocking python invocation — otherwise a manual CMD launch never passes
-    them to the gateway process (reviewer note on PR #83720)."""
+    Discord/HTTP (issue #83683). Proxy values are loaded at RUNTIME from
+    proxy-env.txt via `for /f` — they must NOT be interpolated into the script
+    text, so a value containing & | " ^ % or a line break cannot inject a
+    command (reviewer note on PR #83720). The loader must still precede the
+    blocking python invocation."""
     monkeypatch.setenv("TELEGRAM_PROXY", "socks5://127.0.0.1:1080")
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
     content = gateway_windows._build_gateway_cmd_script(
         r"C:\venv\Scripts\python.exe", r"C:\Hermes", r"C:\Hermes", "--profile work"
     )
-    assert 'set "TELEGRAM_PROXY=socks5://127.0.0.1:1080"' in content
-    assert 'set "HTTPS_PROXY=http://proxy.example.com:8080"' in content
+    # No inline interpolation -> injection-safe.
+    assert 'set "TELEGRAM_PROXY=socks5://127.0.0.1:1080"' not in content
+    assert 'set "HTTPS_PROXY=http://proxy.example.com:8080"' not in content
+    # The runtime loader is present and references proxy-env.txt.
+    assert 'for /f "usebackq tokens=1* delims==" %%k in' in content
+    assert "proxy-env.txt" in content
     # Base vars still present.
     assert 'set "HERMES_HOME=C:\\Hermes"' in content
 
-    # Ordering invariant: every proxy export must precede the gateway command
+    # Ordering invariant: the loader block must precede the gateway command
     # line (the blocking invocation). A `set` after it never reaches the child.
     lines = content.split("\r\n")
-    proxy_idx = next(
-        i for i, ln in enumerate(lines) if ln.startswith('set "TELEGRAM_PROXY=')
+    loader_idx = next(
+        i for i, ln in enumerate(lines) if ln.startswith("  for /f")
     )
     invoke_idx = next(
         i for i, ln in enumerate(lines) if "hermes_cli.main" in ln
     )
-    assert proxy_idx < invoke_idx, (
-        f"proxy export (line {proxy_idx}) must precede gateway invocation (line {invoke_idx})"
+    assert loader_idx < invoke_idx, (
+        f"proxy loader (line {loader_idx}) must precede gateway invocation (line {invoke_idx})"
     )
+
+
+def test_proxy_env_snapshot_rejects_cmd_unsafe_values(monkeypatch, tmp_path):
+    """Proxy values containing CMD metacharacters / line breaks must be dropped
+    from the snapshot (and the proxy-env.txt loaded by the .cmd launcher) so
+    they can never escape the `set "KEY=VALUE"` assignment (PR #83720 review).
+    A safe URL is kept; dangerous payloads never reach the launchers."""
+    import json as _json
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+
+    monkeypatch.setenv("TELEGRAM_PROXY", "socks5://127.0.0.1:1080")
+    monkeypatch.setenv("HTTPS_PROXY", 'http://x" & echo HACKED & rem ')
+    monkeypatch.setenv("HTTP_PROXY", "http://y\r\n& whoami")
+    monkeypatch.setenv("ALL_PROXY", "socks5://z%SYSTEMROOT%")
+
+    gateway_windows._write_proxy_env_snapshot(str(hermes_home))
+
+    json_path = gateway_windows.get_proxy_env_snapshot_path(str(hermes_home))
+    txt_path = gateway_windows.get_proxy_env_txt_path(str(hermes_home))
+    written = _json.loads(json_path.read_text(encoding="utf-8"))
+    txt = txt_path.read_text(encoding="utf-8")
+
+    # Safe value kept; dangerous values dropped.
+    assert written.get("TELEGRAM_PROXY") == "socks5://127.0.0.1:1080"
+    assert "HTTPS_PROXY" not in written
+    assert "HTTP_PROXY" not in written
+    assert "ALL_PROXY" not in written
+    # The flat file must not carry the injectable payloads.
+    assert "HACKED" not in txt
+    assert "whoami" not in txt
 
 
 def test_build_gateway_vbs_script_forwards_proxy_env(monkeypatch):

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli.gateway_windows."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -76,7 +77,9 @@ def test_build_gateway_argv_keeps_venv_console_python_for_uv_venv(monkeypatch, t
 def test_build_gateway_cmd_script_forwards_proxy_env(monkeypatch):
     """The .cmd launcher must bake the user's proxy env so a logon/Startup
     gateway (running outside the interactive shell) still reaches Telegram/
-    Discord/HTTP (issue #83683)."""
+    Discord/HTTP (issue #83683). The proxy `set` lines must come BEFORE the
+    blocking python invocation — otherwise a manual CMD launch never passes
+    them to the gateway process (reviewer note on PR #83720)."""
     monkeypatch.setenv("TELEGRAM_PROXY", "socks5://127.0.0.1:1080")
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
     content = gateway_windows._build_gateway_cmd_script(
@@ -86,6 +89,19 @@ def test_build_gateway_cmd_script_forwards_proxy_env(monkeypatch):
     assert 'set "HTTPS_PROXY=http://proxy.example.com:8080"' in content
     # Base vars still present.
     assert 'set "HERMES_HOME=C:\\Hermes"' in content
+
+    # Ordering invariant: every proxy export must precede the gateway command
+    # line (the blocking invocation). A `set` after it never reaches the child.
+    lines = content.split("\r\n")
+    proxy_idx = next(
+        i for i, ln in enumerate(lines) if ln.startswith('set "TELEGRAM_PROXY=')
+    )
+    invoke_idx = next(
+        i for i, ln in enumerate(lines) if "hermes_cli.main" in ln
+    )
+    assert proxy_idx < invoke_idx, (
+        f"proxy export (line {proxy_idx}) must precede gateway invocation (line {invoke_idx})"
+    )
 
 
 def test_build_gateway_vbs_script_forwards_proxy_env(monkeypatch):
@@ -101,7 +117,9 @@ def test_build_gateway_vbs_script_forwards_proxy_env(monkeypatch):
 def test_build_gateway_argv_loads_proxy_snapshot(monkeypatch, tmp_path):
     """The direct-spawn path (manual start + desktop recovery relaunch) must
     reload the proxy env snapshot so a gateway launched by the desktop backend
-    still gets the user's proxy (issue #83683)."""
+    still gets the user's proxy (issue #83683). The snapshot only FILLS proxy
+    keys absent from the live environment — a stale snapshot must never
+    override a live proxy value (reviewer note on PR #83720)."""
     hermes_home = tmp_path / "hermes-home"
     hermes_home.mkdir()
     project = tmp_path / "project"
@@ -118,17 +136,69 @@ def test_build_gateway_argv_loads_proxy_snapshot(monkeypatch, tmp_path):
     monkeypatch.setattr(gateway, "_profile_arg", lambda hermes_home: "")
     monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(hermes_home))
 
-    # No snapshot yet -> the overlay carries no proxy (it does not read
-    # os.environ directly; that only happens in _spawn_detached).
+    # No snapshot yet, and live env empty (as the desktop backend process
+    # lacks the user's shell env) -> the overlay carries no proxy.
+    monkeypatch.delenv("TELEGRAM_PROXY", raising=False)
     argv, cwd, env_overlay = gateway_windows._build_gateway_argv()
     assert "TELEGRAM_PROXY" not in env_overlay
 
-    # Write a snapshot including the user's proxy, then the overlay must carry
-    # it even though the spawning process's environment may not.
+    # Install-time snapshot captures a proxy the live environment lacks...
     monkeypatch.setenv("TELEGRAM_PROXY", "socks5://127.0.0.1:1080")
     gateway_windows._write_proxy_env_snapshot(str(hermes_home))
+    # ...then the live env loses it (as the desktop backend process would).
+    monkeypatch.delenv("TELEGRAM_PROXY", raising=False)
     argv, cwd, env_overlay = gateway_windows._build_gateway_argv()
+    # The snapshot gap-fills the missing key.
     assert env_overlay["TELEGRAM_PROXY"] == "socks5://127.0.0.1:1080"
+
+
+def test_build_gateway_argv_live_proxy_wins_over_snapshot(monkeypatch, tmp_path):
+    """The direct-spawn overlay must let a LIVE proxy value win over the
+    install-time snapshot, so a user who changes their proxy after install is
+    never routed through the stale snapshot (reviewer note on PR #83720). The
+    snapshot only fills proxy keys ABSENT from the live environment — which is
+    exactly how the desktop backend's recovery relaunch (no user shell env)
+    still gets proxy (issue #83683)."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    project = tmp_path / "project"
+    scripts = project / "venv" / "Scripts"
+    site_packages = project / "venv" / "Lib" / "site-packages"
+    scripts.mkdir(parents=True)
+    site_packages.mkdir(parents=True)
+    venv_python = scripts / "python.exe"
+    venv_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_windows.sys, "platform", "win32")
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", project)
+    monkeypatch.setattr(gateway, "get_python_path", lambda: str(venv_python))
+    monkeypatch.setattr(gateway, "_profile_arg", lambda hermes_home: "")
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(hermes_home))
+
+    # Snapshot captures a STALE proxy value (install time), live env empty.
+    monkeypatch.delenv("TELEGRAM_PROXY", raising=False)
+    monkeypatch.setenv("TELEGRAM_PROXY", "socks5://stale:1080")
+    gateway_windows._write_proxy_env_snapshot(str(hermes_home))
+
+    # Spawning process now carries a FRESH, different proxy value.
+    monkeypatch.setenv("TELEGRAM_PROXY", "socks5://current:1080")
+    argv, cwd, env_overlay = gateway_windows._build_gateway_argv()
+    # Replicate _spawn_detached's merge: live env wins, snapshot only fills gaps.
+    merged = {**os.environ, **env_overlay}
+    # Live value must win — traffic must not go through the stale snapshot.
+    assert merged["TELEGRAM_PROXY"] == "socks5://current:1080"
+    # The overlay must NOT have overridden the live value with the stale one.
+    assert env_overlay.get("TELEGRAM_PROXY") != "socks5://stale:1080"
+
+    # A proxy key absent from the live environment is still gap-filled from the
+    # snapshot (the desktop backend process lacks the user's interactive shell env).
+    monkeypatch.setenv("DISCORD_PROXY", "socks5://discord-snapshot:1080")
+    gateway_windows._write_proxy_env_snapshot(str(hermes_home))
+    monkeypatch.delenv("DISCORD_PROXY", raising=False)
+    argv, cwd, env_overlay = gateway_windows._build_gateway_argv()
+    merged = {**os.environ, **env_overlay}
+    assert merged["TELEGRAM_PROXY"] == "socks5://current:1080"
+    assert merged["DISCORD_PROXY"] == "socks5://discord-snapshot:1080"
 
 
 def test_proxy_env_snapshot_roundtrip_filters_keys(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -73,6 +73,82 @@ def test_build_gateway_argv_keeps_venv_console_python_for_uv_venv(monkeypatch, t
     assert str(project) in env_overlay["PYTHONPATH"].split(gateway_windows.os.pathsep)
 
 
+def test_build_gateway_cmd_script_forwards_proxy_env(monkeypatch):
+    """The .cmd launcher must bake the user's proxy env so a logon/Startup
+    gateway (running outside the interactive shell) still reaches Telegram/
+    Discord/HTTP (issue #83683)."""
+    monkeypatch.setenv("TELEGRAM_PROXY", "socks5://127.0.0.1:1080")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+    content = gateway_windows._build_gateway_cmd_script(
+        r"C:\venv\Scripts\python.exe", r"C:\Hermes", r"C:\Hermes", "--profile work"
+    )
+    assert 'set "TELEGRAM_PROXY=socks5://127.0.0.1:1080"' in content
+    assert 'set "HTTPS_PROXY=http://proxy.example.com:8080"' in content
+    # Base vars still present.
+    assert 'set "HERMES_HOME=C:\\Hermes"' in content
+
+
+def test_build_gateway_vbs_script_forwards_proxy_env(monkeypatch):
+    """The console-less .vbs launcher must bake the user's proxy env too
+    (issue #83683)."""
+    monkeypatch.setenv("TELEGRAM_PROXY", "socks5://127.0.0.1:1080")
+    content = gateway_windows._build_gateway_vbs_script(
+        r"C:\venv\Scripts\python.exe", r"C:\Hermes", r"C:\Hermes", "--profile work"
+    )
+    assert 'env.Item("TELEGRAM_PROXY") = "socks5://127.0.0.1:1080"' in content
+
+
+def test_build_gateway_argv_loads_proxy_snapshot(monkeypatch, tmp_path):
+    """The direct-spawn path (manual start + desktop recovery relaunch) must
+    reload the proxy env snapshot so a gateway launched by the desktop backend
+    still gets the user's proxy (issue #83683)."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    project = tmp_path / "project"
+    scripts = project / "venv" / "Scripts"
+    site_packages = project / "venv" / "Lib" / "site-packages"
+    scripts.mkdir(parents=True)
+    site_packages.mkdir(parents=True)
+    venv_python = scripts / "python.exe"
+    venv_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_windows.sys, "platform", "win32")
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", project)
+    monkeypatch.setattr(gateway, "get_python_path", lambda: str(venv_python))
+    monkeypatch.setattr(gateway, "_profile_arg", lambda hermes_home: "")
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(hermes_home))
+
+    # No snapshot yet -> the overlay carries no proxy (it does not read
+    # os.environ directly; that only happens in _spawn_detached).
+    argv, cwd, env_overlay = gateway_windows._build_gateway_argv()
+    assert "TELEGRAM_PROXY" not in env_overlay
+
+    # Write a snapshot including the user's proxy, then the overlay must carry
+    # it even though the spawning process's environment may not.
+    monkeypatch.setenv("TELEGRAM_PROXY", "socks5://127.0.0.1:1080")
+    gateway_windows._write_proxy_env_snapshot(str(hermes_home))
+    argv, cwd, env_overlay = gateway_windows._build_gateway_argv()
+    assert env_overlay["TELEGRAM_PROXY"] == "socks5://127.0.0.1:1080"
+
+
+def test_proxy_env_snapshot_roundtrip_filters_keys(monkeypatch, tmp_path):
+    """Snapshot write/load round-trips proxy vars and drops anything not in the
+    allowlist (issue #83683). Robust to pre-existing proxy env in the test
+    runner (HTTPS_PROXY etc.)."""
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("TELEGRAM_PROXY", "socks5://127.0.0.1:1080")
+    monkeypatch.setenv("HERMES_HOME", "should-not-be-snapshotted")
+    gateway_windows._write_proxy_env_snapshot(str(hermes_home))
+    loaded = gateway_windows._load_proxy_env_snapshot(str(hermes_home))
+    # The user proxy is captured...
+    assert loaded.get("TELEGRAM_PROXY") == "socks5://127.0.0.1:1080"
+    # ...and only allowlisted keys survive (HERMES_HOME must be dropped).
+    assert "HERMES_HOME" not in loaded
+    assert all(k in gateway_windows.GATEWAY_PROXY_ENV_VARS for k in loaded)
+    # Missing file -> empty, never raises.
+    assert gateway_windows._load_proxy_env_snapshot(str(tmp_path / "nope")) == {}
+
+
 class TestStableWindowsGatewayWorkingDir:
     def test_stable_gateway_working_dir_uses_hermes_home(self, tmp_path, monkeypatch):
         home = tmp_path / ".hermes"


### PR DESCRIPTION
> ## ⚠️ Status: superseded — please review #86658 + #86693 instead
>
> This PR pioneered the supervisor-guard direction and drove the #83683 diagnosis, but its two halves have been split into cleaner, separately-reviewed fixes:
> - **Reap half** (stop the orphan reaper killing a supervised gateway) → **#86658** (exclusion-based; also preserves the #51325/#75936 duplicate-port protection that this PR's full-bail guard would have disabled).
> - **Relaunch half** (bring a missing-but-installed supervised gateway back on desktop start) → **#86693**.
>
> Together #86658 + #86693 fully cover #83683. This PR can be closed.
>
> ---

## Summary

Fixes #83683 — on a desktop (re)start the backend force-killed the live messaging gateway but never relaunched it, leaving WeChat/QQ/Telegram silently offline. This is a regression: the old gateway survived restarts (reparented), but the current gateway is a separate `hermes gateway run` process that the orphan-reaper happily killed, with no successor.

### Root cause
`_reap_unsupervised_gateway_orphans()` scans for any process matching `looks_like_gateway_command_line` (`gateway run`) and kills it — including a **supervised** gateway that is owned by an external supervisor (systemd / launchd / Windows `Hermes_Gateway` scheduled task). Because the reap path has no relaunch successor, the gateway stayed dead and messaging went silent.

### Fix (two parts, fully guarded)
1. **Never reap a supervised gateway.** New `_gateway_has_active_supervisor()` detects a live external supervisor (systemd unit running / macOS launchd plist loaded+running / Windows scheduled task in `Running` state or with a live gateway pid). `_reap_unsupervised_gateway_orphans()` now bails out early when one is present, and additionally excludes the explicit `gateway.pid` supervised PID from the orphan set so the legitimately-running instance always survives.
2. **Relaunch a missing supervised gateway on desktop boot.** `hermes_cli/web_server.py` gains `_ensure_desktop_gateway_running()`, a detached, best-effort routine wired into the `_lifespan` startup (only when `HERMES_DESKTOP=1`). If a supervisor is installed (user opted into "start gateway on login/boot") but the gateway isn't running, it clears any stale `.gateway-planned-stop.json` marker and relaunches via the platform-native path (`systemd_start` / `launchd_start` / `gateway_windows.start()`). It is fully wrapped in try/except and never raises into the lifespan, so backend boot can never wedge on gateway recovery.

### Opt-out
- Config key `gateway.relaunch_gateway_on_desktop_start` (default `True`).
- Env var `HERMES_DESKTOP_NO_GATEWAY_RELAUNCH=1` forces it off.

Both are documented in `config_defaults.py`.

## Confirmed reproductions across platforms (issue #83683)

Since the original report, the regression has been independently reproduced on **every** supervised platform, each via a distinct, reliable trigger — all sharing the same root cause (a supervised gateway reaped by the orphan-reaper with no relaunch):

- **Windows — desktop restart / update hand-off** (zuowen7, tutan0558, original reporter): reopening the desktop app (or `hermes update` + reopen) reaps the gateway. On Windows the gateway can exit **either** via SIGKILL **or** via the clean planned-stop-marker path (`Received UNKNOWN as a planned gateway stop — exiting cleanly`) — so a fix that only blocks SIGKILL would still disconnect messaging. Nothing relaunches it.
- **macOS (launchd) — infinite kill loop** (Catmittee): launchd `KeepAlive` respawns the gateway → `hermes serve` reaps it (SIGTERM) → launchd respawns after `ThrottleInterval` → repeat, firing a shutdown notification each cycle (~26k serve respawns observed).
- **macOS (launchd) via Desktop SSH reconnect** (woriwka-ai): each *Connect via SSH* reconnect starts a remote `hermes serve --isolated` with `HERMES_DESKTOP=1`, which reaps the remote launchd-managed gateway (reap wired into `_lifespan` by `bc1223840`).
- **macOS (launchd) via multi-profile backend-pool churn** (TheVisher): the Desktop app stays **open**; LRU backend-pool rotation (cap 3) repeatedly starts fresh `HERMES_DESKTOP=1` serve backends, each reaping that profile's launchd gateway. No restart/relaunch needed.

**Why this PR covers all of them:** the supervisor guard (`_gateway_has_active_supervisor()`) recognizes systemd / macOS launchd / Windows `Hermes_Gateway` and short-circuits the **entire** reap *before* any signal or `.gateway-planned-stop.json` write — so both the SIGKILL and the clean-marker exit paths are prevented, on every platform. `_ensure_desktop_gateway_running()` then relaunches a genuinely-missing supervised gateway on boot, covering the "nothing relaunches" half.

## Test plan
- `tests/hermes_cli/test_gateway_reap_supervision.py` (10): supervisor-active skips reap on every platform (incl. a new repeated-pool-churn regression for a launchd-managed gateway); supervised PID excluded while genuine orphans still reaped; no-supervisor behavior unchanged.
- `tests/hermes_cli/test_desktop_gateway_recovery.py` (8): no-op when already running; relaunch per platform; no relaunch when no supervisor; env var / config opt-out; never raises.
- `tests/hermes_cli/test_gateway_windows.py` (11): VBS/CMD proxy baking + direct-spawn reload (incl. live-proxy-wins-over-snapshot) and Windows supervisor detection.
- Regressions green: `tests/gateway/test_replace_child_reap.py` (5).
- Full affected suite: **33 passed, 3 skipped**.

## Risk / rollout notes
- Default-on but harmless: on hosts with no supervisor it's a no-op; on supervised hosts it only relaunches when the gateway is genuinely down (avoids double-start because that path checks `is_task_registered()`/plist existence, and the gateway's own supervisor would already be running it).
- All recovery is best-effort; any failure is logged and swallowed.

