### PR TITLE
fix(mcp): run catalog bootstrap commands as argv, never through the shell

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -28,6 +28,7 @@ See references/mcp-catalog.md (this repo's skill) for the manifest schema.
 from __future__ import annotations
 
 import re
+import shlex
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -391,12 +392,18 @@ def _install_root() -> Path:
 def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """Execute bootstrap commands in *cwd*. Raise CatalogError on first failure.
 
-    Each command runs through the shell (so `&&` etc. work). The output is
-    streamed to the user's terminal for visibility.
+    Each command runs as an argv list — never through the shell — so shell
+    metacharacters in a catalog entry stay literal arguments and cannot
+    inject extra commands at install time (the catalog dir is
+    user-overridable via HERMES_OPTIONAL_MCPS). The output is streamed to
+    the user's terminal for visibility.
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        argv = shlex.split(cmd)
+        if not argv:
+            continue
+        proc = subprocess.run(argv, cwd=str(cwd))
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -636,3 +636,36 @@ class TestShippedCatalog:
                     )
 
         assert not problems, "unpinned catalog entries:\n" + "\n".join(problems)
+
+
+def test_bootstrap_commands_run_as_argv_not_shell(tmp_path):
+    """Catalog bootstrap must never go through a shell (#81365).
+
+    Shell metacharacters in a manifest bootstrap entry are literal argv
+    arguments: ``>`` must not create a file and a ``;``-chained command
+    must not run.
+    """
+    import hermes_cli.mcp_catalog as mc
+
+    pwned = tmp_path / "pwned"
+    marker = tmp_path / "marker"
+    # Under a shell, ``> pwned`` redirects (creating the file) and
+    # ``; touch marker`` chains a second command. As argv both are literal
+    # arguments to python3 and create nothing.
+    mc._run_bootstrap(
+        tmp_path,
+        ["python3 -c \"import sys; print(sys.argv)\" > pwned ; touch marker"],
+    )
+    assert not pwned.exists()
+    assert not marker.exists()
+
+
+def test_bootstrap_still_runs_plain_commands(tmp_path):
+    """Plain bootstrap commands keep working after the argv switch."""
+    import hermes_cli.mcp_catalog as mc
+
+    mc._run_bootstrap(
+        tmp_path,
+        ["python3 -c \"import pathlib; pathlib.Path('ok.txt').write_text('ok')\""],
+    )
+    assert (tmp_path / "ok.txt").read_text(encoding="utf-8") == "ok"


### PR DESCRIPTION
## What does this PR do?

Security hardening: `_run_bootstrap` in `hermes_cli/mcp_catalog.py` handed each `install.bootstrap` command string to a shell subprocess. The catalog directory is user-overridable via `HERMES_OPTIONAL_MCPS` and manifests are plain YAML, so a bootstrap entry containing shell metacharacters (redirection, command chaining, command substitution) executed them during install.

Each command is now split with `shlex` and run as an argv list — metacharacters stay literal arguments and cannot inject extra commands.

## Related Issue

Fixes #81365

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/mcp_catalog.py` — `_run_bootstrap` runs commands via `subprocess.run(argv, ...)` after `shlex.split` (added `shlex` import); docstring updated to state the no-shell contract
- `tests/hermes_cli/test_mcp_catalog.py` — regression test proving `>`/`;` in a bootstrap entry creates nothing, plus a test that plain commands still run

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_mcp_security.py` — all pass
2. The shipped n8n manifest (`optional-mcps/n8n/manifest.yaml`) uses only plain commands (`python3 -m venv .venv`, `.venv/bin/pip install -r requirements.txt`) and is unaffected

## Checklist

- [x] Tests run via the canonical `scripts/run_tests.sh` runner (per-file isolation, deterministic env)
- [x] Full MCP test suite (`tests/hermes_cli/test_mcp_*.py`) and `tests/cli/` pass: 1,039 tests, 0 failures
- [x] No behavior change for the shipped catalog
