### PR TITLE
fix(model-switch): dedup providers: key in configured-provider detection

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1240,6 +1240,14 @@ def _configured_provider_matches(
             slug = f"custom:{name}"
             if slug in matches:
                 continue
+            # Skip if this custom_providers entry was derived from a
+            # ``providers:`` key that already matched in the user_providers
+            # pass above — it is the same provider in a different shape
+            # (user_providers key ``zai`` vs custom_providers ``custom:zai``),
+            # not a second declaration.
+            provider_key = str(entry.get("provider_key", "") or "").strip()
+            if provider_key and provider_key in matches:
+                continue
             for key in ("models", "model", "default_model"):
                 hit = _match(entry.get(key))
                 if hit:

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -122,3 +122,87 @@ def test_xai_oauth_soft_accept_preserved_when_no_match():
     )
     assert result.success is True, result.error_message
     assert result.target_provider == "xai-oauth"
+
+
+# ---------------------------------------------------------------------------
+# Regression: providers_dict_to_custom_providers() derives a custom_providers
+# entry from every ``providers:`` key.  _configured_provider_matches must not
+# count the same provider twice (once as the user_providers key, once as the
+# derived custom: entry) — otherwise /model <name> fails with "declared by
+# multiple configured providers" for any model declared under ``providers:``.
+# ---------------------------------------------------------------------------
+
+def test_configured_provider_matches_dedups_user_and_custom():
+    """A provider declared under ``providers:`` that also appears in the
+    derived custom_providers list must be counted once, not twice."""
+    from hermes_cli.config import providers_dict_to_custom_providers
+    from hermes_cli.model_switch import _configured_provider_matches
+
+    user_providers = {
+        "my-zai": {
+            "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+            "models": {"glm-5.2": {"context_length": 262144}},
+        }
+    }
+    # This is the real derivation path — providers_dict_to_custom_providers
+    # is called by get_compatible_custom_providers() which feeds the picker.
+    custom_providers = providers_dict_to_custom_providers(user_providers)
+
+    matches = _configured_provider_matches("glm-5.2", user_providers, custom_providers)
+    assert len(matches) == 1, (
+        f"Same provider counted twice: {matches}. "
+        "providers_dict_to_custom_providers() derives a custom: entry from "
+        "every providers: key — _configured_provider_matches must dedup by "
+        "provider_key so it is not mistaken for two separate declarations."
+    )
+    assert "my-zai" in matches
+
+
+def test_configured_provider_matches_truly_different_providers():
+    """Two genuinely different providers (not derived from the same key) both
+    declaring the same model must still be reported as multiple matches."""
+    from hermes_cli.model_switch import _configured_provider_matches
+
+    matches = _configured_provider_matches(
+        "shared-model",
+        user_providers={"provider-a": {"models": ["shared-model"]}},
+        custom_providers=[
+            {"name": "provider-b", "models": ["shared-model"]},
+        ],
+    )
+    assert len(matches) == 2
+    assert "provider-a" in matches
+    assert "custom:provider-b" in matches
+
+
+def test_switch_model_no_multiple_providers_error(tmp_path, monkeypatch):
+    """End-to-end: ``/model glm-5.2`` while already on the zai provider must
+    succeed, not error with 'declared by multiple configured providers'.
+
+    Repro: a provider declared under ``providers:`` in config.yaml is
+    simultaneously present in ``user_providers`` (key ``zai``) and in the
+    derived ``custom_providers`` list (key ``custom:zai``).  Before the fix,
+    _configured_provider_matches returned both slugs and switch_model refused
+    with an ambiguous-provider error.
+    """
+    from hermes_cli.config import providers_dict_to_custom_providers
+
+    user_providers = {
+        "zai": {
+            "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+            "models": {"glm-5.2": {"context_length": 262144}},
+        }
+    }
+    custom_providers = providers_dict_to_custom_providers(user_providers)
+
+    result = _run_switch(
+        raw_input="glm-5.2",
+        current_provider="zai",
+        current_model="glm-5.2",
+        current_base_url="https://open.bigmodel.cn/api/coding/paas/v4",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "zai"
+    assert result.new_model == "glm-5.2"


### PR DESCRIPTION
## Fix

`_configured_provider_matches()` scans both `user_providers` (the `providers:` dict) and `custom_providers` (the legacy list) for exact model-name matches. `get_compatible_custom_providers()` derives a `custom_providers` entry from every `providers:` key via `providers_dict_to_custom_providers()`, so a single provider declared under `providers:` appears in both data sources — once as the dict key (e.g. `zai`) and once as the derived custom entry (e.g. `custom:zai`).

The function counted both as separate declarations, so `/model <name>` failed with "declared by multiple configured providers (custom:zai, zai)" for any model declared under `providers:` while the current provider was set to that same provider.

Fix: skip a `custom_providers` entry when its `provider_key` already matched in the `user_providers` pass — it is the same provider in a different shape, not a second declaration. This mirrors the dedup pattern already used in `get_compatible_custom_providers()` (config.py:1552-1567).

## How to test

```yaml
# config.yaml
providers:
  zai:
    base_url: https://open.bigmodel.cn/api/coding/paas/v4
    models:
      glm-5.2:
        context_length: 262144

model:
  provider: zai
  default: glm-5.2
```

Before fix: `/model glm-5.2` → `✗ 'glm-5.2' is declared by multiple configured providers (custom:zai, zai).`

After fix: `/model glm-5.2` → switch succeeds.

Regression tests in `tests/hermes_cli/test_model_switch_configured_provider_routing.py`:
- `test_configured_provider_matches_dedups_user_and_custom` — dedup via the real `providers_dict_to_custom_providers()` derivation path
- `test_configured_provider_matches_truly_different_providers` — genuinely different providers still reported as multiple
- `test_switch_model_no_multiple_providers_error` — full `switch_model()` E2E

## What platforms you tested on

- macOS 26.2, Python 3.11.12

Fixes #83814.
