### PR TITLE
fix(vision): keep native image ingest tool available

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -684,6 +684,9 @@ class TestVisionRegistration:
         assert entry.toolset == "vision"
         assert entry.is_async is True
         assert callable(entry.handler)
+        # Native-vision sessions do not require an auxiliary vision client.
+        # A static auxiliary probe must therefore never hide this tool.
+        assert entry.check_fn is None
 
         props = entry.schema.get("parameters", {}).get("properties", {})
         assert "image_url" in props

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1800,7 +1800,11 @@ registry.register(
     toolset="vision",
     schema=VISION_ANALYZE_SCHEMA,
     handler=_handle_vision_analyze,
-    check_fn=check_vision_requirements,
+    # Availability cannot be decided by probing only the auxiliary client:
+    # the live session may use the native multimodal tool-result path instead.
+    # Keep the canonical image-ingest tool visible and let the handler choose
+    # the native or auxiliary route from the active runtime.
+    check_fn=None,
     is_async=True,
     emoji="👁️",
 )


### PR DESCRIPTION
## What does this PR do?

Keeps `vision_analyze` visible when a session can use the active model's native multimodal tool-result path but has no separately configured auxiliary vision client.

Current `main` registers the tool with `check_vision_requirements`, which probes only auxiliary-client resolution. The registry runs that probe before tool dispatch and drops the schema on failure, so the handler never gets a chance to evaluate `_should_use_native_vision_fast_path()`. This contradicts both the dual-route handler and the tool reference's no-extra-environment contract.

The fix removes the auxiliary-only registration gate for `vision_analyze`. Route selection remains centralized in `_handle_vision_analyze`: native-capable sessions attach pixels to the active model, while text-only sessions use the existing auxiliary fallback and retain its normal error reporting when unavailable. `video_analyze` remains auxiliary-gated.

## Related Issue

No existing equivalent issue or PR found. Related native-vision work exists, but none addresses the registry hiding `vision_analyze` before its native route can run.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Register `vision_analyze` without the auxiliary-only `check_fn` gate in `tools/vision_tools.py`.
- Add a registration-contract regression test ensuring native vision cannot be hidden by an auxiliary probe.
- Leave `check_vision_requirements()` and the `video_analyze` gate unchanged for auxiliary-only callers.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/tools/test_vision_tools.py -q`.
2. Verify 32 tests pass (2 optional-dependency skips).
3. Optionally run `pytest tests/agent/test_image_routing.py tests/test_model_tools_async_bridge.py tests/test_toolsets.py -q`; 71 pass with 1 optional skip.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.2, Python 3.12.12

Targeted canonical-runner and adjacent routing/registry coverage is green (103 passed total, 3 optional skips). The full suite was not claimed locally.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Canonical targeted runner: 32 passed, 0 failed, 2 skipped.
- Adjacent routing/registry suite: 71 passed, 0 failed, 1 skipped.
- Ruff: passed.
- `scripts/check-windows-footguns.py --diff upstream/main`: passed.
- `git diff --check`: passed.
