### PR TITLE
fix(gateway/desktop): durable row-id addressing for rewind truncation (#82959)

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -43,8 +43,8 @@ import {
   planRestore,
   rebindSurvivorRowIds,
   runRewindSubmit,
-  type SurvivorUserRowIds,
   survivorRowIdsFrom,
+  type SurvivorUserRowIds,
   truncateSubmitParams
 } from '../session/hooks/use-prompt-actions/rewind'
 import { useSubmitPrompt } from '../session/hooks/use-prompt-actions/submit'

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -366,13 +366,28 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
   // Rewind primitive (interrupt-first for live turns, busy-retry) — shared with
   // the primary chat so the two can't diverge.
   const submitRewind = useCallback(
-    (text: string, truncateOrdinal: number | undefined, interruptFirst: boolean) =>
-      runRewindSubmit(requestGateway, runtimeIdRef.current, text, truncateOrdinal, interruptFirst, {
-        storedSessionId: storedIdRef.current,
-        onSessionRecovered: recoveredId => {
-          runtimeIdRef.current = recoveredId
-        }
-      }),
+    (
+      text: string,
+      truncateOrdinal: number | undefined,
+      interruptFirst: boolean,
+      truncateMessageId?: string,
+      truncateRowId?: number
+    ) =>
+      runRewindSubmit(
+        requestGateway,
+        runtimeIdRef.current,
+        text,
+        truncateOrdinal,
+        truncateMessageId,
+        interruptFirst,
+        {
+          storedSessionId: storedIdRef.current,
+          onSessionRecovered: recoveredId => {
+            runtimeIdRef.current = recoveredId
+          }
+        },
+        truncateRowId
+      ),
     [requestGateway]
   )
 
@@ -398,7 +413,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
           {
             session_id: runtimeIdRef.current,
             text: plan.text,
-            ...truncateSubmitParams(plan.truncateOrdinal)
+            ...truncateSubmitParams(plan.truncateOrdinal, plan.truncateMessageId, plan.truncateRowId)
           },
           PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
         )
@@ -425,7 +440,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       update(state => applyRewindOptimistic(state, plan.sourceIndex))
 
       try {
-        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy)
+        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy, plan.truncateMessageId, plan.truncateRowId)
       } catch (err) {
         update(state => ({ ...state, busy: false, awaitingResponse: false, messages }))
         throw err
@@ -454,7 +469,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       update(state => applyRewindOptimistic(state, plan.sourceIndex, plan.editedMessage))
 
       try {
-        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy)
+        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy, plan.truncateMessageId, plan.truncateRowId)
       } catch (err) {
         update(state => ({ ...state, busy: false, awaitingResponse: false, messages }))
         notifyError(err, copy.editFailed)

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -41,7 +41,10 @@ import {
   planEdit,
   planReload,
   planRestore,
+  rebindSurvivorRowIds,
   runRewindSubmit,
+  type SurvivorUserRowIds,
+  survivorRowIdsFrom,
   truncateSubmitParams
 } from '../session/hooks/use-prompt-actions/rewind'
 import { useSubmitPrompt } from '../session/hooks/use-prompt-actions/submit'
@@ -391,6 +394,22 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     [requestGateway]
   )
 
+  // After a durable rewind the surviving bubbles' cached rowIds are stale (the
+  // gateway re-inserted the kept prefix as new SQLite rows). Rebind them to the
+  // authoritative post-rewrite ids so the NEXT rewind/edit/regenerate doesn't
+  // send a dead id and get refused with 4018 (consecutive-rewind staleness,
+  // #83202 review).
+  const applySurvivorRowIds = useCallback(
+    (survivorRowIds: SurvivorUserRowIds | undefined) => {
+      if (!survivorRowIds) {
+        return
+      }
+
+      update(state => ({ ...state, messages: rebindSurvivorRowIds(state.messages, survivorRowIds) }))
+    },
+    [update]
+  )
+
   const reloadFromMessage = useCallback(
     async (parentId: string | null) => {
       const state = readState()
@@ -408,7 +427,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       update(current => applyReloadOptimistic(current, plan))
 
       try {
-        await requestGateway(
+        const result = await requestGateway<{ survivor_user_row_ids?: unknown }>(
           'prompt.submit',
           {
             session_id: runtimeIdRef.current,
@@ -417,12 +436,14 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
           },
           PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
         )
+
+        applySurvivorRowIds(survivorRowIdsFrom(result))
       } catch (err) {
         update(current => ({ ...current, busy: false, awaitingResponse: false }))
         notifyError(err, copy.regenerateFailed)
       }
     },
-    [copy.regenerateFailed, readState, requestGateway, update]
+    [applySurvivorRowIds, copy.regenerateFailed, readState, requestGateway, update]
   )
 
   const restoreToMessage = useCallback(
@@ -440,13 +461,15 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       update(state => applyRewindOptimistic(state, plan.sourceIndex))
 
       try {
-        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy, plan.truncateMessageId, plan.truncateRowId)
+        applySurvivorRowIds(
+          await submitRewind(plan.text, plan.truncateOrdinal, wasBusy, plan.truncateMessageId, plan.truncateRowId)
+        )
       } catch (err) {
         update(state => ({ ...state, busy: false, awaitingResponse: false, messages }))
         throw err
       }
     },
-    [readMessages, readState, submitRewind, update]
+    [applySurvivorRowIds, readMessages, readState, submitRewind, update]
   )
 
   const editMessage = useCallback(
@@ -469,13 +492,15 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       update(state => applyRewindOptimistic(state, plan.sourceIndex, plan.editedMessage))
 
       try {
-        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy, plan.truncateMessageId, plan.truncateRowId)
+        applySurvivorRowIds(
+          await submitRewind(plan.text, plan.truncateOrdinal, wasBusy, plan.truncateMessageId, plan.truncateRowId)
+        )
       } catch (err) {
         update(state => ({ ...state, busy: false, awaitingResponse: false, messages }))
         notifyError(err, copy.editFailed)
       }
     },
-    [copy.editFailed, readMessages, readState, submitRewind, update]
+    [applySurvivorRowIds, copy.editFailed, readMessages, readState, submitRewind, update]
   )
 
   // Branch-visibility sync (assistant-ui hides non-active branches).

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2294,6 +2294,7 @@ describe('usePromptActions restoreToMessage', () => {
         text: 'first prompt',
         confirm_truncate: true,
         truncate_before_user_ordinal: 0,
+        truncate_before_message_id: 'u1',
         confirm_empty_truncate: true
       },
       1_800_000
@@ -2363,6 +2364,7 @@ describe('usePromptActions restoreToMessage', () => {
         text: 'first prompt',
         confirm_truncate: true,
         truncate_before_user_ordinal: 0,
+        truncate_before_message_id: 'u1',
         confirm_empty_truncate: true
       },
       1_800_000
@@ -2410,6 +2412,7 @@ describe('usePromptActions restoreToMessage', () => {
         text: 'first prompt',
         confirm_truncate: true,
         truncate_before_user_ordinal: 0,
+        truncate_before_message_id: 'u1',
         confirm_empty_truncate: true
       },
       1_800_000

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -56,7 +56,10 @@ import {
   planEdit,
   planReload,
   planRestore,
+  rebindSurvivorRowIds,
   runRewindSubmit,
+  type SurvivorUserRowIds,
+  survivorRowIdsFrom,
   truncateSubmitParams
 } from './rewind'
 import { useSlashCommand } from './slash'
@@ -784,6 +787,25 @@ export function usePromptActions({
     [activeSessionIdRef, appendSessionTextMessage, requestGateway, selectedStoredSessionIdRef, updateSessionState]
   )
 
+  // After a durable rewind the surviving bubbles' cached rowIds are stale (the
+  // gateway re-inserted the kept prefix as new SQLite rows). Rebind them to the
+  // authoritative post-rewrite ids so the NEXT rewind/edit/regenerate doesn't
+  // send a dead id and get refused with 4018 (consecutive-rewind staleness,
+  // #83202 review).
+  const applySurvivorRowIds = useCallback(
+    (sessionId: string, survivorRowIds: SurvivorUserRowIds | undefined) => {
+      if (!survivorRowIds) {
+        return
+      }
+
+      updateSessionState(sessionId, state => ({
+        ...state,
+        messages: rebindSurvivorRowIds(state.messages, survivorRowIds)
+      }))
+    },
+    [updateSessionState]
+  )
+
   const reloadFromMessage = useCallback(
     async (parentId: string | null) => {
       // Ref, not the closure-captured prop — a truncating resubmit aimed at a
@@ -804,7 +826,7 @@ export function usePromptActions({
       updateSessionState(sessionId, state => applyReloadOptimistic(state, plan))
 
       try {
-        await requestGateway(
+        const result = await requestGateway<{ survivor_user_row_ids?: unknown }>(
           'prompt.submit',
           {
             session_id: sessionId,
@@ -813,6 +835,8 @@ export function usePromptActions({
           },
           PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
         )
+
+        applySurvivorRowIds(sessionId, survivorRowIdsFrom(result))
       } catch (err) {
         updateSessionState(sessionId, state => ({
           ...state,
@@ -822,7 +846,7 @@ export function usePromptActions({
         notifyError(err, copy.regenerateFailed)
       }
     },
-    [activeSessionIdRef, copy.regenerateFailed, requestGateway, updateSessionState]
+    [activeSessionIdRef, applySurvivorRowIds, copy.regenerateFailed, requestGateway, updateSessionState]
   )
 
   // Cursor-style "restore checkpoint": rewind the conversation to a past user
@@ -889,7 +913,7 @@ export function usePromptActions({
       updateSessionState(sessionId, state => applyRewindOptimistic(state, plan.sourceIndex))
 
       try {
-        await submitRewindPrompt(
+        const survivorRowIds = await submitRewindPrompt(
           sessionId,
           plan.text,
           plan.truncateOrdinal,
@@ -897,6 +921,8 @@ export function usePromptActions({
           busyRef.current || $busy.get(),
           plan.truncateRowId
         )
+
+        applySurvivorRowIds(sessionId, survivorRowIds)
       } catch (err) {
         // The rewind never landed (e.g. the gateway stayed busy past the retry
         // deadline). Roll the optimistic truncation back to the full original
@@ -914,7 +940,7 @@ export function usePromptActions({
         throw err
       }
     },
-    [activeSessionIdRef, busyRef, submitRewindPrompt, updateSessionState]
+    [activeSessionIdRef, applySurvivorRowIds, busyRef, submitRewindPrompt, updateSessionState]
   )
 
   const editMessage = useCallback(
@@ -944,7 +970,7 @@ export function usePromptActions({
       updateSessionState(sessionId, state => applyRewindOptimistic(state, plan.sourceIndex, plan.editedMessage))
 
       try {
-        await submitRewindPrompt(
+        const survivorRowIds = await submitRewindPrompt(
           sessionId,
           plan.text,
           plan.truncateOrdinal,
@@ -952,6 +978,8 @@ export function usePromptActions({
           busyRef.current || $busy.get(),
           plan.truncateRowId
         )
+
+        applySurvivorRowIds(sessionId, survivorRowIds)
       } catch (err) {
         // Roll the optimistic edit/truncation back to the original history so the
         // UI stays in sync with what's persisted instead of stranding a partial
@@ -963,7 +991,7 @@ export function usePromptActions({
         notifyError(err, copy.editFailed)
       }
     },
-    [activeSessionIdRef, busyRef, copy.editFailed, submitRewindPrompt, updateSessionState]
+    [activeSessionIdRef, applySurvivorRowIds, busyRef, copy.editFailed, submitRewindPrompt, updateSessionState]
   )
 
   const handleThreadMessagesChange = useCallback(

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -809,7 +809,7 @@ export function usePromptActions({
           {
             session_id: sessionId,
             text: plan.text,
-            ...truncateSubmitParams(plan.truncateOrdinal)
+            ...truncateSubmitParams(plan.truncateOrdinal, plan.truncateMessageId, plan.truncateRowId)
           },
           PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
         )
@@ -835,14 +835,30 @@ export function usePromptActions({
   // fresh turn. Live/stuck turns interrupt first, and a raced "session busy"
   // response interrupts + retries through the shared busy gate.
   const submitRewindPrompt = useCallback(
-    (sessionId: string, text: string, truncateOrdinal: number | undefined, interruptFirst: boolean) =>
-      runRewindSubmit(requestGateway, sessionId, text, truncateOrdinal, interruptFirst, {
-        storedSessionId: selectedStoredSessionIdRef.current,
-        onSessionRecovered: recoveredId => {
-          activeSessionIdRef.current = recoveredId
-          setActiveSessionId(recoveredId)
-        }
-      }),
+    (
+      sessionId: string,
+      text: string,
+      truncateOrdinal: number | undefined,
+      truncateMessageId: string | undefined,
+      interruptFirst: boolean,
+      truncateRowId?: number
+    ) =>
+      runRewindSubmit(
+        requestGateway,
+        sessionId,
+        text,
+        truncateOrdinal,
+        truncateMessageId,
+        interruptFirst,
+        {
+          storedSessionId: selectedStoredSessionIdRef.current,
+          onSessionRecovered: recoveredId => {
+            activeSessionIdRef.current = recoveredId
+            setActiveSessionId(recoveredId)
+          }
+        },
+        truncateRowId
+      ),
     [activeSessionIdRef, requestGateway, selectedStoredSessionIdRef]
   )
 
@@ -873,7 +889,14 @@ export function usePromptActions({
       updateSessionState(sessionId, state => applyRewindOptimistic(state, plan.sourceIndex))
 
       try {
-        await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, busyRef.current || $busy.get())
+        await submitRewindPrompt(
+          sessionId,
+          plan.text,
+          plan.truncateOrdinal,
+          plan.truncateMessageId,
+          busyRef.current || $busy.get(),
+          plan.truncateRowId
+        )
       } catch (err) {
         // The rewind never landed (e.g. the gateway stayed busy past the retry
         // deadline). Roll the optimistic truncation back to the full original
@@ -920,25 +943,16 @@ export function usePromptActions({
       setAwaitingResponse(true)
       updateSessionState(sessionId, state => applyRewindOptimistic(state, plan.sourceIndex, plan.editedMessage))
 
-      const isStaleTargetError = (err: unknown) =>
-        /no longer in session history|not in session history/i.test(err instanceof Error ? err.message : String(err))
-
       try {
-        await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, busyRef.current || $busy.get())
+        await submitRewindPrompt(
+          sessionId,
+          plan.text,
+          plan.truncateOrdinal,
+          plan.truncateMessageId,
+          busyRef.current || $busy.get(),
+          plan.truncateRowId
+        )
       } catch (err) {
-        let surfaced = err
-
-        if (!plan.isFailedTurn && isStaleTargetError(err)) {
-          try {
-            // Already interrupted on the first attempt — submit as a plain resend.
-            await submitRewindPrompt(sessionId, plan.text, undefined, false)
-
-            return
-          } catch (retryErr) {
-            surfaced = retryErr
-          }
-        }
-
         // Roll the optimistic edit/truncation back to the original history so the
         // UI stays in sync with what's persisted instead of stranding a partial
         // timeline.
@@ -946,7 +960,7 @@ export function usePromptActions({
         setBusy(false)
         setAwaitingResponse(false)
         updateSessionState(sessionId, state => ({ ...state, busy: false, awaitingResponse: false, messages }))
-        notifyError(surfaced, copy.editFailed)
+        notifyError(err, copy.editFailed)
       }
     },
     [activeSessionIdRef, busyRef, copy.editFailed, submitRewindPrompt, updateSessionState]

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -58,8 +58,8 @@ import {
   planRestore,
   rebindSurvivorRowIds,
   runRewindSubmit,
-  type SurvivorUserRowIds,
   survivorRowIdsFrom,
+  type SurvivorUserRowIds,
   truncateSubmitParams
 } from './rewind'
 import { useSlashCommand } from './slash'

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -30,4 +30,31 @@ describe('truncateSubmitParams', () => {
       expect(params.confirm_truncate).toBe(true)
     }
   })
+
+  it('includes truncate_before_row_id when passed', () => {
+    expect(truncateSubmitParams(1, 'msg-123', 456)).toEqual({
+      confirm_truncate: true,
+      truncate_before_user_ordinal: 1,
+      truncate_before_message_id: 'msg-123',
+      truncate_before_row_id: 456
+    })
+    expect(truncateSubmitParams(undefined, undefined, 456)).toEqual({
+      confirm_truncate: true,
+      truncate_before_row_id: 456
+    })
+  })
+
+  it('drops renderer-synthetic message ids but keeps durable row ids', () => {
+    // chat-messages.ts: `${timestamp}-${index}-${role}`
+    expect(truncateSubmitParams(1, '1723456789-0-user', 456)).toEqual({
+      confirm_truncate: true,
+      truncate_before_user_ordinal: 1,
+      truncate_before_row_id: 456
+    })
+    expect(truncateSubmitParams(0, 'user-1723456789-0', undefined)).toEqual({
+      confirm_truncate: true,
+      truncate_before_user_ordinal: 0,
+      confirm_empty_truncate: true
+    })
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
-import { truncateSubmitParams } from './rewind'
+import { type ChatMessage, textPart } from '@/lib/chat-messages'
+
+import { rebindSurvivorRowIds, survivorRowIdsFrom, truncateSubmitParams } from './rewind'
 
 describe('truncateSubmitParams', () => {
   it('omits truncation fields when no ordinal is set', () => {
@@ -56,5 +58,70 @@ describe('truncateSubmitParams', () => {
       truncate_before_user_ordinal: 0,
       confirm_empty_truncate: true
     })
+  })
+})
+
+describe('survivorRowIdsFrom', () => {
+  it('returns undefined when the field is absent or not an array (older gateway)', () => {
+    expect(survivorRowIdsFrom(undefined)).toBeUndefined()
+    expect(survivorRowIdsFrom({ status: 'streaming' })).toBeUndefined()
+    expect(survivorRowIdsFrom({ survivor_user_row_ids: 'nope' })).toBeUndefined()
+  })
+
+  it('keeps integer ids and nulls anything else', () => {
+    expect(survivorRowIdsFrom({ survivor_user_row_ids: [7, null, 9.5, '11', 12] })).toEqual([7, null, null, null, 12])
+  })
+})
+
+describe('rebindSurvivorRowIds', () => {
+  const user = (id: string, rowId?: number, hidden?: boolean): ChatMessage => ({
+    id,
+    role: 'user',
+    parts: [textPart(`text ${id}`)],
+    ...(rowId !== undefined ? { rowId } : {}),
+    ...(hidden ? { hidden } : {})
+  })
+  const assistant = (id: string, rowId?: number): ChatMessage => ({
+    id,
+    role: 'assistant',
+    parts: [textPart(`reply ${id}`)],
+    ...(rowId !== undefined ? { rowId } : {})
+  })
+
+  it('rebinds surviving visible user turns positionally and clears the resubmitted turn', () => {
+    // Post-rewind state: two survivors + the resubmitted turn (stale rowId 5).
+    const messages = [user('u0', 1), assistant('a0', 2), user('u1', 3), assistant('a1', 4), user('u2', 5)]
+    const rebound = rebindSurvivorRowIds(messages, [7, 9])
+
+    expect(rebound[0].rowId).toBe(7)
+    expect(rebound[2].rowId).toBe(9)
+    // Resubmitted turn is past the survivor list — its durable id doesn't
+    // exist yet, and keeping the stale one would 4018 the next rewind.
+    expect(rebound[4].rowId).toBeUndefined()
+    // Assistant rows are untouched (only user turns are rewind targets).
+    expect(rebound[1].rowId).toBe(2)
+  })
+
+  it('clears the cached id for null entries instead of keeping a stale one', () => {
+    const messages = [user('u0', 1), user('u1', 3)]
+    const rebound = rebindSurvivorRowIds(messages, [null, 9])
+
+    expect(rebound[0].rowId).toBeUndefined()
+    expect(rebound[1].rowId).toBe(9)
+  })
+
+  it('skips hidden user turns — same visible-user filter as the ordinal math', () => {
+    const messages = [user('u0', 1), user('hidden', 2, true), user('u1', 3)]
+    const rebound = rebindSurvivorRowIds(messages, [7, 9])
+
+    expect(rebound[0].rowId).toBe(7)
+    expect(rebound[1].rowId).toBe(2) // hidden: untouched
+    expect(rebound[2].rowId).toBe(9)
+  })
+
+  it('preserves object identity when nothing changes', () => {
+    const messages = [user('u0', 7)]
+
+    expect(rebindSurvivorRowIds(messages, [7])[0]).toBe(messages[0])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -81,6 +81,7 @@ describe('rebindSurvivorRowIds', () => {
     ...(rowId !== undefined ? { rowId } : {}),
     ...(hidden ? { hidden } : {})
   })
+
   const assistant = (id: string, rowId?: number): ChatMessage => ({
     id,
     role: 'assistant',

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -27,6 +27,61 @@ import {
 type RequestGateway = <T = unknown>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
 
 /**
+ * Post-rewrite durable ids of the surviving visible user turns, in visible-user
+ * ordinal order — the gateway's `survivor_user_row_ids` on a truncating
+ * `prompt.submit`. A rewind's `replace_messages` re-inserts the kept prefix as
+ * NEW SQLite rows, so every pre-rewind `ChatMessage.rowId` on a surviving
+ * bubble is stale the moment the rewind lands; targeting one on the next
+ * rewind/edit/regenerate gets a fail-closed 4018 from the gateway. `null`
+ * means that turn has no durable id (drop the cached one, don't keep a stale
+ * one). Absent entirely = the submit didn't truncate a durable session (or an
+ * older gateway) — leave state untouched.
+ */
+export type SurvivorUserRowIds = readonly (null | number)[]
+
+interface PromptSubmitResult {
+  status?: string
+  survivor_user_row_ids?: unknown
+}
+
+export function survivorRowIdsFrom(result: PromptSubmitResult | undefined): SurvivorUserRowIds | undefined {
+  const raw = result?.survivor_user_row_ids
+
+  if (!Array.isArray(raw)) {
+    return undefined
+  }
+
+  return raw.map(entry => (typeof entry === 'number' && Number.isInteger(entry) ? entry : null))
+}
+
+/**
+ * Rebind the surviving visible user turns to their authoritative post-rewind
+ * row ids (positional, same visible-user filter `visibleUserOrdinal` uses —
+ * the exact parity truncate ordinals already rely on). Turns past the end of
+ * the survivor list — the resubmitted turn itself, whose durable id doesn't
+ * exist yet — and `null` entries get their cached rowId cleared instead: a
+ * stale id now addresses an archived row and would be refused with 4018.
+ */
+export function rebindSurvivorRowIds(messages: ChatMessage[], survivorRowIds: SurvivorUserRowIds): ChatMessage[] {
+  let ordinal = 0
+
+  return messages.map(message => {
+    if (message.role !== 'user' || message.hidden) {
+      return message
+    }
+
+    const next = ordinal < survivorRowIds.length ? survivorRowIds[ordinal] : null
+    ordinal += 1
+
+    if (typeof next === 'number') {
+      return message.rowId === next ? message : { ...message, rowId: next }
+    }
+
+    return message.rowId === undefined ? message : { ...message, rowId: undefined }
+  })
+}
+
+/**
  * Build `prompt.submit` truncation params. `confirm_truncate` states that this
  * submit really is a rewind/edit/regenerate: the gateway drops history only for
  * a submit that says so, so a leftover ordinal riding along on an ordinary send
@@ -70,6 +125,10 @@ export function truncateSubmitParams(
  * / `truncate_before_message_id` / `truncate_before_row_id` (drops that user turn + everything after).
  * Idle rewinds submit directly; live/stuck turns interrupt first, and a raced
  * "session busy" response interrupts + retries through the shared busy gate.
+ *
+ * Resolves with the gateway's post-rewrite survivor row ids (see
+ * `SurvivorUserRowIds`) so the caller can rebind surviving bubbles, or
+ * undefined when the submit didn't truncate a durable transcript.
  */
 export async function runRewindSubmit(
   requestGateway: RequestGateway,
@@ -80,7 +139,7 @@ export async function runRewindSubmit(
   interruptFirst: boolean,
   recovery?: { storedSessionId?: null | string; onSessionRecovered?: (sessionId: string) => void },
   truncateRowId?: number
-): Promise<void> {
+): Promise<SurvivorUserRowIds | undefined> {
   // Recovery may rebind the live id mid-flight; interrupt/submit must both
   // follow it rather than pinning the dead one.
   let liveSessionId = sessionId
@@ -94,7 +153,7 @@ export async function runRewindSubmit(
   }
 
   const submitFor = (targetId: string) =>
-    requestGateway(
+    requestGateway<PromptSubmitResult>(
       'prompt.submit',
       {
         session_id: targetId,
@@ -105,15 +164,22 @@ export async function runRewindSubmit(
     )
 
   const submit = async () => {
-    const { sessionId: usedId } = await withSessionNotFoundResume(liveSessionId, recovery?.storedSessionId, submitFor, {
-      requestGateway,
-      onRecovered: recoveredId => {
-        liveSessionId = recoveredId
-        recovery?.onSessionRecovered?.(recoveredId)
+    const { result, sessionId: usedId } = await withSessionNotFoundResume(
+      liveSessionId,
+      recovery?.storedSessionId,
+      submitFor,
+      {
+        requestGateway,
+        onRecovered: recoveredId => {
+          liveSessionId = recoveredId
+          recovery?.onSessionRecovered?.(recoveredId)
+        }
       }
-    })
+    )
 
     liveSessionId = usedId
+
+    return survivorRowIdsFrom(result)
   }
 
   if (interruptFirst) {
@@ -121,14 +187,15 @@ export async function runRewindSubmit(
   }
 
   try {
-    await submit()
+    return await submit()
   } catch (err) {
     if (!isSessionBusyError(err)) {
       throw err
     }
 
     await interrupt()
-    await withSessionBusyRetry(submit)
+
+    return await withSessionBusyRetry(submit)
   }
 }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -34,38 +34,52 @@ type RequestGateway = <T = unknown>(method: string, params?: Record<string, unkn
  * transcript (restore/regenerate the first user turn), which the gateway gates
  * behind `confirm_empty_truncate` on top of that.
  */
-export function truncateSubmitParams(truncateOrdinal: number | undefined): Record<string, unknown> {
-  if (truncateOrdinal === undefined) {
+export function truncateSubmitParams(
+  truncateOrdinal: number | undefined,
+  truncateMessageId?: string,
+  truncateRowId?: number
+): Record<string, unknown> {
+  const hasOrdinal = typeof truncateOrdinal === 'number' && Number.isInteger(truncateOrdinal) && truncateOrdinal >= 0;
+  const hasRowId = typeof truncateRowId === 'number' && Number.isInteger(truncateRowId);
+  // Renderer ids are ephemeral (`${timestamp}-${index}-${role}` from
+  // chat-messages.ts, plus older `user-…` / `assistant-…` shapes). Gateway
+  // history never carries them — only durable `row_id` / platform message_id.
+  const isSyntheticId =
+    typeof truncateMessageId === 'string' &&
+    (truncateMessageId.startsWith('user-') ||
+      truncateMessageId.startsWith('assistant-') ||
+      truncateMessageId.includes('-synthetic-') ||
+      /^\d+-\d+-(user|assistant|tools)\b/.test(truncateMessageId))
+  const hasMessageId = typeof truncateMessageId === 'string' && truncateMessageId.length > 0 && !isSyntheticId;
+
+  if (!hasOrdinal && !hasMessageId && !hasRowId) {
     return {}
   }
 
   return {
     confirm_truncate: true,
-    truncate_before_user_ordinal: truncateOrdinal,
+    ...(hasOrdinal ? { truncate_before_user_ordinal: truncateOrdinal } : {}),
+    ...(hasMessageId ? { truncate_before_message_id: truncateMessageId } : {}),
+    ...(hasRowId ? { truncate_before_row_id: truncateRowId } : {}),
     ...(truncateOrdinal === 0 ? { confirm_empty_truncate: true } : {})
   }
 }
 
 /**
  * Rewind a turn: `prompt.submit` with an optional `truncate_before_user_ordinal`
- * (drops that user turn + everything after). Idle rewinds submit directly
- * (interrupting an idle agent can leave a stale interrupt flag that cancels the
- * fresh turn); live/stuck turns interrupt first, and a raced "session busy"
- * response interrupts + retries through the shared busy gate.
- *
- * A rewind runs right after `cancelRun`, and interrupting can drop the
- * gateway's in-memory session — so the follow-up submit hits a dead runtime id
- * and used to surface a bare "session not found" ("Restore checkpoint" failing
- * after a stop). Pass `recovery` so a stale id re-registers and retries like
- * every other session-scoped RPC.
+ * / `truncate_before_message_id` / `truncate_before_row_id` (drops that user turn + everything after).
+ * Idle rewinds submit directly; live/stuck turns interrupt first, and a raced
+ * "session busy" response interrupts + retries through the shared busy gate.
  */
 export async function runRewindSubmit(
   requestGateway: RequestGateway,
   sessionId: string,
   text: string,
   truncateOrdinal: number | undefined,
+  truncateMessageId: string | undefined,
   interruptFirst: boolean,
-  recovery?: { storedSessionId?: null | string; onSessionRecovered?: (sessionId: string) => void }
+  recovery?: { storedSessionId?: null | string; onSessionRecovered?: (sessionId: string) => void },
+  truncateRowId?: number
 ): Promise<void> {
   // Recovery may rebind the live id mid-flight; interrupt/submit must both
   // follow it rather than pinning the dead one.
@@ -85,7 +99,7 @@ export async function runRewindSubmit(
       {
         session_id: targetId,
         text,
-        ...truncateSubmitParams(truncateOrdinal)
+        ...truncateSubmitParams(truncateOrdinal, truncateMessageId, truncateRowId)
       },
       PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
     )
@@ -133,6 +147,8 @@ export interface ReloadPlan {
   branchGroupId: string
   text: string
   truncateOrdinal: number
+  truncateMessageId?: string
+  truncateRowId?: number
   userIndex: number
 }
 
@@ -164,6 +180,8 @@ export function planReload(messages: ChatMessage[], parentId: null | string): nu
     branchGroupId: targetAssistant?.branchGroupId ?? branchGroupForUser(userMessage),
     text,
     truncateOrdinal: visibleUserOrdinal(messages, userIndex),
+    truncateMessageId: userMessage.id,
+    truncateRowId: userMessage.rowId,
     userIndex
   }
 }
@@ -202,6 +220,8 @@ export interface RestorePlan {
   sourceIndex: number
   text: string
   truncateOrdinal: number
+  truncateMessageId?: string
+  truncateRowId?: number
 }
 
 /** Resolve the user turn to rewind to; throws with a user-facing reason. */
@@ -231,7 +251,7 @@ export function planRestore(messages: ChatMessage[], messageId: string, target?:
       ? visibleUserOrdinal(messages, sourceIndex)
       : target.userOrdinal
 
-  return { sourceIndex, text, truncateOrdinal }
+  return { sourceIndex, text, truncateOrdinal, truncateMessageId: source.id, truncateRowId: source.rowId }
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +264,8 @@ export interface EditPlan {
   sourceIndex: number
   text: string
   truncateOrdinal: number | undefined
+  truncateMessageId?: string
+  truncateRowId?: number
 }
 
 /** Resolve the edited user turn, or null when nothing changed / invalid. */
@@ -272,7 +294,9 @@ export function planEdit(messages: ChatMessage[], edited: AppendMessage): EditPl
     isFailedTurn,
     sourceIndex,
     text,
-    truncateOrdinal: isFailedTurn ? undefined : visibleUserOrdinal(messages, sourceIndex)
+    truncateOrdinal: isFailedTurn ? undefined : visibleUserOrdinal(messages, sourceIndex),
+    truncateMessageId: isFailedTurn ? undefined : source.id,
+    truncateRowId: isFailedTurn ? undefined : source.rowId
   }
 }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -18,6 +18,7 @@ import { branchGroupForUser, type ChatMessage, chatMessageText, textPart } from 
 import {
   appendText,
   isSessionBusyError,
+  isVisibleUserMessage,
   visibleUserIndexAtOrdinal,
   visibleUserOrdinal,
   withSessionBusyRetry,
@@ -66,7 +67,7 @@ export function rebindSurvivorRowIds(messages: ChatMessage[], survivorRowIds: Su
   let ordinal = 0
 
   return messages.map(message => {
-    if (message.role !== 'user' || message.hidden) {
+    if (!isVisibleUserMessage(message)) {
       return message
     }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -39,8 +39,8 @@ export function truncateSubmitParams(
   truncateMessageId?: string,
   truncateRowId?: number
 ): Record<string, unknown> {
-  const hasOrdinal = typeof truncateOrdinal === 'number' && Number.isInteger(truncateOrdinal) && truncateOrdinal >= 0;
-  const hasRowId = typeof truncateRowId === 'number' && Number.isInteger(truncateRowId);
+  const hasOrdinal = typeof truncateOrdinal === 'number' && Number.isInteger(truncateOrdinal) && truncateOrdinal >= 0
+  const hasRowId = typeof truncateRowId === 'number' && Number.isInteger(truncateRowId)
   // Renderer ids are ephemeral (`${timestamp}-${index}-${role}` from
   // chat-messages.ts, plus older `user-…` / `assistant-…` shapes). Gateway
   // history never carries them — only durable `row_id` / platform message_id.
@@ -50,7 +50,7 @@ export function truncateSubmitParams(
       truncateMessageId.startsWith('assistant-') ||
       truncateMessageId.includes('-synthetic-') ||
       /^\d+-\d+-(user|assistant|tools)\b/.test(truncateMessageId))
-  const hasMessageId = typeof truncateMessageId === 'string' && truncateMessageId.length > 0 && !isSyntheticId;
+  const hasMessageId = typeof truncateMessageId === 'string' && truncateMessageId.length > 0 && !isSyntheticId
 
   if (!hasOrdinal && !hasMessageId && !hasRowId) {
     return {}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -495,8 +495,15 @@ export function appendText(message: AppendMessage): string {
     .trim()
 }
 
+/** The one visible-user filter every user-ordinal computation must share —
+ *  truncate ordinals, ordinal→index resolution, and survivor-rowId rebinding
+ *  all rely on counting exactly the same turns. */
+export function isVisibleUserMessage(message: ChatMessage): boolean {
+  return message.role === 'user' && !message.hidden
+}
+
 export function visibleUserOrdinal(messages: readonly ChatMessage[], end: number): number {
-  return messages.slice(0, end).filter(m => m.role === 'user' && !m.hidden).length
+  return messages.slice(0, end).filter(isVisibleUserMessage).length
 }
 
 export function visibleUserIndexAtOrdinal(messages: readonly ChatMessage[], targetOrdinal: number): number {
@@ -505,7 +512,7 @@ export function visibleUserIndexAtOrdinal(messages: readonly ChatMessage[], targ
   for (let index = 0; index < messages.length; index += 1) {
     const message = messages[index]
 
-    if (message.role !== 'user' || message.hidden) {
+    if (!isVisibleUserMessage(message)) {
       continue
     }
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8146,7 +8146,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             api_content = msg.get("api_content")
 
-            conn.execute(
+            cur = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
@@ -8176,6 +8176,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._encode_display_metadata(msg.get("display_metadata")),
                 ),
             )
+            if isinstance(msg, dict) and cur.lastrowid is not None:
+                msg["_row_id"] = cur.lastrowid
             inserted += 1
             if tool_calls is not None:
                 tool_calls_total += (

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -678,7 +678,7 @@ class TestTodoSnapshotScaffoldingTails:
             _msgs(), "sys", approx_tokens=120_000
         )
 
-        assert compressed == expected
+        assert [{k: v for k, v in m.items() if k != "_row_id"} for m in compressed] == expected
         assert not any(
             TODO_INJECTION_HEADER in str(message.get("content") or "")
             for message in compressed

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17922,3 +17922,80 @@ def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
         assert isinstance(survivors2, list) and len(survivors2) == 1
     finally:
         server._sessions.pop(sid, None)
+
+
+def test_prompt_submit_unconfirmed_truncation_refuses_before_target_resolution(
+    monkeypatch,
+):
+    """Consent (4029) is checked BEFORE target resolution: an unconfirmed
+    submit carrying truncation params must not pay the durable-transcript
+    read or heal-stamp live history (simplify review on #83785), and an
+    out-of-range unconfirmed ordinal refuses 4029, not 4018 — the baseline
+    precedence before the row-id feature.
+    """
+    db_reads = []
+
+    class _SpyDB:
+        def get_messages_as_conversation(self, *a, **k):
+            db_reads.append(1)
+            return []
+
+        def replace_messages(self, *a, **k):
+            pytest.fail("must not write")
+
+    hist = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "r1"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "r2"},
+    ]
+    sess = _session(history=list(hist), session_key="consent-precedence-key")
+    sid = "consent-precedence-sid"
+    server._sessions[sid] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: _SpyDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        # Unconfirmed row_id: 4029, no DB read, no heal stamps on history.
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "x", "truncate_before_row_id": 3},
+            }
+        )
+        assert (resp.get("error") or {}).get("code") == 4029, resp
+        assert db_reads == []
+        assert all("_row_id" not in m for m in sess["history"])
+
+        # Malformed param still beats consent: bool row_id is 4004.
+        resp = server.handle_request(
+            {
+                "id": "2",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "x", "truncate_before_row_id": True},
+            }
+        )
+        assert (resp.get("error") or {}).get("code") == 4004, resp
+
+        # Unconfirmed out-of-range ordinal: 4029 (consent), not 4018 (range).
+        resp = server.handle_request(
+            {
+                "id": "3",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": sid,
+                    "text": "x",
+                    "truncate_before_user_ordinal": 99,
+                },
+            }
+        )
+        assert (resp.get("error") or {}).get("code") == 4029, resp
+        assert len(sess["history"]) == 4
+    finally:
+        server._sessions.pop(sid, None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17820,3 +17820,105 @@ def test_prompt_submit_row_id_db_fallback_ordinal_mapping_verifies_content(
         assert len(sess["history"]) == 5
     finally:
         server._sessions.pop(sid, None)
+
+
+def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
+    monkeypatch, tmp_path
+):
+    """#83202 review (consecutive-rewind staleness): replace_messages re-inserts
+    the surviving prefix as NEW rows, so the pre-rewind client row ids die on
+    the first rewind. The submit response must return the fresh survivor ids,
+    and a second rewind using them must succeed where the stale id fail-closes.
+    """
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "rowid-consec.db")
+    session_key = "real-db-consec-rewind"
+    db.create_session(session_key, "cli")
+    msgs = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "reply 2"},
+        {"role": "user", "content": "third"},
+        {"role": "assistant", "content": "reply 3"},
+    ]
+    with db._lock:
+        db._insert_message_rows(db._conn, session_key, msgs)
+        db._conn.commit()
+    original_row_ids = [m["_row_id"] for m in msgs]
+
+    sess = _session(history=[dict(m) for m in msgs], session_key=session_key)
+    sid = "real-db-consec-rewind-sid"
+    server._sessions[sid] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
+
+    try:
+        # Rewind 1: cut before "third" (last user turn). Survivors: turns
+        # "first" + "second" (+ assistant replies) — re-inserted as NEW rows.
+        resp1 = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": sid,
+                    "text": "rewound third",
+                    "truncate_before_row_id": original_row_ids[4],
+                    "truncate_before_user_ordinal": 2,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp1.get("error") is None, resp1
+        survivors = resp1["result"].get("survivor_user_row_ids")
+        # Fresh ids for the two surviving user turns, in visible-user order.
+        assert isinstance(survivors, list) and len(survivors) == 2
+        assert all(isinstance(r, int) for r in survivors)
+        # They must be NEW rows — the old ids are archived (active=0) now.
+        assert set(survivors).isdisjoint(set(original_row_ids))
+        sess["running"] = False
+
+        # Rewind 2a: the STALE pre-rewind id for "second" must fail closed.
+        stale_resp = server.handle_request(
+            {
+                "id": "2",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": sid,
+                    "text": "rewound second (stale id)",
+                    "truncate_before_row_id": original_row_ids[2],
+                    "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert stale_resp.get("error") is not None
+        assert stale_resp["error"]["code"] == 4018
+        assert len(sess["history"]) == 4  # nothing cut
+
+        # Rewind 2b: the RETURNED survivor id for "second" must succeed.
+        resp2 = server.handle_request(
+            {
+                "id": "3",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": sid,
+                    "text": "rewound second (fresh id)",
+                    "truncate_before_row_id": survivors[1],
+                    "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp2.get("error") is None, resp2
+        assert len(sess["history"]) == 2
+        assert sess["history"][0]["content"] == "first"
+        active = db.get_messages_as_conversation(session_key)
+        assert [m["content"] for m in active] == ["first", "reply 1"]
+        # And the second response rebinds again: one surviving user turn.
+        survivors2 = resp2["result"].get("survivor_user_row_ids")
+        assert isinstance(survivors2, list) and len(survivors2) == 1
+    finally:
+        server._sessions.pop(sid, None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17675,4 +17675,204 @@ def test_prompt_submit_row_id_real_sessiondb_unknown_refuses_despite_ordinal(
         server._sessions.pop(sid, None)
 
 
+def test_prompt_submit_row_id_misaligned_memory_refuses_content_swap(
+    monkeypatch, tmp_path
+):
+    """#82959 heal-path guard: equal-length but content-misaligned live memory
+    must refuse (4018), not zip-stamp durable ids positionally and cut the
+    wrong turn. Probe 4a from the PR #83202 review.
+    """
+    from hermes_state import SessionDB
 
+    db = SessionDB(db_path=tmp_path / "rowid-misalign-content.db")
+    session_key = "real-db-row-misalign-content"
+    db.create_session(session_key, "cli")
+    msgs = [
+        {"role": "user", "content": "A"},
+        {"role": "assistant", "content": "ra"},
+        {"role": "user", "content": "B"},
+        {"role": "assistant", "content": "rb"},
+    ]
+    with db._lock:
+        db._insert_message_rows(db._conn, session_key, msgs)
+        db._conn.commit()
+    rid_b = msgs[2]["_row_id"]
+
+    # Same length + same role pattern, but content positions swapped: a
+    # positional stamp would mark live "B" with durable A's row id and the
+    # cut would keep the very turn the user rewound past.
+    live_history = [
+        {"role": "user", "content": "B"},
+        {"role": "assistant", "content": "rb"},
+        {"role": "user", "content": "A"},
+        {"role": "assistant", "content": "ra"},
+    ]
+    sess = _session(history=list(live_history), session_key=session_key)
+    sid = "misalign-content-sid"
+    server._sessions[sid] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    n_before = len(db.get_messages_as_conversation(session_key))
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": sid,
+                    "text": "rewind B",
+                    "truncate_before_row_id": rid_b,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4018
+        # Fail-closed: nothing stamped onto the misaligned dicts, nothing cut.
+        assert all("_row_id" not in m for m in sess["history"])
+        assert len(sess["history"]) == 4
+        assert len(db.get_messages_as_conversation(session_key)) == n_before
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_prompt_submit_row_id_misaligned_memory_role_shift_targets_real_turn(
+    monkeypatch, tmp_path
+):
+    """#82959 heal-path guard: equal-length but role-misaligned live memory
+    must not be positionally stamped. The content-verified DB fallback still
+    resolves the REAL target turn in live order — the cut drops exactly the
+    addressed user turn, never a positionally mis-aimed one. Probe 4b from
+    the PR #83202 review.
+    """
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "rowid-misalign-role.db")
+    session_key = "real-db-row-misalign-role"
+    db.create_session(session_key, "cli")
+    msgs = [
+        {"role": "user", "content": "A"},
+        {"role": "assistant", "content": "ra"},
+        {"role": "user", "content": "B"},
+        {"role": "assistant", "content": "rb"},
+    ]
+    with db._lock:
+        db._insert_message_rows(db._conn, session_key, msgs)
+        db._conn.commit()
+    rid_b = msgs[2]["_row_id"]
+
+    live_history = [
+        {"role": "user", "content": "A"},
+        {"role": "assistant", "content": "ra"},
+        {"role": "assistant", "content": "rb"},
+        {"role": "user", "content": "B"},
+    ]
+    sess = _session(history=list(live_history), session_key=session_key)
+    sid = "misalign-role-sid"
+    server._sessions[sid] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": sid,
+                    "text": "rewind B",
+                    "truncate_before_row_id": rid_b,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is None, resp
+        # The addressed turn ("B") is dropped exactly; earlier live turns
+        # survive untouched. Before the guard, a positional zip-stamp put a
+        # user-row id on an assistant dict and the pre-guard fallback cut at
+        # a mis-aimed index. (Fresh _row_id stamps on survivors are expected —
+        # replace_messages re-inserts and re-stamps the surviving dicts.)
+        survivors = [(m["role"], m["content"]) for m in sess["history"]]
+        assert survivors == [
+            ("user", "A"),
+            ("assistant", "ra"),
+            ("assistant", "rb"),
+        ]
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_prompt_submit_row_id_db_fallback_ordinal_mapping_verifies_content(
+    monkeypatch,
+):
+    """#82959 db-fallback guard: when live/durable lengths differ, mapping the
+    durable user-ordinal onto live indices must verify the mapped turn shows
+    the durable target's content — a repaired user;user merge shifts ordinals
+    and would otherwise cut an extra turn silently.
+    """
+    replaced = []
+
+    # Durable transcript (repaired): the merge collapsed two user turns, so
+    # durable user-ordinal 1 ("second") maps onto a DIFFERENT live user turn.
+    durable_history = [
+        {"_row_id": 601, "role": "user", "content": "first\nfollow-up"},
+        {"_row_id": 603, "role": "assistant", "content": "reply 1"},
+        {"_row_id": 604, "role": "user", "content": "second"},
+        {"_row_id": 605, "role": "assistant", "content": "reply 2"},
+    ]
+    # Live memory (unrepaired, longer): user ordinal 1 here is "follow-up",
+    # NOT "second".
+    live_history = [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "follow-up"},
+        {"role": "assistant", "content": "reply 1"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "reply 2"},
+    ]
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+            replaced.append((key, list(messages)))
+
+        def get_messages_as_conversation(self, key, repair_alternation=False, include_row_ids=False):
+            return [dict(m) for m in durable_history]
+
+    sess = _session(history=list(live_history), session_key="db-fallback-verify-key")
+    sid = "db-fallback-verify-sid"
+    server._sessions[sid] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": sid,
+                    "text": "rewind to second",
+                    "truncate_before_row_id": 604,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        # Mapped live turn ("follow-up") does not match durable target
+        # ("second") — refuse instead of cutting the wrong turn.
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4018
+        assert replaced == []
+        assert len(sess["history"]) == 5
+    finally:
+        server._sessions.pop(sid, None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4622,9 +4622,6 @@ def test_prompt_submit_refuses_ordinal_and_message_id_mismatch(monkeypatch):
         server._sessions.pop("mismatch-trunc-sid", None)
 
 
-
-
-
 def test_prompt_submit_truncates_by_row_id(monkeypatch):
     """#82959: prompt.submit with truncate_before_row_id must cut at the target row id."""
     replaced = []
@@ -4706,57 +4703,6 @@ def test_prompt_submit_truncates_by_string_row_id(monkeypatch):
         assert len(sess["history"]) == 2
     finally:
         server._sessions.pop("str-row-id-trunc-sid", None)
-
-
-def test_reproduce_row_id_truncation(monkeypatch):
-    """#82959: Reproduction test for durable row_id truncation and 4030 ordinal mismatch validation."""
-    replaced = []
-
-    class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
-            replaced.append((key, list(messages)))
-
-    history = [
-        {"_row_id": 101, "role": "user", "content": "first"},
-        {"_row_id": 102, "role": "assistant", "content": "reply 1"},
-        {"_row_id": 103, "role": "user", "content": "second"},
-        {"_row_id": 104, "role": "assistant", "content": "reply 2"},
-    ]
-    server._sessions["repro-sid"] = _session(history=list(history))
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
-    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
-
-    try:
-        # 1. Target turn 2 via row_id 103
-        resp = server.handle_request({
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {
-                "session_id": "repro-sid",
-                "text": "edited second turn",
-                "truncate_before_row_id": 103,
-                "confirm_truncate": True,
-            }
-        })
-        assert resp.get("error") is None
-
-        # 2. Refuse ordinal & row_id mismatch with code 4030
-        server._sessions["mismatch-sid"] = _session(history=list(history))
-        resp_mismatch = server.handle_request({
-            "id": "2",
-            "method": "prompt.submit",
-            "params": {
-                "session_id": "mismatch-sid",
-                "text": "stale rewind",
-                "truncate_before_row_id": 103,
-                "truncate_before_user_ordinal": 0,
-                "confirm_truncate": True,
-            }
-        })
-        assert resp_mismatch["error"]["code"] == 4030
-    finally:
-        server._sessions.pop("repro-sid", None)
-        server._sessions.pop("mismatch-sid", None)
 
 
 def test_prompt_submit_refuses_ordinal_and_row_id_mismatch(monkeypatch):
@@ -4868,8 +4814,6 @@ def test_prompt_submit_row_id_ignores_platform_id_fallback(monkeypatch):
         assert resp["error"]["code"] == 4018
     finally:
         server._sessions.pop("string-id-sid", None)
-
-
 
 
 def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4542,6 +4542,336 @@ def test_prompt_submit_refuses_unconfirmed_nonempty_truncation(monkeypatch):
         server._sessions.pop("unconfirmed-trunc-sid", None)
 
 
+def test_prompt_submit_truncates_by_message_id(monkeypatch):
+    """#82756: truncate_before_message_id resolves target message and cuts history accurately."""
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"id": "msg-1", "role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+        {"id": "msg-2", "role": "user", "content": "second"},
+        {"role": "assistant", "content": "reply 2"},
+    ]
+    server._sessions["msg-id-trunc-sid"] = _session(history=list(history))
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: None
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "msg-id-trunc-sid",
+                    "text": "new turn",
+                    "truncate_before_message_id": "msg-2",
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("result") is not None
+        assert len(replaced) == 1
+        assert replaced[0][1] == history[:2]
+    finally:
+        server._sessions.pop("msg-id-trunc-sid", None)
+
+
+def test_prompt_submit_refuses_ordinal_and_message_id_mismatch(monkeypatch):
+    """#82756: A mismatch between truncate_before_user_ordinal and truncate_before_message_id must return 4030."""
+    history = [
+        {"id": "msg-1", "role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+        {"id": "msg-2", "role": "user", "content": "second"},
+        {"role": "assistant", "content": "reply 2"},
+    ]
+    server._sessions["mismatch-trunc-sid"] = _session(history=list(history))
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "mismatch-trunc-sid",
+                    "text": "new turn",
+                    "truncate_before_message_id": "msg-2",  # ordinal index 1
+                    "truncate_before_user_ordinal": 0,      # mismatch (stale 0)
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4030
+        assert "does not match" in resp["error"]["message"]
+    finally:
+        server._sessions.pop("mismatch-trunc-sid", None)
+
+
+
+
+
+def test_prompt_submit_truncates_by_row_id(monkeypatch):
+    """#82959: prompt.submit with truncate_before_row_id must cut at the target row id."""
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"_row_id": 101, "role": "user", "content": "first"},
+        {"_row_id": 102, "role": "assistant", "content": "reply 1"},
+        {"_row_id": 103, "role": "user", "content": "second"},
+        {"_row_id": 104, "role": "assistant", "content": "reply 2"},
+    ]
+    sess = _session(history=list(history))
+    server._sessions["row-id-trunc-sid"] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    started = []
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: started.append(k)
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "row-id-trunc-sid",
+                    "text": "new turn",
+                    "truncate_before_row_id": 103,
+                    "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is None
+        assert len(sess["history"]) == 2
+        assert sess["history"][-1]["content"] == "reply 1"
+        assert len(replaced) == 1
+        assert replaced[0][1] == history[:2]
+    finally:
+        server._sessions.pop("row-id-trunc-sid", None)
+
+
+def test_prompt_submit_truncates_by_string_row_id(monkeypatch):
+    """#82959: String row IDs in history match correctly against integer truncate_before_row_id."""
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"_row_id": "101", "role": "user", "content": "first"},
+        {"_row_id": "102", "role": "assistant", "content": "reply 1"},
+        {"_row_id": "103", "role": "user", "content": "second"},
+        {"_row_id": "104", "role": "assistant", "content": "reply 2"},
+    ]
+    sess = _session(history=list(history))
+    server._sessions["str-row-id-trunc-sid"] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "str-row-id-trunc-sid",
+                    "text": "new turn",
+                    "truncate_before_row_id": 103,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is None
+        assert len(sess["history"]) == 2
+    finally:
+        server._sessions.pop("str-row-id-trunc-sid", None)
+
+
+def test_reproduce_row_id_truncation(monkeypatch):
+    """#82959: Reproduction test for durable row_id truncation and 4030 ordinal mismatch validation."""
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"_row_id": 101, "role": "user", "content": "first"},
+        {"_row_id": 102, "role": "assistant", "content": "reply 1"},
+        {"_row_id": 103, "role": "user", "content": "second"},
+        {"_row_id": 104, "role": "assistant", "content": "reply 2"},
+    ]
+    server._sessions["repro-sid"] = _session(history=list(history))
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+
+    try:
+        # 1. Target turn 2 via row_id 103
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "repro-sid",
+                "text": "edited second turn",
+                "truncate_before_row_id": 103,
+                "confirm_truncate": True,
+            }
+        })
+        assert resp.get("error") is None
+
+        # 2. Refuse ordinal & row_id mismatch with code 4030
+        server._sessions["mismatch-sid"] = _session(history=list(history))
+        resp_mismatch = server.handle_request({
+            "id": "2",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "mismatch-sid",
+                "text": "stale rewind",
+                "truncate_before_row_id": 103,
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+            }
+        })
+        assert resp_mismatch["error"]["code"] == 4030
+    finally:
+        server._sessions.pop("repro-sid", None)
+        server._sessions.pop("mismatch-sid", None)
+
+
+def test_prompt_submit_refuses_ordinal_and_row_id_mismatch(monkeypatch):
+    """#82959: A mismatch between truncate_before_user_ordinal and truncate_before_row_id must return 4030."""
+    history = [
+        {"_row_id": 201, "role": "user", "content": "first"},
+        {"_row_id": 202, "role": "assistant", "content": "reply 1"},
+        {"_row_id": 203, "role": "user", "content": "second"},
+        {"_row_id": 204, "role": "assistant", "content": "reply 2"},
+    ]
+    server._sessions["row-mismatch-sid"] = _session(history=list(history))
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "row-mismatch-sid",
+                    "text": "new turn",
+                    "truncate_before_row_id": 203,  # user turn ordinal 1
+                    "truncate_before_user_ordinal": 0,  # mismatch (stale 0)
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4030
+        assert "does not match" in resp["error"]["message"]
+    finally:
+        server._sessions.pop("row-mismatch-sid", None)
+
+
+def test_prompt_submit_refuses_boolean_row_id(monkeypatch):
+    """Boolean truncate_before_row_id must return 4004."""
+    history = [
+        {"_row_id": 301, "role": "user", "content": "first"},
+        {"_row_id": 302, "role": "assistant", "content": "reply 1"},
+    ]
+    server._sessions["bool-row-sid"] = _session(history=list(history))
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "bool-row-sid",
+                    "text": "new turn",
+                    "truncate_before_row_id": True,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4004
+        assert "must be an integer" in resp["error"]["message"]
+    finally:
+        server._sessions.pop("bool-row-sid", None)
+
+
+def test_prompt_submit_row_id_not_found(monkeypatch):
+    """Unknown truncate_before_row_id must return 4018."""
+    history = [
+        {"_row_id": 401, "role": "user", "content": "first"},
+    ]
+    server._sessions["missing-row-sid"] = _session(history=list(history))
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "missing-row-sid",
+                    "text": "new turn",
+                    "truncate_before_row_id": 999,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4018
+        assert "no longer in session history" in resp["error"]["message"]
+    finally:
+        server._sessions.pop("missing-row-sid", None)
+
+
+def test_prompt_submit_row_id_ignores_platform_id_fallback(monkeypatch):
+    """truncate_before_row_id must not match string platform IDs."""
+    history = [
+        {"id": "999", "role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+    ]
+    server._sessions["string-id-sid"] = _session(history=list(history))
+    try:
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "string-id-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 999,
+                "confirm_truncate": True,
+            }
+        })
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4018
+    finally:
+        server._sessions.pop("string-id-sid", None)
+
+
+
+
 def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
     """A confirmed rewind still must not wipe a non-empty transcript by accident.
 
@@ -17061,3 +17391,288 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
         assert captured.get("active_only") is True
     finally:
         server._sessions.pop("archive-trunc-sid", None)
+
+
+def test_insert_message_rows_sets_row_id_on_fresh_dicts(tmp_path):
+    """#82959: _insert_message_rows must assign _row_id on freshly inserted message dicts."""
+    from hermes_state import SessionDB
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("fresh-msg-row-id-sid", "cli")
+    msg = {"role": "user", "content": "fresh turn without pre-existing _row_id"}
+    with db._lock:
+        db._insert_message_rows(db._conn, "fresh-msg-row-id-sid", [msg])
+    assert "_row_id" in msg, "New message dict did not receive _row_id"
+    assert isinstance(msg["_row_id"], int) and msg["_row_id"] > 0
+
+
+def test_prompt_submit_unmatched_row_id_refuses_even_with_ordinal(monkeypatch):
+    """#82959: Unknown row_id must refuse (4018), not fall back to a client ordinal."""
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"_row_id": 101, "role": "user", "content": "first"},
+        {"_row_id": 102, "role": "assistant", "content": "reply 1"},
+        {"_row_id": 103, "role": "user", "content": "second"},
+        {"_row_id": 104, "role": "assistant", "content": "reply 2"},
+    ]
+    sess = _session(history=list(history))
+    server._sessions["fallback-row-id-sid"] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        # Stale row_id 999 not in history — even with a valid ordinal, refuse.
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "fallback-row-id-sid",
+                    "text": "new turn",
+                    "truncate_before_row_id": 999,
+                    "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4018
+        assert replaced == []
+        assert len(sess["history"]) == 4
+    finally:
+        server._sessions.pop("fallback-row-id-sid", None)
+
+
+def test_prompt_submit_unmatched_message_id_refuses_even_with_ordinal(monkeypatch):
+    """#82959: Unknown message_id must refuse; no silent ordinal degradation."""
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+            replaced.append((key, list(messages)))
+
+    # Production-shaped history: no renderer "id" keys on user dicts.
+    history = [
+        {"_row_id": 201, "role": "user", "content": "first"},
+        {"_row_id": 202, "role": "assistant", "content": "reply 1"},
+        {"_row_id": 203, "role": "user", "content": "second"},
+        {"_row_id": 204, "role": "assistant", "content": "reply 2"},
+    ]
+    sess = _session(history=list(history))
+    server._sessions["synthetic-msg-id-sid"] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "synthetic-msg-id-sid",
+                    "text": "fresh start",
+                    "truncate_before_message_id": "user-1723456789-0",
+                    "truncate_before_user_ordinal": 0,
+                    "confirm_truncate": True,
+                    "confirm_empty_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4018
+        assert replaced == []
+        assert len(sess["history"]) == 4
+    finally:
+        server._sessions.pop("synthetic-msg-id-sid", None)
+
+
+def test_prompt_submit_row_id_resolves_via_db_when_memory_lacks_stamps(monkeypatch):
+    """#82959: After turn rewrite strips _row_id, resolve against durable DB history."""
+    replaced = []
+    # Live memory after turn completion: provider-format, no _row_id stamps.
+    live_history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "reply 2"},
+    ]
+    durable_history = [
+        {"_row_id": 501, "role": "user", "content": "first"},
+        {"_row_id": 502, "role": "assistant", "content": "reply 1"},
+        {"_row_id": 503, "role": "user", "content": "second"},
+        {"_row_id": 504, "role": "assistant", "content": "reply 2"},
+    ]
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+            replaced.append((key, list(messages)))
+
+        def get_messages_as_conversation(self, key, repair_alternation=False, include_row_ids=False):
+            assert include_row_ids is True
+            return list(durable_history)
+
+    sess = _session(history=list(live_history), session_key="db-row-key")
+    server._sessions["db-row-resolve-sid"] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "db-row-resolve-sid",
+                    "text": "new turn",
+                    "truncate_before_row_id": 503,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is None, resp
+        assert len(sess["history"]) == 2
+        assert sess["history"][-1]["content"] == "reply 1"
+        assert len(replaced) == 1
+        # Healing: live list should now carry stamps for subsequent rewinds.
+        assert sess["history"][0].get("_row_id") == 501
+    finally:
+        server._sessions.pop("db-row-resolve-sid", None)
+
+
+def test_prompt_submit_row_id_real_sessiondb_resolve_without_memory_stamps(
+    monkeypatch, tmp_path
+):
+    """#82959 production path: real SessionDB insert → live history without
+    _row_id (turn rewrite) → truncate_before_row_id cuts durable + memory.
+
+    No hand-seeded ids and no MagicMock state manager — the contract that
+    #82766 review said unit fixtures must exercise.
+    """
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "rowid-trunc.db")
+    session_key = "real-db-row-trunc"
+    db.create_session(session_key, "cli")
+    msgs = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "reply 2"},
+        {"role": "user", "content": "third"},
+        {"role": "assistant", "content": "reply 3"},
+    ]
+    with db._lock:
+        db._insert_message_rows(db._conn, session_key, msgs)
+        db._conn.commit()
+    row_ids = [m["_row_id"] for m in msgs]
+    assert all(isinstance(r, int) and r > 0 for r in row_ids)
+
+    # After turn completion gateway rewrites history as provider-format dicts
+    # without _row_id — production-shaped live memory.
+    live_history = [{"role": m["role"], "content": m["content"]} for m in msgs]
+    assert all("_row_id" not in m for m in live_history)
+
+    sess = _session(history=list(live_history), session_key=session_key)
+    sid = "real-db-row-trunc-sid"
+    server._sessions[sid] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
+
+    try:
+        # Cut before second user turn (row_ids[2]) — leave first exchange only.
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": sid,
+                    "text": "rewound second",
+                    "truncate_before_row_id": row_ids[2],
+                    "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is None, resp
+        assert len(sess["history"]) == 2
+        assert sess["history"][0]["content"] == "first"
+        assert sess["history"][1]["content"] == "reply 1"
+        # Durable active transcript matches the cut (archive_dropped keeps
+        # inactive rows; get_messages_as_conversation returns active only).
+        active = db.get_messages_as_conversation(session_key)
+        assert len(active) == 2
+        assert active[0]["content"] == "first"
+        assert active[1]["content"] == "reply 1"
+        # Heal stamps for subsequent rewinds when memory lined up with DB.
+        assert sess["history"][0].get("_row_id") is not None
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_prompt_submit_row_id_real_sessiondb_unknown_refuses_despite_ordinal(
+    monkeypatch, tmp_path
+):
+    """#82959 fail-closed: unknown row_id + valid ordinal must not truncate
+    real SessionDB (the mass-delete class when durable id cannot resolve).
+    """
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "rowid-refuse.db")
+    session_key = "real-db-row-refuse"
+    db.create_session(session_key, "cli")
+    msgs = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "reply 2"},
+    ]
+    with db._lock:
+        db._insert_message_rows(db._conn, session_key, msgs)
+        db._conn.commit()
+
+    live_history = [{"role": m["role"], "content": m["content"]} for m in msgs]
+    sess = _session(history=list(live_history), session_key=session_key)
+    sid = "real-db-row-refuse-sid"
+    server._sessions[sid] = sess
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    n_before = len(db.get_messages_as_conversation(session_key))
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": sid,
+                    "text": "stale durable id",
+                    "truncate_before_row_id": 999_999_999,
+                    "truncate_before_user_ordinal": 0,
+                    "confirm_truncate": True,
+                    "confirm_empty_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4018
+        assert len(sess["history"]) == 4
+        assert len(db.get_messages_as_conversation(session_key)) == n_before
+    finally:
+        server._sessions.pop(sid, None)
+
+
+

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -349,6 +349,10 @@ def _(rid, params: dict) -> dict:
         # claim so this prompt starts normally instead of being stranded in a
         # queue whose drain already ran.
 
+    # Filled when this submit performed a truncation against a durable session:
+    # the fresh post-rewrite row ids of the surviving user turns, for client
+    # rowId rebinding (see comment at the assignment site).
+    survivor_user_row_ids = None
     with session["history_lock"]:
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
@@ -586,6 +590,22 @@ def _(rid, params: dict) -> dict:
                     )
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            if db is not None:
+                # replace_messages re-inserted the surviving prefix as NEW rows
+                # and stamped fresh _row_id values onto these same dicts.
+                # Surface the surviving user-turn ids (in visible-user-ordinal
+                # order) so the client can rebind its cached rowId stamps —
+                # otherwise a second rewind targeting an older surviving turn
+                # sends the pre-rewind id and the fail-closed resolver refuses
+                # it with 4018 (#83202 review: consecutive-rewind staleness).
+                # Ordinal order matches the client's visible-user filter the
+                # same way truncate ordinals already do. Entries are None when
+                # a row somehow has no stamp — the client must drop its cached
+                # id for that turn rather than keep a stale one.
+                survivor_user_row_ids = [
+                    _message_row_id(truncated[i])
+                    for i in _history_user_indices(truncated)
+                ]
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
@@ -594,6 +614,13 @@ def _(rid, params: dict) -> dict:
     if turn_isolation:
         isolated_response = _submit_prompt_to_compute_host(rid, sid, session, text)
         if not isolated_response.get("error"):
+            if survivor_user_row_ids is not None:
+                # The truncation already happened inline above (memory + DB),
+                # before compute-host dispatch — the rebind payload applies to
+                # this path exactly as it does to the inline one.
+                isolated_response["result"][
+                    "survivor_user_row_ids"
+                ] = survivor_user_row_ids
             return isolated_response
         logger.warning(
             "compute-host dispatch failed for session %s; falling back inline: %s",
@@ -678,7 +705,17 @@ def _(rid, params: dict) -> dict:
     # `running` flag (a turn that died without clearing it) and recover the latter.
     session["_run_thread"] = run_thread
     run_thread.start()
-    return _ok(rid, {"status": "streaming"})
+    return _ok(
+        rid,
+        {
+            "status": "streaming",
+            **(
+                {"survivor_user_row_ids": survivor_user_row_ids}
+                if survivor_user_row_ids is not None
+                else {}
+            ),
+        },
+    )
 
 
 @method("clipboard.paste")

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -155,19 +155,19 @@ def _resolve_truncate_row_id(session: dict, history: list, target_row_id: int):
     return db_ord, mem_idx
 
 
-def _coerce_truncate_ordinal(rid, value):
-    """Return ``(ordinal, error_response)`` for a client-supplied ordinal.
+def _coerce_truncate_int(rid, value, param_name="truncate_before_user_ordinal"):
+    """Return ``(int_value, error_response)`` for a client-supplied integer param.
 
     bool is an int subclass: a JSON ``true`` would coerce via int() to
-    ordinal 1 and aim a confirmed rewind at the second user turn — refuse it
-    like any other non-integer.
+    1 and aim a confirmed rewind at the wrong turn — refuse it like any
+    other non-integer.
     """
     if isinstance(value, bool):
-        return None, _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
+        return None, _err(rid, 4004, f"{param_name} must be an integer")
     try:
         return int(value), None
     except (TypeError, ValueError):
-        return None, _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
+        return None, _err(rid, 4004, f"{param_name} must be an integer")
 
 
 def _reconcile_client_ordinal(rid, sid, client_ordinal, msg_ordinal, param_name, target_repr):
@@ -180,7 +180,7 @@ def _reconcile_client_ordinal(rid, sid, client_ordinal, msg_ordinal, param_name,
     """
     if client_ordinal is None:
         return msg_ordinal, None
-    ordinal, err = _coerce_truncate_ordinal(rid, client_ordinal)
+    ordinal, err = _coerce_truncate_int(rid, client_ordinal)
     if err is not None:
         return None, err
     if ordinal != msg_ordinal:
@@ -380,26 +380,60 @@ def _(rid, params: dict) -> dict:
             or truncate_row_id is not None
         ):
             history = session.get("history", [])
+
+            # Malformed params refuse first (4004), regardless of consent —
+            # the historical ordinal-path precedence.
+            target_row_id = None
+            if truncate_row_id is not None:
+                target_row_id, err = _coerce_truncate_int(
+                    rid, truncate_row_id, "truncate_before_row_id"
+                )
+                if err is not None:
+                    return err
+            client_ordinal = None
+            if truncate_user_ordinal is not None:
+                client_ordinal, err = _coerce_truncate_int(rid, truncate_user_ordinal)
+                if err is not None:
+                    return err
+
+            # An ordinal/id alone is not consent. A client that carries a leftover
+            # ordinal into an ORDINARY submit sends a request that is
+            # indistinguishable, field by field, from a real rewind — same
+            # method, same shape, an in-range target — and the cut it asks for
+            # is a destructive replace_messages() the user never requested
+            # (#80763: 296 -> 52 messages, 244 durable rows gone). Only the
+            # client knows whether this submit is a rewind/edit/regenerate, so
+            # it has to say so; refuse the cut when it doesn't. Consent is
+            # checked BEFORE target resolution: an unconfirmed (leaked-state)
+            # request must refuse with 4029 without paying the durable
+            # transcript read or heal-stamping live history dicts that
+            # row-id resolution performs.
+            if not is_truthy_value(params.get("confirm_truncate")):
+                logger.warning(
+                    "prompt.submit: REFUSED unconfirmed truncation of session %s "
+                    "(%d messages held; ordinal=%s, row_id=%s, message_id=%s). "
+                    "The client attached truncation parameters without "
+                    "confirm_truncate — likely stale truncation parameters on "
+                    "an ordinary submit.",
+                    sid,
+                    len(history),
+                    client_ordinal,
+                    target_row_id,
+                    truncate_message_id,
+                )
+                return _err(
+                    rid,
+                    4029,
+                    "truncation parameters require confirm_truncate=true; "
+                    "an ordinary prompt.submit must not drop session history "
+                    "(update your Hermes client if a rewind was intended)",
+                )
+
             user_indices = _history_user_indices(history)
 
             ordinal = None
 
-            if truncate_row_id is not None:
-                if isinstance(truncate_row_id, bool):
-                    return _err(
-                        rid,
-                        4004,
-                        "truncate_before_row_id must be an integer",
-                    )
-                try:
-                    target_row_id = int(truncate_row_id)
-                except (TypeError, ValueError):
-                    return _err(
-                        rid,
-                        4004,
-                        "truncate_before_row_id must be an integer",
-                    )
-
+            if target_row_id is not None:
                 # Durable address first — never degrade a missing row_id into a
                 # client ordinal cut (#82959 / #82766 review). Unknown id refuses
                 # without touching data; stale ordinal with a *resolved* row_id
@@ -407,8 +441,6 @@ def _(rid, params: dict) -> dict:
                 found_match = _resolve_truncate_row_id(
                     session, history, target_row_id
                 )
-                # user_indices may have been healed with _row_id stamps
-                user_indices = _history_user_indices(history)
 
                 if found_match is None:
                     logger.warning(
@@ -425,7 +457,7 @@ def _(rid, params: dict) -> dict:
 
                 msg_ordinal, _ = found_match
                 ordinal, err = _reconcile_client_ordinal(
-                    rid, sid, truncate_user_ordinal, msg_ordinal,
+                    rid, sid, client_ordinal, msg_ordinal,
                     "truncate_before_row_id", target_row_id,
                 )
                 if err is not None:
@@ -457,49 +489,14 @@ def _(rid, params: dict) -> dict:
 
                 msg_ordinal, _ = found_match
                 ordinal, err = _reconcile_client_ordinal(
-                    rid, sid, truncate_user_ordinal, msg_ordinal,
+                    rid, sid, client_ordinal, msg_ordinal,
                     "truncate_before_message_id", msg_id_str,
                 )
                 if err is not None:
                     return err
             else:
-                ordinal, err = _coerce_truncate_ordinal(rid, truncate_user_ordinal)
-                if err is not None:
-                    return err
+                ordinal = client_ordinal
 
-                if ordinal < 0 or ordinal >= len(user_indices):
-                    return _err(
-                        rid,
-                        4018,
-                        "target user message is no longer in session history",
-                    )
-
-            # An ordinal/id alone is not consent. A client that carries a leftover
-            # ordinal into an ORDINARY submit sends a request that is
-            # indistinguishable, field by field, from a real rewind — same
-            # method, same shape, an in-range target — and the cut it asks for
-            # is a destructive replace_messages() the user never requested
-            # (#80763: 296 -> 52 messages, 244 durable rows gone). Only the
-            # client knows whether this submit is a rewind/edit/regenerate, so
-            # it has to say so; refuse the cut when it doesn't.
-            if not is_truthy_value(params.get("confirm_truncate")):
-                logger.warning(
-                    "prompt.submit: REFUSED unconfirmed truncation of session %s "
-                    "(%d messages held; ordinal=%d). The client attached "
-                    "truncation parameter without confirm_truncate — "
-                    "likely stale truncation parameters on an ordinary submit.",
-                    sid,
-                    len(history),
-                    ordinal,
-                )
-                return _err(
-                    rid,
-                    4029,
-                    "truncation parameters require confirm_truncate=true; "
-                    "an ordinary prompt.submit must not drop session history "
-                    "(update your Hermes client if a rewind was intended)",
-                )
-            user_indices = _history_user_indices(history)
             # Reject out-of-range ordinals on BOTH ends. A negative value would
             # otherwise sail past the upper-bound check and hit Python's negative
             # indexing below (user_indices[-1] -> the LAST user turn), silently
@@ -1341,7 +1338,7 @@ def register(server) -> None:
         _mem_db_pair_agrees,
         _find_user_turn_by_row_id,
         _resolve_truncate_row_id,
-        _coerce_truncate_ordinal,
+        _coerce_truncate_int,
         _reconcile_client_ordinal,
         _pending_reaction_notes,
     ):

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -13,13 +13,107 @@ method = _registry.method
 _profile_scoped = _registry.profile_scoped
 
 
+def _history_user_indices(history: list) -> list:
+    """Indices of model-visible user turns (excludes display_kind timeline markers)."""
+    return [
+        i
+        for i, m in enumerate(history)
+        if m.get("role") == "user" and not m.get("display_kind")
+    ]
+
+
+def _message_row_id(msg: dict):
+    """Parse durable SQLite row id from a history entry, or None."""
+    raw = msg.get("_row_id")
+    if raw is None:
+        raw = msg.get("row_id")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _find_user_turn_by_row_id(history: list, target_row_id: int):
+    """Return ``(user_ordinal, history_index)`` for ``target_row_id``, or None."""
+    for u_ord, h_idx in enumerate(_history_user_indices(history)):
+        if _message_row_id(history[h_idx]) == target_row_id:
+            return u_ord, h_idx
+    return None
+
+
+def _resolve_truncate_row_id(session: dict, history: list, target_row_id: int):
+    """Resolve ``truncate_before_row_id`` to ``(user_ordinal, history_index)``.
+
+    Prefer in-memory ``_row_id`` / ``row_id`` stamps. When a live turn rewrote
+    ``session["history"]`` without stamps (provider-format messages), load the
+    session's durable transcript with ``include_row_ids=True`` and map the
+    matched user-turn ordinal onto the live list. Does **not** fall back to a
+    client-supplied ordinal — unknown row ids must refuse (#82959).
+    """
+    hit = _find_user_turn_by_row_id(history, target_row_id)
+    if hit is not None:
+        return hit
+
+    session_key = str(session.get("session_key") or "")
+    if not session_key:
+        return None
+
+    try:
+        db = _get_db()
+    except Exception:
+        db = None
+    if db is None:
+        return None
+
+    get_conv = getattr(db, "get_messages_as_conversation", None)
+    if not callable(get_conv):
+        return None
+
+    try:
+        db_history = get_conv(
+            session_key, repair_alternation=True, include_row_ids=True
+        )
+    except Exception:
+        logger.debug(
+            "prompt.submit: failed loading DB history for row_id %s session %s",
+            target_row_id,
+            session_key,
+            exc_info=True,
+        )
+        return None
+
+    if not isinstance(db_history, list):
+        return None
+
+    # Heal missing in-memory stamps when the live list still lines up 1:1 with
+    # the durable transcript (common after turn-completion rewrites).
+    if len(db_history) == len(history):
+        for mem, db_msg in zip(history, db_history):
+            db_rid = _message_row_id(db_msg) if isinstance(db_msg, dict) else None
+            if db_rid is not None and _message_row_id(mem) is None:
+                mem["_row_id"] = db_rid
+        hit = _find_user_turn_by_row_id(history, target_row_id)
+        if hit is not None:
+            return hit
+
+    db_hit = _find_user_turn_by_row_id(db_history, target_row_id)
+    if db_hit is None:
+        return None
+    db_ord, _ = db_hit
+    mem_user_indices = _history_user_indices(history)
+    if db_ord < 0 or db_ord >= len(mem_user_indices):
+        return None
+    return db_ord, mem_user_indices[db_ord]
+
+
 def _pending_reaction_notes(session: dict) -> str:
     """Note block describing reactions the user added since the last turn, or "".
 
     Applied to the MODEL INPUT only (``run_message``, beside the
     speech-interrupted note) — never to the text that gets persisted. Prefixing
-    the persisted prompt bakes scaffolding into the transcript, which every
-    surface then renders as a garbled user message on reload. Each reaction is
+    the persisted prompt bakes scaffolding into the transcript. Each reaction is
     announced once — the row is stamped ``seen`` on read.
     """
     session_key = str(session.get("session_key") or "")
@@ -118,7 +212,12 @@ def _(rid, params: dict) -> dict:
     # in turn: a stale "hud" would tell the model the user is still floating
     # over another app when they are back in Hermes.
     session["client_surface"] = "hud" if params.get("surface") == "hud" else ""
-    if truncate_user_ordinal is not None and isinstance(text, str):
+    has_truncation = (
+        truncate_user_ordinal is not None
+        or params.get("truncate_before_row_id") is not None
+        or params.get("truncate_before_message_id") is not None
+    )
+    if has_truncation and isinstance(text, str):
         # A rewind/regenerate replays a turn from what the transcript shows. A
         # skill turn shows its invocation, so re-expand it here — otherwise
         # re-running `/work fix it` sends the agent nine literal characters
@@ -162,27 +261,189 @@ def _(rid, params: dict) -> dict:
         # the upgrade resumes the child's transcript as a normal conversation.
         if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
-        # confirm_truncate with no target is malformed: the flag is consent for
-        # a specific cut, and a client that sends it bare has leaked rewind
-        # state onto an ordinary submit (#82756). Fail fast instead of quietly
-        # ignoring the flag so the broken client state is surfaced.
-        if is_truthy_value(params.get("confirm_truncate")) and truncate_user_ordinal is None:
+        truncate_message_id = params.get("truncate_before_message_id")
+        truncate_row_id = params.get("truncate_before_row_id")
+        if (
+            is_truthy_value(params.get("confirm_truncate"))
+            and truncate_user_ordinal is None
+            and truncate_message_id is None
+            and truncate_row_id is None
+        ):
             return _err(
                 rid,
                 4004,
-                "confirm_truncate requires truncate_before_user_ordinal",
+                "confirm_truncate requires truncate_before_user_ordinal, truncate_before_message_id, or truncate_before_row_id",
             )
-        if truncate_user_ordinal is not None:
-            # bool is an int subclass: a JSON `true` would coerce via int() to
-            # ordinal 1 and aim a confirmed rewind at the second user turn.
-            if isinstance(truncate_user_ordinal, bool):
-                return _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
-            try:
-                ordinal = int(truncate_user_ordinal)
-            except (TypeError, ValueError):
-                return _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
+        if (
+            truncate_user_ordinal is not None
+            or truncate_message_id is not None
+            or truncate_row_id is not None
+        ):
             history = session.get("history", [])
-            # An ordinal alone is not consent. A client that carries a leftover
+            user_indices = _history_user_indices(history)
+
+            target_idx = None
+            ordinal = None
+
+            if truncate_row_id is not None:
+                if isinstance(truncate_row_id, bool):
+                    return _err(
+                        rid,
+                        4004,
+                        "truncate_before_row_id must be an integer",
+                    )
+                try:
+                    target_row_id = int(truncate_row_id)
+                except (TypeError, ValueError):
+                    return _err(
+                        rid,
+                        4004,
+                        "truncate_before_row_id must be an integer",
+                    )
+
+                # Durable address first — never degrade a missing row_id into a
+                # client ordinal cut (#82959 / #82766 review). Unknown id refuses
+                # without touching data; stale ordinal with a *resolved* row_id
+                # is a separate 4030 mismatch below.
+                found_match = _resolve_truncate_row_id(
+                    session, history, target_row_id
+                )
+                # user_indices may have been healed with _row_id stamps
+                user_indices = _history_user_indices(history)
+
+                if found_match is None:
+                    logger.warning(
+                        "prompt.submit: target row_id %d not found for session %s "
+                        "(in-memory + durable); refusing truncation without fallback",
+                        target_row_id,
+                        sid,
+                    )
+                    return _err(
+                        rid,
+                        4018,
+                        "target user message is no longer in session history",
+                    )
+
+                msg_ordinal, target_idx = found_match
+
+                if truncate_user_ordinal is not None:
+                    if isinstance(truncate_user_ordinal, bool):
+                        return _err(
+                            rid,
+                            4004,
+                            "truncate_before_user_ordinal must be an integer",
+                        )
+                    try:
+                        ordinal = int(truncate_user_ordinal)
+                    except (TypeError, ValueError):
+                        return _err(
+                            rid,
+                            4004,
+                            "truncate_before_user_ordinal must be an integer",
+                        )
+                    if ordinal != msg_ordinal:
+                        logger.warning(
+                            "prompt.submit: REFUSED truncation due to ordinal mismatch for session %s "
+                            "(ordinal=%d, row_id_ordinal=%d, row_id=%d). "
+                            "Stale truncate_before_user_ordinal detected.",
+                            sid,
+                            ordinal,
+                            msg_ordinal,
+                            target_row_id,
+                        )
+                        return _err(
+                            rid,
+                            4030,
+                            f"truncate_before_user_ordinal ({ordinal}) does not match "
+                            f"truncate_before_row_id target turn ({msg_ordinal})",
+                        )
+                else:
+                    ordinal = msg_ordinal
+            elif truncate_message_id is not None:
+                msg_id_str = str(truncate_message_id)
+                found_match = None
+                for u_ord, h_idx in enumerate(user_indices):
+                    msg = history[h_idx]
+                    if msg.get("id") == msg_id_str or msg.get("message_id") == msg_id_str:
+                        found_match = (u_ord, h_idx)
+                        break
+
+                if found_match is None:
+                    # Fail closed: a supplied message_id that does not resolve
+                    # must not fall back to a (possibly stale) ordinal. Desktop
+                    # clients should send truncate_before_row_id instead.
+                    logger.warning(
+                        "prompt.submit: target message_id %s not found in history "
+                        "for session %s; refusing truncation without fallback",
+                        msg_id_str,
+                        sid,
+                    )
+                    return _err(
+                        rid,
+                        4018,
+                        "target user message is no longer in session history",
+                    )
+
+                msg_ordinal, target_idx = found_match
+
+                if truncate_user_ordinal is not None:
+                    if isinstance(truncate_user_ordinal, bool):
+                        return _err(
+                            rid,
+                            4004,
+                            "truncate_before_user_ordinal must be an integer",
+                        )
+                    try:
+                        ordinal = int(truncate_user_ordinal)
+                    except (TypeError, ValueError):
+                        return _err(
+                            rid,
+                            4004,
+                            "truncate_before_user_ordinal must be an integer",
+                        )
+                    if ordinal != msg_ordinal:
+                        logger.warning(
+                            "prompt.submit: REFUSED truncation due to ordinal mismatch for session %s "
+                            "(ordinal=%d, message_id_ordinal=%d, message_id=%s). "
+                            "Stale truncate_before_user_ordinal detected.",
+                            sid,
+                            ordinal,
+                            msg_ordinal,
+                            msg_id_str,
+                        )
+                        return _err(
+                            rid,
+                            4030,
+                            f"truncate_before_user_ordinal ({ordinal}) does not match "
+                            f"truncate_before_message_id target turn ({msg_ordinal})",
+                        )
+                else:
+                    ordinal = msg_ordinal
+            else:
+                if isinstance(truncate_user_ordinal, bool):
+                    return _err(
+                        rid,
+                        4004,
+                        "truncate_before_user_ordinal must be an integer",
+                    )
+                try:
+                    ordinal = int(truncate_user_ordinal)
+                except (TypeError, ValueError):
+                    return _err(
+                        rid,
+                        4004,
+                        "truncate_before_user_ordinal must be an integer",
+                    )
+
+                if ordinal < 0 or ordinal >= len(user_indices):
+                    return _err(
+                        rid,
+                        4018,
+                        "target user message is no longer in session history",
+                    )
+                target_idx = user_indices[ordinal]
+
+            # An ordinal/id alone is not consent. A client that carries a leftover
             # ordinal into an ORDINARY submit sends a request that is
             # indistinguishable, field by field, from a real rewind — same
             # method, same shape, an in-range target — and the cut it asks for
@@ -194,8 +455,8 @@ def _(rid, params: dict) -> dict:
                 logger.warning(
                     "prompt.submit: REFUSED unconfirmed truncation of session %s "
                     "(%d messages held; ordinal=%d). The client attached "
-                    "truncate_before_user_ordinal without confirm_truncate — "
-                    "likely a stale ordinal on an ordinary submit.",
+                    "truncation parameter without confirm_truncate — "
+                    "likely stale truncation parameters on an ordinary submit.",
                     sid,
                     len(history),
                     ordinal,
@@ -203,7 +464,7 @@ def _(rid, params: dict) -> dict:
                 return _err(
                     rid,
                     4029,
-                    "truncate_before_user_ordinal requires confirm_truncate=true; "
+                    "truncation parameters require confirm_truncate=true; "
                     "an ordinary prompt.submit must not drop session history "
                     "(update your Hermes client if a rewind was intended)",
                 )
@@ -1010,12 +1271,24 @@ def register(server) -> None:
     """Bind this module's handlers onto ``server``'s globals and registry."""
     _registry.install(server)
     # Module-level helpers aren't @method handlers, so install() doesn't see
-    # them — but server.py's run path calls this one (run_message enrichment,
-    # beside the speech-interrupted note). Rebind and publish it the same way.
-    server._pending_reaction_notes = types.FunctionType(
-        _pending_reaction_notes.__code__,
-        vars(server),
-        _pending_reaction_notes.__name__,
-        _pending_reaction_notes.__defaults__,
-        _pending_reaction_notes.__closure__,
-    )
+    # them. Rebind onto server globals so handler bodies (and server.py call
+    # sites) resolve the same free names after the split.
+    g = vars(server)
+    for helper in (
+        _history_user_indices,
+        _message_row_id,
+        _find_user_turn_by_row_id,
+        _resolve_truncate_row_id,
+        _pending_reaction_notes,
+    ):
+        setattr(
+            server,
+            helper.__name__,
+            types.FunctionType(
+                helper.__code__,
+                g,
+                helper.__name__,
+                helper.__defaults__,
+                helper.__closure__,
+            ),
+        )

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -35,6 +35,35 @@ def _message_row_id(msg: dict):
         return None
 
 
+def _mem_db_pair_agrees(mem, db_msg) -> bool:
+    """True when a live-memory entry plausibly corresponds to a durable row.
+
+    Positional trust across the live and durable lists needs evidence, not
+    just equal lengths/ordinals: roles must match, display-marker status must
+    match (a marker living only on one side shifts every later position), and
+    an addressable user turn must show the same text. Non-string (multimodal)
+    content can't be compared cheaply — role/marker agreement suffices there.
+    Self-contained on builtins: register() rebinds callers onto server
+    globals, so any helper this calls must be in that namespace too.
+    """
+    if not isinstance(mem, dict) or not isinstance(db_msg, dict):
+        return False
+    if mem.get("role") != db_msg.get("role"):
+        return False
+    if bool(mem.get("display_kind")) != bool(db_msg.get("display_kind")):
+        return False
+    if mem.get("role") == "user" and not mem.get("display_kind"):
+        mem_content = mem.get("content")
+        db_content = db_msg.get("content")
+        if (
+            isinstance(mem_content, str)
+            and isinstance(db_content, str)
+            and mem_content.strip() != db_content.strip()
+        ):
+            return False
+    return True
+
+
 def _find_user_turn_by_row_id(history: list, target_row_id: int):
     """Return ``(user_ordinal, history_index)`` for ``target_row_id``, or None."""
     for u_ord, h_idx in enumerate(_history_user_indices(history)):
@@ -88,8 +117,18 @@ def _resolve_truncate_row_id(session: dict, history: list, target_row_id: int):
         return None
 
     # Heal missing in-memory stamps when the live list still lines up 1:1 with
-    # the durable transcript (common after turn-completion rewrites).
-    if len(db_history) == len(history):
+    # the durable transcript (common after turn-completion rewrites). Equal
+    # length alone is NOT proof of alignment: the durable copy above is loaded
+    # with repair_alternation=True (which can merge/drop rows) while the live
+    # list is unrepaired, and memory can carry optimistic/marker rows — so the
+    # two can coincide in length while position-shifted. A positional stamp on
+    # a misaligned pair is sticky and re-aims every later rewind at the wrong
+    # durable row. Stamp only when EVERY pair agrees (all-or-nothing): roles
+    # must match on every pair, and addressable user turns must match content.
+    if len(db_history) == len(history) and all(
+        _mem_db_pair_agrees(mem, db_msg)
+        for mem, db_msg in zip(history, db_history)
+    ):
         for mem, db_msg in zip(history, db_history):
             db_rid = _message_row_id(db_msg) if isinstance(db_msg, dict) else None
             if db_rid is not None and _message_row_id(mem) is None:
@@ -101,11 +140,19 @@ def _resolve_truncate_row_id(session: dict, history: list, target_row_id: int):
     db_hit = _find_user_turn_by_row_id(db_history, target_row_id)
     if db_hit is None:
         return None
-    db_ord, _ = db_hit
+    db_ord, db_idx = db_hit
     mem_user_indices = _history_user_indices(history)
     if db_ord < 0 or db_ord >= len(mem_user_indices):
         return None
-    return db_ord, mem_user_indices[db_ord]
+    mem_idx = mem_user_indices[db_ord]
+    # Same-ordinal mapping across two lists that can diverge (the repaired
+    # durable copy may have merged a user;user pair, shifting every later
+    # user ordinal). Trust the mapping only when the mapped live turn shows
+    # the same content as the durable target — otherwise refuse (the caller
+    # returns fail-closed 4018) rather than cut the wrong turn (#82959).
+    if not _mem_db_pair_agrees(history[mem_idx], db_history[db_idx]):
+        return None
+    return db_ord, mem_idx
 
 
 def _pending_reaction_notes(session: dict) -> str:
@@ -1277,6 +1324,7 @@ def register(server) -> None:
     for helper in (
         _history_user_indices,
         _message_row_id,
+        _mem_db_pair_agrees,
         _find_user_turn_by_row_id,
         _resolve_truncate_row_id,
         _pending_reaction_notes,

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -155,6 +155,55 @@ def _resolve_truncate_row_id(session: dict, history: list, target_row_id: int):
     return db_ord, mem_idx
 
 
+def _coerce_truncate_ordinal(rid, value):
+    """Return ``(ordinal, error_response)`` for a client-supplied ordinal.
+
+    bool is an int subclass: a JSON ``true`` would coerce via int() to
+    ordinal 1 and aim a confirmed rewind at the second user turn — refuse it
+    like any other non-integer.
+    """
+    if isinstance(value, bool):
+        return None, _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
+    try:
+        return int(value), None
+    except (TypeError, ValueError):
+        return None, _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
+
+
+def _reconcile_client_ordinal(rid, sid, client_ordinal, msg_ordinal, param_name, target_repr):
+    """Cross-check a client ordinal against a resolved durable target.
+
+    Returns ``(ordinal, error_response)``: the target's ordinal when the
+    client sent none or agreed, else the 4004/4030 refusal. A stale ordinal
+    alongside a *resolved* durable id is the #82756 drift class — refuse
+    rather than guess which address the user meant.
+    """
+    if client_ordinal is None:
+        return msg_ordinal, None
+    ordinal, err = _coerce_truncate_ordinal(rid, client_ordinal)
+    if err is not None:
+        return None, err
+    if ordinal != msg_ordinal:
+        logger.warning(
+            "prompt.submit: REFUSED truncation due to ordinal mismatch for session %s "
+            "(ordinal=%d, %s_ordinal=%d, %s=%s). "
+            "Stale truncate_before_user_ordinal detected.",
+            sid,
+            ordinal,
+            param_name,
+            msg_ordinal,
+            param_name,
+            target_repr,
+        )
+        return None, _err(
+            rid,
+            4030,
+            f"truncate_before_user_ordinal ({ordinal}) does not match "
+            f"{param_name} target turn ({msg_ordinal})",
+        )
+    return ordinal, None
+
+
 def _pending_reaction_notes(session: dict) -> str:
     """Note block describing reactions the user added since the last turn, or "".
 
@@ -329,7 +378,6 @@ def _(rid, params: dict) -> dict:
             history = session.get("history", [])
             user_indices = _history_user_indices(history)
 
-            target_idx = None
             ordinal = None
 
             if truncate_row_id is not None:
@@ -371,41 +419,13 @@ def _(rid, params: dict) -> dict:
                         "target user message is no longer in session history",
                     )
 
-                msg_ordinal, target_idx = found_match
-
-                if truncate_user_ordinal is not None:
-                    if isinstance(truncate_user_ordinal, bool):
-                        return _err(
-                            rid,
-                            4004,
-                            "truncate_before_user_ordinal must be an integer",
-                        )
-                    try:
-                        ordinal = int(truncate_user_ordinal)
-                    except (TypeError, ValueError):
-                        return _err(
-                            rid,
-                            4004,
-                            "truncate_before_user_ordinal must be an integer",
-                        )
-                    if ordinal != msg_ordinal:
-                        logger.warning(
-                            "prompt.submit: REFUSED truncation due to ordinal mismatch for session %s "
-                            "(ordinal=%d, row_id_ordinal=%d, row_id=%d). "
-                            "Stale truncate_before_user_ordinal detected.",
-                            sid,
-                            ordinal,
-                            msg_ordinal,
-                            target_row_id,
-                        )
-                        return _err(
-                            rid,
-                            4030,
-                            f"truncate_before_user_ordinal ({ordinal}) does not match "
-                            f"truncate_before_row_id target turn ({msg_ordinal})",
-                        )
-                else:
-                    ordinal = msg_ordinal
+                msg_ordinal, _ = found_match
+                ordinal, err = _reconcile_client_ordinal(
+                    rid, sid, truncate_user_ordinal, msg_ordinal,
+                    "truncate_before_row_id", target_row_id,
+                )
+                if err is not None:
+                    return err
             elif truncate_message_id is not None:
                 msg_id_str = str(truncate_message_id)
                 found_match = None
@@ -431,56 +451,17 @@ def _(rid, params: dict) -> dict:
                         "target user message is no longer in session history",
                     )
 
-                msg_ordinal, target_idx = found_match
-
-                if truncate_user_ordinal is not None:
-                    if isinstance(truncate_user_ordinal, bool):
-                        return _err(
-                            rid,
-                            4004,
-                            "truncate_before_user_ordinal must be an integer",
-                        )
-                    try:
-                        ordinal = int(truncate_user_ordinal)
-                    except (TypeError, ValueError):
-                        return _err(
-                            rid,
-                            4004,
-                            "truncate_before_user_ordinal must be an integer",
-                        )
-                    if ordinal != msg_ordinal:
-                        logger.warning(
-                            "prompt.submit: REFUSED truncation due to ordinal mismatch for session %s "
-                            "(ordinal=%d, message_id_ordinal=%d, message_id=%s). "
-                            "Stale truncate_before_user_ordinal detected.",
-                            sid,
-                            ordinal,
-                            msg_ordinal,
-                            msg_id_str,
-                        )
-                        return _err(
-                            rid,
-                            4030,
-                            f"truncate_before_user_ordinal ({ordinal}) does not match "
-                            f"truncate_before_message_id target turn ({msg_ordinal})",
-                        )
-                else:
-                    ordinal = msg_ordinal
+                msg_ordinal, _ = found_match
+                ordinal, err = _reconcile_client_ordinal(
+                    rid, sid, truncate_user_ordinal, msg_ordinal,
+                    "truncate_before_message_id", msg_id_str,
+                )
+                if err is not None:
+                    return err
             else:
-                if isinstance(truncate_user_ordinal, bool):
-                    return _err(
-                        rid,
-                        4004,
-                        "truncate_before_user_ordinal must be an integer",
-                    )
-                try:
-                    ordinal = int(truncate_user_ordinal)
-                except (TypeError, ValueError):
-                    return _err(
-                        rid,
-                        4004,
-                        "truncate_before_user_ordinal must be an integer",
-                    )
+                ordinal, err = _coerce_truncate_ordinal(rid, truncate_user_ordinal)
+                if err is not None:
+                    return err
 
                 if ordinal < 0 or ordinal >= len(user_indices):
                     return _err(
@@ -488,7 +469,6 @@ def _(rid, params: dict) -> dict:
                         4018,
                         "target user message is no longer in session history",
                     )
-                target_idx = user_indices[ordinal]
 
             # An ordinal/id alone is not consent. A client that carries a leftover
             # ordinal into an ORDINARY submit sends a request that is
@@ -515,10 +495,7 @@ def _(rid, params: dict) -> dict:
                     "an ordinary prompt.submit must not drop session history "
                     "(update your Hermes client if a rewind was intended)",
                 )
-            user_indices = [
-                i for i, m in enumerate(history)
-                if m.get("role") == "user" and not m.get("display_kind")
-            ]
+            user_indices = _history_user_indices(history)
             # Reject out-of-range ordinals on BOTH ends. A negative value would
             # otherwise sail past the upper-bound check and hit Python's negative
             # indexing below (user_indices[-1] -> the LAST user turn), silently
@@ -1327,6 +1304,8 @@ def register(server) -> None:
         _mem_db_pair_agrees,
         _find_user_turn_by_row_id,
         _resolve_truncate_row_id,
+        _coerce_truncate_ordinal,
+        _reconcile_client_ordinal,
         _pending_reaction_notes,
     ):
         setattr(

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -456,7 +456,9 @@ def _(rid, params: dict) -> dict:
                 # history becomes the resumed session record's working conversation),
                 # so heal a durable ``user;user`` violation once here instead of
                 # re-firing the pre-request repair on every subsequent turn.
-                history = db.get_messages_as_conversation(target, repair_alternation=True)
+                history = db.get_messages_as_conversation(
+                    target, repair_alternation=True, include_row_ids=True
+                )
             except Exception as e:
                 if lease is not None:
                     lease.release()

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -70,6 +70,8 @@ A rewind / edit / regenerate is a `prompt.submit` that drops part of the stored 
 
 A truncation parameter without `confirm_truncate` is refused with code `4004` or `4029` and nothing is written. Hosts that implement rewind must set the flag at the moment the user asks for it, and must never keep truncation parameters in state across ordinary submits. Prefer `truncate_before_row_id` (from resume `row_id` / `_row_id`) over ordinals; keep the ordinal as a back-compat / optimistic-row path only when no durable id is available yet.
 
+On a successful truncating submit against a durable session, the `prompt.submit` result additionally carries `survivor_user_row_ids` — the fresh post-rewrite row IDs of the surviving user turns, in visible-user-ordinal order. The rewrite re-inserts the kept prefix as new rows, so every row ID the host cached before the rewind is stale afterward; rebind cached IDs from this list (a `null` entry means that turn has no durable ID — drop the cached one) or the next rewind targeting an older surviving turn will be refused with `4018`.
+
 ### Events streamed back
 
 `message.delta`, `message.complete`, `tool.start`, `tool.progress`, `tool.complete`, `approval.request`, `clarify.request`, `sudo.request`, `sudo.expire`, `secret.request`, `secret.expire`, `gateway.ready`, plus session lifecycle and error events. Expiry events carry the original `{ request_id }`; external hosts should clear only the matching pending prompt.

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -64,10 +64,11 @@ A rewind / edit / regenerate is a `prompt.submit` that drops part of the stored 
 | Parameter | Meaning |
 |-----------|---------|
 | `truncate_before_user_ordinal` | Zero-based index of the user turn to cut at. Everything from that turn onward is dropped. Display-only timeline rows (`display_kind`) are not counted. Must be a real integer — a JSON boolean is refused with code `4004`. |
-| `confirm_truncate` | Required whenever an ordinal is sent. Declares that this submit really is a rewind, not an ordinary send that happens to carry a leftover ordinal. Sending it without an ordinal is refused with code `4004` (leaked rewind state). |
+| `truncate_before_row_id` | Integer SQLite row ID (`messages.id` / `row_id`) of the target user turn to cut at. Preferred durable address. When both ordinal and row ID are provided, gateway verifies they match (returning `4030` on mismatch). An unknown/stale row ID is refused with `4018` — it does **not** fall back to the ordinal. |
+| `confirm_truncate` | Required whenever an ordinal, message ID, or row ID is sent. Declares that this submit really is a rewind, not an ordinary send that happens to carry leftover parameters. Sending it without a target is refused with code `4004`. |
 | `confirm_empty_truncate` | Additionally required when the cut would leave the transcript empty (ordinal `0`). |
 
-An ordinal without `confirm_truncate` is refused with code `4029` and nothing is written. Hosts that implement rewind must set the flag at the moment the user asks for it, and must never keep the ordinal in state across ordinary submits.
+A truncation parameter without `confirm_truncate` is refused with code `4004` or `4029` and nothing is written. Hosts that implement rewind must set the flag at the moment the user asks for it, and must never keep truncation parameters in state across ordinary submits. Prefer `truncate_before_row_id` (from resume `row_id` / `_row_id`) over ordinals; keep the ordinal as a back-compat / optimistic-row path only when no durable id is available yet.
 
 ### Events streamed back
 


### PR DESCRIPTION
## Summary

Salvage of #83202 by @StanleyStetson (authorship preserved via cherry-pick): durable SQLite `row_id` addressing for rewind/edit/regenerate truncation (#82959), plus two review follow-ups — an alignment guard that closes a mis-aimed-cut hole in the PR's DB heal/fallback path, and a dedup/cleanup pass.

## What the salvaged PR does (commit 1, @StanleyStetson)

Rewinds target a stable `messages.id` (`truncate_before_row_id`) instead of a drift-prone user-turn ordinal:

- Gateway resolves the id against in-memory `_row_id`/`row_id` stamps, then the durable transcript (`include_row_ids=True`) when a live turn rewrote history without stamps.
- Unknown row id / message id refuses with **4018** — never falls back to a client ordinal (fail-closed).
- Ordinal + row id disagreement refuses with **4030**.
- `_insert_message_rows` stamps `msg["_row_id"] = cur.lastrowid`, so fresh persists and post-rewind survivors carry durable ids (consecutive rewinds keep resolving).
- Desktop sends `truncate_before_row_id` from `ChatMessage.rowId`, filters renderer-synthetic message ids, and drops the silent "failed targeted edit → untruncated resend" fallback.
- Covers all three pitfalls catalogued in #82959 from the failed #82766 attempt.

## Review follow-ups (commits 2-4, ours)

**fix: verify memory/durable alignment before trusting position.** The heal path zip-stamped `_row_id` onto live dicts purely by position whenever the durable and live lists had equal length, and the DB fallback mapped durable user-ordinals onto live indices with only a bounds check. Equal length isn't proof of alignment: the durable copy is loaded with `repair_alternation=True` (merges `user;user`, collapses consecutive assistants) while live memory is unrepaired and can carry optimistic/marker rows. Real-`SessionDB` E2E probes during review showed a wrong-content cut (kept the very turn the user rewound past) and a persisted alternation break — and a misaligned stamp is sticky, re-aiming every later rewind. `_mem_db_pair_agrees()` now gates both paths (role + display-marker + user-turn content agreement, all-or-nothing stamping; ordinal fallback verifies the mapped turn's content or refuses via the existing 4018). Regression tests derived from the probes; the guards fail on the pre-fix code (mutation-checked).

**refactor: dedupe target validation.** The ordinal bool-check/coercion block was duplicated 3×, the 4030 mismatch block 2× (~90 lines); `target_idx` was dead (4 writes, 0 reads); a stale inline user-indices comprehension duplicated the new `_history_user_indices` helper; `test_reproduce_row_id_truncation` was a weaker subset of two adjacent tests. Behavior-preserving — error codes/messages byte-identical.

**style:** stray semicolons in `rewind.ts`.

## Validation

| Check | Result |
|---|---|
| `tests/test_tui_gateway_server.py` (full file) | 549 passed |
| + `test_message_reactions.py` + `test_compression_rotation_state.py` | 578 passed (1 pre-existing ordering flake deselected; fails identically on main, passes in isolation) |
| Desktop vitest (`rewind.test.ts` + `index.test.tsx`) | 109 passed |
| Real-`SessionDB` E2E probes (happy path, fail-closed, 4030, misalignment 4a, re-stamp) | all safe post-fix; 4a flipped UNSAFE→PASS |
| Mutation check (revert fix, re-run guards) | content-swap + db-fallback tests fail on pre-fix code |
| ruff | clean |

Prompt-cache safety verified: the single production payload builder clones and pops `_row_id` before the wire (pre-existing); no transcript writer serializes raw history dicts.

## Deferred (noted, not blocking)

`runRewindSubmit`'s positional params (`truncateOrdinal`/`truncateRowId` both `number | undefined`, sibling wrappers with different orders) would be safer as an options object — call sites are correct today; filed as a follow-up candidate rather than widening this salvage.

## Credit

Based on #83202 by @StanleyStetson — commit cherry-picked with authorship preserved. Direction from #82959 (@RichardGuan1's #82756 proposal + the #82766/#82950 review chain).

Closes #83202. Fixes #82959.
