### PR TITLE
fix(sessions): list reset continuations

### DIFF
--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -98,19 +98,39 @@ _COMPRESSION_CHILD_SQL = (
 )
 
 
-# Rows that surface in pickers: roots + branch children (subagent runs and
-# compression continuations stay hidden).
-_LISTABLE_CHILD_SQL = f"(s.parent_session_id IS NULL OR {_BRANCH_CHILD_SQL.format(a='s')})"
+# A session reset/expiry creates a fresh top-level conversation while retaining
+# parent_session_id for provenance.  It is neither a branch nor a compression
+# continuation, so list and retention paths must recognize it explicitly rather
+# than treating it like an ephemeral subagent row.
+_BOUNDARY_CHILD_SQL = (
+    "json_extract(COALESCE({a}.model_config, '{{}}'), '$._delegate_from') IS NULL"
+    " AND EXISTS (SELECT 1 FROM sessions p"
+    "            WHERE p.id = {a}.parent_session_id"
+    "            AND p.end_reason IN ('session_reset', 'session_switch', 'idle',"
+    "                                 'daily', 'suspended', 'resume_pending_expired')"
+    "            AND {a}.started_at >= p.ended_at)"
+)
+
+
+# Rows that surface in pickers: roots, real branches, and new conversations
+# created at an explicit/automatic session boundary. Subagent runs and
+# compression continuations stay hidden.
+_LISTABLE_CHILD_SQL = (
+    f"(s.parent_session_id IS NULL OR {_BRANCH_CHILD_SQL.format(a='s')}"
+    f" OR {_BOUNDARY_CHILD_SQL.format(a='s')})"
+)
 
 
 def _ephemeral_child_sql(alias: str = "s") -> str:
-    """Subagent runs (cascade-delete targets), not branches or compression tips."""
+    """Subagent runs (cascade-delete targets), not user-visible continuations."""
     branch = _BRANCH_CHILD_SQL.format(a=alias)
     compression = _COMPRESSION_CHILD_SQL.format(a=alias)
+    boundary = _BOUNDARY_CHILD_SQL.format(a=alias)
     return (
         f"({alias}.parent_session_id IS NOT NULL"
         f" AND NOT ({branch})"
-        f" AND NOT ({compression}))"
+        f" AND NOT ({compression})"
+        f" AND NOT ({boundary}))"
     )
 
 

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -107,6 +107,31 @@ class TestHandleResumeCommand:
         assert "/resume 1" in result
         db.close()
 
+    @pytest.mark.asyncio
+    async def test_list_named_sessions_includes_reset_continuation(self, tmp_path):
+        """A reset child is a new user conversation, not an invisible subagent."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(text="/resume")
+        lane_key = _session_key_for_event(event)
+        db.create_session(
+            "before_reset", "telegram", session_key=lane_key,
+            user_id="12345", chat_id="67890",
+        )
+        db.end_session("before_reset", "session_reset")
+        db.create_session(
+            "after_reset", "telegram", session_key=lane_key,
+            user_id="12345", chat_id="67890", parent_session_id="before_reset",
+        )
+        db.set_session_title("after_reset", "Plan four weeks of fun")
+
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Plan four weeks of fun" in result
+        db.close()
+
 
     @pytest.mark.asyncio
     async def test_resume_clears_session_model_overrides(self, tmp_path):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1842,6 +1842,23 @@ class TestListSessionsRich:
         assert [session["id"] for session in sessions] == ["lane_tip"]
         assert sessions[0]["_lineage_root_id"] == "lane_root"
 
+    def test_session_reset_continuation_remains_listable(self, db):
+        """A reset starts a new conversation; its persisted lineage must not hide it."""
+        db.create_session("before_reset", "telegram")
+        db.set_session_title("before_reset", "Before reset")
+        db.end_session("before_reset", "session_reset")
+        db.create_session(
+            "after_reset",
+            "telegram",
+            parent_session_id="before_reset",
+        )
+        db.set_session_title("after_reset", "After reset")
+        db.append_message("after_reset", "user", "new conversation")
+
+        ids = [session["id"] for session in db.list_sessions_rich(source="telegram")]
+
+        assert "after_reset" in ids
+
     def test_session_key_predicate_can_use_session_key_index(self, db):
         plan = db._conn.execute(
             "EXPLAIN QUERY PLAN "


### PR DESCRIPTION
## Summary

A session created after a reset keeps `parent_session_id` for provenance. The session-list predicate previously treated every non-branch child as hidden, so a normal reset continuation could disappear from the CLI and gateway `/resume` picker even though it remained in `state.db`.

Classify continuations after explicit or automatic session boundaries as user-visible while keeping compression continuations and delegated/subagent rows hidden. The migration-time ephemeral-child classifier uses the same distinction.

Related: #43008 covers reset behavior and recovery UX; this fixes the separate discoverability failure after a reset.

## Reproduction

1. Create a gateway session.
2. End it with `session_reset` and create a successor with the former session as `parent_session_id`.
3. Title the successor.
4. Observe that `hermes sessions list --source telegram` and gateway `/resume` omit it.

## Verification

- Added state-store regression coverage for listing reset continuations.
- Added gateway `/resume` listing coverage for a Telegram reset continuation.
- `scripts/run_tests.sh tests/test_hermes_state.py tests/gateway/test_resume_command.py -q`
  - 247 passed in the hermetic, per-file CI-parity runner.
- `uv run --extra dev ruff check hermes_state_common.py tests/test_hermes_state.py tests/gateway/test_resume_command.py`
- Manually exercised the CLI listing path with a reset continuation.

Tested on Linux. The change is SQL/session-classification only; it does not touch file I/O, process management, terminal handling, or platform-specific adapter code.