### PR TITLE
fix(gateway): use curated PATH for launchd plist instead of capturing shell env (#83699)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4094,22 +4094,35 @@ def generate_launchd_plist() -> str:
     log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
     profile_arg = _profile_arg(hermes_home)
-    # Build a sane PATH for the launchd plist.  launchd provides only a
+    # Build a curated PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
-    # nvm, cargo, etc.  We prepend venv/bin and node_modules/.bin (matching
-    # the systemd unit), then capture the user's full shell PATH so every
-    # user-installed tool (node, ffmpeg, …) is reachable.
+    # nvm, cargo, etc.  We use the same curated approach as the systemd unit
+    # instead of capturing the invoking shell's os.environ["PATH"], which
+    # bakes session-scoped directories (sandbox bins, transient tool dirs)
+    # into a service definition that persists across reboots.  The staleness
+    # check masks PATH during comparison, so a stale session PATH is never
+    # detected and the daemon runs with a dead PATH indefinitely (#83699).
     detected_venv = _detect_venv_dir()
     venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
     # Resolve the directory containing the node binary (e.g. Homebrew, nvm)
     # so it's explicitly in PATH even if the user's shell PATH changes later.
     priority_dirs = _build_service_path_dirs()
     _append_node_dir_for_service(priority_dirs)
-    sane_path = ":".join(
-        dict.fromkeys(
-            priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p]
-        )
-    )
+    # Add user-local bin dirs (uv, cargo, go, npm-global) if they exist.
+    priority_dirs.extend(_build_user_local_paths(Path.home(), priority_dirs))
+    # macOS standard tool locations (Homebrew Apple Silicon, Intel, system).
+    macos_common = [
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+    ]
+    for p in macos_common:
+        if p not in priority_dirs:
+            priority_dirs.append(p)
+    sane_path = ":".join(dict.fromkeys(priority_dirs))
 
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [


### PR DESCRIPTION
fix(gateway): use curated PATH for launchd plist instead of capturing shell env (#83699)

## Summary

`generate_launchd_plist()` was appending `os.environ["PATH"]` to the curated `priority_dirs`, which bakes the invoking shell's session-scoped directories (sandbox bins, transient tool dirs) into a service definition that persists across reboots.

Since `_normalize_launchd_plist_for_comparison()` masks the PATH value during staleness checks, these stale entries are never detected and the daemon runs with a dead PATH indefinitely.

## Root Cause

The PATH building in `generate_launchd_plist()` was:
```python
sane_path = ":".join(
    dict.fromkeys(
        priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p]
    )
)
```

This captures the full shell environment PATH at install time, including session-scoped directories that may be deleted later. The staleness check masks PATH, so the dead entries are invisible.

## Fix

Use the same curated approach as the systemd unit:
- `_build_service_path_dirs()` — venv, node_modules, hermes managed dirs
- `_append_node_dir_for_service()` — resolved node binary directory
- `_build_user_local_paths()` — `~/.local/bin`, `~/.cargo/bin`, `~/.go/bin`, `~/.npm-global/bin`
- macOS common paths — `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`

No `os.environ["PATH"]` capture. The PATH is deterministic and won't contain session-scoped directories.

Fixes #83699
