### PR TITLE
fix(browser): discover browser-use from user-level tool directories

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -151,20 +151,40 @@ class TestFindCli:
     def test_prefers_installed_binary(self, monkeypatch):
         monkeypatch.setattr(
             bu_cli.shutil, "which",
-            lambda name: "/usr/local/bin/browser-use" if name == "browser-use" else "/usr/local/bin/uvx",
+            lambda name, path=None: "/usr/local/bin/browser-use"
+            if name == "browser-use"
+            else "/usr/local/bin/uvx",
         )
         assert bu_cli._find_cli_unpatched() == ["/usr/local/bin/browser-use"]
 
     def test_falls_back_to_uvx(self, monkeypatch):
         monkeypatch.setattr(
             bu_cli.shutil, "which",
-            lambda name: "/usr/local/bin/uvx" if name == "uvx" else None,
+            lambda name, path=None: "/usr/local/bin/uvx" if name == "uvx" else None,
         )
         assert bu_cli._find_cli_unpatched() == ["/usr/local/bin/uvx", "browser-use"]
 
     def test_none_when_neither_available(self, monkeypatch):
-        monkeypatch.setattr(bu_cli.shutil, "which", lambda name: None)
+        monkeypatch.setattr(bu_cli.shutil, "which", lambda name, path=None: None)
         assert bu_cli._find_cli_unpatched() is None
+
+    def test_finds_user_local_binary_outside_inherited_path(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        cli_dir = home / ".local" / "bin"
+        cli_dir.mkdir(parents=True)
+        cli = cli_dir / "browser-use"
+        cli.write_text("#!/bin/sh\n")
+        cli.chmod(cli.stat().st_mode | stat.S_IXUSR)
+
+        monkeypatch.setattr(
+            bu_cli.os.path,
+            "expanduser",
+            lambda value: str(home) if value == "~" else value,
+        )
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setattr(bu_cli, "get_hermes_home", lambda: tmp_path / "hermes")
+
+        assert bu_cli._find_cli_unpatched() == [str(cli)]
 
 
 class TestLegacyCloudMigration:

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -13,6 +13,7 @@ import subprocess
 import time
 from typing import Any, Dict, List, Optional
 
+from hermes_constants import get_hermes_home
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -137,13 +138,24 @@ def is_browser_use_cli_mode() -> bool:
 def _find_cli() -> Optional[List[str]]:
     """Locate the browser-use CLI, or None when it can't be run.
 
-    Prefers an installed browser-use binary; falls back to running it
-    through uvx
+    Prefer an installed browser-use binary; fall back to running it through
+    uvx. The desktop backend may start with a minimal PATH, so also search
+    the standard user tool directory and Hermes' managed bin directory.
     """
-    direct = shutil.which("browser-use")
+    paths = [
+        os.environ.get("PATH", ""),
+        os.path.join(os.path.expanduser("~"), ".local", "bin"),
+    ]
+    try:
+        paths.append(os.path.join(os.fspath(get_hermes_home()), "bin"))
+    except Exception:
+        pass
+    search_path = os.pathsep.join(dict.fromkeys(path for path in paths if path))
+
+    direct = shutil.which("browser-use", path=search_path)
     if direct:
         return [direct]
-    uvx = shutil.which("uvx")
+    uvx = shutil.which("uvx", path=search_path)
     if uvx:
         return [uvx, "browser-use"]
     return None


### PR DESCRIPTION
## What does this PR do?

Fixes Browser Use CLI discovery when Hermes Desktop starts with a minimal `PATH`.

The Desktop backend may inherit a restricted environment that does not include the user's standard tool directory. In that situation, an installed `browser-use` binary under `~/.local/bin` is runnable from a normal shell but is invisible to Hermes, so Browser Use mode can fall back or report that the CLI is unavailable.

This PR is independent of #83471 and #83627, which address `PYTHONPATH` / `PYTHONHOME` leakage into the Browser Use subprocess. This PR only fixes executable-path discovery.

## Related Issue

No existing issue matching this path-discovery failure was found during the duplicate search.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_use_cli.py`
  - Preserve the inherited `PATH` search.
  - Also search the standard user tool directory (`~/.local/bin`).
  - Also search Hermes' managed bin directory (`$HERMES_HOME/bin`).
  - Apply the combined search path to both the native `browser-use` binary and the `uvx` fallback.
- `tests/tools/test_browser_use_cli.py`
  - Add a regression test that simulates a minimal inherited `PATH` while a user-local `browser-use` binary exists.
  - Update `shutil.which` test doubles to accept its optional `path` argument.

## How to Test

1. Run the targeted pytest file:
   ```text
   uv run --extra dev pytest -q tests/tools/test_browser_use_cli.py
   ```
   Result: `68 passed`.
2. Run the project's per-file test wrapper:
   ```text
   scripts/run_tests.sh tests/tools/test_browser_use_cli.py -q
   ```
   Result: `68 tests passed, 0 failed`.
3. Simulate the Desktop-style restricted environment:
   ```text
   env PATH=/usr/bin PYTHONPATH=<checkout> <hermes-venv>/bin/python -c 'from tools.browser_use_cli import _find_cli; print(_find_cli())'
   ```
   On macOS, this resolved the installed user-local binary at `/Users/kim/.local/bin/browser-use`.

The full test suite was started but not completed. During the macOS run, unrelated gateway tests failed because the environment does not provide the expected Unix abstract socket support, including `tests/gateway/test_systemd_notify.py::test_notify_supports_systemd_abstract_socket`. The browser-specific targeted suite is fully green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] No configuration keys, tool schemas, or user-facing documentation changed

## Screenshots / Logs

Not applicable. The fix changes subprocess executable discovery and has no UI change.
