### PR TITLE
fix(agent): bound unmatched credential rotations across select() calls

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -631,6 +631,10 @@ def _write_through_provider_state_to_global_root(
 
 
 class CredentialPool:
+    # #83447: consecutive unmatched-hint rotations are bounded by a time
+    # window (see _unmatched_rotation_streak / _unmatched_rotation_streak_last_ts).
+    _UNMATCHED_ROTATION_WINDOW_SECONDS = 60
+
     def __init__(self, provider: str, entries: List[PooledCredential]):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
@@ -658,6 +662,12 @@ class CredentialPool:
         # loop runs unbounded and non-interruptible.  Reset whenever a real
         # entry is identified or an escape path returns None.
         self._unmatched_rotation_streak: int = 0
+        # #83447: the caller re-selects between retries (rotate -> swap ->
+        # retry -> select), so the streak must NOT be reset on every
+        # selection — that wiped the cap each cycle and the loop never
+        # terminated. "Consecutive" is enforced by a time window instead:
+        # rotations closer than this many seconds apart accumulate.
+        self._unmatched_rotation_streak_last_ts: float = 0.0
 
     def has_credentials(self) -> bool:
         with self._lock:
@@ -1771,14 +1781,11 @@ class CredentialPool:
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
         if entry is not None:
-            self._unmatched_rotation_streak = 0
             return entry
         # If no entry was available but we just refreshed some, re-select
         # now that the refreshed entries are back in the pool.
         if pending_refresh:
             entry, _ = self._select_under_lock()
-            if entry is not None:
-                self._unmatched_rotation_streak = 0
         return entry
 
     def _select_under_lock(self) -> Tuple[Optional[PooledCredential], List[tuple]]:
@@ -2105,7 +2112,17 @@ class CredentialPool:
                 # handed back at least once without recovery, so stop
                 # guessing and surface the error (no cooldown is written for
                 # anybody — healthy keys stay available for the next turn).
+                # #83447: time-window the streak instead of resetting on
+                # select() — the caller re-selects between retries, so a
+                # per-selection reset lets an all-failing pool rotate the
+                # same dead token forever. Rotations within the window are
+                # "consecutive" and accumulate; a long gap means the streak
+                # is stale and starts fresh.
+                now = time.time()
+                if now - self._unmatched_rotation_streak_last_ts > self._UNMATCHED_ROTATION_WINDOW_SECONDS:
+                    self._unmatched_rotation_streak = 0
                 self._unmatched_rotation_streak += 1
+                self._unmatched_rotation_streak_last_ts = now
                 available_count, _ = self._available_entries()
                 available_count = len(available_count)
                 if self._unmatched_rotation_streak > max(available_count, 1):

--- a/tests/agent/test_credential_pool_unmatched_rotation_bound.py
+++ b/tests/agent/test_credential_pool_unmatched_rotation_bound.py
@@ -108,3 +108,64 @@ class TestUnmatchedHintRotationIsBounded:
         assert statuses["cred-0"] != "exhausted"
         assert nxt is not None
         assert nxt.access_token == "key-healthy"
+
+
+    def test_select_between_rotations_does_not_defeat_the_bound(
+        self, tmp_path, monkeypatch
+    ):
+        """#83447: the agent flow calls select() between consecutive 401
+        rotations (rotate -> swap -> retry -> re-select). The old select()
+        reset wiped the streak every cycle, so a pool whose entries all fail
+        401 with an unmatched hint looped forever. The bound must survive
+        select() calls within the retry window."""
+        pool = _seed_pool(
+            tmp_path, monkeypatch,
+            [_entry(0, "key-a"), _entry(1, "key-b")],
+        )
+        results = []
+        for _ in range(10):  # caller's retry loop, re-selecting each time
+            pool.select()  # agent re-selects between retries
+            nxt = pool.mark_exhausted_and_rotate(
+                status_code=401,
+                error_context={"reason": "unauthorized"},
+                api_key_hint="oauth-runtime-token-that-matches-nothing",
+            )
+            results.append(nxt)
+            if nxt is None:
+                break
+        else:
+            pytest.fail(
+                "unbounded 401 retry loop: select() reset the streak every "
+                "cycle (#83447)"
+            )
+        assert results[-1] is None
+        # The escape must NOT have invented cooldowns for healthy keys.
+        statuses = {e.id: e.last_status for e in pool._entries}
+        assert all(status != "exhausted" for status in statuses.values())
+
+
+    def test_streak_decays_after_window(self, tmp_path, monkeypatch):
+        """Rotations separated by more than the window are not consecutive:
+        a stale streak must not trip the bound for a genuinely new problem."""
+        pool = _seed_pool(
+            tmp_path, monkeypatch,
+            [_entry(0, "key-a"), _entry(1, "key-b"), _entry(2, "key-c")],
+        )
+        # Two rotations within the window accumulate...
+        for _ in range(2):
+            pool.mark_exhausted_and_rotate(
+                status_code=401,
+                error_context={"reason": "unauthorized"},
+                api_key_hint="no-match",
+            )
+        assert pool._unmatched_rotation_streak == 2
+        # ...then a long gap: the next rotation starts a fresh streak.
+        pool._unmatched_rotation_streak_last_ts -= (
+            pool._UNMATCHED_ROTATION_WINDOW_SECONDS + 1
+        )
+        pool.mark_exhausted_and_rotate(
+            status_code=401,
+            error_context={"reason": "unauthorized"},
+            api_key_hint="no-match",
+        )
+        assert pool._unmatched_rotation_streak == 1


### PR DESCRIPTION
## What does this PR do?

Fixes the dashboard slash-worker infinite 401 retry loop (#83447). The root cause is a gap in the #70401 rotation bound:

- `mark_exhausted_and_rotate()` bounds **consecutive** unmatched-hint rotations with `_unmatched_rotation_streak`
- But `select()` **reset the streak to 0 on every successful selection**
- The agent's 401 retry flow re-selects between rotations (rotate → swap → retry → select), so the streak never accumulated — an all-failing pool rotated the same dead token forever, spinning at ~6/sec with no error surfaced

The streak is now **time-windowed**: rotations closer than 60s apart are "consecutive" and accumulate; a longer gap decays the streak. `select()` no longer wipes it; it still resets on matched-hint marks and the existing escape paths. Innocent keys still carry no cooldowns (the #70401 semantics are preserved).

**Empirically reproduced before the fix** (select + unmatched rotation loop, 2-entry pool): never terminated over 10 iterations. **After the fix**: terminates at iteration 2 with the bound message and returns None so the caller surfaces the error / activates fallback.

## Related Issue

Fixes #83447

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py` — added `_UNMATCHED_ROTATION_WINDOW_SECONDS = 60`; time-windowed streak accumulation in the unmatched branch of `mark_exhausted_and_rotate`; removed the streak resets in `select()`
- `tests/agent/test_credential_pool_unmatched_rotation_bound.py` — regression test for the real agent flow (`select()` between rotations, which the existing #70401 test missed) + test that the streak decays after the window

## How to Test

1. `scripts/run_tests.sh tests/agent/test_credential_pool_unmatched_rotation_bound.py tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py tests/agent/test_custom_pool_mismatch_guard.py` — 82 tests pass
2. Related credential/runtime suites: 43 tests pass
3. Direct repro: `select()` + unmatched `mark_exhausted_and_rotate` in a loop now terminates and returns None instead of looping forever

## Checklist

- [x] Tests run via the canonical `scripts/run_tests.sh` runner (per-file isolation, deterministic env)
- [x] #70401 semantics preserved: innocent keys never carry cooldowns (asserted in tests)
- [x] Stale-streak behavior preserved: rotations > 60s apart start a fresh streak
