### PR TITLE
fix(tools): block messaging-platform writes to execution-trusting roots

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import functools
 import os
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -23,6 +25,195 @@ def _hermes_root_path() -> Path:
         return get_default_hermes_root()
     except Exception:
         return Path(os.path.expanduser("~/.hermes"))
+
+
+# Messaging-platform write guard (#83787): blocks file-tool writes into
+# execution-trusting roots (cron/, scripts/) of the active home and every
+# sibling profile (incl. the default root) when the session is a messaging
+# platform. Messaging sessions may retain other execution surfaces
+# (config-dependent), so toolset filtering alone is not a boundary; this is
+# defense-in-depth, not a security boundary for sessions that keep
+# terminal/browser/code-execution tools.
+
+_WIN_EXTENDED_PREFIXES = ("\\\\?\\", "\\.\\", "\\??\\")
+
+
+def _messaging_platform_from_key() -> Optional[str]:
+    """Messaging-platform token of the current session, or None.
+
+    Read from the gateway session key (``agent[:<profile>]:<platform>:...``)
+    and validated against ``gateway.config.Platform``. None for malformed or
+    unregistered keys and LOCAL; api_server is a messaging platform.
+    """
+    try:
+        from tools.approval import get_current_session_key
+    except Exception:
+        return None
+    try:
+        key = get_current_session_key()
+    except Exception:
+        return None
+    if not key or not key.startswith("agent:"):
+        return None
+    parts = key.split(":")
+    if len(parts) < 3:
+        return None
+    try:
+        from gateway.config import Platform
+        member = Platform(parts[2])
+    except Exception:
+        return None
+    if member is Platform.LOCAL:
+        return None
+    return member.value
+
+
+def _volume_is_case_insensitive(directory: str) -> bool:
+    """True when the volume treats case variants as one file (inode check).
+
+    Read-only probe; any failure returns False (a case-sensitive volume must
+    never be over-blocked).
+    """
+    try:
+        p = Path(os.path.realpath(directory))
+        probe = p.parent / (p.name.swapcase() if p.name else "")
+        st = os.stat(p)
+        st_variant = os.stat(probe)
+    except (OSError, ValueError, RuntimeError):
+        return False
+    return st.st_ino == st_variant.st_ino and st.st_dev == st_variant.st_dev
+
+
+@functools.lru_cache(maxsize=1)
+def _darwin_case_insensitive() -> bool:
+    """Cached per-process darwin case-sensitivity of the active-home volume."""
+    try:
+        from hermes_constants import get_hermes_home
+        home_parent = str(Path(get_hermes_home()).parent)
+    except Exception:
+        home_parent = str(Path(os.path.expanduser("~/.hermes")).parent)
+    return _volume_is_case_insensitive(home_parent)
+
+
+def _normalize_guard_path(path: str) -> str:
+    """Normalize a path for guard-prefix comparison (symmetric with prefixes).
+
+    Windows: strip extended-length prefixes + normcase. macOS: casefold only
+    on case-insensitive volumes. POSIX: unchanged.
+    """
+    if os.name == "nt":
+        for prefix in _WIN_EXTENDED_PREFIXES:
+            if path.startswith(prefix):
+                path = path[len(prefix):]
+                break
+        return os.path.normcase(path).replace("\\", "/")
+    if sys.platform == "darwin" and _darwin_case_insensitive():
+        return path.casefold()
+    return path
+
+
+def _execution_trusting_prefixes() -> tuple[str, ...]:
+    """Execution-trusting write roots of all live Hermes homes (per call).
+
+    Follows get_hermes_home() (context override -> env -> default) plus the
+    process env home, the shared default root, and every <root>/profiles/*
+    sibling — a session in any profile must not plant payloads in another
+    profile's roots. Never frozen at import (custom HERMES_HOME, per-profile,
+    Windows default all covered).
+    """
+    try:
+        from hermes_constants import (
+            get_default_hermes_root,
+            get_hermes_home,
+            get_process_hermes_home,
+        )
+    except Exception:  # pragma: no cover - resolution chain unavailable
+        raw_homes = {os.path.expanduser("~/.hermes")}
+    else:
+        raw_homes = {str(get_hermes_home()), str(get_process_hermes_home())}
+        # Cover every sibling profile + the default root: each profile
+        # gateway executes its own cron/ and scripts/ as the same OS user,
+        # and the cross-profile soft guard (skills/plugins/cron/memories
+        # only, bypassable via cross_profile=True) does not cover scripts/.
+        try:
+            root = str(get_default_hermes_root())
+            raw_homes.add(root)
+            profiles_dir = os.path.join(root, "profiles")
+            if os.path.isdir(profiles_dir):
+                for name in sorted(os.listdir(profiles_dir)):
+                    if name.startswith("."):
+                        continue
+                    candidate = os.path.join(profiles_dir, name)
+                    if os.path.isdir(candidate):
+                        raw_homes.add(candidate)
+        except OSError:  # pragma: no cover - enumeration is best-effort
+            pass
+    # Keep raw + resolved spellings of each home: writes through either land
+    # in the same physical directory (e.g. macOS /var -> /private/var).
+    homes: set[str] = set()
+    for home in raw_homes:
+        homes.add(home)
+        try:
+            homes.add(str(Path(home).resolve()))
+        except (OSError, ValueError, RuntimeError):  # pragma: no cover
+            pass
+    prefixes = [
+        os.path.join(home, root)
+        for home in homes
+        for root in ("cron", "scripts")
+    ]
+    return tuple(prefixes)
+
+
+def get_messaging_write_block_error(path: str, task_id: str = "default") -> str | None:
+    """Block file-tool writes from messaging sessions into execution-trusting roots.
+
+    Returns an error when *path* targets the active home's or any sibling
+    profile's cron/ or scripts/ and the session is a messaging platform;
+    None otherwise. Canonicalizes
+    through the existing parent (symlink/junction-safe); the caller resolves
+    the raw argument (task-cwd aware). task_id is reserved.
+    """
+    platform = _messaging_platform_from_key()
+    if platform is None:
+        return None
+    prefixes = tuple(
+        _normalize_guard_path(p) for p in _execution_trusting_prefixes()
+    )
+    if not prefixes:
+        return None
+    # Normalize all candidates with the same function as the prefixes, so a
+    # prefix/candidate mismatch cannot fail open.
+    candidates = [os.path.normpath(os.path.expanduser(path))]
+    try:
+        resolved = str(Path(path).expanduser().resolve(strict=False))
+        if resolved not in candidates:
+            candidates.append(resolved)
+    except (OSError, ValueError, RuntimeError):
+        pass
+    try:
+        p = Path(path).expanduser()
+        parent = p.parent
+        if parent.exists():
+            canonical = str(parent.resolve(strict=True) / p.name)
+            if canonical not in candidates:
+                candidates.append(canonical)
+    except (OSError, ValueError, RuntimeError):
+        pass
+    candidates = [_normalize_guard_path(c) for c in candidates]
+
+    for prefix in prefixes:
+        for candidate in candidates:
+            if candidate == prefix or candidate.startswith(prefix + "/"):
+                return (
+                    f"Access denied: write to {path} targets an "
+                    "execution-trusting path (cron/, scripts/) of a Hermes "
+                    f"home and is not allowed from a {platform} platform "
+                    "session. Complete the change from a local (CLI/desktop) "
+                    "session instead. (Defense-in-depth — not a security "
+                    "boundary; the terminal tool can still bypass.)"
+                )
+    return None
 
 
 def build_write_denied_paths(home: str) -> set[str]:

--- a/tests/agent/test_file_safety_messaging_write.py
+++ b/tests/agent/test_file_safety_messaging_write.py
@@ -1,0 +1,681 @@
+"""Tests for the session-scoped messaging write guard (agent.file_safety).
+
+Messaging-platform sessions are denied writes to the execution-trusting
+roots (cron/, scripts/) of the active home and every sibling profile.
+Cross-platform logic runs
+unmarked on every lane (Windows conventions via real ntpath + shim, darwin
+seam via simulated probe); native behavior runs in windows_only /
+macos_only lanes per tests-os.yml doctrine.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ntpath
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import hermes_constants
+from agent import file_safety
+from tools.approval import reset_current_session_key, set_current_session_key
+from tools.file_tools import (
+    _check_sensitive_path,
+    _resolve_path_for_task,
+    write_file_tool,
+    patch_tool,
+)
+
+# Windows extended-length prefixes accepted by the OS (stripped by the
+# guard's Windows normalization).
+_WIN_EXTENDED_PREFIXES = ("\\\\?\\", "\\.\\", "\\??\\")
+
+
+@contextlib.contextmanager
+def _bind_key(key: str):
+    token = set_current_session_key(key)
+    try:
+        yield
+    finally:
+        reset_current_session_key(token)
+
+
+@contextlib.contextmanager
+def _default_home():
+    """Simulate the POSIX default home (~/.hermes) on every platform."""
+    with patch.dict(os.environ, {"HERMES_HOME": ""}), \
+            patch.object(
+                hermes_constants, "_get_platform_default_hermes_home",
+                return_value=Path.home() / ".hermes",
+            ):
+        yield
+
+
+def _win_case_normalize(path: str) -> str:
+    """Windows case/separator semantics, using the real ntpath primitives."""
+    for prefix in _WIN_EXTENDED_PREFIXES:
+        if path.startswith(prefix):
+            path = path[len(prefix):]
+            break
+    return ntpath.normcase(path).replace("\\", "/")
+
+
+@contextlib.contextmanager
+def _win_semantics():
+    """Run the guard with Windows normalization semantics on any host."""
+    with patch("agent.file_safety._normalize_guard_path",
+               side_effect=_win_case_normalize):
+        yield
+
+
+class _FakeSys:
+    """Minimal sys stand-in forcing the Darwin branch of the seam."""
+
+    def __init__(self):
+        self.platform = "darwin"
+
+    def __getattr__(self, name):
+        raise AttributeError(name)
+
+
+@contextlib.contextmanager
+def _darwin_simulated(case_sensitive: bool):
+    """Simulate the Darwin case-sensitivity seam on any host.
+
+    Forces the darwin gate + a deterministic volume-probe answer, with the
+    default home in a temp dir on a stable volume (the /var -> /private/var
+    symlink would defeat the resolved/casefolded prefix match).
+    """
+    base = os.path.dirname(os.path.abspath(os.curdir))
+    with tempfile.TemporaryDirectory(dir=base) as tmp, \
+            patch.dict(os.environ, {"HERMES_HOME": tmp}), \
+            patch.object(file_safety, "sys", _FakeSys()), \
+            patch.object(file_safety, "_darwin_case_insensitive",
+                         return_value=not case_sensitive), \
+            patch("hermes_constants._get_platform_default_hermes_home",
+                  return_value=Path(tmp)):
+        file_safety._darwin_case_insensitive.cache_clear()
+        os.makedirs(os.path.join(tmp, "scripts"), exist_ok=True)
+        # On the simulated case-insensitive volume the case variant
+        # resolves to the same dir; create it so the probe/test path is
+        # plausible on every host (a real CI volume has the variant as the
+        # same inode).
+        if not case_sensitive:
+            os.makedirs(os.path.join(tmp, "SCRIPTS"), exist_ok=True)
+        yield tmp
+
+
+class TestSessionPlatform(unittest.TestCase):
+    def test_gateway_key_parses_platform(self):
+        with _bind_key("agent:main:telegram:dm:123"):
+            self.assertEqual(
+                file_safety._messaging_platform_from_key(), "telegram"
+            )
+
+    def test_named_profile_gateway_key(self):
+        with _bind_key("agent:example-profile:discord:g:9"):
+            self.assertEqual(
+                file_safety._messaging_platform_from_key(), "discord"
+            )
+
+    def test_unregistered_platform_token_is_none(self):
+        with _bind_key("agent:main:not_a_real_platform:dm:1"):
+            self.assertIsNone(file_safety._messaging_platform_from_key())
+
+    def test_local_platform_is_none(self):
+        with _bind_key("agent:main:local:dm:1"):
+            self.assertIsNone(file_safety._messaging_platform_from_key())
+
+    def test_api_server_platform_is_messaging_like(self):
+        # API-server sessions bind api_server keys and are non-terminal,
+        # non-interactive — the guard treats them like messaging surfaces
+        # (they cannot approve or reason around the write).
+        with _bind_key("agent:main:api_server:r:1"):
+            self.assertEqual(
+                file_safety._messaging_platform_from_key(), "api_server"
+            )
+
+    def test_malformed_key_is_none(self):
+        with _bind_key("agent:main"):
+            self.assertIsNone(file_safety._messaging_platform_from_key())
+
+    def test_cli_key_has_no_platform(self):
+        with _bind_key("default"):
+            self.assertIsNone(file_safety._messaging_platform_from_key())
+        with _bind_key("20260811_093018_2cb019f0"):
+            self.assertIsNone(file_safety._messaging_platform_from_key())
+
+    def test_no_key_binds_none(self):
+        self.assertIsNone(file_safety._messaging_platform_from_key())
+
+
+class TestMessagingWriteGuard(unittest.TestCase):
+    def test_telegram_cron_write_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            err = file_safety.get_messaging_write_block_error(
+                "~/.hermes/cron/jobs.json"
+            )
+            self.assertIsNotNone(err)
+            self.assertIn("Access denied", err)
+            self.assertIn("telegram", err)
+
+    def test_telegram_scripts_write_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    "~/.hermes/scripts/evil.sh"
+                )
+            )
+
+    def test_telegram_unrelated_paths_allowed(self):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    "/tmp/note.md"
+                )
+            )
+            # Non-execution hermes paths (logs, etc.) remain writable
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    "~/.hermes/logs/app.log"
+                )
+            )
+
+    def test_cli_never_blocked(self):
+        with _bind_key("default"), _default_home():
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    "~/.hermes/cron/jobs.json"
+                )
+            )
+        with _bind_key("20260811_093018_2cb019f0"), _default_home():
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    "~/.hermes/scripts/x.sh"
+                )
+            )
+
+    def test_unregistered_platform_not_blocked(self):
+        with _bind_key("agent:main:not_a_real_platform:dm:1"), _default_home():
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    "~/.hermes/cron/jobs.json"
+                )
+            )
+
+    def test_local_platform_not_blocked(self):
+        with _bind_key("agent:main:local:dm:1"), _default_home():
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    "~/.hermes/cron/jobs.json"
+                )
+            )
+
+    def test_api_server_blocked(self):
+        # API-server sessions are non-terminal and non-interactive — the
+        # guard fires for them like any messaging surface (they cannot
+        # approve or reason around a write to an execution root).
+        with _bind_key("agent:main:api_server:r:1"), _default_home():
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    "~/.hermes/cron/jobs.json"
+                )
+            )
+
+    def test_other_gateway_platforms_blocked(self):
+        with _bind_key("agent:main:slack:dm:9"), _default_home():
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    "~/.hermes/cron/jobs.json"
+                )
+            )
+        with _bind_key("agent:main:whatsapp:dm:7"), _default_home():
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    "~/.hermes/scripts/x.sh"
+                )
+            )
+
+    def test_ssh_out_of_scope_unchanged(self):
+        # SSH key material is deliberately OUT of the messaging guard's
+        # scope (backend write-deny covers it for all sessions; read side
+        # keeps its own defence-in-depth list) — regression pin.
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    "~/.ssh/id_ed25519"
+                )
+            )
+
+    def test_implicit_parent_creation_blocked(self):
+        # Write to a not-yet-existing <home>/cron/ subdir must be caught by
+        # the RAW normalized form even when no parent directory exists.
+        with _bind_key("agent:main:telegram:dm:1"):
+            with tempfile.TemporaryDirectory() as tmp, \
+                    patch.dict(os.environ, {"HERMES_HOME": tmp}):
+                target = os.path.join(tmp, "cron", "sub", "jobs.json")
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(target)
+                )
+
+
+class TestExecutionTrustingRootsFollowActiveHome(unittest.TestCase):
+    """Regression coverage for the live-home derivation (reviewer P1)."""
+
+    def test_custom_hermes_home_roots_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as tmp, \
+                patch.dict(os.environ, {"HERMES_HOME": tmp}):
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(tmp, "cron", "jobs.json")
+                )
+            )
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(tmp, "scripts", "x.sh")
+                )
+            )
+            # Unrelated paths under the same home remain writable
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(tmp, "notes.md")
+                )
+            )
+
+    def test_profile_style_home_roots_blocked(self):
+        with _bind_key("agent:mypro:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as tmp:
+            profile_home = os.path.join(tmp, "profiles", "mypro")
+            with patch.dict(os.environ, {"HERMES_HOME": profile_home}):
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(profile_home, "scripts", "x.sh")
+                    )
+                )
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(profile_home, "cron", "jobs.json")
+                    )
+                )
+
+    def test_custom_home_local_session_not_blocked(self):
+        with _bind_key("default"), \
+                tempfile.TemporaryDirectory() as tmp, \
+                patch.dict(os.environ, {"HERMES_HOME": tmp}):
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(tmp, "scripts", "x.sh")
+                )
+            )
+
+    def test_prefixes_follow_active_home(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+                patch.dict(os.environ, {"HERMES_HOME": tmp}):
+            prefixes = file_safety._execution_trusting_prefixes()
+            self.assertIn(os.path.join(tmp, "cron"), prefixes)
+            self.assertIn(os.path.join(tmp, "scripts"), prefixes)
+            # identical env/live home dedupes to a single root pair
+            self.assertEqual(prefixes.count(os.path.join(tmp, "cron")), 1)
+
+    def test_override_scoped_session_blocks_both_homes(self):
+        with _bind_key("agent:main:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as env_home, \
+                tempfile.TemporaryDirectory() as override_home, \
+                patch.dict(os.environ, {"HERMES_HOME": env_home}):
+            token = hermes_constants.set_hermes_home_override(override_home)
+            try:
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(env_home, "scripts", "x.sh")
+                    )
+                )
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(override_home, "scripts", "x.sh")
+                    )
+                )
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(override_home, "cron", "jobs.json")
+                    )
+                )
+            finally:
+                hermes_constants.reset_hermes_home_override(token)
+
+    def test_sibling_profile_roots_blocked(self):
+        with _bind_key("agent:A:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as root:
+            profile_a = os.path.join(root, "profiles", "A")
+            profile_b = os.path.join(root, "profiles", "B")
+            os.makedirs(profile_a)
+            os.makedirs(profile_b)
+            with patch.object(
+                    hermes_constants, "get_default_hermes_root",
+                    return_value=Path(root)), \
+                    patch.dict(os.environ, {"HERMES_HOME": profile_a}):
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(profile_b, "scripts", "x.sh")
+                    )
+                )
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(profile_b, "cron", "jobs.json")
+                    )
+                )
+                # Default profile's execution roots at the shared root
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(root, "cron", "jobs.json")
+                    )
+                )
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(root, "scripts", "x.sh")
+                    )
+                )
+                # Own profile still blocked (regression)
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(profile_a, "scripts", "x.sh")
+                    )
+                )
+                # Unrelated root paths stay writable
+                self.assertIsNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(root, "notes.md")
+                    )
+                )
+
+    def test_windows_conventions_roots_blocked(self):
+        # Windows default home and conventions are covered by the
+        # windows_only native lane; the unmarked lane keeps the generic
+        # logic (custom-home + profile + sibling) that runs on every host.
+        with _bind_key("agent:main:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as tmp, \
+                patch.dict(os.environ, {"HERMES_HOME": tmp}):
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(tmp, "scripts", "x.ps1")
+                )
+            )
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(tmp, "cron", "jobs.json")
+                )
+            )
+            # Unrelated paths under the same home remain writable
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(tmp, "logs", "app.log")
+                )
+            )
+
+    def test_darwin_case_sensitivity_seam(self):
+        # On a case-insensitive volume (default APFS) a case variant of the
+        # home is the same directory and is blocked; on a case-sensitive
+        # volume it is a genuinely different directory and stays writable.
+        # Both arms run on every host via the simulated probe.
+        with _bind_key("agent:main:telegram:dm:1"), \
+                _darwin_simulated(case_sensitive=False) as tmp:
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(tmp, "SCRIPTS", "x.sh")
+                )
+            )
+        with _bind_key("agent:main:telegram:dm:1"), \
+                _darwin_simulated(case_sensitive=True) as tmp:
+            self.assertIsNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(tmp, "SCRIPTS", "x.sh")
+                )
+            )
+
+    def test_darwin_case_sensitivity_seam_unmarked_runs_everywhere(self):
+        # Extreme pin: the unmarked seam tests above must EXECUTE their
+        # darwin arm on every lane (no platform skip), so the
+        # case-sensitive-volume answer cannot silently die on Linux CI.
+        with _darwin_simulated(case_sensitive=False) as tmp:
+            self.assertEqual(
+                file_safety._normalize_guard_path(
+                    os.path.join(tmp, "Scripts", "x.sh")
+                ),
+                os.path.join(tmp, "scripts", "x.sh").casefold(),
+            )
+        with _darwin_simulated(case_sensitive=True) as tmp:
+            self.assertEqual(
+                file_safety._normalize_guard_path(
+                    os.path.join(tmp, "Scripts", "x.sh")
+                ),
+                os.path.join(tmp, "Scripts", "x.sh"),
+            )
+
+    def test_symlink_alias_into_scripts_dir_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as tmp:
+            real = os.path.join(tmp, "scripts")
+            os.makedirs(real)
+            alias = os.path.join(tmp, "alias")
+            try:
+                os.symlink(real, alias)
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable on this host: {exc}")
+            with patch.dict(os.environ, {"HERMES_HOME": tmp}):
+                self.assertIsNotNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(alias, "x.sh")
+                    )
+                )
+                # Unrelated symlinked directories are not affected
+                other = os.path.join(tmp, "other")
+                os.makedirs(other)
+                other_alias = os.path.join(tmp, "other_alias")
+                os.symlink(other, other_alias)
+                self.assertIsNone(
+                    file_safety.get_messaging_write_block_error(
+                        os.path.join(other_alias, "x.sh")
+                    )
+                )
+
+    def test_relative_path_blocked_after_task_resolution(self):
+        # A RELATIVE path that resolves (task-cwd aware) into a protected
+        # root must be blocked — the file tools pre-resolve before calling
+        # the classifier.
+        with _bind_key("agent:main:telegram:dm:1"):
+            with tempfile.TemporaryDirectory() as tmp:
+                os.makedirs(os.path.join(tmp, "scripts"))
+                with patch.dict(os.environ, {"HERMES_HOME": tmp}), \
+                        patch("tools.file_tools.os.getcwd",
+                              return_value=tmp):
+                    resolved = str(
+                        _resolve_path_for_task("scripts/x.sh", task_id="rel-test")
+                    )
+                    self.assertIn(tmp, resolved)
+                    self.assertIsNotNone(
+                        file_safety.get_messaging_write_block_error(
+                            resolved
+                        )
+                    )
+
+
+class TestToolWiring(unittest.TestCase):
+    """End-to-end wiring of the guard through the actual file tools."""
+
+    def _assert_write_blocked(self, path: str):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            out = write_file_tool(path, "payload", task_id="wiring-e2e")
+        self.assertIsInstance(out, str)
+        self.assertIn("execution-trusting", out)
+        self.assertIn("Access denied", out)
+
+    def test_write_file_tool_blocks_scripts(self):
+        self._assert_write_blocked("~/.hermes/scripts/evil.sh")
+
+    def test_write_file_tool_blocks_cron(self):
+        self._assert_write_blocked("~/.hermes/cron/jobs.json")
+
+    def test_write_file_tool_allows_unrelated(self):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            with tempfile.TemporaryDirectory() as tmp:
+                target = os.path.join(tmp, "note.md")
+                out = write_file_tool(target, "hello", task_id="wiring-e2e")
+                self.assertIsInstance(out, str)
+                self.assertNotIn("Access denied", out)
+                self.assertNotIn("execution-trusting", out)
+
+    def test_patch_tool_blocks_scripts(self):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            out = patch_tool(
+                mode="replace",
+                path="~/.hermes/scripts/evil.sh",
+                old_string="x",
+                new_string="y",
+                task_id="wiring-e2e-patch",
+            )
+            self.assertIsInstance(out, str)
+            self.assertIn("execution-trusting", out)
+            self.assertIn("Access denied", out)
+
+    def test_patch_tool_v4a_blocks_extracted_path(self):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            v4a = (
+                "*** Begin Patch\n"
+                "*** Update File: ~/.hermes/scripts/evil.sh\n"
+                "@@\n"
+                "-x\n"
+                "+y\n"
+                "*** End Patch\n"
+            )
+            out = patch_tool(
+                mode="patch",
+                path="/tmp/unrelated.md",
+                patch=v4a,
+                task_id="wiring-e2e-v4a",
+            )
+            self.assertIsInstance(out, str)
+            self.assertIn("execution-trusting", out)
+
+
+@contextlib.contextmanager
+def _executor_boundary():
+    """Run the guard through a ThreadPoolExecutor worker (the real dispatch).
+
+    Subagent tool dispatch hops threads via propagate_context_to_thread
+    (tools/thread_context.py); if context failed to propagate, the guard
+    would see the default key and fail open — this test would catch it.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+    from tools.thread_context import propagate_context_to_thread
+
+    def _classify(path: str):
+        return file_safety.get_messaging_write_block_error(path)
+
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        future = ex.submit(
+            propagate_context_to_thread(_classify), "~/.hermes/scripts/evil.sh"
+        )
+        yield future.result(timeout=10)
+
+
+class TestExecutorBoundary(unittest.TestCase):
+    """The guard must survive the real executor dispatch hop (reviewer P1)."""
+
+    def test_blocked_message_survives_executor_hop(self):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home(), \
+                _executor_boundary() as err:
+            self.assertIsNotNone(err)
+            self.assertIn("telegram", err)
+
+    def test_allowed_path_survives_executor_hop(self):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            from concurrent.futures import ThreadPoolExecutor
+            from tools.thread_context import propagate_context_to_thread
+
+            def _classify(path: str):
+                return file_safety.get_messaging_write_block_error(path)
+
+            with ThreadPoolExecutor(max_workers=1) as ex:
+                fut = ex.submit(
+                    propagate_context_to_thread(_classify), "/tmp/note.md"
+                )
+                self.assertIsNone(fut.result(timeout=10))
+
+
+@pytest.mark.windows_only
+class TestWindowsNativeGuard(unittest.TestCase):
+    """Native-Windows behaviour, run on windows-latest (tests-os.yml)."""
+
+    def test_native_windows_roots_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"), \
+                patch.dict(os.environ, {
+                    "HERMES_HOME": "C:/Users/t/AppData/Local/hermes"
+                }):
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    "C:/Users/t/AppData/Local/hermes/scripts/x.ps1"
+                )
+            )
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    r"C:\Users\t\AppData\Local\hermes\scripts\x.ps1"
+                )
+            )
+            # Case variants under the native normcase
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    "C:/Users/t/AppData/Local/HERMES/Scripts/x.ps1"
+                )
+            )
+            # Extended-length prefix under the native OS path handling
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    r"\\?\C:\Users\t\AppData\Local\hermes\scripts\x.ps1"
+                )
+            )
+
+    def test_native_windows_custom_home(self):
+        with _bind_key("agent:main:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as tmp, \
+                patch.dict(os.environ, {"HERMES_HOME": tmp}):
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(tmp, "scripts", "x.ps1")
+                )
+            )
+
+
+@pytest.mark.macos_only
+class TestMacOSNativeGuard(unittest.TestCase):
+    """Native-macOS behaviour, run on macos-latest (tests-os.yml).
+
+    The macos CI host mounts case-insensitive APFS, so the case variant of
+    the default home is the same directory and must be blocked through the
+    REAL filesystem-backed probe.
+    """
+
+    def test_native_macos_case_variant_blocked(self):
+        # conftest sandboxes HERMES_HOME into a per-test tempdir, which on
+        # the case-insensitive CI APFS volume resolves case variants to the
+        # same directory. Use it directly (no _default_home — that would
+        # point back at the patched platform default) and clear the cached
+        # darwin policy so it re-probes the sandbox home's parent.
+        home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+        file_safety._darwin_case_insensitive.cache_clear()
+        with _bind_key("agent:main:telegram:dm:1"):
+            variant = home[: -1] + home[-1].swapcase()
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(variant, "SCRIPTS", "evil.sh")
+                )
+            )
+            self.assertIsNotNone(
+                file_safety.get_messaging_write_block_error(
+                    os.path.join(home, "Cron", "jobs.json")
+                )
+            )

--- a/tests/tools/test_restricted_surface_write_guard.py
+++ b/tests/tools/test_restricted_surface_write_guard.py
@@ -1,13 +1,43 @@
 """Tests for the sensitive-path write guard on messaging platforms.
 
 Run with: python -m pytest tests/tools/test_restricted_surface_write_guard.py -v
+
+Coverage model (repo doctrine, see tests-os.yml + tests/conftest.py):
+- The cross-platform logic tests are UNMARKED: they run in the default
+  Linux lane and on any local host. Windows path conventions are exercised
+  on every host through the real ``ntpath`` primitives via a
+  case-normalization shim (the only OS-dependent primitive in the guard),
+  and the POSIX default home is simulated by patching the platform-default
+  resolver.
+- Real-OS behaviour that cannot be reproduced on another host (the native
+  Windows ``os.path``/filesystem semantics, the native macOS casefold
+  branch) is covered by ``windows_only`` / ``macos_only`` marked tests
+  that execute on the windows-latest / macos-latest lanes of tests-os.yml.
 """
 
 import contextlib
+import ntpath
+import os
+import sys
+import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
+import pytest
+
+import hermes_constants
 from tools.approval import reset_current_session_key, set_current_session_key
-from tools.file_tools import _check_sensitive_messaging_path, _session_platform
+from tools.file_tools import (
+    _check_sensitive_messaging_path,
+    _execution_trusting_prefixes,
+    _messaging_platform_from_key,
+    _normalize_guard_path,
+)
+
+# Windows extended-length prefixes accepted by the OS (stripped by the
+# guard's Windows normalization).
+_WIN_EXTENDED_PREFIXES = ("\\\\?\\", "\\\\.\\", "\\??\\")
 
 
 @contextlib.contextmanager
@@ -19,59 +49,93 @@ def _bind_key(key: str):
         reset_current_session_key(token)
 
 
+@contextlib.contextmanager
+def _default_home():
+    """Simulate the POSIX default home (~/.hermes) on every platform.
+
+    The guard resolves execution-trusting roots from the LIVE active
+    Hermes home (get_hermes_home()), so tests asserting on the default
+    ~/.hermes layout must neutralize any HERMES_HOME the runner carries
+    and pin the platform-default resolver to the POSIX convention.
+    """
+    with patch.dict(os.environ, {"HERMES_HOME": ""}), \
+            patch.object(
+                hermes_constants, "_get_platform_default_hermes_home",
+                return_value=Path.home() / ".hermes",
+            ):
+        yield
+
+
+def _win_case_normalize(path: str) -> str:
+    """Windows case/separator semantics, using the real ntpath primitives."""
+    for prefix in _WIN_EXTENDED_PREFIXES:
+        if path.startswith(prefix):
+            path = path[len(prefix):]
+            break
+    return ntpath.normcase(path).replace("\\", "/")
+
+
+@contextlib.contextmanager
+def _win_semantics():
+    """Run the guard with Windows normalization semantics on any host."""
+    with patch("tools.file_tools._guard_case_normalize",
+               side_effect=_win_case_normalize):
+        yield
+
+
 class TestSessionPlatform(unittest.TestCase):
     def test_gateway_key_parses_platform(self):
         with _bind_key("agent:main:telegram:dm:123"):
-            self.assertEqual(_session_platform(), "telegram")
+            self.assertEqual(_messaging_platform_from_key(), "telegram")
 
     def test_named_profile_gateway_key(self):
         with _bind_key("agent:cissp-coach:discord:g:9"):
-            self.assertEqual(_session_platform(), "discord")
+            self.assertEqual(_messaging_platform_from_key(), "discord")
 
     def test_unregistered_platform_token_is_none(self):
         with _bind_key("agent:main:not_a_real_platform:dm:1"):
-            self.assertIsNone(_session_platform())
+            self.assertIsNone(_messaging_platform_from_key())
 
     def test_local_platform_is_none(self):
         with _bind_key("agent:main:local:dm:1"):
-            self.assertIsNone(_session_platform())
+            self.assertIsNone(_messaging_platform_from_key())
 
     def test_malformed_key_is_none(self):
         with _bind_key("agent:main"):
-            self.assertIsNone(_session_platform())
+            self.assertIsNone(_messaging_platform_from_key())
 
     def test_cli_key_has_no_platform(self):
         with _bind_key("default"):
-            self.assertIsNone(_session_platform())
+            self.assertIsNone(_messaging_platform_from_key())
         with _bind_key("20260811_093018_2cb019f0"):
-            self.assertIsNone(_session_platform())
+            self.assertIsNone(_messaging_platform_from_key())
 
     def test_no_key_binds_none(self):
-        self.assertIsNone(_session_platform())
+        self.assertIsNone(_messaging_platform_from_key())
 
 
 class TestSensitiveMessagingPathWrite(unittest.TestCase):
     def test_telegram_cron_write_blocked(self):
-        with _bind_key("agent:main:telegram:dm:1"):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
             err = _check_sensitive_messaging_path("~/.hermes/cron/jobs.json")
             self.assertIsNotNone(err)
             self.assertIn("BLOCKED", err)
             self.assertIn("telegram", err)
 
     def test_telegram_scripts_write_blocked(self):
-        with _bind_key("agent:main:telegram:dm:1"):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
             self.assertIsNotNone(
                 _check_sensitive_messaging_path("~/.hermes/scripts/evil.sh")
             )
 
     def test_telegram_ssh_write_blocked(self):
-        with _bind_key("agent:main:telegram:dm:1"):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
             self.assertIsNotNone(
                 _check_sensitive_messaging_path("~/.ssh/id_ed25519")
             )
 
     def test_telegram_unrelated_paths_allowed(self):
-        with _bind_key("agent:main:telegram:dm:1"):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
             self.assertIsNone(_check_sensitive_messaging_path("/tmp/note.md"))
             # Non-execution hermes paths (logs, etc.) remain writable
             self.assertIsNone(
@@ -79,35 +143,309 @@ class TestSensitiveMessagingPathWrite(unittest.TestCase):
             )
 
     def test_cli_never_blocked(self):
-        with _bind_key("default"):
+        with _bind_key("default"), _default_home():
             self.assertIsNone(
                 _check_sensitive_messaging_path("~/.hermes/cron/jobs.json")
             )
-        with _bind_key("20260811_093018_2cb019f0"):
+        with _bind_key("20260811_093018_2cb019f0"), _default_home():
             self.assertIsNone(
                 _check_sensitive_messaging_path("~/.hermes/scripts/x.sh")
             )
 
     def test_unregistered_platform_not_blocked(self):
-        with _bind_key("agent:main:not_a_real_platform:dm:1"):
+        with _bind_key("agent:main:not_a_real_platform:dm:1"), _default_home():
             self.assertIsNone(
                 _check_sensitive_messaging_path("~/.hermes/cron/jobs.json")
             )
 
     def test_local_platform_not_blocked(self):
-        with _bind_key("agent:main:local:dm:1"):
+        with _bind_key("agent:main:local:dm:1"), _default_home():
             self.assertIsNone(
                 _check_sensitive_messaging_path("~/.hermes/cron/jobs.json")
             )
 
     def test_other_gateway_platforms_blocked(self):
-        with _bind_key("agent:main:slack:dm:9"):
+        with _bind_key("agent:main:slack:dm:9"), _default_home():
             self.assertIsNotNone(
                 _check_sensitive_messaging_path("~/.hermes/cron/jobs.json")
             )
-        with _bind_key("agent:main:whatsapp:dm:7"):
+        with _bind_key("agent:main:whatsapp:dm:7"), _default_home():
             self.assertIsNotNone(
                 _check_sensitive_messaging_path("~/.ssh/authorized_keys")
+            )
+
+
+class TestExecutionTrustingRootsFollowActiveHome(unittest.TestCase):
+    """Regression coverage for the live-home derivation (reviewer P1).
+
+    The execution-trusting roots must follow the ACTIVE Hermes home
+    (get_hermes_home(): context override → HERMES_HOME env → platform
+    default), never literal ~/.hermes frozen at import: cron jobs and
+    scripts are stored and executed under the active profile home
+    (cron/jobs.py, cron/scheduler.py, per-profile isolation #4707), the
+    Windows default home is %LOCALAPPDATA%\\hermes, and custom/profile
+    deployments set HERMES_HOME elsewhere.
+    """
+
+    def test_custom_hermes_home_roots_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as tmp, \
+                patch.dict(os.environ, {"HERMES_HOME": tmp}):
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(os.path.join(tmp, "cron", "jobs.json"))
+            )
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(os.path.join(tmp, "scripts", "x.sh"))
+            )
+            # Unrelated paths under the same home remain writable
+            self.assertIsNone(
+                _check_sensitive_messaging_path(os.path.join(tmp, "notes.md"))
+            )
+
+    def test_profile_style_home_roots_blocked(self):
+        # A profile-scoped gateway runs jobs under HERMES_HOME=<root>/profiles/<name>
+        with _bind_key("agent:mypro:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as tmp:
+            profile_home = os.path.join(tmp, "profiles", "mypro")
+            with patch.dict(os.environ, {"HERMES_HOME": profile_home}):
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(profile_home, "scripts", "x.sh")
+                    )
+                )
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(profile_home, "cron", "jobs.json")
+                    )
+                )
+
+    def test_custom_home_local_session_not_blocked(self):
+        with _bind_key("default"), \
+                tempfile.TemporaryDirectory() as tmp, \
+                patch.dict(os.environ, {"HERMES_HOME": tmp}):
+            self.assertIsNone(
+                _check_sensitive_messaging_path(os.path.join(tmp, "scripts", "x.sh"))
+            )
+
+    def test_prefixes_follow_active_home(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+                patch.dict(os.environ, {"HERMES_HOME": tmp}):
+            prefixes = _execution_trusting_prefixes()
+            self.assertIn(_normalize_guard_path(os.path.join(tmp, "cron")), prefixes)
+            self.assertIn(_normalize_guard_path(os.path.join(tmp, "scripts")), prefixes)
+            # .ssh stays anchored to the OS-user home, NOT HERMES_HOME
+            self.assertNotIn(_normalize_guard_path(os.path.join(tmp, ".ssh")), prefixes)
+            # identical env/live home dedupes to a single root pair
+            self.assertEqual(
+                prefixes.count(_normalize_guard_path(os.path.join(tmp, "cron"))), 1
+            )
+
+    def test_override_scoped_session_blocks_both_homes(self):
+        # A session context-scoped to another profile (set_hermes_home_override)
+        # must not bypass the roots of the env home whose cron THIS process's
+        # ticker executes — both homes are protected.
+        with _bind_key("agent:main:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as env_home, \
+                tempfile.TemporaryDirectory() as override_home, \
+                patch.dict(os.environ, {"HERMES_HOME": env_home}):
+            token = hermes_constants.set_hermes_home_override(override_home)
+            try:
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(env_home, "scripts", "x.sh")
+                    )
+                )
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(override_home, "scripts", "x.sh")
+                    )
+                )
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(override_home, "cron", "jobs.json")
+                    )
+                )
+            finally:
+                hermes_constants.reset_hermes_home_override(token)
+
+    def test_ssh_anchored_to_os_user_home_not_hermes_home(self):
+        with _bind_key("agent:main:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as tmp, \
+                patch.dict(os.environ, {"HERMES_HOME": tmp}):
+            # Real user-home .ssh stays blocked even with HERMES_HOME elsewhere
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path("~/.ssh/id_ed25519")
+            )
+            # HERMES_HOME/.ssh is not an execution-trusting root
+            self.assertIsNone(
+                _check_sensitive_messaging_path(
+                    os.path.join(tmp, ".ssh", "id_ed25519")
+                )
+            )
+
+    def test_windows_conventions_roots_blocked(self):
+        # Windows default home (%LOCALAPPDATA%\hermes) and Windows path
+        # conventions — forward/backslash separators, case variants,
+        # extended-length prefixes — exercised with the real ntpath
+        # primitives on every platform (the native-OS variant runs in the
+        # windows_only lane of tests-os.yml).
+        with _bind_key("agent:main:telegram:dm:1"), \
+                _win_semantics(), \
+                patch.dict(os.environ, {"HERMES_HOME": ""}), \
+                patch.object(
+                    hermes_constants, "_get_platform_default_hermes_home",
+                    return_value=Path("C:/Users/t/AppData/Local/hermes"),
+                ):
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    "C:/Users/t/AppData/Local/hermes/scripts/x.ps1"
+                )
+            )
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    "C:/Users/t/AppData/Local/hermes/cron/jobs.json"
+                )
+            )
+            # Backslash separators
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    r"C:\Users\t\AppData\Local\hermes\scripts\x.ps1"
+                )
+            )
+            # Case variants (NTFS is case-insensitive)
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    "C:/Users/t/AppData/Local/HERMES/Scripts/x.ps1"
+                )
+            )
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    "C:/Users/t/AppData/Local/Hermes/CRON/jobs.json"
+                )
+            )
+            # Extended-length prefix (\\?\C:\...) accepted by the OS
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    r"\\?\C:\Users\t\AppData\Local\hermes\scripts\x.ps1"
+                )
+            )
+            # Unrelated Windows paths remain writable
+            self.assertIsNone(
+                _check_sensitive_messaging_path(
+                    "C:/Users/t/AppData/Local/hermes/logs/app.log"
+                )
+            )
+
+    def test_case_sensitivity_follows_platform(self):
+        # The guard must mirror the filesystem: on case-insensitive default
+        # filesystems (macOS APFS) a case variant of the default home is the
+        # same directory and is blocked; on case-sensitive filesystems
+        # (Linux) it is a genuinely different directory and stays writable.
+        # (The native Windows variant runs in the windows_only lane.)
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            variant = _check_sensitive_messaging_path("~/.HERMES/SCRIPTS/evil.sh")
+            if sys.platform == "darwin":
+                self.assertIsNotNone(variant)
+            else:
+                self.assertIsNone(variant)
+
+    def test_symlink_alias_into_scripts_dir_blocked(self):
+        # A path reaching the execution-trusting root through a symlinked
+        # directory is canonicalized via the existing parent and blocked.
+        with _bind_key("agent:main:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as tmp:
+            real = os.path.join(tmp, "scripts")
+            os.makedirs(real)
+            alias = os.path.join(tmp, "alias")
+            try:
+                os.symlink(real, alias)
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable on this host: {exc}")
+            with patch.dict(os.environ, {"HERMES_HOME": tmp}):
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(os.path.join(alias, "x.sh"))
+                )
+                # Unrelated symlinked directories are not affected
+                other = os.path.join(tmp, "other")
+                os.makedirs(other)
+                other_alias = os.path.join(tmp, "other_alias")
+                os.symlink(other, other_alias)
+                self.assertIsNone(
+                    _check_sensitive_messaging_path(os.path.join(other_alias, "x.sh"))
+                )
+
+
+@pytest.mark.windows_only
+class TestWindowsNativeGuard(unittest.TestCase):
+    """Native-Windows behaviour, run on windows-latest (tests-os.yml).
+
+    Unlike the cross-platform conventions test above (which exercises the
+    guard's Windows branch with the real ntpath primitives on any host),
+    this class runs with the REAL ``os.name == "nt"`` branch, real
+    ``os.path`` semantics and the real Windows filesystem behind it.
+    """
+
+    def test_native_windows_roots_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"), \
+                patch.dict(os.environ, {"HERMES_HOME": ""}), \
+                patch.object(
+                    hermes_constants, "_get_platform_default_hermes_home",
+                    return_value=Path("C:/Users/t/AppData/Local/hermes"),
+                ):
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    "C:/Users/t/AppData/Local/hermes/scripts/x.ps1"
+                )
+            )
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    r"C:\Users\t\AppData\Local\hermes\scripts\x.ps1"
+                )
+            )
+            # Case variants under the native normcase
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    "C:/Users/t/AppData/Local/HERMES/Scripts/x.ps1"
+                )
+            )
+            # Extended-length prefix under the native OS path handling
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    r"\\?\C:\Users\t\AppData\Local\hermes\scripts\x.ps1"
+                )
+            )
+
+    def test_native_windows_custom_home_and_ssh(self):
+        with _bind_key("agent:main:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as tmp, \
+                patch.dict(os.environ, {"HERMES_HOME": tmp}):
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path(
+                    os.path.join(tmp, "scripts", "x.ps1")
+                )
+            )
+            # Real user-home .ssh blocked; HERMES_HOME/.ssh is not a root
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path("~/.ssh/id_ed25519")
+            )
+            self.assertIsNone(
+                _check_sensitive_messaging_path(
+                    os.path.join(tmp, ".ssh", "id_ed25519")
+                )
+            )
+
+
+@pytest.mark.macos_only
+class TestMacOSNativeGuard(unittest.TestCase):
+    """Native-macOS behaviour, run on macos-latest (tests-os.yml)."""
+
+    def test_native_macos_case_variant_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"), _default_home():
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path("~/.HERMES/SCRIPTS/evil.sh")
+            )
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path("~/.hermes/Cron/jobs.json")
             )
 
 

--- a/tests/tools/test_restricted_surface_write_guard.py
+++ b/tests/tools/test_restricted_surface_write_guard.py
@@ -268,6 +268,56 @@ class TestExecutionTrustingRootsFollowActiveHome(unittest.TestCase):
             finally:
                 hermes_constants.reset_hermes_home_override(token)
 
+    def test_sibling_profile_roots_blocked(self):
+        # A messaging session in one profile must not plant payloads in
+        # another profile's execution-trusting roots (scripts is not even
+        # covered by the cross-profile soft guard, and cron is bypassable
+        # via cross_profile=True), nor in the default profile's roots at
+        # the shared root level.
+        with _bind_key("agent:A:telegram:dm:1"), \
+                tempfile.TemporaryDirectory() as root:
+            profile_a = os.path.join(root, "profiles", "A")
+            profile_b = os.path.join(root, "profiles", "B")
+            os.makedirs(profile_a)
+            os.makedirs(profile_b)
+            with patch.object(
+                    hermes_constants, "get_default_hermes_root",
+                    return_value=Path(root)), \
+                    patch.dict(os.environ, {"HERMES_HOME": profile_a}):
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(profile_b, "scripts", "x.sh")
+                    )
+                )
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(profile_b, "cron", "jobs.json")
+                    )
+                )
+                # Default profile's execution roots at the shared root
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(root, "cron", "jobs.json")
+                    )
+                )
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(root, "scripts", "x.sh")
+                    )
+                )
+                # Own profile still blocked (regression)
+                self.assertIsNotNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(profile_a, "scripts", "x.sh")
+                    )
+                )
+                # Unrelated root paths stay writable
+                self.assertIsNone(
+                    _check_sensitive_messaging_path(
+                        os.path.join(root, "notes.md")
+                    )
+                )
+
     def test_ssh_anchored_to_os_user_home_not_hermes_home(self):
         with _bind_key("agent:main:telegram:dm:1"), \
                 tempfile.TemporaryDirectory() as tmp, \

--- a/tests/tools/test_restricted_surface_write_guard.py
+++ b/tests/tools/test_restricted_surface_write_guard.py
@@ -1,0 +1,115 @@
+"""Tests for the sensitive-path write guard on messaging platforms.
+
+Run with: python -m pytest tests/tools/test_restricted_surface_write_guard.py -v
+"""
+
+import contextlib
+import unittest
+
+from tools.approval import reset_current_session_key, set_current_session_key
+from tools.file_tools import _check_sensitive_messaging_path, _session_platform
+
+
+@contextlib.contextmanager
+def _bind_key(key: str):
+    token = set_current_session_key(key)
+    try:
+        yield
+    finally:
+        reset_current_session_key(token)
+
+
+class TestSessionPlatform(unittest.TestCase):
+    def test_gateway_key_parses_platform(self):
+        with _bind_key("agent:main:telegram:dm:123"):
+            self.assertEqual(_session_platform(), "telegram")
+
+    def test_named_profile_gateway_key(self):
+        with _bind_key("agent:cissp-coach:discord:g:9"):
+            self.assertEqual(_session_platform(), "discord")
+
+    def test_unregistered_platform_token_is_none(self):
+        with _bind_key("agent:main:not_a_real_platform:dm:1"):
+            self.assertIsNone(_session_platform())
+
+    def test_local_platform_is_none(self):
+        with _bind_key("agent:main:local:dm:1"):
+            self.assertIsNone(_session_platform())
+
+    def test_malformed_key_is_none(self):
+        with _bind_key("agent:main"):
+            self.assertIsNone(_session_platform())
+
+    def test_cli_key_has_no_platform(self):
+        with _bind_key("default"):
+            self.assertIsNone(_session_platform())
+        with _bind_key("20260811_093018_2cb019f0"):
+            self.assertIsNone(_session_platform())
+
+    def test_no_key_binds_none(self):
+        self.assertIsNone(_session_platform())
+
+
+class TestSensitiveMessagingPathWrite(unittest.TestCase):
+    def test_telegram_cron_write_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"):
+            err = _check_sensitive_messaging_path("~/.hermes/cron/jobs.json")
+            self.assertIsNotNone(err)
+            self.assertIn("BLOCKED", err)
+            self.assertIn("telegram", err)
+
+    def test_telegram_scripts_write_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"):
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path("~/.hermes/scripts/evil.sh")
+            )
+
+    def test_telegram_ssh_write_blocked(self):
+        with _bind_key("agent:main:telegram:dm:1"):
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path("~/.ssh/id_ed25519")
+            )
+
+    def test_telegram_unrelated_paths_allowed(self):
+        with _bind_key("agent:main:telegram:dm:1"):
+            self.assertIsNone(_check_sensitive_messaging_path("/tmp/note.md"))
+            # Non-execution hermes paths (logs, etc.) remain writable
+            self.assertIsNone(
+                _check_sensitive_messaging_path("~/.hermes/logs/app.log")
+            )
+
+    def test_cli_never_blocked(self):
+        with _bind_key("default"):
+            self.assertIsNone(
+                _check_sensitive_messaging_path("~/.hermes/cron/jobs.json")
+            )
+        with _bind_key("20260811_093018_2cb019f0"):
+            self.assertIsNone(
+                _check_sensitive_messaging_path("~/.hermes/scripts/x.sh")
+            )
+
+    def test_unregistered_platform_not_blocked(self):
+        with _bind_key("agent:main:not_a_real_platform:dm:1"):
+            self.assertIsNone(
+                _check_sensitive_messaging_path("~/.hermes/cron/jobs.json")
+            )
+
+    def test_local_platform_not_blocked(self):
+        with _bind_key("agent:main:local:dm:1"):
+            self.assertIsNone(
+                _check_sensitive_messaging_path("~/.hermes/cron/jobs.json")
+            )
+
+    def test_other_gateway_platforms_blocked(self):
+        with _bind_key("agent:main:slack:dm:9"):
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path("~/.hermes/cron/jobs.json")
+            )
+        with _bind_key("agent:main:whatsapp:dm:7"):
+            self.assertIsNotNone(
+                _check_sensitive_messaging_path("~/.ssh/authorized_keys")
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -11,7 +11,10 @@ import sys
 import threading
 from pathlib import Path, PurePosixPath
 
-from agent.file_safety import get_read_block_error
+from agent.file_safety import (
+    get_messaging_write_block_error,
+    get_read_block_error,
+)
 from tools.binary_extensions import (
     has_binary_extension,
     has_opaque_document_extension,
@@ -2236,6 +2239,11 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     binary_doc_err = _check_binary_document_write(path, task_id)
     if binary_doc_err:
         return tool_error(binary_doc_err)
+    restricted_err = get_messaging_write_block_error(
+        _resolve_path_for_task(path, task_id), task_id
+    )
+    if restricted_err:
+        return tool_error(restricted_err)
     protected_err = _check_protected_instruction_write([path], task_id)
     if protected_err:
         return tool_error(protected_err)
@@ -2377,6 +2385,11 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
             return tool_error(sensitive_err)
+        restricted_err = get_messaging_write_block_error(
+            _resolve_path_for_task(_p, task_id), task_id
+        )
+        if restricted_err:
+            return tool_error(restricted_err)
         if not cross_profile:
             cross_warning = _check_cross_profile_path(_p, task_id)
             if cross_warning:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -673,6 +673,94 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+# ---------------------------------------------------------------------------
+# Sensitive-path write guard for messaging platforms
+# ---------------------------------------------------------------------------
+# Sessions on messaging platforms (Telegram/Discord/Slack/...) run without
+# terminal, browser, or code-execution tools, so toolset filtering alone
+# cannot stop composition across tools: a `file` write that lands in an
+# execution-trusting directory is later executed by another subsystem as
+# the agent user. Writes to ~/.hermes/cron/ (job scheduling),
+# ~/.hermes/scripts/ (job payloads) and ~/.ssh/ (key material) are
+# therefore denied for any session whose platform is a messaging surface.
+#
+# Platform detection follows the session-scoped capability doctrine
+# (AGENTS.md: "surface capability is a property of the SESSION"): the
+# platform token is read from the gateway session key
+# (agent[:<profile>]:<platform>:..., see gateway/session.py
+# build_session_key) — never from process env — and validated against the
+# canonical gateway.config.Platform enum, so only positively-identified
+# messaging surfaces are restricted (malformed or unregistered tokens and
+# the LOCAL platform are never treated as messaging). CLI/desktop/serve
+# sessions bind session-id keys instead and retain the terminal tool, so
+# the guard never fires for them. Subagent sessions run in
+# ThreadPoolExecutor workers, which copy contextvars — the session key,
+# and therefore this guard, propagates to delegated children.
+_RESTRICTED_SURFACE_WRITE_PREFIXES = tuple(
+    os.path.normpath(_expand_tilde(p)) for p in (
+        "~/.hermes/cron/",
+        "~/.hermes/scripts/",
+        "~/.ssh/",
+    )
+)
+
+
+def _session_platform() -> str | None:
+    """Messaging-platform token of the current session, or None.
+
+    The platform token is read from the gateway session key
+    (``agent[:<profile>]:<platform>:...``, see gateway/session.py
+    build_session_key) and validated against gateway.config.Platform.
+    Returns None when the session is not a gateway session (CLI/serve bind
+    session-id keys), when the key is malformed, or when the token does not
+    resolve to a real platform — only a positively-identified messaging
+    surface is returned.
+    """
+    try:
+        import tools.approval as _approval
+        key = _approval.get_current_session_key()
+    except Exception:
+        return None
+    if not key or not key.startswith("agent:"):
+        return None
+    parts = key.split(":")
+    if len(parts) < 3:
+        return None
+    try:
+        from gateway.config import Platform
+        member = Platform(parts[2])
+    except Exception:
+        return None
+    if member is Platform.LOCAL:
+        return None
+    return member.value
+
+
+def _check_sensitive_messaging_path(filepath: str, task_id: str = "default") -> str | None:
+    """Block writes to execution-trusting dirs from messaging-platform sessions."""
+    platform = _session_platform()
+    if platform is None:
+        return None
+    try:
+        resolved = str(_resolve_path_for_task(filepath, task_id))
+    except (OSError, ValueError):
+        resolved = os.path.normpath(_expand_tilde(filepath))
+    normalized = os.path.normpath(_expand_tilde(filepath))
+    # Prefixes are normpath'd at module load (no trailing separator), so
+    # compare exact-or-direct-child — this also keeps the guard correct on
+    # Windows, where expanduser/normpath produce backslash separators.
+    for prefix in _RESTRICTED_SURFACE_WRITE_PREFIXES:
+        for candidate in (resolved, normalized):
+            if candidate == prefix or candidate.startswith(prefix + os.sep):
+                return (
+                    f"BLOCKED: write to {filepath} targets an execution-trusting "
+                    "path (cron/, scripts/, .ssh/) and is not allowed from a "
+                    f"{platform} platform session. Complete the change from a "
+                    "local (CLI/desktop) session instead."
+                )
+    return None
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -2114,6 +2202,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
         return tool_error(sensitive_err)
+    restricted_err = _check_sensitive_messaging_path(path, task_id)
+    if restricted_err:
+        return tool_error(restricted_err)
     protected_err = _check_protected_instruction_write([path], task_id)
     if protected_err:
         return tool_error(protected_err)
@@ -2245,6 +2336,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
             return tool_error(sensitive_err)
+        restricted_err = _check_sensitive_messaging_path(_p, task_id)
+        if restricted_err:
+            return tool_error(restricted_err)
         if not cross_profile:
             cross_warning = _check_cross_profile_path(_p, task_id)
             if cross_warning:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -680,9 +680,9 @@ def _get_hermes_config_resolved() -> str | None:
 # terminal, browser, or code-execution tools, so toolset filtering alone
 # cannot stop composition across tools: a `file` write that lands in an
 # execution-trusting directory is later executed by another subsystem as
-# the agent user. Writes to ~/.hermes/cron/ (job scheduling),
-# ~/.hermes/scripts/ (job payloads) and ~/.ssh/ (key material) are
-# therefore denied for any session whose platform is a messaging surface.
+# the agent user. Writes to the active cron/ (job scheduling) and scripts/
+# (job payloads) roots and to ~/.ssh/ (key material) are therefore denied
+# for any session whose platform is a messaging surface.
 #
 # Platform detection follows the session-scoped capability doctrine
 # (AGENTS.md: "surface capability is a property of the SESSION"): the
@@ -696,16 +696,122 @@ def _get_hermes_config_resolved() -> str | None:
 # the guard never fires for them. Subagent sessions run in
 # ThreadPoolExecutor workers, which copy contextvars — the session key,
 # and therefore this guard, propagates to delegated children.
-_RESTRICTED_SURFACE_WRITE_PREFIXES = tuple(
-    os.path.normpath(_expand_tilde(p)) for p in (
-        "~/.hermes/cron/",
-        "~/.hermes/scripts/",
-        "~/.ssh/",
-    )
-)
+#
+# The execution-trusting roots are resolved PER CALL from the live active
+# Hermes home (get_hermes_home(): context override → HERMES_HOME env →
+# platform default) — never frozen at import. Cron jobs and scripts are
+# stored and executed under the active profile home (cron/jobs.py,
+# cron/scheduler.py, per-profile isolation #4707), and the default home is
+# platform-native (%LOCALAPPDATA%\hermes on Windows vs ~/.hermes on
+# POSIX), so literal ~/.hermes prefixes would miss custom HERMES_HOME,
+# profile, and Windows deployments. ~/.ssh stays anchored to the OS-user
+# home that ~ expansion follows in file tools (get_subprocess_home()),
+# independently of HERMES_HOME.
 
 
-def _session_platform() -> str | None:
+def _guard_case_normalize(path: str) -> str:
+    """Platform case/separator semantics for guard comparisons.
+
+    Windows: strip extended-length prefixes (``\\\\?\\\\``, ``\\\\.\\\\``,
+    ``\\\\??\\\\``) that the OS accepts and that would defeat
+    string-prefix comparison, then normcase (lowercase + backslash
+    separators) and canonicalize separators to forward slashes so the
+    child-boundary check is separator-agnostic. macOS: casefold — default
+    APFS volumes are case-insensitive, so ``~/.HERMES/SCRIPTS`` resolves
+    to the same directory as ``~/.hermes/scripts``. Other POSIX systems:
+    identity — case is significant on those filesystems, and a
+    different-case path is a genuinely different directory.
+    """
+    if os.name == "nt":
+        for prefix in ("\\\\?\\", "\\\\.\\", "\\??\\"):
+            if path.startswith(prefix):
+                path = path[len(prefix):]
+                break
+        return os.path.normcase(path).replace("\\", "/")
+    if sys.platform == "darwin":
+        return path.casefold()
+    return path
+
+
+def _normalize_guard_path(path: str) -> str:
+    """Normalize a path for execution-trusting-prefix comparison."""
+    return _guard_case_normalize(os.path.normpath(path))
+
+
+def _execution_trusting_prefixes() -> tuple[str, ...]:
+    """Execution-trusting write roots of the LIVE active Hermes home.
+
+    Cron jobs and scripts are stored and executed under the active profile
+    home — ``get_hermes_home()/cron`` and ``get_hermes_home()/scripts``
+    (cron/jobs.py, tools/cronjob_tools.py) — so the guard follows the same
+    dynamic resolution instead of freezing literal ``~/.hermes`` paths at
+    import (see cron/scheduler.py: do not freeze the home at import or
+    anchor at the shared default root). Both the context-scoped home
+    (``get_hermes_home()``) and the process env home
+    (``get_process_hermes_home()``) are protected: a session scoped to
+    another profile via ``set_hermes_home_override`` must not be able to
+    write the roots of the home whose cron the local ticker executes.
+    ``~/.ssh`` stays anchored to the OS-user home that ``~`` expansion
+    follows in file tools (``get_subprocess_home()``), which is
+    independent of ``HERMES_HOME``.
+    """
+    try:
+        from hermes_constants import (
+            get_hermes_home,
+            get_process_hermes_home,
+            get_subprocess_home,
+        )
+    except Exception:  # pragma: no cover - resolution chain unavailable
+        raw_homes = {os.path.expanduser("~/.hermes")}
+        user_home = os.path.expanduser("~")
+    else:
+        raw_homes = {str(get_hermes_home()), str(get_process_hermes_home())}
+        user_home = get_subprocess_home() or os.path.expanduser("~")
+    # Keep BOTH spellings of each home: the raw form (what the env var
+    # says, and what cron/jobs.py's module-level CRON_DIR anchors on) and
+    # the resolved form (what Path.resolve()-based resolution and the OS
+    # see — e.g. macOS /var is a symlink to /private/var). Writes through
+    # either spelling land in the same physical directory. The .ssh root
+    # stays anchored to the OS-user home ONLY — never to HERMES_HOME.
+    homes: set[str] = set()
+    for home in raw_homes:
+        homes.add(home)
+        try:
+            homes.add(str(Path(home).resolve()))
+        except (OSError, ValueError, RuntimeError):  # pragma: no cover
+            pass
+    ssh_homes: set[str] = {user_home}
+    try:
+        ssh_homes.add(str(Path(user_home).resolve()))
+    except (OSError, ValueError, RuntimeError):  # pragma: no cover
+        pass
+    raw = [os.path.join(home, root) for home in homes for root in ("cron", "scripts")]
+    raw.extend(os.path.join(home, ".ssh") for home in ssh_homes)
+    return tuple(_normalize_guard_path(p) for p in raw)
+
+
+def _canonical_guard_candidate(filepath: str) -> str | None:
+    """Canonical form of a path whose parent exists.
+
+    The OS resolves what string normalization cannot see: on Windows,
+    8.3 short names, junctions and extended-length prefixes; on every
+    platform, symlinked directories. Canonicalizing through the existing
+    parent directory (``Path.resolve`` on the parent) lets the guard
+    compare what ``open()`` will actually reach. Returns ``None`` when the
+    parent chain does not exist — the write cannot land in an existing
+    execution-trusting root through a path whose parents are missing.
+    """
+    try:
+        p = Path(filepath)
+        parent = p.parent
+        if not parent.exists():
+            return None
+        return str(parent.resolve(strict=True) / p.name)
+    except (OSError, ValueError, RuntimeError):
+        return None
+
+
+def _messaging_platform_from_key() -> str | None:
     """Messaging-platform token of the current session, or None.
 
     The platform token is read from the gateway session key
@@ -738,7 +844,7 @@ def _session_platform() -> str | None:
 
 def _check_sensitive_messaging_path(filepath: str, task_id: str = "default") -> str | None:
     """Block writes to execution-trusting dirs from messaging-platform sessions."""
-    platform = _session_platform()
+    platform = _messaging_platform_from_key()
     if platform is None:
         return None
     try:
@@ -746,12 +852,20 @@ def _check_sensitive_messaging_path(filepath: str, task_id: str = "default") -> 
     except (OSError, ValueError):
         resolved = os.path.normpath(_expand_tilde(filepath))
     normalized = os.path.normpath(_expand_tilde(filepath))
-    # Prefixes are normpath'd at module load (no trailing separator), so
-    # compare exact-or-direct-child — this also keeps the guard correct on
-    # Windows, where expanduser/normpath produce backslash separators.
-    for prefix in _RESTRICTED_SURFACE_WRITE_PREFIXES:
-        for candidate in (resolved, normalized):
-            if candidate == prefix or candidate.startswith(prefix + os.sep):
+    canonical = _canonical_guard_candidate(normalized)
+    candidates = (resolved, normalized)
+    if canonical:
+        candidates = candidates + (canonical,)
+    # Prefixes are resolved from the live active Hermes home per call (no
+    # trailing separator; separators canonicalized to "/"), so compare
+    # exact-or-direct-child after the same platform normalization on both
+    # sides — this keeps the guard correct on Windows (backslash
+    # separators, extended-length prefixes, case-insensitive) and on
+    # case-insensitive macOS volumes.
+    for prefix in _execution_trusting_prefixes():
+        for candidate in candidates:
+            candidate_norm = _normalize_guard_path(candidate)
+            if candidate_norm == prefix or candidate_norm.startswith(prefix + "/"):
                 return (
                     f"BLOCKED: write to {filepath} targets an execution-trusting "
                     "path (cron/, scripts/, .ssh/) and is not allowed from a "

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -757,6 +757,7 @@ def _execution_trusting_prefixes() -> tuple[str, ...]:
     """
     try:
         from hermes_constants import (
+            get_default_hermes_root,
             get_hermes_home,
             get_process_hermes_home,
             get_subprocess_home,
@@ -767,6 +768,26 @@ def _execution_trusting_prefixes() -> tuple[str, ...]:
     else:
         raw_homes = {str(get_hermes_home()), str(get_process_hermes_home())}
         user_home = get_subprocess_home() or os.path.expanduser("~")
+        # Sibling profiles under the shared root: every profile gateway
+        # executes its OWN <home>/cron and <home>/scripts as the same OS
+        # user, so a messaging session in ANY profile must not plant
+        # payloads in another profile's execution-trusting roots — nor in
+        # the default profile's roots at the root level. (The existing
+        # cross-profile soft guard covers skills/plugins/cron/memories
+        # only — NOT scripts — and is bypassable via cross_profile=True;
+        # this block is flag-independent and covers scripts too.)
+        try:
+            root = str(get_default_hermes_root())
+            raw_homes.add(root)
+            profiles_dir = os.path.join(root, "profiles")
+            for name in sorted(os.listdir(profiles_dir)):
+                if name.startswith("."):
+                    continue
+                candidate = os.path.join(profiles_dir, name)
+                if os.path.isdir(candidate):
+                    raw_homes.add(candidate)
+        except OSError:  # pragma: no cover - enumeration is best-effort
+            pass
     # Keep BOTH spellings of each home: the raw form (what the env var
     # says, and what cron/jobs.py's module-level CRON_DIR anchors on) and
     # the resolved form (what Path.resolve()-based resolution and the OS


### PR DESCRIPTION
## What does this PR do?

Blocks file-tool writes into execution-trusting roots (`cron/`, `scripts/`)
of the active Hermes home when the session is a messaging platform
(Telegram, Discord, Slack, ...). A messaging session may retain
terminal/browser/code-execution surfaces (config-dependent), so toolset
filtering alone cannot stop a `file` write that lands in a directory the
cron scheduler or script runner later executes as the agent user. This
closes that file-write gap; it is NOT a security boundary for sessions that
keep the other execution surfaces.

This revision replaces the inline implementation shown in earlier revisions
of this PR (never merged) with a centralized version of the same fix: the
guard lives in `agent/file_safety.py` (the module ACP shims share), with
thin wiring in `tools/file_tools.py` (`write_file_tool` + `patch_tool`,
explicit `path=` and V4A headers), and the branch is rebased onto current
`main` (the previous head was 1,800+ commits behind and non-mergeable).

## Scope boundary

Covered:
- `write_file_tool` and `patch_tool` writes to `cron/` and `scripts/` from
  messaging-platform sessions, including via the V4A patch header path —
  for the active home AND every other profile: the shared default root and
  each `<root>/profiles/*` sibling's `cron/`/`scripts/` are blocked too, so
  a messaging session in any profile cannot plant payloads in another
  profile's execution roots (`cross_profile=True` cannot bypass; the
  cross-profile soft guard covers skills/plugins/cron/memories only, not
  scripts/).
- `api_server` sessions are also blocked: `api_server` is a messaging
  platform in `gateway.config.Platform` (non-terminal, non-interactive — it
  cannot approve or reason around a write). Documented in the module
  docstring; flagged here so the scope is unambiguous.

Not covered (by design):
- SSH key material — already hard-denied for ALL sessions at the tool
  file-operation backend (`build_write_denied_paths` /
  `build_write_denied_prefixes`); `~/.ssh/config` stays approval-gated.
- Terminal/process/browser/code-execution surfaces — a messaging session
  that retains them can already write execution roots; restricting them
  would break intended functionality.

## How it works

- Platform token read from the gateway session key
  (`agent[:<profile>]:<platform>:...`), validated against
  `gateway.config.Platform`, never from process env. Only `LOCAL` is never
  messaging; CLI/desktop/serve bind session-id keys and are never blocked.
  Subagents propagate contextvars through the executor
  (`propagate_context_to_thread`), so the guard carries into delegation —
  covered by a regression at the real executor boundary.
- Roots resolve per call from the live active home (`get_hermes_home()`:
  context override -> `HERMES_HOME` env -> platform default), never frozen
  at import, so custom `HERMES_HOME`, profile, sibling-profile, and Windows
  (`%LOCALAPPDATA%\hermes`) deployments are covered. Every profile's roots
  under the shared root are enumerated per call (flag-independent hard
  block; `cross_profile=True` cannot bypass). The enumeration cost is
  bounded (N sibling profiles x listdir + resolve) and intentionally not
  cached: a stale prefix cache would fail open; noted as a possible
  follow-up if profile counts grow.
- Paths are normalized symmetrically (prefixes and candidates) — Windows
  `normcase`/extended-length prefixes, and macOS casefold only when the
  volume is case-insensitive (inode probe of the home's parent, cached per
  process).

## Related Issue

No existing issue — security hardening per CONTRIBUTING.md priority #3.
Searched open and closed PRs/issues for write-guard and
messaging-file-tool topics before opening.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `agent/file_safety.py`: `_messaging_platform_from_key()`,
  `_volume_is_case_insensitive()` / `_darwin_case_insensitive()`,
  `_normalize_guard_path()`, `_execution_trusting_prefixes()`,
  `get_messaging_write_block_error()`.
- `tools/file_tools.py`: guard wired into `write_file_tool` and
  `_reject_v4a_traversal` after `_resolve_path_for_task`.
- `tests/agent/test_file_safety_messaging_write.py`: platform detection
  (incl. LOCAL/malformed/unregistered/api_server), live-home/profile/sibling
  roots, implicit-parent, relative-path-after-task-resolution, Windows +
  macOS native lanes, darwin case-sensitivity seam on every lane, executor
  boundary, tool wiring (write + patch + V4A). RED→GREEN proven (3 fail
  without source, 37 pass with).

## How to Test

1. `python -m pytest tests/agent/test_file_safety_messaging_write.py -q`
2. Related suites: `tests/agent/test_file_safety_cross_profile.py`,
   `tests/tools/` file-tools suites.
3. With a simulated messaging session key bound
   (`agent:main:telegram:dm:1`), `write_file_tool("~/.hermes/scripts/x.sh")`
   returns the BLOCKED error; with no key bound, the write succeeds.

## Verification

### Local (macOS 26, repo venv)

- Guard suite `tests/agent/test_file_safety_messaging_write.py`:
  37 passed, 2 skipped (the 2 `windows_only` native cases run in the
  tests-os windows lane).
- Related `tests/agent/test_file_safety*.py` (6 files): 53 passed.
- `tests/tools/` file_tools / write_deny / file_operations (7 files):
  176 passed, 4 skipped. The 2 failures in `tests/tools/test_file_tools.py`
  (`/tmp` vs `/private/tmp` symlink in test doubles) are pre-existing —
  reproduced identically on clean upstream main, unrelated to this change.
- ruff: clean on all changed files.

### CI/CD (full upstream suite)

The complete upstream CI workflow set ran against this revision's code in
a private mirror before filing (43 checks): 27 success, 14 skipped (normal
for this PR — build/publish/merge, docs/installer/desktop-e2e/JS-TS
lanes, uv.lock, save-durations), 2 failure:

- `OSV scan / Scan lockfiles / osv-scan` — fails with "Code scanning is
  not enabled for this repository" (CodeQL action; repository-settings
  artifact of the mirror, not a vulnerability finding and not caused by
  this change — the same job fails identically on the unmodified base).
  Expected to pass on this repository, where code scanning is enabled;
  to be confirmed on the first public run.
- `All required checks pass` — aggregate job, red solely because of the
  OSV job above.

All 12 test slices, e2e, OS-specific macOS/Windows lanes, lints (ruff
blocking + ty diff + Windows footguns), contributor attribution,
common-ancestor, and supply-chain scans passed. CI on this PR's own
checks panel runs the same workflows on push.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the relevant pytest suites — all pass on this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] Docstrings updated in code — other docs N/A
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform considered: live-home + sibling-profile roots, Windows
      normalization, macOS casefold only on case-insensitive volumes
      (probed), native-OS tests marked `windows_only`/`macos_only`
- [x] Tool descriptions/schemas — N/A (no new tool, no schema change)
