### PR TITLE
fix(tools): assign unique synthetic ids in todo dedup to prevent item loss (#83389)

### DIFF
--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -191,12 +191,18 @@ class TodoStore:
     def _dedupe_by_id(todos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Collapse duplicate ids, keeping the last occurrence in its position."""
         last_index: Dict[str, int] = {}
+        _synth_counter = 0
         for i, item in enumerate(todos):
             if not isinstance(item, dict):
                 # Non-dict items get a synthetic key so _validate can handle them
                 last_index[f"__invalid_{i}"] = i
                 continue
-            item_id = str(item.get("id", "")).strip() or "?"
+            item_id = str(item.get("id", "")).strip()
+            if not item_id:
+                # Use a unique synthetic key per item so distinct items
+                # without ids are not collapsed into one (#83389).
+                item_id = f"__synth_{_synth_counter}"
+                _synth_counter += 1
             last_index[item_id] = i
         return [todos[i] for i in sorted(last_index.values())]
 


### PR DESCRIPTION
## Problem

`TodoStore._dedupe_by_id` uses a static fallback `"?"` for all items lacking an explicit `id` key. Since `last_index["?"]` gets overwritten by each subsequent item without an id, only the **last** item survives deduplication. All earlier items are silently dropped.

## Root Cause

```python
item_id = str(item.get("id", "")).strip() or "?"
last_index[item_id] = i  # overwrites previous "?" entry
```

## Fix

Use a unique synthetic key (`__synth_0`, `__synth_1`, ...) per item instead of the shared `"?"` fallback, so each item gets its own slot in `last_index`:

```python
item_id = str(item.get("id", "")).strip()
if not item_id:
    item_id = f"__synth_{_synth_counter}"
    _synth_counter += 1
```

## Test

```python
from tools.todo_tool import TodoStore
store = TodoStore()
result = store.write([
    {"content": "Task 1", "status": "pending"},
    {"content": "Task 2", "status": "pending"}
])
assert len(result) == 2  # Previously only 1 survived
```

Fixes #83389