### PR TITLE
fix(agent): retry title generation when provider rejects json_schema

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -105,6 +105,71 @@ _TITLE_RESPONSE_FORMAT = {
     },
 }
 
+# json_object is the loosest structured-output hint: DeepSeek, Moonshot/Kimi
+# and other OpenAI-compatible endpoints document only json_object (DeepSeek
+# rejects json_schema with HTTP 400 "This response_format type is unavailable
+# now"). The title prompt already embeds the expected shape and
+# _extract_title_text() has a loose-JSON scan, so a looser hint stays safe.
+_TITLE_RESPONSE_FORMAT_JSON_OBJECT = {"type": "json_object"}
+
+
+def _response_format_rejected(exc: BaseException) -> bool:
+    """True when the provider rejected the ``response_format`` parameter.
+
+    Matches the parameter name in the error text (DeepSeek: "This
+    response_format type is unavailable now"; most providers echo the
+    parameter they reject). Also catches HTTP 400s that never mention
+    ``response_format`` — e.g. vLLM gateways translating json_schema into
+    ``guided_grammar`` and failing with ``compile_grammar_error: No module
+    named 'xgrammar'`` — so the retry ladder still rescues those. Auth,
+    quota, and network failures (403/429/timeout) are deliberately excluded:
+    a different response format cannot fix those, so they break out of the
+    ladder immediately.
+    """
+    text = str(exc)
+    if "response_format" in text or "json_schema" in text:
+        return True
+    status = getattr(exc, "status_code", None)
+    if status == 400 and ("grammar" in text or "guided" in text):
+        return True
+    return False
+
+
+def _title_call_kwargs(
+    *,
+    response_format,
+    disable_thinking: bool,
+    messages: list,
+    timeout,
+    main_runtime,
+) -> dict:
+    """Build call_llm kwargs for one rung of the response-format ladder.
+
+    ``disable_thinking`` pins reasoning off through both available channels:
+    ``reasoning_config`` (translated to the native thinking field by
+    reasoning-aware provider profiles) and ``extra_body.thinking`` (the
+    OpenAI-compatible wire shape DeepSeek and similar endpoints read
+    directly). Profiles override extra_body, so sending both guarantees the
+    disable lands whether or not the provider has a profile.
+    """
+    extra_body: dict = {}
+    if response_format is not None:
+        extra_body["response_format"] = response_format
+    if disable_thinking:
+        extra_body["thinking"] = {"type": "disabled"}
+    return {
+        "task": "title_generation",
+        "messages": messages,
+        # A title is a handful of tokens. The old 500-token ceiling let a
+        # chatty model burn seconds generating prose we then threw away.
+        "max_tokens": 64,
+        "temperature": 0.3,
+        "timeout": timeout,
+        "main_runtime": main_runtime,
+        "reasoning_config": {"enabled": False} if disable_thinking else None,
+        "extra_body": extra_body,
+    }
+
 # Control-tag wrappers that surround machine-authored content inside what is
 # nominally a "user" message. Titling from these is what produces a session
 # named after a slash command or an injected reminder rather than the user's
@@ -391,31 +456,47 @@ def generate_title(
         {"role": "user", "content": user_snippet},
     ]
 
-    try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
-            # A title is a handful of tokens. The old 500-token ceiling let a
-            # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
-        content = response.choices[0].message.content or ""
-        return _clean_title(_extract_title_text(content))
-    except Exception as e:
-        # Log at WARNING so this shows up in agent.log without debug mode.
-        # Full detail at debug level for operators who need the stack.
-        logger.warning("Title generation failed: %s", e)
-        logger.debug("Title generation traceback", exc_info=True)
-        if failure_callback is not None:
-            try:
-                failure_callback("title generation", e)
-            except Exception:
-                logger.debug("Title generation failure_callback raised", exc_info=True)
-        return None
+    # Walk a response-format ladder: strict json_schema → json_object →
+    # unconstrained. Providers without structured-output support (DeepSeek,
+    # Moonshot/Kimi, some vLLM gateways) 400 on json_schema; retrying looser
+    # keeps titling alive instead of dropping to the derived title forever.
+    # Failures unrelated to response_format (auth, quota, network) break out
+    # immediately — a different format cannot fix those. The retried rungs
+    # also pin thinking off: DeepSeek V4 and similar default-on reasoning
+    # models burn the 64-token budget on reasoning_content and return an
+    # empty content even after the 400 is gone (verified live 2026-08-11).
+    last_exc: Optional[BaseException] = None
+    for response_format, disable_thinking in (
+        (_TITLE_RESPONSE_FORMAT, False),
+        (_TITLE_RESPONSE_FORMAT_JSON_OBJECT, True),
+        (None, True),
+    ):
+        try:
+            response = call_llm(
+                **_title_call_kwargs(
+                    response_format=response_format,
+                    disable_thinking=disable_thinking,
+                    messages=messages,
+                    timeout=timeout,
+                    main_runtime=main_runtime,
+                )
+            )
+            content = response.choices[0].message.content or ""
+            return _clean_title(_extract_title_text(content))
+        except Exception as e:
+            last_exc = e
+            if not _response_format_rejected(e):
+                break
+    # Log at WARNING so this shows up in agent.log without debug mode.
+    # Full detail at debug level for operators who need the stack.
+    logger.warning("Title generation failed: %s", last_exc)
+    logger.debug("Title generation traceback", exc_info=True)
+    if failure_callback is not None:
+        try:
+            failure_callback("title generation", last_exc)
+        except Exception:
+            logger.debug("Title generation failure_callback raised", exc_info=True)
+    return None
 
 
 def _persist_session_title(session_db, session_id, title, *, source, dedupe=True):

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -108,6 +108,171 @@ class TestGenerateTitle:
         assert captured[0][0] == "title generation"
         assert captured[0][1] is exc
 
+    def test_falls_back_to_json_object_when_json_schema_rejected(self):
+        """DeepSeek-style providers reject json_schema with HTTP 400; the
+        title must be retried with json_object + thinking disabled."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError(
+                    "Error code: 400 - {'error': {'message': 'This "
+                    "response_format type is unavailable now', ...}}"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Fix login button"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title("fix login button")
+
+        assert title == "Fix login button"
+        assert len(calls) == 2
+        # First attempt keeps the ideal strict json_schema constraint.
+        assert calls[0]["extra_body"] == {
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "session_title",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {"title": {"type": "string"}},
+                        "required": ["title"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        }
+        # Retry loosens to json_object AND pins thinking off through both
+        # channels (reasoning_config + extra_body.thinking) so a default-on
+        # reasoning model (deepseek-v4-flash) doesn't burn the token budget.
+        assert calls[1]["extra_body"] == {
+            "response_format": {"type": "json_object"},
+            "thinking": {"type": "disabled"},
+        }
+        assert calls[1]["reasoning_config"] == {"enabled": False}
+
+    def test_falls_back_to_unconstrained_when_json_object_also_rejected(self):
+        """A provider that rejects both json_schema and json_object still
+        titles via the prompt's own JSON instruction + loose scan."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) < 3:
+                raise RuntimeError(
+                    "Error code: 400 - {'error': {'message': 'This "
+                    "response_format type is unavailable now', ...}}"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = (
+                'Here is the title: {"title": "Triage dashboard alerts"}'
+            )
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title("triage alerts")
+
+        assert title == "Triage dashboard alerts"
+        assert len(calls) == 3
+        # Last rung: no response_format at all, thinking still pinned off.
+        assert calls[2]["extra_body"] == {"thinking": {"type": "disabled"}}
+        assert calls[2]["reasoning_config"] == {"enabled": False}
+
+    def test_format_ladder_does_not_retry_unrelated_failures(self):
+        """Auth/quota/network errors must not burn format-retry attempts."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError(
+                "Error code: 403 - usage limit reached for this billing cycle"
+            )
+
+        captured = []
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            result = generate_title(
+                "question", failure_callback=lambda t, e: captured.append(t)
+            )
+
+        assert result is None
+        assert len(calls) == 1
+        assert captured == ["title generation"]
+
+    def test_format_ladder_reports_failure_after_all_rungs(self):
+        """When every rung is rejected on format grounds, the failure
+        callback fires exactly once with the last exception."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError(
+                "Error code: 400 - {'error': {'message': 'This response_format "
+                "type is unavailable now', ...}}"
+            )
+
+        captured = []
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            result = generate_title(
+                "question", failure_callback=lambda t, e: captured.append(t)
+            )
+
+        assert result is None
+        assert len(calls) == 3
+        assert len(captured) == 1
+        assert captured[0] == "title generation"
+
+    def test_format_ladder_catches_vllm_guided_grammar_400(self):
+        """vLLM gateways translate json_schema to guided_grammar and 400 with
+        an error that never mentions response_format — the retry must still
+        fire (status_code 400 + grammar marker)."""
+        calls = []
+
+        class Vllm400(RuntimeError):
+            status_code = 400
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise Vllm400(
+                    "Error code: 400 - {'error': {'message': 'guided_grammar "
+                    "'{\"additionalProperties\":false,...}' has "
+                    "compile_grammar_error: No module named 'xgrammar', ...}}"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Debug xgrammar error"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title("debug xgrammar")
+
+        assert title == "Debug xgrammar error"
+        assert len(calls) == 2
+        assert calls[1]["extra_body"]["response_format"] == {"type": "json_object"}
+
+    def test_rejects_unrelated_400_without_grammar_marker(self):
+        """A plain 400 with no response_format/grammar marker is not a format
+        rejection and must not retry."""
+        calls = []
+
+        class Plain400(RuntimeError):
+            status_code = 400
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            raise Plain400("Error code: 400 - temperature must be between 0 and 2")
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            result = generate_title("question")
+
+        assert result is None
+        assert len(calls) == 1
+
 
 
 


### PR DESCRIPTION
## Problem

Auto-generated session titles fail **100% of the time** on providers that reject the strict `json_schema` `response_format`. DeepSeek's Chat Completions API returns `HTTP 400 "This response_format type is unavailable now"` for every request carrying `response_format: {"type": "json_schema", ...}`; Moonshot/Kimi document the same limitation; vLLM gateways fail differently (guided_grammar / xgrammar `compile_grammar_error`). The 400 lands in the generic best-effort exception bucket as non-retryable, and every session keeps its truncated **derived** title (a 48-char slice of the first message) forever. The only trace is a WARNING in `agent.log` per new session.

## Root cause

1. **Hardcoded strict `json_schema` with no escape hatch.** `_TITLE_RESPONSE_FORMAT` is sent unconditionally via `extra_body`, and the call-site `extra_body` overrides any config-level `response_format` — there is no per-provider way to disable structured output for titling.
2. **A second, subtler failure mode:** DeepSeek V4 (and similar default-on reasoning models) burn the 64-token title budget on `reasoning_content` and return an **empty `content`** even after the HTTP 400 is gone. A `json_object` retry alone does **not** fix titling on DeepSeek — thinking must be pinned off too. Verified live (2026-08-11):

```
response_format={"type":"json_object"}                     -> content: "", reasoning_content: "We need answer user..." (finish_reason: length)
response_format={"type":"json_object"} + thinking disabled -> content: '{"title": "Fix login button"}' (finish_reason: stop)
```

## Fix

`generate_title()` now walks a three-rung response-format constraint ladder instead of failing on the first attempt:

1. `json_schema` (ideal — unchanged first attempt, byte-identical for providers that support it)
2. `json_object` + thinking disabled
3. no `response_format` + thinking disabled

The retried rungs pin thinking off through **both** channels — `reasoning_config={"enabled": False}` (translated to the native thinking field by reasoning-aware provider profiles) *and* `extra_body["thinking"] = {"type": "disabled"}` (the OpenAI-compatible wire shape DeepSeek reads directly). Profiles override `extra_body`, so sending both guarantees the disable lands whether or not the provider has a profile.

Retries only fire when the provider actually rejected `response_format`:
- error text mentions `response_format` / `json_schema` (DeepSeek, Moonshot/Kimi), **or**
- HTTP 400 with a vLLM `guided_grammar` / `grammar` marker (xgrammar case, whose error never mentions `response_format`)

Auth / quota / network failures (403, 429, timeouts) break out immediately — a different format cannot fix those, and burning extra calls on a dead quota is wasteful.

## Verification

- 6 new regression tests: json_schema→json_object fallback, json_object→unconstrained fallback, no retry on unrelated failures (403), single `failure_callback` after all rungs exhausted, vLLM guided_grammar 400 caught, plain 400 without grammar marker not retried
- Full suite: `tests/agent/test_title_generator.py` + `tests/agent/test_auxiliary_client.py` -> **219 passed**
- Live DeepSeek check: first attempt rejected with the exact 400 -> json_object retry returned a valid title (verified against the real API)

## Notes on related PRs

Several independent PRs address this bug: #82073, #82372, #82751, #82868, #82890, #83186. This PR differs in two ways:

1. **Pins thinking off via `reasoning_config` AND `extra_body.thinking`.** #83186 pins via `extra_body` only — on setups where a provider profile is active (e.g. the DeepSeek profile shipped in `plugins/model-providers/deepseek`), the profile's `build_api_kwargs_extras` overrides `extra_body` back to `{"type": "enabled"}` unless `reasoning_config` says otherwise, so the disable silently never lands. Sending both channels covers profiled and non-profiled endpoints.
2. **Catches the vLLM guided_grammar/xgrammar 400** via the status-code + grammar-marker check, which the message-substring-only detectors miss (their error text never mentions `response_format`).

## Impact

Low risk. The first attempt is byte-identical to current behavior; the ladder only activates when the provider explicitly rejects `response_format`. Non-format failures keep the previous single-attempt + `failure_callback` behavior.
