### PR TITLE
fix(tools): preserve id-less todo items during dedupe

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -30,6 +30,34 @@ class TestWriteAndRead:
             {"id": "1", "content": "Latest version", "status": "in_progress"},
         ]
 
+    def test_write_preserves_multiple_items_without_ids(self):
+        # Regression: id-less items used to share the "?" fallback key, so
+        # every id-less item after the first was silently dropped.
+        store = TodoStore()
+        result = store.write([
+            {"content": "Task 1", "status": "pending"},
+            {"content": "Task 2", "status": "pending"},
+        ])
+        assert len(result) == 2
+        assert result[0]["content"] == "Task 1"
+        assert result[1]["content"] == "Task 2"
+
+    def test_dedupe_keeps_idless_items_and_still_collapses_real_ids(self):
+        # Mixed list: real duplicate ids collapse to the last occurrence in
+        # its position, while id-less items are all preserved.
+        store = TodoStore()
+        result = store.write([
+            {"id": "1", "content": "First version", "status": "pending"},
+            {"content": "No id A", "status": "pending"},
+            {"id": "1", "content": "Latest version", "status": "in_progress"},
+            {"content": "No id B", "status": "pending"},
+        ])
+        assert [item["content"] for item in result] == [
+            "No id A",
+            "Latest version",
+            "No id B",
+        ]
+
 
 class TestHasItems:
     def test_empty_store(self):

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -189,14 +189,25 @@ class TodoStore:
 
     @staticmethod
     def _dedupe_by_id(todos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Collapse duplicate ids, keeping the last occurrence in its position."""
+        """Collapse duplicate ids, keeping the last occurrence in its position.
+
+        Items without an id (or with an empty id) get a unique positional
+        synthetic key so they are never collapsed against each other. A bare
+        ``"?"`` fallback key made every id-less item overwrite the previous
+        one's index, silently dropping all but the last id-less item on
+        multi-item writes.
+        """
         last_index: Dict[str, int] = {}
         for i, item in enumerate(todos):
             if not isinstance(item, dict):
                 # Non-dict items get a synthetic key so _validate can handle them
                 last_index[f"__invalid_{i}"] = i
                 continue
-            item_id = str(item.get("id", "")).strip() or "?"
+            item_id = str(item.get("id", "")).strip()
+            if not item_id:
+                # Id-less items must not dedupe against each other; keep them all.
+                last_index[f"__noid_{i}"] = i
+                continue
             last_index[item_id] = i
         return [todos[i] for i in sorted(last_index.values())]
 


### PR DESCRIPTION
## What does this PR do?

Fixes a silent data-loss bug in the `todo` tool: `TodoStore._dedupe_by_id` assigned every item without an `id` the shared fallback key `"?"`, so on multi-item writes each id-less item overwrote the previous one's index and **all but the last were silently dropped** — e.g. `write([{Task 1}, {Task 2}])` stored only Task 2.

Id-less items now get a unique positional synthetic key (mirroring the existing `__invalid_<i>` pattern for non-dict items), so they are never collapsed against each other. The `"?"` fallback id assigned by `_validate` is unchanged for single items.

## Related Issue

Fixes #83389

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/todo_tool.py` — `_dedupe_by_id` uses a unique `__noid_<i>` key for items with missing/empty `id` instead of the shared `"?"` key
- `tests/tools/test_todo_tool.py` — two regression tests: multi-item no-id write preserves all items; mixed id-less + duplicate-id list keeps id-less items while still collapsing real duplicate ids

## How to Test

1. Reproduce the issue: `TodoStore().write([{"content": "Task 1"}, {"content": "Task 2"}])` previously returned only `[Task 2]`
2. With the fix, both tasks are preserved
3. `scripts/run_tests.sh tests/tools/test_todo_tool.py tests/tools/test_todo_tool_type_coercion.py tests/agent/test_display_todo_progress.py` — all pass

## Checklist

- [x] Tests run via the canonical `scripts/run_tests.sh` runner (per-file isolation, deterministic env)
- [x] No new core-tool surface, no schema or prompt-cache changes
- [x] Existing `"?"` fallback behavior for single id-less items preserved
