### PR TITLE
feat(tools): auto-mount $HERMES_HOME/bin for sidecar CLI skills

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -417,7 +417,7 @@ COPY --chmod=0755 docker/entrypoint-dispatch.sh /opt/hermes/docker/entrypoint-di
 # shim wins PATH resolution. The shim's last act is to exec the venv
 # binary by absolute path, so this PATH ordering is transparent to
 # every other consumer.
-ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
+ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/bin:/opt/data/.local/bin:${PATH}"
 RUN mkdir -p /opt/data
 VOLUME [ "/opt/data" ]
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2724,6 +2724,9 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
+    hermes_bin = hermes_home / "bin"
+    if _is_dir(hermes_bin):
+        candidates.append(str(hermes_bin))
     hermes_node = hermes_home / "node" / "bin"
     if _is_dir(hermes_node):
         candidates.append(str(hermes_node))

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -8,12 +8,15 @@ import pytest
 
 from tools.credential_files import (
     clear_credential_files,
+    get_bin_directory_mount,
     get_credential_file_mounts,
     get_cache_directory_mounts,
     get_skills_directory_mount,
+    iter_bin_files,
     iter_cache_files,
     iter_skills_files,
     map_cache_path_to_container,
+    prepend_bin_to_path,
     register_credential_file,
     register_credential_files,
 )
@@ -123,6 +126,67 @@ class TestSkillsDirectoryMount:
             mounts = get_skills_directory_mount()
 
         assert mounts[0]["host_path"] == str(skills_dir)
+
+
+class TestBinDirectoryMount:
+    def test_returns_mount_when_bin_dir_exists(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        bin_dir = hermes_home / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "my-tool").write_text("#!/bin/sh\necho ok\n")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            mounts = get_bin_directory_mount()
+
+        assert len(mounts) == 1
+        assert mounts[0]["host_path"] == str(bin_dir)
+        assert mounts[0]["container_path"] == "/root/.hermes/bin"
+
+    def test_empty_when_bin_missing(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            assert get_bin_directory_mount() == []
+
+    def test_custom_container_base(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "bin").mkdir(parents=True)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            mounts = get_bin_directory_mount(container_base="/home/user/.hermes")
+
+        assert mounts[0]["container_path"] == "/home/user/.hermes/bin"
+
+    def test_iter_bin_files_skips_symlinks(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        bin_dir = hermes_home / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "ok").write_text("#!/bin/sh\n")
+        secret = tmp_path / "secret"
+        secret.write_text("nope")
+        (bin_dir / "evil").symlink_to(secret)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            files = iter_bin_files()
+
+        paths = {Path(f["host_path"]).name for f in files}
+        assert "ok" in paths
+        assert "evil" not in paths
+        assert files[0]["container_path"].startswith("/root/.hermes/bin/")
+
+    def test_prepend_bin_to_path(self):
+        env = prepend_bin_to_path({"PATH": "/usr/bin:/bin"})
+        assert env["PATH"].startswith("/root/.hermes/bin:")
+        assert "/usr/bin" in env["PATH"]
+
+        # Idempotent when already present
+        again = prepend_bin_to_path(env)
+        assert again["PATH"].count("/root/.hermes/bin") == 1
+
+        seeded = prepend_bin_to_path({})
+        assert seeded["PATH"].startswith("/root/.hermes/bin:")
+        assert "/usr/bin" in seeded["PATH"]
 
 
 class TestIterSkillsFiles:

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -142,6 +142,37 @@ class TestBinDirectoryMount:
         assert mounts[0]["host_path"] == str(bin_dir)
         assert mounts[0]["container_path"] == "/root/.hermes/bin"
 
+    def test_symlinks_are_sanitized(self, tmp_path):
+        """Symlinks in bin dir should be excluded from the mount."""
+        hermes_home = tmp_path / ".hermes"
+        bin_dir = hermes_home / "bin"
+        bin_dir.mkdir(parents=True)
+        tool = bin_dir / "ok"
+        tool.write_text("#!/bin/sh\necho ok\n")
+        secret = tmp_path / "secret.txt"
+        secret.write_text("TOP SECRET")
+        (bin_dir / "evil_link").symlink_to(secret)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            mounts = get_bin_directory_mount()
+
+        assert len(mounts) == 1
+        safe_path = Path(mounts[0]["host_path"])
+        assert safe_path != bin_dir
+        assert (safe_path / "ok").exists()
+        assert not (safe_path / "evil_link").exists()
+
+    def test_no_symlinks_returns_original_dir(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        bin_dir = hermes_home / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "ok").write_text("#!/bin/sh\n")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            mounts = get_bin_directory_mount()
+
+        assert mounts[0]["host_path"] == str(bin_dir)
+
     def test_empty_when_bin_missing(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1257,6 +1257,10 @@ def test_credential_mount_skipped_when_source_is_directory(monkeypatch, tmp_path
         lambda: [],
     )
     monkeypatch.setattr(
+        "tools.credential_files.get_bin_directory_mount",
+        lambda: [],
+    )
+    monkeypatch.setattr(
         "tools.credential_files.get_cache_directory_mounts",
         lambda: [],
     )
@@ -1294,6 +1298,10 @@ def test_credential_mount_skipped_when_source_missing(monkeypatch, tmp_path, cap
     )
     monkeypatch.setattr(
         "tools.credential_files.get_skills_directory_mount",
+        lambda: [],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_bin_directory_mount",
         lambda: [],
     )
     monkeypatch.setattr(

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -1,9 +1,10 @@
 """File passthrough registry for remote terminal backends.
 
 Remote backends (Docker, Modal, SSH) create sandboxes with no host files.
-This module ensures that credential files, skill directories, and host-side
-cache directories (documents, images, audio, screenshots) are mounted or
-synced into those sandboxes so the agent can access them.
+This module ensures that credential files, skill directories, host-side
+cache directories (documents, images, audio, screenshots), and the local
+``bin/`` sidecar directory are mounted or synced into those sandboxes so
+the agent can access them.
 
 **Credentials and skills** — session-scoped registry fed by skill declarations
 (``required_credential_files``) and user config (``terminal.credential_files``).
@@ -12,8 +13,14 @@ synced into those sandboxes so the agent can access them.
 audio, and processed images.  Mounted read-only so the remote terminal can
 reference files the host side created (e.g. ``unzip`` an uploaded archive).
 
+**Sidecar CLI bin** — ``$HERMES_HOME/bin`` holds host-installed CLIs that
+skills shell out to (mail helpers, identity helpers, etc.).  Mounted/synced
+read-only so bare command names resolve inside docker/singularity sandboxes
+the same way the local terminal already puts ``$HERMES_HOME/bin`` on PATH.
+
 Remote backends call :func:`get_credential_file_mounts`,
-:func:`get_skills_directory_mount` / :func:`iter_skills_files`, and
+:func:`get_skills_directory_mount` / :func:`iter_skills_files`,
+:func:`get_bin_directory_mount` / :func:`iter_bin_files`, and
 :func:`get_cache_directory_mounts` / :func:`iter_cache_files` at sandbox
 creation time and before each command (for resync on Modal).
 """
@@ -379,6 +386,87 @@ def iter_skills_files(
         pass
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Sidecar CLI bin ($HERMES_HOME/bin)
+# ---------------------------------------------------------------------------
+
+# Sane PATH used when docker_env did not already set PATH and we need to
+# prepend the mounted bin dir.  Matches common Linux container defaults
+# (incl. nikolaik/python-nodejs) so node/python stay resolvable.
+_DEFAULT_SANDBOX_PATH = (
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+)
+
+
+def get_bin_directory_mount(
+    container_base: str = "/root/.hermes",
+) -> list[Dict[str, str]]:
+    """Return mount info for ``$HERMES_HOME/bin`` when it exists.
+
+    Skills that shell out to local CLIs install shims/binaries here (same
+    directory Hermes already uses for managed ``uv``, ``tirith``, etc.).
+    The local terminal backend already appends this dir to PATH; docker and
+    singularity need an explicit bind mount so the binaries are visible.
+
+    Returns a list of dicts with ``host_path`` and ``container_path`` keys
+    (empty when the directory is missing).  Symlinks inside ``bin/`` are
+    followed by the bind mount — operators should only place trusted
+    binaries there.
+    """
+    hermes_home = _resolve_hermes_home()
+    bin_dir = hermes_home / "bin"
+    if not bin_dir.is_dir():
+        return []
+    return [{
+        "host_path": str(bin_dir),
+        "container_path": f"{container_base.rstrip('/')}/bin",
+    }]
+
+
+def iter_bin_files(
+    container_base: str = "/root/.hermes",
+) -> List[Dict[str, str]]:
+    """Yield individual file entries under ``$HERMES_HOME/bin`` for upload sync.
+
+    Skips symlinks.  Used by Modal/Daytona/SSH backends that cannot bind-mount.
+    """
+    result: List[Dict[str, str]] = []
+    hermes_home = _resolve_hermes_home()
+    bin_dir = hermes_home / "bin"
+    if not bin_dir.is_dir():
+        return result
+    container_root = f"{container_base.rstrip('/')}/bin"
+    for item in bin_dir.rglob("*"):
+        if item.is_symlink() or not item.is_file():
+            continue
+        rel = item.relative_to(bin_dir)
+        result.append({
+            "host_path": str(item),
+            "container_path": f"{container_root}/{rel}",
+        })
+    return result
+
+
+def prepend_bin_to_path(
+    env: dict[str, str],
+    container_bin: str = "/root/.hermes/bin",
+) -> dict[str, str]:
+    """Return *env* with ``container_bin`` prepended to PATH when absent.
+
+    If PATH is unset, seed a sane Linux container PATH so we do not wipe
+    the image default entirely when docker ``-e PATH=`` replaces it.
+    """
+    out = dict(env)
+    current = out.get("PATH", "")
+    parts = [p for p in current.split(":") if p] if current else []
+    if container_bin in parts:
+        return out
+    if not parts:
+        parts = [p for p in _DEFAULT_SANDBOX_PATH.split(":") if p]
+    out["PATH"] = ":".join([container_bin, *parts])
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -410,19 +410,69 @@ def get_bin_directory_mount(
     The local terminal backend already appends this dir to PATH; docker and
     singularity need an explicit bind mount so the binaries are visible.
 
+    **Security:** Bind mounts follow symlinks, so a malicious symlink in
+    ``bin/`` could expose arbitrary host files.  When symlinks are detected,
+    this function creates a sanitized copy (regular files only) — matching
+    :func:`get_skills_directory_mount`.
+
     Returns a list of dicts with ``host_path`` and ``container_path`` keys
-    (empty when the directory is missing).  Symlinks inside ``bin/`` are
-    followed by the bind mount — operators should only place trusted
-    binaries there.
+    (empty when the directory is missing).
     """
     hermes_home = _resolve_hermes_home()
     bin_dir = hermes_home / "bin"
     if not bin_dir.is_dir():
         return []
     return [{
-        "host_path": str(bin_dir),
+        "host_path": _safe_bin_path(bin_dir),
         "container_path": f"{container_base.rstrip('/')}/bin",
     }]
+
+
+_safe_bin_tempdir: Path | None = None
+
+
+def _safe_bin_path(bin_dir: Path) -> str:
+    """Return *bin_dir* if symlink-free, else a sanitized temp copy."""
+    global _safe_bin_tempdir
+
+    symlinks = [p for p in bin_dir.rglob("*") if p.is_symlink()]
+    if not symlinks:
+        return str(bin_dir)
+
+    for link in symlinks:
+        logger.warning(
+            "credential_files: skipping symlink in bin dir: %s -> %s",
+            link, os.readlink(link),
+        )
+
+    import atexit
+    import shutil
+    import tempfile
+
+    if _safe_bin_tempdir and _safe_bin_tempdir.is_dir():
+        shutil.rmtree(_safe_bin_tempdir, ignore_errors=True)
+
+    safe_dir = Path(tempfile.mkdtemp(prefix="hermes-bin-safe-"))
+    _safe_bin_tempdir = safe_dir
+
+    for item in bin_dir.rglob("*"):
+        if item.is_symlink():
+            continue
+        rel = item.relative_to(bin_dir)
+        target = safe_dir / rel
+        if item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        elif item.is_file():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(item), str(target))
+
+    def _cleanup():
+        if safe_dir.is_dir():
+            shutil.rmtree(safe_dir, ignore_errors=True)
+
+    atexit.register(_cleanup)
+    logger.info("credential_files: created symlink-safe bin copy at %s", safe_dir)
+    return str(safe_dir)
 
 
 def iter_bin_files(
@@ -457,6 +507,8 @@ def prepend_bin_to_path(
 
     If PATH is unset, seed a sane Linux container PATH so we do not wipe
     the image default entirely when docker ``-e PATH=`` replaces it.
+    On Windows the local terminal backend already handles PATH via
+    ``os.pathsep``; this helper is for Linux sandbox containers only.
     """
     out = dict(env)
     current = out.get("PATH", "")

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1010,8 +1010,10 @@ class DockerEnvironment(BaseEnvironment):
 
         # Mount credential files (OAuth tokens, etc.) declared by skills.
         # Read-only so the container can authenticate but not modify host creds.
+        self._bin_container_path: str | None = None
         try:
             from tools.credential_files import (
+                get_bin_directory_mount,
                 get_credential_file_mounts,
                 get_skills_directory_mount,
                 get_cache_directory_mounts,
@@ -1062,6 +1064,27 @@ class DockerEnvironment(BaseEnvironment):
                     "Docker: mounting skills dir %s -> %s",
                     skills_mount["host_path"],
                     skills_mount["container_path"],
+                )
+
+            # Mount $HERMES_HOME/bin so sidecar CLIs (skills that shell out)
+            # resolve the same way they do on the local terminal backend.
+            for bin_mount in get_bin_directory_mount():
+                src = Path(bin_mount["host_path"])
+                if not src.is_dir():
+                    logger.warning(
+                        "Docker: skipping bin mount — source is not a directory: %s",
+                        src,
+                    )
+                    continue
+                volume_args.extend([
+                    "-v",
+                    f"{bin_mount['host_path']}:{bin_mount['container_path']}:ro",
+                ])
+                self._bin_container_path = bin_mount["container_path"]
+                logger.info(
+                    "Docker: mounting bin dir %s -> %s",
+                    bin_mount["host_path"],
+                    bin_mount["container_path"],
                 )
 
             # Mount host-side cache directories (documents, images, audio,
@@ -1235,6 +1258,11 @@ class DockerEnvironment(BaseEnvironment):
         else:
             merged_env = dict(egress_env_overrides)
             merged_env.update(self._env)
+
+        # Prepend mounted $HERMES_HOME/bin so sidecar CLIs resolve by name.
+        if self._bin_container_path:
+            from tools.credential_files import prepend_bin_to_path
+            merged_env = prepend_bin_to_path(merged_env, self._bin_container_path)
 
         # arshkumarsingh #1: NODE_OPTIONS append-merge.  The egress path
         # wants ``--use-openssl-ca`` so Node routes through the OpenSSL

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -53,15 +53,16 @@ GetFilesFn = Callable[[], list[tuple[str, str]]]  # () -> [(host_path, remote_pa
 def iter_sync_files(container_base: str = "/root/.hermes") -> list[tuple[str, str]]:
     """Enumerate all files that should be synced to a remote environment.
 
-    Combines credentials, skills, and cache into a single flat list of
-    (host_path, remote_path) pairs.  Credential paths are remapped from
-    the hardcoded /root/.hermes to *container_base* because the remote
-    user's home may differ (e.g. /home/daytona, /home/user).
+    Combines credentials, skills, sidecar ``bin/`` CLIs, and cache into a
+    single flat list of (host_path, remote_path) pairs.  Credential paths are
+    remapped from the hardcoded /root/.hermes to *container_base* because the
+    remote user's home may differ (e.g. /home/daytona, /home/user).
     """
     # Late import: credential_files imports agent modules that create
     # circular dependencies if loaded at file_sync module level.
     from tools.credential_files import (
         get_credential_file_mounts,
+        iter_bin_files,
         iter_cache_files,
         iter_skills_files,
     )
@@ -73,6 +74,8 @@ def iter_sync_files(container_base: str = "/root/.hermes") -> list[tuple[str, st
         )
         files.append((entry["host_path"], remote))
     for entry in iter_skills_files(container_base=container_base):
+        files.append((entry["host_path"], entry["container_path"]))
+    for entry in iter_bin_files(container_base=container_base):
         files.append((entry["host_path"], entry["container_path"]))
     for entry in iter_cache_files(container_base=container_base):
         files.append((entry["host_path"], entry["container_path"]))

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -207,13 +207,19 @@ class SingularityEnvironment(BaseEnvironment):
             cmd.append("--writable-tmpfs")
 
         try:
-            from tools.credential_files import get_credential_file_mounts, get_skills_directory_mount
+            from tools.credential_files import (
+                get_bin_directory_mount,
+                get_credential_file_mounts,
+                get_skills_directory_mount,
+            )
             for mount_entry in get_credential_file_mounts():
                 cmd.extend(["--bind", f"{mount_entry['host_path']}:{mount_entry['container_path']}:ro"])
             for skills_mount in get_skills_directory_mount():
                 cmd.extend(["--bind", f"{skills_mount['host_path']}:{skills_mount['container_path']}:ro"])
+            for bin_mount in get_bin_directory_mount():
+                cmd.extend(["--bind", f"{bin_mount['host_path']}:{bin_mount['container_path']}:ro"])
         except Exception as e:
-            logger.debug("Singularity: could not load credential/skills mounts: %s", e)
+            logger.debug("Singularity: could not load credential/skills/bin mounts: %s", e)
 
         if self._memory > 0:
             cmd.extend(["--memory", f"{self._memory}M"])

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -163,6 +163,16 @@ terminal:
 
 See `skills/apple/` for examples of macOS-only skills.
 
+## Sidecar host CLIs
+
+If your skill shells out to a local binary (rather than an HTTP API), install
+the binary or shim under `$HERMES_HOME/bin/` and document the bare command name
+in `SKILL.md`. Hermes puts that directory on PATH for the local terminal and
+auto-mounts/syncs it into docker, singularity, and remote sandboxes. Secrets
+stay under `$HERMES_HOME/secrets/` and are **not** auto-mounted — opt in with
+`terminal.docker_volumes` when needed. Full convention:
+[Sidecar CLI skills](/guides/sidecar-cli-skills).
+
 ## Secure Setup on Load
 
 Use `required_environment_variables` when a skill needs an API key or token. Missing values do **not** hide the skill from discovery. Instead, Hermes prompts for them securely when the skill is loaded in the local CLI.

--- a/website/docs/guides/sidecar-cli-skills.md
+++ b/website/docs/guides/sidecar-cli-skills.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 13
+title: "Sidecar CLI skills"
+description: "Install host CLIs under $HERMES_HOME/bin so skills can shell out from the gateway and docker sandboxes"
+---
+
+# Sidecar CLI skills
+
+Some skills work by shelling out to a **local CLI** (mail clients, identity
+helpers, custom ops tools) rather than calling an HTTP API from Python. Hermes
+supports that pattern without baking the CLI into the agent image.
+
+## Convention
+
+| Host path | Role |
+|-----------|------|
+| `$HERMES_HOME/skills/…/SKILL.md` | Instructions: when to use the tool, which commands to run |
+| `$HERMES_HOME/bin/<command>` | Executable shim or binary the skill invokes |
+| `$HERMES_HOME/secrets/…` (optional) | Credentials the CLI reads — **not** auto-mounted; add via `terminal.docker_volumes` if the sandbox needs them |
+
+`$HERMES_HOME` is `~/.hermes` by default, or `/opt/data` in the official
+Docker/Podman gateway image.
+
+## What Hermes does automatically
+
+1. **Local terminal** — `$HERMES_HOME/bin` is already on the agent subshell PATH.
+2. **Docker / Singularity sandboxes** — if `$HERMES_HOME/bin` exists, Hermes
+   bind-mounts it at `/root/.hermes/bin` (read-only) and prepends that path to
+   `PATH` inside the sandbox.
+3. **Modal / Daytona / SSH** — files under `$HERMES_HOME/bin` are synced into
+   the remote home the same way skills are.
+4. **Gateway container image** — `/opt/data/bin` is on the image `PATH`, so
+   shims installed into the persistent volume work after `docker exec` /
+   gateway restart without hand-editing `PATH`.
+
+You should **not** need to hand-edit `terminal.docker_volumes` just to expose
+`$HERMES_HOME/bin`. Extra mounts (tool trees outside Hermes home, secrets,
+datasets) still go in `docker_volumes` as today.
+
+## Install shape
+
+```bash
+# 1. Skill instructions
+mkdir -p "$HERMES_HOME/skills/identity/my-tool"
+cp SKILL.md "$HERMES_HOME/skills/identity/my-tool/"
+
+# 2. CLI on PATH for gateway + sandboxes
+mkdir -p "$HERMES_HOME/bin"
+install -m 755 ./my-tool "$HERMES_HOME/bin/my-tool"
+
+# 3. Optional secrets (host only unless you mount them)
+mkdir -p "$HERMES_HOME/secrets/my-tool"
+chmod 700 "$HERMES_HOME/secrets" "$HERMES_HOME/secrets/my-tool"
+```
+
+In the skill, tell the agent to call `my-tool` (not an absolute path), and
+never to print JWTs or private keys into chat.
+
+## Optional secrets in the docker sandbox
+
+Secrets stay off the default mount list on purpose. If a sidecar CLI must read
+them inside the docker terminal backend, opt in:
+
+```yaml
+terminal:
+  backend: docker
+  docker_volumes:
+    - "${HERMES_HOME}/secrets/my-tool:/root/.hermes/secrets/my-tool:ro"
+```
+
+Prefer host-absolute paths when the gateway itself runs inside Docker/Podman
+and spawns nested sandboxes — nested `docker run -v` resolves paths on the
+**host** engine, not at `/opt/data` inside the gateway container. Dual-mount
+the app dir at its host path (or set `HERMES_HOME` to that host path) so volume
+sources resolve.
+
+## Example consumers
+
+Anything that is “skill + binary under `bin/`” benefits: email CLIs, cloud
+CLIs you do not want in the image, and third-party identity helpers. Keep
+product-specific enroll/purchase flows in the external package; Hermes only
+needs the PATH + mount convention above.

--- a/website/docs/guides/sidecar-cli-skills.md
+++ b/website/docs/guides/sidecar-cli-skills.md
@@ -26,7 +26,8 @@ Docker/Podman gateway image.
 1. **Local terminal** — `$HERMES_HOME/bin` is already on the agent subshell PATH.
 2. **Docker / Singularity sandboxes** — if `$HERMES_HOME/bin` exists, Hermes
    bind-mounts it at `/root/.hermes/bin` (read-only) and prepends that path to
-   `PATH` inside the sandbox.
+   `PATH` inside the sandbox. Symlinks inside `bin/` are sanitized (same as
+   skills mounts) so a malicious link cannot expose arbitrary host paths.
 3. **Modal / Daytona / SSH** — files under `$HERMES_HOME/bin` are synced into
    the remote home the same way skills are.
 4. **Gateway container image** — `/opt/data/bin` is on the image `PATH`, so

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -505,6 +505,13 @@ This is useful for:
 - **Receiving files** from the agent (generated code, reports, exports)
 - **Shared workspaces** where both you and the agent access the same files
 
+:::tip Sidecar CLIs under `$HERMES_HOME/bin`
+Skills that shell out to a host binary do **not** need a manual `docker_volumes`
+entry for `$HERMES_HOME/bin`. When that directory exists, Hermes auto-mounts it
+into docker/singularity sandboxes and prepends it to `PATH`. See
+[Sidecar CLI skills](/guides/sidecar-cli-skills).
+:::
+
 If you use a messaging gateway and want the agent to send generated files via
 `MEDIA:/...`, prefer a dedicated host-visible export mount such as
 `/home/user/.hermes/cache/documents:/output`.


### PR DESCRIPTION
## What does this PR do?

Skills that shell out to a **host CLI** (mail helpers, identity helpers, custom ops tools) already work on the local terminal because `$HERMES_HOME/bin` is on PATH — but docker/singularity sandboxes and the gateway image required each add-on to hand-edit `terminal.docker_volumes` and inject `PATH`.

This adds a small, **product-neutral** convention (skill + `$HERMES_HOME/bin`) so third-party CLI skills install without forking Hermes. No third-party product is baked into core — aligned with CONTRIBUTING’s “widen the generic surface, don’t special-case a vendor.”

## Related Issue

No existing issue/PR covered auto-mounting `$HERMES_HOME/bin` into sandboxes (searched open + closed for `HERMES_HOME/bin`, `sidecar CLI`, `docker_volumes bin`). Closest neighbors are PATH/resolution bugs for managed Node/uv under `$HERMES_HOME`, not this mount convention.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/credential_files.py` — `get_bin_directory_mount`, `iter_bin_files`, `prepend_bin_to_path`; symlink-safe copy (same pattern as skills mounts)
- `tools/environments/docker.py` — auto-mount bin + prepend PATH in sandbox env
- `tools/environments/singularity.py` — auto-bind bin
- `tools/environments/file_sync.py` — include bin files in Modal/Daytona/SSH sync
- `Dockerfile` — add `/opt/data/bin` to image `PATH`
- `hermes_cli/gateway.py` — include `$HERMES_HOME/bin` in service PATH candidates
- `website/docs/guides/sidecar-cli-skills.md` — new guide
- `website/docs/user-guide/configuration.md`, `website/docs/developer-guide/creating-skills.md` — cross-links
- `tests/tools/test_credential_files.py`, `tests/tools/test_docker_environment.py` — coverage + mock updates

**Not in this PR:** product-specific enroll flows, identity providers, or baking any third-party CLI into the image. Secrets under `$HERMES_HOME/secrets/` stay opt-in via `docker_volumes`.

## How to Test

1. `HERMES_PYTHON=… python -m pytest tests/tools/test_credential_files.py -q` (50 passed locally)
2. Unit: `TestBinDirectoryMount` — mount path, missing dir, symlink sanitization, PATH prepend
3. Manual: `mkdir -p ~/.hermes/bin && printf '#!/bin/sh\necho hi\n' > ~/.hermes/bin/hello && chmod +x ~/.hermes/bin/hello`
4. With `terminal.backend: docker`, run `which hello` / `hello` in a terminal turn → `/root/.hermes/bin/hello`
5. Gateway image: place shim in `/opt/data/bin`, recreate container, `docker exec … which hello`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted pytest for touched modules (`test_credential_files.py` — 50 passed); full `scripts/run_tests.sh` not run in this environment
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: AlmaLinux / RHEL 10 (x86_64 Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - Local PATH for `$HERMES_HOME/bin` already handled in `tools/environments/local.py`
  - Bind-mount / file-sync paths are Linux sandbox–oriented; Windows uses the local backend
  - Symlink sanitization tests use `tmp_path` on Linux CI
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Security notes

Bind mounts follow symlinks. `$HERMES_HOME/bin` is sanitized like skills mounts when symlinks are present (regular-file temp copy), so a malicious link cannot expose arbitrary host paths into the sandbox.

## Screenshots / Logs

```
tests/tools/test_credential_files.py  .............................. 50 passed
```