### PR TITLE
fix(kanban): guard block_task against live-claim theft

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -637,6 +637,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "triage to break unblock loops. Omit for a generic block."
         ),
     )
+    p_block.add_argument(
+        "--force", action="store_true",
+        help=(
+            "Override the live-claim guard: block a running, claimed task "
+            "even without owning its run (clears the worker's claim)."
+        ),
+    )
 
     p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
     p_schedule.add_argument("task_id")
@@ -2329,6 +2336,7 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id_for(tid),
+                force=bool(getattr(args, "force", False)),
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5886,6 +5886,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    force: bool = False,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -5913,6 +5914,14 @@ def block_task(
 
     Returns True on any successful transition (to ``blocked``, ``todo``, or
     ``triage``), False when the task wasn't in a blockable state.
+
+    When the task is ``running`` under a live claim, a caller that supplies
+    no ``expected_run_id`` must pass ``force=True`` (explicit human/CLI
+    override) — otherwise the request is refused instead of silently
+    clearing the live worker's ``claim_lock``/``worker_pid`` and ending its
+    in-flight run out from under it. Workers prove ownership by passing
+    their own run id as ``expected_run_id`` (unchanged). Mirrors
+    :func:`request_review`'s M1 live-claim-theft guard.
     """
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
@@ -5921,10 +5930,17 @@ def block_task(
     recurrences = 0
     with write_txn(conn):
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            "SELECT status, block_kind, block_recurrences, claim_lock FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
+            return False
+        if (
+            expected_run_id is None
+            and not force
+            and cur_row["status"] == "running"
+            and cur_row["claim_lock"] is not None
+        ):
             return False
         source_status = (
             _retry_status_for_run(conn, task_id)

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -904,7 +904,12 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     metadata=payload.metadata,
                 )
             elif s == "blocked":
-                ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
+                ok = kanban_db.block_task(
+                    conn, task_id, reason=payload.block_reason,
+                    # Dashboard PATCH is an explicit human action — allowed
+                    # to override a live worker claim (M1 guard).
+                    force=True,
+                )
             elif s == "scheduled":
                 ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
             elif s == "review":
@@ -1335,7 +1340,8 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             metadata=payload.metadata,
                         )
                     elif s == "blocked":
-                        ok = kanban_db.block_task(conn, tid)
+                        # Bulk dashboard action: explicit human override.
+                        ok = kanban_db.block_task(conn, tid, force=True)
                     elif s == "review":
                         # Non-block review handoff (mirror of PATCH /tasks/{id}).
                         ok = kanban_db.request_review(

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -66,10 +66,14 @@ def _make_running_again(conn, tid):
 def test_block_loop_detected_event_emitted(kanban_home: Path) -> None:
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        kb.block_task(conn, tid, reason="x", kind="capability")
+        # M1 guard: prove ownership of the live claim, mirroring how a real
+        # worker (the claimer) blocks its own running task.
+        run_id = kb.get_task(conn, tid).current_run_id
+        kb.block_task(conn, tid, reason="x", kind="capability", expected_run_id=run_id)
         kb.unblock_task(conn, tid)
         _make_running_again(conn, tid)
-        kb.block_task(conn, tid, reason="x", kind="capability")
+        run_id = kb.get_task(conn, tid).current_run_id
+        kb.block_task(conn, tid, reason="x", kind="capability", expected_run_id=run_id)
         events = [e for e in kb.list_events(conn, tid)
                   if e.kind == "block_loop_detected"]
         assert events, "expected a block_loop_detected event"
@@ -89,7 +93,8 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
         parent = kb.create_task(conn, title="parent", assignee="worker")
         child = _running_task(conn, title="child")
         kb.link_tasks(conn, parent_id=parent, child_id=child)
-        kb.block_task(conn, child, reason="wait", kind="dependency")
+        run_id = kb.get_task(conn, child).current_run_id
+        kb.block_task(conn, child, reason="wait", kind="dependency", expected_run_id=run_id)
         assert kb.get_task(conn, child).status == "todo"
         # Finish the parent, then let recompute_ready run.
         with kb.write_txn(conn):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -434,6 +434,49 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
         conn.close()
 
 
+def test_block_task_refuses_to_clear_live_claim_without_ownership(kanban_home):
+    """M1 regression (mirrors request_review's live-claim guard, 1810cfc8dd).
+
+    ``block_task`` on a running+claimed task without ``expected_run_id`` must
+    not silently NULL the live worker's ``claim_lock``/``worker_pid`` and end
+    its in-flight run out from under it. ``force=True`` (explicit human/CLI
+    override) and the worker path (``expected_run_id=<own run>``) both still
+    work.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="live claim block", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+
+        # 1) No run id, no force -> refused; live claim untouched.
+        assert kb.block_task(conn, tid, reason="stolen") is False
+        row = conn.execute(
+            "SELECT status, claim_lock, current_run_id FROM tasks WHERE id = ?",
+            (tid,),
+        ).fetchone()
+        assert row["status"] == "running"
+        assert row["claim_lock"] is not None
+        assert row["current_run_id"] == claimed.current_run_id
+
+        # 2) Worker path: proving ownership via expected_run_id works.
+        assert kb.block_task(
+            conn, tid, reason="worker-owned",
+            expected_run_id=claimed.current_run_id,
+        ) is True
+        assert kb.get_task(conn, tid).status == "blocked"
+    finally:
+        conn.close()
+
+    # 3) force=True: explicit human override on a fresh live-claimed task.
+    conn = kb.connect()
+    try:
+        tid2 = kb.create_task(conn, title="forced block", assignee="worker")
+        assert kb.claim_task(conn, tid2) is not None
+        assert kb.block_task(conn, tid2, reason="operator override", force=True) is True
+        assert kb.get_task(conn, tid2).status == "blocked"
+    finally:
+        conn.close()
 
 
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -46,8 +46,8 @@ def test_kanban_tools_hidden_without_env_var(monkeypatch, tmp_path):
 
 @pytest.fixture
 def worker_env(monkeypatch, tmp_path):
-    """Simulate being a worker: HERMES_HOME isolated, HERMES_KANBAN_TASK set
-    after we've created the task."""
+    """Simulate being a worker: HERMES_HOME isolated, HERMES_KANBAN_TASK and
+    HERMES_KANBAN_RUN_ID set after we've created and claimed the task."""
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
@@ -62,10 +62,17 @@ def worker_env(monkeypatch, tmp_path):
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="worker-test", assignee="test-worker")
-        kb.claim_task(conn, tid)
+        claimed = kb.claim_task(conn, tid)
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    # Real worker spawns get this alongside HERMES_KANBAN_TASK (see
+    # kanban_db.py's dispatcher env-build) — without it, _worker_run_id()
+    # can't prove ownership of the live claim (M1 guard on block_task/
+    # request_review), so kanban_block/request_review calls in this fixture's
+    # tests would be refused as if from an unrelated caller.
+    if claimed is not None and claimed.current_run_id is not None:
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
     return tid
 
 


### PR DESCRIPTION
## Summary

`request_review()` just gained an M1 guard (commit `1810cfc8dd`, same day): a caller with no `expected_run_id` must pass `force=True` before it clears `claim_lock`/`worker_pid` on a running, live-claimed task — otherwise the transition is refused instead of silently stealing the live worker's claim.

`block_task()` has the identical shape (same optional `expected_run_id`, same unconditional `claim_lock`/`worker_pid` clear on the `running`/`ready` update) but never got the same guard. Concretely:

- The dashboard's `PATCH /tasks/{id}` (single) and `POST /tasks/bulk` (bulk) "blocked" transitions call `kanban_db.block_task()` with no `expected_run_id` at all.
- A plain `hermes kanban block <id>` from a shell resolves `expected_run_id` via `_worker_run_id_for(tid)`, which only returns non-`None` inside a worker's own execution context (matching `HERMES_KANBAN_TASK`/`HERMES_KANBAN_RUN_ID`) — a human running the command from their own shell gets `None`.

So today, an operator (or a second/stale dashboard tab, or a scripted CLI caller) can mark a task `blocked` with zero ownership proof, silently clearing an actively-running worker's claim and ending its in-flight run out from under it — the exact class of bug M1 just closed for `request_review()`, left open here.

## Fix

Mirrors the M1 pattern exactly:

- `block_task()` gains a `force: bool = False` parameter. When the task is `running` under a live claim (`claim_lock IS NOT NULL`) and the caller supplies neither `expected_run_id` (worker ownership) nor `force=True` (explicit operator override), the call now returns `False` instead of clearing the claim.
- Dashboard `PATCH`/bulk-update pass `force=True` — an explicit human action, matching how `request_review`'s dashboard wiring was already updated.
- `hermes kanban block` gains a `--force` flag, mirroring `request-review`'s.

Existing worker call sites (`cli.py`'s goal-loop `_block()`, `tools/kanban_tools.py`'s `kanban_block` tool) already pass `expected_run_id` and are unaffected.

## Test plan

- New regression test `test_block_task_refuses_to_clear_live_claim_without_ownership` (mirrors `request_review`'s own M1 regression test): asserts a run-id-less, force-less call is refused with the live claim untouched, the worker-ownership path (`expected_run_id`) still works, and `force=True` still works as an explicit override.
- Mutation-verified: stashed the `hermes_cli/kanban_db.py` fix and confirmed the new test fails against pre-fix code (`AssertionError: assert True is False`).
- Fixed three existing tests whose `block_task()` calls modeled a worker blocking its own live-claimed task without ever proving ownership (a shape that was never realistic before this guard existed, and is now correctly refused): `tests/hermes_cli/test_kanban_block_kinds.py`'s two block-loop/dependency-routing tests now pass `expected_run_id`, and `tests/tools/test_kanban_tools.py`'s `worker_env` fixture now also sets `HERMES_KANBAN_RUN_ID` alongside `HERMES_KANBAN_TASK`, matching how a real worker spawn's environment looks (`kanban_db.py`'s dispatcher already sets both).
- Ran the full neighboring kanban suite (`test_kanban_core_functionality.py`, `test_kanban_blocked_sticky.py`, `test_kanban_review_lifecycle{,_complete}.py`, `test_kanban_block_kinds.py`, `test_kanban_review_surfaces.py`, `test_kanban_swarm.py`, `test_kanban_dashboard_plugin.py`, `test_kanban_tools.py`): 136 passed, 1 skipped, 1 pre-existing failure unrelated to this change (`test_review_tools_are_gated_and_visible_to_kanban_workers` fails on `main` too — missing `acp` package in this environment, not caused by this diff).
- Ran `tests/stress/test_atypical_scenarios.py` directly (its own scenario runner): 2 pre-existing failures (`workspace_nonexistent_path`, `parent_in_different_status_states`) reproduce identically on `main` without this change — confirmed via `git stash`, not a regression from this PR.
- `ruff check` clean on all changed files.

## Scope note

`complete_task()` has the same shape and arguably deserves the same guard, but two open PRs (#73188, #81170) are already circling that specific function with different, not-fully-overlapping approaches — this PR is scoped to `block_task()` only to avoid stepping on that in-flight work.