### PR TITLE
gateway: scope session revival to the requesting profile under multiplex

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1708,10 +1708,17 @@ class SessionStore:
         requested_session_key: str,
         recovered: Dict[str, Any],
     ) -> bool:
-        """Prevent non-multiplexed gateways from reviving another profile's row."""
-        if getattr(self.config, "multiplex_profiles", False):
-            return True
+        """Prevent a gateway from reviving another profile's session row.
 
+        Multiplex fix (AdroLab patch 3): the previous short-circuit returned
+        True for ANY cross-profile revival whenever multiplex_profiles was on,
+        which let the self-heal path bind one profile's routing key to another
+        profile's live session object (observed as agent B answering with
+        agent A's frozen persona and history in a shared channel). Under
+        multiplex the recovered row is allowed only when its profile namespace
+        matches the REQUESTED key's namespace; unparseable keys keep the
+        permissive legacy behavior.
+        """
         recovered_key = str(recovered.get("session_key") or "")
         if not recovered_key or recovered_key == requested_session_key:
             return True
@@ -1719,6 +1726,12 @@ class SessionStore:
         recovered_profile = self._profile_from_session_key(recovered_key)
         if recovered_profile is None:
             return True
+
+        if getattr(self.config, "multiplex_profiles", False):
+            requested_profile = self._profile_from_session_key(requested_session_key)
+            if requested_profile is None:
+                return True
+            return recovered_profile == requested_profile
 
         return recovered_profile == self._active_profile_name()
 

--- a/tests/gateway/run_multiplex_session_isolation_regressions.py
+++ b/tests/gateway/run_multiplex_session_isolation_regressions.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Dependency-light regressions for multiplex session profile isolation.
+
+The defect: with ``multiplex_profiles`` on,
+``SessionStore._recovered_row_allowed_for_active_profile`` short-circuited to
+True for ANY cross-profile revival, letting the routing self-heal bind one
+profile's key to another profile's live session (agent B then answers with
+agent A's frozen persona and history in a shared channel).
+
+Run: python tests/gateway/run_multiplex_session_isolation_regressions.py \
+        --source-root <hermes tree>
+Exit 0 = all pass; exit 1 = failures (expected on the vanilla pin).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--source-root", required=True)
+    args = ap.parse_args()
+    sys.path.insert(0, str(Path(args.source_root).expanduser()))
+
+    from gateway.session import SessionStore
+
+    def store(multiplex: bool) -> SessionStore:
+        s = SessionStore.__new__(SessionStore)
+        s.config = SimpleNamespace(multiplex_profiles=multiplex)
+        return s
+
+    def allowed(s, requested, recovered_key):
+        return s._recovered_row_allowed_for_active_profile(
+            requested_session_key=requested,
+            recovered={"session_key": recovered_key},
+        )
+
+    BUILDER = "agent:adrolab-builder:buzz:group:chan1:user1"
+    QA = "agent:adrolab-qa:buzz:group:chan1:user1"
+    QA_DM = "agent:adrolab-qa:buzz:dm:chan2:user1"
+    LEGACY = "agent:main:buzz:group:chan1:user1"
+
+    results = []
+
+    def check(name, got, want):
+        ok = got == want
+        results.append((name, ok))
+        print(f"{'PASS' if ok else 'FAIL'}  {name}  (got {got}, want {want})")
+
+    mux = store(True)
+    # The defect under test: cross-profile revival must be DENIED under multiplex.
+    check("mux_cross_profile_denied", allowed(mux, QA, BUILDER), False)
+    # Same profile, different chat: allowed (the self-heal's legitimate case).
+    check("mux_same_profile_allowed", allowed(mux, QA, QA_DM), True)
+    # Same key: allowed.
+    check("mux_same_key_allowed", allowed(mux, QA, QA), True)
+    # Legacy/main row for a profile-namespaced request: denied under multiplex
+    # (the default profile owns agent:main).
+    check("mux_legacy_row_for_profile_denied", allowed(mux, QA, LEGACY), False)
+    # Unparseable recovered key: permissive legacy behavior retained.
+    check("mux_unparseable_recovered_allowed", allowed(mux, QA, "weird-key"), True)
+    # Missing recovered key: allowed (nothing to protect).
+    check("mux_empty_recovered_allowed", allowed(mux, QA, ""), True)
+
+    # Non-multiplex behavior unchanged: compares against the active profile name.
+    plain = store(False)
+    active = SessionStore._active_profile_name()
+    same_active = f"agent:{active}:buzz:group:chan1:user1"
+    check("plain_same_active_allowed", allowed(plain, QA, same_active), True)
+    other = "agent:someone-else:buzz:group:chan1:user1"
+    check("plain_other_profile_denied", allowed(plain, QA, other), False)
+
+    failed = [n for n, ok in results if not ok]
+    print(f"\n{len(results) - len(failed)} PASS / {len(failed)} FAIL")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem
`SessionStore._recovered_row_allowed_for_active_profile` short-circuits to `True` for ANY revival when `multiplex_profiles` is on — the cross-profile guard only exists for non-multiplexed gateways. The routing self-heal can then bind profile B's fresh session key to profile A's live session object. Observed live in a shared channel: the second agent mentioned answered from its own platform identity but with the first agent's frozen system prompt and conversation history.

## Fix
Under multiplex, revival is allowed only when the recovered row's profile namespace matches the REQUESTING key's namespace (`_profile_from_session_key` on both sides). Unparseable keys keep the permissive legacy behavior; the non-multiplex path is byte-identical.

## Verification
Dependency-light runner included (`tests/gateway/run_multiplex_session_isolation_regressions.py`): 8/8 on the patched tree; the unpatched v2026.8.3 tree fails exactly the two cross-profile cases (exit 1). Live-verified: after the fix, agent B introduces itself with its own persona and explicitly denies knowledge of agent A's conversation in the same channel.

Part 3 of the series (independent of #83719 — touches only `gateway/session.py`).
