### PR TITLE
fix(agent): honour model-level temperature rules on the provider path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4118,6 +4118,13 @@ def _is_unsupported_parameter_error(exc: Exception, param: str) -> bool:
     err_lower = str(exc).lower()
     if param_lower not in err_lower:
         return False
+    # Some gateways name the parameter directly instead of using a generic
+    # "unsupported parameter" marker, e.g. Moonshot/Kimi via opencode-go:
+    #   "invalid temperature: only 1 is allowed for this model"
+    # Treat "invalid <param>" as the same class so the reactive retry fires
+    # instead of the caller re-sending an identical request that cannot work.
+    if f"invalid {param_lower}" in err_lower:
+        return True
     return any(marker in err_lower for marker in (
         "unsupported parameter",
         "unsupported_parameter",

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -623,11 +623,20 @@ class ChatCompletionsTransport(ProviderTransport):
             "messages": sanitized,
         }
 
-        # Temperature
-        if profile.fixed_temperature is OMIT_TEMPERATURE:
+        # Temperature. The profile rule is provider-scoped; when the profile
+        # has none, fall back to the model-scoped directive the caller computed
+        # via _fixed_temperature_for_model(). Without this fallback a model with
+        # a strict temperature contract reached through a generic provider — a
+        # Kimi model behind provider="custom", say — silently loses its own rule
+        # and receives the caller's temperature, which the upstream rejects with
+        # "invalid temperature: only 1 is allowed for this model".
+        _temp_rule = profile.fixed_temperature
+        if _temp_rule is None:
+            _temp_rule = params.get("fixed_temperature")
+        if _temp_rule is OMIT_TEMPERATURE:
             pass  # Don't include temperature at all
-        elif profile.fixed_temperature is not None:
-            api_kwargs["temperature"] = profile.fixed_temperature
+        elif _temp_rule is not None:
+            api_kwargs["temperature"] = _temp_rule
         else:
             # Use caller's temperature if provided
             temp = params.get("temperature")


### PR DESCRIPTION
Two related defects that together make Kimi models unusable behind a custom OpenAI-compatible endpoint.

### 1. The provider path discards the model-level temperature rule

`_build_kwargs_from_profile()` reads only `profile.fixed_temperature` and drops the caller's model-level directive computed by `_fixed_temperature_for_model()`.

Hermes correctly returns `OMIT_TEMPERATURE` for any Kimi model — I verified `_fixed_temperature_for_model('ocg/kimi-k2.7-code')` does exactly that. But only the `kimi-coding` / `kimi-coding-cn` provider profiles carry that rule themselves. The same model reached through `provider="custom"` (a router, a proxy, any OpenAI-compatible endpoint) loses its own contract and receives the caller's temperature. Upstream rejects it:

```
invalid temperature: only 1 is allowed for this model
```

Confirmed directly against the endpoint: `temperature: 1` succeeds, `0.7` and `0.3` both fail.

The profile rule still wins when it is set. The model rule is now the fallback instead of being silently dropped.

### 2. The reactive retry cannot recognise this error

`_is_unsupported_parameter_error()` matches the parameter name plus a generic marker (`unsupported parameter`, `not supported`, `unknown parameter`, …). Gateways that name the parameter directly fall through:

```python
>>> _is_unsupported_temperature_error(Exception('invalid temperature: only 1 is allowed for this model'))
False
>>> _is_unsupported_temperature_error(Exception('Unsupported parameter: temperature'))
True
```

So the drop-the-parameter-and-retry path never fires and the caller re-sends an identical request that cannot succeed. `invalid <param>` is now treated as the same class, which generalises to `max_tokens`, `seed`, `top_p` and anything else routed through the same helper.

### Verification

Transport resolution, four cases:

| case | temperature sent |
|---|---|
| Kimi model via `provider="custom"`, model rule `OMIT` | absent |
| ordinary model, no model rule, caller passes 0.7 | 0.7 |
| profile rule `OMIT` (existing behaviour) | absent |
| model-level float directive 0.5 | 0.5 |

Detector: the real error now matches, standard phrasing still matches, other parameters generalise, and unrelated text plus incidental mentions of the word still return `False`.

`tests/agent/transports/`, `tests/providers/`, and the unsupported-parameter suites: 334 passed. Wider run at equal scope: 657 passed with a failure set identical to baseline. `ruff check` clean.