### PR TITLE
fix(agent): try the fallback chain before the compression dead-ends give up

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5003,6 +5003,22 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached for payload-too-large error.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error("%s413 compression failed after %d attempts.", agent.log_prefix, max_compression_attempts)
+                        # A different provider may accept what this one refused: its context
+                        # window or request-size limit can simply be larger. Every other
+                        # terminal error class escalates to the chain before giving up (rate
+                        # limit, billing, transport, auth) -- the compression dead-ends were
+                        # the exception, so a configured fallback was never tried for a 413
+                        # or a context overflow. Mirrors the auth-failover block above.
+                        if agent._try_activate_fallback():
+                            agent._buffer_status(
+                                "Compression exhausted -- switching to fallback provider..."
+                            )
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt)
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            continue
                         agent._persist_session(messages, conversation_history)
                         _final_response = f"Request payload too large: max compression attempts ({max_compression_attempts}) reached."
                         return {
@@ -5075,6 +5091,22 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}❌ Payload too large and cannot compress further.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error("%s413 payload too large. Cannot compress further.", agent.log_prefix)
+                        # A different provider may accept what this one refused: its context
+                        # window or request-size limit can simply be larger. Every other
+                        # terminal error class escalates to the chain before giving up (rate
+                        # limit, billing, transport, auth) -- the compression dead-ends were
+                        # the exception, so a configured fallback was never tried for a 413
+                        # or a context overflow. Mirrors the auth-failover block above.
+                        if agent._try_activate_fallback():
+                            agent._buffer_status(
+                                "Compression exhausted -- switching to fallback provider..."
+                            )
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt)
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            continue
                         agent._persist_session(messages, conversation_history)
                         _final_response = "Request payload too large (413). Cannot compress further."
                         return {
@@ -5148,6 +5180,22 @@ def run_conversation(
                             agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
                             agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logger.error("%sContext compression failed after %d attempts.", agent.log_prefix, max_compression_attempts)
+                            # A different provider may accept what this one refused: its context
+                            # window or request-size limit can simply be larger. Every other
+                            # terminal error class escalates to the chain before giving up (rate
+                            # limit, billing, transport, auth) -- the compression dead-ends were
+                            # the exception, so a configured fallback was never tried for a 413
+                            # or a context overflow. Mirrors the auth-failover block above.
+                            if agent._try_activate_fallback():
+                                agent._buffer_status(
+                                    "Compression exhausted -- switching to fallback provider..."
+                                )
+                                active_system_prompt = _sync_failover_system_message(
+                                    agent, api_messages, active_system_prompt)
+                                retry_count = 0
+                                compression_attempts = 0
+                                _retry.primary_recovery_attempted = False
+                                continue
                             agent._persist_session(messages, conversation_history)
                             _final_response = f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached."
                             return {
@@ -5302,6 +5350,22 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                         logger.error("%sContext compression failed after %d attempts.", agent.log_prefix, max_compression_attempts)
+                        # A different provider may accept what this one refused: its context
+                        # window or request-size limit can simply be larger. Every other
+                        # terminal error class escalates to the chain before giving up (rate
+                        # limit, billing, transport, auth) -- the compression dead-ends were
+                        # the exception, so a configured fallback was never tried for a 413
+                        # or a context overflow. Mirrors the auth-failover block above.
+                        if agent._try_activate_fallback():
+                            agent._buffer_status(
+                                "Compression exhausted -- switching to fallback provider..."
+                            )
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt)
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            continue
                         agent._persist_session(messages, conversation_history)
                         _final_response = f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached."
                         return {
@@ -5365,6 +5429,22 @@ def run_conversation(
                         agent._vprint(f"{agent.log_prefix}❌ Context length exceeded and cannot compress further.", force=True)
                         agent._vprint(f"{agent.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
                         logger.error("%sContext length exceeded: %s tokens. Cannot compress further.", agent.log_prefix, f"{new_tokens:,}")
+                        # A different provider may accept what this one refused: its context
+                        # window or request-size limit can simply be larger. Every other
+                        # terminal error class escalates to the chain before giving up (rate
+                        # limit, billing, transport, auth) -- the compression dead-ends were
+                        # the exception, so a configured fallback was never tried for a 413
+                        # or a context overflow. Mirrors the auth-failover block above.
+                        if agent._try_activate_fallback():
+                            agent._buffer_status(
+                                "Compression exhausted -- switching to fallback provider..."
+                            )
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt)
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            continue
                         agent._persist_session(messages, conversation_history)
                         _final_response = f"Context length exceeded ({new_tokens:,} tokens). Cannot compress further."
                         return {

--- a/tests/run_agent/test_failover_on_compression_exhausted.py
+++ b/tests/run_agent/test_failover_on_compression_exhausted.py
@@ -1,0 +1,131 @@
+"""Failover must be tried before the compression dead-ends give up.
+
+``run_conversation`` has five terminal paths for "payload too large / context
+overflow and compression cannot help any further". Every *other* terminal error
+class (rate limit, billing, transport, auth) escalates to the fallback chain
+before returning -- these five did not, so a configured provider with a larger
+context window or request-size limit was never tried for a 413.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+import agent.conversation_loop as conversation_loop
+
+
+CHAIN = [
+    {
+        "provider": "openrouter",
+        "model": "google/gemma-4-26b-a4b-it:free",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+]
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Compression retries sleep for rate-limit smoothing; tests assert behaviour."""
+    import time as _time
+
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+
+
+def _make_agent(fallback_model=None):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.groq.com/openai/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = True
+    agent.save_trajectories = False
+    return agent
+
+
+def _413():
+    err = Exception("Request entity too large")
+    err.status_code = 413
+    return err
+
+
+def _ok(text="Hello"):
+    msg = SimpleNamespace(
+        content=text, tool_calls=None, reasoning_content=None, reasoning=None
+    )
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=msg, finish_reason="stop")], model="fb/model"
+    )
+    resp.usage = None
+    return resp
+
+
+class TestFailoverBeforeCompressionDeadEnd:
+    def test_uncompressible_payload_switches_provider(self):
+        """A 413 that cannot be compressed should move to the next provider."""
+        agent = _make_agent(fallback_model=CHAIN)
+        agent.client.chat.completions.create.side_effect = [_413(), _ok("Hello")]
+
+        def _activate(*_a, **_k):
+            agent.provider = "openrouter"
+            agent.model = "google/gemma-4-26b-a4b-it:free"
+            agent._fallback_index = 1
+            return True
+
+        with (
+            patch.object(agent, "_compress_context") as compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(
+                agent, "_try_activate_fallback", side_effect=_activate
+            ) as activate,
+        ):
+            # Same message count back -> nothing left to compress.
+            compress.return_value = (
+                [{"role": "user", "content": "hello"}],
+                "same prompt",
+            )
+            result = agent.run_conversation("hello")
+
+        assert activate.called, "fallback chain was never consulted"
+        assert result.get("final_response") == "Hello"
+        assert result.get("completed") is True
+        assert not result.get("compression_exhausted")
+
+    def test_without_a_chain_the_terminal_result_is_unchanged(self):
+        """No fallback configured -> the existing partial-failure result stands."""
+        agent = _make_agent(fallback_model=None)
+        agent.client.chat.completions.create.side_effect = [_413()]
+
+        with (
+            patch.object(agent, "_compress_context") as compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            compress.return_value = (
+                [{"role": "user", "content": "hello"}],
+                "same prompt",
+            )
+            result = agent.run_conversation("hello")
+
+        assert result.get("completed") is False
+        assert result.get("partial") is True
+        assert result.get("compression_exhausted") is True
+        assert "413" in result.get("error", "")
+        # The terminal result still carries a user-facing string.
+        assert result.get("final_response")


### PR DESCRIPTION
## What

`run_conversation()` has five terminal paths for *"payload too large / context overflow, and compression cannot reduce it any further"*. All five `return` directly — which skips the failover escalation that **every other** terminal error class performs first.

Rate limit, billing, transport failure and auth all call `_try_activate_fallback()` before giving up. The compression dead-ends do not, so a user with a configured `fallback_providers` chain still gets a hard failure on a 413 and the chain is never consulted.

That is the case where switching providers is *most* likely to help: the next provider's context window or request-size limit may simply be larger.

## Why this shape

The change mirrors the auth-failover block a few hundred lines above, including its reasoning — that block was added for the same class of problem:

> Previously the loop only printed "switch providers manually" advice and fell through, so a user with a configured fallback chain kept thrashing on the same dead credential every turn instead of failing over.

Same pattern, same call, same counter resets:

```python
if agent._try_activate_fallback():
    agent._buffer_status("Compression exhausted -- switching to fallback provider...")
    active_system_prompt = _sync_failover_system_message(
        agent, api_messages, active_system_prompt)
    retry_count = 0
    compression_attempts = 0
    _retry.primary_recovery_attempted = False
    continue
```

When no chain is configured — or it is exhausted — `_try_activate_fallback()` returns `False` and the existing terminal result is returned completely unchanged. That is the intended compatibility property, and the second test pins it.

## How to test

`tests/run_agent/test_failover_on_compression_exhausted.py`:

- uncompressible 413 **with** a chain → switches provider and answers
- uncompressible 413 **without** a chain → the existing partial-failure result stands (`completed=False`, `partial=True`, `compression_exhausted=True`, `final_response` still populated)

On `main` the first test fails with `fallback chain was never consulted`. With the change, both pass, and `tests/run_agent/test_provider_fallback.py` continues to pass unchanged (16 passed together).

**One trap worth recording for anyone testing this path:** the agent fixture must have `compression_enabled = True`. With it disabled, the loop takes the earlier *"Context overflow (payload_too_large) with auto-compaction disabled — not compressing"* branch and never reaches these dead-ends at all — so a test written the obvious way silently exercises different code.

## Real-world trigger

Found on a self-hosted setup where the primary provider (Groq) reports a 131072 context window and still rejects the request with a 413, because its **request-size** limit is a separate, smaller constraint. Context length and payload size are independent, so no amount of correct `context_length` configuration prevents this — only failing over to another provider does.

## Platforms

Tested on Linux (Debian arm64, Python 3.11). No OS-specific code paths touched.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian arm64, Python 3.11

> Note on the suite: `tests/run_agent/` covering this area passes (the new file plus `test_provider_fallback.py`, 16 passed). I could not run the complete `pytest tests/` on this machine — the environment is missing optional dependencies unrelated to this change (e.g. `nemo_relay`), so a full-suite number from here would be misleading rather than informative. CI is the honest arbiter; happy to iterate on anything it flags.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behaviour now matches what the fallback-provider docs already promise)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (no OS-specific calls)
- [x] I've updated tool descriptions/schemas — N/A
