### PR TITLE
feat(acp): expose delegated task telemetry

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import acp
@@ -1303,6 +1305,62 @@ def _is_structured_json_result(result: Optional[str]) -> bool:
     return isinstance(_json_loads_maybe(result), (dict, list))
 
 
+_DELEGATION_ID_PATTERN = re.compile(r"^deleg_[0-9a-f]{8}$")
+_MAX_DELEGATION_TELEMETRY_TASKS = 100
+
+
+def _delegate_task_completion_meta(result: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Extract bounded machine data without depending on polished display text."""
+    parsed = _json_loads_maybe(result)
+    if not isinstance(parsed, dict) or parsed.get("status") != "dispatched":
+        return None
+
+    delegation_id = parsed.get("delegation_id")
+    task_count = parsed.get("count")
+    transcripts = parsed.get("live_transcripts")
+    if (
+        not isinstance(delegation_id, str)
+        or not _DELEGATION_ID_PATTERN.fullmatch(delegation_id)
+        or not isinstance(task_count, int)
+        or isinstance(task_count, bool)
+        or not 1 <= task_count <= _MAX_DELEGATION_TELEMETRY_TASKS
+        or not isinstance(transcripts, list)
+        or len(transcripts) != task_count
+    ):
+        return None
+
+    validated: List[str] = []
+    expected_directory: Optional[Path] = None
+    for index, raw_path in enumerate(transcripts):
+        if not isinstance(raw_path, str) or not raw_path or len(raw_path) > 4096:
+            return None
+        transcript = Path(raw_path)
+        if not transcript.is_absolute():
+            return None
+        directory = transcript.parent
+        if directory.name != delegation_id:
+            return None
+        if expected_directory is None:
+            expected_directory = directory
+        elif directory != expected_directory:
+            return None
+        if transcript != directory / f"task-{index}.log":
+            return None
+        validated.append(raw_path)
+
+    return {
+        "hermes": {
+            "delegateTask": {
+                "schemaVersion": 1,
+                "status": "dispatched",
+                "delegationId": delegation_id,
+                "taskCount": task_count,
+                "liveTranscripts": validated,
+            }
+        }
+    }
+
+
 def build_tool_complete(
     tool_call_id: str,
     tool_name: str,
@@ -1322,13 +1380,16 @@ def build_tool_complete(
             function_args=function_args,
             snapshot=snapshot,
         )
-    return acp.update_tool_call(
+    progress = acp.update_tool_call(
         tool_call_id,
         kind=kind,
         status="failed" if _tool_result_failed(result, tool_name) else "completed",
         content=content,
         raw_output=None if tool_name in _POLISHED_TOOLS or _is_structured_json_result(result) else result,
     )
+    if tool_name == "delegate_task" and progress.status == "completed":
+        progress.field_meta = _delegate_task_completion_meta(result)
+    return progress
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -195,6 +195,76 @@ class TestBuildToolComplete:
         assert "total 42" in content_item.content.text
         assert result.raw_output is None
 
+    def test_delegate_completion_has_compact_machine_metadata_when_display_is_truncated(self):
+        paths = [
+            f"/tmp/.hermes/cache/delegation/live/deleg_abcdef12/task-{index}.log"
+            for index in range(3)
+        ]
+        payload = {
+            "status": "dispatched",
+            "mode": "background",
+            "count": 3,
+            "delegation_id": "deleg_abcdef12",
+            "goals": ["x" * 2_000, "y" * 2_000, "z" * 2_000],
+            "live_transcripts": paths,
+        }
+
+        result = build_tool_complete(
+            "tc-delegate",
+            "delegate_task",
+            __import__("json").dumps(payload),
+        )
+
+        assert result.field_meta == {
+            "hermes": {
+                "delegateTask": {
+                    "schemaVersion": 1,
+                    "status": "dispatched",
+                    "delegationId": "deleg_abcdef12",
+                    "taskCount": 3,
+                    "liveTranscripts": paths,
+                }
+            }
+        }
+        assert "truncated" in result.content[0].content.text
+
+    def test_delegate_completion_omits_machine_metadata_for_inconsistent_paths(self):
+        result = build_tool_complete(
+            "tc-delegate",
+            "delegate_task",
+            '{"status":"dispatched","count":1,"delegation_id":"deleg_abcdef12",'
+            '"live_transcripts":["/tmp/other/task-0.log"]}',
+        )
+
+        assert result.field_meta is None
+
+    def test_delegate_completion_metadata_supports_configured_batch_boundary(self):
+        paths = [
+            f"/tmp/.hermes/cache/delegation/live/deleg_abcdef12/task-{index}.log"
+            for index in range(100)
+        ]
+        payload = {
+            "status": "dispatched",
+            "count": len(paths),
+            "delegation_id": "deleg_abcdef12",
+            "live_transcripts": paths,
+        }
+
+        result = build_tool_complete(
+            "tc-delegate-boundary", "delegate_task", __import__("json").dumps(payload)
+        )
+
+        assert result.field_meta["hermes"]["delegateTask"]["taskCount"] == 100
+
+        payload["count"] = 101
+        payload["live_transcripts"] = paths + [
+            "/tmp/.hermes/cache/delegation/live/deleg_abcdef12/task-100.log"
+        ]
+        rejected = build_tool_complete(
+            "tc-delegate-over-boundary", "delegate_task", __import__("json").dumps(payload)
+        )
+        assert rejected.field_meta is None
+
 
 
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -15,6 +15,7 @@ import threading
 import time
 import types
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -1314,7 +1315,7 @@ class TestDelegateEventEnum(unittest.TestCase):
 
 
 class TestConcurrencyDefaults(unittest.TestCase):
-    """Tests for the concurrency default and no hard ceiling."""
+    """Tests for the concurrency default and telemetry-aligned safety ceiling."""
 
     def test_load_config_prefers_active_persistent_config_over_cli_defaults(self):
         stale_cli = types.ModuleType("cli")
@@ -1348,6 +1349,108 @@ class TestConcurrencyDefaults(unittest.TestCase):
     def test_zero_clamped_to_one(self, mock_cfg):
         """Floor of 1 is enforced; zero or negative values raise to 1."""
         self.assertEqual(_get_max_concurrent_children(), 1)
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"max_concurrent_children": 101})
+    def test_value_above_telemetry_boundary_is_clamped(self, mock_cfg):
+        self.assertEqual(_get_max_concurrent_children(), 100)
+
+
+def test_single_child_keyboard_interrupt_finalizes_live_state(monkeypatch):
+    from tools import delegate_tool as delegate
+    from tools.delegation_live_log import create_live_transcripts
+
+    delegation_id, writers, paths = create_live_transcripts(
+        [{"goal": "interrupt safely"}], delegation_id="deleg_abcdef12"
+    )
+    assert delegation_id == "deleg_abcdef12"
+    child = MagicMock()
+
+    def interrupt(*args, **kwargs):
+        raise KeyboardInterrupt("operator stopped child")
+
+    monkeypatch.setattr(delegate, "_run_single_child", interrupt)
+    with unittest.TestCase().assertRaises(KeyboardInterrupt):
+        delegate._run_single_child_with_abrupt_finalization(
+            task_index=0,
+            goal="interrupt safely",
+            child=child,
+            parent_agent=MagicMock(),
+            delegation_id=delegation_id,
+            writer=writers[0],
+        )
+
+    manifest = json.loads(
+        (Path(paths[0]).parent / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["tasks"][0]["status"] == "interrupted"
+    assert "completed" in manifest
+    assert "interrupted" in Path(paths[0]).read_text(encoding="utf-8").lower()
+
+
+def test_batch_keyboard_interrupt_finalizes_every_live_task(monkeypatch):
+    from tools import delegate_tool as delegate
+    from tools.delegation_live_log import live_transcript_root
+
+    delegation_id = "deleg_deadbeef"
+    parent = _make_mock_parent(depth=0)
+    sibling_started = threading.Event()
+    release_sibling = threading.Event()
+
+    def interrupt(*args, **kwargs):
+        task_index = args[0] if args else kwargs["task_index"]
+        if task_index == 0:
+            sibling_started.set()
+            release_sibling.wait(timeout=5)
+            return {
+                "task_index": task_index,
+                "status": "completed",
+                "summary": "finished too late",
+                "api_calls": 0,
+                "duration_seconds": 0,
+            }
+        assert sibling_started.wait(timeout=1)
+        raise KeyboardInterrupt(f"child {task_index} stopped")
+
+    monkeypatch.setattr(delegate, "_run_single_child", interrupt)
+    monkeypatch.setattr(
+        "tools.delegation_live_log.new_live_delegation_id",
+        lambda: delegation_id,
+    )
+    monkeypatch.setattr(
+        "gateway.session_context.async_delivery_supported",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation._current_origin_session_id",
+        lambda: "",
+    )
+
+    try:
+        with unittest.TestCase().assertRaises(KeyboardInterrupt):
+            delegate_task(
+                tasks=[
+                    {"goal": "investigate the first delegated task"},
+                    {"goal": "investigate the second delegated task"},
+                ],
+                parent_agent=parent,
+                background=False,
+            )
+    finally:
+        release_sibling.set()
+
+    delegation_dir = live_transcript_root() / delegation_id
+    manifest = json.loads(
+        (delegation_dir / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert [task["status"] for task in manifest["tasks"]] == [
+        "interrupted",
+        "interrupted",
+    ]
+    assert "completed" in manifest
+    for index in range(2):
+        text = (delegation_dir / f"task-{index}.log").read_text(encoding="utf-8")
+        assert "end status=interrupted" in text
 
 class TestAsyncCapUnified(unittest.TestCase):
     """max_async_children is deprecated: the async cap IS max_concurrent_children."""

--- a/tests/tools/test_delegation_live_log.py
+++ b/tests/tools/test_delegation_live_log.py
@@ -24,6 +24,7 @@ from tools.delegation_live_log import (
     create_live_transcripts,
     live_transcript_root,
     prune_stale_live_dirs,
+    update_manifest_task_status,
     update_manifest_statuses,
     wrap_progress_callback,
 )
@@ -253,6 +254,44 @@ def test_manifest_goal_is_redacted():
 
     assert _BEARER not in goal
     assert "deploy using" in goal, "redaction must not blank the goal entirely"
+
+
+def test_maximum_task_and_unicode_goal_manifest_fits_consumer_envelope():
+    delegation_id, _writers, _paths = create_live_transcripts(
+        [{"goal": "🧪" * 500} for _ in range(100)],
+        delegation_id="deleg_feedface",
+    )
+
+    assert delegation_id == "deleg_feedface"
+    manifest_path = live_transcript_root() / delegation_id / "manifest.json"
+    size = manifest_path.stat().st_size
+    assert size > 64 * 1024, "regression must exceed the superseded consumer limit"
+    assert size <= 1024 * 1024, "producer envelope must fit the bounded consumer read"
+
+
+def test_manifest_task_status_updates_as_each_sibling_finishes():
+    delegation_id, _writers, _paths = create_live_transcripts(
+        [{"goal": "fast"}, {"goal": "slow"}]
+    )
+    manifest_path = live_transcript_root() / delegation_id / "manifest.json"
+
+    update_manifest_task_status(
+        delegation_id,
+        {"task_index": 0, "status": "completed", "exit_reason": "completed"},
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert [task["status"] for task in manifest["tasks"]] == ["completed", "running"]
+    assert "completed" not in manifest
+
+    update_manifest_task_status(
+        delegation_id,
+        {"task_index": 1, "status": "error", "exit_reason": "provider_error"},
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert [task["status"] for task in manifest["tasks"]] == ["completed", "error"]
+    assert manifest["completed"]
 
 
 def test_no_file_in_the_dispatch_directory_carries_the_raw_key():

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -588,7 +588,8 @@ def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
 
-    Users can raise this as high as they want; only the floor (1) is enforced.
+    Values are bounded to 100 so execution and delegated-worker telemetry share
+    one explicit resource ceiling rather than silently dropping valid batches.
 
     Uses the same ``_load_config()`` path that the rest of ``delegate_task``
     uses, keeping config priority consistent (config.yaml > env > default).
@@ -597,7 +598,14 @@ def _get_max_concurrent_children() -> int:
     val = cfg.get("max_concurrent_children")
     if val is not None:
         try:
-            result = max(1, int(val))
+            requested = max(1, int(val))
+            result = min(requested, 100)
+            if requested > 100:
+                logger.warning(
+                    "delegation.max_concurrent_children=%d exceeds the supported "
+                    "maximum 100; clamping to 100.",
+                    requested,
+                )
             if result > 10:
                 global _HIGH_CONCURRENCY_WARNED
                 if not _HIGH_CONCURRENCY_WARNED:
@@ -619,7 +627,14 @@ def _get_max_concurrent_children() -> int:
     env_val = os.getenv("DELEGATION_MAX_CONCURRENT_CHILDREN")
     if env_val:
         try:
-            return max(1, int(env_val))
+            requested = max(1, int(env_val))
+            if requested > 100:
+                logger.warning(
+                    "DELEGATION_MAX_CONCURRENT_CHILDREN=%d exceeds the supported "
+                    "maximum 100; clamping to 100.",
+                    requested,
+                )
+            return min(requested, 100)
         except (TypeError, ValueError):
             return _DEFAULT_MAX_CONCURRENT_CHILDREN
     return _DEFAULT_MAX_CONCURRENT_CHILDREN
@@ -2898,6 +2913,54 @@ def _run_single_child(
             logger.debug("Failed to close child Relay session after delegation")
 
 
+def _run_single_child_with_abrupt_finalization(
+    *,
+    task_index: int,
+    goal: str,
+    child,
+    parent_agent,
+    delegation_id: Optional[str],
+    writer,
+    **kwargs,
+):
+    """Run one child and durably terminate telemetry before re-raising BaseException.
+
+    Normal returns stay on the shared aggregation/finalization path. Abrupt
+    process-level exits cannot reach that path, so they are recorded here.
+    """
+    try:
+        return _run_single_child(
+            task_index,
+            goal,
+            child,
+            parent_agent,
+            **kwargs,
+        )
+    except BaseException as exc:
+        status = "interrupted" if isinstance(exc, (KeyboardInterrupt, SystemExit)) else "error"
+        entry = {
+            "task_index": task_index,
+            "status": status,
+            "summary": None,
+            "error": str(exc) or type(exc).__name__,
+            "api_calls": 0,
+            "duration_seconds": 0,
+            "_child_role": getattr(child, "_delegate_role", None),
+        }
+        if writer is not None:
+            try:
+                writer.finalize(entry)
+            except BaseException:
+                logger.debug("Abrupt live transcript finalize failed", exc_info=True)
+        try:
+            from tools.delegation_live_log import update_manifest_task_status
+
+            update_manifest_task_status(delegation_id, entry)
+        except BaseException:
+            logger.debug("Abrupt live manifest finalize failed", exc_info=True)
+        raise
+
+
 _PARENT_FINALIZATION_LOCK_GUARD = threading.Lock()
 _PARENT_FINALIZATION_FALLBACK_LOCK = threading.RLock()
 _CHILD_CONSTRUCTION_LOCK = threading.RLock()
@@ -3296,6 +3359,7 @@ def delegate_task(
     from tools.delegation_live_log import (
         create_live_transcripts,
         update_manifest_statuses,
+        update_manifest_task_status,
         wrap_progress_callback,
     )
 
@@ -3393,19 +3457,23 @@ def delegate_task(
         results block. That is the contract: fan-out runs in the background,
         waits on each other, and returns together.
         """
+        abrupt_batch_exception: Optional[BaseException] = None
         if n_tasks == 1:
             # Single task -- run directly (no thread pool overhead)
             _i, _t, child = children[0]
-            result = _run_single_child(
-                _i,
-                _t["goal"],
-                child,
-                parent_agent,
+            result = _run_single_child_with_abrupt_finalization(
+                task_index=_i,
+                goal=_t["goal"],
+                child=child,
+                parent_agent=parent_agent,
+                delegation_id=live_deleg_id,
+                writer=live_writers[_i] if _i < len(live_writers) else None,
                 owner_session_id=_origin_ui_session_id or None,
                 owner_transport=_origin_owner_transport,
                 owner_session_record=_origin_owner_session_record,
             )
             results.append(result)
+            update_manifest_task_status(live_deleg_id, result)
         else:
             # Batch -- run in parallel with per-task progress lines
             completed_count = 0
@@ -3415,17 +3483,21 @@ def delegate_task(
             # normally, but if the parent is interrupted while a child is
             # wedged, the abandoned worker must not block interpreter exit.
             from tools.daemon_pool import DaemonThreadPoolExecutor
-            with DaemonThreadPoolExecutor(max_workers=max_children) as executor:
+            executor = DaemonThreadPoolExecutor(max_workers=max_children)
+            abandon_pending = False
+            try:
                 futures = {}
                 for i, t, child in children:
                     child_context = contextvars.copy_context()
                     future = executor.submit(
                         child_context.run,
-                        _run_single_child,
+                        _run_single_child_with_abrupt_finalization,
                         task_index=i,
                         goal=t["goal"],
                         child=child,
                         parent_agent=parent_agent,
+                        delegation_id=live_deleg_id,
+                        writer=live_writers[i] if i < len(live_writers) else None,
                         owner_session_id=_origin_ui_session_id or None,
                         owner_transport=_origin_owner_transport,
                         owner_session_record=_origin_owner_session_record,
@@ -3455,10 +3527,12 @@ def delegate_task(
                             if f.done():
                                 try:
                                     entry = f.result()
-                                except Exception as exc:
+                                except BaseException as exc:
                                     entry = {
                                         "task_index": idx,
-                                        "status": "error",
+                                        "status": "interrupted" if isinstance(
+                                            exc, (KeyboardInterrupt, SystemExit)
+                                        ) else "error",
                                         "summary": None,
                                         "error": str(exc),
                                         "api_calls": 0,
@@ -3480,7 +3554,9 @@ def delegate_task(
                                     ),
                                 }
                             results.append(entry)
+                            update_manifest_task_status(live_deleg_id, entry)
                             completed_count += 1
+                        abandon_pending = True
                         break
 
                     from concurrent.futures import wait as _cf_wait, FIRST_COMPLETED
@@ -3491,20 +3567,25 @@ def delegate_task(
                     for future in done:
                         try:
                             entry = future.result()
-                        except Exception as exc:
+                        except BaseException as exc:
                             idx = futures[future]
                             entry = {
                                 "task_index": idx,
-                                "status": "error",
+                                "status": "interrupted" if isinstance(
+                                    exc, (KeyboardInterrupt, SystemExit)
+                                ) else "error",
                                 "summary": None,
-                                "error": str(exc),
+                                "error": str(exc) or type(exc).__name__,
                                 "api_calls": 0,
                                 "duration_seconds": 0,
                                 "_child_role": getattr(
                                     _child_by_index.get(idx), "_delegate_role", None
                                 ),
                             }
+                            if abrupt_batch_exception is None:
+                                abrupt_batch_exception = exc
                         results.append(entry)
+                        update_manifest_task_status(live_deleg_id, entry)
                         completed_count += 1
 
                         # Print per-task completion line above the spinner
@@ -3533,6 +3614,36 @@ def delegate_task(
                                 )
                             except Exception as e:
                                 logger.debug("Spinner update_text failed: %s", e)
+
+                    if abrupt_batch_exception is not None:
+                        # One worker crossed a process-level boundary. Do not
+                        # leave siblings visible as running while that exception
+                        # propagates; cancel queued work and durably mark every
+                        # still-running sibling as interrupted.
+                        for future in pending:
+                            idx = futures[future]
+                            future.cancel()
+                            entry = {
+                                "task_index": idx,
+                                "status": "interrupted",
+                                "summary": None,
+                                "error": "Sibling exited abruptly — delegated task abandoned",
+                                "api_calls": 0,
+                                "duration_seconds": 0,
+                                "_child_role": getattr(
+                                    _child_by_index.get(idx), "_delegate_role", None
+                                ),
+                            }
+                            results.append(entry)
+                            update_manifest_task_status(live_deleg_id, entry)
+                        pending.clear()
+                        abandon_pending = True
+                        break
+            finally:
+                executor.shutdown(
+                    wait=not abandon_pending,
+                    cancel_futures=abandon_pending,
+                )
 
             # Sort by task_index so results match input order
             results.sort(key=lambda r: r["task_index"])
@@ -3571,6 +3682,8 @@ def delegate_task(
         }
         if live_paths:
             combined["live_transcripts"] = list(live_paths)
+        if abrupt_batch_exception is not None:
+            raise abrupt_batch_exception
         return combined
 
     # ----- Background dispatch: run the WHOLE batch as one async unit -----

--- a/tools/delegation_live_log.py
+++ b/tools/delegation_live_log.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+_MANIFEST_LOCK = threading.Lock()
 
 # Live transcript directories older than this are pruned on new dispatches.
 LIVE_RETENTION_DAYS = 7
@@ -350,6 +351,20 @@ def _manifest_path(delegation_id: str) -> Path:
     return live_transcript_root() / delegation_id / "manifest.json"
 
 
+def _write_manifest_atomic(path: Path, manifest: Dict[str, Any]) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        temporary.replace(path)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
 def _write_manifest(delegation_id: str, task_list: List[Dict[str, Any]],
                     paths: List[str]) -> None:
     try:
@@ -372,11 +387,35 @@ def _write_manifest(delegation_id: str, task_list: List[Dict[str, Any]],
                 for i, t in enumerate(task_list)
             ],
         }
-        _manifest_path(delegation_id).write_text(
-            json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
+        _write_manifest_atomic(_manifest_path(delegation_id), manifest)
     except Exception as exc:
         logger.debug("Live transcript manifest write failed: %s", exc)
+
+
+def update_manifest_task_status(
+    delegation_id: Optional[str], result: Dict[str, Any]
+) -> None:
+    """Best-effort atomic update as one delegated task reaches a terminal state."""
+    if not delegation_id or not isinstance(result, dict):
+        return
+    try:
+        with _MANIFEST_LOCK:
+            mp = _manifest_path(delegation_id)
+            manifest = json.loads(mp.read_text(encoding="utf-8"))
+            task_index = result.get("task_index")
+            for task in manifest.get("tasks", []):
+                if task.get("index") != task_index:
+                    continue
+                task["status"] = result.get("status", task.get("status"))
+                if result.get("exit_reason"):
+                    task["exit_reason"] = result["exit_reason"]
+                break
+            tasks = manifest.get("tasks", [])
+            if tasks and all(task.get("status") != "running" for task in tasks):
+                manifest["completed"] = time.strftime("%Y-%m-%d %H:%M:%S")
+            _write_manifest_atomic(mp, manifest)
+    except Exception as exc:
+        logger.debug("Live transcript task status update failed: %s", exc)
 
 
 def update_manifest_statuses(delegation_id: Optional[str],
@@ -385,18 +424,18 @@ def update_manifest_statuses(delegation_id: Optional[str],
     if not delegation_id:
         return
     try:
-        mp = _manifest_path(delegation_id)
-        manifest = json.loads(mp.read_text(encoding="utf-8"))
-        by_index = {r.get("task_index"): r for r in results if isinstance(r, dict)}
-        for task in manifest.get("tasks", []):
-            r = by_index.get(task.get("index"))
-            if r is not None:
-                task["status"] = r.get("status", task.get("status"))
-                if r.get("exit_reason"):
-                    task["exit_reason"] = r["exit_reason"]
-        manifest["completed"] = time.strftime("%Y-%m-%d %H:%M:%S")
-        mp.write_text(json.dumps(manifest, indent=2, ensure_ascii=False),
-                      encoding="utf-8")
+        with _MANIFEST_LOCK:
+            mp = _manifest_path(delegation_id)
+            manifest = json.loads(mp.read_text(encoding="utf-8"))
+            by_index = {r.get("task_index"): r for r in results if isinstance(r, dict)}
+            for task in manifest.get("tasks", []):
+                r = by_index.get(task.get("index"))
+                if r is not None:
+                    task["status"] = r.get("status", task.get("status"))
+                    if r.get("exit_reason"):
+                        task["exit_reason"] = r["exit_reason"]
+            manifest["completed"] = time.strftime("%Y-%m-%d %H:%M:%S")
+            _write_manifest_atomic(mp, manifest)
     except Exception as exc:
         logger.debug("Live transcript manifest update failed: %s", exc)
 


### PR DESCRIPTION
## Summary

Publish a bounded, machine-readable `delegate_task` telemetry contract for ACP clients while preserving existing human-readable tool output.

- exposes compact dispatch registration metadata with delegation ID, bounded task count, and live transcript paths;
- persists per-task terminal state atomically so clients can remove completed worker activity deterministically;
- preserves telemetry through foreground presentation cancellation;
- finalises single and multi-child abrupt exits, including abandoned siblings, before propagating process-level exceptions;
- retains current and legacy live-transcript layouts;
- bounds configured concurrency at the explicit 100-task telemetry ceiling.

This is the producer half of the companion Hermes VS Code delegated-worker activity change.

## Verification

Exact candidate: `f7c550047eeea61b7aac0c9f97dee1232cdf3414`

- focused ACP/delegation/live-log suite: 109 passed
- expanded delegation/lifecycle selection: 237 passed
- Ruff: passed
- `git diff --check`: passed
- maximum 100-task, 500-Unicode-character manifest exceeds the old 64 KiB limit and remains within the consumer's bounded 1 MiB envelope
- deterministic multi-child `KeyboardInterrupt` regression proves every task terminal and the batch manifest completed before re-raise

## Compatibility and safety

- Human-readable output remains available for older clients.
- Telemetry writes remain best-effort and atomic.
- Paths and task counts are bounded; the consumer independently enforces home/profile/session/generation containment.
- No shared profile, credential, or transcript content is included in this PR.
