### PR TITLE
fix(kanban): fail open on goal judge transport errors during handoff

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2207,8 +2207,9 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str) -> Opti
 
     verdict = "done"
     reason = ""
+    transport_failed = False
     try:
-        verdict, reason, _, _, _ = judge_goal(
+        verdict, reason, _, _, transport_failed = judge_goal(
             goal=f"{task.title}\n\n{task.body or ''}".strip(),
             last_response=evidence.strip(),
         )
@@ -2220,6 +2221,8 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str) -> Opti
             judge_exc,
             exc_info=True,
         )
+    if transport_failed or verdict == "skipped":
+        return None
     return reason if verdict != "done" else None
 
 

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -145,7 +145,8 @@ class TestCLIJudgeGate:
     """
 
     def _run(self, monkeypatch, *, goal_mode=True, judge_available=True,
-             verdict="done", reason="", complete_ok=True, summary="done"):
+             verdict="done", reason="", transport_failed=False,
+             complete_ok=True, summary="done"):
         import argparse
         import types
         from unittest.mock import MagicMock
@@ -184,7 +185,7 @@ class TestCLIJudgeGate:
         # (verdict, reason, parse_failed, wait_directive, transport_failed)
         monkeypatch.setattr(
             "hermes_cli.goals.judge_goal",
-            lambda **kw: (verdict, reason, False, None, False),
+            lambda **kw: (verdict, reason, False, None, transport_failed),
         )
 
         args = argparse.Namespace(task_ids=["t1"], summary=summary, result=None, metadata=None)
@@ -199,9 +200,97 @@ class TestCLIJudgeGate:
             "complete_task must NOT be invoked when the judge rejects"
         )
 
+    def test_judge_fail_open_on_transport_failure(self, monkeypatch):
+        rc, complete_calls = self._run(
+            monkeypatch,
+            verdict="continue",
+            reason="judge error: ConnectError",
+            transport_failed=True,
+        )
+        assert rc == 0, "transport failure must fail open and allow completion"
+        assert complete_calls == ["t1"]
+
 
     def test_non_goal_mode_task_skips_gate(self, monkeypatch):
         """Plain (non-goal_mode) tasks are never sent to the judge."""
         rc, complete_calls = self._run(monkeypatch, goal_mode=False)
         assert rc == 0
         assert complete_calls == ["t1"]
+
+
+class TestCLIHandoffRejection:
+    """Unit tests for hermes_cli.kanban._goal_mode_handoff_rejection (#83610)."""
+
+    @staticmethod
+    def _task():
+        import types
+
+        return types.SimpleNamespace(
+            goal_mode=True,
+            title="Review handoff",
+            body="request independent review",
+        )
+
+    @pytest.mark.parametrize(
+        ("judge_return", "judge_side_effect", "expected"),
+        [
+            (
+                ("continue", "criteria not met", False, None, False),
+                None,
+                "criteria not met",
+            ),
+            (
+                ("continue", "judge error: ConnectError", False, None, True),
+                None,
+                None,
+            ),
+            (
+                ("skipped", "empty goal", False, None, False),
+                None,
+                None,
+            ),
+            (
+                ("done", "achieved", False, None, False),
+                None,
+                None,
+            ),
+            (
+                None,
+                RuntimeError("boom"),
+                None,
+            ),
+        ],
+        ids=[
+            "real_rejection",
+            "transport_failure",
+            "skipped",
+            "success",
+            "exception",
+        ],
+    )
+    def test_handoff_rejection_matrix(
+        self,
+        monkeypatch,
+        judge_return,
+        judge_side_effect,
+        expected,
+    ):
+        from hermes_cli import kanban as kc
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            lambda name: (object(), "judge-model"),
+        )
+        if judge_side_effect is not None:
+            monkeypatch.setattr(
+                "hermes_cli.goals.judge_goal",
+                lambda **kw: (_ for _ in ()).throw(judge_side_effect),
+            )
+        else:
+            monkeypatch.setattr(
+                "hermes_cli.goals.judge_goal",
+                lambda **kw: judge_return,
+            )
+
+        result = kc._goal_mode_handoff_rejection(self._task(), "implementation complete")
+        assert result == expected

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -361,6 +361,91 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
         assert cli_after.status == "running"
 
 
+def test_goal_mode_review_handoff_fail_open_on_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Transient judge transport errors must not block request-review (#83610)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    with kb.connect() as conn:
+        tool_task = kb.create_task(
+            conn,
+            title="Goal-mode tool task",
+            assignee="builder",
+            goal_mode=True,
+        )
+        claimed = kb.claim_task(conn, tool_task, claimer="builder:1")
+        assert claimed is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tool_task)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+
+    from tools import kanban_tools as tools
+
+    monkeypatch.setattr(tools, "_goal_judge_available", lambda: True)
+    monkeypatch.setattr(
+        tools,
+        "judge_goal",
+        lambda *args, **kwargs: (
+            "continue",
+            "judge error: ConnectError",
+            False,
+            None,
+            True,
+        ),
+    )
+    ok = json.loads(tools._handle_request_review({"summary": "Looks ready."}))
+    assert ok.get("ok") is True
+    assert ok.get("status") == "review"
+    with kb.connect() as conn:
+        tool_after = kb.get_task(conn, tool_task)
+        assert tool_after is not None
+        assert tool_after.status == "review"
+
+    with kb.connect() as conn:
+        cli_task = kb.create_task(
+            conn,
+            title="Goal-mode CLI task",
+            assignee="builder",
+            goal_mode=True,
+        )
+        cli_claimed = kb.claim_task(conn, cli_task, claimer="builder:2")
+        assert cli_claimed is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", cli_task)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(cli_claimed.current_run_id))
+
+    import agent.auxiliary_client as auxiliary_client
+    from hermes_cli import goals
+
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_text_auxiliary_client",
+        lambda purpose: (object(), "judge-model"),
+    )
+    monkeypatch.setattr(
+        goals,
+        "judge_goal",
+        lambda *args, **kwargs: (
+            "continue",
+            "judge error: ConnectError",
+            False,
+            None,
+            True,
+        ),
+    )
+    output = kc.run_slash(f"request-review {cli_task} --summary 'Looks ready.'")
+    assert "rejected by judge" not in output
+    with kb.connect() as conn:
+        cli_after = kb.get_task(conn, cli_task)
+        assert cli_after is not None
+        assert cli_after.status == "review"
+
+
 def test_goal_loop_stops_after_reviewer_requests_changes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -215,6 +215,79 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
         conn2.close()
 
 
+class TestGoalModeHandoffRejectionTool:
+    """Unit tests for tools.kanban_tools._goal_mode_handoff_rejection (#83610)."""
+
+    @staticmethod
+    def _task():
+        import types
+
+        return types.SimpleNamespace(
+            goal_mode=True,
+            title="Review handoff",
+            body="request independent review",
+        )
+
+    @pytest.mark.parametrize(
+        ("judge_return", "judge_side_effect", "expected"),
+        [
+            (
+                ("continue", "criteria not met", False, None, False),
+                None,
+                "criteria not met",
+            ),
+            (
+                ("continue", "judge error: ConnectError", False, None, True),
+                None,
+                None,
+            ),
+            (
+                ("skipped", "empty goal", False, None, False),
+                None,
+                None,
+            ),
+            (
+                ("done", "achieved", False, None, False),
+                None,
+                None,
+            ),
+            (
+                None,
+                RuntimeError("boom"),
+                None,
+            ),
+        ],
+        ids=[
+            "real_rejection",
+            "transport_failure",
+            "skipped",
+            "success",
+            "exception",
+        ],
+    )
+    def test_handoff_rejection_matrix(
+        self,
+        monkeypatch,
+        judge_return,
+        judge_side_effect,
+        expected,
+    ):
+        from tools import kanban_tools as kt
+
+        monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+        if judge_side_effect is not None:
+            monkeypatch.setattr(
+                kt,
+                "judge_goal",
+                lambda **kw: (_ for _ in ()).throw(judge_side_effect),
+            )
+        else:
+            monkeypatch.setattr(kt, "judge_goal", lambda **kw: judge_return)
+
+        result = kt._goal_mode_handoff_rejection(self._task(), "implementation complete")
+        assert result == expected
+
+
 def test_block_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_block({"reason": "need clarification"})
@@ -254,6 +327,74 @@ def _make_goal_mode_worker_env(monkeypatch, tmp_path):
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
     return goal_task_id
+
+
+def test_complete_goal_mode_fail_open_on_transport_failure(monkeypatch, tmp_path):
+    """Transient judge transport errors must not block kanban_complete (#83610)."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+    monkeypatch.setattr(
+        kt,
+        "judge_goal",
+        lambda **kw: (
+            "continue",
+            "judge error: ConnectError",
+            False,
+            None,
+            True,
+        ),
+    )
+
+    out = json.loads(kt._handle_complete({"summary": "implementation complete"}))
+    assert out.get("ok") is True
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "done"
+    finally:
+        conn.close()
+
+
+def test_request_review_goal_mode_fail_open_on_transport_failure(monkeypatch, tmp_path):
+    """Transient judge transport errors must not block kanban_request_review (#83610)."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, tid)
+        assert run is not None
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run.id))
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+    monkeypatch.setattr(
+        kt,
+        "judge_goal",
+        lambda **kw: (
+            "continue",
+            "judge error: ConnectError",
+            False,
+            None,
+            True,
+        ),
+    )
+
+    out = json.loads(kt._handle_request_review({"summary": "implementation complete"}))
+    assert out.get("ok") is True
+    assert out.get("status") == "review"
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "review"
+    finally:
+        conn.close()
 
 
 def test_block_goal_mode_rejects_missing_kind(monkeypatch, tmp_path):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -257,8 +257,9 @@ def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
         return None
     verdict = "done"
     reason = ""
+    transport_failed = False
     try:
-        verdict, reason, _, _, _ = judge_goal(
+        verdict, reason, _, _, transport_failed = judge_goal(
             goal=f"{task.title}\n\n{task.body or ''}".strip(),
             last_response=evidence.strip(),
         )
@@ -270,6 +271,8 @@ def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
             judge_exc,
             exc_info=True,
         )
+    if transport_failed or verdict == "skipped":
+        return None
     return reason if verdict != "done" else None
 
 


### PR DESCRIPTION
## What does this PR do?

When a `goal_mode` Kanban worker calls a terminal lifecycle handoff (`kanban_complete` or `kanban_request_review`), `_goal_mode_handoff_rejection()` consults `judge_goal()`. On API/transport errors, `judge_goal()` does not raise — it returns `("continue", "judge error: …", False, None, True)` with `transport_failed=True`.

Both handoff gates were discarding the fifth tuple element and rejecting any non-`done` verdict, so a transient `ConnectError` blocked review/complete even though `judge_goal`'s docstring and the goal loop treat transport failures as fail-open.

This change honors `transport_failed=True` and `verdict == "skipped"` in both the tool path (`tools/kanban_tools.py`) and the CLI path (`hermes_cli/kanban.py`), so handoffs proceed when the judge is unreachable. Real `continue` verdicts with `transport_failed=False` still reject premature handoffs.

## Related Issue

Fixes #83610

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/kanban_tools.py` — `_goal_mode_handoff_rejection` returns `None` when `transport_failed` or `verdict == "skipped"`
- `hermes_cli/kanban.py` — same fail-open logic on the CLI path
- `tests/tools/test_kanban_tools.py` — parametrized unit tests for tool-path handoff gate + integration tests for `kanban_complete` and `kanban_request_review` fail-open on transport failure
- `tests/hermes_cli/test_kanban_goal_mode.py` — parametrized CLI-path unit tests + CLI complete fail-open test
- `tests/hermes_cli/test_kanban_review_surfaces.py` — tool + CLI request-review fail-open on transport failure

## How to Test

1. Run targeted regression tests:
   ```bash
   scripts/run_tests.sh tests/tools/test_kanban_tools.py -k "goal_mode or handoff" -q
   scripts/run_tests.sh tests/hermes_cli/test_kanban_goal_mode.py -q
   scripts/run_tests.sh tests/hermes_cli/test_kanban_review_surfaces.py -k goal_mode -q