### PR TITLE
feat(webhook): recognize X-Gitea-Event and X-Forgejo-Event headers

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -708,6 +708,8 @@ class WebhookAdapter(BasePlatformAdapter):
         event_type = (
             request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
+            or request.headers.get("X-Gitea-Event", "")
+            or request.headers.get("X-Forgejo-Event", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
             or "unknown"

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -348,6 +348,33 @@ class TestEventFilter:
             )
             assert resp.status == 202
 
+    @pytest.mark.parametrize(
+        "header_name",
+        ["X-Gitea-Event", "X-Forgejo-Event"],
+    )
+    @pytest.mark.asyncio
+    async def test_event_filter_accepts_gitea_and_forgejo_headers(self, header_name):
+        """Forgejo/Gitea deliver events via their own headers, not X-GitHub-Event."""
+        routes = {
+            "gh": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "prompt": "PR: {action}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        # Stub handle_message to avoid running the agent
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gh",
+                json={"action": "opened"},
+                headers={header_name: "pull_request"},
+            )
+            assert resp.status == 202
+
 
 # ===================================================================
 # Payload filters


### PR DESCRIPTION
Closing in favor of **#66895** (feat(webhook): Add Gitea webhook signature validation support), which is a strict superset: it includes the same `X-Gitea-Event` / `X-Forgejo-Event` header recognition plus Gitea/Forgejo signature validation. I verified #66895 rebases cleanly onto current main (105 tests pass), so no information is lost by folding this in.

Saving the focused patch locally (branch `feat/webhook-forgejo-event-headers`) in case the rebased #66895 stalls.