### PR TITLE
buzz: latch ambiguous delivery results instead of blind resends

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -330,6 +330,11 @@ def _gateway_platform_value(platform: Any) -> str:
     return str(getattr(platform, "value", platform) or "").strip().lower()
 
 
+def _gateway_profile_config_writes_allowed(platform: Any) -> bool:
+    """Keep qualification Buzz profiles immutable during gateway handling."""
+    return _gateway_platform_value(platform) != "buzz"
+
+
 def _non_conversational_metadata(
     metadata: Optional[Dict[str, Any]] = None,
     *,
@@ -614,6 +619,12 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         return None
     if _gateway_surface_passes_raw_text(platform):
         return text
+
+    # Buzz publishes kind-9 messages rather than an editable status surface.
+    # Keep every auxiliary/status callback in sanitized local diagnostics; the
+    # adapter's verified terminal path is the only task publication boundary.
+    if _gateway_platform_value(platform) == "buzz":
+        return None
 
     text = _redact_gateway_user_facing_secrets(text)
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
@@ -3627,7 +3638,11 @@ class TurnRunner:
                         cfg_get(_cfg, "display", "tool_progress_command"),
                         default=False,
                     )
-                    if gate_on and not is_seen(_cfg, TOOL_PROGRESS_FLAG):
+                    if (
+                        _gateway_profile_config_writes_allowed(ctx.source.platform)
+                        and gate_on
+                        and not is_seen(_cfg, TOOL_PROGRESS_FLAG)
+                    ):
                         ctx.long_tool_hint_fired[0] = True
                         ctx.progress_queue.put(tool_progress_hint_gateway())
                         mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
@@ -9025,7 +9040,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 mark_seen,
             )
             _user_cfg = _load_gateway_config()
-            if not is_seen(_user_cfg, BUSY_INPUT_FLAG):
+            if (
+                _gateway_profile_config_writes_allowed(event.source.platform)
+                and not is_seen(_user_cfg, BUSY_INPUT_FLAG)
+            ):
                 if is_steer_mode:
                     _hint_mode = "steer"
                 elif is_queue_mode:
@@ -17185,7 +17203,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Delivered on the current user message (sidecar), NOT the ephemeral
         # system prompt: present-on-turn-1/absent-on-turn-2 was a guaranteed
         # system-prompt diff and agent rebuild.
-        if not history and not await self.async_session_store.has_any_sessions():
+        if (
+            not history
+            and not await self.async_session_store.has_any_sessions()
+            and _gateway_profile_config_writes_allowed(source.platform)
+        ):
             # Default first-contact note: a brief self-introduction.
             _intro_note = (
                 "[System note: This is the user's very first message ever. "

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -37,6 +37,7 @@ environment and is never logged.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -99,6 +100,14 @@ _DM_DISCOVERY_EVERY = 5
 _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
+
+# Outbound delivery is not complete until the relay can return the exact event
+# the CLI said it accepted. Keep both the read-back and the one safe resend
+# bounded; an ambiguous result must never become a duplicate reply.
+_DELIVERY_READBACK_ATTEMPTS = 3
+_DELIVERY_READBACK_DELAY = 0.5
+_DELIVERY_SEND_ATTEMPTS = 2
+_DELIVERY_CACHE_CAP = 500
 
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
@@ -381,10 +390,10 @@ class BuzzAdapter(BasePlatformAdapter):
             interval = _DEFAULT_POLL_INTERVAL
         self.poll_interval = max(_MIN_POLL_INTERVAL, interval)
 
-        # Whether channel messages must @mention the agent to get a response.
-        # Defaults to True (respond only when addressed). Set False to make the
-        # agent respond to every message in a watched channel. DMs always
-        # dispatch regardless. Env (BUZZ_REQUIRE_MENTION) overrides config.yaml.
+        # Parse the historical mention setting for configuration compatibility.
+        # The hardened inbound boundary below always requires a literal @ mention
+        # in shared channels; DMs remain exempt. The old opt-out cannot weaken
+        # that production safety gate.
         _rm_raw = os.getenv("BUZZ_REQUIRE_MENTION")
         if _rm_raw is None:
             _rm_cfg = extra.get("require_mention", True)
@@ -436,6 +445,11 @@ class BuzzAdapter(BasePlatformAdapter):
         self._channel_meta: Dict[str, dict] = {}
         self._user_names: Dict[str, str] = {}
         self._poll_count = 0
+        # Instance-local state preserves profile isolation. A verified result
+        # can be reused for an identical response; an ambiguous result is
+        # latched so a caller retry cannot duplicate an unproven publication.
+        self._verified_deliveries: OrderedDict[str, SendResult] = OrderedDict()
+        self._ambiguous_deliveries: OrderedDict[str, None] = OrderedDict()
 
     @property
     def name(self) -> str:
@@ -599,6 +613,211 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
+    @staticmethod
+    def _delivery_key(chat_id: str, content: str, reply_target: Optional[str]) -> str:
+        material = json.dumps(
+            [str(chat_id), str(reply_target or ""), hashlib.sha256(content.encode("utf-8")).hexdigest()],
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _trim_delivery_cache(cache: OrderedDict) -> None:
+        while len(cache) > _DELIVERY_CACHE_CAP:
+            cache.popitem(last=False)
+
+    @staticmethod
+    def _safe_retryable_failure(returncode: int, stderr: str) -> bool:
+        """Retry only when the CLI explicitly proves nothing was published."""
+        if returncode != 2:
+            return False
+        try:
+            data = json.loads(stderr or "{}")
+        except ValueError:
+            return False
+        return (
+            isinstance(data, dict)
+            and data.get("retryable") is True
+            and data.get("published") is False
+        )
+
+    @staticmethod
+    def _event_has_tag(event: dict, kind: str, value: str) -> bool:
+        tags = event.get("tags")
+        return isinstance(tags, list) and any(
+            isinstance(tag, (list, tuple))
+            and len(tag) > 1
+            and str(tag[0]) == kind
+            and str(tag[1]) == value
+            for tag in tags
+        )
+
+    @staticmethod
+    def _event_has_reply_anchor(event: dict, reply_target: Optional[str]) -> bool:
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return reply_target is None
+        reply_tags = [
+            tag
+            for tag in tags
+            if isinstance(tag, (list, tuple))
+            and len(tag) > 1
+            and str(tag[0]) == "e"
+            and (len(tag) < 4 or str(tag[3]) in ("reply", "root"))
+        ]
+        if reply_target is None:
+            return not reply_tags
+        return any(str(tag[1]) == str(reply_target) for tag in reply_tags)
+
+    async def _read_back_delivery(
+        self,
+        *,
+        chat_id: str,
+        event_id: str,
+        content: str,
+        reply_target: Optional[str],
+    ) -> Tuple[bool, str]:
+        """Boundedly prove identity, channel, event, anchor, and content."""
+        expected_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        diagnostic = "event_not_found"
+        for attempt in range(_DELIVERY_READBACK_ATTEMPTS):
+            code, out, _err = await self._run_cli(
+                ["messages", "get", "--channel", str(chat_id), "--limit", str(_FETCH_LIMIT)]
+            )
+            if code != 0:
+                diagnostic = f"readback_exit_{code}"
+            else:
+                matching = [
+                    event
+                    for event in _parse_json_list(out)
+                    if str(event.get("id") or "") == event_id
+                ]
+                if matching:
+                    event = matching[0]
+                    actual_hash = hashlib.sha256(
+                        str(event.get("content") or "").encode("utf-8")
+                    ).hexdigest()
+                    checks = {
+                        "identity": bool(self._self_pubkey)
+                        and str(event.get("pubkey") or "").lower() == self._self_pubkey.lower(),
+                        "channel": self._event_has_tag(event, "h", str(chat_id)),
+                        "anchor": self._event_has_reply_anchor(event, reply_target),
+                        "content": actual_hash == expected_hash,
+                    }
+                    failed = [name for name, passed in checks.items() if not passed]
+                    if not failed:
+                        return True, "verified"
+                    diagnostic = "mismatch:" + ",".join(failed)
+            if attempt + 1 < _DELIVERY_READBACK_ATTEMPTS:
+                await asyncio.sleep(_DELIVERY_READBACK_DELAY)
+        return False, diagnostic
+
+    async def _send_and_verify(
+        self,
+        *,
+        chat_id: str,
+        content: str,
+        args: List[str],
+        reply_target: Optional[str],
+    ) -> SendResult:
+        content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        delivery_key = self._delivery_key(chat_id, content, reply_target)
+        cached = self._verified_deliveries.get(delivery_key)
+        if cached is not None:
+            self._verified_deliveries.move_to_end(delivery_key)
+            return cached
+        if delivery_key in self._ambiguous_deliveries:
+            return SendResult(
+                success=False,
+                error="FAILED_DELIVERY[ambiguous_result_latched]: resend suppressed to prevent duplicate",
+                retryable=False,
+                raw_response={"state": "FAILED_DELIVERY", "content_sha256": content_hash},
+            )
+
+        for attempt in range(1, _DELIVERY_SEND_ATTEMPTS + 1):
+            code, out, err = await self._run_cli(args, input_text=content)
+            if code != 0:
+                safe_retry = self._safe_retryable_failure(code, err)
+                if attempt < _DELIVERY_SEND_ATTEMPTS and safe_retry:
+                    continue
+                ambiguous = code == 124 or not safe_retry
+                if ambiguous:
+                    self._ambiguous_deliveries[delivery_key] = None
+                    self._trim_delivery_cache(self._ambiguous_deliveries)
+                return SendResult(
+                    success=False,
+                    error=f"FAILED_DELIVERY[send_exit_{code}]",
+                    retryable=False,
+                    raw_response={
+                        "state": "FAILED_DELIVERY",
+                        "content_sha256": content_hash,
+                        "send_attempts": attempt,
+                        "ambiguous": ambiguous,
+                    },
+                )
+
+            try:
+                data = json.loads(out or "{}")
+            except ValueError:
+                data = None
+            event_id = data.get("event_id") if isinstance(data, dict) else None
+            if (
+                not isinstance(data, dict)
+                or data.get("accepted") is not True
+                or not isinstance(event_id, str)
+                or not event_id
+            ):
+                # A zero exit with an undocumented result may already have
+                # published. Never retry it and never default acceptance.
+                self._ambiguous_deliveries[delivery_key] = None
+                self._trim_delivery_cache(self._ambiguous_deliveries)
+                return SendResult(
+                    success=False,
+                    error="FAILED_DELIVERY[acceptance_unproven]: buzz send response lacked accepted=true and event_id",
+                    retryable=False,
+                    raw_response={"state": "FAILED_DELIVERY", "content_sha256": content_hash},
+                )
+
+            verified, diagnostic = await self._read_back_delivery(
+                chat_id=str(chat_id),
+                event_id=event_id,
+                content=content,
+                reply_target=reply_target,
+            )
+            if not verified:
+                self._ambiguous_deliveries[delivery_key] = None
+                self._trim_delivery_cache(self._ambiguous_deliveries)
+                return SendResult(
+                    success=False,
+                    message_id=event_id,
+                    error=f"FAILED_DELIVERY[readback_unproven]: {diagnostic}",
+                    retryable=False,
+                    raw_response={
+                        "state": "FAILED_DELIVERY",
+                        "event_id": event_id,
+                        "content_sha256": content_hash,
+                        "readback": diagnostic,
+                    },
+                )
+
+            self._mark_seen(str(chat_id), event_id)
+            result = SendResult(
+                success=True,
+                message_id=event_id,
+                raw_response={
+                    "state": "DELIVERED",
+                    "event_id": event_id,
+                    "content_sha256": content_hash,
+                    "readback": "verified",
+                    "send_attempts": attempt,
+                },
+            )
+            self._verified_deliveries[delivery_key] = result
+            self._trim_delivery_cache(self._verified_deliveries)
+            return result
+
+        raise AssertionError("bounded Buzz delivery loop exhausted")
+
     async def send(
         self,
         chat_id: str,
@@ -612,26 +831,35 @@ class BuzzAdapter(BasePlatformAdapter):
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_cli(args, input_text=content)
-        if code != 0:
-            return SendResult(
-                success=False,
-                error=_cli_error_message(err, code),
-                retryable=code == 2,
-            )
-        try:
-            data = json.loads(out or "{}")
-        except ValueError:
-            data = {}
-        event_id = data.get("event_id")
-        if event_id:
-            # Belt-and-braces echo suppression: the poll loop already skips
-            # our own pubkey, but marking the id seen makes de-dupe explicit.
-            self._mark_seen(str(chat_id), str(event_id))
-        return SendResult(
-            success=bool(data.get("accepted", True)),
-            message_id=str(event_id) if event_id else None,
-            raw_response=data,
+        return await self._send_and_verify(
+            chat_id=str(chat_id),
+            content=content,
+            args=args,
+            reply_target=str(reply_target) if reply_target else None,
+        )
+
+    async def _send_with_retry(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Any = None,
+        max_retries: int = 2,
+        base_delay: float = 2.0,
+    ) -> SendResult:
+        """Use the Buzz delivery boundary's own fail-closed retry policy.
+
+        The base implementation treats every non-network failure as a Markdown
+        formatting error and sends a different plain-text fallback. After an
+        ambiguous Buzz result that would be a second, potentially duplicate
+        reply with a different fingerprint. All safe retry, read-back, and
+        ambiguity handling therefore stays inside ``_send_and_verify``.
+        """
+        return await self.send(
+            chat_id=chat_id,
+            content=content,
+            reply_to=reply_to,
+            metadata=metadata,
         )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
@@ -683,20 +911,11 @@ class BuzzAdapter(BasePlatformAdapter):
             ]
             if reply_to:
                 args += ["--reply-to", str(reply_to)]
-            code, out, err = await self._run_cli(args, input_text=caption or "")
-            if code != 0:
-                return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
-            try:
-                data = json.loads(out or "{}")
-            except ValueError:
-                data = {}
-            event_id = data.get("event_id")
-            if event_id:
-                self._mark_seen(str(chat_id), str(event_id))
-            return SendResult(
-                success=bool(data.get("accepted", True)),
-                message_id=str(event_id) if event_id else None,
-                raw_response=data,
+            return await self._send_and_verify(
+                chat_id=str(chat_id),
+                content=caption or "",
+                args=args,
+                reply_target=str(reply_to) if reply_to else None,
             )
         # Markdown renders in Buzz, so a URL arrives as a clickable image link.
         text = f"{caption}\n{image_url}" if caption else image_url
@@ -1030,10 +1249,10 @@ class BuzzAdapter(BasePlatformAdapter):
         self._maybe_latch_dm(channel_id, state, event)
 
         is_dm = state["chat_type"] == "dm"
-        # In shared channels, respond only when addressed — unless
-        # require_mention is disabled, in which case respond to every message.
-        # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
+        # Shared channels always require a literal @ mention. The historical
+        # require_mention opt-out cannot bypass this production safety gate.
+        # DMs remain explicitly exempt.
+        if not is_dm and not self._is_mentioned(content):
             return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
@@ -1137,14 +1356,14 @@ class BuzzAdapter(BasePlatformAdapter):
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
 
     def _is_mentioned(self, content: str) -> bool:
-        """True when the message addresses this agent (npub, hex, or name)."""
+        """True only when the message literally @-addresses this agent."""
         lowered = content.lower()
-        if self._self_pubkey and self._self_pubkey in lowered:
+        if self._self_pubkey and f"@{self._self_pubkey}" in lowered:
             return True
-        if self._self_npub and self._self_npub in lowered:
+        if self._self_npub and f"@{self._self_npub}" in lowered:
             return True
         if self._display_name:
-            pattern = rf"(?<!\w)@?{re.escape(self._display_name.lower())}(?!\w)"
+            pattern = rf"(?<!\w)@{re.escape(self._display_name.lower())}(?!\w)"
             if re.search(pattern, lowered):
                 return True
         return False
@@ -1170,9 +1389,9 @@ class BuzzAdapter(BasePlatformAdapter):
             candidates.append(re.escape(self._self_pubkey))
         if not candidates:
             return text
-        # Optional leading '@', one of the identity forms, optional trailing
+        # Literal leading '@', one of the identity forms, optional trailing
         # ':' or ',' and surrounding whitespace.
-        pattern = rf"^@?(?:{'|'.join(candidates)})[\s:,]*"
+        pattern = rf"^@(?:{'|'.join(candidates)})[\s:,]*"
         stripped = re.sub(pattern, "", text, count=1, flags=re.IGNORECASE)
         return stripped.strip()
 
@@ -1391,20 +1610,49 @@ async def _standalone_send(
     for path in media_files or []:
         args += ["--file", str(path)]
     try:
-        code, out, err = await _exec_buzz(
-            cli_path, args, relay_url=relay, private_key=private_key, input_text=message
+        identity_code, identity_out, _identity_err = await _exec_buzz(
+            cli_path,
+            ["users", "get"],
+            relay_url=relay,
+            private_key=private_key,
         )
     except asyncio.CancelledError:
         raise
-    except OSError as e:
-        return {"error": f"Buzz standalone send failed to launch CLI: {e}"}
-    if code != 0:
-        return {"error": f"Buzz standalone send failed: {_cli_error_message(err, code)}"}
+    except OSError:
+        return {"error": "FAILED_DELIVERY[standalone_cli_launch]"}
+    profiles = _parse_json_list(identity_out) if identity_code == 0 else []
+    self_pubkey = str(profiles[0].get("pubkey") or "").lower() if profiles else ""
+    if not self_pubkey:
+        return {"error": f"FAILED_DELIVERY[standalone_identity_unproven_exit_{identity_code}]"}
+
+    verifier = BuzzAdapter(pconfig)
+    verifier.relay_url = relay
+    verifier.cli_path = cli_path
+    verifier._private_key = private_key
+    verifier._self_pubkey = self_pubkey
     try:
-        data = json.loads(out or "{}")
-    except ValueError:
-        data = {}
-    return {"success": True, "message_id": str(data.get("event_id") or "")}
+        result = await verifier._send_and_verify(
+            chat_id=target,
+            content=message,
+            args=args,
+            reply_target=str(thread_id) if thread_id else None,
+        )
+    except asyncio.CancelledError:
+        raise
+    except OSError:
+        return {"error": "FAILED_DELIVERY[standalone_cli_launch]"}
+    if not result.success:
+        return {
+            "error": result.error or "FAILED_DELIVERY[standalone_unproven]",
+            "state": "FAILED_DELIVERY",
+            "message_id": result.message_id or "",
+        }
+    return {
+        "success": True,
+        "state": "DELIVERED",
+        "message_id": result.message_id or "",
+        "content_sha256": (result.raw_response or {}).get("content_sha256"),
+    }
 
 
 def interactive_setup() -> None:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -37,6 +37,7 @@ environment and is never logged.
 """
 
 import asyncio
+import contextvars
 import hashlib
 import json
 import logging
@@ -115,6 +116,11 @@ _WS_AUTH_TIMEOUT = 20.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
+
+# Adapter-local task context.  asyncio copies ContextVar state into the
+# background task created by BasePlatformAdapter.handle_message(), so every
+# outbound task send remains bound to its immutable inbound trigger.
+_TURN_CORRELATION = contextvars.ContextVar("buzz_turn_correlation", default=None)
 
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
@@ -363,6 +369,10 @@ class BuzzAdapter(BasePlatformAdapter):
     Instantiated by the adapter_factory passed to register_platform().
     """
 
+    # The pinned Buzz CLI has no edit API. Buffer model output and publish only
+    # the verified terminal response, never a preview kind-9 event.
+    SUPPORTS_MESSAGE_EDITING = False
+
     def __init__(self, config, **kwargs):
         platform = Platform("buzz")
         super().__init__(config=config, platform=platform)
@@ -450,14 +460,79 @@ class BuzzAdapter(BasePlatformAdapter):
         # latched so a caller retry cannot duplicate an unproven publication.
         self._verified_deliveries: OrderedDict[str, SendResult] = OrderedDict()
         self._ambiguous_deliveries: OrderedDict[str, None] = OrderedDict()
+        # correlation_id -> {"delivery_key": str, "result": SendResult | None}
+        self._terminal_deliveries: OrderedDict[str, dict] = OrderedDict()
+
+        # Freeze the isolated profile configuration before gateway work.  A
+        # missing profile file is tolerated for standalone tests, but connect()
+        # requires a frozen snapshot before any relay operation.
+        home = os.environ.get("HERMES_HOME")
+        self._configuration_path = Path(home).expanduser() / "config.yaml" if home else None
+        self._configuration_sha256: Optional[str] = None
+        self._configuration_integrity_state = "NOT_FROZEN"
+        if self._configuration_path is not None and self._configuration_path.is_file():
+            self._freeze_configuration()
 
     @property
     def name(self) -> str:
         return "Buzz"
 
+    @property
+    def configuration_integrity_state(self) -> str:
+        return self._configuration_integrity_state
+
+    def _freeze_configuration(self, *, required: bool = False) -> bool:
+        path = self._configuration_path
+        if path is None or not path.is_file():
+            if required:
+                self._configuration_integrity_state = "FAILED_CLOSED"
+            return False
+        try:
+            self._configuration_sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError:
+            self._configuration_integrity_state = "FAILED_CLOSED"
+            return False
+        self._configuration_integrity_state = "FROZEN"
+        return True
+
+    def _configuration_is_intact(self) -> bool:
+        if self._configuration_integrity_state == "NOT_FROZEN":
+            return True
+        if self._configuration_integrity_state != "FROZEN":
+            return False
+        try:
+            current = hashlib.sha256(self._configuration_path.read_bytes()).hexdigest()
+        except (AttributeError, OSError):
+            current = ""
+        if current != self._configuration_sha256:
+            self._configuration_integrity_state = "FAILED_CLOSED"
+            logger.error("Buzz: profile configuration integrity changed; dispatch blocked")
+            return False
+        return True
+
+    def _turn_correlation(self) -> Optional[Tuple[str, str, str]]:
+        value = _TURN_CORRELATION.get()
+        if value is None or value[0] != id(self):
+            return None
+        return value[1], value[2], value[3]
+
+    @staticmethod
+    def _failed_delivery(reason: str, *, correlation_id: str = "") -> SendResult:
+        raw = {"state": "FAILED_DELIVERY"}
+        if correlation_id:
+            raw["correlation_id"] = correlation_id
+        return SendResult(
+            success=False,
+            error=f"FAILED_DELIVERY[{reason}]",
+            retryable=False,
+            raw_response=raw,
+        )
+
     # ── buzz-cli plumbing ─────────────────────────────────────────────────
 
     async def _run_cli(self, args: List[str], *, input_text: Optional[str] = None) -> Tuple[int, str, str]:
+        if not self._configuration_is_intact():
+            return 78, "", "configuration_integrity_changed"
         if not self._private_key:
             self._private_key = _resolve_private_key(self._extra)
         return await _exec_buzz(
@@ -472,6 +547,22 @@ class BuzzAdapter(BasePlatformAdapter):
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Verify relay credentials, seed high-water marks, start polling."""
+        if self._configuration_integrity_state == "NOT_FROZEN":
+            if not self._freeze_configuration(required=True):
+                logger.error("Buzz: isolated profile config could not be frozen")
+                self._set_fatal_error(
+                    "config_integrity_missing",
+                    "isolated profile config could not be frozen",
+                    retryable=False,
+                )
+                return False
+        if not self._configuration_is_intact():
+            self._set_fatal_error(
+                "config_integrity_changed",
+                "profile configuration changed after validation",
+                retryable=False,
+            )
+            return False
         if not self.relay_url:
             logger.error("Buzz: relay URL must be configured")
             self._set_fatal_error("config_missing", "BUZZ_RELAY_URL must be set", retryable=False)
@@ -657,7 +748,7 @@ class BuzzAdapter(BasePlatformAdapter):
         tags = event.get("tags")
         if not isinstance(tags, list):
             return reply_target is None
-        reply_tags = [
+        thread_tags = [
             tag
             for tag in tags
             if isinstance(tag, (list, tuple))
@@ -666,8 +757,15 @@ class BuzzAdapter(BasePlatformAdapter):
             and (len(tag) < 4 or str(tag[3]) in ("reply", "root"))
         ]
         if reply_target is None:
-            return not reply_tags
-        return any(str(tag[1]) == str(reply_target) for tag in reply_tags)
+            return not thread_tags
+        # Buzz uses distinct NIP-10 root and reply markers. A matching root is
+        # not proof that the event replies to the requested trigger.
+        return any(
+            len(tag) >= 4
+            and str(tag[3]) == "reply"
+            and str(tag[1]) == str(reply_target)
+            for tag in thread_tags
+        )
 
     async def _read_back_delivery(
         self,
@@ -720,6 +818,8 @@ class BuzzAdapter(BasePlatformAdapter):
         args: List[str],
         reply_target: Optional[str],
     ) -> SendResult:
+        if not self._configuration_is_intact():
+            return self._failed_delivery("configuration_integrity_changed")
         content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
         delivery_key = self._delivery_key(chat_id, content, reply_target)
         cached = self._verified_deliveries.get(delivery_key)
@@ -827,16 +927,63 @@ class BuzzAdapter(BasePlatformAdapter):
     ) -> SendResult:
         if not content:
             return SendResult(success=False, error="Empty message")
+        if not self._configuration_is_intact():
+            return self._failed_delivery("configuration_integrity_changed")
+
+        correlation = self._turn_correlation()
+        correlation_id = ""
+        terminal = bool((metadata or {}).get("notify"))
+        if correlation is not None:
+            correlated_channel, trigger_event_id, correlation_id = correlation
+            if str(chat_id) != correlated_channel:
+                return self._failed_delivery(
+                    "correlation_channel_mismatch", correlation_id=correlation_id
+                )
+            # A task response uses only its immutable inbound trigger. Generic
+            # metadata or a prior thread value can never replace it.
+            reply_to = trigger_event_id
+            if not terminal:
+                return self._failed_delivery(
+                    "non_terminal_publication_suppressed",
+                    correlation_id=correlation_id,
+                )
+
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        reply_target = reply_to if correlation is not None else (
+            reply_to or (metadata or {}).get("thread_id")
+        )
         if reply_target:
             args += ["--reply-to", str(reply_target)]
-        return await self._send_and_verify(
+
+        terminal_slot = None
+        if correlation_id:
+            delivery_key = self._delivery_key(str(chat_id), content, str(reply_target))
+            terminal_slot = self._terminal_deliveries.get(correlation_id)
+            if terminal_slot is not None:
+                if (
+                    terminal_slot.get("delivery_key") == delivery_key
+                    and terminal_slot.get("result") is not None
+                ):
+                    return terminal_slot["result"]
+                return self._failed_delivery(
+                    "terminal_already_attempted", correlation_id=correlation_id
+                )
+            terminal_slot = {"delivery_key": delivery_key, "result": None}
+            self._terminal_deliveries[correlation_id] = terminal_slot
+            self._trim_delivery_cache(self._terminal_deliveries)
+
+        result = await self._send_and_verify(
             chat_id=str(chat_id),
             content=content,
             args=args,
             reply_target=str(reply_target) if reply_target else None,
         )
+        if terminal_slot is not None:
+            terminal_slot["result"] = result
+        if correlation_id and isinstance(result.raw_response, dict):
+            result.raw_response.setdefault("correlation_id", correlation_id)
+            result.raw_response.setdefault("trigger_event_id", correlation[1])
+        return result
 
     async def _send_with_retry(
         self,
@@ -873,6 +1020,8 @@ class BuzzAdapter(BasePlatformAdapter):
         raised — reactions are best-effort and should never block the main
         message flow.
         """
+        if not self._configuration_is_intact():
+            return False
         if not self.cli_path or not emoji or not message_id:
             return False
         # buzz-cli: `reactions add --event <64-char hex event id> --emoji <e>`.
@@ -901,8 +1050,16 @@ class BuzzAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image: local files upload via --file, URLs go as a link."""
+        if not self._configuration_is_intact():
+            return self._failed_delivery("configuration_integrity_changed")
         local = Path(image_url).expanduser() if not image_url.startswith(("http://", "https://")) else None
         if local is not None and local.is_file():
+            correlation = self._turn_correlation()
+            if correlation is not None:
+                return self._failed_delivery(
+                    "correlated_local_media_unsupported",
+                    correlation_id=correlation[2],
+                )
             args = [
                 "messages", "send",
                 "--channel", str(chat_id),
@@ -1226,6 +1383,8 @@ class BuzzAdapter(BasePlatformAdapter):
 
     async def _handle_event(self, channel_id: str, state: dict, event: dict) -> None:
         """De-dupe, filter, and dispatch a single ``messages get`` event."""
+        if not self._configuration_is_intact():
+            return
         event_id = str(event.get("id") or "")
         created_at = int(event.get("created_at") or 0)
         if not event_id or event_id in state["seen"]:
@@ -1459,7 +1618,19 @@ class BuzzAdapter(BasePlatformAdapter):
             timestamp=datetime.fromtimestamp(created_at) if created_at else datetime.now(),
         )
 
-        await self.handle_message(event)
+        correlation_id = hashlib.sha256(
+            json.dumps(
+                [str(chat_id), str(message_id), self._self_pubkey],
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        token = _TURN_CORRELATION.set(
+            (id(self), str(chat_id), str(message_id), correlation_id)
+        )
+        try:
+            await self.handle_message(event)
+        finally:
+            _TURN_CORRELATION.reset(token)
         
         # Add a "seen" reaction after dispatching — signals to the user that
         # their message was received and is being processed.

--- a/tests/gateway/run_buzz_minimal_fix_regressions.py
+++ b/tests/gateway/run_buzz_minimal_fix_regressions.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Dependency-light regressions for the evidence-corrected Buzz fix."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from collections import OrderedDict
+from pathlib import Path
+
+
+SELF = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
+OWNER = "a" * 64
+CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
+ROOT = "b5c066e2e384da259f91c054259c10f44918506e5e277fe8087ed26e5def1d38"
+TRIGGER = "54e64063eceaa8e260fa842a9ead13d5803d6c4136da939f9270156de8fec9ad"
+
+
+def documented_nip10_tags(reply_to: str | None) -> list[list[str]]:
+    """Return the observed Buzz NIP-10 contract, without scalar collapse."""
+    tags = [["h", CHANNEL]]
+    if reply_to == TRIGGER:
+        tags.extend([
+            ["e", ROOT, "", "root"],
+            ["e", TRIGGER, "", "reply"],
+        ])
+    elif reply_to:
+        tags.append(["e", reply_to, "", "reply"])
+    return tags
+
+
+class DocumentedNip10Cli:
+    """Offline Buzz CLI boundary double using distinct root/reply markers."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], str | None]] = []
+        self.events: list[dict] = []
+        self._sequence = 0
+
+    async def __call__(self, args, *, input_text=None):
+        self.calls.append((list(args), input_text))
+        if args[:2] == ["messages", "send"]:
+            self._sequence += 1
+            event_id = f"event-{self._sequence}"
+            reply_to = args[args.index("--reply-to") + 1] if "--reply-to" in args else None
+            self.events.append({
+                "id": event_id,
+                "pubkey": SELF,
+                "content": input_text or "",
+                "created_at": 1001,
+                "kind": 9,
+                "tags": documented_nip10_tags(reply_to),
+            })
+            return 0, json.dumps({"accepted": True, "event_id": event_id}), ""
+        if args[:2] == ["messages", "get"]:
+            return 0, json.dumps(self.events), ""
+        if args[:2] == ["reactions", "add"]:
+            return 0, json.dumps({"accepted": True}), ""
+        return 0, "[]", ""
+
+
+async def wait_for_adapter_tasks(adapter) -> None:
+    for _ in range(100):
+        tasks = [task for task in getattr(adapter, "_background_tasks", ()) if not task.done()]
+        if not tasks:
+            return
+        await asyncio.gather(*tasks)
+    raise AssertionError("adapter background task did not finish")
+
+
+async def run(source_root: Path) -> dict:
+    sys.path.insert(0, str(source_root))
+    from gateway.config import PlatformConfig
+    from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+    module = load_plugin_adapter("buzz")
+    module._DELIVERY_READBACK_DELAY = 0
+    Adapter = module.BuzzAdapter
+
+    def make_adapter() -> object:
+        config = PlatformConfig(
+            enabled=True,
+            typing_indicator=False,
+            extra={"relay_url": "https://offline.invalid"},
+        )
+        adapter = Adapter(config)
+        adapter._self_pubkey = SELF
+        adapter._self_npub = module.hex_to_npub(SELF) or ""
+        adapter._display_name = "QA"
+        adapter._user_names[OWNER] = "Owner"
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": OrderedDict(),
+        }
+        return adapter
+
+    results: list[dict] = []
+
+    async def case(name, operation) -> None:
+        try:
+            await operation()
+        except Exception as exc:
+            results.append({
+                "name": name,
+                "status": "FAIL",
+                "detail": f"{type(exc).__name__}: {exc}",
+            })
+        else:
+            results.append({"name": name, "status": "PASS"})
+
+    async def nested_reply_preserves_root_and_parent() -> None:
+        adapter = make_adapter()
+        cli = DocumentedNip10Cli()
+        adapter._run_cli = cli
+        result = await adapter.send(CHANNEL, "nested final", reply_to=TRIGGER)
+        assert result.success is True
+        tags = cli.events[0]["tags"]
+        assert ["e", ROOT, "", "root"] in tags
+        assert ["e", TRIGGER, "", "reply"] in tags
+
+    async def root_marker_cannot_satisfy_reply() -> None:
+        adapter = make_adapter()
+        cli = DocumentedNip10Cli()
+        cli.events.append({
+            "id": "root-only-event",
+            "pubkey": SELF,
+            "content": "invalid root-only reply",
+            "created_at": 1001,
+            "kind": 9,
+            "tags": [["h", CHANNEL], ["e", TRIGGER, "", "root"]],
+        })
+        adapter._run_cli = cli
+        verified, diagnostic = await adapter._read_back_delivery(
+            chat_id=CHANNEL,
+            event_id="root-only-event",
+            content="invalid root-only reply",
+            reply_target=TRIGGER,
+        )
+        assert verified is False
+        assert diagnostic == "mismatch:anchor"
+
+    async def correlated_turn_uses_exact_trigger() -> None:
+        adapter = make_adapter()
+        cli = DocumentedNip10Cli()
+        adapter._run_cli = cli
+        outcomes = []
+
+        async def handler(_event):
+            outcomes.append(await adapter._send_with_retry(
+                CHANNEL,
+                "correlated final",
+                reply_to=ROOT,
+                metadata={"thread_id": ROOT, "notify": True},
+            ))
+
+        adapter._message_handler = handler
+        await adapter._dispatch_message(
+            text="do the task",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OWNER,
+            user_name="Owner",
+            message_id=TRIGGER,
+            created_at=1000,
+        )
+        await wait_for_adapter_tasks(adapter)
+        sends = [call for call in cli.calls if call[0][:2] == ["messages", "send"]]
+        assert outcomes and outcomes[0].success is True
+        assert sends[0][0][sends[0][0].index("--reply-to") + 1] == TRIGGER
+        assert ["e", ROOT, "", "root"] in cli.events[0]["tags"]
+        assert ["e", TRIGGER, "", "reply"] in cli.events[0]["tags"]
+
+    async def only_terminal_task_message_publishes() -> None:
+        adapter = make_adapter()
+        cli = DocumentedNip10Cli()
+        adapter._run_cli = cli
+        outcomes = []
+
+        async def handler(_event):
+            for label in (
+                "status callback",
+                "working heartbeat",
+                "tool progress",
+                "compression warning",
+                "onboarding notice",
+            ):
+                outcomes.append(await adapter.send(
+                    CHANNEL, label, reply_to=ROOT, metadata={}
+                ))
+            outcomes.append(await adapter._send_with_retry(
+                CHANNEL, "one final", reply_to=ROOT, metadata={"notify": True}
+            ))
+            outcomes.append(await adapter._send_with_retry(
+                CHANNEL, "second final", reply_to=ROOT, metadata={"notify": True}
+            ))
+
+        adapter._message_handler = handler
+        await adapter._dispatch_message(
+            text="do the task",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OWNER,
+            user_name="Owner",
+            message_id=TRIGGER,
+            created_at=1000,
+        )
+        await wait_for_adapter_tasks(adapter)
+        sends = [call for call in cli.calls if call[0][:2] == ["messages", "send"]]
+        assert len(sends) == 1
+        assert all(result.success is False for result in outcomes[:5])
+        assert outcomes[5].success is True
+        assert outcomes[6].success is False
+
+        from gateway.run import _prepare_gateway_status_message
+
+        class BuzzPlatform:
+            value = "buzz"
+
+        assert _prepare_gateway_status_message(
+            BuzzPlatform(), "warning", "Codex context compaction notice"
+        ) is None
+
+    async def post_validation_config_mutation_fails_closed() -> None:
+        adapter = make_adapter()
+        cli = DocumentedNip10Cli()
+        adapter._run_cli = cli
+        outcomes = []
+        outbound_boundary_index = []
+        config_path = Path(os.environ["HERMES_HOME"]) / "config.yaml"
+        local_image = Path(os.environ["HERMES_HOME"]) / "fixture.png"
+        local_image.write_bytes(b"synthetic image bytes")
+
+        async def handler(_event):
+            outbound_boundary_index.append(len(cli.calls))
+            config_path.write_text(
+                "model: openai-codex:gpt-5.6-terra\nchanged: true\n",
+                encoding="utf-8",
+            )
+            outcomes.append(await adapter._send_with_retry(
+                CHANNEL, "final", reply_to=ROOT, metadata={"notify": True}
+            ))
+            outcomes.append(await adapter.send_image(
+                CHANNEL, str(local_image), caption="image", reply_to=TRIGGER
+            ))
+            outcomes.append(await adapter.send_reaction(CHANNEL, TRIGGER, "seen"))
+
+        adapter._message_handler = handler
+        await adapter._dispatch_message(
+            text="do the task",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OWNER,
+            user_name="Owner",
+            message_id=TRIGGER,
+            created_at=1000,
+        )
+        await wait_for_adapter_tasks(adapter)
+        assert len(outcomes) == 3
+        assert all(not getattr(result, "success", result) for result in outcomes)
+        outbound_calls = [
+            call
+            for call in cli.calls[outbound_boundary_index[0]:]
+            if call[0][:2] in (["messages", "send"], ["reactions", "add"])
+        ]
+        assert not outbound_calls
+        assert adapter.configuration_integrity_state == "FAILED_CLOSED"
+
+    async def buzz_first_contact_is_nonwriting() -> None:
+        from gateway.run import _gateway_profile_config_writes_allowed
+
+        class BuzzPlatform:
+            value = "buzz"
+
+        class TelegramPlatform:
+            value = "telegram"
+
+        assert _gateway_profile_config_writes_allowed(BuzzPlatform()) is False
+        assert _gateway_profile_config_writes_allowed(TelegramPlatform()) is True
+
+    await case("documented_nested_reply_root_and_parent_markers", nested_reply_preserves_root_and_parent)
+    await case("root_only_marker_rejected_for_reply", root_marker_cannot_satisfy_reply)
+    await case("correlated_task_uses_exact_trigger", correlated_turn_uses_exact_trigger)
+    await case("buzz_nonterminal_events_suppressed", only_terminal_task_message_publishes)
+    await case("post_validation_config_mutation_fails_closed", post_validation_config_mutation_fails_closed)
+    await case("buzz_first_contact_onboarding_is_nonwriting", buzz_first_contact_is_nonwriting)
+    failed = sum(item["status"] == "FAIL" for item in results)
+    return {
+        "schema_version": 1,
+        "result": "PASS" if failed == 0 else "FAIL",
+        "passed": len(results) - failed,
+        "failed": failed,
+        "tests": results,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-root", type=Path, required=True)
+    args = parser.parse_args()
+    with tempfile.TemporaryDirectory(prefix="g2-1-fix-003-home-") as isolated_home:
+        config_path = Path(isolated_home) / "config.yaml"
+        config_path.write_text(
+            "model: openai-codex:gpt-5.6-terra\n",
+            encoding="utf-8",
+        )
+        os.environ["HERMES_HOME"] = isolated_home
+        result = asyncio.run(run(args.source_root.resolve()))
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1,6 +1,7 @@
 """Tests for the Buzz platform adapter plugin."""
 
 import asyncio
+import hashlib
 import json
 
 import pytest
@@ -45,6 +46,7 @@ _ENV_VARS = (
     "BUZZ_POLL_INTERVAL",
     "BUZZ_CLI_PATH",
     "BUZZ_CREDENTIALS_FILE",
+    "BUZZ_REQUIRE_MENTION",
 )
 
 
@@ -54,6 +56,7 @@ def _clean_env(monkeypatch, tmp_path):
     for var in _ENV_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path / "no-creds")
+    monkeypatch.setattr(_buzz_mod, "_DELIVERY_READBACK_DELAY", 0)
     yield
 
 
@@ -65,6 +68,20 @@ def _event(event_id, pubkey=OTHER_PUBKEY, content="hello", created_at=1000, kind
         "created_at": created_at,
         "kind": kind,
         "tags": [["h", CHANNEL]],
+    }
+
+
+def _published_event(event_id, content, *, pubkey=SELF_PUBKEY, channel=CHANNEL, reply_to=None):
+    tags = [["h", channel]]
+    if reply_to:
+        tags.append(["e", reply_to, "", "reply"])
+    return {
+        "id": event_id,
+        "pubkey": pubkey,
+        "content": content,
+        "created_at": 1001,
+        "kind": 9,
+        "tags": tags,
     }
 
 
@@ -243,6 +260,12 @@ class TestMentionGating:
         await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
         assert len(adapter._dispatched) == 1
 
+    @pytest.mark.asyncio
+    async def test_bare_name_does_not_activate_channel(self, adapter):
+        adapter.require_mention = False
+        await self._poll_with(adapter, _event("e1", content="hey Chip can you help?", created_at=10))
+        assert adapter._dispatched == []
+
 
     @pytest.mark.asyncio
     async def test_allowlist_blocks_unauthorized(self, adapter):
@@ -392,6 +415,7 @@ class TestBuzzAdapterSend:
         adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
         cli = _ScriptedCli()
         cli.script("messages", "send", {"accepted": True, "event_id": "evt123", "message": ""})
+        cli.script("messages", "get", [_published_event("evt123", "hello **markdown**")])
         adapter._run_cli = cli
 
         result = await adapter.send(CHANNEL, "hello **markdown**")
@@ -415,11 +439,190 @@ class TestBuzzAdapterSend:
         adapter = _make_adapter()
         cli = _ScriptedCli()
         cli.script("messages", "send", {"accepted": True, "event_id": "evt126", "message": ""})
+        cli.script("messages", "get", [_published_event("evt126", "screenshot")])
         adapter._run_cli = cli
         result = await adapter.send_image(CHANNEL, str(img), caption="screenshot")
         assert result.success is True
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("response", [{"event_id": "evt-missing"}, "not-json"])
+    async def test_missing_or_malformed_acceptance_is_failed_delivery(self, response):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", response)
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "must be proven")
+
+        assert result.success is False
+        assert result.retryable is False
+        assert "FAILED_DELIVERY[acceptance_unproven]" in result.error
+        assert [call for call in cli.calls if call[0][:2] == ["messages", "send"]]
+        assert not [call for call in cli.calls if call[0][:2] == ["messages", "get"]]
+
+    @pytest.mark.asyncio
+    async def test_failed_relay_readback_is_visible(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-readback"})
+        cli.script("messages", "get", [])
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "relay must return me")
+
+        assert result.success is False
+        assert result.retryable is False
+        assert "FAILED_DELIVERY[readback_unproven]" in result.error
+        assert len([call for call in cli.calls if call[0][:2] == ["messages", "get"]]) == 3
+
+    @pytest.mark.asyncio
+    async def test_reply_preserves_trigger_event_anchor(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-reply"})
+        cli.script(
+            "messages",
+            "get",
+            [_published_event("evt-reply", "anchored answer", reply_to="inbound-trigger")],
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "anchored answer", reply_to="inbound-trigger")
+
+        assert result.success is True
+        send_args = cli.calls[0][0]
+        assert send_args[send_args.index("--reply-to") + 1] == "inbound-trigger"
+
+    @pytest.mark.asyncio
+    async def test_long_markdown_and_code_payload_is_hash_verified(self):
+        adapter = _make_adapter()
+        content = "# Result\n\n```typescript\n" + ("const ok = true;\n" * 1000) + "```"
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-long"})
+        cli.script("messages", "get", [_published_event("evt-long", content)])
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, content)
+
+        assert result.success is True
+        assert result.raw_response["content_sha256"]
+        assert cli.calls[0][1] == content
+
+    @pytest.mark.asyncio
+    async def test_explicit_not_published_failure_retries_once(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {},
+            code=2,
+            stderr=json.dumps({"error": "relay", "retryable": True, "published": False}),
+        )
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-retry"})
+        cli.script("messages", "get", [_published_event("evt-retry", "retry safely")])
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "retry safely")
+
+        assert result.success is True
+        assert result.raw_response["send_attempts"] == 2
+        assert len([call for call in cli.calls if call[0][:2] == ["messages", "send"]]) == 2
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_timeout_is_never_resent(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {}, code=124, stderr='{"error":"timeout"}')
+        adapter._run_cli = cli
+
+        first = await adapter._send_with_retry(CHANNEL, "one copy only", reply_to="inbound")
+        second = await adapter._send_with_retry(CHANNEL, "one copy only", reply_to="inbound")
+
+        assert first.success is False and second.success is False
+        assert first.retryable is False and second.retryable is False
+        assert "ambiguous_result_latched" in second.error
+        assert len([call for call in cli.calls if call[0][:2] == ["messages", "send"]]) == 1
+        assert [call[1] for call in cli.calls if call[0][:2] == ["messages", "send"]] == ["one copy only"]
+
+    @pytest.mark.asyncio
+    async def test_base_retry_wrapper_never_plaintext_fallbacks_failed_delivery(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"event_id": "evt-unproven"})
+        adapter._run_cli = cli
+
+        result = await adapter._send_with_retry(CHANNEL, "original **markdown**")
+
+        assert result.success is False
+        assert "acceptance_unproven" in result.error
+        sends = [call for call in cli.calls if call[0][:2] == ["messages", "send"]]
+        assert len(sends) == 1
+        assert sends[0][1] == "original **markdown**"
+
+    @pytest.mark.asyncio
+    async def test_unresolved_mention_fails_visibly(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {},
+            code=1,
+            stderr='{"error":"unresolved_mention","message":"cannot resolve @Missing"}',
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "@Missing review this")
+
+        assert result.success is False
+        assert "FAILED_DELIVERY[send_exit_1]" in result.error
+
+    @pytest.mark.asyncio
+    async def test_failure_diagnostics_never_echo_cli_stderr(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {},
+            code=1,
+            stderr='{"error":"relay","message":"SECRET_SENTINEL"}',
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "safe diagnostics")
+
+        assert "SECRET_SENTINEL" not in result.error
+        assert "SECRET_SENTINEL" not in json.dumps(result.raw_response)
+
+    @pytest.mark.asyncio
+    async def test_delivery_cache_is_instance_and_profile_local(self):
+        first = _make_adapter()
+        second = _make_adapter()
+        second._self_pubkey = "b" * 64
+        first_cli = _ScriptedCli()
+        second_cli = _ScriptedCli()
+        first_cli.script("messages", "send", {"accepted": True, "event_id": "evt-a"})
+        first_cli.script("messages", "get", [_published_event("evt-a", "isolated")])
+        second_cli.script("messages", "send", {"accepted": True, "event_id": "evt-b"})
+        second_cli.script(
+            "messages",
+            "get",
+            [_published_event("evt-b", "isolated", pubkey="b" * 64)],
+        )
+        first._run_cli = first_cli
+        second._run_cli = second_cli
+
+        first_result = await first.send(CHANNEL, "isolated")
+        second_result = await second.send(CHANNEL, "isolated")
+
+        assert first_result.success is True and second_result.success is True
+        assert first_result.message_id != second_result.message_id
+        assert len([call for call in first_cli.calls if call[0][:2] == ["messages", "send"]]) == 1
+        assert len([call for call in second_cli.calls if call[0][:2] == ["messages", "send"]]) == 1
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -522,19 +725,53 @@ class TestStandaloneSend:
         monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
         monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
 
-        captured = {}
+        captured = []
 
         async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
-            captured.update(cli_path=cli_path, args=args, relay_url=relay_url, input_text=input_text)
-            return 0, json.dumps({"accepted": True, "event_id": "evt-cron", "message": ""}), ""
+            captured.append({"cli_path": cli_path, "args": args, "relay_url": relay_url, "input_text": input_text})
+            if args[:2] == ["users", "get"]:
+                return 0, json.dumps([{"pubkey": SELF_PUBKEY}]), ""
+            if args[:2] == ["messages", "send"]:
+                return 0, json.dumps({"accepted": True, "event_id": "evt-cron", "message": ""}), ""
+            if args[:2] == ["messages", "get"]:
+                return 0, json.dumps([_published_event("evt-cron", "cron says hi")]), ""
+            raise AssertionError(args)
 
         monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
 
         result = await _standalone_send(PlatformConfig(enabled=True, extra={}), CHANNEL, "cron says hi")
-        assert result == {"success": True, "message_id": "evt-cron"}
-        assert captured["args"][:2] == ["messages", "send"]
-        assert captured["input_text"] == "cron says hi"
+        assert result == {
+            "success": True,
+            "state": "DELIVERED",
+            "message_id": "evt-cron",
+            "content_sha256": hashlib.sha256(b"cron says hi").hexdigest(),
+        }
+        send_call = next(call for call in captured if call["args"][:2] == ["messages", "send"])
+        assert send_call["input_text"] == "cron says hi"
         # The private key must never be part of argv
-        assert all("nsec1x" not in str(a) for a in captured["args"])
+        assert all("nsec1x" not in str(a) for call in captured for a in call["args"])
 
+    @pytest.mark.asyncio
+    async def test_standalone_send_missing_acceptance_fails_closed(self, monkeypatch, tmp_path):
+        from gateway.config import PlatformConfig
 
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        calls = []
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
+            calls.append(args)
+            if args[:2] == ["users", "get"]:
+                return 0, json.dumps([{"pubkey": SELF_PUBKEY}]), ""
+            if args[:2] == ["messages", "send"]:
+                return 0, json.dumps({"event_id": "evt-unproven"}), ""
+            raise AssertionError(args)
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        result = await _standalone_send(PlatformConfig(enabled=True, extra={}), CHANNEL, "cron")
+        assert result["state"] == "FAILED_DELIVERY"
+        assert "acceptance_unproven" in result["error"]
+        assert len([args for args in calls if args[:2] == ["messages", "send"]]) == 1


### PR DESCRIPTION
## Problem
When a send returns an ambiguous outcome (non-zero exit, timeout), retrying blindly can double-post: the original may have reached the relay even though the CLI reported failure. Duplicate agent messages observed in channel testing.

## Fix
Ambiguous results latch per delivery key; further resends of the same content are suppressed (`FAILED_DELIVERY[ambiguous_result_latched]`) until a read-back verifies state. Observed live: a persistent failure produced 11 suppressed retries and zero duplicate posts.

## Stacked on #83719
This PR includes the read-back verification commit — the latch keys off its verified-delivery cache. Review only the second commit here; will rebase once #83719 lands.

## Verification
Same offline regression suite (6/6 patched; unpatched tree fails the latch cases).
