### PR TITLE
fix(cron): normalize auto model/provider sentinel to resolve defaults (#83596)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3691,7 +3691,16 @@ def run_job(
         # re-read from storage every tick so a ``cronjob action=update
         # model=...`` after a failed run takes effect on the next tick — there
         # is no in-memory cache.
-        model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        # Normalize "auto" sentinel — the agent naturally writes model=auto
+        # provider=auto when the user says "use the default", but the run
+        # path treats any non-empty pin as an explicit choice (#83596).
+        _raw_model = str(job.get("model") or "").strip()
+        _raw_provider = str(job.get("provider") or "").strip()
+        if _raw_model.lower() == "auto":
+            _raw_model = ""
+        if _raw_provider.lower() == "auto":
+            _raw_provider = ""
+        model = _raw_model or os.getenv("HERMES_MODEL") or ""
 
         # cron.model / cron.model_provider: a deliberate cron-fleet default
         # so unattended jobs stop shadowing chat `/model` switches. When an
@@ -3891,7 +3900,7 @@ def run_job(
             else ""
         )
         primary_provider_for_drift = (
-            str(job.get("provider") or "").strip().lower()
+            _raw_provider.lower()
             or configured_provider_for_drift
             or None
         )
@@ -3905,7 +3914,7 @@ def run_job(
                 # Per-job user pin wins; otherwise the cron-fleet default
                 # provider (cron.model_provider); otherwise resolve from
                 # persisted global config.
-                "requested": job.get("provider") or _cron_default_provider or None,
+                "requested": _raw_provider or _cron_default_provider or None,
                 # Derive provider-specific api_mode from the model this job
                 # will actually run (per-job pin > env > config default), not
                 # the stale persisted default — mirrors the fallback path


### PR DESCRIPTION
## Problem

When the agent creates cron jobs with `model=auto` / `provider=auto` (the natural user spelling for "follow the default"), the cron scheduler treats `"auto"` as an explicit model/provider name and sends it directly to the provider API. This causes HTTP 400/401 errors, and the retry ladder silently burns through fallback provider balances.

## Root Cause

```python
model = job.get("model") or os.getenv("HERMES_MODEL") or ""
# "auto" is truthy, so fallback chain is skipped entirely
```

Same for `job.get("provider")` — `"auto"` is passed directly to `resolve_runtime_provider()`.

## Fix

Normalize case-insensitive `"auto"` to empty string early in the resolution chain, so the normal fallback (cron default > env > config.yaml) takes effect:

```python
_raw_model = str(job.get("model") or "").strip()
_raw_provider = str(job.get("provider") or "").strip()
if _raw_model.lower() == "auto":
    _raw_model = ""
if _raw_provider.lower() == "auto":
    _raw_provider = ""
model = _raw_model or os.getenv("HERMES_MODEL") or ""
```

Three call sites updated: model resolution, drift detection, and runtime provider resolution.

Fixes #83596