### PR TITLE
fix(vision): preserve downloads when cleanup fails

### DIFF
--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -8,6 +8,7 @@ media caches and every other path is read inside the sandbox via exec-read.
 
 import base64
 import importlib
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -56,6 +57,37 @@ class TestDataUrl:
         with pytest.raises(isrc.NotAnImage):
             await isrc.resolve_image_source(
                 f"data:text/plain;base64,{b64}", isrc.ResolveContext())
+
+
+class TestHttpDownload:
+    @pytest.mark.asyncio
+    async def test_cleanup_failure_does_not_discard_downloaded_bytes(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        downloaded = {}
+
+        async def fake_download(_url, destination):
+            downloaded["path"] = destination
+            destination.write_bytes(PNG)
+
+        monkeypatch.setattr("tools.vision_tools._download_image", fake_download)
+
+        try:
+            with (
+                patch.object(Path, "unlink", side_effect=OSError("file is busy")),
+                caplog.at_level(logging.WARNING, logger="tools.image_source"),
+            ):
+                data = await isrc._download_to_bytes(
+                    "https://example.com/image.png"
+                )
+        finally:
+            path = downloaded.get("path")
+            if path is not None:
+                path.unlink(missing_ok=True)
+
+        assert data == PNG
+        assert "Could not delete temporary image download" in caplog.text
 
 
 class TestLocalBackend:

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -34,11 +34,14 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import logging
 import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 # Raw-bytes INGEST budget — what the resolver will load before handing off.
 # This is deliberately the 50MB download cap (tools/vision_tools._VISION_MAX_DOWNLOAD_BYTES),
@@ -206,7 +209,17 @@ async def _download_to_bytes(url: str) -> bytes:
     except PermissionError as exc:  # website policy block
         raise SourceUnsafe(str(exc), src=url, origin="http")
     finally:
-        tmp.unlink(missing_ok=True)
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            # Cleanup is best-effort. Do not replace successfully downloaded
+            # image bytes (or the original download error) with an unlink
+            # failure from an antivirus scan, concurrent reader, or filesystem.
+            logger.warning(
+                "Could not delete temporary image download %s",
+                tmp,
+                exc_info=True,
+            )
 
 
 def _is_local_terminal_backend() -> bool:


### PR DESCRIPTION
## What does this PR do?

Makes temporary-file deletion best-effort after HTTP image ingestion.

`_download_to_bytes()` currently returns the validated bytes from inside a `try`, then unconditionally calls `Path.unlink()` in `finally`. If cleanup fails (for example because an antivirus scanner or concurrent reader temporarily holds the file on Windows), the unlink exception replaces the successful return value. The caller sees a failed vision request even though the download and read both completed.

The fix catches only `OSError` from cleanup and logs it with a traceback. Successfully downloaded bytes are preserved, and an earlier download/read exception also remains the primary error instead of being masked by cleanup.

## Related Issue

No existing equivalent issue or PR found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Wrap temporary image cleanup in an `OSError` guard in `tools/image_source.py`.
- Log cleanup failures with `exc_info=True` for observability.
- Add a regression test that simulates a successful download followed by an unlink failure and verifies the bytes are still returned.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/tools/test_image_source.py -q`.
2. Verify all 19 tests pass.
3. The new test forces `Path.unlink()` to raise `OSError("file is busy")`; the resolver still returns the exact downloaded PNG bytes and records a warning.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.2, Python 3.12.12

Targeted canonical-runner coverage is green; the expanded related run completed with 51 passed and 2 optional skips. The full suite was not claimed locally.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Canonical targeted runner: 19 passed, 0 failed.
- Adjacent image-source + vision suite: 51 passed, 0 failed, 2 skipped.
- Ruff: passed.
- `scripts/check-windows-footguns.py --diff upstream/main`: passed.
- `git diff --check`: passed.

