### PR TITLE
fix(delegate): stop rejecting single-goal calls that carry an empty tasks list

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3224,6 +3224,14 @@ def delegate_task(
     if recovered_tasks is not None:
         tasks = recovered_tasks
 
+    # Whether batch mode was actually selected. The batch-only quality gate
+    # below must key off this, not off ``tasks is not None`` — models routinely
+    # emit every declared parameter, so a legitimate single-task call arrives as
+    # ``goal="..."`` alongside an empty ``tasks=[]``. That empty list is falsy
+    # here (single mode, correctly) but is not None, so a ``tasks is not None``
+    # gate would run the batch validator against the 1-item single-task list and
+    # reject a valid call with "Batch mode requires at least 2 tasks".
+    batch_mode = False
     if tasks and isinstance(tasks, list):
         if len(tasks) > max_children:
             return tool_error(
@@ -3234,6 +3242,7 @@ def delegate_task(
                 f"delegation.max_concurrent_children in config.yaml."
             )
         task_list = tasks
+        batch_mode = True
     elif goal and isinstance(goal, str) and goal.strip():
         single_task: Dict[str, Any] = {"goal": goal, "context": context, "role": top_role}
         if output_schema is not None:
@@ -3259,7 +3268,7 @@ def delegate_task(
     # child is spawned.  The single-`goal` form is deliberately exempt —
     # short goals are valid there.  Duplicate goals are allowed (best-of-N).
     # Inspired by: MoonshotAI/kimi-code agent-swarm.md validation rules (MIT).
-    if tasks is not None and isinstance(tasks, list):
+    if batch_mode:
         batch_error = _validate_batch_tasks(task_list)
         if batch_error:
             return tool_error(batch_error)


### PR DESCRIPTION
### Problem

Two guards in `delegate_task` ask different questions about the same value.

Mode selection (`tools/delegate_tool.py`):

```python
if tasks and isinstance(tasks, list):      # empty list is falsy -> single mode, correct
    task_list = tasks
elif goal and isinstance(goal, str) and goal.strip():
    task_list = [single_task]
```

The batch-only quality gate, ~30 lines later:

```python
if tasks is not None and isinstance(tasks, list):   # empty list is NOT None -> gate runs
    batch_error = _validate_batch_tasks(task_list)
```

An empty list is falsy but not `None`. So a legitimate single-task call arriving as `goal="..."` with `tasks=[]` selects single mode correctly, and is then validated as a batch and rejected:

```
Batch mode requires at least 2 tasks. For a single task, use the `goal` parameter instead of `tasks`.
```

The error is actively misleading — the caller *did* use `goal`.

### Why this hits real callers

Models routinely emit every declared parameter, including the empty ones. Pulled from stored `tool_calls` on a live session:

```
arg keys: ['goal', 'context', 'tasks', 'role', 'output_schema', 'background']
   goal  : 'Produce an implementation-ready redesign specification for h...'
   tasks : []
```

That exact call was retried 13 times and tripped two separate loop guardrails (`same_tool_failure_halt` at 8 repeats, then `repeated_exact_failure_block` at 5) before the agent gave up. The error text tells the model to do what it was already doing, so it cannot recover by reading it.

### Fix

Track whether batch mode was actually selected and key the gate off that, rather than off `tasks is not None`. Genuine one-item batches (`tasks=[{...}]`) are still rejected exactly as before.

### Verification

`_validate_batch_tasks` still returns the error for a 1-item batch and `None` for a 2-item batch. Delegation suites: 194 passed, 3 skipped — including `test_delegate_batch_validation.py`. `ruff check` clean.