### PR TITLE
fix(codex): skip provider client in app-server mode

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1120,6 +1120,18 @@ def init_agent(
                     print("🔑 Using credentials: Microsoft Entra ID")
                 elif isinstance(effective_key, str) and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
+    elif agent.api_mode == "codex_app_server":
+        # Codex owns transport construction and authentication in this mode.
+        # The subprocess reads its own CODEX_HOME config/auth state; building a
+        # Hermes provider client here is both unused and breaks the documented
+        # no-API-key path before the first turn can reach the app-server.
+        agent.client = None
+        agent._client_kwargs = {}
+        if not agent.quiet_mode:
+            print(
+                f"🤖 AI Agent initialized with model: {agent.model} "
+                "(Codex app-server)"
+            )
     elif agent.provider == "moa":
         from agent.moa_loop import build_moa_facade
         agent.api_mode = "chat_completions"

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -71,6 +71,26 @@ class TestApiModeAccepted:
         agent = _make_codex_agent()
         assert agent.api_mode == "codex_app_server"
 
+    def test_initialization_does_not_build_provider_client(self):
+        """The app-server subprocess owns auth and the upstream transport."""
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=AssertionError(
+                "codex_app_server must not build a Hermes provider client"
+            ),
+        ):
+            agent = run_agent.AIAgent(
+                model="gpt-5.4",
+                provider="openai",
+                api_mode="codex_app_server",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert agent.client is None
+        assert agent._client_kwargs == {}
+
 
 class TestRunConversationCodexPath:
     def test_run_conversation_returns_codex_shape(self, fake_session):


### PR DESCRIPTION
## What does this PR do?

Prevents `AIAgent` from constructing an unused Hermes provider client when `api_mode="codex_app_server"`.

The Codex app-server subprocess owns its transport and authenticates from its own `CODEX_HOME` state. On current `main`, initialization still falls through to `resolve_provider_client()` when Hermes has no explicit API key/base URL. That makes the documented no-API-key app-server path fail before the first turn reaches Codex.

The new branch mirrors the existing native-transport initialization paths: it leaves `agent.client` unset and records empty client kwargs while preserving all later Codex app-server lifecycle behavior.

## Related Issue

No existing equivalent issue or PR found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a dedicated `codex_app_server` initialization branch in `agent/agent_init.py`.
- Add a regression test proving provider-client resolution is never invoked when constructing an app-server agent without Hermes API credentials.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/run_agent/test_codex_app_server_integration.py tests/hermes_cli/test_codex_runtime_switch.py -q`.
2. Verify all 49 tests pass.
3. The regression test patches `resolve_provider_client()` to raise; construction succeeds with `client is None`, proving the unused provider path is skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.2, Python 3.12.12

Targeted canonical-runner coverage is green (49 passed). The full suite was not claimed locally; current unmodified `upstream/main` also reproduces an unrelated Qwen OAuth fallback test failure in this environment.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Canonical targeted runner: 49 passed, 0 failed.
- Ruff: passed.
- `scripts/check-windows-footguns.py --diff upstream/main`: passed.
- `git diff --check`: passed.
