### PR TITLE
fix(tui): parse multi-line Rich markup in skin banners

### DIFF
--- a/ui-tui/src/__tests__/banner.test.ts
+++ b/ui-tui/src/__tests__/banner.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import { artWidth, logo, parseRichMarkup } from '../banner.js'
+
+const hasMarkupLeak = (lines: [string, string][]) =>
+  lines.some(([, text]) => /\[(?:bold\s+|dim\s+)?#|\[\/\]/.test(text))
+
+// Multi-line block shape used by real skins (kaylee-agent, etc.): one open tag
+// on the first line, art in the middle, closing [/] on the last line.
+const MULTILINE_LOGO = `[bold #1a5fb4]██╗  ██╗ █████╗ ██╗   ██╗██╗     ███████╗███████╗     █████╗  ██████╗ ███████╗███╗   ██╗████████╗
+██║ ██╔╝██╔══██╗╚██╗ ██╔╝██║     ██╔════╝██╔════╝    ██╔══██╗██╔════╝ ██╔════╝████╗  ██║╚══██╔══╝
+█████╔╝ ███████║ ╚████╔╝ ██║     █████╗  █████╗      ███████║██║  ███╗█████╗  ██╔██╗ ██║   ██║
+██╔═██╗ ██╔══██║  ╚██╔╝  ██║     ██╔══╝  ██╔══╝      ██╔══██║██║   ██║██╔══╝  ██║╚██╗██║   ██║
+██║  ██╗██║  ██║   ██║   ███████╗███████╗███████╗    ██║  ██║╚██████╔╝███████╗██║ ╚████║   ██║
+╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚══════╝╚══════╝╚══════╝    ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝   ╚═╝[/]`
+
+const MULTILINE_HERO = `[#62a0ea]⡏⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢉⣉⣉⣉⣉⣉⣉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⢹
+⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣤⣤⣤⣀⠉⠙⠻⣿⣿⣿⣷⣶⣤⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸
+⣇⣀⣀⣀⣀⣀⣀⣀⣠⣾⣿⣿⣿⣛⣻⣣⣋⣀⣀⣠⣊⣰⣋⣀⣀⣀⣀⣀⣀⣀⣀⣀⣛⣀⣀⣀⣀⣀⣸[/]`
+
+describe('parseRichMarkup', () => {
+  it('keeps per-line open/close tags (classic Hermes logo style)', () => {
+    const markup = ['[bold #FFD700]LINE ONE[/]', '[#FFBF00]LINE TWO[/]', '[dim #CD7F32]LINE THREE[/]'].join(
+      '\n'
+    )
+
+    const lines = parseRichMarkup(markup)
+    expect(lines).toEqual([
+      ['#FFD700', 'LINE ONE'],
+      ['#FFBF00', 'LINE TWO'],
+      ['#CD7F32', 'LINE THREE']
+    ])
+    expect(hasMarkupLeak(lines)).toBe(false)
+  })
+
+  it('carries a multi-line open tag until the closing [/]', () => {
+    const markup = ['[bold #1a5fb4]AAA', 'BBB', 'CCC[/]'].join('\n')
+
+    const lines = parseRichMarkup(markup)
+    expect(lines).toEqual([
+      ['#1a5fb4', 'AAA'],
+      ['#1a5fb4', 'BBB'],
+      ['#1a5fb4', 'CCC']
+    ])
+    expect(hasMarkupLeak(lines)).toBe(false)
+  })
+
+  it('does not emit a row for a trailing close-only line', () => {
+    const markup = ['[#62a0ea]art', '[/]'].join('\n')
+    expect(parseRichMarkup(markup)).toEqual([['#62a0ea', 'art']])
+  })
+
+  it('preserves plain lines and blank rows', () => {
+    expect(parseRichMarkup('plain\n\nstill plain')).toEqual([
+      ['', 'plain'],
+      ['', ' '],
+      ['', 'still plain']
+    ])
+  })
+
+  it('resets color after [/] mid-stream', () => {
+    const markup = ['[#ff0000]red', 'still red[/]', 'plain again'].join('\n')
+    expect(parseRichMarkup(markup)).toEqual([
+      ['#ff0000', 'red'],
+      ['#ff0000', 'still red'],
+      ['', 'plain again']
+    ])
+  })
+
+  it('parses multi-line skin banner_logo without leaking tags', () => {
+    const lines = parseRichMarkup(MULTILINE_LOGO)
+    expect(lines).toHaveLength(6)
+    expect(hasMarkupLeak(lines)).toBe(false)
+    expect(lines.every(([color]) => color === '#1a5fb4')).toBe(true)
+    expect(lines[0]![1]).toMatch(/^██/)
+    expect(lines[5]![1]).toMatch(/╚═╝/)
+    expect(artWidth(lines)).toBeGreaterThan(80)
+  })
+
+  it('parses multi-line skin banner_hero without leaking tags', () => {
+    const lines = parseRichMarkup(MULTILINE_HERO)
+    expect(lines).toHaveLength(3)
+    expect(hasMarkupLeak(lines)).toBe(false)
+    expect(lines.every(([color]) => color === '#62a0ea')).toBe(true)
+  })
+
+  it('logo() routes custom markup through the parser', () => {
+    const colors = {
+      primary: '#fff',
+      accent: '#0ff',
+      border: '#888',
+      muted: '#444',
+      text: '#eee',
+      danger: '#f00',
+      ok: '#0f0',
+      warn: '#ff0',
+      surface: '#111',
+      background: '#000'
+    }
+    const lines = logo(colors as never, '[#00b4d8]HI\nTHERE[/]')
+    expect(lines).toEqual([
+      ['#00b4d8', 'HI'],
+      ['#00b4d8', 'THERE']
+    ])
+  })
+})

--- a/ui-tui/src/banner.ts
+++ b/ui-tui/src/banner.ts
@@ -1,43 +1,72 @@
 import type { ThemeColors } from './theme.js'
 
-const RICH_RE = /\[(?:bold\s+)?(?:dim\s+)?(#(?:[0-9a-fA-F]{3,8}))\]([\s\S]*?)(\[\/\])/g
+/**
+ * Open color tag: optional bold/dim modifier + required #hex.
+ * Close tag: [/]
+ *
+ * Skin banner_logo / banner_hero are authored as Rich markup. Classic CLI
+ * (Rich Console) accepts a single open tag wrapping many lines; the TUI must
+ * do the same. Matching open+close only within one line left multi-line skins
+ * painting raw `[bold #1a5fb4]` / `[/]` into the dashboard xterm.
+ */
+const TAG_RE = /\[(?:(?:bold|dim)\s+)?(#[0-9a-fA-F]{3,8})\]|\[\/\]/gi
 
 export function parseRichMarkup(markup: string): Line[] {
   const lines: Line[] = []
+  // Color carries across lines until a closing [/] — same as Rich.
+  let activeColor = ''
 
   for (const raw of markup.split('\n')) {
     const trimmed = raw.trimEnd()
 
     if (!trimmed) {
       lines.push(['', ' '])
-
       continue
     }
 
-    const matches = [...trimmed.matchAll(RICH_RE)]
-
-    if (!matches.length) {
-      lines.push(['', trimmed])
-
-      continue
-    }
-
+    let text = ''
+    // Color of the first visible glyph on this line (banner art is one color
+    // per row; ArtLines renders one Text per Line).
+    let rowColor = activeColor
+    let sawContent = false
     let cursor = 0
+    TAG_RE.lastIndex = 0
 
-    for (const m of matches) {
-      const before = trimmed.slice(cursor, m.index)
-
-      if (before) {
-        lines.push(['', before])
+    let match: RegExpExecArray | null
+    while ((match = TAG_RE.exec(trimmed)) !== null) {
+      if (match.index > cursor) {
+        const chunk = trimmed.slice(cursor, match.index)
+        if (!sawContent) {
+          rowColor = activeColor
+          sawContent = true
+        }
+        text += chunk
       }
 
-      lines.push([m[1]!, m[2]!])
-      cursor = m.index! + m[0].length
+      if (match[0] === '[/]') {
+        activeColor = ''
+      } else {
+        // Group 1 is the #hex from an open tag.
+        activeColor = match[1] ?? ''
+      }
+      cursor = match.index + match[0].length
     }
 
     if (cursor < trimmed.length) {
-      lines.push(['', trimmed.slice(cursor)])
+      const chunk = trimmed.slice(cursor)
+      if (!sawContent) {
+        rowColor = activeColor
+        sawContent = true
+      }
+      text += chunk
     }
+
+    // Line was only tags (e.g. a lone `[/]` after art) — don't emit a blank row.
+    if (!sawContent) {
+      continue
+    }
+
+    lines.push([rowColor, text])
   }
 
   return lines


### PR DESCRIPTION
## Bug Description

Custom skins that wrap `banner_logo` / `banner_hero` in a single multi-line Rich color span (valid Rich markup, works in classic CLI) leak raw tags into the TUI and the dashboard Chat tab:

```
[bold #1a5fb4]
HERMES AGENT art...
[/]
[#62a0ea]
portrait art...
[/]
```

Classic CLI (`display.interface: cli`) looks fine because Rich Console handles multi-line spans. Dashboard Chat always spawns `hermes --tui` into xterm.js, so those skins look broken only in the web UI (and in `--tui`).

## Root Cause

`ui-tui/src/banner.ts` `parseRichMarkup` split on newlines first, then required open+close on the **same** line via:

```ts
/\[(?:bold\s+)?(?:dim\s+)?(#...)\]([\s\S]*?)(\[\/\])/g
```

A block like `[bold #1a5fb4]line1\nline2\nline3[/]` never matched, so tags were painted as plain text. Built-in skins mostly use per-line tags and hide the bug; many hand-authored skins use one open/close around the whole art block.

## Fix

- Rewrite `parseRichMarkup` to tokenize tags per line and **carry active color across lines** until `[/]` (Rich-compatible).
- Keep one art row per source line (matches `ArtLines`).
- Skip tag-only lines (e.g. a trailing `[/]`).
- Add `ui-tui/src/__tests__/banner.test.ts` covering per-line tags, multi-line blocks, mid-stream reset, and `logo()` routing.

## How to Verify

1. Install a skin whose `banner_logo` / `banner_hero` use one open tag on the first line and `[/]` on the last (multi-line block).
2. `hermes --tui` or open dashboard **Chat**.
3. Banner art is colored; no visible `[bold #…]` / `[#…]` / `[/]` tags.
4. `cd ui-tui && npm test -- src/__tests__/banner.test.ts`

## Test Plan

- [x] Added regression test for this bug
- [x] Tests pass locally (`vitest` — 8/8 on banner.test.ts in live tree)
- [x] Manual verification in dashboard Chat after rebuilding `ui-tui/dist` and killing the keep-alive PTY TUI process

## Risk Assessment

**Low** — isolated to skin banner art parsing in the TUI. Per-line tagged logos (default Hermes + built-in skins like Ares) still parse the same. No agent-loop / tool-schema / prompt-cache impact.