### PR TITLE
fix(banner): scope get_available_skills() cache by hermes_home

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -96,7 +96,7 @@ HERMES_CADUCEUS = """[#CD7F32]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⣀⣀�
 # Skills scanning
 # =========================================================================
 
-_available_skills_cache: Optional[tuple] = None  # (result,) once computed
+_available_skills_cache: Dict[str, Dict[str, List[str]]] = {}  # hermes_home -> result
 
 
 def get_available_skills() -> Dict[str, List[str]]:
@@ -106,13 +106,19 @@ def get_available_skills() -> Dict[str, List[str]]:
     handles platform gating (``platforms:`` frontmatter) and respects the
     user's ``skills.disabled`` config list.
 
-    Cached per-process: this feeds only the startup banner, whose snapshot
-    is taken once anyway, and the underlying skills-tree walk costs ~100ms.
-    ``prefetch_banner_data()`` uses the cache to pay that walk off-thread.
+    Cached per-process, keyed by the active ``get_hermes_home()``: this feeds
+    only the startup banner, whose snapshot is taken once anyway, and the
+    underlying skills-tree walk costs ~100ms. ``prefetch_banner_data()`` uses
+    the cache to pay that walk off-thread. Keying by hermes_home matters in a
+    multiplex/remote-backend gateway process, where a single process serves
+    multiple profiles under ``set_hermes_home_override()`` — without the key,
+    the first profile to call this wins the cache for every later profile's
+    ``session.info``/``skills.manage`` calls too.
     """
-    global _available_skills_cache
-    if _available_skills_cache is not None:
-        return _available_skills_cache[0]
+    cache_key = str(get_hermes_home())
+    cached = _available_skills_cache.get(cache_key)
+    if cached is not None:
+        return cached
     try:
         from tools.skills_tool import _find_all_skills
         all_skills = _find_all_skills()  # already filtered
@@ -123,7 +129,7 @@ def get_available_skills() -> Dict[str, List[str]]:
     for skill in all_skills:
         category = skill.get("category") or "general"
         skills_by_category.setdefault(category, []).append(skill["name"])
-    _available_skills_cache = (skills_by_category,)
+    _available_skills_cache[cache_key] = skills_by_category
     return skills_by_category
 
 

--- a/tests/hermes_cli/test_banner_skills.py
+++ b/tests/hermes_cli/test_banner_skills.py
@@ -17,9 +17,9 @@ def _reset_skills_cache():
     the cache around each test so patched _find_all_skills results are
     actually observed."""
     import hermes_cli.banner as banner
-    banner._available_skills_cache = None
+    banner._available_skills_cache.clear()
     yield
-    banner._available_skills_cache = None
+    banner._available_skills_cache.clear()
 
 
 def test_get_available_skills_delegates_to_find_all_skills():
@@ -60,3 +60,45 @@ def test_get_available_skills_is_memoized():
 
     assert first == second
     assert len(calls) == 1
+
+
+def test_get_available_skills_is_scoped_per_profile_home():
+    """A multiplex/remote-backend gateway process serves multiple profiles
+    under set_hermes_home_override() (see tui_gateway/server.py's session
+    build, which scopes HERMES_HOME per profile). Without keying the cache
+    by the active hermes_home, the first profile to call this wins the
+    cache for every later profile's session.info/skills.manage calls too.
+    """
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    import hermes_cli.banner as banner
+
+    profile_a_skills = [
+        {"name": "alpha-skill", "description": "A", "category": "tools"},
+    ]
+    profile_b_skills = [
+        {"name": "beta-skill", "description": "B", "category": "tools"},
+    ]
+
+    token_a = set_hermes_home_override("/tmp/profile-a-repro")
+    try:
+        with patch(
+            "tools.skills_tool._find_all_skills", return_value=list(profile_a_skills)
+        ):
+            result_a = banner.get_available_skills()
+    finally:
+        reset_hermes_home_override(token_a)
+    assert result_a["tools"] == ["alpha-skill"]
+
+    token_b = set_hermes_home_override("/tmp/profile-b-repro")
+    try:
+        with patch(
+            "tools.skills_tool._find_all_skills", return_value=list(profile_b_skills)
+        ):
+            result_b = banner.get_available_skills()
+    finally:
+        reset_hermes_home_override(token_b)
+
+    assert result_b["tools"] == ["beta-skill"], (
+        "profile B's session.info/skills.manage call got profile A's cached "
+        "skills — the cache is not scoped per hermes_home"
+    )


### PR DESCRIPTION
## Summary

`get_available_skills()` (`hermes_cli/banner.py`) was given a raw, unconditional, never-expiring module-level cache by `55f9e472a0` ("sub-400ms warm startup"): first caller wins, forever, for the life of the process — no signature check, no TTL, no profile key.

This bypasses the underlying `tools/skills_tool.py::_find_all_skills()`'s own cache, which correctly re-resolves `_skills_dir()` from the *live* `get_hermes_home()` contextvar on every call (that module's own comment: "the module-level SKILLS_DIR can be stale in long-lived runtimes").

In a multiplex/remote-backend gateway process serving multiple profiles under `set_hermes_home_override()` (see `tui_gateway/server.py`'s session build, which correctly scopes `HERMES_HOME` per profile for everything else — config, model, credentials), the first profile's session to call `get_available_skills()` — via `session.info` (`tui_gateway/server.py:5285`) or `skills.manage(action=list)` (`tui_gateway/methods_tools.py:1720`) — wins the cache for every later profile's calls too, until the gateway process restarts.

This is the same recurring bug class found and fixed independently several times in this repo (a process-global cache/singleton missing profile scoping): the Nous access-token cache, the A2A adapter's contextvar propagation, the MoA runtime cache, and the heartbeat poller all had this exact shape.

## Fix

Key the cache by `str(get_hermes_home())` instead of a bare `Optional[tuple]` — matching the pattern used to fix the other instances of this bug class.

## Test plan

- New regression test `test_get_available_skills_is_scoped_per_profile_home`: simulates two profiles via `set_hermes_home_override()`/`reset_hermes_home_override()`, each with a different mocked `_find_all_skills()` result, and asserts the second profile's call returns its own skills, not the first's.
- Mutation-verified: stashed the `hermes_cli/banner.py` fix and confirmed all 4 tests in `tests/hermes_cli/test_banner_skills.py` fail against pre-fix code (`AttributeError: 'NoneType' object has no attribute 'clear'` — the pre-fix cache is a bare `Optional[tuple]`, not a dict).
- Updated the existing `_reset_skills_cache` autouse fixture (`banner._available_skills_cache = None` → `.clear()`) to match the new dict shape; the other 3 pre-existing tests in the file continue to pass unchanged.
- Ran `tests/hermes_cli/test_banner_skills.py`, `tests/hermes_cli/test_banner.py`, `tests/hermes_cli/test_banner_skills_width.py` (every test file that references `get_available_skills`): all pass.
- `ruff check` clean on both changed files.