### PR TITLE
fix(plugins): stop tampered directory plugins from running backdoors before rejection

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3244,7 +3244,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 34,
+    "_config_version": 35,
 }
 
 # Optional environment variables that enhance functionality

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -718,6 +718,42 @@ def _migrate_to_34(results: Dict[str, Any], quiet: bool) -> None:
                 )
 
 
+def _migrate_to_35(results: Dict[str, Any], quiet: bool) -> None:
+    # ── Version 34 → 35: establish host-owned directory-plugin evidence ──
+    # Existing enabled user plugins predate the pre-import integrity boundary.
+    # Bind their current entrypoints once during the trusted host upgrade so
+    # later edits fail closed before top-level Python executes. Project plugins
+    # are included when their existing explicit discovery opt-in is active.
+    from pathlib import Path
+
+    from hermes_cli.plugin_integrity import record_plugin_entrypoint
+    from hermes_cli.plugins import PluginManager
+
+    recorded = 0
+    for manifest in PluginManager()._collect_directory_manifests():
+        if manifest.source not in {"user", "project"} or manifest.portable:
+            continue
+        plugin_dir = Path(manifest.path or "")
+        if not (plugin_dir / "__init__.py").exists():
+            continue
+        try:
+            record_plugin_entrypoint(manifest.key or manifest.name, plugin_dir)
+            recorded += 1
+        except Exception as exc:
+            results["warnings"].append(
+                f"Could not record integrity evidence for plugin "
+                f"{manifest.key or manifest.name}: {exc}"
+            )
+    results["config_added"].append(
+        f"directory plugin integrity evidence ({recorded} plugin(s))"
+    )
+    if not quiet:
+        print(
+            f"  ✓ Recorded host-owned integrity evidence for {recorded} "
+            "directory plugin(s)"
+        )
+
+
 #: Registry of (target_version, migration_fn), strictly ascending. The driver
 #: applies every entry whose target version is greater than the on-disk
 #: version captured before the ladder started. Order matters: later steps may
@@ -740,6 +776,7 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
     (32, _migrate_to_32),
     (33, _migrate_to_33),
     (34, _migrate_to_34),
+    (35, _migrate_to_35),
 )
 
 

--- a/hermes_cli/plugin_integrity.py
+++ b/hermes_cli/plugin_integrity.py
@@ -1,0 +1,290 @@
+"""Host-owned integrity evidence for native directory plugins.
+
+The evidence store lives under the active profile, outside every plugin
+package.  User and project plugin entrypoints are read, hashed, and returned
+from the same open file so callers can execute the verified bytes without a
+second path lookup.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+_STORE_VERSION = 1
+_STORE_DIR = "plugin-integrity"
+_STORE_FILE = "directory-plugins.json"
+_CONFIG_VERSION_GATE = 35
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class PluginIntegrityError(RuntimeError):
+    """Raised when directory-plugin integrity cannot be established safely."""
+
+
+def evidence_path() -> Path:
+    return get_hermes_home() / _STORE_DIR / _STORE_FILE
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    obj: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in obj:
+            raise PluginIntegrityError(
+                f"duplicate key {key!r} in plugin integrity evidence"
+            )
+        obj[key] = value
+    return obj
+
+
+def _read_regular_bytes(path: Path, *, label: str) -> bytes:
+    """Read one ordinary non-symlink file without following a replaced link."""
+    try:
+        before = path.lstat()
+    except FileNotFoundError as exc:
+        raise PluginIntegrityError(f"missing {label}: {path}") from exc
+    except OSError as exc:
+        raise PluginIntegrityError(f"cannot inspect {label} {path}: {exc}") from exc
+
+    if stat.S_ISLNK(before.st_mode):
+        raise PluginIntegrityError(f"refusing symlinked {label}: {path}")
+    if not stat.S_ISREG(before.st_mode):
+        raise PluginIntegrityError(f"refusing non-regular {label}: {path}")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise PluginIntegrityError(f"cannot open {label} {path}: {exc}") from exc
+
+    try:
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode):
+            raise PluginIntegrityError(f"refusing non-regular {label}: {path}")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        data = b"".join(chunks)
+    finally:
+        os.close(fd)
+
+    try:
+        after = path.lstat()
+    except OSError as exc:
+        raise PluginIntegrityError(f"{label} changed while being read: {path}") from exc
+    if stat.S_ISLNK(after.st_mode) or not stat.S_ISREG(after.st_mode):
+        raise PluginIntegrityError(f"{label} changed type while being read: {path}")
+    if (
+        before.st_dev != opened.st_dev
+        or before.st_ino != opened.st_ino
+        or after.st_dev != opened.st_dev
+        or after.st_ino != opened.st_ino
+        or opened.st_size != len(data)
+    ):
+        raise PluginIntegrityError(f"{label} changed while being read: {path}")
+    return data
+
+
+def _canonical_plugin_dir(plugin_dir: Path) -> str:
+    try:
+        if plugin_dir.is_symlink():
+            raise PluginIntegrityError(f"refusing symlinked plugin directory: {plugin_dir}")
+        resolved = plugin_dir.resolve(strict=True)
+    except OSError as exc:
+        raise PluginIntegrityError(
+            f"cannot resolve plugin directory {plugin_dir}: {exc}"
+        ) from exc
+    if not resolved.is_dir():
+        raise PluginIntegrityError(f"plugin path is not a directory: {plugin_dir}")
+    return str(resolved)
+
+
+def _validate_record(raw: Any) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        raise PluginIntegrityError("plugin integrity record must be an object")
+    if set(raw) != {"key", "path", "entrypoint", "sha256"}:
+        raise PluginIntegrityError("plugin integrity record has unsafe fields")
+    key = raw.get("key")
+    plugin_path = raw.get("path")
+    entrypoint = raw.get("entrypoint")
+    digest = raw.get("sha256")
+    if (
+        not isinstance(key, str)
+        or not key
+        or key.strip() != key
+        or "\\" in key
+        or any(segment in {"", ".", ".."} for segment in key.split("/"))
+    ):
+        raise PluginIntegrityError("plugin integrity record has an unsafe key")
+    if not isinstance(plugin_path, str) or not Path(plugin_path).is_absolute():
+        raise PluginIntegrityError("plugin integrity record path must be absolute")
+    resolved_path = str(Path(plugin_path).resolve(strict=False))
+    if os.path.normcase(plugin_path) != os.path.normcase(resolved_path):
+        raise PluginIntegrityError("plugin integrity record path is not canonical")
+    if entrypoint != "__init__.py":
+        raise PluginIntegrityError("plugin integrity record has an unsafe entrypoint")
+    if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+        raise PluginIntegrityError("plugin integrity record has an invalid SHA-256 digest")
+    return {
+        "key": key,
+        "path": plugin_path,
+        "entrypoint": entrypoint,
+        "sha256": digest,
+    }
+
+
+def _load_records(*, missing_ok: bool) -> list[dict[str, str]]:
+    store = evidence_path()
+    if not store.exists() and not store.is_symlink():
+        if missing_ok:
+            return []
+        raise PluginIntegrityError(f"missing plugin integrity evidence: {store}")
+    data = _read_regular_bytes(store, label="plugin integrity evidence")
+    try:
+        payload = json.loads(data.decode("utf-8"), object_pairs_hook=_unique_object)
+    except PluginIntegrityError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PluginIntegrityError(f"invalid plugin integrity evidence: {exc}") from exc
+    if not isinstance(payload, dict) or set(payload) != {"version", "plugins"}:
+        raise PluginIntegrityError("plugin integrity evidence has an unsafe structure")
+    if payload.get("version") != _STORE_VERSION:
+        raise PluginIntegrityError("unsupported plugin integrity evidence version")
+    raw_records = payload.get("plugins")
+    if not isinstance(raw_records, list):
+        raise PluginIntegrityError("plugin integrity evidence plugins must be a list")
+
+    records = [_validate_record(raw) for raw in raw_records]
+    seen_keys: set[str] = set()
+    seen_paths: set[str] = set()
+    for record in records:
+        if record["key"] in seen_keys or record["path"] in seen_paths:
+            raise PluginIntegrityError("duplicate plugin integrity evidence")
+        seen_keys.add(record["key"])
+        seen_paths.add(record["path"])
+    return records
+
+
+def _write_records(records: list[dict[str, str]]) -> None:
+    store = evidence_path()
+    parent = store.parent
+    if parent.exists() and parent.is_symlink():
+        raise PluginIntegrityError(f"refusing symlinked integrity directory: {parent}")
+    parent.mkdir(parents=True, exist_ok=True)
+    if parent.is_symlink() or not parent.is_dir():
+        raise PluginIntegrityError(f"unsafe integrity directory: {parent}")
+
+    payload = {
+        "version": _STORE_VERSION,
+        "plugins": sorted(records, key=lambda item: (item["key"], item["path"])),
+    }
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    fd, tmp_name = tempfile.mkstemp(prefix=".directory-plugins-", dir=parent)
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, store)
+    except Exception:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def integrity_enforced() -> bool:
+    """Return whether this profile has crossed the host-evidence boundary."""
+    store = evidence_path()
+    if store.exists() or store.is_symlink():
+        return True
+    config_path = get_hermes_home() / "config.yaml"
+    try:
+        raw = config_path.read_text(encoding="utf-8")
+        from utils import fast_safe_load
+
+        config = fast_safe_load(raw) or {}
+        version = config.get("_config_version", 0) if isinstance(config, dict) else 0
+        return int(version) >= _CONFIG_VERSION_GATE
+    except (OSError, TypeError, ValueError):
+        return False
+
+
+def record_plugin_entrypoint(key: str, plugin_dir: Path) -> None:
+    """Replace host-owned evidence for one exact directory entrypoint."""
+    canonical = _canonical_plugin_dir(plugin_dir)
+    entrypoint = plugin_dir / "__init__.py"
+    data = _read_regular_bytes(entrypoint, label="plugin entrypoint")
+    record = {
+        "key": key,
+        "path": canonical,
+        "entrypoint": "__init__.py",
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+    _validate_record(record)
+    records = _load_records(missing_ok=True)
+    records = [
+        item
+        for item in records
+        if item["key"] != key and item["path"] != canonical
+    ]
+    records.append(record)
+    _write_records(records)
+
+
+def remove_plugin_evidence(key: str, plugin_dir: Path | None = None) -> None:
+    store = evidence_path()
+    if not store.exists() and not store.is_symlink():
+        return
+    canonical: str | None = None
+    if plugin_dir is not None:
+        try:
+            canonical = str(plugin_dir.resolve(strict=False))
+        except OSError:
+            canonical = None
+    records = _load_records(missing_ok=False)
+    kept = [
+        item
+        for item in records
+        if item["key"] != key and (canonical is None or item["path"] != canonical)
+    ]
+    if kept != records:
+        _write_records(kept)
+
+
+def verified_entrypoint_bytes(key: str, plugin_dir: Path) -> bytes:
+    """Return exact verified entrypoint bytes or fail before Python executes."""
+    canonical = _canonical_plugin_dir(plugin_dir)
+    records = _load_records(missing_ok=False)
+    matches = [
+        item for item in records if item["key"] == key and item["path"] == canonical
+    ]
+    if len(matches) != 1:
+        if not matches:
+            raise PluginIntegrityError(
+                f"missing plugin integrity evidence for {key!r} at {canonical}"
+            )
+        raise PluginIntegrityError(f"duplicate plugin integrity evidence for {key!r}")
+    data = _read_regular_bytes(
+        plugin_dir / matches[0]["entrypoint"], label="plugin entrypoint"
+    )
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != matches[0]["sha256"]:
+        raise PluginIntegrityError(
+            f"plugin entrypoint integrity mismatch for {key!r}"
+        )
+    return data

--- a/hermes_cli/plugin_integrity.py
+++ b/hermes_cli/plugin_integrity.py
@@ -14,6 +14,8 @@ import os
 import re
 import stat
 import tempfile
+import threading
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +26,7 @@ _STORE_DIR = "plugin-integrity"
 _STORE_FILE = "directory-plugins.json"
 _CONFIG_VERSION_GATE = 35
 _SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+_PROCESS_LOCK = threading.RLock()
 
 
 class PluginIntegrityError(RuntimeError):
@@ -207,6 +210,68 @@ def _write_records(records: list[dict[str, str]]) -> None:
         raise
 
 
+@contextmanager
+def _locked_evidence_update():
+    """Serialize evidence read-modify-write across threads and processes."""
+    store = evidence_path()
+    parent = store.parent
+    if parent.exists() and parent.is_symlink():
+        raise PluginIntegrityError(f"refusing symlinked integrity directory: {parent}")
+    parent.mkdir(parents=True, exist_ok=True)
+    if parent.is_symlink() or not parent.is_dir():
+        raise PluginIntegrityError(f"unsafe integrity directory: {parent}")
+
+    lock_path = parent / ".directory-plugins.lock"
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    with _PROCESS_LOCK:
+        try:
+            fd = os.open(lock_path, flags, 0o600)
+        except OSError as exc:
+            raise PluginIntegrityError(
+                f"cannot open plugin integrity lock {lock_path}: {exc}"
+            ) from exc
+        handle = os.fdopen(fd, "r+b", buffering=0)
+        try:
+            opened = os.fstat(handle.fileno())
+            if not stat.S_ISREG(opened.st_mode) or lock_path.is_symlink():
+                raise PluginIntegrityError(
+                    f"refusing unsafe plugin integrity lock: {lock_path}"
+                )
+            if os.name == "nt":
+                import msvcrt
+
+                if opened.st_size == 0:
+                    handle.write(b"\0")
+                    handle.flush()
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                handle.seek(0)
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except PluginIntegrityError:
+            raise
+        except OSError as exc:
+            raise PluginIntegrityError(
+                f"cannot lock plugin integrity evidence: {exc}"
+            ) from exc
+        finally:
+            handle.close()
+
+
 def integrity_enforced() -> bool:
     """Return whether this profile has crossed the host-evidence boundary."""
     store = evidence_path()
@@ -236,34 +301,36 @@ def record_plugin_entrypoint(key: str, plugin_dir: Path) -> None:
         "sha256": hashlib.sha256(data).hexdigest(),
     }
     _validate_record(record)
-    records = _load_records(missing_ok=True)
-    records = [
-        item
-        for item in records
-        if item["key"] != key and item["path"] != canonical
-    ]
-    records.append(record)
-    _write_records(records)
+    with _locked_evidence_update():
+        records = _load_records(missing_ok=True)
+        records = [
+            item
+            for item in records
+            if item["key"] != key and item["path"] != canonical
+        ]
+        records.append(record)
+        _write_records(records)
 
 
 def remove_plugin_evidence(key: str, plugin_dir: Path | None = None) -> None:
     store = evidence_path()
-    if not store.exists() and not store.is_symlink():
-        return
     canonical: str | None = None
     if plugin_dir is not None:
         try:
             canonical = str(plugin_dir.resolve(strict=False))
         except OSError:
             canonical = None
-    records = _load_records(missing_ok=False)
-    kept = [
-        item
-        for item in records
-        if item["key"] != key and (canonical is None or item["path"] != canonical)
-    ]
-    if kept != records:
-        _write_records(kept)
+    with _locked_evidence_update():
+        if not store.exists() and not store.is_symlink():
+            return
+        records = _load_records(missing_ok=False)
+        kept = [
+            item
+            for item in records
+            if item["key"] != key and (canonical is None or item["path"] != canonical)
+        ]
+        if kept != records:
+            _write_records(kept)
 
 
 def verified_entrypoint_bytes(key: str, plugin_dir: Path) -> bytes:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2053,6 +2053,19 @@ class PluginManager:
         if not init_file.exists():
             raise FileNotFoundError(f"No __init__.py in {plugin_dir}")
 
+        verified_source: bytes | None = None
+        if manifest.source in {"user", "project"}:
+            from hermes_cli.plugin_integrity import (
+                integrity_enforced,
+                verified_entrypoint_bytes,
+            )
+
+            if integrity_enforced():
+                verified_source = verified_entrypoint_bytes(
+                    manifest.key or manifest.name,
+                    plugin_dir,
+                )
+
         # Ensure the namespace parent package exists
         if _NS_PARENT not in sys.modules:
             ns_pkg = types.ModuleType(_NS_PARENT)
@@ -2075,7 +2088,18 @@ class PluginManager:
         module.__package__ = module_name
         module.__path__ = [str(plugin_dir)]  # type: ignore[attr-defined]
         sys.modules[module_name] = module
-        spec.loader.exec_module(module)
+        try:
+            if verified_source is None:
+                spec.loader.exec_module(module)
+            else:
+                # Execute the exact bytes held open and hashed by the host.
+                # Asking the import loader to reopen the path here would leave
+                # a hash-check/use race in the integrity boundary.
+                code = compile(verified_source, str(init_file), "exec")
+                exec(code, module.__dict__)
+        except BaseException:
+            sys.modules.pop(module_name, None)
+            raise
         return module
 
     def _load_entrypoint_module(self, manifest: PluginManifest) -> types.ModuleType:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -578,6 +578,19 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
     _copy_example_files(target, Console())
     installed_manifest = _read_manifest(target)
     installed_name = installed_manifest.get("name") or target.name
+    if has_yaml and (target / "__init__.py").exists():
+        from hermes_cli.plugin_integrity import (
+            PluginIntegrityError,
+            record_plugin_entrypoint,
+        )
+
+        try:
+            record_plugin_entrypoint(installed_name, target)
+        except PluginIntegrityError as exc:
+            shutil.rmtree(target, ignore_errors=True)
+            raise PluginOperationError(
+                f"Cannot record plugin entrypoint integrity: {exc}"
+            ) from exc
     return target, installed_manifest, installed_name
 
 
@@ -699,6 +712,22 @@ def cmd_update(name: str) -> None:
     # __pycache__ compiled from the previous revision.
     _clear_plugin_bytecode(target)
 
+    if (target / "__init__.py").exists():
+        from hermes_cli.plugin_integrity import (
+            PluginIntegrityError,
+            record_plugin_entrypoint,
+        )
+
+        manifest = _read_manifest(target)
+        key = manifest.get("name") or name
+        try:
+            record_plugin_entrypoint(key, target)
+        except PluginIntegrityError as exc:
+            console.print(
+                f"[red]Error:[/red] Updated plugin integrity could not be recorded: {exc}"
+            )
+            sys.exit(1)
+
     # Copy any new .example files
     _copy_example_files(target, console)
 
@@ -725,6 +754,10 @@ def cmd_remove(name: str) -> None:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
+    from hermes_cli.plugin_integrity import remove_plugin_evidence
+
+    manifest = _read_manifest(target)
+    remove_plugin_evidence(manifest.get("name") or name, target)
     shutil.rmtree(target)
     _display_removed(name, plugins_dir)
 
@@ -857,6 +890,26 @@ def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
     return None
 
 
+def _record_discovered_plugin_integrity(key: str, source: str) -> None:
+    """Bind the current user/project entrypoint at the explicit enable gate."""
+    if source not in {"user", "project"}:
+        return
+    for entry in _discover_all_plugins():
+        # entry = (name, version, description, source, dir_path, key)
+        if entry[5] != key or entry[3] != source:
+            continue
+        plugin_dir = entry[4]
+        if not plugin_dir:
+            break
+        from hermes_cli.plugin_integrity import record_plugin_entrypoint
+
+        record_plugin_entrypoint(key, Path(plugin_dir))
+        return
+    raise PluginOperationError(
+        f"Cannot locate directory entrypoint for plugin '{key}'."
+    )
+
+
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
     """Write ``plugins.entries.<plugin_id>.<key> = value`` into config.yaml."""
     from hermes_cli.config import load_config, save_config
@@ -897,6 +950,12 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
     key, source = resolved
+
+    try:
+        _record_discovered_plugin_integrity(key, source)
+    except (OSError, PluginOperationError, RuntimeError) as exc:
+        console.print(f"[red]Error:[/red] Cannot trust plugin '{key}': {exc}")
+        sys.exit(1)
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -892,7 +892,9 @@ def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
 
 def _record_discovered_plugin_integrity(key: str, source: str) -> None:
     """Bind the current user/project entrypoint at the explicit enable gate."""
-    if source not in {"user", "project"}:
+    # CLI discovery labels git-backed user plugins as ``git`` for display,
+    # while PluginManager still loads them from the user trust boundary.
+    if source not in {"user", "git", "project"}:
         return
     for entry in _discover_all_plugins():
         # entry = (name, version, description, source, dir_path, key)
@@ -2062,6 +2064,14 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     if enabled:
         if name in en and name not in dis:
             return {"ok": True, "name": name, "unchanged": True}
+        resolved = _resolve_plugin_key_and_source(name)
+        if resolved is None:
+            return {"ok": False, "error": f"Plugin '{name}' could not be resolved."}
+        key, source = resolved
+        try:
+            _record_discovered_plugin_integrity(key, source)
+        except (OSError, PluginOperationError, RuntimeError) as exc:
+            return {"ok": False, "error": f"Cannot trust plugin '{key}': {exc}"}
         en.add(name)
         dis.discard(name)
         _save_enabled_set(en)
@@ -2112,6 +2122,22 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
     # Sibling of the CLI ``hermes plugins update`` path: drop bytecode
     # compiled from the pre-pull plugin revision.
     _clear_plugin_bytecode(target)
+
+    if (target / "__init__.py").exists():
+        from hermes_cli.plugin_integrity import (
+            PluginIntegrityError,
+            record_plugin_entrypoint,
+        )
+
+        manifest = _read_manifest(target)
+        key = manifest.get("name") or name
+        try:
+            record_plugin_entrypoint(key, target)
+        except PluginIntegrityError as exc:
+            return {
+                "ok": False,
+                "error": f"Updated plugin integrity could not be recorded: {exc}",
+            }
 
     from rich.console import Console
 
@@ -2183,6 +2209,16 @@ def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
             "error": f"Plugin '{name}' was not found under {plugins_dir}.",
         }
 
+    from hermes_cli.plugin_integrity import PluginIntegrityError, remove_plugin_evidence
+
+    manifest = _read_manifest(target)
+    try:
+        remove_plugin_evidence(manifest.get("name") or name, target)
+    except PluginIntegrityError as exc:
+        return {
+            "ok": False,
+            "error": f"Plugin integrity evidence could not be removed: {exc}",
+        }
     shutil.rmtree(target)
     return {"ok": True, "name": name}
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -912,6 +912,16 @@ def _record_discovered_plugin_integrity(key: str, source: str) -> None:
     )
 
 
+def _record_newly_enabled_plugin_integrity(keys: set[str]) -> None:
+    """Bind directory entrypoints before a multi-select UI enables them."""
+    for key in sorted(keys):
+        resolved = _resolve_plugin_key_and_source(key)
+        if resolved is None:
+            raise PluginOperationError(f"Cannot resolve plugin '{key}'.")
+        canonical_key, source = resolved
+        _record_discovered_plugin_integrity(canonical_key, source)
+
+
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
     """Write ``plugins.entries.<plugin_id>.<key> = value`` into config.yaml."""
     from hermes_cli.config import load_config, save_config
@@ -1828,6 +1838,11 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
     disabled_changed = new_disabled != disabled
 
     if enabled_changed or disabled_changed:
+        try:
+            _record_newly_enabled_plugin_integrity(new_enabled - prev_enabled)
+        except (OSError, PluginOperationError, RuntimeError) as exc:
+            console.print(f"\n[red]Error:[/red] Cannot trust selected plugin: {exc}")
+            return
         _save_enabled_set(new_enabled)
         _save_disabled_set(new_disabled)
         console.print(
@@ -1895,6 +1910,11 @@ def _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
                 new_disabled.add(key)
         prev_enabled = _get_enabled_set()
         if new_enabled != prev_enabled or new_disabled != disabled:
+            try:
+                _record_newly_enabled_plugin_integrity(new_enabled - prev_enabled)
+            except (OSError, PluginOperationError, RuntimeError) as exc:
+                console.print(f"\n[red]Error:[/red] Cannot trust selected plugin: {exc}")
+                return
             _save_enabled_set(new_enabled)
             _save_disabled_set(new_disabled)
 

--- a/tests/hermes_cli/test_plugin_integrity.py
+++ b/tests/hermes_cli/test_plugin_integrity.py
@@ -6,6 +6,8 @@ import json
 import os
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -272,3 +274,82 @@ def test_v35_migration_seeds_existing_user_plugin_evidence(
         plugin / "__init__.py"
     ).read_bytes()
     assert results["warnings"] == []
+
+
+def test_concurrent_records_do_not_lose_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.plugin_integrity as integrity
+
+    home = tmp_path / "home"
+    first = _write_plugin(home, "first")
+    second = _write_plugin(home, "second")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    original_load = integrity._load_records
+
+    def _slow_load(*, missing_ok: bool):
+        records = original_load(missing_ok=missing_ok)
+        time.sleep(0.05)
+        return records
+
+    monkeypatch.setattr(integrity, "_load_records", _slow_load)
+    failures: list[BaseException] = []
+
+    def _record(key: str, path: Path) -> None:
+        try:
+            integrity.record_plugin_entrypoint(key, path)
+        except BaseException as exc:
+            failures.append(exc)
+
+    threads = [
+        threading.Thread(target=_record, args=("first", first)),
+        threading.Thread(target=_record, args=("second", second)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not failures
+    assert all(not thread.is_alive() for thread in threads)
+    assert integrity.verified_entrypoint_bytes("first", first) == (
+        first / "__init__.py"
+    ).read_bytes()
+    assert integrity.verified_entrypoint_bytes("second", second) == (
+        second / "__init__.py"
+    ).read_bytes()
+
+
+def test_record_waits_for_cross_process_evidence_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    env = {**os.environ, "HERMES_HOME": str(home)}
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import time; "
+            "from hermes_cli.plugin_integrity import _locked_evidence_update; "
+            "ctx=_locked_evidence_update(); ctx.__enter__(); "
+            "print('locked', flush=True); time.sleep(0.5); ctx.__exit__(None,None,None)",
+        ],
+        cwd=Path.cwd(),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+    assert child.stdout is not None
+    assert child.stdout.readline().strip() == "locked"
+
+    started = time.monotonic()
+    record_plugin_entrypoint("guarded", plugin)
+    elapsed = time.monotonic() - started
+    _stdout, stderr = child.communicate(timeout=5)
+
+    assert child.returncode == 0, stderr
+    assert elapsed >= 0.2

--- a/tests/hermes_cli/test_plugin_integrity.py
+++ b/tests/hermes_cli/test_plugin_integrity.py
@@ -1,0 +1,274 @@
+"""Behavior coverage for directory-plugin pre-import integrity."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli.plugin_integrity import (
+    PluginIntegrityError,
+    evidence_path,
+    record_plugin_entrypoint,
+    verified_entrypoint_bytes,
+)
+from hermes_cli.plugins import PluginManager, PluginManifest
+
+
+def _write_plugin(home: Path, name: str = "guarded") -> Path:
+    plugin = home / "plugins" / name
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": name, "version": "1.0.0"}),
+        encoding="utf-8",
+    )
+    (plugin / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    from pathlib import Path\n"
+        "    Path(__file__).with_name('registered').write_text('yes')\n",
+        encoding="utf-8",
+    )
+    return plugin
+
+
+def _enable_integrity(home: Path, name: str = "guarded") -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"_config_version": 35, "plugins": {"enabled": [name]}}
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_clean_verified_fixture_imports_and_registers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    _enable_integrity(home)
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    record_plugin_entrypoint("guarded", plugin)
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    assert manager._plugins["guarded"].enabled is True
+    assert (plugin / "registered").read_text(encoding="utf-8") == "yes"
+
+
+@pytest.mark.parametrize("source", ["user", "project"])
+def test_missing_evidence_rejects_before_import(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, source: str
+) -> None:
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    _enable_integrity(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manifest = PluginManifest(
+        name="guarded", key="guarded", source=source, path=str(plugin)
+    )
+
+    with pytest.raises(PluginIntegrityError, match="missing plugin integrity evidence"):
+        PluginManager()._load_directory_module(manifest)
+
+    assert not (plugin / "registered").exists()
+
+
+def test_tampered_entrypoint_never_executes_in_subprocess(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    _enable_integrity(home)
+    previous_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = str(home)
+    try:
+        record_plugin_entrypoint("guarded", plugin)
+    finally:
+        if previous_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = previous_home
+
+    sentinel = plugin / "sentinel"
+    (plugin / "__init__.py").write_text(
+        "from pathlib import Path\n"
+        "Path(__file__).with_name('sentinel').write_text('executed')\n"
+        "def register(ctx):\n"
+        "    Path(__file__).with_name('registered').write_text('yes')\n",
+        encoding="utf-8",
+    )
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    env = {
+        **os.environ,
+        "HERMES_HOME": str(home),
+        "HERMES_BUNDLED_PLUGINS": str(bundled),
+        "PYTHONPATH": os.pathsep.join(
+            value
+            for value in [str(Path.cwd()), os.environ.get("PYTHONPATH", "")]
+            if value
+        ),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from hermes_cli.plugins import PluginManager; "
+            "m=PluginManager(); m.discover_and_load(); "
+            "p=m._plugins['guarded']; "
+            "assert not p.enabled; assert 'integrity mismatch' in (p.error or '')",
+        ],
+        cwd=Path.cwd(),
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not sentinel.exists()
+    assert not (plugin / "registered").exists()
+
+
+def _write_evidence(home: Path, plugins: list[dict[str, str]]) -> None:
+    store = home / "plugin-integrity" / "directory-plugins.json"
+    store.parent.mkdir(parents=True, exist_ok=True)
+    store.write_text(
+        json.dumps({"version": 1, "plugins": plugins}),
+        encoding="utf-8",
+    )
+
+
+def _valid_record(plugin: Path) -> dict[str, str]:
+    import hashlib
+
+    return {
+        "key": "guarded",
+        "path": str(plugin.resolve()),
+        "entrypoint": "__init__.py",
+        "sha256": hashlib.sha256((plugin / "__init__.py").read_bytes()).hexdigest(),
+    }
+
+
+def test_duplicate_evidence_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    record = _valid_record(plugin)
+    _write_evidence(home, [record, dict(record)])
+
+    with pytest.raises(PluginIntegrityError, match="duplicate plugin integrity evidence"):
+        verified_entrypoint_bytes("guarded", plugin)
+
+
+def test_unsafe_evidence_entrypoint_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    record = _valid_record(plugin)
+    record["entrypoint"] = "../outside.py"
+    _write_evidence(home, [record])
+
+    with pytest.raises(PluginIntegrityError, match="unsafe entrypoint"):
+        verified_entrypoint_bytes("guarded", plugin)
+
+
+def test_non_regular_evidence_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    store = evidence_path()
+    store.mkdir(parents=True)
+
+    with pytest.raises(PluginIntegrityError, match="non-regular"):
+        verified_entrypoint_bytes("guarded", plugin)
+
+
+def test_symlinked_evidence_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    target = tmp_path / "outside-evidence.json"
+    target.write_text(
+        json.dumps({"version": 1, "plugins": [_valid_record(plugin)]}),
+        encoding="utf-8",
+    )
+    store = evidence_path()
+    store.parent.mkdir(parents=True)
+    try:
+        store.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"file symlinks unavailable on this host: {exc}")
+
+    with pytest.raises(PluginIntegrityError, match="symlinked"):
+        verified_entrypoint_bytes("guarded", plugin)
+
+
+def test_symlinked_entrypoint_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    target = tmp_path / "outside.py"
+    target.write_text("def register(ctx):\n    pass\n", encoding="utf-8")
+    (plugin / "__init__.py").unlink()
+    try:
+        (plugin / "__init__.py").symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"file symlinks unavailable on this host: {exc}")
+
+    with pytest.raises(PluginIntegrityError, match="symlinked plugin entrypoint"):
+        record_plugin_entrypoint("guarded", plugin)
+
+
+def test_non_regular_entrypoint_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (plugin / "__init__.py").unlink()
+    (plugin / "__init__.py").mkdir()
+
+    with pytest.raises(PluginIntegrityError, match="non-regular plugin entrypoint"):
+        record_plugin_entrypoint("guarded", plugin)
+
+
+def test_v35_migration_seeds_existing_user_plugin_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hermes_cli.config_migrations import _migrate_to_35
+
+    home = tmp_path / "home"
+    plugin = _write_plugin(home)
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    results: dict[str, list[str]] = {"config_added": [], "warnings": []}
+
+    _migrate_to_35(results, quiet=True)
+
+    assert verified_entrypoint_bytes("guarded", plugin) == (
+        plugin / "__init__.py"
+    ).read_bytes()
+    assert results["warnings"] == []

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -697,3 +698,78 @@ def test_portable_manifest_is_visible_to_plugin_cli(tmp_path):
         "Portable test plugin",
         "portable.test",
     )
+
+
+def _write_dashboard_native_plugin(home: Path, name: str = "guarded") -> Path:
+    plugin = home / "plugins" / name
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.yaml").write_text(
+        f"name: {name}\nversion: 1.0.0\n",
+        encoding="utf-8",
+    )
+    (plugin / "__init__.py").write_text("VALUE = 'old'\n", encoding="utf-8")
+    (plugin / ".git").mkdir()
+    return plugin
+
+
+def test_dashboard_enable_records_git_user_plugin_integrity(tmp_path, monkeypatch):
+    from hermes_cli import plugins_cmd as pc
+    from hermes_cli.plugin_integrity import verified_entrypoint_bytes
+
+    home = tmp_path / "home"
+    plugin = _write_dashboard_native_plugin(home)
+    (home / "config.yaml").write_text(
+        "_config_version: 35\nplugins:\n  enabled: []\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(pc, "_toggle_plugin_toolset", lambda *args, **kwargs: None)
+
+    result = pc.dashboard_set_agent_plugin_enabled("guarded", enabled=True)
+
+    assert result == {"ok": True, "name": "guarded", "unchanged": False}
+    assert verified_entrypoint_bytes("guarded", plugin) == (
+        plugin / "__init__.py"
+    ).read_bytes()
+
+
+def test_dashboard_update_refreshes_plugin_integrity(tmp_path, monkeypatch):
+    from hermes_cli import plugins_cmd as pc
+    from hermes_cli.plugin_integrity import (
+        record_plugin_entrypoint,
+        verified_entrypoint_bytes,
+    )
+
+    home = tmp_path / "home"
+    plugin = _write_dashboard_native_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    record_plugin_entrypoint("guarded", plugin)
+
+    def _pull(target):
+        (target / "__init__.py").write_text("VALUE = 'new'\n", encoding="utf-8")
+        return True, "Updated"
+
+    monkeypatch.setattr(pc, "_git_pull_plugin_dir", _pull)
+
+    result = pc.dashboard_update_user_plugin("guarded")
+
+    assert result["ok"] is True
+    assert verified_entrypoint_bytes("guarded", plugin) == (
+        plugin / "__init__.py"
+    ).read_bytes()
+
+
+def test_dashboard_remove_clears_plugin_integrity(tmp_path, monkeypatch):
+    from hermes_cli import plugins_cmd as pc
+    from hermes_cli.plugin_integrity import evidence_path, record_plugin_entrypoint
+
+    home = tmp_path / "home"
+    plugin = _write_dashboard_native_plugin(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    record_plugin_entrypoint("guarded", plugin)
+
+    result = pc.dashboard_remove_user_plugin("guarded")
+
+    assert result == {"ok": True, "name": "guarded"}
+    assert not plugin.exists()
+    assert json.loads(evidence_path().read_text(encoding="utf-8"))["plugins"] == []

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -733,6 +733,31 @@ def test_dashboard_enable_records_git_user_plugin_integrity(tmp_path, monkeypatc
     ).read_bytes()
 
 
+def test_composite_fallback_records_newly_enabled_plugin_integrity(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import plugins_cmd as pc
+    from hermes_cli.plugin_integrity import verified_entrypoint_bytes
+
+    home = tmp_path / "home"
+    plugin = _write_dashboard_native_plugin(home)
+    (home / "config.yaml").write_text(
+        "_config_version: 35\nplugins:\n  enabled: []\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    answers = iter(["1", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+
+    pc._run_composite_fallback(
+        ["guarded"], ["guarded"], set(), set(), [], MagicMock()
+    )
+
+    assert verified_entrypoint_bytes("guarded", plugin) == (
+        plugin / "__init__.py"
+    ).read_bytes()
+
+
 def test_dashboard_update_refreshes_plugin_integrity(tmp_path, monkeypatch):
     from hermes_cli import plugins_cmd as pc
     from hermes_cli.plugin_integrity import (

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -262,10 +262,17 @@ class TestCmdInstall:
 class TestCmdUpdate:
     """Test the update command."""
 
+    @patch("hermes_cli.plugin_integrity.record_plugin_entrypoint")
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd.subprocess.run")
-    def test_update_git_pull_success(self, mock_run, mock_plugins_dir, mock_sanitize):
+    def test_update_git_pull_success(
+        self,
+        mock_run,
+        mock_plugins_dir,
+        mock_sanitize,
+        mock_record_integrity,
+    ):
         from hermes_cli.plugins_cmd import cmd_update
 
         mock_plugins_dir_val = MagicMock()
@@ -282,6 +289,7 @@ class TestCmdUpdate:
         cmd_update("test-plugin")
 
         mock_run.assert_called_once()
+        mock_record_integrity.assert_called_once_with("test-plugin", mock_target)
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
@@ -587,6 +595,7 @@ class TestSubdirInstallE2E:
         plugins_dir = tmp_path / "installed"
         plugins_dir.mkdir()
         monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
 
         identifier = f"file://{repo_root}#my-plugin"
         target, manifest, name = pc._install_plugin_core(identifier, force=False)
@@ -602,6 +611,11 @@ class TestSubdirInstallE2E:
         # ...and the repo-root noise is NOT.
         assert not (target / "README.md").exists()
         assert not (target / "tests").exists()
+        from hermes_cli.plugin_integrity import verified_entrypoint_bytes
+
+        assert verified_entrypoint_bytes("my-plugin", target) == (
+            target / "__init__.py"
+        ).read_bytes()
 
     def test_missing_subdir_raises(self, tmp_path, monkeypatch):
         if shutil.which("git") is None:


### PR DESCRIPTION
## What does this PR do?

Enabled user and project directory plugins now have their Python entrypoint verified by the host before any plugin-owned code executes. Previously, a tampered `__init__.py` could run top-level backdoor or persistence code before a plugin's later self-check rejected registration. The host now records integrity evidence outside plugin directories and executes the exact bytes that passed verification.

### Symptom

A directory plugin with stale integrity evidence could be rejected during `register(ctx)`, but top-level code in its modified `__init__.py` had already executed. In the isolated Windows reproduction, this ordering allowed a sentinel write before registration was denied.

### Impact

Users who enable user or project directory plugins were exposed to one execution of a tampered entrypoint before the existing registration-time rejection. This creates a local backdoor and persistence opportunity within the Hermes process privileges. Bundled plugins and pip entry points are outside this directory-plugin trust boundary.

### Bug Cause

**Trigger:** `hermes_cli/plugins.py:_load_directory_module` imported an enabled user or project directory plugin before `register(ctx)` could perform a plugin-owned integrity check.

**Causal chain:**
1. A directory plugin was enabled with evidence for its original `__init__.py`.
2. The entrypoint was modified while the old evidence remained.
3. Python executed the modified module's top-level code before registration was rejected.

**Why it is wrong:** A check performed by the plugin cannot establish trust before importing that same plugin. Import is already arbitrary code execution.

**Working sibling / contrast:** Bundled plugins are shipped with Hermes, while pip entry points use package installation provenance. This change is limited to enabled user, project, and git-backed directory plugins.

**Ruled out:** Moving the existing self-check earlier inside `register(ctx)` cannot close the gap because module import must complete before the host can call that function.

### Fix

- Store SHA-256 evidence under the active Hermes profile, outside plugin-controlled directories.
- Reject missing, malformed, duplicate, symlinked, non-regular, path-mismatched, or stale evidence before import.
- Read and verify an entrypoint once, then compile and execute those same verified bytes to avoid a second path lookup.
- Seed existing enabled directory plugins during config migration and maintain evidence across CLI, dashboard, install, update, enable, and remove flows.
- Serialize evidence updates across threads and processes so concurrent lifecycle operations cannot lose records.

## Related Issue

Closes #83646

## Type of Change

- [x] Security fix

## Changes Made

- `hermes_cli/plugin_integrity.py` - add the host-owned evidence store, strict validation, safe entrypoint reads, and cross-process update locking.
- `hermes_cli/plugins.py` - verify enabled directory entrypoints before compiling and executing the verified bytes.
- `hermes_cli/plugins_cmd.py` - maintain evidence across install, update, enable, disable, remove, dashboard, and multi-select lifecycle paths.
- `hermes_cli/config_defaults.py` and `hermes_cli/config_migrations.py` - seed evidence once for existing enabled directory plugins.
- `tests/hermes_cli/test_plugin_integrity.py` and `tests/hermes_cli/test_plugins_cmd.py` - cover tampering, unsafe evidence and files, migration, concurrency, and lifecycle behavior.

## How to Test

1. In an isolated `HERMES_HOME`, enable a clean directory plugin and record its entrypoint evidence.
2. Keep the old evidence, replace `__init__.py` with top-level sentinel and registration-marker writes, and load plugins in a fresh process. Confirm the plugin reports an integrity mismatch and neither marker exists.
3. Restore the exact recorded entrypoint and confirm the clean plugin imports and registers.
4. Automated verification already run locally: 112 related plugin tests and 14 migration-focused config tests passed.

```bash
scripts/run_tests.sh tests/hermes_cli/test_plugin_integrity.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugin_scanner_recursion.py -q
scripts/run_tests.sh tests/hermes_cli/test_config.py -k 'migration or migrate' -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all 126 tests pass
- [x] I've added tests for the security fix
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation: N/A - this hardens existing plugin behavior without adding user-facing configuration
- [x] `cli-config.yaml.example`: N/A - no user-facing config key was added or changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no contributor workflow changed
- [x] Cross-platform impact considered: Windows and POSIX locking and filesystem behavior are covered
- [x] Tool descriptions/schemas: N/A - no model tool behavior changed
