### PR TITLE
fix(model): bind direct alias credentials to endpoint

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1810,15 +1810,6 @@ def switch_model(
         except Exception:
             pass
 
-    # --- Direct alias override: use exact base_url from the alias if set ---
-    if resolved_alias:
-        _da = direct_alias
-        if _da is not None and _da.base_url:
-            base_url = _da.base_url
-            api_mode = ""  # clear so determine_api_mode re-detects from URL
-            if not api_key:
-                api_key = "no-key-required"
-
     # --- Resolve api_mode from the final (provider, base_url) before validation ---
     # Two cases this closes, both surfaced when the switched model's reasoning
     # is actually applied (post the reasoning-unification refactor):

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -365,6 +365,8 @@ class DirectAlias(NamedTuple):
     model: str
     provider: str
     base_url: str
+    api_key: str = ""
+    key_env: str = ""
 
 
 # Built-in direct aliases (can be extended via config.yaml model_aliases:)
@@ -410,7 +412,11 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                 base_url = entry.get("base_url", "")
                 if model:
                     merged[name.strip().lower()] = DirectAlias(
-                        model=model, provider=provider, base_url=base_url,
+                        model=model,
+                        provider=provider,
+                        base_url=base_url,
+                        api_key=str(entry.get("api_key", "") or ""),
+                        key_env=str(entry.get("key_env", "") or ""),
                     )
 
         # --- model.aliases (string-based format, from config set) ---
@@ -1687,7 +1693,42 @@ def switch_model(
     base_url = current_base_url
     api_mode = ""
 
-    if provider_changed or explicit_provider:
+    direct_alias = None
+    if resolved_alias:
+        _ensure_direct_aliases()
+        direct_alias = DIRECT_ALIASES.get(resolved_alias)
+
+    # A direct alias is an endpoint-and-credential binding.  Resolving the
+    # current/default provider first and applying its base_url afterwards can
+    # send that provider's API key to the alias host (#83612).
+    if direct_alias is not None and direct_alias.base_url:
+        direct_api_key = direct_alias.api_key.strip()
+        if direct_api_key.startswith("${") and direct_api_key.endswith("}"):
+            direct_api_key = _scoped_key_env(direct_api_key[2:-1])
+        if not direct_api_key and direct_alias.key_env.strip():
+            direct_api_key = _scoped_key_env(direct_alias.key_env.strip())
+        try:
+            runtime = resolve_runtime_provider(
+                requested=target_provider,
+                explicit_api_key=direct_api_key or None,
+                explicit_base_url=direct_alias.base_url,
+                target_model=new_model,
+            )
+            api_key = runtime.get("api_key", "") or "no-key-required"
+            base_url = runtime.get("base_url", "") or direct_alias.base_url
+            api_mode = runtime.get("api_mode", "")
+        except Exception as e:
+            return ModelSwitchResult(
+                success=False,
+                target_provider=target_provider,
+                provider_label=provider_label,
+                is_global=is_global,
+                error_message=(
+                    f"Could not resolve credentials for direct alias "
+                    f"'{resolved_alias}': {e}"
+                ),
+            )
+    elif provider_changed or explicit_provider:
         import os
         # User-config providers (providers.<name> in config.yaml) carry their
         # own base_url + transport + key reference. resolve_runtime_provider()
@@ -1771,8 +1812,7 @@ def switch_model(
 
     # --- Direct alias override: use exact base_url from the alias if set ---
     if resolved_alias:
-        _ensure_direct_aliases()
-        _da = DIRECT_ALIASES.get(resolved_alias)
+        _da = direct_alias
         if _da is not None and _da.base_url:
             base_url = _da.base_url
             api_mode = ""  # clear so determine_api_mode re-detects from URL

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -377,20 +377,20 @@ def _run_agent(
             if direct is not None:
                 effective_model = direct.model
                 effective_provider = direct.provider
+                explicit_api_key_from_alias = direct.api_key.strip()
+                if (
+                    explicit_api_key_from_alias.startswith("${")
+                    and explicit_api_key_from_alias.endswith("}")
+                ):
+                    explicit_api_key_from_alias = _ms._scoped_key_env(
+                        explicit_api_key_from_alias[2:-1]
+                    )
+                if not explicit_api_key_from_alias and direct.key_env.strip():
+                    explicit_api_key_from_alias = _ms._scoped_key_env(
+                        direct.key_env.strip()
+                    )
                 if direct.base_url:
                     explicit_base_url_from_alias = direct.base_url.rstrip("/")
-                    explicit_api_key_from_alias = direct.api_key.strip()
-                    if (
-                        explicit_api_key_from_alias.startswith("${")
-                        and explicit_api_key_from_alias.endswith("}")
-                    ):
-                        explicit_api_key_from_alias = _ms._scoped_key_env(
-                            explicit_api_key_from_alias[2:-1]
-                        )
-                    if not explicit_api_key_from_alias and direct.key_env.strip():
-                        explicit_api_key_from_alias = _ms._scoped_key_env(
-                            direct.key_env.strip()
-                        )
             else:
                 cfg_provider = ""
                 if isinstance(model_cfg, dict):

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -358,6 +358,7 @@ def _run_agent(
     # the caller just asked for.
     effective_provider = (provider or "").strip() or None
     explicit_base_url_from_alias: Optional[str] = None
+    explicit_api_key_from_alias: Optional[str] = None
     if effective_provider is None and (model or env_model):
         # Only auto-detect when the model was explicitly requested via arg or
         # env var (not when it came from config — that's the "use my defaults"
@@ -378,6 +379,18 @@ def _run_agent(
                 effective_provider = direct.provider
                 if direct.base_url:
                     explicit_base_url_from_alias = direct.base_url.rstrip("/")
+                    explicit_api_key_from_alias = direct.api_key.strip()
+                    if (
+                        explicit_api_key_from_alias.startswith("${")
+                        and explicit_api_key_from_alias.endswith("}")
+                    ):
+                        explicit_api_key_from_alias = _ms._scoped_key_env(
+                            explicit_api_key_from_alias[2:-1]
+                        )
+                    if not explicit_api_key_from_alias and direct.key_env.strip():
+                        explicit_api_key_from_alias = _ms._scoped_key_env(
+                            direct.key_env.strip()
+                        )
             else:
                 cfg_provider = ""
                 if isinstance(model_cfg, dict):
@@ -395,6 +408,7 @@ def _run_agent(
         requested=effective_provider,
         target_model=effective_model or None,
         explicit_base_url=explicit_base_url_from_alias,
+        explicit_api_key=explicit_api_key_from_alias,
     )
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1127,8 +1127,21 @@ def _resolve_named_custom_runtime(
     if not base_url:
         return None
 
+    # An explicit alias key is bound to the explicit endpoint.  Do not let a
+    # credential-pool entry for the named provider override it: an alias may
+    # deliberately target a different host, and substituting the pool key
+    # would disclose that secret to the alias endpoint (#83612).
+    explicit_key = (explicit_api_key or "").strip()
+    if has_usable_secret(explicit_key):
+        pool_result = None
+    else:
+        pool_result = _try_resolve_from_custom_pool(
+            base_url,
+            "custom",
+            custom_provider.get("api_mode"),
+            provider_name=custom_provider.get("name"),
+        )
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -1153,7 +1166,7 @@ def _resolve_named_custom_runtime(
     _cp_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
     _cp_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
     api_key_candidates = [
-        (explicit_api_key or "").strip(),
+        explicit_key,
         str(custom_provider.get("api_key", "") or "").strip(),
         _getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
         # Gate provider env keys on their authoritative hosts — sending

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1127,6 +1127,22 @@ def _resolve_named_custom_runtime(
     if not base_url:
         return None
 
+    # A direct alias may name a configured custom provider for its model/API
+    # mode while deliberately overriding the endpoint.  The named provider's
+    # pool entry, api_key/key_env, and extra_headers are all credentials bound
+    # to the endpoint in that provider entry; none may cross to the alias
+    # endpoint.  Resolve that case as a bare endpoint instead.  Keep the
+    # named-provider path when the routes are the same so ordinary aliases
+    # retain their configured provider behavior.
+    configured_base_url = _normalize_base_url_for_match(custom_provider.get("base_url"))
+    explicit_route = _normalize_base_url_for_match(explicit_base_url)
+    if explicit_route and configured_base_url and explicit_route != configured_base_url:
+        return _resolve_named_custom_runtime(
+            requested_provider="custom",
+            explicit_api_key=explicit_api_key,
+            explicit_base_url=base_url,
+        )
+
     # An explicit alias key is bound to the explicit endpoint.  Do not let a
     # credential-pool entry for the named provider override it: an alias may
     # deliberately target a different host, and substituting the pool key

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1071,6 +1071,20 @@ def _resolve_named_custom_runtime(
             pass
     if requested_norm == "custom" and explicit_base_url:
         base_url = explicit_base_url.strip().rstrip("/")
+        # An explicit key belongs to this exact endpoint and must win over a
+        # pool entry selected only by host.  Direct model aliases use this
+        # path; reversing the order can silently substitute a different key
+        # for the alias's configured credential (#83612).
+        explicit_key = (explicit_api_key or "").strip()
+        if has_usable_secret(explicit_key):
+            return {
+                "provider": "custom",
+                "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
+                "base_url": base_url,
+                "api_key": explicit_key,
+                "source": "direct-alias",
+                "requested_provider": requested_provider,
+            }
         # Check credential pool first — mirrors the named-custom-provider path
         # so bare `provider: custom` with a configured custom_providers entry
         # also gets its api_key from the pool instead of env var fallbacks.
@@ -1081,7 +1095,6 @@ def _resolve_named_custom_runtime(
         _da_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
         _da_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
         api_key_candidates = [
-            (explicit_api_key or "").strip(),
             # Gate env key fallbacks on authoritative hosts (#28660)
             (_getenv("OPENAI_API_KEY", "").strip()     if _da_is_openai_url else ""),
             (_getenv("OPENROUTER_API_KEY", "").strip() if _da_is_openrouter  else ""),

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -68,6 +68,38 @@ class TestOllamaCloudCredentials:
 
         assert runtime["api_key"] == "alias-key"
 
+    def test_named_custom_endpoint_explicit_key_beats_pool_entry(self, monkeypatch):
+        """A direct alias may name a configured custom provider but select a
+        different endpoint. Its explicit key must win before pool lookup."""
+        from hermes_cli import runtime_provider as rp
+
+        monkeypatch.setattr(
+            rp,
+            "_get_named_custom_provider",
+            lambda _name: {
+                "name": "foo",
+                "base_url": "https://configured.example/v1",
+            },
+        )
+        monkeypatch.setattr(
+            rp,
+            "_try_resolve_from_custom_pool",
+            lambda *args, **kwargs: {
+                "api_key": "pool-key-that-must-not-leak",
+                "base_url": "https://alias.example/v1",
+                "api_mode": "chat_completions",
+            },
+        )
+
+        runtime = rp.resolve_runtime_provider(
+            requested="custom:foo",
+            explicit_base_url="https://alias.example/v1",
+            explicit_api_key="alias-key",
+        )
+
+        assert runtime["api_key"] == "alias-key"
+        assert runtime["base_url"] == "https://alias.example/v1"
+
 
 # ---------------------------------------------------------------------------
 # Direct alias resolution

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -100,6 +100,50 @@ class TestOllamaCloudCredentials:
         assert runtime["api_key"] == "alias-key"
         assert runtime["base_url"] == "https://alias.example/v1"
 
+    def test_named_custom_alias_endpoint_drops_provider_credentials(self, monkeypatch):
+        """An alias endpoint override must not inherit a named provider's
+        pool key, static key, auth headers, or request overrides (#83612)."""
+        from hermes_cli import runtime_provider as rp
+
+        monkeypatch.setattr(
+            rp,
+            "_get_named_custom_provider",
+            lambda _name: {
+                "name": "trusted",
+                "base_url": "https://trusted.example/v1",
+                "api_key": "trusted-key-that-must-not-leak",
+                "key_env": "TRUSTED_API_KEY",
+                "extra_headers": {"Authorization": "Bearer trusted-header"},
+                "extra_body": {"tenant": "trusted"},
+            },
+        )
+        monkeypatch.setenv("TRUSTED_API_KEY", "trusted-env-key-that-must-not-leak")
+        pool_calls = []
+
+        def pool(*args, **kwargs):
+            pool_calls.append((args, kwargs))
+            if kwargs.get("provider_name") is None:
+                return None
+            return {
+                "api_key": "trusted-pool-key-that-must-not-leak",
+                "base_url": args[0],
+                "api_mode": "chat_completions",
+            }
+
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", pool)
+
+        runtime = rp.resolve_runtime_provider(
+            requested="custom:trusted",
+            explicit_base_url="https://alias.example/v1",
+        )
+
+        assert runtime["base_url"] == "https://alias.example/v1"
+        assert runtime["api_key"] == "no-key-required"
+        assert runtime["source"] == "direct-alias"
+        assert "extra_headers" not in runtime
+        assert "request_overrides" not in runtime
+        assert pool_calls == [(('https://alias.example/v1', 'custom', None), {})]
+
 
 # ---------------------------------------------------------------------------
 # Direct alias resolution

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -45,6 +45,29 @@ class TestOllamaCloudCredentials:
         assert runtime["api_key"] == "test-ollama-key-12345"
         assert runtime["provider"] == "custom"
 
+    def test_explicit_custom_endpoint_key_beats_pool_entry(self, monkeypatch):
+        """An explicit alias key is bound to its endpoint and cannot be
+        replaced by a host-level pool credential (#83612)."""
+        from hermes_cli import runtime_provider as rp
+
+        monkeypatch.setattr(
+            rp,
+            "_try_resolve_from_custom_pool",
+            lambda *args: {
+                "api_key": "pool-key-that-must-not-win",
+                "base_url": "https://theta.example/infer_request",
+                "api_mode": "chat_completions",
+            },
+        )
+
+        runtime = rp.resolve_runtime_provider(
+            requested="custom",
+            explicit_base_url="https://theta.example/infer_request",
+            explicit_api_key="alias-key",
+        )
+
+        assert runtime["api_key"] == "alias-key"
+
 
 # ---------------------------------------------------------------------------
 # Direct alias resolution
@@ -76,6 +99,30 @@ class TestDirectAliases:
         assert aliases["mymodel"].model == "custom-model:latest"
         assert aliases["mymodel"].provider == "custom"
         assert aliases["mymodel"].base_url == "https://example.com/v1"
+
+    def test_direct_alias_loads_credential_fields(self, monkeypatch):
+        """Direct aliases must retain credentials instead of silently
+        discarding the api_key / key_env supplied for their endpoint (#83612)."""
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model_aliases": {
+                    "theta": {
+                        "model": "glm_5_2",
+                        "provider": "custom",
+                        "base_url": "https://theta.example/infer_request",
+                        "api_key": "theta-key",
+                        "key_env": "THETA_API_KEY",
+                    }
+                }
+            },
+        )
+
+        from hermes_cli.model_switch import _load_direct_aliases
+
+        alias = _load_direct_aliases()["theta"]
+        assert alias.api_key == "theta-key"
+        assert alias.key_env == "THETA_API_KEY"
 
     def test_direct_alias_resolved_before_catalog(self, monkeypatch):
         """Direct aliases take priority over models.dev catalog lookup."""
@@ -420,6 +467,63 @@ class TestSwitchModelDirectAliasOverride:
         assert result.success
         assert result.api_key == "no-key-required"
         assert result.base_url == "http://localhost:11434/v1"
+
+    def test_switch_model_binds_alias_key_before_runtime_resolution(self, monkeypatch):
+        """The endpoint and key of a direct alias are one security boundary.
+        A current provider key must never be resolved and then carried to the
+        alias host (#83612)."""
+        from hermes_cli.model_switch import DirectAlias
+        import hermes_cli.model_switch as ms
+
+        monkeypatch.setattr(
+            ms,
+            "DIRECT_ALIASES",
+            {
+                "theta": DirectAlias(
+                    "glm_5_2",
+                    "custom",
+                    "https://theta.example/infer_request",
+                    "theta-key",
+                )
+            },
+        )
+        monkeypatch.setattr(
+            ms,
+            "resolve_alias",
+            lambda raw, provider: ("custom", "glm_5_2", "theta"),
+        )
+        captured = {}
+
+        def fake_resolve_runtime_provider(**kwargs):
+            captured.update(kwargs)
+            return {
+                "api_key": kwargs["explicit_api_key"],
+                "base_url": kwargs["explicit_base_url"],
+                "api_mode": "chat_completions",
+                "provider": "custom",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.validate_requested_model",
+            lambda *a, **kw: {"accepted": True, "persist": True, "recognized": True, "message": None},
+        )
+        monkeypatch.setattr("hermes_cli.models.opencode_model_api_mode", lambda *a, **kw: "openai_compat")
+
+        result = ms.switch_model(
+            "theta",
+            "openrouter",
+            "old-model",
+            current_api_key="openrouter-key-that-must-not-leak",
+        )
+
+        assert captured["explicit_base_url"] == "https://theta.example/infer_request"
+        assert captured["explicit_api_key"] == "theta-key"
+        assert result.api_key == "theta-key"
+        assert result.base_url == "https://theta.example/infer_request"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_oneshot_direct_alias_credentials.py
+++ b/tests/hermes_cli/test_oneshot_direct_alias_credentials.py
@@ -1,0 +1,119 @@
+"""Credential binding regressions for ``hermes -z --model <alias>``."""
+
+
+def test_oneshot_forwards_direct_alias_key_to_runtime_resolution(monkeypatch):
+    """The non-interactive alias path must not drop its configured key and
+    fall back to a credential-pool secret for the alias endpoint (#83612)."""
+    import hermes_cli.oneshot as oneshot
+    import hermes_cli.model_switch as ms
+    from hermes_cli.model_switch import DirectAlias
+
+    monkeypatch.setattr(
+        ms,
+        "DIRECT_ALIASES",
+        {
+            "theta": DirectAlias(
+                "glm_5_2",
+                "custom",
+                "https://theta.example/infer_request",
+                "theta-key",
+            )
+        },
+    )
+    monkeypatch.setattr(ms, "_ensure_direct_aliases", lambda: None)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(oneshot, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+        lambda **kwargs: None,
+    )
+    captured = {}
+
+    def fake_runtime(**kwargs):
+        captured.update(kwargs)
+        return {
+            "provider": "custom",
+            "requested_provider": "custom",
+            "base_url": kwargs["explicit_base_url"],
+            "api_key": kwargs["explicit_api_key"],
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime)
+
+    class FakeAgent:
+        def __init__(self, **_kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, _prompt):
+            return {"final_response": "ok"}
+
+        def shutdown_memory_provider(self, *_args):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+
+    response, _result = oneshot._run_agent("ping", model="theta")
+
+    assert response == "ok"
+    assert captured["requested"] == "custom"
+    assert captured["explicit_base_url"] == "https://theta.example/infer_request"
+    assert captured["explicit_api_key"] == "theta-key"
+
+
+def test_oneshot_resolves_direct_alias_key_env(monkeypatch):
+    """``key_env`` is an alias credential too, not merely interactive
+    picker metadata (#83612)."""
+    import hermes_cli.oneshot as oneshot
+    import hermes_cli.model_switch as ms
+    from hermes_cli.model_switch import DirectAlias
+
+    monkeypatch.setattr(
+        ms,
+        "DIRECT_ALIASES",
+        {
+            "theta": DirectAlias(
+                "glm_5_2",
+                "custom",
+                "https://theta.example/infer_request",
+                "",
+                "THETA_API_KEY",
+            )
+        },
+    )
+    monkeypatch.setattr(ms, "_ensure_direct_aliases", lambda: None)
+    monkeypatch.setattr(ms, "_scoped_key_env", lambda name: "theta-env-key" if name == "THETA_API_KEY" else "")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(oneshot, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build", lambda **kwargs: None)
+    captured = {}
+
+    def fake_runtime(**kwargs):
+        captured.update(kwargs)
+        return {
+            "provider": "custom", "requested_provider": "custom",
+            "base_url": kwargs["explicit_base_url"], "api_key": kwargs["explicit_api_key"],
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime)
+
+    class FakeAgent:
+        def __init__(self, **_kwargs):
+            self._session_messages = []
+        def run_conversation(self, _prompt):
+            return {"final_response": "ok"}
+        def shutdown_memory_provider(self, *_args):
+            pass
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+    oneshot._run_agent("ping", model="theta")
+
+    assert captured["explicit_api_key"] == "theta-env-key"

--- a/tests/hermes_cli/test_oneshot_direct_alias_credentials.py
+++ b/tests/hermes_cli/test_oneshot_direct_alias_credentials.py
@@ -117,3 +117,37 @@ def test_oneshot_resolves_direct_alias_key_env(monkeypatch):
     oneshot._run_agent("ping", model="theta")
 
     assert captured["explicit_api_key"] == "theta-env-key"
+
+
+def test_oneshot_forwards_direct_alias_key_without_base_url(monkeypatch):
+    """An alias key still overrides provider credentials without an endpoint override."""
+    import hermes_cli.oneshot as oneshot
+    import hermes_cli.model_switch as ms
+    from hermes_cli.model_switch import DirectAlias
+
+    monkeypatch.setattr(
+        ms, "DIRECT_ALIASES", {"theta": DirectAlias("glm_5_2", "custom", "", "theta-key")}
+    )
+    monkeypatch.setattr(ms, "_ensure_direct_aliases", lambda: None)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(oneshot, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build", lambda **_kwargs: None)
+    captured = {}
+
+    def fake_runtime(**kwargs):
+        captured.update(kwargs)
+        return {"provider": "custom", "base_url": "https://configured.example/v1", "api_key": "theta-key"}
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime)
+
+    class FakeAgent:
+        def __init__(self, **_kwargs): self._session_messages = []
+        def run_conversation(self, _prompt): return {"final_response": "ok"}
+        def shutdown_memory_provider(self, *_args): pass
+        def close(self): pass
+
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+    oneshot._run_agent("ping", model="theta")
+    assert captured["explicit_base_url"] is None
+    assert captured["explicit_api_key"] == "theta-key"


### PR DESCRIPTION
## Summary

Fixes #83612.

- Retain `api_key` and `key_env` on config-defined direct model aliases.
- Resolve a direct alias's endpoint and credential together before any generic provider lookup.
- Give an explicit alias key precedence over a host-level credential-pool entry.
- Prevent the active/default provider credential from being carried to a direct alias's custom host.

## Security invariant

The API key selected for a model switch must be authorized for the final `base_url`; changing the endpoint after generic credential resolution is not permitted.

## Validation

- Added regression coverage for config loading, endpoint/key binding, and explicit-key precedence.
- `62 passed` across custom-provider and model-switch regression suites.
- `ruff check` and `git diff --check` pass.