### PR TITLE
test(terminal): cover Foundry absolute path lifecycle guard

### DIFF
--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -8,6 +8,7 @@ Covers:
 
 import json
 import os
+import shlex
 from argparse import Namespace
 
 import pytest
@@ -418,6 +419,37 @@ class TestTerminalToolGatewayLifecycleGuard:
         result = json.loads(tt.terminal_tool(command=str(script)))
 
         assert result["exit_code"] == 1
+
+    def test_absolute_foundry_binary_reaches_execution(self, monkeypatch, tmp_path):
+        """A gateway command may invoke Foundry by absolute executable path.
+
+        The referenced-script fallback must classify ELF bytes as binary rather
+        than recursively scanning decoded machine code as shell text.
+        """
+        import tools.terminal_tool as tt
+
+        forge = tmp_path / "forge"
+        forge.write_bytes(b"\x7fELF\x02\x01\n/opt/foundry\x00 --version\n")
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+            cwd = str(tmp_path)
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "forge Version: test", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+        command = f"{shlex.quote(str(forge))} --version"
+
+        result = json.loads(tt.terminal_tool(command=command))
+
+        assert result["exit_code"] == 0
+        assert calls == [command]
 
     def test_launchctl_submit_parser_handles_shell_quoting(self, monkeypatch):
         import tools.terminal_tool as tt


### PR DESCRIPTION
## Summary

- Adds a terminal-boundary regression for gateway sessions invoking a Foundry-style ELF executable by absolute path.
- Proves the binary is classified as non-script content and the exact command reaches execution.
- Keeps the existing lifecycle protections unchanged; genuine gateway stop/restart commands remain blocked.

## Root cause and existing fix

The affected deployed runtime predates upstream commit `49d8a155c`, which fixed the underlying bug. The local referenced-script reader correctly skipped NUL-bearing ELF bytes, but the terminal environment fallback re-read and decoded the same binary, recursively scanned machine code as shell text, and eventually raised `ValueError: embedded null byte` from `os.open()`.

This PR adds incident-specific integration coverage at `tools.terminal_tool.terminal_tool()` so that fix cannot regress for absolute Foundry executable paths. It intentionally changes no production code because current `main` already contains the minimal fix.

## TDD evidence

- The regression failed on historical pre-fix commit `ae6c2e57e` with `exit_code == -1` and `ValueError: embedded null byte`.
- The same regression passes on current `main`.
- A quoted-path variant passes with a pre-created `TMPDIR` containing spaces.

## Test plan

- `uv run --extra dev pytest tests/hermes_cli/test_gateway_restart_loop.py::TestTerminalToolGatewayLifecycleGuard::test_absolute_foundry_binary_reaches_execution -q`
- `TMPDIR='/tmp/hermes review tmp' uv run --extra dev pytest tests/hermes_cli/test_gateway_restart_loop.py::TestTerminalToolGatewayLifecycleGuard::test_absolute_foundry_binary_reaches_execution -q`
- Focused lifecycle positive/negative checks: 11 passed locally.
- `uv run --extra dev pytest tests/hermes_cli/test_gateway_restart_loop.py -q -k 'not test_shell_c_payload_recursively_scans_script'` — 125 passed, 1 deselected.
- `uv run --extra dev pytest tests/tools/test_terminal_tool.py -q` — 10 passed.
- `uv run --extra dev ruff check tests/hermes_cli/test_gateway_restart_loop.py`
- `git diff --check`

The deselected test is an existing order-dependent failure reproduced unchanged on pristine `origin/main`; it passes in isolation and is unrelated to this test-only diff.

## Runtime scope

No live runtime mutation, restart, deployment, or Truthgates change is included. Live Hannibal V2 deployment remains a separate supervised decision.
