### PR TITLE
fix(gateway): guard platforms dict access when config is a list (#83185)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4757,7 +4757,7 @@ class TurnRunner:
         # slower than Linux. Off by default; soul identity is preserved so
         # the persona survives even with minimal context.
         _platforms_gw_cfg = (ctx.user_config.get("gateway") or {}).get("platforms") or {}
-        _plat_gw_cfg = _platforms_gw_cfg.get(platform_key) or {}
+        _plat_gw_cfg = (_platforms_gw_cfg.get(platform_key) or {}) if isinstance(_platforms_gw_cfg, dict) else {}
         _skip_context = _plat_gw_cfg.get("skip_context_files")
         skip_context_files = bool(_skip_context) if _skip_context is not None else False
 


### PR DESCRIPTION
## Problem

`hermes gateway setup` writes `gateway.platforms` as a **list**:

```yaml
gateway:
  platforms:
    - telegram
    - discord
```

But commit 003b4c8 added code in `gateway/run.py` (~line 4759) that assumes it is always a **dict**:

```python
_platforms_gw_cfg = (ctx.user_config.get('gateway') or {}).get('platforms') or {}
_plat_gw_cfg = _platforms_gw_cfg.get(platform_key) or {}
```

When `platforms` is a list, `.get()` raises `AttributeError: 'list' object has no attribute 'get'`, crashing every incoming gateway message.

## Fix

Add `isinstance` guard: if `_platforms_gw_cfg` is not a dict, treat the per-platform config as empty:

```python
_plat_gw_cfg = (_platforms_gw_cfg.get(platform_key) or {}) if isinstance(_platforms_gw_cfg, dict) else {}
```

Single line change. No behavioral change for dict configs; list configs gracefully fall back to no `skip_context_files`.

Fixes #83185