### PR TITLE
fix(agent): retry 503/529 capacity overloads over a bounded window before fallback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -81,6 +81,9 @@ from agent.prompt_caching import (
 )
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
+    capacity_overload_backoff,
+    capacity_overload_retry_ceiling,
+    is_capacity_overload_error,
     is_zai_coding_overload_error,
     jittered_backoff,
     zai_coding_overload_retry_ceiling,
@@ -4810,9 +4813,22 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                # #68771: generic 503/529 "upstream capacity limits" overloads
+                # get the same shape of treatment as Z.AI overloads — a
+                # bounded long-backoff window on the PRIMARY before the
+                # fallback chain activates. Capacity outages often clear in
+                # seconds-to-minutes; falling back (or giving up when no
+                # fallback chain exists) after one ~2s retry is too eager.
+                _is_capacity_overload = is_capacity_overload_error(api_error)
+                if _is_capacity_overload:
+                    max_retries = max(max_retries, capacity_overload_retry_ceiling())
                 _should_fallback = (
                     is_rate_limited
-                    or (_is_transport_failure and retry_count >= 2)
+                    or (
+                        _is_transport_failure
+                        and retry_count >= 2
+                        and not _is_capacity_overload
+                    )
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
@@ -5912,7 +5928,7 @@ def run_conversation(
                                 pass
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
-                if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
+                if (is_rate_limited or _is_zai_coding_overload or _is_capacity_overload) and not _retry_after:
                     wait_time, _backoff_policy = adaptive_rate_limit_backoff(
                         retry_count,
                         base_url=str(_base),
@@ -5920,18 +5936,28 @@ def run_conversation(
                         error=api_error,
                         default_wait=wait_time,
                     )
-                if is_rate_limited or _is_zai_coding_overload:
+                    if _is_capacity_overload and _backoff_policy is None:
+                        # adaptive_rate_limit_backoff only fires for Z.AI
+                        # overloads; apply the generic capacity schedule.
+                        wait_time, _backoff_policy = capacity_overload_backoff(
+                            retry_count, wait_time
+                        )
+                if is_rate_limited or _is_zai_coding_overload or _is_capacity_overload:
                     _policy_note = ""
                     if _backoff_policy == "zai_coding_overload_long":
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"
                     elif _backoff_policy == "zai_coding_overload_short":
                         _policy_note = " (Z.AI Coding overload short retry)"
-                    _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
+                    elif _backoff_policy == "capacity_overload_long":
+                        _policy_note = " (upstream capacity overload — waiting for the model to come back)"
+                    elif _backoff_policy == "capacity_overload_short":
+                        _policy_note = " (upstream capacity overload short retry)"
+                    _wait_reason = "Provider overloaded" if (_is_zai_coding_overload or _is_capacity_overload) and not is_rate_limited else "Rate limited"
                     _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
                     # Normal retries are buffered to avoid noisy transient chatter. Long
-                    # Z.AI Coding waits are different: they can last minutes, so surface
-                    # progress immediately instead of making the TUI look frozen.
-                    if _backoff_policy == "zai_coding_overload_long":
+                    # Z.AI Coding / capacity waits are different: they can last minutes, so
+                    # surface progress immediately instead of making the TUI look frozen.
+                    if _backoff_policy in ("zai_coding_overload_long", "capacity_overload_long"):
                         agent._emit_status(_rate_limit_status)
                     else:
                         agent._buffer_status(_rate_limit_status)

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -34,6 +34,20 @@ _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 # the two from silently desyncing if the short-retry count is ever tuned.
 _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
 
+# #68771: generic provider 503/529 "upstream capacity limits" overloads.
+# Capacity outages typically last tens of seconds to a few minutes, so a
+# single ~2s retry followed by eager fallback (or give-up when no fallback
+# chain exists) is too aggressive. Keep the first retry on the normal short
+# schedule, then walk a longer backoff table so the primary gets a few
+# retries over ~75s before the fallback chain activates.
+_CAPACITY_OVERLOAD_LONG_BACKOFF = (5.0, 10.0, 20.0, 40.0)
+
+# Number of initial short retries before the capacity long-backoff tier
+# kicks in. Shared by ``capacity_overload_backoff`` and
+# ``capacity_overload_retry_ceiling`` for the same desync-prevention reason
+# as the Z.AI constants above.
+_CAPACITY_OVERLOAD_SHORT_ATTEMPTS = 1
+
 
 def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     """Parse a ``Retry-After`` value into non-negative seconds.
@@ -206,3 +220,50 @@ def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD
     value for Z.AI Coding overload 429s so the 30/60/90/120s waits run.
     """
     return short_attempts + len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) + 1
+
+
+def is_capacity_overload_error(error: Any) -> bool:
+    """True when ``error`` is a provider 503/529 overload.
+
+    Status-code based — the reliable signal; message wording varies wildly
+    across providers (Anthropic/OpenRouter: "temporarily unavailable due to
+    upstream capacity limits"; Cloudflare 529: origin overload). 503 Service
+    Unavailable and Cloudflare 529 both mean the model cannot serve right now
+    but may recover in seconds-to-minutes.
+    """
+    return getattr(error, "status_code", None) in {503, 529}
+
+
+def capacity_overload_backoff(attempt: int, default_wait: float) -> tuple[float, str | None]:
+    """Adaptive 503/529 overload backoff.
+
+    The first retry keeps the caller's default wait (normal short schedule);
+    subsequent attempts walk ``_CAPACITY_OVERLOAD_LONG_BACKOFF`` (5/10/20/40s)
+    with light jitter, so a capacity outage gets a few retries over roughly a
+    minute instead of one quick retry then fallback.
+
+    ``attempt`` is 1-based, matching the retry loop's logged attempt number.
+    Returns ``(wait_seconds, policy_label)``.
+    """
+    if attempt <= _CAPACITY_OVERLOAD_SHORT_ATTEMPTS:
+        return default_wait, "capacity_overload_short"
+    idx = min(
+        attempt - _CAPACITY_OVERLOAD_SHORT_ATTEMPTS - 1,
+        len(_CAPACITY_OVERLOAD_LONG_BACKOFF) - 1,
+    )
+    base_delay = _CAPACITY_OVERLOAD_LONG_BACKOFF[idx]
+    return (
+        jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2),
+        "capacity_overload_long",
+    )
+
+
+def capacity_overload_retry_ceiling(short_attempts: int = _CAPACITY_OVERLOAD_SHORT_ATTEMPTS) -> int:
+    """Retry-loop ceiling needed for the full capacity backoff schedule.
+
+    Same rationale as ``zai_coding_overload_retry_ceiling``: the retry loop
+    gives up as soon as ``retry_count >= ceiling`` and that check runs before
+    the attempt's backoff is computed, so the ceiling must sit one past the
+    final long-backoff entry for every long tier to execute.
+    """
+    return short_attempts + len(_CAPACITY_OVERLOAD_LONG_BACKOFF) + 1

--- a/tests/agent/test_capacity_overload_retry.py
+++ b/tests/agent/test_capacity_overload_retry.py
@@ -1,0 +1,99 @@
+"""#68771: 503/529 "upstream capacity limits" overloads retry over a bounded
+backoff window on the primary BEFORE the fallback chain activates.
+
+The Z.AI overload path already gets a long adaptive backoff; this generalizes
+that policy to provider-agnostic 503/529 overloads so a capacity outage gets
+a few retries over ~a minute instead of one quick retry then fallback (or
+give-up when no fallback chain is configured).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.error_classifier import FailoverReason, classify_api_error
+from agent.retry_utils import (
+    capacity_overload_backoff,
+    capacity_overload_retry_ceiling,
+    is_capacity_overload_error,
+)
+
+
+class _Err(Exception):
+    def __init__(self, status_code, message="Service Unavailable"):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = None
+
+
+def test_503_and_529_are_capacity_overloads():
+    assert is_capacity_overload_error(_Err(503)) is True
+    assert is_capacity_overload_error(_Err(529)) is True
+    assert is_capacity_overload_error(_Err(500)) is False
+    assert is_capacity_overload_error(_Err(502)) is False
+    assert is_capacity_overload_error(_Err(429)) is False
+    assert is_capacity_overload_error(ValueError("no status")) is False
+
+
+def test_503_classified_as_retryable_overloaded():
+    result = classify_api_error(_Err(503), provider="nous")
+    assert result.reason == FailoverReason.overloaded
+    assert result.retryable is True
+
+
+def test_capacity_backoff_schedule():
+    # First retry keeps the caller's default (short) wait.
+    wait, policy = capacity_overload_backoff(1, 2.0)
+    assert wait == 2.0
+    assert policy == "capacity_overload_short"
+    # Long tier walks 5/10/20/40 (light jitter: delay in [base, base*1.2])
+    # and caps at the last entry.
+    waits = [capacity_overload_backoff(a, 2.0)[0] for a in range(2, 8)]
+    expected_bases = [5.0, 10.0, 20.0, 40.0, 40.0, 40.0]
+    for got, base in zip(waits, expected_bases):
+        assert base <= got <= base * 1.2, f"{got} not in [{base}, {base * 1.2}]"
+    assert waits[3] == pytest.approx(waits[4], rel=0.2)  # capped, same tier
+    assert all(
+        capacity_overload_backoff(a, 2.0)[1] == "capacity_overload_long"
+        for a in range(2, 8)
+    )
+
+
+def test_capacity_ceiling_reaches_all_long_tiers():
+    # 1 short + 4 long + 1 (the pre-backoff ceiling check) = 6
+    assert capacity_overload_retry_ceiling() == 6
+
+
+def _gate(is_rate_limited, is_transport, is_capacity, retry_count):
+    """Mirror the conversation_loop _should_fallback expression."""
+    return is_rate_limited or (
+        is_transport and retry_count >= 2 and not is_capacity
+    )
+
+
+def test_capacity_overload_does_not_eager_fallback():
+    # Capacity overloads must NOT trip the transport eager-fallback gate.
+    assert _gate(False, True, True, 2) is False
+    assert _gate(False, True, True, 5) is False
+    # Other transport failures still fall back after one real retry.
+    assert _gate(False, True, False, 2) is True
+    # Rate limits stay immediate.
+    assert _gate(True, False, False, 1) is True
+
+
+def test_503_retries_beyond_default_budget_then_fallback():
+    """Simulate the loop's retry/ceiling math for a 503: the primary must get
+    retries past the default api_max_retries (3) — the eager-fallback gate
+    stays off — and the loop only stops at the capacity ceiling, where the
+    ceiling path activates fallback."""
+    ceiling = capacity_overload_retry_ceiling()
+    max_retries = max(3, ceiling)  # default api_max_retries, raised by the 503 path
+
+    retry_count = 0
+    while retry_count < max_retries:
+        retry_count += 1
+        # The eager-fallback gate must never fire during the window.
+        assert _gate(False, True, True, retry_count) is False
+
+    assert retry_count == ceiling
+    assert retry_count > 3  # more than the default retry budget


### PR DESCRIPTION
## What does this PR do?

Implements the **retry-over-time** half of #68771 for provider 503/529 "upstream capacity limits" overloads (the exact error from #38929: *"The requested model is temporarily unavailable due to upstream capacity limits. Please try again in a moment."*).

**Before:** 503/529 → classified `overloaded` → treated as a transport failure → **one ~2s retry**, then eager fallback — or, with no fallback chain configured, give-up. A capacity outage that clears in 30s wasted a healthy primary and either burned a fallback on a transient blip or dropped the turn entirely.

**After:** the primary gets **a few retries over ~75s** (short retry, then 5s → 10s → 20s → 40s with light jitter), the retry ceiling is raised so the long tier actually runs, and the eager-fallback gate excludes capacity overloads — fallback activates **only after the capacity window**, via the existing ceiling path. Long capacity waits surface immediately in the TUI instead of buffering.

This mirrors the existing Z.AI Coding overload pattern (`adaptive_rate_limit_backoff` + `zai_coding_overload_retry_ceiling`) and generalizes it to provider-agnostic 503/529s.

## Related Issue

Fixes the retry half of #68771 (the fallback-trigger half is #68886). Also addresses #38929's exact error message.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/retry_utils.py` — new `is_capacity_overload_error` (status-based 503/529 detection), `capacity_overload_backoff` (short retry → 5/10/20/40s jittered long tier), `capacity_overload_retry_ceiling` (sizes the loop so every long tier runs)
- `agent/conversation_loop.py` — detect capacity overloads in the failover gate: raise `max_retries` to the capacity ceiling, exclude them from the transport eager-fallback (`retry_count >= 2`) gate, apply the capacity backoff schedule, surface long waits via `_emit_status`
- `tests/agent/test_capacity_overload_retry.py` — new: detection, classification, backoff schedule (with jitter bounds), ceiling math, gate simulation (no eager fallback for 503/529; retries past the default `api_max_retries` budget before fallback)

## How to Test

1. `scripts/run_tests.sh tests/agent/test_capacity_overload_retry.py` — 6 tests pass
2. Adjacent retry/error-classifier/fallback suites (6 files): 113 tests pass; failover/fallback suites: 19 tests pass
3. `ruff check` clean on all changed files

## Checklist

- [x] Tests run via the canonical `scripts/run_tests.sh` runner (per-file isolation, deterministic env)
- [x] No behavior change for non-503/529 errors (rate limits still fall back immediately; other transport failures still fall back after one retry)
- [x] Z.AI overload path untouched (its own schedule still applies; capacity detection is status-based 503/529 only)
- [x] No new config surface — schedule constants mirror the existing Z.AI constants
