### PR TITLE
fix(desktop): route messaging settings to active profile

### DIFF
--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -5,13 +5,16 @@ import {
   getActionStatus,
   getElevenLabsVoices,
   getMemoryProviderConfig,
+  getMessagingPlatforms,
   getStatus,
   restartGateway,
   saveMemoryProviderConfig,
   setApiRequestProfile,
   speakText,
+  testMessagingPlatform,
   transcribeAudio,
-  updateHermes
+  updateHermes,
+  updateMessagingPlatform
 } from './hermes'
 
 // Contract: every backend-targeted action helper must carry the active gateway
@@ -79,5 +82,19 @@ describe('backend action helpers are profile-scoped', () => {
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBe('jarvis')
     }
+  })
+
+  it('forwards the active profile to every messaging-platform request', () => {
+    setApiRequestProfile('jeeves')
+
+    void getMessagingPlatforms()
+    void updateMessagingPlatform('weixin', { enabled: true })
+    void testMessagingPlatform('weixin')
+
+    expect(api.mock.calls.map(([request]) => [request.path, request.profile])).toEqual([
+      ['/api/messaging/platforms', 'jeeves'],
+      ['/api/messaging/platforms/weixin', 'jeeves'],
+      ['/api/messaging/platforms/weixin/test', 'jeeves']
+    ])
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1268,6 +1268,7 @@ export function grantComputerUsePermissions(): Promise<ActionResponse> {
 
 export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
   return window.hermesDesktop.api<MessagingPlatformsResponse>({
+    ...profileScoped(),
     path: '/api/messaging/platforms'
   })
 }
@@ -1277,6 +1278,7 @@ export function updateMessagingPlatform(
   body: MessagingPlatformUpdate
 ): Promise<{ ok: boolean; platform: string }> {
   return window.hermesDesktop.api<{ ok: boolean; platform: string }>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}`,
     method: 'PUT',
     body
@@ -1285,6 +1287,7 @@ export function updateMessagingPlatform(
 
 export function testMessagingPlatform(platformId: string): Promise<MessagingPlatformTestResponse> {
   return window.hermesDesktop.api<MessagingPlatformTestResponse>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
     method: 'POST'
   })


### PR DESCRIPTION
## Summary
Desktop Messaging Platforms settings now read, save, and connectivity-test the selected profile instead of silently targeting the default profile.

Root cause: the three messaging helpers in `apps/desktop/src/hermes.ts` were the last settings surface not routed through the existing `profileScoped()` request seam, so Electron served them from the default profile's backend regardless of the active profile.

## Changes
- `apps/desktop/src/hermes.ts`: attach the active profile to `getMessagingPlatforms()`, `updateMessagingPlatform()`, `testMessagingPlatform()`
- `apps/desktop/src/hermes-profile-scope.test.ts`: regression test asserting all three helpers forward the active profile

## Validation
| Check | Result |
|---|---|
| `vitest run src/hermes-profile-scope.test.ts src/app/messaging/index.test.tsx` | 12/12 passed |
| `npm run typecheck` (renderer + electron + e2e) | passed |
| Packaged-app E2E (by @ctaylor86 on #76913) | profile switch shows correct per-profile state |

## Credit
Salvage of the earliest submission of this fix. Same change was independently submitted five times:
- #58110 (@rod-fernandez / rod-nxtlevel, Jul 4 — earliest; messaging half of an omnibus PR; fix commit authored to them)
- #71343 (@phudinhvfx, Jul 25)
- #72318 (@EvanProgramming, Jul 27)
- #76913 (@Christopher-Schulze, Aug 2 — cleanest regression test; test commit authored to them)
- #83591 (@friendfish, Aug 11)

Fixes #76899

## Infographic

![Messaging settings follow the active profile](https://v3b.fal.media/files/b/0aa5e3c2/1S51vFYVK-R045Sk_pYCH_RNqW1Vmz.png)
