### PR TITLE
fix(discord): reconcile ambiguous auto-thread creation

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6817,6 +6817,71 @@ class DiscordAdapter(BasePlatformAdapter):
             thread_name = thread_name[:77] + "..."
         return thread_name
 
+    @staticmethod
+    def _is_starter_message_thread(candidate: Any, message_id: Any) -> bool:
+        """Return whether ``candidate`` is the thread backed by ``message_id``."""
+        if candidate is None or message_id is None:
+            return False
+        if str(getattr(candidate, "id", "")) != str(message_id):
+            return False
+
+        thread_type = getattr(discord, "Thread", None)
+        return not isinstance(thread_type, type) or isinstance(candidate, thread_type)
+
+    async def _reconcile_starter_message_thread(
+        self,
+        message: 'DiscordMessage',
+    ) -> Tuple[Optional[Any], bool]:
+        """Return an existing starter thread and whether REST confirmed absence."""
+        message_id = getattr(message, "id", None)
+        fetch_thread = getattr(message, "fetch_thread", None)
+        not_found_type = getattr(discord, "NotFound", None)
+        confirmed_absences = 0
+
+        for reconciliation_attempt in range(2):
+            existing_thread = getattr(message, "thread", None)
+            if self._is_starter_message_thread(existing_thread, message_id):
+                return existing_thread, False
+
+            client = self._client
+            get_channel = getattr(client, "get_channel", None) if client is not None else None
+            if message_id is not None and callable(get_channel):
+                try:
+                    existing_thread = get_channel(int(message_id))
+                except (TypeError, ValueError):
+                    existing_thread = None
+                if self._is_starter_message_thread(existing_thread, message_id):
+                    return existing_thread, False
+
+            if not callable(fetch_thread):
+                return None, False
+
+            try:
+                existing_thread = await fetch_thread()
+            except Exception as exc:
+                if isinstance(not_found_type, type) and isinstance(exc, not_found_type):
+                    confirmed_absences += 1
+                else:
+                    logger.debug(
+                        "[%s] Could not fetch Discord thread for starter message %s",
+                        self.name,
+                        message_id,
+                        exc_info=True,
+                    )
+            else:
+                if self._is_starter_message_thread(existing_thread, message_id):
+                    return existing_thread, False
+                logger.debug(
+                    "[%s] Discord returned an unexpected thread for starter message %s",
+                    self.name,
+                    message_id,
+                )
+
+            if reconciliation_attempt == 0:
+                await asyncio.sleep(0.25)
+
+        return None, confirmed_absences == 2
+
     async def _auto_create_thread(self, message: 'DiscordMessage') -> Optional[Any]:
         """Create a thread from a user message for auto-threading.
 
@@ -6843,6 +6908,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 return thread
             except Exception as direct_error:
                 last_direct_error = direct_error
+                existing_thread, absence_confirmed = await self._reconcile_starter_message_thread(message)
+                if existing_thread is not None:
+                    return existing_thread
+                if not absence_confirmed:
+                    logger.warning(
+                        "[%s] Direct auto-thread creation failed and reconciliation remained "
+                        "inconclusive; skipping fallback to avoid a duplicate thread. Direct error: %s",
+                        self.name,
+                        direct_error,
+                    )
+                    return None
+
                 try:
                     seed_msg = await message.channel.send(
                         f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -427,6 +427,111 @@ async def test_auto_create_thread_strips_mention_syntax_from_name(adapter):
     assert name == "please help"
 
 
+class _ThreadNotFound(Exception):
+    """Test double for discord.NotFound without constructing an HTTP response."""
+
+
+def _failed_auto_thread_message():
+    return SimpleNamespace(
+        id=123,
+        content="Trip idea",
+        create_thread=AsyncMock(side_effect=ConnectionError("response lost")),
+        thread=None,
+        fetch_thread=AsyncMock(),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_reuses_thread_attached_during_connection_error(adapter):
+    existing = _FakeThreadChannel(channel_id=123, name="already-there")
+    message = _failed_auto_thread_message()
+
+    async def create_then_lose_response(**_kwargs):
+        message.thread = existing
+        raise ConnectionError("response lost after Discord committed the thread")
+
+    message.create_thread.side_effect = create_then_lose_response
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is existing
+    message.create_thread.assert_awaited_once()
+    message.fetch_thread.assert_not_awaited()
+    message.channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_reuses_cached_starter_thread(adapter):
+    existing = _FakeThreadChannel(channel_id=123, name="already-there")
+    message = _failed_auto_thread_message()
+    adapter._client.get_channel = MagicMock(return_value=existing)
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is existing
+    adapter._client.get_channel.assert_called_once_with(message.id)
+    message.fetch_thread.assert_not_awaited()
+    message.channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_retries_fetch_before_fallback(adapter, monkeypatch):
+    existing = _FakeThreadChannel(channel_id=123, name="eventually-visible")
+    message = _failed_auto_thread_message()
+    adapter._client.get_channel = MagicMock(return_value=None)
+    message.fetch_thread.side_effect = [_ThreadNotFound(), existing]
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.discord.adapter.discord.NotFound", _ThreadNotFound)
+    monkeypatch.setattr("plugins.platforms.discord.adapter.asyncio.sleep", sleep)
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is existing
+    assert message.fetch_thread.await_count == 2
+    sleep.assert_awaited_once_with(0.25)
+    message.channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_falls_back_after_confirmed_absence(adapter, monkeypatch):
+    fallback = _FakeThreadChannel(channel_id=456, name="fallback")
+    seed_message = SimpleNamespace(create_thread=AsyncMock(return_value=fallback))
+    message = _failed_auto_thread_message()
+    message.channel.send.return_value = seed_message
+    adapter._client.get_channel = MagicMock(return_value=None)
+    message.fetch_thread.side_effect = [_ThreadNotFound(), _ThreadNotFound()]
+    monkeypatch.setattr("plugins.platforms.discord.adapter.discord.NotFound", _ThreadNotFound)
+    monkeypatch.setattr("plugins.platforms.discord.adapter.asyncio.sleep", AsyncMock())
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is fallback
+    message.create_thread.assert_awaited_once()
+    assert message.fetch_thread.await_count == 2
+    message.channel.send.assert_awaited_once()
+    seed_message.create_thread.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_skips_fallback_when_fetch_is_inconclusive(adapter, monkeypatch):
+    message = _failed_auto_thread_message()
+    adapter._client.get_channel = MagicMock(return_value=None)
+    message.fetch_thread.side_effect = [
+        ConnectionError("lookup failed"),
+        ConnectionError("lookup still failed"),
+    ]
+    monkeypatch.setattr("plugins.platforms.discord.adapter.asyncio.sleep", AsyncMock())
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    message.create_thread.assert_awaited_once()
+    assert message.fetch_thread.await_count == 2
+    message.channel.send.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_rename_thread_edits_only_when_current_name_matches(adapter):
     thread = SimpleNamespace(


### PR DESCRIPTION
## Summary

- reconcile ambiguous Discord auto-thread creation through `message.thread`, the client channel cache, and `Message.fetch_thread()`
- retry reconciliation briefly for delayed thread visibility
- use the seed-message fallback only after two authoritative `NotFound` responses; fail closed instead of retrying creation when reconciliation is inconclusive

Fixes #73032.

This supersedes #73092 and #73097 with a current-`main` patch. Compared with #73097, this version does not retry direct thread creation after an inconclusive lookup, because that retry can duplicate an already-created thread.

## Root cause

Discord can commit `message.create_thread()` server-side while the client receives a transport error. The old path treated every exception as definitive failure and immediately created another thread from a seed message.

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_double_dispatch.py -q -j 3` — 29 passed
- [x] `scripts/run_tests.sh tests/gateway -q -j 12` — 4,826 passed; three unrelated failures reproduced unchanged on the exact upstream base (two stale-timestamp readiness fixtures and Linux abstract-socket coverage on macOS)
- [x] `uvx --from ruff==0.15.10 ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_slash_commands.py`
