### PR TITLE
fix(voice): finish a capture cycle immediately when the loop will not re-arm the mic

### DIFF
--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -826,24 +826,29 @@ def _continuous_on_silence() -> None:
                 pass
         return
 
-    # CLI parity (cli.py:10619-10621): wait for any in-flight TTS to
-    # finish before re-arming the mic, then leave a small gap to avoid
-    # catching the tail of the speaker output.  Without this the voice
-    # loop becomes a feedback loop — the agent's spoken reply lands
-    # back in the mic and gets re-submitted.
-    if not _tts_playing.is_set():
-        _debug("_continuous_on_silence: waiting for TTS to finish")
-        _tts_playing.wait(timeout=60)
-        import time as _time
-        _time.sleep(0.3)
-
-        # User may have stopped the loop during the wait.
-        with _continuous_lock:
-            if not _continuous_active:
-                _debug("_continuous_on_silence: stopped while waiting for TTS")
-                return
-
     if _continuous_auto_restart:
+        # CLI parity (cli.py:17869-17871): wait for any in-flight TTS to
+        # finish before re-arming the mic, then leave a small gap to avoid
+        # catching the tail of the speaker output.  Without this the voice
+        # loop becomes a feedback loop — the agent's spoken reply lands
+        # back in the mic and gets re-submitted.
+        #
+        # Deliberately scoped to this branch: the wait exists only to guard
+        # the re-arm below.  The ``else`` branch never reopens the mic, so
+        # waiting there cannot prevent any feedback — it only withholds the
+        # terminal "idle" status and holds the loop "active" for up to 60s.
+        if not _tts_playing.is_set():
+            _debug("_continuous_on_silence: waiting for TTS to finish")
+            _tts_playing.wait(timeout=60)
+            import time as _time
+            _time.sleep(0.3)
+
+            # User may have stopped the loop during the wait.
+            with _continuous_lock:
+                if not _continuous_active:
+                    _debug("_continuous_on_silence: stopped while waiting for TTS")
+                    return
+
         # Restart for the next turn.
         _debug(f"_continuous_on_silence: restarting loop (no_speech={no_speech})")
         _play_beep(frequency=880, count=1)

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -426,6 +426,102 @@ class TestContinuousLoopSimulation:
         assert voice._continuous_no_speech_count == 0
         voice.stop_continuous()
 
+    class _RecordingTTSEvent:
+        """Non-blocking stand-in for ``voice._tts_playing``.
+
+        ``is_set()`` returns False ("TTS still playing") so the production
+        code takes the wait path wherever it reaches one, and ``wait()``
+        records the recorder's ``start_calls`` at that moment and returns
+        False — i.e. the 60s timeout expiring, without the test paying it.
+        """
+
+        def __init__(self, recorder):
+            self._recorder = recorder
+            self.waits = []
+
+        def is_set(self):
+            return False
+
+        def wait(self, timeout=None):
+            self.waits.append(self._recorder.start_calls)
+            return False
+
+    def test_non_restart_cycle_finalizes_without_waiting_on_tts(
+        self, fake_recorder, monkeypatch
+    ):
+        """auto_restart=False must not block on the re-arm's TTS wait.
+
+        The wait guards re-arming the mic against speaker feedback. This
+        branch never re-arms, so waiting on it cannot prevent feedback — it
+        only withholds "idle" and holds the loop "active" for up to 60s
+        while the mic is already stopped.
+        """
+        import hermes_cli.voice as voice
+
+        monkeypatch.setattr(
+            voice,
+            "transcribe_recording",
+            lambda _p: {"success": True, "transcript": "hello world"},
+        )
+        monkeypatch.setattr(voice, "is_whisper_hallucination", lambda _t: False)
+
+        playing = self._RecordingTTSEvent(fake_recorder)
+        monkeypatch.setattr(voice, "_tts_playing", playing)
+
+        statuses = []
+        transcripts = []
+
+        voice.start_continuous(
+            on_transcript=lambda t: transcripts.append(t),
+            on_status=lambda s: statuses.append(s),
+            auto_restart=False,
+        )
+
+        fake_recorder.last_callback()
+
+        # The transcript is delivered before the wait either way, so the
+        # stall bought nothing.
+        assert transcripts == ["hello world"]
+        assert playing.waits == []
+        assert statuses[-1] == "idle"
+        assert voice.is_continuous_active() is False
+        assert fake_recorder.start_calls == 1  # never re-armed
+
+    def test_restart_path_still_waits_for_tts_before_rearming(
+        self, fake_recorder, monkeypatch
+    ):
+        """The auto-restart branch must keep waiting out in-flight TTS.
+
+        Guards against "fixing" the stall by deleting the wait outright,
+        which would reopen the mic into live speaker output and feed the
+        agent's own reply back in.
+        """
+        import hermes_cli.voice as voice
+
+        monkeypatch.setattr(
+            voice,
+            "transcribe_recording",
+            lambda _p: {"success": True, "transcript": "hello world"},
+        )
+        monkeypatch.setattr(voice, "is_whisper_hallucination", lambda _t: False)
+
+        playing = self._RecordingTTSEvent(fake_recorder)
+        monkeypatch.setattr(voice, "_tts_playing", playing)
+
+        voice.start_continuous(
+            on_transcript=lambda _t: None,
+            auto_restart=True,
+        )
+
+        fake_recorder.last_callback()
+
+        assert fake_recorder.start_calls == 2  # re-armed
+        # Waited exactly once, and did so while only the initial start had
+        # happened — i.e. before the mic was reopened, not after.
+        assert playing.waits == [1]
+
+        voice.stop_continuous()
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Stops the continuous-voice loop from blocking up to **60.3 seconds** at the end of every capture cycle in the one configuration production actually uses.

`_continuous_on_silence` (`hermes_cli/voice.py`) waited for in-flight TTS to finish *before* it tested `_continuous_auto_restart`, so the wait ran on both branches. The block's own comment says why it exists:

> wait for any in-flight TTS to finish **before re-arming the mic** … Without this the voice loop becomes a feedback loop — the agent's spoken reply lands back in the mic and gets re-submitted.

But the `auto_restart=False` branch re-arms nothing. It only sets `_continuous_active = False` and reports `"idle"` (`voice.py:869-878`, comment: *"Do not auto-restart. Clean up state and notify idle."*). There is no mic to protect on that path, so the wait could not prevent any feedback — it only stalled.

**That branch is the production path, not a theoretical one.** The sole non-test caller of `start_continuous` is `tui_gateway/server.py:14085`, and it passes `auto_restart=False` (`server.py:14091`). And `start_continuous`'s own docstring already states the contract this violated:

> If `auto_restart` is False, the first silence-triggered transcription ends the loop and reports `"idle"`.

The transcript is delivered at `voice.py:791-795`, *before* the wait, so the stall bought nothing.

### User-visible symptom

TUI/desktop voice mode with TTS enabled, on default config — user talks over the assistant's reply, so TTS is still playing when the silence callback fires:

- the mic indicator sticks on **"transcribing" for up to a minute**, because `on_status("idle")` is withheld for the whole wait;
- `_continuous_active` stays `True` throughout, so pressing record again hits `start_continuous`'s already-active no-op (`voice.py:464-466`) and the server answers `{"status": "recording"}` (`server.py:14085-14097`) — **while the recorder was already stopped at `voice.py:713` and no audio is being captured**;
- escaping via stop makes it worse: `stop_continuous(force_transcribe=True)` re-stops an already-stopped recorder, gets `wav_path=None`, and reports a spurious **"no speech detected"** (`voice.py:617-641`).

Reachability grew when the 4000-char speak cap was removed (`73997c41bb4`): replies now routinely play for over 60 s, so the timeout ceiling is hit rather than the playback-finished path.

**Blast radius:** every TUI and desktop user of continuous / push-to-talk voice with TTS on — the single production caller — on default config. No OS, container, config hand-edit, or unusual prior state required.

### The fix

Move the wait *inside* the `if _continuous_auto_restart:` branch, above `rec.start(...)`, so it still guards the only thing it protects — reopening the mic into live speaker output — and the non-restart branch finalizes immediately. No new state, no new imports, no behaviour change on the re-arm path: it keeps the identical guard, including the `_continuous_active` re-check after the wait.

Second-order check: after the move, the `else` branch clears `_continuous_active` while TTS may still be playing. Nothing on that path touches the recorder, so no mic is ever opened into a live speaker and the feedback-loop invariant is untouched. `speak_text`'s own re-arm (`voice.py:1049-1061`) already re-checks `_continuous_active` under `_continuous_lock`, so TTS finishing after the cycle finalized correctly declines to reopen the mic.

### Scope — one defective site, not one of several

Sweeping every `_tts_playing` wait and every blocking TTS gate in the tree:

| site | verdict |
|---|---|
| `hermes_cli/voice.py:834-838` | **the defect** — fixed here |
| `cli.py:17869-17871` (`self._voice_tts_done.wait(timeout=60)`) | **already correct, excluded** — nested inside its auto-restart block and immediately followed by `self._voice_start_recording()`. This is the well-formed original that `voice.py` cites for "CLI parity"; the gateway copy hoisted the wait above the branch. |
| `voice.py:334`, `:955`, `:1043`; `cli.py:12790/12963/14442/16538` | `.is_set()` predicates, not blocking waits — no stall possible |

`_tts_playing.wait(...)` occurs exactly once in the tree. This fix is complete rather than a subset.

The block's stale source reference (`cli.py:10619-10621`) is corrected to the current `cli.py:17869-17871` as part of the lines being moved.

## Related Issue

No filed issue — found by inspection of the continuous-voice lifecycle. Not linking a number rather than guessing one.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/voice.py` — move the in-flight-TTS wait from above the `_continuous_auto_restart` test to inside the auto-restart branch, above `rec.start(...)`; correct the stale `cli.py` line reference in the moved comment and record why the wait is scoped to that branch.
- `tests/hermes_cli/test_voice_wrapper.py` — two regression tests in `TestContinuousLoopSimulation`, using the existing `fake_recorder` fixture.

## How to Test

1. **Red before / green after** on the non-restart path:
   ```
   pytest tests/hermes_cli/test_voice_wrapper.py::TestContinuousLoopSimulation -q
   ```
   With `hermes_cli/voice.py` reverted to `main` and the new tests in place, `test_non_restart_cycle_finalizes_without_waiting_on_tts` fails with `assert [1] == []` — the recorded `wait()` call proving the non-restart path blocks on TTS. With the fix applied, `24 passed`.

2. **The opposite direction is pinned too.** `test_restart_path_still_waits_for_tts_before_rearming` fails if the wait is simply deleted instead of scoped: with `auto_restart=True` the loop must wait exactly once, and the recorder's `start_calls` captured at that moment proves the wait happened *before* the mic reopened, not after.

3. **Manually:** start voice mode with TTS enabled, speak over a long spoken reply. Before: the indicator sits on "transcribing" for up to a minute and the record button is a no-op. After: the cycle reports "idle" as soon as the transcript is delivered.

Suites run locally (macOS 15, Python 3.11): `tests/hermes_cli/test_voice_wrapper.py` **24 passed**; `tests/tools/test_voice_cli_integration.py` passed. In `tests/tools/test_voice_mode.py`, 4 failures (`TestPulseSocketReachable`, `TestWSL2PowerShellFallback`) reproduce identically on clean `origin/main@9829746dfe3` — they are Linux/WSL2-only paths failing on macOS, pre-existing and unrelated to this diff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused and adjacent voice suites instead (listed above); not claiming a full-suite run I didn't do
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(no doc change needed; the existing docstring already described the intended behaviour this restores)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(no config keys)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(pure control-flow move, no platform-specific code)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

Text searches across open PRs for `_continuous_on_silence`, `_continuous_auto_restart`, `_tts_playing`, and `auto_restart` each return zero results, so no open PR addresses this gate. The open PRs that do touch `hermes_cli/voice.py` were each checked hunk-by-hunk and are disjoint from the `829-878` region changed here: #53589 (from line 881), #40025, #64086, #78234, #61337, #74257 / #74184 (line 183), #42916 / #49884 (lines 245-248), #80398 (lines 932-998).
