### PR TITLE
fix(web): serialize provider client initialization

### DIFF
--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
 # :mod:`tools.web_tools` so tests that do ``tools.web_tools._exa_client =
 # None`` between cases see fresh state. The plugin reads/writes through
 # that public module (see :func:`_get_exa_client`).
+_client_lock = threading.Lock()
 
 
 def _get_exa_client() -> Any:
@@ -51,30 +53,35 @@ def _get_exa_client() -> Any:
     if cached is not None:
         return cached
 
-    from agent.web_search_provider import get_provider_env
+    with _client_lock:
+        cached = getattr(_wt, "_exa_client", None)
+        if cached is not None:
+            return cached
 
-    api_key = get_provider_env("EXA_API_KEY")
-    if not api_key:
-        raise ValueError(
-            "EXA_API_KEY environment variable not set. "
-            "Get your API key at https://exa.ai"
-        )
+        from agent.web_search_provider import get_provider_env
 
-    try:
-        from tools.lazy_deps import ensure as _lazy_ensure
+        api_key = get_provider_env("EXA_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "EXA_API_KEY environment variable not set. "
+                "Get your API key at https://exa.ai"
+            )
 
-        _lazy_ensure("search.exa", prompt=False)
-    except ImportError:
-        pass
-    except Exception as exc:  # noqa: BLE001 — lazy_deps surfaces install hints
-        raise ImportError(str(exc))
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
 
-    from exa_py import Exa  # noqa: WPS433 — deliberately lazy
+            _lazy_ensure("search.exa", prompt=False)
+        except ImportError:
+            pass
+        except Exception as exc:  # noqa: BLE001 — lazy_deps surfaces install hints
+            raise ImportError(str(exc))
 
-    client = Exa(api_key=api_key)
-    client.headers["x-exa-integration"] = "hermes-agent"
-    _wt._exa_client = client
-    return client
+        from exa_py import Exa  # noqa: WPS433 — deliberately lazy
+
+        client = Exa(api_key=api_key)
+        client.headers["x-exa-integration"] = "hermes-agent"
+        _wt._exa_client = client
+        return client
 
 
 def _reset_client_for_tests() -> None:

--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -49,6 +49,8 @@ def _get_exa_client() -> Any:
     """
     import tools.web_tools as _wt
 
+    # Intentionally lock-free after publication; the slow path double-checks
+    # under the lock before constructing the singleton.
     cached = getattr(_wt, "_exa_client", None)
     if cached is not None:
         return cached
@@ -88,7 +90,8 @@ def _reset_client_for_tests() -> None:
     """Drop the cached Exa client so tests can re-instantiate cleanly."""
     import tools.web_tools as _wt
 
-    _wt._exa_client = None
+    with _client_lock:
+        _wt._exa_client = None
 
 
 class ExaWebSearchProvider(WebSearchProvider):

--- a/plugins/web/parallel/provider.py
+++ b/plugins/web/parallel/provider.py
@@ -43,7 +43,6 @@ logger = logging.getLogger(__name__)
 # The plugin reads/writes through that public module (see
 # :func:`_get_sync_client` / :func:`_get_async_client`).
 _sync_client_lock = threading.Lock()
-_async_client_lock = threading.Lock()
 
 
 def _ensure_parallel_sdk_installed() -> None:
@@ -72,6 +71,8 @@ def _get_sync_client() -> Any:
     """
     import tools.web_tools as _wt
 
+    # Intentionally lock-free after publication; the slow path double-checks
+    # under the lock before constructing the singleton.
     cached = getattr(_wt, "_parallel_client", None)
     if cached is not None:
         return cached
@@ -109,26 +110,21 @@ def _get_async_client() -> Any:
     if cached is not None:
         return cached
 
-    with _async_client_lock:
-        cached = getattr(_wt, "_async_parallel_client", None)
-        if cached is not None:
-            return cached
+    from agent.web_search_provider import get_provider_env
 
-        from agent.web_search_provider import get_provider_env
+    api_key = get_provider_env("PARALLEL_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "PARALLEL_API_KEY environment variable not set. "
+            "Get your API key at https://parallel.ai"
+        )
 
-        api_key = get_provider_env("PARALLEL_API_KEY")
-        if not api_key:
-            raise ValueError(
-                "PARALLEL_API_KEY environment variable not set. "
-                "Get your API key at https://parallel.ai"
-            )
+    _ensure_parallel_sdk_installed()
+    from parallel import AsyncParallel  # noqa: WPS433 — deliberately lazy
 
-        _ensure_parallel_sdk_installed()
-        from parallel import AsyncParallel  # noqa: WPS433 — deliberately lazy
-
-        client = AsyncParallel(api_key=api_key)
-        _wt._async_parallel_client = client
-        return client
+    client = AsyncParallel(api_key=api_key)
+    _wt._async_parallel_client = client
+    return client
 
 
 def _reset_clients_for_tests() -> None:
@@ -139,7 +135,8 @@ def _reset_clients_for_tests() -> None:
     """
     import tools.web_tools as _wt
 
-    _wt._parallel_client = None
+    with _sync_client_lock:
+        _wt._parallel_client = None
     _wt._async_parallel_client = None
 
 

--- a/plugins/web/parallel/provider.py
+++ b/plugins/web/parallel/provider.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
@@ -41,6 +42,8 @@ logger = logging.getLogger(__name__)
 # ``tools.web_tools._parallel_client = None`` between cases see fresh state.
 # The plugin reads/writes through that public module (see
 # :func:`_get_sync_client` / :func:`_get_async_client`).
+_sync_client_lock = threading.Lock()
+_async_client_lock = threading.Lock()
 
 
 def _ensure_parallel_sdk_installed() -> None:
@@ -73,21 +76,26 @@ def _get_sync_client() -> Any:
     if cached is not None:
         return cached
 
-    from agent.web_search_provider import get_provider_env
+    with _sync_client_lock:
+        cached = getattr(_wt, "_parallel_client", None)
+        if cached is not None:
+            return cached
 
-    api_key = get_provider_env("PARALLEL_API_KEY")
-    if not api_key:
-        raise ValueError(
-            "PARALLEL_API_KEY environment variable not set. "
-            "Get your API key at https://parallel.ai"
-        )
+        from agent.web_search_provider import get_provider_env
 
-    _ensure_parallel_sdk_installed()
-    from parallel import Parallel  # noqa: WPS433 — deliberately lazy
+        api_key = get_provider_env("PARALLEL_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "PARALLEL_API_KEY environment variable not set. "
+                "Get your API key at https://parallel.ai"
+            )
 
-    client = Parallel(api_key=api_key)
-    _wt._parallel_client = client
-    return client
+        _ensure_parallel_sdk_installed()
+        from parallel import Parallel  # noqa: WPS433 — deliberately lazy
+
+        client = Parallel(api_key=api_key)
+        _wt._parallel_client = client
+        return client
 
 
 def _get_async_client() -> Any:
@@ -101,21 +109,26 @@ def _get_async_client() -> Any:
     if cached is not None:
         return cached
 
-    from agent.web_search_provider import get_provider_env
+    with _async_client_lock:
+        cached = getattr(_wt, "_async_parallel_client", None)
+        if cached is not None:
+            return cached
 
-    api_key = get_provider_env("PARALLEL_API_KEY")
-    if not api_key:
-        raise ValueError(
-            "PARALLEL_API_KEY environment variable not set. "
-            "Get your API key at https://parallel.ai"
-        )
+        from agent.web_search_provider import get_provider_env
 
-    _ensure_parallel_sdk_installed()
-    from parallel import AsyncParallel  # noqa: WPS433 — deliberately lazy
+        api_key = get_provider_env("PARALLEL_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "PARALLEL_API_KEY environment variable not set. "
+                "Get your API key at https://parallel.ai"
+            )
 
-    client = AsyncParallel(api_key=api_key)
-    _wt._async_parallel_client = client
-    return client
+        _ensure_parallel_sdk_installed()
+        from parallel import AsyncParallel  # noqa: WPS433 — deliberately lazy
+
+        client = AsyncParallel(api_key=api_key)
+        _wt._async_parallel_client = client
+        return client
 
 
 def _reset_clients_for_tests() -> None:

--- a/tests/plugins/web/test_provider_client_concurrency.py
+++ b/tests/plugins/web/test_provider_client_concurrency.py
@@ -34,17 +34,6 @@ from plugins.web.parallel import provider as parallel_provider
             id="parallel-sync",
         ),
         pytest.param(
-            parallel_provider,
-            "_async_client_lock",
-            "_get_async_client",
-            "_async_parallel_client",
-            "PARALLEL_API_KEY",
-            "parallel",
-            "AsyncParallel",
-            False,
-            id="parallel-async",
-        ),
-        pytest.param(
             exa_provider,
             "_client_lock",
             "_get_exa_client",

--- a/tests/plugins/web/test_provider_client_concurrency.py
+++ b/tests/plugins/web/test_provider_client_concurrency.py
@@ -1,0 +1,133 @@
+from concurrent.futures import ThreadPoolExecutor
+import sys
+import threading
+import types
+
+import pytest
+
+import tools.web_tools as web_tools
+from plugins.web.exa import provider as exa_provider
+from plugins.web.parallel import provider as parallel_provider
+
+
+@pytest.mark.parametrize(
+    (
+        "provider_module",
+        "lock_name",
+        "getter_name",
+        "cache_name",
+        "env_name",
+        "sdk_module_name",
+        "constructor_name",
+        "needs_headers",
+    ),
+    [
+        pytest.param(
+            parallel_provider,
+            "_sync_client_lock",
+            "_get_sync_client",
+            "_parallel_client",
+            "PARALLEL_API_KEY",
+            "parallel",
+            "Parallel",
+            False,
+            id="parallel-sync",
+        ),
+        pytest.param(
+            parallel_provider,
+            "_async_client_lock",
+            "_get_async_client",
+            "_async_parallel_client",
+            "PARALLEL_API_KEY",
+            "parallel",
+            "AsyncParallel",
+            False,
+            id="parallel-async",
+        ),
+        pytest.param(
+            exa_provider,
+            "_client_lock",
+            "_get_exa_client",
+            "_exa_client",
+            "EXA_API_KEY",
+            "exa_py",
+            "Exa",
+            True,
+            id="exa",
+        ),
+    ],
+)
+def test_concurrent_first_use_constructs_one_client(
+    monkeypatch,
+    provider_module,
+    lock_name,
+    getter_name,
+    cache_name,
+    env_name,
+    sdk_module_name,
+    constructor_name,
+    needs_headers,
+):
+    workers = 8
+    callers_ready = threading.Barrier(workers, timeout=5)
+    release_constructor = threading.Event()
+    state_changed = threading.Condition()
+    lock_attempts = [0]
+    constructed = []
+
+    class ObservedLock:
+        def __init__(self):
+            self._lock = threading.Lock()
+
+        def __enter__(self):
+            with state_changed:
+                lock_attempts[0] += 1
+                state_changed.notify_all()
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, *_args):
+            self._lock.release()
+
+    def constructor(*_args, **_kwargs):
+        client = types.SimpleNamespace(headers={}) if needs_headers else object()
+        with state_changed:
+            constructed.append(client)
+            state_changed.notify_all()
+        assert release_constructor.wait(timeout=5)
+        return client
+
+    sdk_module = types.ModuleType(sdk_module_name)
+    setattr(sdk_module, constructor_name, constructor)
+    monkeypatch.setitem(sys.modules, sdk_module_name, sdk_module)
+    monkeypatch.setenv(env_name, "test-key")
+    monkeypatch.setattr(web_tools, cache_name, None)
+    monkeypatch.setattr(provider_module, lock_name, ObservedLock())
+    if provider_module is parallel_provider:
+        monkeypatch.setattr(
+            parallel_provider, "_ensure_parallel_sdk_installed", lambda: None
+        )
+    else:
+        from tools import lazy_deps
+
+        monkeypatch.setattr(lazy_deps, "ensure", lambda *_args, **_kwargs: None)
+
+    getter = getattr(provider_module, getter_name)
+
+    def get_client(_index):
+        callers_ready.wait()
+        return getter()
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(get_client, index) for index in range(workers)]
+        with state_changed:
+            reached_boundary = state_changed.wait_for(
+                lambda: lock_attempts[0] == workers or len(constructed) == workers,
+                timeout=5,
+            )
+        release_constructor.set()
+        returned = [future.result(timeout=5) for future in futures]
+
+    assert reached_boundary
+    assert len(constructed) == 1
+    assert all(client is returned[0] for client in returned)


### PR DESCRIPTION
## What does this PR do?

Prevents concurrent first-use calls from constructing and leaking duplicate **synchronous** Parallel and Exa SDK clients.

Addresses the sync Parallel and Exa portions of #24736. The loop-affine `AsyncParallel` lifecycle is intentionally excluded and handled by #87168.

## Root cause

The two synchronous lazy getters read their canonical cache slots on `tools.web_tools`, constructed a client without synchronization, and then published it. A barrier reproduction on current main made simultaneous callers construct duplicate clients on both paths.

The provider migration moved these getters out of `tools/web_tools.py`, so synchronization belongs in the canonical modules under `plugins/web/parallel` and `plugins/web/exa`.

## Changes

- add independent first-initialization locks for sync Parallel and Exa clients
- double-check each shared compatibility cache after acquiring its lock
- keep credential lookup, lazy SDK setup, client construction, and Exa header setup inside the serialized initialization boundary
- acquire the same locks in test reset helpers so reset cannot race publication
- retain lock-free post-publication reads, documented at the fast path
- add deterministic eight-caller regressions for both constructors; each proves one construction and one returned object identity without timing sleeps

## Async ownership

This PR does not change `_get_async_client()` relative to current main and no longer asserts that `AsyncParallel` should be a process-wide singleton. `AsyncParallel` owns an HTTPX transport with event-loop affinity, so #87168 gives each extraction its own client and closes it on the loop that used it.

## Validation

- provider/config matrix: 108 passed
- adjacent extraction and session-hygiene suites: 17 passed
- two constructor-contention regressions repeated 25 times: 50 parameterized cases passed
- `ruff check` on all changed Python files
- `ruff format --check` on the new test
- `uv lock --check`
- `git diff --check`
- contribution publish gate and gitleaks: passed

## Overlap and attribution

This is the current-main refresh invited by closed PR #24741 from @wesleysimplicio. That PR identified the original races before the provider migration. The current implementation preserves the valid sync-client direction at the canonical provider owners. Thanks to @goslingmanagment for identifying the distinct async loop-ownership invariant and implementing it in #87168.
