### PR TITLE
fix(kanban): prevent removed board resurrection

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -562,6 +562,22 @@ def board_exists(board: Optional[str] = None) -> bool:
     return (d / "board.json").exists() or (d / "kanban.db").exists()
 
 
+def _require_existing_named_board(board: Optional[str]) -> None:
+    """Reject stale opens of named boards removed by another process.
+
+    ``connect()`` creates its parent directory for fresh databases. Without
+    this guard, a gateway poll that captured a board slug before ``boards rm``
+    can recreate the removed board as an empty DB. Named boards must be
+    created through :func:`create_board`; only the legacy ``default`` board
+    may be initialized implicitly.
+    """
+    if board is None:
+        return
+    slug = _normalize_board_slug(board)
+    if slug and slug != DEFAULT_BOARD and not board_exists(slug):
+        raise FileNotFoundError(f"board {slug!r} does not exist")
+
+
 def kanban_db_path(board: Optional[str] = None) -> Path:
     """Return the path to the ``kanban.db`` for ``board``.
 
@@ -2172,6 +2188,7 @@ def connect(
     if db_path is not None:
         path = db_path
     else:
+        _require_existing_named_board(board)
         path = kanban_db_path(board=board)
     path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -145,35 +145,22 @@ class TestBoardCRUD:
 
 
     @pytest.mark.parametrize("archive", [True, False])
-    def test_remove_clears_init_cache_for_recreated_db(self, fresh_home, archive):
-        # Regression for #23833: poll loops that call connect(board=slug) right
-        # after remove_board() recreate an empty kanban.db at the same path
-        # (connect() does mkdir(exist_ok=True)). If _INITIALIZED_PATHS still
-        # contains the resolved path, the CREATE TABLE pass is skipped and
-        # downstream readers hit `no such table: task_events`.
+    def test_removed_board_cannot_be_reopened_by_stale_connection(self, fresh_home, archive):
+        """A stale gateway poll must not resurrect a removed named board."""
         kb.create_board("recycle")
-        # First connect populates _INITIALIZED_PATHS for this DB.
         with kb.connect(board="recycle") as conn:
             kb.create_task(conn, title="t1", assignee="dev")
         db_path = kb.board_dir("recycle") / "kanban.db"
         assert str(db_path.resolve()) in kb._INITIALIZED_PATHS
 
         kb.remove_board("recycle", archive=archive)
-        # remove_board must drop the cache entry so a re-create through
-        # connect() gets a fresh schema-init pass.
         assert str(db_path.resolve()) not in kb._INITIALIZED_PATHS
+        assert not kb.board_exists("recycle")
 
-        # Simulate the event-stream poll: re-open the same slug. connect()
-        # recreates the directory + empty .db; the schema must be re-applied.
-        with kb.connect(board="recycle") as conn:
-            tables = {
-                row[0]
-                for row in conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table'"
-                )
-            }
-        assert "task_events" in tables
-        assert "tasks" in tables
+        with pytest.raises(FileNotFoundError, match="board 'recycle' does not exist"):
+            kb.connect(board="recycle")
+
+        assert not db_path.exists()
 
     def test_rename_updates_metadata(self, fresh_home):
         kb.create_board("slug-immutable")


### PR DESCRIPTION
## Summary
- Reject stale connections to removed named boards before SQLite can recreate their directories.
- Replace the prior resurrection regression test with coverage for both archived and hard-deleted boards.

## Test plan
- `uv run --python 3.12 --extra dev python -m pytest tests/hermes_cli/test_kanban_boards.py -q`
- `uv run --python 3.12 --extra dev ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_boards.py`
- `git diff --check`