### PR TITLE
fix(tests): mark routed profile as served in busy-mode test

### DIFF
--- a/tests/gateway/test_multiplex_busy_input_mode.py
+++ b/tests/gateway/test_multiplex_busy_input_mode.py
@@ -320,7 +320,10 @@ async def test_missing_or_invalid_secondary_mode_falls_back_to_gateway_default(
     assert runner._busy_text_mode == "queue"
 
 
-def test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries():
+def test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries(
+    monkeypatch,
+    tmp_path,
+):
     runner = _runner(default_mode="interrupt")
     runner._snapshot_profile_busy_modes(
         "research",
@@ -334,6 +337,12 @@ def test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries():
             chat_id="chat-1",
         )
     ]
+    # Route acceptance requires the target profile to be in the served set.
+    # Other tests stamp source.profile directly; this one resolves via routes.
+    monkeypatch.setattr(
+        "gateway.run._multiplex_profile_homes",
+        lambda _config: [("research", tmp_path / "research")],
+    )
     source = _event(profile=None).source
 
     assert runner._effective_busy_input_mode(source) == "steer"


### PR DESCRIPTION
## What does this PR do?

`test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries` always fails on CI after selective multiplex profile serving landed in c8f235a106 (`feat(gateway): allow selective multiplex profile serving`). Route resolution now rejects target profile `research` when it is not in `_multiplex_profile_homes(config)`, so busy-input mode falls back to default `interrupt` instead of the snapshotted `steer`.

This PR monkeypatches `_multiplex_profile_homes` in that boundary test so `research` is in the served set. The test keeps asserting the multiplex / non-multiplex busy-mode boundary, not the serving allowlist. Bisect: green at a31be48030, red from c8f235a106.

## Related Issue

Fixes #83743

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tests/gateway/test_multiplex_busy_input_mode.py` - mark `research` as served via `_multiplex_profile_homes` monkeypatch in the profile-route boundary test

## How to Test

1. On this branch, run:
   `scripts/run_tests.sh tests/gateway/test_multiplex_busy_input_mode.py -q`
2. Confirm all tests in the file pass, including `test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries`.
3. Optional: temporarily remove the monkeypatch and confirm the original `assert 'interrupt' == 'steer'` failure returns.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for the bug fix (fixture correction for the failing case)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation: N/A - test-only fixture fix
- [x] `cli-config.yaml.example`: N/A - no config key changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no contributor workflow changed
- [x] Cross-platform impact considered: N/A - pure unit-test fixture
- [x] Tool descriptions/schemas: N/A - no model tool behavior changed
