### PR TITLE
fix(agent): drop empty assistant messages before they reach the provider

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3476,6 +3476,36 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # 4. Drop assistant messages left with nothing to send. Step 3 empties an
+    # assistant message's tool_calls when every call it carried was a duplicate,
+    # which happens with models that reuse the same tool_call_id across turns
+    # (observed: kimi-k2.7-code re-emitting "terminal_121"). Strict providers
+    # reject the resulting content-less message with HTTP 400 "the message at
+    # position N with role 'assistant' must not be empty", and that error is
+    # non-retryable, so the whole turn dies. Reasoning-bearing messages are kept
+    # so codex-style continuity is untouched.
+    pruned: List[Dict[str, Any]] = []
+    removed_empty = 0
+    for msg in messages:
+        if (
+            msg.get("role") == "assistant"
+            and not str(msg.get("content") or "").strip()
+            and not msg.get("tool_calls")
+            and not msg.get("function_call")
+            and not msg.get("reasoning")
+            and not msg.get("reasoning_content")
+            and not msg.get("reasoning_details")
+        ):
+            removed_empty += 1
+            continue
+        pruned.append(msg)
+    if removed_empty:
+        messages = pruned
+        _ra().logger.warning(
+            "Pre-call sanitizer: dropped %d empty assistant message(s)",
+            removed_empty,
+        )
     return messages
 
 


### PR DESCRIPTION
Fixes #82924.

### Problem

`sanitize_api_messages()` deduplicates `tool_call_id`s in step 3 by removing duplicate entries from an assistant message's `tool_calls`. When *every* call in that list is a duplicate the list becomes empty. If the same message also has empty `content` — normal when a model calls a tool without emitting text — the sanitizer produces an assistant message with no content and no tool calls.

Strict providers reject it:

```
400 invalid_request_error: the message at position 261 with role 'assistant' must not be empty
```

The error is classified as a non-retryable client error, so the turn dies.

### Why it is worse than a single failed turn

Once that message is persisted, every subsequent request carries it. A bare `ping` fails. The session stays broken until the row is manually deactivated in `state.db`, and clearing it is not durable — the next duplicated tool call recreates it.

Observed with `kimi-k2.7-code`, which re-emitted the id `terminal_121` on four separate assistant messages in one session. The duplicate ids come from the model, not from Hermes.

### Fix

A step 4 that drops assistant messages left with nothing to send, after dedup has run. Messages carrying reasoning payloads (`reasoning`, `reasoning_content`, `reasoning_details`) are preserved so codex-style continuity is unaffected.

### Verification

Reproduced the exact failure and confirmed it is fixed, plus three regression cases:

| case | result |
|---|---|
| two assistant msgs sharing `terminal_121`, second empty | empty message dropped, 5 msgs → 3 |
| plain chat exchange | unchanged |
| assistant with empty content but live `tool_calls` | kept |
| assistant with empty content but `reasoning_content` | kept |

`tests/agent/` at equal scope: 657 passed, and the failure set is byte-identical with and without this patch (3 pre-existing failures, unrelated). `ruff check` clean.