### PR TITLE
fix(qqbot): handle WSMsgType.CLOSING to stop CPU spin

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -736,7 +736,11 @@ class QQAdapter(BasePlatformAdapter):
                 pass
             elif msg.type == aiohttp.WSMsgType.CLOSE:
                 raise QQCloseError(msg.data, msg.extra)
-            elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
+            elif msg.type in {
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.ERROR,
+                aiohttp.WSMsgType.CLOSING,
+            }:
                 raise RuntimeError("WebSocket closed")
 
     async def _heartbeat_loop(self) -> None:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -5,6 +5,7 @@ import os
 from types import SimpleNamespace
 from unittest import mock
 
+import aiohttp
 import httpx
 import pytest
 
@@ -1209,7 +1210,12 @@ class TestCloseCodeClassification:
 class TestReadEventsClosedWsGuard:
     """Regression: a closed-but-non-None ws must raise on entry, not return
     normally, so _listen_loop goes through reconnect/backoff instead of
-    busy-looping at 100% CPU (issues #31193 / #31771)."""
+    busy-looping at 100% CPU (issues #31193 / #31771).
+
+    Also cover WSMsgType.CLOSING (issue #41872): unclean disconnects can
+    leave the socket half-closed so receive() returns CLOSING immediately
+    while ws.closed is still False — that must raise too, or the loop spins.
+    """
 
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
@@ -1220,5 +1226,16 @@ class TestReadEventsClosedWsGuard:
         adapter._running = True
         adapter._ws = SimpleNamespace(closed=True)
         with pytest.raises(RuntimeError):
+            asyncio.run(adapter._read_events())
+
+    def test_read_events_raises_on_ws_closing_message(self):
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._ws = mock.AsyncMock()
+        adapter._ws.closed = False
+        adapter._ws.receive = mock.AsyncMock(
+            return_value=SimpleNamespace(type=aiohttp.WSMsgType.CLOSING)
+        )
+        with pytest.raises(RuntimeError, match="WebSocket closed"):
             asyncio.run(adapter._read_events())
 


### PR DESCRIPTION
Unclean WebSocket disconnects can make aiohttp return CLOSING while ws.closed is still False. Treat it like CLOSED/ERROR so _read_events raises into the reconnect path instead of tight-looping receive().

## What does this PR do?

When the QQ gateway WebSocket disconnects without a clean CLOSE frame, aiohttp can return `WSMsgType.CLOSING` while `ws.closed` is still `False`. `_read_events()` handled `TEXT` / `PING` / `CLOSE` / `CLOSED` / `ERROR`, but not `CLOSING`, so `receive()` was called in a tight loop and pinned one CPU core at ~100%.

This change treats `CLOSING` as a terminal disconnect (same as `CLOSED` / `ERROR`): raise `RuntimeError("WebSocket closed")` so `_listen_loop` exits into the existing reconnect/backoff path. Same approach as the earlier WeCom fix.

## Related Issue

Fixes #41872

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/qqbot/adapter.py`: add `aiohttp.WSMsgType.CLOSING` to the terminal-state branch in `_read_events()`
- `tests/gateway/test_qqbot.py`: add `test_read_events_raises_on_ws_closing_message` under `TestReadEventsClosedWsGuard`

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_qqbot.py -k ReadEventsClosedWsGuard -q