### PR TITLE
fix(agent): stop emitting copyable truncation markers in compacted tool-call args

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1172,6 +1172,13 @@ def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
     to begin with — some model backends use non-JSON tool arguments — the
     original string is returned unchanged rather than replaced with
     something neither we nor the backend can parse.
+
+    Long string leaves are cut at ``head_chars`` with NO truncation marker
+    appended. The compacted arguments are history context, not the executed
+    call, and a marker inside the JSON is copyable content: a model that
+    re-emits a truncated patch (e.g. after a retry) pastes the marker into
+    the written file, corrupting it with literal ``...[truncated]`` text
+    (issue #83714).
     """
     try:
         parsed = json.loads(args)
@@ -1181,7 +1188,7 @@ def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
     def _shrink(obj: Any) -> Any:
         if isinstance(obj, str):
             if len(obj) > head_chars:
-                return obj[:head_chars] + "...[truncated]"
+                return obj[:head_chars]
             return obj
         if isinstance(obj, dict):
             return {k: _shrink(v) for k, v in obj.items()}

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2106,9 +2106,32 @@ class TestTruncateToolCallArgsJson:
         shrunk = shrink(original)
         parsed = _json.loads(shrunk)  # must not raise
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
-        assert parsed["content"].endswith("...[truncated]")
+        # No copyable truncation marker (#83714) — just a silent head cut.
+        assert "...[truncated]" not in shrunk
+        assert len(parsed["content"]) == 200  # capped at head_chars=200
         assert len(shrunk) < len(original)
 
+
+
+
+    def test_no_copyable_marker_in_shrunken_args(self):
+        """Issue #83714: shrunken patch args must not contain a literal
+        ``...[truncated]`` marker — models copy it into the written file
+        when they re-emit a truncated patch from compacted history."""
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({
+            "path": "/tmp/example.py",
+            "old_string": "def old():",
+            "new_string": "def new():\n    return " + "x" * 400,
+        })
+        shrunk = shrink(payload)
+        assert "...[truncated]" not in shrunk
+        assert "…[truncated]" not in shrunk
+        parsed = _json.loads(shrunk)  # still valid JSON
+        assert parsed["path"] == "/tmp/example.py"
+        assert parsed["old_string"] == "def old():"
+        assert len(parsed["new_string"]) == 200  # head cut, no marker
 
 
 
@@ -2127,7 +2150,8 @@ class TestTruncateToolCallArgsJson:
         assert parsed["enabled"] is True
         assert parsed["timeout"] is None
         assert parsed["items"] == [1, 2, 3]
-        assert parsed["note"].endswith("...[truncated]")
+        assert parsed["note"] == "z" * 200  # capped at head_chars, no marker
+        assert "...[truncated]" not in _json.dumps(parsed)
 
 
 
@@ -2165,7 +2189,9 @@ class TestTruncateToolCallArgsJson:
         # Must parse — otherwise downstream provider returns 400
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
-        assert parsed["content"].endswith("...[truncated]")
+        # No copyable truncation marker (#83714) — silent head cut only.
+        assert "...[truncated]" not in shrunk
+        assert len(parsed["content"]) == 200
 
 
 class TestLazyContextResolution:


### PR DESCRIPTION
## What does this PR do?

Fixes silent file corruption: during in-place context compaction, Pass 3 (`_truncate_tool_call_args_at`) shrinks assistant-message tool-call argument payloads larger than 500 chars, and `_truncate_tool_call_args_json` capped every long string leaf at 200 chars **appending the literal `...[truncated]` marker inside the string value**.

The marker is copyable content. A model that re-emits a truncated patch from compacted history (e.g. after a retry) pastes the marker into the written file — producing `"You can also specify a kind:...[truncated]"` in source and SyntaxError/IndentationError in the target. This matches the reported ~300–500 char corruption threshold (args > 500 chars → string leaves cut at 200).

Long string leaves are now cut **silently** at `head_chars`. The function's contract (issue #11762) is JSON validity for downstream providers — the marker is not part of that contract, only a leftover from the old byte-slice implementation its own docstring criticizes. JSON stays valid, the shape is preserved, and compacted history no longer hands the model a marker to copy into future tool calls.

## Related Issue

Fixes #83714

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` — `_truncate_tool_call_args_json` cuts long string leaves at `head_chars` without appending `...[truncated]`; docstring documents why the marker is dangerous
- `tests/agent/test_context_compressor.py` — updated 3 assertions that pinned the marker (they asserted the #11762 JSON-validity contract, which is preserved) to assert no marker + 200-char cap; added `test_no_copyable_marker_in_shrunken_args` regression for #83714

## How to Test

1. `scripts/run_tests.sh tests/agent/test_context_compressor.py` — 137 tests pass
2. Adjacent compaction/compression suites: 40 tests pass
3. Direct check: `_truncate_tool_call_args_json` on a patch-shaped blob (long `new_string`) returns valid JSON with `new_string` capped at 200 chars and **no** `...[truncated]` anywhere

## Checklist

- [x] Tests run via the canonical `scripts/run_tests.sh` runner (per-file isolation, deterministic env)
- [x] JSON-validity contract from #11762 preserved (all three affected tests updated, end-to-end Pass-3 test green)
- [x] No behavior change for args under the 500-char threshold
