### PR TITLE
feat(terminal): operator-trusted env passthrough | WE-19116

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -310,6 +310,13 @@ DEFAULT_CONFIG = {
         # (terminal and execute_code).  Skill-declared required_environment_variables
         # are passed through automatically; this list is for non-skill use cases.
         "env_passthrough": [],
+        # Operator-only override letting protected credentials (names in the
+        # provider blocklist, e.g. GH_TOKEN for gh/git) reach TERMINAL
+        # subprocesses only. Empty by default. Unlike env_passthrough above it
+        # may name provider credentials, but it is config-only — skills can
+        # never populate it — and can never expose a dynamic Hermes-internal
+        # secret (AUXILIARY_*_API_KEY / _BASE_URL, GATEWAY_RELAY_* auth).
+        "trusted_env_passthrough": [],
         # HOME handling for host tool subprocesses:
         #   auto    — host keeps the real OS-user HOME; containers use
         #             HERMES_HOME/home for persistent state (default)

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -1,6 +1,7 @@
 """Tests for tools.env_passthrough — skill and config env var passthrough."""
 
 import os
+from unittest.mock import patch
 import pytest
 import yaml
 
@@ -10,6 +11,7 @@ from tools.env_passthrough import (
     clear_env_passthrough,
     get_all_passthrough,
     is_env_passthrough,
+    is_trusted_env_passthrough,
     register_env_passthrough,
     resolve_passthrough_value,
 )
@@ -20,10 +22,12 @@ def _clean_passthrough():
     """Ensure a clean passthrough state for every test."""
     clear_env_passthrough()
     _ep_mod._config_passthrough = None
+    _ep_mod._trusted_passthrough = None
     ss.set_multiplex_active(False)
     yield
     clear_env_passthrough()
     _ep_mod._config_passthrough = None
+    _ep_mod._trusted_passthrough = None
     ss.set_multiplex_active(False)
 
 
@@ -411,3 +415,156 @@ class TestTerminalIntegration:
         assert "OPENAI_API_KEY" not in child_env
         assert "ANTHROPIC_API_KEY" not in child_env
         assert child_env["PATH"] == "/usr/bin"
+
+
+class TestTrustedConfigPassthrough:
+    """Operator-only ``terminal.trusted_env_passthrough`` — the sanctioned way
+    to let a protected credential (e.g. GH_TOKEN) reach terminal subprocesses.
+    Config-only: skills can never populate it, and dynamic Hermes-internal
+    secrets can never be trusted through it."""
+
+    def _write_config(self, tmp_path, monkeypatch, trusted):
+        config = {"terminal": {"trusted_env_passthrough": trusted}}
+        (tmp_path / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _ep_mod._trusted_passthrough = None
+        _ep_mod._config_passthrough = None
+
+    def test_defaults_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _ep_mod._trusted_passthrough = None
+        assert not is_trusted_env_passthrough("GH_TOKEN")
+
+    def test_reads_gh_token_from_config(self, tmp_path, monkeypatch):
+        self._write_config(tmp_path, monkeypatch, ["GH_TOKEN"])
+        assert is_trusted_env_passthrough("GH_TOKEN")
+        assert not is_trusted_env_passthrough("SOME_OTHER_VAR")
+
+    def test_rejects_dynamic_internal_secret(self, tmp_path, monkeypatch):
+        # An operator cannot trust a dynamically-named Hermes secret, even by
+        # listing it explicitly — the loader filters these out.
+        self._write_config(tmp_path, monkeypatch, [
+            "GH_TOKEN",
+            "AUXILIARY_VISION_API_KEY",
+            "AUXILIARY_VISION_BASE_URL",
+            "GATEWAY_RELAY_SECRET",
+        ])
+        assert is_trusted_env_passthrough("GH_TOKEN")
+        assert not is_trusted_env_passthrough("AUXILIARY_VISION_API_KEY")
+        assert not is_trusted_env_passthrough("AUXILIARY_VISION_BASE_URL")
+        assert not is_trusted_env_passthrough("GATEWAY_RELAY_SECRET")
+
+    def test_is_config_only_skills_cannot_populate(self, tmp_path, monkeypatch):
+        # Trusting GH_TOKEN in config does NOT add it to the skill/ordinary
+        # allowlist, and a skill registering it is still refused there.
+        self._write_config(tmp_path, monkeypatch, ["GH_TOKEN"])
+        register_env_passthrough(["GH_TOKEN"])
+        assert not is_env_passthrough("GH_TOKEN")
+        assert "GH_TOKEN" not in get_all_passthrough()
+        # The trusted set stays separate and authoritative for the terminal.
+        assert is_trusted_env_passthrough("GH_TOKEN")
+
+    def test_ordinary_passthrough_unaffected(self, tmp_path, monkeypatch):
+        # Ordinary skill/config passthrough of non-protected vars keeps working
+        # alongside a trusted-credential config, and does not leak into trusted.
+        config = {
+            "terminal": {
+                "trusted_env_passthrough": ["GH_TOKEN"],
+                "env_passthrough": ["MY_CUSTOM_KEY"],
+            }
+        }
+        (tmp_path / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _ep_mod._trusted_passthrough = None
+        _ep_mod._config_passthrough = None
+
+        register_env_passthrough(["TENOR_API_KEY"])
+        assert is_env_passthrough("MY_CUSTOM_KEY")   # ordinary config
+        assert is_env_passthrough("TENOR_API_KEY")   # skill
+        assert not is_trusted_env_passthrough("MY_CUSTOM_KEY")
+
+
+class TestTrustedTerminalPassthrough:
+    """The trusted override is honored ONLY by terminal env construction
+    (``_make_run_env``) and never widens beyond it."""
+
+    def test_make_run_env_strips_gh_token_by_default(self):
+        from tools.environments.local import _make_run_env
+
+        _ep_mod._trusted_passthrough = frozenset()
+        with patch.dict(os.environ, {"PATH": "/usr/bin", "GH_TOKEN": "ghp_secret"}, clear=True):
+            run_env = _make_run_env({})
+        assert "GH_TOKEN" not in run_env
+
+    def test_make_run_env_allows_trusted_gh_token(self):
+        from tools.environments.local import _make_run_env
+
+        _ep_mod._trusted_passthrough = frozenset({"GH_TOKEN"})
+        with patch.dict(os.environ, {"PATH": "/usr/bin", "GH_TOKEN": "ghp_secret"}, clear=True):
+            run_env = _make_run_env({})
+        assert run_env.get("GH_TOKEN") == "ghp_secret"
+
+    def test_make_run_env_never_exposes_dynamic_secret_even_if_trusted(self):
+        # Defense in depth: even if the trusted set somehow named a dynamic
+        # internal secret, _make_run_env strips it before the trusted check.
+        from tools.environments.local import _make_run_env
+
+        _ep_mod._trusted_passthrough = frozenset(
+            {"AUXILIARY_VISION_API_KEY", "GATEWAY_RELAY_SECRET"}
+        )
+        with patch.dict(os.environ, {
+            "PATH": "/usr/bin",
+            "AUXILIARY_VISION_API_KEY": "sk-secret",
+            "GATEWAY_RELAY_SECRET": "relay-secret",
+        }, clear=True):
+            run_env = _make_run_env({})
+        assert "AUXILIARY_VISION_API_KEY" not in run_env
+        assert "GATEWAY_RELAY_SECRET" not in run_env
+
+    def test_trusted_gh_token_has_no_effect_outside_terminal(self):
+        from tools.code_execution_tool import _scrub_child_env
+        from tools.environments.local import _sanitize_subprocess_env
+
+        _ep_mod._trusted_passthrough = frozenset({"GH_TOKEN"})
+        # execute_code sandbox is unaffected.
+        child_env = _scrub_child_env(
+            {"GH_TOKEN": "ghp_secret", "PATH": "/usr/bin"}, is_windows=False
+        )
+        assert "GH_TOKEN" not in child_env
+        # Background/PTY + generic build_subprocess_env engine is unaffected.
+        sanitized = _sanitize_subprocess_env({"GH_TOKEN": "ghp_secret", "PATH": "/usr/bin"})
+        assert "GH_TOKEN" not in sanitized
+        # The ordinary/skill allowlist never reports it either.
+        assert not is_env_passthrough("GH_TOKEN")
+
+    def test_make_run_env_trusted_uses_active_profile_scope(self, monkeypatch):
+        # Profile-scoped secret resolution is preserved for trusted credentials:
+        # the routed profile's value wins over the process env value.
+        from tools.environments.local import _make_run_env
+
+        _ep_mod._trusted_passthrough = frozenset({"GH_TOKEN"})
+        monkeypatch.setenv("GH_TOKEN", "ghp-default-profile")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"GH_TOKEN": "ghp-routed-profile"})
+        try:
+            run_env = _make_run_env({})
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+        assert run_env.get("GH_TOKEN") == "ghp-routed-profile"
+
+    def test_make_run_env_trusted_omits_missing_scoped_secret(self, monkeypatch):
+        # A trusted credential absent from the routed scope must not fall back
+        # to the process env under active multiplexing.
+        from tools.environments.local import _make_run_env
+
+        _ep_mod._trusted_passthrough = frozenset({"GH_TOKEN"})
+        monkeypatch.setenv("GH_TOKEN", "ghp-default-profile")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({})
+        try:
+            run_env = _make_run_env({})
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+        assert "GH_TOKEN" not in run_env

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -17,6 +17,14 @@ Both ``code_execution_tool.py`` and ``tools/environments/local.py`` consult
 :func:`is_env_passthrough` before stripping a variable.
 When profile multiplexing is active, their forwarded values are resolved
 through the current profile's secret scope rather than the process environment.
+
+For protected credentials an operator explicitly needs in the local terminal
+(e.g. ``GH_TOKEN`` for ``gh``/``git``), ``terminal.trusted_env_passthrough`` is
+a separate, config-only override read by :func:`is_trusted_env_passthrough`.
+Unlike the two sources above it MAY name provider credentials, but only the
+terminal backend's environment construction honours it — never skills,
+execute_code, or the non-terminal spawn helpers — and it can never expose a
+dynamic Hermes-internal secret.
 """
 
 from __future__ import annotations
@@ -177,6 +185,71 @@ def is_env_passthrough(var_name: str) -> bool:
 def get_all_passthrough() -> frozenset[str]:
     """Return the union of skill-registered and config-based passthrough vars."""
     return frozenset(_get_allowed()) | _load_config_passthrough()
+
+
+# Cache for the operator-configured trusted terminal allowlist (loaded once
+# per process). Kept distinct from _config_passthrough: skills never feed it
+# and it MAY name protected provider credentials.
+_trusted_passthrough: frozenset[str] | None = None
+
+
+def _load_trusted_env_passthrough() -> frozenset[str]:
+    """Load ``terminal.trusted_env_passthrough`` from config.yaml (cached).
+
+    This operator-only allowlist is the single sanctioned way to let a
+    protected provider credential — a name in ``_HERMES_PROVIDER_ENV_BLOCKLIST``
+    such as ``GH_TOKEN`` — reach terminal subprocesses, for operators who want
+    ``gh``/``git`` in the agent terminal to use their own token. It defaults
+    empty and is read only from config.yaml: skills cannot populate it, so the
+    skill-bypass surface closed by GHSA-rhgp-j443-p4rf is untouched.
+
+    Dynamic Hermes-internal secrets (``_is_hermes_internal_secret``:
+    ``AUXILIARY_*_API_KEY`` / ``_BASE_URL``, ``GATEWAY_RELAY_*`` auth) can never
+    be trusted this way; they are filtered out here and remain stripped
+    unconditionally on every spawn path.
+    """
+    global _trusted_passthrough
+    if _trusted_passthrough is not None:
+        return _trusted_passthrough
+
+    result: set[str] = set()
+    try:
+        from hermes_cli.config import read_raw_config
+        from tools.environments.local import _is_hermes_internal_secret
+
+        cfg = read_raw_config()
+        trusted = cfg_get(cfg, "terminal", "trusted_env_passthrough")
+        if isinstance(trusted, list):
+            for item in trusted:
+                if not isinstance(item, str) or not item.strip():
+                    continue
+                name = item.strip()
+                if _is_hermes_internal_secret(name):
+                    logger.warning(
+                        "env passthrough: refusing to trust dynamic Hermes "
+                        "internal secret %r via terminal.trusted_env_passthrough",
+                        name,
+                    )
+                    continue
+                result.add(name)
+    except Exception as e:
+        logger.debug("Could not read terminal.trusted_env_passthrough: %s", e)
+
+    _trusted_passthrough = frozenset(result)
+    return _trusted_passthrough
+
+
+def is_trusted_env_passthrough(var_name: str) -> bool:
+    """Return True if *var_name* is operator-trusted for terminal subprocesses.
+
+    Distinct from :func:`is_env_passthrough`: this consults only the operator's
+    ``terminal.trusted_env_passthrough`` config (never skill state or the
+    ordinary ``terminal.env_passthrough`` allowlist) and MAY name protected
+    provider credentials. Only the terminal backend's environment construction
+    (``tools.environments.local._make_run_env``) honours it, so the override
+    never widens beyond terminal subprocesses.
+    """
+    return var_name in _load_trusted_env_passthrough()
 
 
 def resolve_passthrough_value(

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1270,10 +1270,12 @@ def _make_run_env(env: dict) -> dict:
     try:
         from tools.env_passthrough import (
             is_env_passthrough as _is_passthrough,
+            is_trusted_env_passthrough as _is_trusted_passthrough,
             resolve_passthrough_value as _resolve_passthrough_value,
         )
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
+        _is_trusted_passthrough = lambda _: False  # noqa: E731
         _resolve_passthrough_value = lambda _name, fallback: fallback  # noqa: E731
 
     merged = dict(os.environ | env)
@@ -1287,7 +1289,10 @@ def _make_run_env(env: dict) -> dict:
         elif _is_hermes_internal_secret(k):
             continue
         else:
-            passthrough = _is_passthrough(k)
+            # Operators may trust specific protected credentials (e.g. GH_TOKEN)
+            # into the terminal via terminal.trusted_env_passthrough; skills
+            # cannot, and dynamic internal secrets are already stripped above.
+            passthrough = _is_passthrough(k) or _is_trusted_passthrough(k)
             if k in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
                 continue
             value = _resolve_passthrough_value(k, v) if passthrough else v


### PR DESCRIPTION
## What does this PR do?

Adds an operator-only `terminal.trusted_env_passthrough` config key that lets an operator explicitly permit protected credentials (e.g. `GH_TOKEN` for `gh`/`git`) into **terminal** subprocesses, while keeping the secure strip-by-default posture intact.

Today `GH_TOKEN` (and the rest of `_HERMES_PROVIDER_ENV_BLOCKLIST`) is stripped from terminal subprocesses, and neither skills nor `terminal.env_passthrough` can re-allow a protected credential (GHSA-rhgp-j443-p4rf). That protection is deliberately preserved — this adds a *separate*, config-only override for operators who genuinely want their own token available to `gh`/`git` in the agent terminal.

## Related Issue

Internal tracking: WE-19116 (no public GitHub issue).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/env_passthrough.py`: new `_load_trusted_env_passthrough()` + `is_trusted_env_passthrough()` reading `terminal.trusted_env_passthrough` (config-only, cached, defaults empty). Dynamic internal secrets are filtered out of the trusted set; skills never feed it.
- `tools/environments/local.py` (`_make_run_env`): the terminal env builder treats a var as passthrough when `is_env_passthrough(k) or is_trusted_env_passthrough(k)`. Dynamic internal secrets are already stripped earlier in the same loop, so a trusted entry can never expose them.
- `hermes_cli/config_defaults.py`: declare `terminal.trusted_env_passthrough: []` (empty default) with documentation so `hermes config set` recognizes the key.
- `tests/tools/test_env_passthrough.py`: focused tests (below).

## Security properties

- **Strip-by-default preserved:** with no config, `GH_TOKEN` and every other blocklisted credential remain stripped from terminal subprocesses.
- **Skills cannot self-grant:** the trusted set is read only from `config.yaml`; `register_env_passthrough` / `terminal.env_passthrough` still refuse protected credentials, so a malicious skill cannot populate it.
- **Dynamic internal secrets never trusted:** `_is_hermes_internal_secret` names (`AUXILIARY_*_API_KEY` / `_BASE_URL`, `GATEWAY_RELAY_*` auth) are filtered from the trusted set *and* stripped unconditionally in `_make_run_env` regardless of the trusted set.
- **Terminal-scoped only:** consulted solely by `_make_run_env`. `execute_code` (`_scrub_child_env`), the background/PTY + generic `_sanitize_subprocess_env` engine, and the non-terminal `hermes_subprocess_env` helper are unchanged and still strip these vars.
- **Profile scope + redaction preserved:** trusted values resolve through `resolve_passthrough_value`, so under profile multiplexing the routed profile's value wins and a missing scoped value is omitted (no cross-profile fallback).

## How to Test

```
uv run --frozen --extra dev pytest \
  tests/tools/test_env_passthrough.py \
  tests/tools/test_local_env_blocklist.py -q
```

Result on this branch: **76 passed, 1 skipped** (11 new tests). New coverage:

- `TestTrustedConfigPassthrough`: default-empty; reads `GH_TOKEN` from config; rejects dynamic internal secrets; config-only (skills cannot populate); ordinary skill/config passthrough unaffected.
- `TestTrustedTerminalPassthrough`: default strips `GH_TOKEN`; trusted `GH_TOKEN` passes `_make_run_env`; a dynamic secret is never exposed even if present in the trusted set; no effect on `execute_code` / `_sanitize_subprocess_env`; profile-scoped resolution (routed value wins, missing scoped value omitted).

`ruff check` (PLW1514, the repo's enabled lint) is clean on both changed source files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(terminal): ...`)
- [x] I searched for existing PRs — no duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] `pytest tests/ -q` — ran the focused tests above for the changed contract (full suite intentionally not run here); all executed tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] Docstrings updated; new config key documented in `config_defaults.py`
- [x] `cli-config.yaml.example` — N/A (the sibling `env_passthrough` is likewise not listed there; config keys live in `config_defaults.py`)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — the `_make_run_env` change is platform-agnostic
- [x] Tool descriptions/schemas — N/A
