### PR TITLE
fix(cli): drop shell fallback when launching EDITOR for /prompt

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2951,9 +2951,10 @@ class CLICommandsMixin:
             try:
                 subprocess.call([*shlex.split(editor), path])
             except Exception:
-                # Fall back to a bare invocation (editor value may not be a
-                # simple argv-splittable string on some platforms).
-                subprocess.call(f"{editor} {shlex.quote(path)}", shell=True)
+                # A failed editor launch cancels the compose. Never fall back
+                # to a shell invocation — an unquoted $EDITOR string handed
+                # to a shell is an injection sink (#81364).
+                return ""
             with open(path, "r", encoding="utf-8") as fh:
                 raw = fh.read()
         finally:

--- a/tests/hermes_cli/test_prompt_compose_command.py
+++ b/tests/hermes_cli/test_prompt_compose_command.py
@@ -59,3 +59,17 @@ def test_empty_buffer_does_not_seed(monkeypatch):
     s = _Stub()
     s._handle_prompt_compose_command("/prompt")
     assert s._pending_agent_seed is None
+
+
+def test_failed_editor_cancels_without_shell_fallback(monkeypatch, tmp_path):
+    """A failing editor cancels the compose; no shell fallback runs (#81364).
+
+    The old code retried through a shell with the raw $EDITOR string, so an
+    editor value containing shell metacharacters executed them. The new code
+    only ever launches argv and returns an empty buffer on failure.
+    """
+    marker = tmp_path / "pwned"
+    monkeypatch.setenv("EDITOR", f"definitely-not-an-editor; touch {marker}")
+    out = _Stub()._compose_in_editor("seed text")
+    assert out == ""
+    assert not marker.exists()


### PR DESCRIPTION
## What does this PR do?

Security hardening: `_compose_in_editor` (`/prompt` / `/compose`) retried a failed editor launch through the shell with the raw `$EDITOR` string interpolated, so shell metacharacters in `$EDITOR` executed with the user's privileges (via cmd.exe on Windows).

The shell fallback is removed entirely: a failed editor launch cancels the compose by returning an empty buffer, matching the method's documented behavior. Editor strings that argv can split — including quoted paths with spaces — launch exactly as before.

## Related Issue

Fixes #81364

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/cli_commands_mixin.py` — `_compose_in_editor` returns `""` on launch failure instead of falling back to a shell invocation
- `tests/hermes_cli/test_prompt_compose_command.py` — regression test: an `EDITOR` value with shell metacharacters cancels the compose and executes nothing

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_prompt_compose_command.py` — all pass
2. Existing fake-editor tests still pass (the argv launch path is unchanged for launchable editors)
3. The empty-buffer cancel path is exercised by `test_empty_buffer_does_not_seed`

## Checklist

- [x] Tests run via the canonical `scripts/run_tests.sh` runner (per-file isolation, deterministic env)
- [x] Full `tests/cli/` suite passes (1,039 tests with MCP suite, 0 failures)
- [x] No shell is ever involved in launching the editor
