### PR TITLE
fix(cli): label process wait timeout previews (#83807)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -502,7 +502,9 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
         if data:
             parts.append(f'"{_oneline(str(data)[:20])}"')
         if timeout_val and action == "wait":
-            parts.append(f"{timeout_val}s")
+            # This is a requested timeout, not elapsed time. Label it so a
+            # large model-supplied value cannot be mistaken for time spent waiting.
+            parts.append(f"timeout={timeout_val}s")
         parts = [p for p in parts if p]
         return " ".join(parts) if parts else None
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -100,6 +100,13 @@ class TestBuildToolPreview:
         assert result == "2 tasks: AAAAAAAAAAAAAAAAAA..."
         assert len(result) == 30
 
+    def test_process_wait_labels_timeout_as_requested_duration(self):
+        preview = build_tool_preview(
+            "process",
+            {"action": "wait", "session_id": "proc_abc123", "timeout": 40000},
+        )
+        assert preview == "wait proc_abc123 timeout=40000s"
+
     def test_false_like_args_zero(self):
         """Non-dict falsy values should return None, not crash."""
         assert build_tool_preview("terminal", 0) is None


### PR DESCRIPTION
## Summary
- label the `process wait` timeout preview as a requested timeout
- add a regression test for large timeout values

Fixes #83807

## Tests
- `python3 -m pytest -q tests/agent/test_display.py`
- `python3 -m py_compile agent/display.py`
