### PR TITLE
fix(execute-code): correct helper import contract

### DIFF
--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -281,7 +281,7 @@ TIPS = [
     "The terminal tool annotates common exit codes: grep returning 1 = 'No matches found (not an error)'.",
     "Failed foreground terminal commands auto-retry up to 3 times with exponential backoff (2s, 4s, 8s).",
     "Bare sudo commands are auto-rewritten to pipe SUDO_PASSWORD from .env — no interactive prompt needed.",
-    "execute_code has built-in helpers: json_parse() for tolerant parsing, shell_quote(), and retry() with backoff.",
+    "execute_code helpers require explicit imports, e.g. from hermes_tools import json_parse, shell_quote, retry.",
     "execute_code's 7 sandbox tools (web_search, terminal, read/write/search/patch) use RPC — never enter context.",
     "Reading the same file region 3+ times triggers a warning. At 4+, it's hard-blocked to prevent loops.",
     "write_file and patch detect if a file was externally modified since the last read and warn about staleness.",

--- a/tests/hermes_cli/test_tips.py
+++ b/tests/hermes_cli/test_tips.py
@@ -14,6 +14,12 @@ class TestTipsCorpus:
         for i, tip in enumerate(TIPS):
             assert isinstance(tip, str), f"Tip {i} is not a string: {type(tip)}"
 
+    def test_execute_code_helpers_require_explicit_imports(self):
+        helper_tips = [tip for tip in TIPS if "json_parse" in tip]
+
+        assert helper_tips, "Expected an execute_code helper tip in the corpus"
+        assert all("from hermes_tools import" in tip for tip in helper_tips)
+
 
 class TestGetRandomTip:
     """Validate the get_random_tip() function."""

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -136,6 +136,9 @@ print(json.dumps({
                 module_path = os.path.join(tmpdir, "hermes_tools.py")
                 with open(module_path, "w", encoding="utf-8") as handle:
                     handle.write(generate_hermes_tools_module([], transport=transport))
+                # The generated module lives in cwd, which intentionally makes
+                # it the first import candidate for `python -c`, matching the
+                # real sandbox's per-run temp-directory staging contract.
                 completed = subprocess.run(
                     [sys.executable, "-c", probe],
                     cwd=tmpdir,

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -221,6 +221,29 @@ class TestExecuteCode(unittest.TestCase):
         self.assertIn("hello world", result["output"])
         self.assertEqual(result["tool_calls_made"], 0)
 
+    def test_convenience_helpers_are_importable(self):
+        """Helpers advertised by the schema must import and execute as shown."""
+        code = """
+from __future__ import annotations
+import json
+from hermes_tools import json_parse, retry, shell_quote
+
+print(json.dumps({
+    "parsed": json_parse('{"value": 7}')["value"],
+    "quoted": shell_quote("two words"),
+    "retried": retry(lambda: "ok"),
+}, sort_keys=True))
+"""
+        result = self._run(code)
+        self.assertEqual(result["status"], "success")
+        payload = json.loads(result["output"])
+        self.assertEqual(payload, {
+            "parsed": 7,
+            "quoted": "'two words'",
+            "retried": "ok",
+        })
+        self.assertEqual(result["tool_calls_made"], 0)
+
     def test_no_tool_call_script_does_not_wait_for_rpc_accept_timeout(self):
         """A no-tool script should not wait seconds for the idle RPC accept thread."""
         start = time.monotonic()
@@ -457,6 +480,12 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
         self.assertIn("parameters", schema)
         self.assertIn("code", schema["parameters"]["properties"])
         self.assertEqual(schema["parameters"]["required"], ["code"])
+
+    def test_schema_requires_import_for_convenience_helpers(self):
+        desc = build_execute_code_schema()["description"]
+        self.assertIn("Convenience helpers are not preloaded globals", desc)
+        self.assertIn("from hermes_tools import json_parse, shell_quote, retry", desc)
+        self.assertNotIn("Built-in helpers (no import)", desc)
 
     def test_subset_only_lists_enabled_tools(self):
         enabled = {"terminal", "read_file"}

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -18,6 +18,8 @@ import pytest
 import json
 import os
 import socket
+import subprocess
+import tempfile
 import time
 
 os.environ["TERMINAL_ENV"] = "local"
@@ -114,6 +116,40 @@ class TestHermesToolsGeneration(unittest.TestCase):
         src = generate_hermes_tools_module(["terminal"], transport="file")
         self.assertIn("_seq_lock = threading.Lock()", src)
         self.assertIn("with _seq_lock:", src)
+
+    def test_convenience_helpers_import_and_execute_for_each_transport(self):
+        """Both generated transports must expose working helper imports."""
+        probe = """
+import json
+from hermes_tools import json_parse, retry, shell_quote
+print(json.dumps({
+    "parsed": json_parse('{"value": 7}')["value"],
+    "quoted": shell_quote("two words"),
+    "retried": retry(lambda: "ok"),
+}, sort_keys=True))
+"""
+        for transport in ("uds", "file"):
+            with (
+                self.subTest(transport=transport),
+                tempfile.TemporaryDirectory() as tmpdir,
+            ):
+                module_path = os.path.join(tmpdir, "hermes_tools.py")
+                with open(module_path, "w", encoding="utf-8") as handle:
+                    handle.write(generate_hermes_tools_module([], transport=transport))
+                completed = subprocess.run(
+                    [sys.executable, "-c", probe],
+                    cwd=tmpdir,
+                    env=os.environ.copy(),
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+                self.assertEqual(json.loads(completed.stdout), {
+                    "parsed": 7,
+                    "quoted": "'two words'",
+                    "retried": "ok",
+                })
 
 
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):

--- a/tests/tools/test_sandbox_failure_hints.py
+++ b/tests/tools/test_sandbox_failure_hints.py
@@ -16,12 +16,13 @@ class TestSandboxFailureHint:
         assert "read_file" in h and "terminal" in h
         assert "normal tool call" in h
 
-    def test_helper_import_failure_reports_runtime_schema_skew(self):
+    def test_helper_import_failure_reports_actionable_module_skew(self):
         err = "ImportError: cannot import name 'json_parse' from 'hermes_tools'"
         h = _sandbox_failure_hint(err)
         assert h is not None
-        assert "expected to be exported by hermes_tools" in h
-        assert "out of sync" in h
+        assert "from hermes_tools import json_parse" in h
+        assert "stale" in h
+        assert "sys.path" in h
 
     @pytest.mark.parametrize("helper", ["json_parse", "shell_quote", "retry"])
     def test_helper_name_error_recommends_explicit_import(self, helper):

--- a/tests/tools/test_sandbox_failure_hints.py
+++ b/tests/tools/test_sandbox_failure_hints.py
@@ -16,11 +16,19 @@ class TestSandboxFailureHint:
         assert "read_file" in h and "terminal" in h
         assert "normal tool call" in h
 
-    def test_builtin_helper_import_redirects(self):
+    def test_helper_import_failure_reports_runtime_schema_skew(self):
         err = "ImportError: cannot import name 'json_parse' from 'hermes_tools'"
         h = _sandbox_failure_hint(err)
-        assert "BUILT-IN" in h
-        assert "no import" in h.lower()
+        assert h is not None
+        assert "expected to be exported by hermes_tools" in h
+        assert "out of sync" in h
+
+    @pytest.mark.parametrize("helper", ["json_parse", "shell_quote", "retry"])
+    def test_helper_name_error_recommends_explicit_import(self, helper):
+        h = _sandbox_failure_hint(f"NameError: name '{helper}' is not defined")
+        assert h is not None
+        assert f"from hermes_tools import {helper}" in h
+        assert "without importing" not in h
 
     def test_missing_third_party_module(self):
         err = "ModuleNotFoundError: No module named 'matplotlib'"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -397,9 +397,11 @@ def _sandbox_failure_hint(stderr_text: str, enabled_tools=None) -> Optional[str]
             helpers = {"json_parse", "shell_quote", "retry"}
             if missing in helpers:
                 return (
-                    f"{missing} is expected to be exported by hermes_tools, but "
-                    "this sandbox did not expose it. The execute_code runtime and "
-                    "schema may be out of sync; retry in a fresh session."
+                    f"{missing} should be imported from the generated hermes_tools.py, "
+                    "but this module did not export it. Verify the import uses "
+                    f"`from hermes_tools import {missing}`; if it does, the generated "
+                    "module may be stale or a different hermes_tools may be first on "
+                    "sys.path. Retry in a fresh session and report it if the mismatch persists."
                 )
             return (
                 f"'{missing}' is not available inside the execute_code sandbox. "

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -394,11 +394,12 @@ def _sandbox_failure_hint(stderr_text: str, enabled_tools=None) -> Optional[str]
         if m:
             missing = m.group(1)
             available = sorted(SANDBOX_ALLOWED_TOOLS & set(enabled_tools or SANDBOX_ALLOWED_TOOLS))
-            builtin = {"json_parse", "shell_quote", "retry"}
-            if missing in builtin:
+            helpers = {"json_parse", "shell_quote", "retry"}
+            if missing in helpers:
                 return (
-                    f"{missing} is a BUILT-IN helper in the sandbox — no import "
-                    f"needed. Remove it from the import line and call {missing}(...) directly."
+                    f"{missing} is expected to be exported by hermes_tools, but "
+                    "this sandbox did not expose it. The execute_code runtime and "
+                    "schema may be out of sync; retry in a fresh session."
                 )
             return (
                 f"'{missing}' is not available inside the execute_code sandbox. "
@@ -407,9 +408,10 @@ def _sandbox_failure_hint(stderr_text: str, enabled_tools=None) -> Optional[str]
             )
         m = re.search(r"NameError: name '(json_parse|shell_quote|retry)' is not defined", window)
         if m:
+            helper = m.group(1)
             return (
-                f"{m.group(1)} is built into the generated sandbox module — "
-                "call it directly at module scope without importing it."
+                f"Import {helper} from hermes_tools before calling it: "
+                f"from hermes_tools import {helper}"
             )
         m = re.search(r"ModuleNotFoundError: No module named '([\w.]+)'", window)
         if m:
@@ -2030,9 +2032,12 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         f"{cwd_note}\n\n"
         "Print your final result to stdout; stdlib (json, re, csv, datetime, ...) "
         "is available for processing.\n\n"
-        "Built-in helpers (no import): json_parse(text) — tolerant json.loads for "
-        "terminal() output; shell_quote(s) — shlex.quote for dynamic shell args; "
-        "retry(fn, max_attempts=3, delay=2) — exponential backoff for transient failures."
+        "Convenience helpers are not preloaded globals. Import them explicitly: "
+        "`from hermes_tools import json_parse, shell_quote, retry`. "
+        "json_parse(text) — tolerant json.loads for terminal() output; "
+        "shell_quote(s) — shlex.quote "
+        "for dynamic shell args; retry(fn, max_attempts=3, delay=2) — exponential "
+        "backoff for transient failures."
     )
 
     return {

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -379,10 +379,10 @@ def _sandbox_failure_hint(stderr_text: str, enabled_tools=None) -> Optional[str]
 
     Production mining (state.db): the top execute_code failure classes are
     hermes_tools import misuse (importing tools that aren't in the sandbox,
-    23x in one window), calling the built-in helpers via import, treating
-    tool results as strings instead of dicts, and importing third-party
-    packages that don't exist in the sandbox interpreter. Bounded scan,
-    first match wins, never raises.
+    23x in one window), calling convenience helpers without importing them,
+    treating tool results as strings instead of dicts, and importing
+    third-party packages that don't exist in the sandbox interpreter.
+    Bounded scan, first match wins, never raises.
     """
     if not stderr_text:
         return None


### PR DESCRIPTION
## Summary

- stop advertising `json_parse`, `shell_quote`, and `retry` as preloaded globals
- point helper `NameError` recovery hints to the working `hermes_tools` import
- distinguish a true helper import failure as runtime/schema skew
- add execution, schema, hint, and cross-transport generated-module regression coverage

## Root cause

The generated helpers are functions in the sibling `hermes_tools.py` module. The execute_code schema and recovery hint instead told models to call them directly without importing them, which deterministically raises `NameError`. Explicit imports from `hermes_tools` already work on both generated transports, so correcting the contract is smaller and safer than injecting names into Python `builtins`.

## Reproduction

```python
print(shell_quote("two words"))
```

Before: `NameError: name 'shell_quote' is not defined`, followed by a misleading hint to call it directly without importing it.

Working contract:

```python
from hermes_tools import shell_quote
print(shell_quote("two words"))
```

## Tests

```text
scripts/run_tests.sh tests/tools/test_code_execution.py tests/tools/test_code_execution_modes.py tests/tools/test_sandbox_failure_hints.py -v
74 passed, 0 failed
```

The committed transport smoke test generates both UDS and file-based `hermes_tools.py` modules, starts a fresh child interpreter for each, and imports and executes `json_parse`, `shell_quote`, and `retry`. A script beginning with a `from __future__` import is also covered.