### PR TITLE
fix(transports): make discovery thread-safe

### DIFF
--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -6,6 +6,8 @@ Usage:
     result = transport.normalize_response(raw_response)
 """
 
+import threading
+
 from agent.transports.types import (
     NormalizedResponse,
     ToolCall,
@@ -16,6 +18,7 @@ from agent.transports.types import (
 
 _REGISTRY: dict = {}
 _discovered: bool = False
+_DISCOVERY_LOCK = threading.Lock()
 
 
 def register_transport(api_mode: str, transport_cls: type) -> None:
@@ -30,7 +33,6 @@ def get_transport(api_mode: str):
     This allows gradual migration — call sites can check for None
     and fall back to the legacy code path.
     """
-    global _discovered
     if not _discovered:
         _discover_transports()
     cls = _REGISTRY.get(api_mode)
@@ -49,20 +51,32 @@ def get_transport(api_mode: str):
 def _discover_transports() -> None:
     """Import all transport modules to trigger auto-registration."""
     global _discovered
-    _discovered = True
-    try:
-        import agent.transports.anthropic  # noqa: F401
-    except ImportError:
-        pass
-    try:
-        import agent.transports.codex  # noqa: F401
-    except ImportError:
-        pass
-    try:
-        import agent.transports.chat_completions  # noqa: F401
-    except ImportError:
-        pass
-    try:
-        import agent.transports.bedrock  # noqa: F401
-    except ImportError:
-        pass
+
+    if _discovered:
+        return
+
+    with _DISCOVERY_LOCK:
+        if _discovered:
+            return
+
+        try:
+            import agent.transports.anthropic  # noqa: F401
+        except ImportError:
+            pass
+        try:
+            import agent.transports.codex  # noqa: F401
+        except ImportError:
+            pass
+        try:
+            import agent.transports.chat_completions  # noqa: F401
+        except ImportError:
+            pass
+        try:
+            import agent.transports.bedrock  # noqa: F401
+        except ImportError:
+            pass
+
+        # Mark discovery complete only after all registration imports finish.
+        # This prevents concurrent callers from observing a partially populated
+        # registry and is safe on both GIL and free-threaded Python builds.
+        _discovered = True

--- a/tests/agent/test_transport_discovery.py
+++ b/tests/agent/test_transport_discovery.py
@@ -1,0 +1,41 @@
+"""Regression coverage for thread-safe transport discovery."""
+
+import builtins
+import threading
+
+import agent.transports as transports
+
+
+def test_discovery_flag_is_set_only_after_imports_complete(monkeypatch):
+    """Concurrent callers must not observe discovery as complete mid-import."""
+    original_discovered = transports._discovered
+    entered_import = threading.Event()
+    release_import = threading.Event()
+    real_import = builtins.__import__
+
+    def blocking_import(name, *args, **kwargs):
+        if name == "agent.transports.anthropic":
+            entered_import.set()
+            assert release_import.wait(timeout=2), "timed out waiting to release import"
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocking_import)
+    transports._discovered = False
+
+    worker = threading.Thread(target=transports._discover_transports)
+    try:
+        worker.start()
+        assert entered_import.wait(timeout=2), "transport discovery never started"
+
+        # The old implementation set this flag before importing transports,
+        # allowing another thread to skip discovery and read a partial registry.
+        assert transports._discovered is False
+
+        release_import.set()
+        worker.join(timeout=2)
+        assert not worker.is_alive()
+        assert transports._discovered is True
+    finally:
+        release_import.set()
+        worker.join(timeout=2)
+        transports._discovered = original_discovered


### PR DESCRIPTION
Fixes #24687.

This changes transport discovery so `_discovered` is only set after all transport imports have completed, and protects discovery with a double-checked `threading.Lock`.

Why:
- concurrent callers can currently observe `_discovered = True` while `_REGISTRY` is only partially populated;
- the existing miss-retry path masks this under the GIL but still allows unnecessary re-entry and is more fragile on free-threaded Python;
- the lock keeps discovery single-flight and the final flag assignment makes the registry publication atomic from callers' perspective.

Also adds a regression test that blocks the first transport import and asserts `_discovered` remains `False` until imports complete.
