### PR TITLE
fix(tool-search): dispatch visible tools through tool_call instead of erroring

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -331,15 +331,17 @@ def _emit_cancelled_terminal_post_tool_call(
 
 
 def _tool_search_scoped_names(agent) -> frozenset:
-    """Return the deferrable tool names the session may invoke via tool_call.
+    """Return every tool name the session may invoke via tool_call.
 
     The Tool Search unwrap dispatches the underlying tool directly, bypassing
     the bridge branch (and its scope check) in
     ``model_tools.handle_function_call``. To keep a restricted-toolset session
     (subagent, kanban worker, curated gateway session) from reaching tools it
     was never granted, the unwrap validates the underlying name against this
-    set: the deferrable subset of the session's own enabled/disabled toolset
-    scope.
+    set: all tools (deferrable + visible) of the session's own
+    enabled/disabled toolset scope. Visible tools are included so a model
+    that wrongly routes a core tool through tool_call gets a successful
+    dispatch instead of an error loop.
 
     Result is cached on the agent and refreshed when the tool registry's
     generation changes (e.g. an MCP server reconnects), so the common case is
@@ -369,7 +371,7 @@ def _tool_search_scoped_names(agent) -> frozenset:
             quiet_mode=True,
             skip_tool_search_assembly=True,
         ) or []
-        names = _ts.scoped_deferrable_names(scoped_defs)
+        names = _ts.scoped_callable_names(scoped_defs)
     except Exception:
         names = frozenset()
     try:

--- a/model_tools.py
+++ b/model_tools.py
@@ -1275,13 +1275,13 @@ def handle_function_call(
                     tool_error(err or "tool_call could not be resolved")
                 )
             # Defense in depth: the underlying tool MUST be in the session's
-            # scoped deferrable catalog. resolve_underlying_call() only checks
-            # that the name is deferrable in the global registry; this gate
-            # additionally rejects any tool the session was not granted, so a
-            # restricted session can never invoke an out-of-scope tool through
-            # the bridge even if the catalog scoping above regressed.
-            _scoped_deferrable = _ts_mod.scoped_deferrable_names(current_defs)
-            if underlying_name not in _scoped_deferrable:
+            # scoped callable set (deferred catalog + visible core tools).
+            # resolve_underlying_call() no longer classifies the name, so this
+            # gate is the only barrier: it rejects any tool the session was
+            # not granted, while letting visible tools fall through to direct
+            # dispatch instead of erroring (see scoped_callable_names).
+            _scoped_callable = _ts_mod.scoped_callable_names(current_defs)
+            if underlying_name not in _scoped_callable:
                 return _return_bridge_result(
                     tool_error(
                         f"'{underlying_name}' is not available in this session. "

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -264,8 +264,11 @@ class TestBridgeDispatch:
             "name": "unknown_xxx",
             "arguments": {"foo": "bar"},
         })
-        # Will fail classification because unknown_xxx isn't deferrable.
-        assert err is not None
+        # resolve no longer classifies the name — the session-scoped gate at
+        # the dispatch sites rejects unknown/out-of-scope tools instead.
+        assert err is None
+        assert name == "unknown_xxx"
+        assert args == {"foo": "bar"}
 
 
     def test_resolve_underlying_call_rejects_recursion(self):
@@ -379,16 +382,21 @@ class TestRegression_OpenClawCron84141:
         # deferrable tools to put behind them.
         assert "terminal" in names
 
-    def test_unwrap_rejects_core_tool_attempt(self):
-        """Even if the model tries to invoke a core tool through tool_call,
-        we reject the call and tell the model to use it directly."""
+    def test_unwrap_passes_core_tool_through(self):
+        """A core tool routed through tool_call resolves cleanly. The old
+        behavior (hard error "not a deferrable tool") sent bridge-happy
+        models into unrecoverable retry loops — observed live with grok-4.5
+        failing 27 consecutive tool_call attempts without ever emitting a
+        direct call. The scope gate at the dispatch sites still bounds the
+        callable set to the session's own toolsets."""
         from tools.tool_search import resolve_underlying_call
-        _, _, err = resolve_underlying_call({
+        name, args, err = resolve_underlying_call({
             "name": "terminal",
             "arguments": {"command": "echo hi"},
         })
-        assert err is not None
-        assert "not a deferrable" in err
+        assert err is None
+        assert name == "terminal"
+        assert args == {"command": "echo hi"}
 
 
 class TestRegression_ToolsetScoping:
@@ -459,6 +467,87 @@ class TestRegression_ToolsetScoping:
         assert "mcp_helper_op" in names
         # core tools are never deferrable
         assert "terminal" not in names
+
+
+class TestToolCallVisibleFallthrough:
+    """tool_call on a *visible* (core) tool dispatches instead of erroring.
+
+    Bridge-happy models route visible tools through tool_call even though the
+    schema is already in the model-facing array. The bridge now falls through
+    to direct dispatch for any tool inside the session's own toolset scope;
+    out-of-scope names still hard-fail.
+    """
+
+    @staticmethod
+    def _register(name, toolset):
+        from tools.registry import registry
+
+        def _handler(args, task_id=None, **kw):
+            return json.dumps({"ok": True, "tool": name, "args": args})
+
+        registry.register(
+            name=name,
+            handler=_handler,
+            schema=_td(name, f"desc for {name}", {"repo": {"type": "string"}}),
+            toolset=toolset,
+        )
+
+    def test_tool_call_dispatches_visible_tool(self, monkeypatch):
+        import model_tools
+        import toolsets
+
+        self._register("fallthrough_core_probe", "fallthroughcore")
+        # Promote the registered tool to core so it classifies as visible.
+        monkeypatch.setattr(
+            toolsets,
+            "_HERMES_CORE_TOOLS",
+            frozenset(toolsets._HERMES_CORE_TOOLS) | {"fallthrough_core_probe"},
+        )
+
+        result = model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={
+                "name": "fallthrough_core_probe",
+                "arguments": {"repo": "hermes"},
+            },
+            enabled_toolsets=["fallthroughcore"],
+        )
+        parsed = json.loads(result)
+        assert parsed.get("ok") is True, f"expected dispatch, got: {result}"
+        assert parsed["tool"] == "fallthrough_core_probe"
+
+    def test_tool_call_still_rejects_out_of_scope(self, monkeypatch):
+        import model_tools
+        import toolsets
+
+        self._register("fallthrough_oos_probe", "fallthroughoos")
+        monkeypatch.setattr(
+            toolsets,
+            "_HERMES_CORE_TOOLS",
+            frozenset(toolsets._HERMES_CORE_TOOLS) | {"fallthrough_oos_probe"},
+        )
+
+        # Session scoped to an unrelated toolset must not reach the tool.
+        result = model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={
+                "name": "fallthrough_oos_probe",
+                "arguments": {"repo": "hermes"},
+            },
+            enabled_toolsets=["some-other-toolset"],
+        )
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "not available in this session" in parsed["error"]
+
+    def test_tool_describe_serves_visible_tool_with_note(self):
+        from tools.tool_search import dispatch_tool_describe
+
+        defs = [_td("terminal", "run shell commands", {"command": {"type": "string"}})]
+        result = json.loads(dispatch_tool_describe({"name": "terminal"}, current_tool_defs=defs))
+        assert result["name"] == "terminal"
+        assert result["parameters"]["properties"]["command"]["type"] == "string"
+        assert "call it directly" in result.get("note", "")
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -924,20 +924,20 @@ def dispatch_tool_describe(args: Dict[str, Any],
     name = str(args.get("name") or "").strip()
     if not name:
         return tool_error("name is required")
-    if not is_deferrable_tool_name(name):
-        return tool_error(
-            f"'{name}' is not a deferrable tool. If you see it in the tools list "
-            "already, call it directly; otherwise check the spelling against tool_search."
-        )
-    _, deferrable = classify_tools(current_tool_defs)
-    for td in deferrable:
+    for td in current_tool_defs:
         fn = td.get("function") or {}
         if fn.get("name") == name:
-            return json.dumps({
+            payload = {
                 "name": name,
                 "description": fn.get("description", ""),
                 "parameters": fn.get("parameters", {}),
-            }, ensure_ascii=False)
+            }
+            if not is_deferrable_tool_name(name):
+                payload["note"] = (
+                    "This tool is already in the model-facing tools list — "
+                    "you can call it directly."
+                )
+            return json.dumps(payload, ensure_ascii=False)
     return tool_error(
         f"'{name}' is not currently available. Re-run tool_search to refresh."
     )
@@ -959,6 +959,30 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     for td in tool_defs:
         name = (td.get("function") or {}).get("name", "")
         if name and is_deferrable_tool_name(name):
+            names.add(name)
+    return frozenset(names)
+
+
+def scoped_callable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
+    """Return every tool name in ``tool_defs`` (visible AND deferrable).
+
+    Same input contract as :func:`scoped_deferrable_names` — the
+    *pre-assembly* tool list for the current session's toolset scope. This is
+    the universe of tools the session may reach through ``tool_call``: the
+    deferred catalog PLUS the visible (core) tools whose schemas are already
+    in the model-facing array.
+
+    Rationale: models — cheaper ones especially — routinely route visible
+    tools through ``tool_call`` anyway. Refusing those calls sends the model
+    into a retry loop it often cannot escape. Dispatching them instead is
+    always safe: the set is still bounded by the session's own
+    enabled/disabled toolsets, so the bridge grants nothing the session could
+    not already call directly.
+    """
+    names: set[str] = set()
+    for td in tool_defs:
+        name = (td.get("function") or {}).get("name", "")
+        if name and name not in BRIDGE_TOOL_NAMES:
             names.add(name)
     return frozenset(names)
 
@@ -1041,11 +1065,12 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
             return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
-    if not is_deferrable_tool_name(name):
-        return None, {}, (
-            f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
-            "list already, call it directly instead of via tool_call."
-        )
+    # No deferrable-only gate here: visible (core) tools resolve too, and the
+    # dispatch sites decide via the session-scoped callable set. Refusing a
+    # visible tool at parse time ("not a deferrable tool") turned one wrong
+    # routing choice into an unrecoverable retry loop for models that keep
+    # routing through the bridge (observed live: grok-4.5 failing 27
+    # consecutive tool_call attempts without ever emitting a direct call).
     return name, raw_args, None
 
 
@@ -1074,5 +1099,6 @@ __all__ = [
     "dispatch_tool_describe",
     "resolve_underlying_call",
     "scoped_deferrable_names",
+    "scoped_callable_names",
     "validate_deferred_call_args",
 ]


### PR DESCRIPTION
## Problem

A model that routes a **visible (core) tool** through the `tool_call` bridge gets a hard error:

> \x27terminal\x27 is not a deferrable tool. If it appears in the model-facing tools list already, call it directly instead of via tool_call.

Bridge-happy models — cheaper ones especially — often do not recover from this. They retry `tool_call` again and again instead of switching to a direct call.

**Observed live** (Hermes gateway, Discord session on grok-4.5): one session burned **27 consecutive tool_call failures across 18 API calls over ~14 minutes** — `terminal`, `execute_code`, `skill_view`, `delegate_task`, `session_search`, `web_search`, `cronjob` all refused — without ever emitting a direct call. The session was effectively tool-blind (and the tool-loop warnings fired the whole time) until the model was switched. Healthy sessions on the same gateway also show sporadic occurrences of the same misroute.

The error message asks the model to change its behavior; dispatching the call is strictly more robust and loses nothing.

## Fix

Let `tool_call` **fall through to direct dispatch** for any tool inside the session\x27s own toolset scope, instead of gating on deferrability:

- `resolve_underlying_call()` no longer rejects non-deferrable names; parse-level checks (bridge recursion, argument shape) remain.
- New `scoped_callable_names()` returns the session\x27s complete callable set (visible + deferrable). The bridge dispatch in `model_tools.handle_function_call` and the unwrap gate in `agent.tool_executor` now validate against it. Out-of-scope names still hard-fail with *not available in this session*.
- `dispatch_tool_describe()` now serves visible tools too (with a note that the tool can be called directly) instead of erroring.

## Security posture unchanged

The callable set is still derived from `get_tool_definitions()` for the session\x27s enabled/disabled toolsets — the bridge grants nothing the session could not already call directly. Restricted-toolset sessions (subagents, curated gateway sessions) keep their exact boundary; the existing out-of-scope rejection tests still pass, and a new test pins it.

## Tests

- Updated: `test_resolve_underlying_call_parses_object_args` (unknown names now resolve; the scoped gate rejects at dispatch), `test_unwrap_rejects_core_tool_attempt` → `test_unwrap_passes_core_tool_through` (deliberate behavior change).
- New: `TestToolCallVisibleFallthrough` — visible-tool dispatch end-to-end through `handle_function_call`, out-of-scope rejection, `tool_describe` on a visible tool.
- `tests/tools/test_tool_search.py`: 33 passed.