### PR TITLE
fix(browser): keep cloud browser sessions alive during long browser_exec runs

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -299,7 +299,9 @@ class TestBackendCdpResolution:
 
     def test_existing_bu_env_wins(self, monkeypatch):
         env = {"BU_CDP_WS": "ws://operator-override:9222"}
-        assert bu_cli._resolve_backend_cdp(env, "t1") is None
+        err, cloud_session_task_id = bu_cli._resolve_backend_cdp(env, "t1")
+        assert err is None
+        assert cloud_session_task_id is None
         assert env["BU_CDP_WS"] == "ws://operator-override:9222"
 
     def test_cdp_override_exported(self, monkeypatch):
@@ -307,7 +309,9 @@ class TestBackendCdpResolution:
 
         monkeypatch.setattr(bt, "_get_cdp_override", lambda: "http://127.0.0.1:9222")
         env = self._env()
-        assert bu_cli._resolve_backend_cdp(env, "t1") is None
+        err, cloud_session_task_id = bu_cli._resolve_backend_cdp(env, "t1")
+        assert err is None
+        assert cloud_session_task_id is None
         assert env["BU_CDP_URL"] == "http://127.0.0.1:9222"
 
     def test_ws_override_uses_bu_cdp_ws(self, monkeypatch):
@@ -315,7 +319,9 @@ class TestBackendCdpResolution:
 
         monkeypatch.setattr(bt, "_get_cdp_override", lambda: "wss://connect.example/x")
         env = self._env()
-        assert bu_cli._resolve_backend_cdp(env, "t1") is None
+        err, cloud_session_task_id = bu_cli._resolve_backend_cdp(env, "t1")
+        assert err is None
+        assert cloud_session_task_id is None
         assert env["BU_CDP_WS"] == "wss://connect.example/x"
 
     def test_cloud_provider_session_exported(self, monkeypatch):
@@ -328,7 +334,13 @@ class TestBackendCdpResolution:
             lambda task_id: {"cdp_url": "wss://browser.example/cdp/abc"},
         )
         env = self._env()
-        assert bu_cli._resolve_backend_cdp(env, "t1") is None
+        err, cloud_session_task_id = bu_cli._resolve_backend_cdp(env, "t1")
+        assert err is None
+        # M1 regression (browser_exec activity heartbeat): a resolved
+        # cloud-provider session must report the key it registered activity
+        # for, so the caller can keep it fresh for the duration of a
+        # long-running exec instead of only at resolution time.
+        assert cloud_session_task_id == "t1"
         assert env["BU_CDP_WS"] == "wss://browser.example/cdp/abc"
 
     def test_no_provider_leaves_env_untouched(self, monkeypatch):
@@ -337,7 +349,9 @@ class TestBackendCdpResolution:
         monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
         monkeypatch.setattr(bt, "_get_cloud_provider", lambda: None)
         env = self._env()
-        assert bu_cli._resolve_backend_cdp(env, "t1") is None
+        err, cloud_session_task_id = bu_cli._resolve_backend_cdp(env, "t1")
+        assert err is None
+        assert cloud_session_task_id is None
         assert "BU_CDP_WS" not in env and "BU_CDP_URL" not in env
 
     def test_provider_failure_returns_error(self, monkeypatch):
@@ -349,8 +363,9 @@ class TestBackendCdpResolution:
         monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
         monkeypatch.setattr(bt, "_get_cloud_provider", lambda: object())
         monkeypatch.setattr(bt, "_get_session_info", boom)
-        err = bu_cli._resolve_backend_cdp(self._env(), "t1")
+        err, cloud_session_task_id = bu_cli._resolve_backend_cdp(self._env(), "t1")
         assert err and "api down" in err
+        assert cloud_session_task_id is None
 
     def test_provider_without_cdp_returns_error(self, monkeypatch):
         import tools.browser_tool as bt
@@ -358,8 +373,9 @@ class TestBackendCdpResolution:
         monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
         monkeypatch.setattr(bt, "_get_cloud_provider", lambda: object())
         monkeypatch.setattr(bt, "_get_session_info", lambda task_id: {"cdp_url": None})
-        err = bu_cli._resolve_backend_cdp(self._env(), "t1")
+        err, cloud_session_task_id = bu_cli._resolve_backend_cdp(self._env(), "t1")
         assert err and "no" in err.lower() and "CDP" in err
+        assert cloud_session_task_id is None
 
     def test_named_session_skips_backend_resolution(self, tmp_path, monkeypatch):
         """session=<name> (BU_NAME cloud browser) must not consume a backend
@@ -691,6 +707,50 @@ class TestBrowserExec:
         monkeypatch.setattr(bu_cli, "_MIN_TIMEOUT_S", 1)
         result = json.loads(bu_cli.browser_exec("print(1)", timeout_s=1))
         assert "timed out" in result["error"]
+
+    def test_long_exec_keeps_cloud_session_activity_fresh(self, tmp_path, monkeypatch):
+        """A long-running browser_exec (subprocess.run's blocking wait made
+        zero further calls into the session tracker) must not let the
+        inactivity reaper's clock run out from under the still-working CLI.
+
+        Regression: browser_exec's subprocess wait only refreshed the
+        resolved cloud-provider session's activity timestamp once, at
+        _resolve_backend_cdp()'s _get_session_info() call — never again for
+        the whole (up to 1800s) run. This drives a fake CLI that sleeps
+        across several heartbeat intervals and asserts
+        _update_session_activity is called repeatedly, not just once.
+        """
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt, "_get_cloud_provider", lambda: object())
+        monkeypatch.setattr(
+            bt, "_get_session_info",
+            lambda task_id: {"cdp_url": "wss://browser.example/cdp/abc"},
+        )
+        heartbeat_calls = []
+        real_update = bt._update_session_activity
+
+        def spy_update(task_id):
+            heartbeat_calls.append(task_id)
+            return real_update(task_id)
+
+        monkeypatch.setattr(bt, "_update_session_activity", spy_update)
+        # Tiny heartbeat interval so the sleeping fake CLI spans several
+        # heartbeats without a slow test.
+        monkeypatch.setattr(bu_cli, "_CLOUD_SESSION_HEARTBEAT_INTERVAL_S", 0.05)
+
+        cli = _fake_cli(tmp_path, "cat > /dev/null\nsleep 0.3\necho done\n")
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        result = json.loads(bu_cli.browser_exec("print(1)", task_id="t42"))
+
+        assert result["success"] is True
+        assert "done" in result["output"]
+        assert len(heartbeat_calls) >= 2, (
+            f"expected repeated heartbeats during the run, got {heartbeat_calls!r}"
+        )
+        assert all(tid == "t42" for tid in heartbeat_calls)
 
 
 class TestFindCliManagedBin:

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -10,6 +10,7 @@ import os
 import re
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -28,6 +29,14 @@ _DEFAULT_TIMEOUT_S = 300
 _MIN_TIMEOUT_S = 5
 _MAX_TIMEOUT_S = 1800
 _STDERR_CAP_CHARS = 4000
+
+# How often to refresh a resolved cloud-provider session's activity timestamp
+# while the (synchronous, long-running) browser-use CLI subprocess is still
+# working. Must stay comfortably under browser.inactivity_timeout's default
+# (120s, see tools/browser_tool.py) so the background reaper never tears the
+# session down mid-exec just because browser_exec itself made no further
+# Python-side calls into the session tracker for the duration of the run.
+_CLOUD_SESSION_HEARTBEAT_INTERVAL_S = 20
 
 # Filesystem-safe task ids for per-task workspace dirs.
 _TASK_ID_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
@@ -364,7 +373,111 @@ def _native_screenshot_result(result: Dict[str, Any], path: str) -> Optional[Dic
         return None
 
 
-def _resolve_backend_cdp(env: dict, task_id: Optional[str]) -> Optional[str]:
+def _drain_pipe(pipe, chunks: List[str]) -> None:
+    """Read a text-mode pipe to EOF, appending each line to *chunks*.
+
+    Runs on a background thread so the parent can poll/wait on the process
+    without risking a deadlock from a full stdout/stderr OS pipe buffer
+    while the browser-use CLI is still writing (long-running exec, 300s
+    default / 1800s max timeout).
+    """
+    try:
+        for line in iter(pipe.readline, ""):
+            chunks.append(line)
+    except Exception:
+        pass
+    finally:
+        try:
+            pipe.close()
+        except Exception:
+            pass
+
+
+def _run_cli_with_activity_heartbeat(
+    cmd: List[str],
+    code: str,
+    env: dict,
+    timeout: float,
+    cloud_session_task_id: Optional[str],
+    popen_extra: dict,
+) -> "tuple[str, str, int]":
+    """Run the browser-use CLI, keeping a resolved cloud session's activity
+    timestamp fresh for the whole run instead of only at session resolution.
+
+    ``subprocess.run(..., timeout=timeout)`` blocks for up to 1800s making no
+    further calls into ``tools/browser_tool.py``'s per-task session tracker
+    (``_get_session_info`` only touches it once, before the CLI subprocess is
+    even started) — so the background inactivity reaper (30s poll, 120s
+    default threshold, see ``_cleanup_inactive_browser_sessions``) can tear
+    the cloud browser down while the CLI is still actively driving it over
+    CDP. Polling with a bounded wait between heartbeats keeps the session
+    alive for cloud-provider sessions without changing behavior for local
+    Chrome / explicit BU_NAME sessions (``cloud_session_task_id`` is ``None``
+    there, so no heartbeat calls are made).
+
+    Returns ``(stdout, stderr, returncode)``. Raises ``subprocess.TimeoutExpired``
+    on overall timeout (mirroring ``subprocess.run``'s contract) and ``OSError``
+    if the subprocess fails to launch.
+    """
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        **popen_extra,
+    )
+    stdout_chunks: List[str] = []
+    stderr_chunks: List[str] = []
+    stdout_thread = threading.Thread(
+        target=_drain_pipe, args=(proc.stdout, stdout_chunks), daemon=True,
+    )
+    stderr_thread = threading.Thread(
+        target=_drain_pipe, args=(proc.stderr, stderr_chunks), daemon=True,
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+    try:
+        proc.stdin.write(code)
+        proc.stdin.close()
+    except Exception:
+        # e.g. a broken pipe because the CLI already exited — proc.wait()
+        # below surfaces the real failure via a non-zero returncode.
+        pass
+
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            proc.kill()
+            proc.wait()
+            stdout_thread.join(timeout=5)
+            stderr_thread.join(timeout=5)
+            raise subprocess.TimeoutExpired(cmd, timeout)
+        try:
+            proc.wait(timeout=min(_CLOUD_SESSION_HEARTBEAT_INTERVAL_S, remaining))
+            break
+        except subprocess.TimeoutExpired:
+            if cloud_session_task_id:
+                try:
+                    from tools.browser_tool import _update_session_activity
+
+                    _update_session_activity(cloud_session_task_id)
+                except Exception as e:
+                    logger.debug(
+                        "Cloud session activity heartbeat failed for %s: %s",
+                        cloud_session_task_id, e,
+                    )
+
+    stdout_thread.join(timeout=5)
+    stderr_thread.join(timeout=5)
+    return "".join(stdout_chunks), "".join(stderr_chunks), proc.returncode
+
+
+def _resolve_backend_cdp(
+    env: dict, task_id: Optional[str]
+) -> "tuple[Optional[str], Optional[str]]":
     """Point the harness at the configured browser backend's CDP endpoint.
 
     Resolution order (first hit wins):
@@ -381,10 +494,20 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str]) -> Optional[str]:
     4. Nothing configured: return None; the harness attaches to local
        Chrome (or Browser Use cloud via BU_AUTOSPAWN for legacy configs).
 
-    Returns an error string on provider failure, None on success.
+    Returns ``(error, cloud_session_task_id)``. ``error`` is a message on
+    provider failure, ``None`` on success. ``cloud_session_task_id`` is the
+    key this call registered activity for with the legacy stack's
+    per-task session tracker (``tools/browser_tool.py``'s
+    ``_session_last_activity`` / inactivity reaper), or ``None`` when no
+    cloud-provider session was resolved (local CDP override, no provider
+    configured, or a Browser Use direct-API config that manages its own
+    session) — the caller uses this to know whether it must keep the
+    session's activity timestamp fresh for the duration of a long-running
+    ``browser_exec`` call, or the inactivity reaper will tear the session
+    down out from under the still-running CLI subprocess.
     """
     if env.get("BU_CDP_WS") or env.get("BU_CDP_URL"):
-        return None
+        return None, None
 
     try:
         from tools.browser_tool import (
@@ -394,7 +517,7 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str]) -> Optional[str]:
         )
     except Exception as e:  # pragma: no cover — stubbed browser_tool in tests
         logger.debug("browser_tool backend resolution unavailable: %s", e)
-        return None
+        return None, None
 
     try:
         override = _get_cdp_override()
@@ -402,7 +525,7 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str]) -> Optional[str]:
         override = ""
     if override:
         env["BU_CDP_URL" if override.startswith(("http://", "https://")) else "BU_CDP_WS"] = override
-        return None
+        return None, None
 
     try:
         provider = _get_cloud_provider()
@@ -410,7 +533,7 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str]) -> Optional[str]:
         logger.debug("Cloud provider lookup failed: %s", e)
         provider = None
     if provider is None:
-        return None
+        return None, None
 
     # Browser Use direct-API configs: the CLI talks to Browser Use cloud
     # natively (BU_AUTOSPAWN / auth login) — routing through the legacy
@@ -422,25 +545,26 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str]) -> Optional[str]:
     if provider_key == _BACKEND_KEY and not is_truthy_value(
         _read_browser_cfg().get("use_gateway"), default=False
     ):
-        return None
+        return None, None
 
+    session_task_id = task_id or "browser-exec-default"
     try:
-        session_info = _get_session_info(task_id or "browser-exec-default")
+        session_info = _get_session_info(session_task_id)
     except Exception as e:
         return (
             f"Cloud browser provider {type(provider).__name__} failed to "
             f"provide a session: {e}. Fix the provider configuration or "
             "switch backends via `hermes tools` → Browser Automation."
-        )
+        ), None
     cdp = str((session_info or {}).get("cdp_url") or "")
     if not cdp:
         return (
             f"Cloud browser provider {type(provider).__name__} returned no "
             "CDP endpoint, so Browser Use mode cannot drive it. Switch to "
             "the built-in browser tools for this provider."
-        )
+        ), None
     env["BU_CDP_URL" if cdp.startswith(("http://", "https://")) else "BU_CDP_WS"] = cdp
-    return None
+    return None, session_task_id
 
 
 def browser_exec(
@@ -469,6 +593,7 @@ def browser_exec(
         )
 
     env = _base_subprocess_env()
+    cloud_session_task_id: Optional[str] = None
     if session:
         if not _SESSION_RE.match(session):
             return tool_error(
@@ -480,7 +605,7 @@ def browser_exec(
         # Route through the configured browser backend (Browserbase,
         # Firecrawl, Nous gateway, CDP override, …). Explicit BU_NAME cloud
         # sessions manage their own browser and skip backend resolution.
-        backend_err = _resolve_backend_cdp(env, task_id)
+        backend_err, cloud_session_task_id = _resolve_backend_cdp(env, task_id)
         if backend_err:
             return tool_error(backend_err)
 
@@ -513,14 +638,8 @@ def browser_exec(
 
     started = time.time()
     try:
-        proc = subprocess.run(
-            cmd,
-            input=code,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            env=env,
-            **popen_extra,
+        stdout_text, stderr_text, returncode = _run_cli_with_activity_heartbeat(
+            cmd, code, env, timeout, cloud_session_task_id, popen_extra,
         )
     except subprocess.TimeoutExpired:
         return tool_error(
@@ -534,21 +653,21 @@ def browser_exec(
         return tool_error(f"Failed to launch browser-use CLI: {e}")
 
     result = {
-        "success": proc.returncode == 0,
-        "exit_code": proc.returncode,
-        "output": proc.stdout,
+        "success": returncode == 0,
+        "exit_code": returncode,
+        "output": stdout_text,
     }
     if workspace:
         result["workspace"] = workspace
     if session:
         result["session"] = session
-    stderr = (proc.stderr or "").strip()
+    stderr = (stderr_text or "").strip()
     if stderr:
         if len(stderr) > _STDERR_CAP_CHARS:
             stderr = stderr[:_STDERR_CAP_CHARS] + "\n… (stderr truncated)"
         result["stderr"] = stderr
 
-    screenshot = _find_screenshot(proc.stdout, started)
+    screenshot = _find_screenshot(stdout_text, started)
     if screenshot:
         result["screenshot_path"] = screenshot
         native = _native_screenshot_result(result, screenshot)


### PR DESCRIPTION
## Summary

`browser_exec`'s Browser Use mode is now the **default** browser backend (`8d8bc85dca`, today) whenever the `browser-use` CLI is runnable. When a cloud provider (Browserbase, Firecrawl, Nous gateway) is configured, `_resolve_backend_cdp()` calls `browser_tool._get_session_info(task_id)` exactly **once**, before the CLI subprocess even starts — that's the only place this call path touches the legacy stack's per-task session activity tracker. It then hands the resolved CDP endpoint to an external `browser-use` CLI subprocess that drives the browser directly over CDP for up to 1800s (raised from 120s/600s by `92968a5c7d`, specifically to support long, multi-step extractions — "split the work into several calls that append to workspace files… so progress survives timeouts"), making **zero** further calls back into Hermes's Python process for the whole run.

A background thread (`_cleanup_inactive_browser_sessions`, 30s poll) reaps any session whose last-activity timestamp is older than `browser.inactivity_timeout` (default **120s**) — and this is a real teardown: it sends an `agent-browser close` command, calls the provider's `close_session()` (destroying the remote browser instance), and kills the local daemon PID.

**Net effect:** with a cloud provider configured and no explicit `session=`, any `browser_exec` call running longer than ~120-150s has its underlying cloud browser destroyed by the reaper *while the browser-use CLI subprocess is still actively connected to it over CDP* — breaking the connection mid-task. This directly undermines `92968a5c7d`'s own raised timeout and "workspace persists across timeouts" design: the failure here is a broken CDP connection, not a clean timeout the workspace-recovery guidance addresses. Local Chrome setups (no cloud provider) are unaffected, since `_resolve_backend_cdp` returns early without touching session tracking there.

## Fix

- `_resolve_backend_cdp()` now returns `(error, cloud_session_task_id)` instead of just `error`. `cloud_session_task_id` is the key it registered activity for with the session tracker when it successfully resolved a cloud-provider session, or `None` when no such session was resolved (local CDP override, no provider configured, or a Browser Use direct-API config that manages its own session).
- `browser_exec()` now runs the CLI via a bounded poll loop (`subprocess.Popen` + background stdout/stderr drain threads, to avoid a pipe-buffer deadlock during a long run) instead of a single blocking `subprocess.run()`. While waiting, it calls `browser_tool._update_session_activity()` every `_CLOUD_SESSION_HEARTBEAT_INTERVAL_S` (20s — well under the 120s default inactivity threshold) whenever a cloud session was resolved, refreshing its activity timestamp for the whole run instead of only at resolution time.
- Local Chrome and explicit `session=`/`BU_NAME` runs are unaffected — `cloud_session_task_id` is `None` there, so no heartbeat calls are made.
- Overall timeout/kill semantics, stdout/stderr capture (including the existing stderr truncation and screenshot detection), and the result dict shape are unchanged.

## Test plan

- New regression test `test_long_exec_keeps_cloud_session_activity_fresh`: drives a fake CLI subprocess that sleeps across several (tiny, monkeypatched) heartbeat intervals with a resolved cloud-provider session, and asserts `browser_tool._update_session_activity` is called repeatedly (not just once) with the correct task id.
- Mutation-verified: stashed the `tools/browser_use_cli.py` fix and confirmed the new test fails against pre-fix code (the heartbeat mechanism/constant doesn't exist at all pre-fix).
- Updated the 7 existing `_resolve_backend_cdp` unit tests for its new `(error, cloud_session_task_id)` return shape; `test_cloud_provider_session_exported` additionally asserts the returned key matches the resolved task id.
- Ran the full `tests/tools/test_browser_use_cli.py` suite (68 tests, including the pre-existing timeout, non-zero-exit, stderr-capture, stdin-piping, session-naming, and screenshot-detection tests, all of which exercise the real subprocess path against a fake CLI script): all pass, confirming the `Popen` rewrite is behaviorally equivalent to the old `subprocess.run` for every existing case.
- Ran the closely-related session/reaper test files (`test_browser_orphan_reaper.py`, `test_browser_cleanup.py`, `test_browser_use_session_expiry.py`, `test_browser_cloud_provider_cache.py`, `test_browser_command_timeout_race.py`, `test_browser_provider_plugins.py`): all pass.
- `ruff check` clean on both changed files.

## Conflict note

Two open PRs touch `tools/browser_use_cli.py`:
- **#83471** ("strip PYTHONPATH/PYTHONHOME from browser-use CLI subprocess env") touches only `_base_subprocess_env()` — no line/function overlap with this PR.
- **#83498** ("add Camofox exec backend for browser_exec") inserts an early-return branch at the top of `browser_exec()`, right after the URL-safety check and before this PR's changes begin — no semantic overlap (the Camofox path returns before reaching the CDP-backend/subprocess-execution code this PR touches), but the insertion point is textually close, so a rebase may need light manual reconciliation if both land.