### PR TITLE
feat(buzz): thread_require_mention for threads the agent is part of

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -344,6 +344,39 @@ def _parse_json_list(stdout: str) -> List[dict]:
     return [item for item in data if isinstance(item, dict)]
 
 
+def _event_thread_root(event: dict) -> str:
+    """Return the id of the thread an event replies into ("" when top-level).
+
+    Buzz delivers thread structure as NIP-10 ``e`` tags, which the relay
+    already puts on every reply:
+
+        [["h", <channel>], ["e", <root>, "", "root"], ["e", <parent>, "", "reply"]]
+
+    A ``root`` marker names the thread directly. Deprecated positional tags
+    (no marker) list the root first. A lone ``reply`` marker means the event
+    answers the root itself, so that id IS the root.
+    """
+    tags = event.get("tags")
+    if not isinstance(tags, list):
+        return ""
+    positional = ""
+    reply = ""
+    for tag in tags:
+        if not isinstance(tag, (list, tuple)) or len(tag) < 2 or tag[0] != "e":
+            continue
+        target = str(tag[1] or "")
+        if not target:
+            continue
+        marker = str(tag[3] or "") if len(tag) > 3 else ""
+        if marker == "root":
+            return target
+        if marker == "reply":
+            reply = reply or target
+        elif not marker:
+            positional = positional or target
+    return positional or reply
+
+
 # ---------------------------------------------------------------------------
 # Buzz Adapter
 # ---------------------------------------------------------------------------
@@ -391,6 +424,23 @@ class BuzzAdapter(BasePlatformAdapter):
         else:
             _rm_cfg = _rm_raw
         self.require_mention = str(_rm_cfg).strip().lower() not in ("false", "0", "no", "off")
+
+        # Whether the mention requirement also applies inside a thread this
+        # agent already takes part in. Defaults to True — identical behavior
+        # to before this setting existed. Set False to keep talking in an
+        # ongoing thread without re-addressing the agent every turn, while
+        # the channel top level stays mention-gated. Mirrors the Discord
+        # adapter's thread_require_mention. Only meaningful while
+        # require_mention is True. Env (BUZZ_THREAD_REQUIRE_MENTION)
+        # overrides config.yaml.
+        _trm_raw = os.getenv("BUZZ_THREAD_REQUIRE_MENTION")
+        if _trm_raw is None:
+            _trm_cfg = extra.get("thread_require_mention", True)
+        else:
+            _trm_cfg = _trm_raw
+        self.thread_require_mention = str(_trm_cfg).strip().lower() not in (
+            "false", "0", "no", "off"
+        )
 
         # Inbound transport: "auto" (WebSocket with poll fallback, default),
         # "websocket" (require WS; fail connect when it can't authenticate),
@@ -628,6 +678,7 @@ class BuzzAdapter(BasePlatformAdapter):
             # Belt-and-braces echo suppression: the poll loop already skips
             # our own pubkey, but marking the id seen makes de-dupe explicit.
             self._mark_seen(str(chat_id), str(event_id))
+            self._note_sent_message(chat_id, str(event_id), str(reply_target or ""))
         return SendResult(
             success=bool(data.get("accepted", True)),
             message_id=str(event_id) if event_id else None,
@@ -693,6 +744,7 @@ class BuzzAdapter(BasePlatformAdapter):
             event_id = data.get("event_id")
             if event_id:
                 self._mark_seen(str(chat_id), str(event_id))
+                self._note_sent_message(chat_id, str(event_id), str(reply_to or ""))
             return SendResult(
                 success=bool(data.get("accepted", True)),
                 message_id=str(event_id) if event_id else None,
@@ -943,6 +995,9 @@ class BuzzAdapter(BasePlatformAdapter):
             # leaked in via ``channels list`` latches to chat_type="dm" here,
             # so it bypasses the mention gate from the very first poll.
             self._maybe_latch_dm(channel_id, state, event)
+            # History also rebuilds thread participation, so a restart does
+            # not silently re-gate threads the agent was already talking in.
+            self._track_thread(state, event)
         self._trim_seen(state)
 
     async def _discover_dms(self, *, seed: bool) -> None:
@@ -1021,6 +1076,11 @@ class BuzzAdapter(BasePlatformAdapter):
         if not pubkey or not isinstance(content, str) or not content.strip():
             return
 
+        # Track thread membership before self-echo suppression: our own
+        # echoed messages are how thread participation is re-learned after a
+        # restart, and they never reach the code below.
+        self._track_thread(state, event)
+
         # Suppress self-echo: never dispatch our own messages back to the agent.
         if pubkey == self._self_pubkey:
             return
@@ -1032,8 +1092,19 @@ class BuzzAdapter(BasePlatformAdapter):
         is_dm = state["chat_type"] == "dm"
         # In shared channels, respond only when addressed — unless
         # require_mention is disabled, in which case respond to every message.
-        # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
+        # DMs always dispatch. Inside a thread the agent already takes part
+        # in, thread_require_mention=False waives the mention requirement,
+        # mirroring the Discord adapter's in_bot_thread bypass; the channel
+        # top level stays gated.
+        in_agent_thread = not self.thread_require_mention and self._in_agent_thread(
+            state, event
+        )
+        if (
+            not is_dm
+            and self.require_mention
+            and not in_agent_thread
+            and not self._is_mentioned(content)
+        ):
             return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
@@ -1210,6 +1281,73 @@ class BuzzAdapter(BasePlatformAdapter):
             state["seen"][event_id] = None
             self._trim_seen(state)
 
+    # ── Thread participation (thread_require_mention) ─────────────────────
+    #
+    # Two bounded per-channel maps, both keyed by event id: ``thread_roots``
+    # resolves any event to the root of its thread, ``agent_threads`` holds
+    # the roots this agent has spoken in. Both are rebuilt from the history
+    # ``_seed_channel`` replays, so participation survives a restart.
+
+    @staticmethod
+    def _remember_root(state: dict, event_id: str, root: str) -> None:
+        roots = state.setdefault("thread_roots", OrderedDict())
+        roots[str(event_id)] = str(root)
+        roots.move_to_end(str(event_id))
+        while len(roots) > _SEEN_CAP:
+            roots.popitem(last=False)
+
+    @staticmethod
+    def _join_thread(state: dict, root: str) -> None:
+        """Record that this agent takes part in the thread rooted at ``root``."""
+        if not root:
+            return
+        threads = state.setdefault("agent_threads", OrderedDict())
+        threads[str(root)] = None
+        threads.move_to_end(str(root))
+        while len(threads) > _SEEN_CAP:
+            threads.popitem(last=False)
+
+    @staticmethod
+    def _thread_root_of(state: dict, event_id: str) -> str:
+        """Resolve an event id to its thread root (itself when unknown)."""
+        return str(state.get("thread_roots", {}).get(str(event_id), event_id))
+
+    def _track_thread(self, state: dict, event: dict) -> None:
+        """Note which thread an inbound chat event belongs to.
+
+        Called for every chat event on both transports, including our own
+        echoes — those are what re-establish participation after a restart.
+        """
+        if int(event.get("kind") or 0) != _CHAT_KIND:
+            return
+        event_id = str(event.get("id") or "")
+        if not event_id:
+            return
+        root = _event_thread_root(event) or event_id
+        self._remember_root(state, event_id, root)
+        if str(event.get("pubkey") or "").lower() == self._self_pubkey:
+            self._join_thread(state, root)
+
+    def _note_sent_message(self, chat_id: str, event_id: str, reply_target: str) -> None:
+        """Join the thread an outgoing message lands in.
+
+        A reply joins the thread of whatever it answers; a fresh top-level
+        message becomes the root of the thread that replies to it will open.
+        """
+        state = self._channel_state.get(str(chat_id))
+        if state is None:
+            return
+        root = self._thread_root_of(state, reply_target) if reply_target else str(event_id)
+        self._remember_root(state, event_id, root)
+        self._join_thread(state, root)
+
+    def _in_agent_thread(self, state: dict, event: dict) -> bool:
+        """True when the event replies into a thread this agent takes part in."""
+        target = _event_thread_root(event)
+        if not target:
+            return False
+        return self._thread_root_of(state, target) in state.get("agent_threads", {})
+
     async def _dispatch_message(
         self,
         text: str,
@@ -1316,6 +1454,10 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
         os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
     if "require_mention" in extra and not os.getenv("BUZZ_REQUIRE_MENTION"):
         os.environ["BUZZ_REQUIRE_MENTION"] = str(extra["require_mention"]).lower()
+    if "thread_require_mention" in extra and not os.getenv("BUZZ_THREAD_REQUIRE_MENTION"):
+        os.environ["BUZZ_THREAD_REQUIRE_MENTION"] = str(
+            extra["thread_require_mention"]
+        ).lower()
     return None
 
 

--- a/plugins/platforms/buzz/plugin.yaml
+++ b/plugins/platforms/buzz/plugin.yaml
@@ -45,6 +45,10 @@ optional_env:
     description: "Allow any community member to talk to the agent (true/false)"
     prompt: "Allow all users? (true/false)"
     password: false
+  - name: BUZZ_THREAD_REQUIRE_MENTION
+    description: "Whether replies inside a thread the agent takes part in still need an @mention (true/false, default true)"
+    prompt: "Require mentions inside the agent's own threads? (true/false)"
+    password: false
   - name: BUZZ_POLL_INTERVAL
     description: "Seconds between inbound poll sweeps (default: 4)"
     prompt: "Poll interval seconds"

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import os
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -42,6 +43,8 @@ _ENV_VARS = (
     "BUZZ_HOME_CHANNEL",
     "BUZZ_ALLOWED_USERS",
     "BUZZ_ALLOW_ALL_USERS",
+    "BUZZ_REQUIRE_MENTION",
+    "BUZZ_THREAD_REQUIRE_MENTION",
     "BUZZ_POLL_INTERVAL",
     "BUZZ_CLI_PATH",
     "BUZZ_CREDENTIALS_FILE",
@@ -538,3 +541,227 @@ class TestStandaloneSend:
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
 
+
+
+# ── Thread-scoped mention gating (thread_require_mention) ────────────────
+#
+# A thread the agent takes part in is rooted at a message it wrote or
+# replied to. With thread_require_mention=False those threads stop needing
+# an address on every turn, while the channel top level stays gated.
+
+
+def _thread_event(event_id, *, content, root=None, parent=None,
+                  pubkey=OTHER_PUBKEY, created_at=1000):
+    """Chat event with NIP-10 markers exactly as the relay delivers them."""
+    tags = [["h", CHANNEL]]
+    if root:
+        tags.append(["e", root, "", "root"])
+    if parent:
+        tags.append(["e", parent, "", "reply"])
+    return {
+        "id": event_id,
+        "pubkey": pubkey,
+        "content": content,
+        "created_at": created_at,
+        "kind": 9,
+        "tags": tags,
+    }
+
+
+class TestEventThreadRoot:
+    """The tag reading that everything below rests on."""
+
+    def test_root_marker_wins_over_reply_marker(self):
+        event = _thread_event("e1", content="x", root="rootid", parent="parentid")
+        assert _buzz_mod._event_thread_root(event) == "rootid"
+
+    def test_lone_reply_marker_is_the_root(self):
+        """A reply to the thread's first message names only that message."""
+        event = _thread_event("e1", content="x", parent="rootid")
+        assert _buzz_mod._event_thread_root(event) == "rootid"
+
+    def test_deprecated_positional_tags_list_root_first(self):
+        event = {"id": "e1", "pubkey": OTHER_PUBKEY, "content": "x", "kind": 9,
+                 "created_at": 1, "tags": [["h", CHANNEL], ["e", "rootid"], ["e", "parentid"]]}
+        assert _buzz_mod._event_thread_root(event) == "rootid"
+
+    def test_top_level_message_has_no_thread(self):
+        assert _buzz_mod._event_thread_root(_thread_event("e1", content="x")) == ""
+
+    def test_malformed_tags_are_ignored(self):
+        for tags in (None, "nope", [["e"], ["e", ""], "junk", 42]):
+            assert _buzz_mod._event_thread_root({"tags": tags}) == ""
+
+
+class TestThreadRequireMentionConfig:
+
+    def test_defaults_to_true(self):
+        assert _make_adapter().thread_require_mention is True
+
+    def test_config_extra_disables_it(self):
+        assert _make_adapter({"thread_require_mention": False}).thread_require_mention is False
+
+    def test_env_overrides_config(self, monkeypatch):
+        monkeypatch.setenv("BUZZ_THREAD_REQUIRE_MENTION", "false")
+        assert _make_adapter({"thread_require_mention": True}).thread_require_mention is False
+
+    def test_yaml_config_bridges_to_env(self, monkeypatch):
+        # Empty, not unset: the bridge treats it as unowned (falsy) and still
+        # writes, while monkeypatch owns the var and unsets it afterwards —
+        # _apply_yaml_config writes straight to os.environ.
+        monkeypatch.setenv("BUZZ_THREAD_REQUIRE_MENTION", "")
+        _buzz_mod._apply_yaml_config({}, {"extra": {"thread_require_mention": False}})
+        assert os.environ["BUZZ_THREAD_REQUIRE_MENTION"] == "false"
+
+    def test_yaml_config_does_not_override_explicit_env(self, monkeypatch):
+        monkeypatch.setenv("BUZZ_THREAD_REQUIRE_MENTION", "false")
+        _buzz_mod._apply_yaml_config({}, {"extra": {"thread_require_mention": True}})
+        assert os.environ["BUZZ_THREAD_REQUIRE_MENTION"] == "false"
+
+
+class TestThreadMentionGating:
+
+    def _adapter(self, extra=None):
+        a = _make_adapter(extra)
+        a._dispatched = []
+
+        async def capture(**kwargs):
+            a._dispatched.append(kwargs)
+
+        a._dispatch_message = capture
+        a._message_handler = AsyncMock()
+        a._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        return a
+
+    async def _poll_with(self, adapter, *events):
+        cli = _ScriptedCli()
+        cli.script("messages", "get", list(events))
+        adapter._run_cli = cli
+        await adapter._poll_channel(CHANNEL)
+
+    async def _agent_sends(self, adapter, event_id, *, reply_to=None):
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": event_id, "message": ""})
+        adapter._run_cli = cli
+        result = await adapter.send(CHANNEL, "on it", reply_to=reply_to)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_stays_gated_by_default(self):
+        """Default true: nothing changes for anyone who does not opt in."""
+        adapter = self._adapter()
+        await self._agent_sends(adapter, "agent1")
+        await self._poll_with(
+            adapter, _thread_event("r1", content="and one more thing", root="agent1"),
+        )
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_reply_to_the_agents_own_message_dispatches(self):
+        """The core case: someone replies to what the agent posted."""
+        adapter = self._adapter({"thread_require_mention": False})
+        await self._agent_sends(adapter, "agent1")
+        await self._poll_with(
+            adapter, _thread_event("r1", content="and one more thing", root="agent1"),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["r1"]
+
+    @pytest.mark.asyncio
+    async def test_agents_reply_joins_a_humans_thread(self):
+        """The agent answering inside someone else's thread joins it, so the
+        follow-up needs no further address."""
+        adapter = self._adapter({"thread_require_mention": False})
+        await self._poll_with(
+            adapter, _thread_event("h1", content="@Chip take a look", created_at=10),
+        )
+        await self._agent_sends(adapter, "agent1", reply_to="h1")
+        await self._poll_with(
+            adapter,
+            _thread_event("h2", content="thanks, and what about the rest?",
+                          root="h1", parent="agent1", created_at=20),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["h1", "h2"]
+
+    @pytest.mark.asyncio
+    async def test_channel_top_level_stays_gated(self):
+        """Waiving mentions in threads must not open the channel itself."""
+        adapter = self._adapter({"thread_require_mention": False})
+        await self._agent_sends(adapter, "agent1")
+        await self._poll_with(adapter, _thread_event("t1", content="unrelated chatter"))
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_foreign_thread_stays_gated(self):
+        """Two humans talking in their own thread are not the agent's cue."""
+        adapter = self._adapter({"thread_require_mention": False})
+        await self._poll_with(
+            adapter, _thread_event("r1", content="what do you think?", root="their-root"),
+        )
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_allowlist_still_applies_inside_the_thread(self):
+        """Waiving the mention changes HOW to phrase a message, never WHO
+        may send one."""
+        adapter = self._adapter({"thread_require_mention": False})
+        adapter._allowed_pubkeys = {"b" * 64}
+        await self._agent_sends(adapter, "agent1")
+        await self._poll_with(
+            adapter, _thread_event("r1", content="do the thing", root="agent1"),
+        )
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_dispatch_still_strips_a_leading_mention(self):
+        adapter = self._adapter({"thread_require_mention": False})
+        await self._agent_sends(adapter, "agent1")
+        await self._poll_with(
+            adapter, _thread_event("r1", content="@Chip /whoami", root="agent1"),
+        )
+        assert [d["text"] for d in adapter._dispatched] == ["/whoami"]
+
+    @pytest.mark.asyncio
+    async def test_free_listening_install_is_unaffected(self):
+        """require_mention=false dispatches everything, threaded or not —
+        this setting only ever relaxes the gate, never tightens it."""
+        adapter = self._adapter({"require_mention": False})
+        await self._poll_with(
+            adapter,
+            _thread_event("t1", content="starting a thread", created_at=10),
+            _thread_event("r1", content="the follow-up", root="t1", created_at=11),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["t1", "r1"]
+
+    @pytest.mark.asyncio
+    async def test_participation_survives_a_restart(self):
+        """A fresh process re-learns its threads from channel history, so a
+        gateway restart does not silently re-gate an ongoing conversation."""
+        adapter = self._adapter({"thread_require_mention": False})
+        cli = _ScriptedCli()
+        cli.script("messages", "get", [
+            _thread_event("h1", content="@Chip take a look", created_at=10),
+            _thread_event("agent1", content="on it", root="h1",
+                          pubkey=SELF_PUBKEY, created_at=11),
+        ])
+        adapter._run_cli = cli
+        await adapter._seed_channel(CHANNEL, chat_type="group")
+        assert adapter._dispatched == []  # history never dispatches
+
+        await self._poll_with(
+            adapter,
+            _thread_event("h2", content="one more question", root="h1", created_at=20),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["h2"]
+
+    @pytest.mark.asyncio
+    async def test_thread_bookkeeping_is_bounded(self):
+        """Both maps are capped like the seen-id set, so a busy channel
+        cannot grow them without bound."""
+        adapter = self._adapter({"thread_require_mention": False})
+        state = adapter._channel_state[CHANNEL]
+        for i in range(_buzz_mod._SEEN_CAP + 50):
+            adapter._track_thread(
+                state, _thread_event(f"e{i}", content="x", pubkey=SELF_PUBKEY),
+            )
+        assert len(state["thread_roots"]) == _buzz_mod._SEEN_CAP
+        assert len(state["agent_threads"]) == _buzz_mod._SEEN_CAP

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -704,6 +704,7 @@ Connect Hermes to [Photon](https://photon.codes/) / Spectrum (iMessage and other
 | `BUZZ_HOME_CHANNEL` | Channel UUID for cron / notification delivery (defaults to the first watched channel) |
 | `BUZZ_ALLOWED_USERS` | Comma-separated npubs or hex pubkeys allowed to talk to the agent |
 | `BUZZ_ALLOW_ALL_USERS` | Allow any community member to talk to the agent (`true`/`false`) |
+| `BUZZ_THREAD_REQUIRE_MENTION` | `true` (default) / `false` — whether replies inside a thread the agent takes part in still need an `@mention`. Equivalent to `buzz.extra.thread_require_mention` in `config.yaml`. Only meaningful while `require_mention` is on. |
 | `BUZZ_TRANSPORT` | Inbound transport: `auto` (WebSocket w/ poll fallback, default), `websocket`, or `poll` |
 | `BUZZ_POLL_INTERVAL` | Seconds between inbound poll sweeps (default: `4`) |
 | `BUZZ_AUTH_TAG` | Optional NIP-OA owner-attestation auth tag JSON for NIP-42 WebSocket auth |

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -80,6 +80,7 @@ gateway:
         credentials_file: ""              # JSON file with the nsec (BUZZ_PRIVATE_KEY fallback)
         allowed_users: []                 # empty = allow all if allow_all_users is true; otherwise restrict to listed npubs/hex pubkeys
         require_mention: true             # in channels: only respond when addressed (@name, npub, or hex pubkey); DMs always dispatch regardless
+        thread_require_mention: true      # set false to keep answering inside threads the agent is already part of, without re-addressing it
         allow_all_users: false            # set true for community mode (everyone can chat, only owner is admin); false for private mode (only allowed_users)
 ```
 
@@ -90,6 +91,7 @@ gateway:
 - `poll_interval: 4` — balances inbound latency (up to 4s delay) against relay load. Lower values increase polling frequency; higher values reduce it.
 - `allowed_users: []` + `allow_all_users: false` — private mode by default. Only listed users can interact. Set `allow_all_users: true` for community mode where everyone can chat (admin tier still restricted to the owner).
 - `require_mention: true` — in channels, the agent only responds when addressed. DMs always dispatch regardless of this setting.
+- `thread_require_mention: true` — a reply inside a thread the agent is part of still has to address it, exactly as before this setting existed.
 
 **Rationale:** Channels are for final results and conversation, not for the agent's internal tool execution log. Users see the final answer, not the steps taken to get there. This matches the behavior on Telegram and email, which already have these defaults.
 
@@ -99,6 +101,7 @@ gateway:
 
 - In shared channels the agent only responds when **addressed** — by `@name`, its npub, or its hex pubkey. Everything else is ignored.
 - Direct messages always reach the agent, no mention needed.
+- With `thread_require_mention: false` a **thread the agent takes part in** — one rooted at a message it wrote or replied to — no longer needs the address on every turn, while the channel top level stays gated. Participation is rebuilt from channel history on startup, so it survives a gateway restart. The allow-list is unaffected: waiving the mention requirement changes *how* someone has to phrase a message, never *who* may send one.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
 
 ## Access control


### PR DESCRIPTION
## What does this PR do?

Gives the Buzz adapter `thread_require_mention`, so an agent can keep talking
inside a **thread it is already part of** without being re-addressed every turn,
while the **channel top level stays mention-gated**.

Today `require_mention` is a single global switch, and both reachable states are
unsatisfying:

- `require_mention: true` — every follow-up inside an ongoing thread needs
  another `@agent`, which makes a multi-turn exchange tedious.
- `require_mention: false` — the agent answers *every* message in *every*
  watched channel. Workable while it watches exactly one channel; it degrades
  the moment it joins a second (a per-team or per-tenant channel), where it
  then reacts to unrelated human chatter.

The thread is the unit of conversation people actually reason about, so it is
the natural scope for "you may assume this is addressed to you".

**This already exists in this codebase — for Discord.** The Discord adapter
solves exactly this with `thread_require_mention`, gating on whether the message
arrives in a thread the bot tracks:

```python
in_bot_thread = (
    isinstance(message.channel, discord.Thread)
    and str(message.channel.id) in self._threads
    and not self._discord_thread_require_mention()
)
if (self._discord_require_mention() and ... and not in_bot_thread
        and not self._self_is_explicitly_mentioned(message)):
    return False
```

So this is not a new concept — it is an established pattern the Buzz adapter has
not received. The name is kept identical so configuration stays consistent
across platforms.

**And it is cheap on Buzz, because the data is already in the event.** Incoming
chat events carry NIP-10 thread markers:

```json
"tags": [["h", "<channel>"], ["e", "<root>", "", "root"], ["e", "<parent>", "", "reply"]]
```

The adapter already parses `event.get("tags")` — it inspects `p` tags to detect
DMs (`_is_direct_message_event`, `_maybe_latch_dm`). The mention gate simply
never looked at the `e` tags. No relay change, no protocol change, no new CLI
surface.

### Semantics

| `require_mention` | `thread_require_mention` | Channel top level | Inside a thread the agent takes part in |
|---|---|---|---|
| `true`  | `true` *(default)* | mention required | mention required *(today's behavior)* |
| `true`  | `false`            | mention required | **free-listening** |
| `false` | *(any)*            | free-listening   | free-listening *(today's behavior)* |

- **Default `true` — no behavior change for any existing installation**, including
  `require_mention: false` ones. The setting can only ever *relax* the gate,
  never tighten it. There is a regression test pinning exactly that.
- "A thread the agent takes part in" = one rooted at a message it wrote or
  replied to — the Buzz equivalent of Discord's `self._threads`.
- Participation is rebuilt from the history `_seed_channel` already replays, so
  a gateway restart does not silently re-gate an ongoing conversation.
- The `allowed_users` allow-list is untouched and still applies: waiving the
  mention requirement changes *how* someone must phrase a message, never *who*
  may send one.
- DMs are unaffected — they always dispatch.
- `config.yaml` is the primary surface (`buzz.extra.thread_require_mention`);
  `BUZZ_THREAD_REQUIRE_MENTION` follows the adapter's existing env-override
  convention, mirroring `require_mention`.

## Related Issue

No issue — opening the patch directly.

Related PRs, none of which this duplicates:

- **#75049 (`feat(buzz): configure active thread mentions`)** — **overlapping**,
  and it got here first, so it deserves a direct comparison. It introduces the
  same setting name plus a Dashboard surface (14 files, incl. `web/`). Two
  differences drove this smaller alternative:

  1. Its gate reads `if reply_target and self.thread_require_mention: return`
     *before* consulting `require_mention`, so with the new setting at its
     default an existing `require_mention: false` install silently stops
     answering **every** threaded reply. I have that reproduced as a test that
     passes on `main` and fails on that branch; posted as a review comment
     there. This PR's gate keeps `require_mention` the outer condition, so
     `false` still means free-listening everywhere.
  2. It re-reads `config.yaml` on **every inbound event** for hot-reload and
     tracks YAML-vs-operator ownership through `_HERMES_YAML_BRIDGED_*` env
     markers. This PR stays on the adapter's existing config path.

  Happy to close this in favor of #75049 if you prefer its scope — the
  regression above is worth fixing there either way.

- **#80120 (`fix(buzz): preserve stable thread roots`)** — touches the same send
  path (`--reply-to` resolution). No conflict with this change; happy to rebase
  if it lands first.

- **#76164 (`feat(buzz): per-channel mention gating via mention_channels`)** —
  complementary: it scopes the mention requirement per *channel*, this scopes it
  per *thread*. They compose — one picks which rooms are strict, the other says
  "…but not once we are already talking".

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/buzz/adapter.py`
  - `_event_thread_root()` — reads the thread an event replies into from its
    NIP-10 `e` tags (`root` marker, lone `reply` marker, deprecated positional
    form, malformed input).
  - `thread_require_mention` config + `BUZZ_THREAD_REQUIRE_MENTION` env
    override, following the `require_mention` precedence exactly; bridged in
    `_apply_yaml_config()` like its neighbours.
  - Thread participation tracked per channel in two `OrderedDict`s capped at
    `_SEEN_CAP`, the same bound as the seen-id set: event id → thread root, and
    the roots the agent has spoken in. Fed from `send()`/`send_image()` and from
    inbound events *before* self-echo suppression (our own echoes are what
    re-establish participation after a restart), plus `_seed_channel()` history.
  - The gate gains `not in_agent_thread` as one more condition — the same shape
    as Discord's `in_bot_thread`; nothing else about it changes.
- `plugins/platforms/buzz/plugin.yaml` — the new var under `optional_env`.
- `website/docs/user-guide/messaging/buzz.md`,
  `website/docs/reference/environment-variables.md` — config + env docs.
- `tests/gateway/test_buzz_adapter.py` — 20 tests (details below).

## How to Test

```
scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q
```
→ 47 passed (43 in the buzz adapter file: 23 pre-existing + 20 new).

`scripts/run_tests.sh tests/gateway/ -q` → 4871 passed, 3 failed. The three
failures are `test_systemd_notify.py::test_notify_supports_systemd_abstract_socket`
and two in `test_wecom_callback.py`; they fail identically on an unmodified
`upstream/main` checkout here (macOS, no abstract Unix sockets), so they are
pre-existing and unrelated to this change.

`ruff check` on both changed Python files → clean. `ty check` → exit 0 (one
pre-existing advisory on an untouched `type: ignore`).

RED evidence — with `adapter.py` reset to `main` and the new tests unchanged:
13 fail (5 tag-reading, 4 config-precedence, 4 gating), 30 pass. The 7 new tests
that pass on `main` too are deliberate: they are the ones pinning what must
**not** change (top level stays gated, foreign threads stay gated, the
allow-list still blocks, `require_mention: false` still dispatches replies).

New coverage:

- Tag reading: `root` marker wins over `reply`; a lone `reply` marker *is* the
  root; deprecated positional tags list the root first; top-level messages have
  no thread; malformed tags never raise.
- Config: default `true`; `extra` disables; env overrides `extra`; YAML bridges
  to env; explicit env survives a YAML update.
- Gating: replies stay gated by default; a reply to the agent's own message
  dispatches; the agent replying into a human's thread joins it; the channel top
  level stays gated; foreign threads stay gated; the allow-list still blocks
  inside the agent's thread; a leading mention is still stripped;
  `require_mention: false` still dispatches threaded replies; participation
  survives a restart (rebuilt from seeded history); both maps stay bounded.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.12

`tests/gateway/` was run in full; the repository-wide suite was not, so that box
is left unchecked rather than claimed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

`cli-config.yaml.example` has no `buzz` section at all today (no Buzz key is
listed there), so the new key is documented where its neighbours are: the Buzz
user guide and the env-var reference. Pure stdlib, no platform-specific code.
