### PR TITLE
fix(agent): stop skipping main provider in vision auto fallback (#50426)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7116,10 +7116,14 @@ def resolve_vision_provider_client(
                         main_provider, rpc_client, rpc_model or vision_model)
 
         # Fall back through aggregators (uses their dedicated vision model,
-        # not the user's main model) when main provider has no client.
+        # not the user's main model) when main provider has no client. Note we
+        # deliberately do NOT skip ``candidate == main_provider`` here: the
+        # aggregators in ``_VISION_AUTO_PROVIDER_ORDER`` carry their own
+        # dedicated vision default that may differ from the user's (text-only)
+        # chat model, and this loop only runs when the main-provider branch
+        # above failed to build a client. A native/direct main provider never
+        # appears in this order, so nothing valid is re-tried (#50426).
         for candidate in _VISION_AUTO_PROVIDER_ORDER:
-            if candidate == main_provider:
-                continue  # already tried above
             sync_client, default_model = _resolve_strict_vision_backend(candidate)
             if sync_client is not None:
                 return _finalize(candidate, sync_client, default_model)

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -215,6 +215,83 @@ model:
         assert _main_model_supports_vision("nonexistent-provider", "nonexistent-model") is True
 
 
+class TestOpenRouterTextOnlyMainFallsBackToItsVisionDefault:
+    """#50426: a text-only main model on an aggregator (OpenRouter) must still
+    resolve a vision backend via that aggregator's dedicated vision default.
+
+    Pre-fix, the fallback loop's ``if candidate == main_provider: continue``
+    guard skipped OpenRouter precisely because it is the main provider — even
+    though the main-provider branch never built a client (the chat model is
+    text-only). That left only the unconfigured aggregators, so ``provider=auto``
+    resolved to *no* backend and every image failed with ``No LLM provider
+    configured for task=vision provider=auto``.
+    """
+
+    def test_openrouter_text_only_main_resolves_via_openrouter_vision_default(
+        self, isolated_home, monkeypatch
+    ):
+        from unittest.mock import MagicMock, patch
+
+        from agent import auxiliary_client as ac
+
+        _write_config(isolated_home, """
+model:
+  provider: openrouter
+  default: deepseek/deepseek-v4-flash
+""")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        _fresh_modules()
+
+        mock_client = MagicMock()
+
+        def fake_strict_backend(provider, model=None):
+            if provider == "openrouter":
+                return mock_client, ac._OPENROUTER_MODEL
+            return None, None
+
+        with (
+            patch.object(ac, "_main_model_supports_vision", return_value=False),
+            patch.object(
+                ac, "_resolve_strict_vision_backend", side_effect=fake_strict_backend
+            ),
+        ):
+            provider, client, model = ac.resolve_vision_provider_client(provider="auto")
+
+        assert provider == "openrouter", (
+            "OpenRouter (the main provider, text-only chat model) must resolve "
+            "through its own dedicated vision default, not be skipped"
+        )
+        assert client is mock_client
+        assert model == ac._OPENROUTER_MODEL
+
+    def test_native_text_only_main_still_returns_no_client_without_aggregator(
+        self, isolated_home, monkeypatch
+    ):
+        """Removing the guard must NOT cause a native (non-aggregator) main
+        provider to be returned to the fallback loop as a vision backend."""
+        from unittest.mock import patch
+
+        from agent import auxiliary_client as ac
+
+        _write_config(isolated_home, """
+model:
+  provider: deepseek
+  default: deepseek-v4-pro
+""")
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+        _fresh_modules()
+
+        with (
+            patch.object(ac, "_main_model_supports_vision", return_value=False),
+            patch.object(ac, "_resolve_strict_vision_backend", return_value=(None, None)),
+        ):
+            provider, client, _model = ac.resolve_vision_provider_client(provider="auto")
+
+        # deepseek is not in _VISION_AUTO_PROVIDER_ORDER, so removing the guard
+        # must not change behaviour — still no backend when no aggregator works.
+        assert client is None
+
+
 # ---------------------------------------------------------------------------
 # Fix 3: check_vision_requirements + check_browser_vision_requirements parity
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes #50426. In `resolve_vision_provider_client(provider="auto")`, the fallback loop's `if candidate == main_provider: continue` guard skipped the **aggregator** that is the user's main provider — even when that provider carries its own dedicated vision default.

## Why it's a double-skip

The vision auto-detect chain has two stages:

1. **Main-provider branch** — build a client for `main_provider` + the user's chat model. Skipped (correctly) when `_main_model_supports_vision()` is `False` for a text-only model (e.g. `deepseek-v4-flash` on OpenRouter).
2. **Aggregator fallback loop** — try each of `_VISION_AUTO_PROVIDER_ORDER` (`openrouter`, `nous`, `deepinfra`) via `_resolve_strict_vision_backend()`, which uses that aggregator's **dedicated vision default**, not the user's chat model.

The guard `if candidate == main_provider: continue` assumed the main provider was "already tried" — but in the double-skip case it was only tried with the user's **text-only chat model** and skipped, never tried as a vision backend. So OpenRouter (the only aggregator that would work) was excluded, `nous`/`deepinfra` had no auth, and `provider=auto` resolved to `(None, None, None)` → `RuntimeError: No LLM provider configured for task=vision provider=auto`.

## The fix

Remove the guard. This is safe because:
- Only `openrouter`/`nous`/`deepinfra` appear in `_VISION_AUTO_PROVIDER_ORDER` — a native/direct main provider never appears in it, so nothing valid is re-tried.
- The loop only runs when the main-provider branch **already failed** to build a client, so re-trying the aggregator with its own vision default is exactly right.

## Verification

- New regression test: text-only OpenRouter main model + `provider=auto` resolves via `_resolve_strict_vision_backend("openrouter")` and returns the openrouter vision default.
- New guard test: native text-only main provider with no aggregator credentials **still** returns no client (behavior unchanged).
- `tests/agent/test_auxiliary_client.py`: 180 passed.
- Vision/auxiliary suite: 24 pass with my change vs 22 on clean HEAD — the same 3 pre-existing env-dependent failures on both (missing Anthropic/Nous credentials in the local env), no new failures.
