### PR TITLE
fix(skills): support editing symlinked Skills

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -69,6 +69,28 @@ description: Use when deploying multi-region Kubernetes clusters with custom CNI
 Step 1.
 """
 
+SYMLINKED_SKILL_CONTENT = """\
+---
+name: linked-skill
+description: A skill stored behind a directory symlink.
+---
+
+# Linked Skill
+
+Original content.
+"""
+
+SYMLINKED_SKILL_CONTENT_2 = """\
+---
+name: linked-skill
+description: Updated content for a skill stored behind a directory symlink.
+---
+
+# Linked Skill v2
+
+Updated content.
+"""
+
 
 # ---------------------------------------------------------------------------
 # _validate_name
@@ -147,6 +169,30 @@ class TestValidateFilePath:
 # ---------------------------------------------------------------------------
 # CRUD operations
 # ---------------------------------------------------------------------------
+
+
+class TestFindSkill:
+    def test_edit_follows_directory_symlink(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        target_dir = tmp_path / "cc-switch" / "linked-skill"
+        skills_dir.mkdir()
+        target_dir.mkdir(parents=True)
+        (target_dir / "SKILL.md").write_text(SYMLINKED_SKILL_CONTENT, encoding="utf-8")
+
+        link = skills_dir / "linked-skill"
+        try:
+            link.symlink_to(target_dir, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+        with _skill_dir(skills_dir):
+            result = _edit_skill("linked-skill", SYMLINKED_SKILL_CONTENT_2)
+
+        assert result["success"] is True
+        assert (
+            (target_dir / "SKILL.md").read_text(encoding="utf-8")
+            == SYMLINKED_SKILL_CONTENT_2
+        )
 
 
 class TestCreateSkill:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -650,11 +650,15 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    from agent.skill_utils import (
+        get_all_skills_dirs,
+        is_excluded_skill_path,
+        iter_skill_index_files,
+    )
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
             if skill_md.parent.name == name:


### PR DESCRIPTION
## Summary

- Fix Skill editor lookup for skills exposed through directory symlinks.
- Reuse the existing Skill index iterator so editor lookup follows the same discovery rules as Skill listing and viewing.
- Add a regression test covering edits to a symlinked Skill directory.

## Root cause

CC Switch imports Skills into Hermes through directory symlinks. Skill listing and viewing already use `iter_skill_index_files()`, which follows those links, while the editor used `Path.rglob("SKILL.md")`, which did not. The Skill appeared in the UI but the editor returned `Skill not found`.

## Test plan

- `uv run --extra dev pytest -q tests/tools/test_skill_manager_tool.py tests/tools/test_skills_tool.py tests/tools/test_skills_tool_discovery_cache.py tests/tools/test_skills_tool_profile_scope.py tests/hermes_cli/test_web_server_skill_editor.py`
- `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -q`
- `uv run --extra dev ruff check tools/skill_manager_tool.py tests/tools/test_skill_manager_tool.py`
- Manually verified the running Desktop Skill content endpoint returns HTTP 200 for a symlinked Skill.

All Skill-related tests passed locally. This PR is intentionally limited to the Skill lookup fix and its regression test; the browser CLI PATH fix is kept in a separate PR.
