### PR TITLE
fix(dashboard): bound profile session read pressure

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -13,11 +13,13 @@ late-binding seam in :mod:`hermes_cli.web_deps` so tests that
 """
 
 import asyncio  # noqa: F401 — used by handlers
+import functools
 import json
 import logging
 import re
 import subprocess  # noqa: F401
 import sys  # noqa: F401
+import threading
 import time  # noqa: F401
 from pathlib import Path  # noqa: F401
 from typing import Any, Dict, List, Optional, Tuple  # noqa: F401
@@ -48,6 +50,35 @@ _log = logging.getLogger("hermes_cli.web_server")
 # (profile, message) per process so a persistent failure is loud in
 # errors.log without turning every sidebar poll into log spam.
 _profile_read_warned: set = set()
+
+# These two endpoints fan one request out across every profile state.db. Keep
+# their combined concurrency small so a slow SQLite read cannot consume the
+# server's whole worker pool and retain one DB/WAL handle per queued request.
+_PROFILE_SESSION_READ_CAPACITY = 2
+_PROFILE_SESSION_READ_ACQUIRE_TIMEOUT_S = 0.25
+_profile_session_read_slots = threading.BoundedSemaphore(
+    _PROFILE_SESSION_READ_CAPACITY
+)
+
+
+def _limit_profile_session_reads(handler):
+    @functools.wraps(handler)
+    def limited(*args, **kwargs):
+        acquired = _profile_session_read_slots.acquire(
+            timeout=_PROFILE_SESSION_READ_ACQUIRE_TIMEOUT_S
+        )
+        if not acquired:
+            raise HTTPException(
+                status_code=503,
+                detail="Profile session reads are busy; retry shortly",
+                headers={"Retry-After": "1"},
+            )
+        try:
+            return handler(*args, **kwargs)
+        finally:
+            _profile_session_read_slots.release()
+
+    return limited
 
 
 def _warn_profile_read_error(profile: str, exc: Exception) -> None:
@@ -80,6 +111,7 @@ _write_profile_model = late("_write_profile_model")
 
 
 @sessions_router.get("/api/profiles/sessions")
+@_limit_profile_session_reads
 def get_profiles_sessions(
     # ``le=500`` caps the per-request page size (idea from #39200) — this
     # endpoint fans the query out across EVERY profile's state.db, so an
@@ -230,6 +262,7 @@ def get_profiles_sessions(
 
 
 @sessions_router.get("/api/profiles/sessions/sidebar")
+@_limit_profile_session_reads
 def get_profiles_sessions_sidebar(
     recents_profile: str = "all",
     recents_limit: int = 20,

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -69,7 +69,7 @@ def _limit_profile_session_reads(handler):
         )
         if not acquired:
             raise HTTPException(
-                status_code=503,
+                status_code=429,
                 detail="Profile session reads are busy; retry shortly",
                 headers={"Retry-After": "1"},
             )

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -185,7 +185,7 @@ class TestProfileSessionReadPressure:
             finally:
                 release_reads.set()
 
-            assert response.status_code == 503
+            assert response.status_code == 429
             assert response.headers["retry-after"] == "1"
             assert [future.result().status_code for future in active] == [200, 200]
 

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -130,6 +130,66 @@ class TestSidebarScope:
         assert {row["profile"] for row in payload["messaging"]["sessions"]} == {"default", "worker"}
 
 
+class TestProfileSessionReadPressure:
+
+    def test_sidebar_rejects_excess_concurrent_fanout_reads(
+        self, client, profiles_on_disk, monkeypatch
+    ):
+        """A stalled profile store must not create an unbounded request backlog."""
+        from concurrent.futures import ThreadPoolExecutor
+        import threading
+
+        from hermes_cli import web_server
+
+        _seed_session(profiles_on_disk["default"], "pressure", source="cli")
+
+        lock = threading.Lock()
+        two_reads_entered = threading.Event()
+        release_reads = threading.Event()
+        entered = 0
+
+        class BlockingDB:
+            def __init__(self):
+                self.first_read = True
+
+            def list_sessions_rich(self, **_kwargs):
+                nonlocal entered
+                if self.first_read:
+                    self.first_read = False
+                    with lock:
+                        entered += 1
+                        if entered == 2:
+                            two_reads_entered.set()
+                    assert release_reads.wait(5)
+                return []
+
+            def usage_totals(self):
+                return {"tokens": 0, "cost_usd": 0.0}
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            web_server,
+            "_open_session_db_at_path",
+            lambda *_args, **_kwargs: BlockingDB(),
+        )
+
+        path = "/api/profiles/sessions/sidebar?recents_profile=default"
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            active = [pool.submit(client.get, path) for _ in range(2)]
+            assert two_reads_entered.wait(2)
+            overloaded = pool.submit(client.get, path)
+            try:
+                response = overloaded.result(timeout=1)
+            finally:
+                release_reads.set()
+
+            assert response.status_code == 503
+            assert response.headers["retry-after"] == "1"
+            assert [future.result().status_code for future in active] == [200, 200]
+
+
 class TestCrossProfileProjectTree:
 
     def test_one_folder_worked_in_by_two_profiles_is_one_project(self, client, profiles_on_disk, tmp_path):


### PR DESCRIPTION
## What does this PR do?

Prevents dashboard profile-session fanout from exhausting process resources under concurrent polling.

Both `/api/profiles/sessions` and `/api/profiles/sessions/sidebar` now share a two-slot read-pressure gate. A third concurrent request fails quickly with HTTP 429 and `Retry-After: 1` instead of spawning more cross-profile SQLite work. Permits are always released, including when handlers fail.

## Related Issue

Production incident follow-up; no public issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a shared bounded semaphore around both profile-session fanout endpoints in `hermes_cli/web_routers/profiles.py`.
- Return HTTP 429 with `Retry-After: 1` when read capacity cannot be acquired within 250 ms.
- Preserve FastAPI endpoint signatures with `functools.wraps` and release capacity in `finally`.
- Add a regression test that holds two requests active, verifies the third is rejected quickly, and confirms the active requests complete normally.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_profiles_sidebar_scope.py -q` — 9 passed.
2. `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q -k "profiles_sidebar_heals_stale_schema_store or profiles_sessions_rejects_negative_limit or profiles_sessions_positive_limit_still_works"` — 3 passed.
3. Structured autoreview against current `origin/main` — `patch is correct`, no accepted/actionable findings.

## Checklist

### Code

- [x] I have read the Contributing Guide and repository `AGENTS.md`.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I ran the complete `tests/` suite; targeted affected tests are green as listed above.
- [x] I added tests for the bug fix.
- [x] Tested on Ubuntu Linux.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or API shape was added.
- [x] `cli-config.yaml.example`: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow policy changed.
- [x] Cross-platform impact considered; implementation uses Python standard-library synchronization primitives.
- [x] Tool descriptions/schemas: N/A.
