### PR TITLE
Preserve structured reply and topic context for /background

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2036,6 +2036,10 @@ def run_conversation(
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     persist_user_platform_id: Optional[str] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    *,
+    current_user_text: Optional[str] = None,
+    reply_to_text: Optional[str] = None,
+    internal_context: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -2116,6 +2120,9 @@ def run_conversation(
             stream_callback,
             persist_user_message,
             persist_user_timestamp,
+            current_user_text=current_user_text,
+            reply_to_text=reply_to_text,
+            internal_context=internal_context,
             persist_user_display_kind=persist_user_display_kind,
             persist_user_display_metadata=persist_user_display_metadata,
             persist_user_platform_id=persist_user_platform_id,
@@ -9265,6 +9272,9 @@ def run_conversation(
         turn_id=turn_id,
         user_message=user_message,
         original_user_message=original_user_message,
+        current_user_text=current_user_text,
+        reply_to_text=reply_to_text,
+        internal_context=internal_context,
         _should_review_memory=_should_review_memory,
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -580,6 +580,9 @@ def build_turn_context(
     persist_user_timestamp: Optional[float] = None,
     persist_user_platform_id: Optional[str] = None,
     *,
+    current_user_text: Optional[str] = None,
+    reply_to_text: Optional[str] = None,
+    internal_context: Optional[Dict[str, Any]] = None,
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     restore_or_build_system_prompt,
@@ -1474,6 +1477,13 @@ def build_turn_context(
             task_id=effective_task_id,
             turn_id=turn_id,
             user_message=original_user_message,
+            current_user_text=(
+                original_user_message
+                if current_user_text is None
+                else current_user_text
+            ),
+            reply_to_text=reply_to_text or "",
+            internal_context=dict(internal_context or {}),
             conversation_history=list(messages),
             is_first_turn=(not bool(conversation_history)),
             model=agent.model,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -150,6 +150,9 @@ def finalize_turn(
     original_user_message,
     _should_review_memory,
     _turn_exit_reason,
+    current_user_text=None,
+    reply_to_text=None,
+    internal_context=None,
     _pending_verification_response=None,
     _pending_verification_response_previewed=False,
 ):
@@ -649,6 +652,13 @@ def finalize_turn(
                 task_id=effective_task_id,
                 turn_id=turn_id,
                 user_message=original_user_message,
+                current_user_text=(
+                    original_user_message
+                    if current_user_text is None
+                    else current_user_text
+                ),
+                reply_to_text=reply_to_text or "",
+                internal_context=dict(internal_context or {}),
                 assistant_response=final_response,
                 conversation_history=list(messages),
                 model=agent.model,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1753,6 +1753,55 @@ def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool
     return bool(channel_prompt and _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER in channel_prompt)
 
 
+def _build_auto_skill_context(
+    auto_skill: Optional[Union[str, List[str]]],
+    *,
+    task_id: str,
+) -> Tuple[str, List[str]]:
+    """Render topic/channel auto-skills for every gateway execution path."""
+    if not auto_skill:
+        return "", []
+    from agent.skill_commands import _build_skill_message, _load_skill_payload
+
+    skill_names = [auto_skill] if isinstance(auto_skill, str) else list(auto_skill)
+    parts: List[str] = []
+    loaded_names: List[str] = []
+    for skill_name in skill_names:
+        loaded = _load_skill_payload(skill_name, task_id=task_id)
+        if not loaded:
+            logger.warning("[Gateway] Auto-skill '%s' not found", skill_name)
+            continue
+        loaded_skill, skill_dir, display_name = loaded
+        note = (
+            f'[IMPORTANT: The "{display_name}" skill is auto-loaded. '
+            "Follow its instructions for this session.]"
+        )
+        part = _build_skill_message(loaded_skill, skill_dir, note)
+        if part:
+            parts.append(part)
+            loaded_names.append(skill_name)
+    return "\n\n".join(parts), loaded_names
+
+
+def _compose_gateway_ephemeral_prompt(
+    runner,
+    *,
+    source: "SessionSource",
+    context_prompt: Optional[str] = None,
+    channel_prompt: Optional[str] = None,
+) -> str:
+    """Compose per-turn gateway context identically for every execution path."""
+    parts = [str(context_prompt or "").strip(), str(channel_prompt or "").strip()]
+    configured = runner._get_system_prompt_for_channel(
+        source.platform,
+        source.chat_id or "",
+        thread_id=getattr(source, "thread_id", None),
+        parent_id=getattr(source, "parent_chat_id", None),
+    )
+    parts.append(str(configured or "").strip())
+    return "\n\n".join(part for part in parts if part)
+
+
 def _csv_or_list_to_set(raw: Any) -> set[str]:
     """Normalize a config list or comma-separated scalar into a string set."""
     if raw is None:
@@ -1923,6 +1972,149 @@ def _build_gateway_agent_history(
 
     observed_context = "\n".join(observed_group_context).strip() or None
     return agent_history, observed_context
+
+
+_BACKGROUND_PARENT_MAX_MESSAGES = 200
+_BACKGROUND_PARENT_MAX_TOKENS = 32_000
+_BACKGROUND_PARENT_CONTEXT_FRACTION = 0.25
+
+
+def _background_parent_token_budget(context_length: Optional[int] = None) -> int:
+    """Reserve most of the child window for its system prompt, tools, and work."""
+    if isinstance(context_length, int) and not isinstance(context_length, bool) and context_length > 0:
+        return max(
+            512,
+            min(
+                _BACKGROUND_PARENT_MAX_TOKENS,
+                int(context_length * _BACKGROUND_PARENT_CONTEXT_FRACTION),
+            ),
+        )
+    return _BACKGROUND_PARENT_MAX_TOKENS
+
+
+def _background_parent_message_text(message: Dict[str, Any]) -> str:
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            str(part.get("text") or "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    return ""
+
+
+def _truncate_background_parent_text(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    marker = "\n[...parent context truncated...]\n"
+    available = max(0, max_chars - len(marker))
+    head = available // 2
+    tail = available - head
+    return f"{text[:head]}{marker}{text[-tail:] if tail else ''}"
+
+
+def _compact_oversized_background_turn(
+    turn: List[Dict[str, Any]],
+    token_budget: int,
+) -> List[Dict[str, Any]]:
+    """Reduce one huge completed turn without leaving orphaned tool messages."""
+    from agent.model_metadata import estimate_messages_tokens_rough
+
+    user = next((msg for msg in turn if msg.get("role") == "user"), None)
+    assistant = next(
+        (
+            msg
+            for msg in reversed(turn)
+            if msg.get("role") == "assistant" and not msg.get("tool_calls")
+        ),
+        None,
+    )
+    if user is None or assistant is None:
+        return []
+
+    user_text = _background_parent_message_text(user)
+    assistant_text = _background_parent_message_text(assistant)
+    if not user_text or not assistant_text:
+        return []
+
+    per_message_chars = max(64, token_budget * 2)
+    while per_message_chars >= 64:
+        compacted = [
+            {
+                "role": "user",
+                "content": _truncate_background_parent_text(user_text, per_message_chars),
+            },
+            {
+                "role": "assistant",
+                "content": _truncate_background_parent_text(assistant_text, per_message_chars),
+            },
+        ]
+        if estimate_messages_tokens_rough(compacted) <= token_budget:
+            return compacted
+        per_message_chars //= 2
+    return []
+
+
+def _bounded_background_parent_history(
+    history: Optional[List[Dict[str, Any]]],
+    *,
+    context_length: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Return a newest-biased, immutable suffix of complete parent turns.
+
+    The child receives parent messages only as ``conversation_history``. The
+    suffix ends on a completed assistant response, so the child's new user
+    instruction remains a distinct final turn. Whole user-led turns are kept
+    or dropped atomically, which prevents truncation from splitting an
+    assistant(tool_calls) -> tool(s) -> assistant block.
+    """
+    from copy import deepcopy
+
+    from agent.model_metadata import estimate_messages_tokens_rough
+    from agent.side_question import trim_snapshot_for_fork
+
+    trimmed = trim_snapshot_for_fork(history)
+    turns: List[List[Dict[str, Any]]] = []
+    current: List[Dict[str, Any]] = []
+    for raw in trimmed:
+        if not isinstance(raw, dict):
+            continue
+        message = deepcopy(raw)
+        if message.get("role") == "user":
+            if current:
+                if (
+                    current[0].get("role") == "user"
+                    and current[-1].get("role") == "assistant"
+                    and not current[-1].get("tool_calls")
+                ):
+                    turns.append(current)
+                current = []
+            current = [message]
+        elif current:
+            current.append(message)
+    if (
+        current
+        and current[0].get("role") == "user"
+        and current[-1].get("role") == "assistant"
+        and not current[-1].get("tool_calls")
+    ):
+        turns.append(current)
+
+    token_budget = _background_parent_token_budget(context_length)
+    selected: List[Dict[str, Any]] = []
+    for turn in reversed(turns):
+        if len(turn) + len(selected) > _BACKGROUND_PARENT_MAX_MESSAGES:
+            break
+        candidate = turn + selected
+        if estimate_messages_tokens_rough(candidate) <= token_budget:
+            selected = candidate
+            continue
+        if not selected:
+            selected = _compact_oversized_background_turn(turn, token_budget)
+        break
+    return selected
 
 
 def _select_cached_agent_history(
@@ -5961,18 +6153,12 @@ class TurnRunner:
         # Combine platform context, YAML channel_prompts hint for this chat,
         # channel_overrides system_prompt (or global ephemeral), and gateway
         # ephemeral prompt from _get_system_prompt_for_channel.
-        combined_ephemeral = ctx.context_prompt or ""
-        event_channel_prompt = (ctx.channel_prompt or "").strip()
-        if event_channel_prompt:
-            combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
-        cfg_channel_prompt = self._runner._get_system_prompt_for_channel(
-            ctx.source.platform,
-            ctx.source.chat_id or "",
-            thread_id=getattr(ctx.source, "thread_id", None),
-            parent_id=getattr(ctx.source, "parent_chat_id", None),
+        combined_ephemeral = _compose_gateway_ephemeral_prompt(
+            self._runner,
+            source=ctx.source,
+            context_prompt=ctx.context_prompt,
+            channel_prompt=ctx.channel_prompt,
         )
-        if cfg_channel_prompt:
-            combined_ephemeral = (combined_ephemeral + "\n\n" + cfg_channel_prompt).strip()
 
         max_iterations = _current_max_iterations()
 
@@ -7096,6 +7282,9 @@ class TurnRunner:
             _conversation_kwargs = {
                 "conversation_history": agent_history,
                 "task_id": ctx.session_id,
+                "current_user_text": ctx.current_user_text,
+                "reply_to_text": ctx.reply_to_text,
+                "internal_context": ctx.internal_context,
             }
             if _persist_user_message_override is not None:
                 _conversation_kwargs["persist_user_message"] = _persist_user_message_override
@@ -7427,6 +7616,11 @@ class TurnRunner:
             "session_id": effective_session_id,
             "response_previewed": result.get("response_previewed", False),
             "response_transformed": result.get("response_transformed", False),
+            "turn_exit_reason": result.get("turn_exit_reason"),
+            "delivery_already_sent": result.get(
+                "delivery_already_sent", False
+            ),
+            "external_deliveries": result.get("external_deliveries", []),
             # Pass through the agent_persisted flag so the persistence block
             # above can correctly determine whether the codex app-server path
             # self-persisted (it didn't — see codex_runtime.py).  Default
@@ -20521,6 +20715,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         history = history or []
         _pending_stt_prepared = hasattr(event, "_gateway_pending_stt_text")
+        _normalized_current_user_text = str(event.text or "")
+        if _pending_stt_prepared:
+            _cached_spoken = getattr(event, "_gateway_pending_stt_transcripts", []) or []
+            if _cached_spoken:
+                _normalized_current_user_text = "\n\n".join(
+                    str(item).strip() for item in _cached_spoken if str(item).strip()
+                )
         message_text = (
             getattr(event, "_gateway_pending_stt_text", None)
             if _pending_stt_prepared
@@ -20653,6 +20854,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_text,
                     audio_paths,
                 )
+                if _successful_transcripts:
+                    _normalized_current_user_text = "\n\n".join(
+                        str(item).strip()
+                        for item in _successful_transcripts
+                        if str(item).strip()
+                    )
                 # Echo each successful transcript back to the user immediately
                 # when configured. Lets users verify STT quality in real-time,
                 # while allowing quiet STT for users who only want the agent to
@@ -20800,7 +21007,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # is referencing. History can contain the same or similar text
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
+            reply_snippet = event.reply_to_text
             if getattr(event, "reply_to_is_own_message", False):
                 message_text = (
                     f'[Replying to your previous message: "{reply_snippet}"]\n\n'
@@ -20918,6 +21125,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.warning("@ context reference expansion failed: %s", exc)
                 logger.debug("@ context reference expansion failure detail", exc_info=True)
 
+        event._gateway_current_user_text = _normalized_current_user_text
         return message_text
 
     async def _prepare_profile_scoped_inbound_message_text(
@@ -21534,6 +21742,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # (single source of truth); only the reset reason needs clearing here.
             session_entry.auto_reset_reason = None
 
+        # Preserve the current instruction before any skill/context enrichment.
+        # Hooks receive this separately from the complete model-visible message.
+        _current_user_text = str(event.text or "")
+        _turn_internal_context = {
+            key: value
+            for key, value in {
+                "auto_skill": getattr(event, "auto_skill", None),
+                "channel_context": getattr(event, "channel_context", None),
+                "channel_prompt": getattr(event, "channel_prompt", None),
+            }.items()
+            if value
+        }
+
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
         # Discord channel_skill_bindings).  Supports a single name or ordered list.
         # Only inject on NEW sessions — ongoing conversations already have the
@@ -21542,27 +21763,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if _is_new_session and _auto:
             _skill_names = [_auto] if isinstance(_auto, str) else list(_auto)
             try:
-                from agent.skill_commands import _load_skill_payload, _build_skill_message
-                _combined_parts: list[str] = []
-                _loaded_names: list[str] = []
-                for _sname in _skill_names:
-                    _loaded = _load_skill_payload(_sname, task_id=_quick_key)
-                    if _loaded:
-                        _loaded_skill, _skill_dir, _display_name = _loaded
-                        _note = (
-                            f'[IMPORTANT: The "{_display_name}" skill is auto-loaded. '
-                            f"Follow its instructions for this session.]"
-                        )
-                        _part = _build_skill_message(_loaded_skill, _skill_dir, _note)
-                        if _part:
-                            _combined_parts.append(_part)
-                            _loaded_names.append(_sname)
-                    else:
-                        logger.warning("[Gateway] Auto-skill '%s' not found", _sname)
-                if _combined_parts:
-                    # Append the user's original text after all skill payloads
-                    _combined_parts.append(event.text)
-                    event.text = "\n\n".join(_combined_parts)
+                _auto_context, _loaded_names = _build_auto_skill_context(
+                    _skill_names,
+                    task_id=_quick_key,
+                )
+                if _auto_context:
+                    event.text = f"{_auto_context}\n\n{event.text}"
                     logger.info(
                         "[Gateway] Auto-loaded skill(s) %s for session %s",
                         _loaded_names, session_key,
@@ -23110,6 +23316,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         if message_text is None:
             return
+        _current_user_text = str(
+            getattr(event, "_gateway_current_user_text", _current_user_text) or ""
+        )
 
         # Capture the platform event time as message metadata and keep the
         # persisted transcript clean (strip any leading timestamp prefix).
@@ -23184,6 +23393,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _turn_started_monotonic = time.monotonic()
             agent_result = await self._run_agent(
                 message=message_text,
+                current_user_text=_current_user_text,
+                reply_to_text=str(getattr(event, "reply_to_text", "") or ""),
+                internal_context=_turn_internal_context,
                 context_prompt=context_prompt,
                 history=history,
                 source=source,
@@ -25429,6 +25641,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         event_message_id: Optional[str] = None,
         media_urls: Optional[List[str]] = None,
         media_types: Optional[List[str]] = None,
+        message_type: Optional[MessageType] = None,
+        parent_session_id: Optional[str] = None,
+        parent_session_key: Optional[str] = None,
+        parent_conversation_history: Optional[List[Dict[str, Any]]] = None,
+        reply_to_text: Optional[str] = None,
+        reply_to_is_own_message: bool = False,
+        auto_skill: Optional[Union[str, List[str]]] = None,
+        channel_prompt: Optional[str] = None,
+        internal_context: Optional[Dict[str, Any]] = None,
+        origin: Optional[dict] = None,
     ) -> None:
         """Profile-scoping wrapper around the background agent task.
 
@@ -25439,13 +25661,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
             return await self._run_background_task_inner(
-                prompt, source, task_id, event_message_id, media_urls, media_types,
+                prompt,
+                source,
+                task_id,
+                event_message_id=event_message_id,
+                media_urls=media_urls,
+                media_types=media_types,
+                message_type=message_type,
+                parent_session_id=parent_session_id,
+                parent_session_key=parent_session_key,
+                parent_conversation_history=parent_conversation_history,
+                reply_to_text=reply_to_text,
+                reply_to_is_own_message=reply_to_is_own_message,
+                auto_skill=auto_skill,
+                channel_prompt=channel_prompt,
+                internal_context=internal_context,
+                origin=origin,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
         with _profile_runtime_scope(profile_home):
             return await self._run_background_task_inner(
-                prompt, source, task_id, event_message_id, media_urls, media_types,
+                prompt,
+                source,
+                task_id,
+                event_message_id=event_message_id,
+                media_urls=media_urls,
+                media_types=media_types,
+                message_type=message_type,
+                parent_session_id=parent_session_id,
+                parent_session_key=parent_session_key,
+                parent_conversation_history=parent_conversation_history,
+                reply_to_text=reply_to_text,
+                reply_to_is_own_message=reply_to_is_own_message,
+                auto_skill=auto_skill,
+                channel_prompt=channel_prompt,
+                internal_context=internal_context,
+                origin=origin,
             )
 
     def _resolve_enabled_toolsets_for_source(
@@ -25491,6 +25743,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         event_message_id: Optional[str] = None,
         media_urls: Optional[List[str]] = None,
         media_types: Optional[List[str]] = None,
+        message_type: Optional[MessageType] = None,
+        parent_session_id: Optional[str] = None,
+        parent_session_key: Optional[str] = None,
+        parent_conversation_history: Optional[List[Dict[str, Any]]] = None,
+        reply_to_text: Optional[str] = None,
+        reply_to_is_own_message: bool = False,
+        auto_skill: Optional[Union[str, List[str]]] = None,
+        channel_prompt: Optional[str] = None,
+        internal_context: Optional[Dict[str, Any]] = None,
+        origin: Optional[dict] = None,
     ) -> None:
         """Execute a background agent task and deliver the result to the chat."""
         from run_agent import AIAgent
@@ -25504,6 +25766,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         _thread_metadata = self._thread_metadata_for_source(source, event_message_id)
+
+        if bool(parent_session_id) != bool(parent_session_key) or (
+            parent_session_id and parent_conversation_history is None
+        ):
+            await adapter.send(
+                chat_id=source.chat_id,
+                content=(
+                    f"❌ Background task {task_id} failed: required parent context "
+                    "snapshot is missing or incomplete."
+                ),
+                metadata=_thread_metadata,
+            )
+            return
 
         try:
             user_config = _load_gateway_config()
@@ -25538,24 +25813,103 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._service_tier = self._resolve_session_service_tier(source=source)
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
 
-            # Enrich the prompt with image descriptions so the background
-            # agent can see user-attached images (same as the main flow).
+            # Reuse the normal inbound attachment preprocessor for every
+            # non-image media type. Images retain their existing background
+            # vision path because detached agents do not consume the foreground
+            # runner's native-image buffer.
             enriched_prompt = prompt
+            normalized_current_user_text = prompt
+            non_image_urls = []
+            non_image_types = []
+            media_event = MessageEvent(
+                text=prompt,
+                message_type=message_type or MessageType.DOCUMENT,
+                source=source,
+                media_urls=media_urls,
+                media_types=media_types,
+            )
+            for i, path in enumerate(media_urls):
+                mtype = media_types[i] if i < len(media_types) else ""
+                if not _event_media_is_image(media_event, i):
+                    non_image_urls.append(path)
+                    non_image_types.append(mtype)
+            if non_image_urls:
+                attachment_event = MessageEvent(
+                    text=prompt,
+                    message_type=message_type or MessageType.DOCUMENT,
+                    source=source,
+                    media_urls=non_image_urls,
+                    media_types=non_image_types,
+                )
+                prepared = await self._prepare_profile_scoped_inbound_message_text(
+                    event=attachment_event,
+                    source=source,
+                    history=[],
+                    session_key=task_id,
+                )
+                if prepared is not None:
+                    enriched_prompt = prepared
+                normalized_current_user_text = str(
+                    getattr(attachment_event, "_gateway_current_user_text", prompt) or ""
+                )
+
+            # Enrich with the same topic/channel auto-skill loader as the normal
+            # gateway path, then with attached image descriptions.
+            auto_skill_context, loaded_auto_skills = _build_auto_skill_context(
+                auto_skill,
+                task_id=task_id,
+            )
+            if auto_skill_context:
+                enriched_prompt = f"{auto_skill_context}\n\n{enriched_prompt}"
             if media_urls:
                 image_paths = []
                 for i, path in enumerate(media_urls):
-                    mtype = media_types[i] if i < len(media_types) else ""
-                    if mtype.startswith("image/"):
+                    if _event_media_is_image(media_event, i):
                         image_paths.append(path)
                 if image_paths:
                     try:
                         enriched_prompt = await self._enrich_message_with_vision(
-                            prompt, image_paths,
+                            enriched_prompt, image_paths,
                         )
                     except Exception as e:
                         logger.warning("Background task vision enrichment failed: %s", e)
 
+            structured_internal_context = dict(internal_context or {})
+            if loaded_auto_skills:
+                structured_internal_context["auto_skill"] = loaded_auto_skills
+            channel_context = str(
+                structured_internal_context.get("channel_context") or ""
+            )
+            if channel_context:
+                enriched_prompt = (
+                    f"{channel_context}\n\n[New message]\n{enriched_prompt}"
+                )
+
+            reply_context = str(reply_to_text or "")
+            if reply_context:
+                reply_label = (
+                    "Replying to your previous message"
+                    if reply_to_is_own_message
+                    else "Replying to"
+                )
+                enriched_prompt = (
+                    f'[{reply_label}: "{reply_context}"]\n\n{enriched_prompt}'
+                )
+
+            context = build_session_context(source, getattr(self, "config", None))
+            redact_pii = bool((user_config.get("privacy") or {}).get("redact_pii", False))
+            context_prompt = _compose_gateway_ephemeral_prompt(
+                self,
+                source=source,
+                context_prompt=build_session_context_prompt(context, redact_pii=redact_pii),
+                channel_prompt=channel_prompt,
+            )
+
             def run_sync():
+                if bool(parent_session_id) != bool(parent_session_key):
+                    raise RuntimeError(
+                        "Background parent session metadata is incomplete"
+                    )
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
@@ -25583,14 +25937,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     chat_name=source.chat_name,
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
+                    parent_session_id=parent_session_id,
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
                 )
                 try:
+                    conversation_history = None
+                    if parent_session_id and parent_session_key:
+                        agent.record_gateway_session_peer(
+                            origin=origin,
+                            routable=False,
+                        )
+                        if agent._session_db is None:
+                            raise RuntimeError(
+                                "Background child session DB unavailable for parent snapshot"
+                            )
+                        conversation_history = agent._session_db.get_messages_as_conversation(
+                            task_id,
+                            repair_alternation=True,
+                        )
+                        if not conversation_history and parent_conversation_history:
+                            context_length = getattr(
+                                getattr(agent, "context_compressor", None),
+                                "context_length",
+                                None,
+                            )
+                            bounded_parent_history = _bounded_background_parent_history(
+                                parent_conversation_history,
+                                context_length=context_length,
+                            )
+                            agent._session_db.append_messages_batch(
+                                task_id,
+                                bounded_parent_history,
+                            )
+                            conversation_history = agent._session_db.get_messages_as_conversation(
+                                task_id,
+                                repair_alternation=True,
+                            )
+                        if parent_conversation_history and not conversation_history:
+                            raise RuntimeError(
+                                "Background parent context snapshot was not persisted"
+                            )
                     return agent.run_conversation(
                         user_message=enriched_prompt,
+                        conversation_history=conversation_history,
+                        system_message=context_prompt,
                         task_id=task_id,
+                        current_user_text=normalized_current_user_text,
+                        reply_to_text=reply_context,
+                        internal_context=structured_internal_context,
                     )
                 finally:
                     self._cleanup_agent_resources(agent)
@@ -25601,9 +25997,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not response and result and result.get("error"):
                 response = f"Error: {result['error']}"
 
-            # Background tasks start a fresh conversation (no prior history),
-            # so history_offset=0: every message in the run belongs to this
-            # turn. Mirrors the repair on the main turn path.
+            # The copied parent prefix is context; this task's prompt remains
+            # the detached child's new active user turn.
             if response:
                 response = repair_explicit_computer_use_media_paths(
                     response,
@@ -31134,6 +31529,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
+        current_user_text: Optional[str] = None,
+        reply_to_text: Optional[str] = None,
+        internal_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -31147,6 +31545,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
             return await self._run_agent_inner(
                 message, context_prompt, history, source, session_id,
+                current_user_text=current_user_text,
+                reply_to_text=reply_to_text,
+                internal_context=internal_context,
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
                 inbound_message_id=inbound_message_id,
@@ -31161,6 +31562,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         with _profile_runtime_scope(profile_home):
             return await self._run_agent_inner(
                 message, context_prompt, history, source, session_id,
+                current_user_text=current_user_text,
+                reply_to_text=reply_to_text,
+                internal_context=internal_context,
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
                 inbound_message_id=inbound_message_id,
@@ -31313,6 +31717,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
+        current_user_text: Optional[str] = None,
+        reply_to_text: Optional[str] = None,
+        internal_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -31598,6 +32005,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _cleanup_progress=_cleanup_progress,
             _cleanup_msg_ids=_cleanup_msg_ids,
             message=message,
+            current_user_text=current_user_text,
+            reply_to_text=reply_to_text,
+            internal_context=dict(internal_context or {}),
             AIAgent=AIAgent,
             resolve_display_setting=resolve_display_setting,
             user_config=user_config,
@@ -32784,6 +33194,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 next_message_id = None
                 next_channel_prompt = None
                 next_session_key = session_key
+                next_current_user_text = str(pending or "")
+                next_reply_to_text = ""
+                next_internal_context: Dict[str, Any] = {}
                 # #60671 — carry the pending event's message_type into the
                 # recursive call so queued voice turns can stream TTS and
                 # re-mark the generation for the final delivered turn.
@@ -32817,6 +33230,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     if next_message is None:
                         return result
+                    next_current_user_text = str(
+                        getattr(
+                            pending_event,
+                            "_gateway_current_user_text",
+                            getattr(pending_event, "text", ""),
+                        )
+                        or ""
+                    )
+                    next_reply_to_text = str(
+                        getattr(pending_event, "reply_to_text", "") or ""
+                    )
+                    next_internal_context = {
+                        key: value
+                        for key, value in {
+                            "auto_skill": getattr(pending_event, "auto_skill", None),
+                            "channel_context": getattr(pending_event, "channel_context", None),
+                            "channel_prompt": getattr(pending_event, "channel_prompt", None),
+                        }.items()
+                        if value
+                    }
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
                     next_message_type = getattr(pending_event, "message_type", None)
@@ -32865,6 +33298,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 followup_result = await self._run_agent(
                     message=next_message,
+                    current_user_text=next_current_user_text,
+                    reply_to_text=next_reply_to_text,
+                    internal_context=next_internal_context,
                     context_prompt=context_prompt,
                     history=updated_history,
                     source=next_source,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7310,6 +7310,36 @@ class TurnRunner:
             # inbound id (NOT event_message_id, which is the reply anchor).
             if ctx.inbound_message_id is not None:
                 _conversation_kwargs["persist_user_platform_id"] = str(ctx.inbound_message_id)
+
+            # Keep overrides and lightweight test agents source-compatible with
+            # the additive structured-turn API.  Inspect before invocation so
+            # a TypeError raised *inside* run_conversation is never mistaken for
+            # an unsupported keyword and retried.
+            _structured_context_keys = (
+                "current_user_text",
+                "reply_to_text",
+                "internal_context",
+            )
+            try:
+                _run_parameters = inspect.signature(
+                    agent.run_conversation
+                ).parameters
+                _accepts_arbitrary_kwargs = any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in _run_parameters.values()
+                )
+            except (TypeError, ValueError):
+                _run_parameters = {}
+                _accepts_arbitrary_kwargs = False
+            if not _accepts_arbitrary_kwargs:
+                for _key in _structured_context_keys:
+                    _parameter = _run_parameters.get(_key)
+                    if (
+                        _parameter is None
+                        or _parameter.kind is inspect.Parameter.POSITIONAL_ONLY
+                    ):
+                        _conversation_kwargs.pop(_key, None)
+
             result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
         finally:
             unregister_gateway_notify(_approval_session_key)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3652,6 +3652,52 @@ class GatewaySlashCommandsMixin:
         source = event.source
         task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
 
+        parent_entry = await self.async_session_store.get_or_create_session(source)
+        parent_session_id = str(getattr(parent_entry, "session_id", "") or "")
+        parent_session_key = self._session_key_for_source(source)
+        recorded_parent_key = str(getattr(parent_entry, "session_key", "") or "")
+        if not parent_session_id or recorded_parent_key != parent_session_key:
+            logger.error(
+                "Refusing /bg parent snapshot for routing key %r: resolved session %r "
+                "belongs to %r",
+                parent_session_key,
+                parent_session_id,
+                recorded_parent_key,
+            )
+            return "❌ Background task not started: parent conversation snapshot unavailable."
+        try:
+            raw_parent_history = await self.async_session_store.load_transcript(
+                parent_session_id
+            )
+            from gateway.run import (
+                _bounded_background_parent_history,
+                _build_gateway_agent_history,
+            )
+
+            parent_conversation_history, _ = _build_gateway_agent_history(
+                raw_parent_history,
+                channel_prompt=getattr(event, "channel_prompt", None),
+            )
+            parent_conversation_history = _bounded_background_parent_history(
+                parent_conversation_history
+            )
+        except Exception:
+            logger.error(
+                "Failed to snapshot /bg parent conversation %s",
+                parent_session_id,
+                exc_info=True,
+            )
+            return "❌ Background task not started: parent conversation snapshot could not be read."
+        reply_to_text = str(getattr(event, "reply_to_text", "") or "")
+        origin = source.to_dict()
+        origin.update(
+            {
+                "execution_kind": "user_explicit_background",
+                "user_initiated": True,
+                "command": "/bg",
+            }
+        )
+
         event_message_id = self._reply_anchor_for_event(event)
 
         # Forward image/audio attachments so the background agent can see them.
@@ -3667,6 +3713,22 @@ class GatewaySlashCommandsMixin:
                 event_message_id=event_message_id,
                 media_urls=media_urls,
                 media_types=media_types,
+                message_type=event.message_type,
+                parent_session_id=parent_session_id,
+                parent_session_key=parent_session_key,
+                parent_conversation_history=parent_conversation_history,
+                reply_to_text=reply_to_text,
+                reply_to_is_own_message=bool(
+                    getattr(event, "reply_to_is_own_message", False)
+                ),
+                auto_skill=getattr(event, "auto_skill", None),
+                channel_prompt=getattr(event, "channel_prompt", None),
+                internal_context=(
+                    {"channel_context": event.channel_context}
+                    if getattr(event, "channel_context", None)
+                    else {}
+                ),
+                origin=origin,
             )
         )
         self._background_tasks.add(_task)

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -76,6 +76,12 @@ class TurnContext:
 
     # --- the ex-``nonlocal`` turn message (rebindable) --------------------
     message: Optional[str] = None
+    # Structured inbound turn data for hooks. ``message`` remains the complete
+    # model-visible composition; these fields preserve the instruction and
+    # contextual sources without requiring plugins to parse that composition.
+    current_user_text: Optional[str] = None
+    reply_to_text: Optional[str] = None
+    internal_context: dict = field(default_factory=dict)
 
     # --- turn parameters / config snapshots (read-only in run_sync) -------
     history: Any = None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7270,6 +7270,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         display_name: str = None,
         origin_json: str = None,
         include_compression_ancestors: bool = False,
+        routable: bool = True,
     ) -> None:
         """Persist the gateway routing peer for an existing session row.
 
@@ -7293,8 +7294,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         an identity-less lazy writer (``update_token_counts`` /
         ``record_auxiliary_usage``) and stay unroutable forever.
         """
-        if not session_id or not session_key:
+        if not session_id or (routable and not session_key):
             return
+
+        if not routable:
+            try:
+                origin = json.loads(origin_json or "{}")
+            except (TypeError, ValueError, json.JSONDecodeError):
+                origin = {}
+            if not isinstance(origin, dict):
+                origin = {}
+            origin["_gateway_routable"] = False
+            origin_json = json.dumps(origin, sort_keys=True)
+            session_key = None
 
         def _do(conn):
             lineage_cte = ""
@@ -7749,11 +7761,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash
                 WHERE s.session_key = ?
                   AND s.source = ?
+                  AND COALESCE(json_extract(s.origin_json, '$._gateway_routable'), 1) != 0
                   AND (s.ended_at IS NULL OR s.end_reason IN ({_RECOVERABLE_END_REASONS_SQL}))
                   AND NOT EXISTS (
                       SELECT 1 FROM sessions b
                       WHERE b.session_key = s.session_key
                         AND b.source = s.source
+                        AND COALESCE(json_extract(b.origin_json, '$._gateway_routable'), 1) != 0
                         AND b.ended_at IS NOT NULL
                         AND b.end_reason IN ({_RESET_END_REASONS_SQL})
                         AND b.ended_at
@@ -7793,6 +7807,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 FROM sessions s
                 LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash
                 WHERE s.source = ?
+                  AND COALESCE(json_extract(s.origin_json, '$._gateway_routable'), 1) != 0
                   AND COALESCE(s.user_id, '') = COALESCE(?, '')
                   AND COALESCE(s.chat_id, '') = COALESCE(?, '')
                   AND COALESCE(s.chat_type, '') = COALESCE(?, '')
@@ -7805,6 +7820,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   AND NOT EXISTS (
                       SELECT 1 FROM sessions b
                       WHERE b.source = s.source
+                        AND COALESCE(json_extract(b.origin_json, '$._gateway_routable'), 1) != 0
                         AND COALESCE(b.user_id, '') = COALESCE(s.user_id, '')
                         AND COALESCE(b.chat_id, '') = COALESCE(s.chat_id, '')
                         AND COALESCE(b.chat_type, '') = COALESCE(s.chat_type, '')
@@ -7882,6 +7898,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   AND EXISTS (SELECT 1 FROM messages m
                                WHERE m.session_id = o.id)
                   AND COALESCE(o.source, '') != 'tool'
+                  AND COALESCE(json_extract(o.origin_json, '$._gateway_routable'), 1) != 0
                   AND json_extract(COALESCE(o.model_config, '{{}}'),
                                    '$._branched_from') IS NULL
                   AND json_extract(COALESCE(o.model_config, '{{}}'),

--- a/run_agent.py
+++ b/run_agent.py
@@ -763,6 +763,37 @@ class AIAgent:
                 "Session DB creation failed (will retry next turn): %s", e
             )
 
+    def record_gateway_session_peer(
+        self,
+        *,
+        origin: Optional[dict] = None,
+        routable: bool = True,
+    ) -> None:
+        """Persist this agent's gateway identity through the public DB API.
+
+        Ordinary gateway sessions require a routing key. Explicit detached
+        background children retain chat/topic provenance with ``routable=False``
+        so restart recovery cannot select them as foreground conversations.
+        """
+        self._ensure_db_session()
+        if self._session_db is None:
+            raise RuntimeError("Session DB unavailable for gateway peer recording")
+        if routable and not self._gateway_session_key:
+            raise RuntimeError("Gateway session key missing for peer recording")
+
+        self._session_db.record_gateway_session_peer(
+            self.session_id,
+            source=_session_source_for_agent(self.platform),
+            user_id=self._user_id,
+            session_key=self._gateway_session_key if routable else None,
+            chat_id=self._chat_id,
+            chat_type=self._chat_type,
+            thread_id=self._thread_id,
+            display_name=self._chat_name,
+            origin_json=json.dumps(origin) if origin is not None else None,
+            routable=routable,
+        )
+
     def _transition_context_engine_session(
         self,
         *,
@@ -9245,6 +9276,10 @@ class AIAgent:
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         persist_user_platform_id: Optional[str] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        *,
+        current_user_text: Optional[str] = None,
+        reply_to_text: Optional[str] = None,
+        internal_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review deliberately shares this agent's session_id for prompt-cache
@@ -9796,6 +9831,9 @@ class AIAgent:
                         persist_user_display_metadata=persist_user_display_metadata,
                         persist_user_platform_id=persist_user_platform_id,
                         moa_config=moa_config,
+                        current_user_text=current_user_text,
+                        reply_to_text=reply_to_text,
+                        internal_context=internal_context,
                     )
                 finally:
                     # The lease remains held through relay/task finalization, but

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -49,6 +49,34 @@ class TestComposeUserApiContent:
         assert out == "hello" + "\n\n" + fenced + "\n\n" + "PLUGIN-CTX"
 
 
+def test_pre_llm_hook_receives_structured_turn_texts():
+    """Hooks can classify the instruction without parsing merged context."""
+    agent = _FakeAgent()
+    captured = {}
+
+    def invoke_hook(name, **kwargs):
+        assert name == "pre_llm_call"
+        captured.update(kwargs)
+        return []
+
+    with patch("hermes_cli.lifecycle.invoke_hook", side_effect=invoke_hook):
+        _build(
+            agent,
+            user_message=(
+                '[Replying to: "recommandation/client"]\n\n'
+                "Ok, je valide pour Amandine"
+            ),
+            current_user_text="Ok, je valide pour Amandine",
+            reply_to_text="recommandation/client",
+            internal_context={"auto_skill": ["support-skill"]},
+        )
+
+    assert captured["user_message"].endswith("Ok, je valide pour Amandine")
+    assert captured["current_user_text"] == "Ok, je valide pour Amandine"
+    assert captured["reply_to_text"] == "recommandation/client"
+    assert captured["internal_context"] == {"auto_skill": ["support-skill"]}
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -5,12 +5,13 @@ background session) across gateway messenger platforms.
 """
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
 
@@ -32,6 +33,7 @@ def _make_runner():
     runner = object.__new__(GatewayRunner)
     runner.adapters = {}
     runner._voice_mode = {}
+    runner.config = GatewayConfig()
     runner._session_db = None
     runner._reasoning_config = None
     runner._provider_routing = {}
@@ -77,6 +79,282 @@ class TestHandleBackgroundCommand:
         result = await runner._handle_background_command(event)
         assert "Usage:" in result
 
+    @pytest.mark.asyncio
+    async def test_passes_parent_and_complete_reply_context(self):
+        runner = _make_runner()
+        event = _make_event(text="/bg inspect this")
+        parent_key = runner._session_key_for_source(event.source)
+        parent = MagicMock(session_id="parent-session", session_key=parent_key)
+        async_store = AsyncMock()
+        async_store._store = runner.session_store
+        async_store.get_or_create_session.return_value = parent
+        async_store.load_transcript.return_value = [
+            {"role": "user", "content": "Original parent request"},
+            {"role": "assistant", "content": "Original parent response"},
+        ]
+        runner._async_session_store = async_store
+        runner._run_background_task = AsyncMock(return_value=None)
+        decision_after_old_limit = "APPROVE_THE_REPORT_AFTER_CHARACTER_500"
+        event.reply_to_text = "q" * 700 + decision_after_old_limit
+        event.reply_to_is_own_message = True
+        event.auto_skill = ["arbitrary-topic-skill"]
+        event.channel_prompt = "ARBITRARY TOPIC RULE"
+        event.channel_context = "SECONDARY TOPIC CONTEXT"
+
+        result = await runner._handle_background_command(event)
+        await asyncio.sleep(0)
+
+        assert "Background" in result
+        kwargs = runner._run_background_task.await_args.kwargs
+        assert kwargs["parent_session_id"] == "parent-session"
+        assert kwargs["parent_session_key"] == runner._session_key_for_source(event.source)
+        assert kwargs["parent_conversation_history"] == [
+            {"role": "user", "content": "Original parent request"},
+            {"role": "assistant", "content": "Original parent response"},
+        ]
+        assert kwargs["reply_to_text"] == event.reply_to_text
+        assert decision_after_old_limit in kwargs["reply_to_text"]
+        assert kwargs["reply_to_is_own_message"] is True
+        assert kwargs["auto_skill"] == ["arbitrary-topic-skill"]
+        assert kwargs["channel_prompt"] == "ARBITRARY TOPIC RULE"
+        assert kwargs["internal_context"] == {
+            "channel_context": "SECONDARY TOPIC CONTEXT",
+        }
+        assert kwargs["origin"]["execution_kind"] == "user_explicit_background"
+        assert kwargs["origin"]["user_initiated"] is True
+        assert kwargs["origin"]["command"] == "/bg"
+
+    @pytest.mark.asyncio
+    async def test_refuses_parent_from_another_topic(self):
+        runner = _make_runner()
+        event = _make_event(text="/bg inspect this")
+        event.source.thread_id = "expected-topic"
+        async_store = AsyncMock()
+        async_store._store = runner.session_store
+        async_store.get_or_create_session.return_value = MagicMock(
+            session_id="other-topic-session",
+            session_key="telegram:67890:other-topic",
+        )
+        runner._async_session_store = async_store
+        runner._run_background_task = AsyncMock(return_value=None)
+
+        result = await runner._handle_background_command(event)
+
+        assert "not started" in result.lower()
+        async_store.load_transcript.assert_not_called()
+        runner._run_background_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_parent_read_failure_is_explicit(self):
+        runner = _make_runner()
+        event = _make_event(text="/bg inspect this")
+        parent_key = runner._session_key_for_source(event.source)
+        async_store = AsyncMock()
+        async_store._store = runner.session_store
+        async_store.get_or_create_session.return_value = MagicMock(
+            session_id="parent-session", session_key=parent_key
+        )
+        async_store.load_transcript.side_effect = RuntimeError("database unreadable")
+        runner._async_session_store = async_store
+        runner._run_background_task = AsyncMock(return_value=None)
+
+        result = await runner._handle_background_command(event)
+
+        assert "not started" in result.lower()
+        assert "could not be read" in result.lower()
+        runner._run_background_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_long_parent_snapshots_only_native_compression_tip(self, tmp_path):
+        from gateway.session import AsyncSessionStore, SessionStore
+        from hermes_state import SessionDB
+
+        runner = _make_runner()
+        store = SessionStore(tmp_path / "sessions", GatewayConfig())
+        if store._db is not None:
+            store._db.close()
+        store._db = SessionDB(db_path=tmp_path / "state.db")
+        runner.session_store = store
+        runner._async_session_store = AsyncSessionStore(store)
+        runner._run_background_task = AsyncMock(return_value=None)
+        event = _make_event(text="/bg current instruction")
+        try:
+            entry = store.get_or_create_session(event.source)
+            old_history = [
+                {"role": "user", "content": f"old request {i}"}
+                if i % 2 == 0
+                else {"role": "assistant", "content": f"old answer {i}"}
+                for i in range(240)
+            ]
+            store._db.append_messages_batch(entry.session_id, old_history)
+            store._db.end_session(entry.session_id, "compression")
+            tip_id = "compressed-parent-tip"
+            store._db.create_session(
+                tip_id,
+                source="telegram",
+                parent_session_id=entry.session_id,
+            )
+            store._db.append_messages_batch(
+                tip_id,
+                [
+                    {"role": "user", "content": "compressed summary"},
+                    {"role": "assistant", "content": "recent context"},
+                ],
+            )
+
+            result = await runner._handle_background_command(event)
+            await asyncio.sleep(0)
+
+            assert "Background" in result
+            snapshot = runner._run_background_task.await_args.kwargs[
+                "parent_conversation_history"
+            ]
+            assert [message["content"] for message in snapshot] == [
+                "compressed summary",
+                "recent context",
+            ]
+        finally:
+            store._db.close()
+
+    @pytest.mark.asyncio
+    async def test_parent_snapshot_isolated_between_real_topics(self, tmp_path):
+        from gateway.session import AsyncSessionStore, SessionStore
+        from hermes_state import SessionDB
+
+        runner = _make_runner()
+        store = SessionStore(tmp_path / "sessions", GatewayConfig())
+        if store._db is not None:
+            store._db.close()
+        store._db = SessionDB(db_path=tmp_path / "state.db")
+        runner.session_store = store
+        runner._async_session_store = AsyncSessionStore(store)
+        runner._run_background_task = AsyncMock(return_value=None)
+
+        event_a = _make_event(text="/bg inspect this")
+        event_a.source.thread_id = "topic-a"
+        event_b = _make_event(text="ordinary message")
+        event_b.source.thread_id = "topic-b"
+        try:
+            entry_a = store.get_or_create_session(event_a.source)
+            entry_b = store.get_or_create_session(event_b.source)
+            store._db.append_messages_batch(
+                entry_a.session_id,
+                [
+                    {"role": "user", "content": "TOPIC_A_SENTINEL"},
+                    {"role": "assistant", "content": "topic A answer"},
+                ],
+            )
+            store._db.append_messages_batch(
+                entry_b.session_id,
+                [
+                    {"role": "user", "content": "TOPIC_B_SENTINEL"},
+                    {"role": "assistant", "content": "topic B answer"},
+                ],
+            )
+
+            result = await runner._handle_background_command(event_a)
+            await asyncio.sleep(0)
+
+            assert "Background" in result
+            snapshot = runner._run_background_task.await_args.kwargs[
+                "parent_conversation_history"
+            ]
+            snapshot_text = json.dumps(snapshot)
+            assert "TOPIC_A_SENTINEL" in snapshot_text
+            assert "TOPIC_B_SENTINEL" not in snapshot_text
+        finally:
+            store._db.close()
+
+    def test_bg_resolves_to_gateway_command(self):
+        from hermes_cli.commands import resolve_command
+
+        command = resolve_command("bg")
+        assert command is not None
+        assert command.name == "bg"
+        assert command.busy_policy == "dispatch"
+
+
+def test_auto_skill_loader_is_shared_and_generic(tmp_path):
+    from gateway.run import _build_auto_skill_context
+
+    payload = ({"name": "arbitrary-topic-skill"}, tmp_path, "arbitrary-topic-skill")
+    with patch("agent.skill_commands._load_skill_payload", return_value=payload) as load, \
+         patch("agent.skill_commands._build_skill_message", return_value="ARBITRARY SKILL PAYLOAD"):
+        context, names = _build_auto_skill_context(
+            ["arbitrary-topic-skill"],
+            task_id="bg-test",
+        )
+
+    load.assert_called_once_with("arbitrary-topic-skill", task_id="bg-test")
+    assert context == "ARBITRARY SKILL PAYLOAD"
+    assert names == ["arbitrary-topic-skill"]
+
+
+def test_background_parent_snapshot_respects_model_budget_and_priority_boundary():
+    from agent.model_metadata import estimate_messages_tokens_rough
+    from gateway.run import _bounded_background_parent_history
+
+    recent_sentinel = "RECENT_PARENT_SENTINEL"
+    history = [
+        {"role": "user", "content": "u" * 30_000 + recent_sentinel},
+        {"role": "assistant", "content": "a" * 30_000 + "RECENT_ANSWER_SENTINEL"},
+        {"role": "user", "content": "stale unfinished instruction"},
+    ]
+
+    snapshot = _bounded_background_parent_history(history, context_length=4_096)
+
+    assert estimate_messages_tokens_rough(snapshot) <= 1_024
+    assert [message["role"] for message in snapshot] == ["user", "assistant"]
+    assert recent_sentinel in snapshot[0]["content"]
+    assert "RECENT_ANSWER_SENTINEL" in snapshot[1]["content"]
+    assert "stale unfinished instruction" not in json.dumps(snapshot)
+
+
+@pytest.mark.parametrize("oversized_index", range(4))
+def test_background_parent_snapshot_never_splits_tool_turn(oversized_index):
+    from gateway.run import _bounded_background_parent_history
+
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": '{"key":"value"}'},
+        }
+    ]
+    turn = [
+        {"role": "user", "content": "look this up", "api_content": "USER_SIDECAR"},
+        {"role": "assistant", "content": "", "tool_calls": tool_calls},
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "name": "lookup",
+            "content": "TOOL_RESULT",
+            "api_content": "TOOL_SIDECAR",
+        },
+        {"role": "assistant", "content": "final answer", "api_content": "ASSISTANT_SIDECAR"},
+    ]
+    if oversized_index == 0:
+        turn[0]["content"] += "x" * 30_000
+    elif oversized_index == 1:
+        turn[1]["content"] = "x" * 30_000
+    elif oversized_index == 2:
+        turn[2]["content"] += "x" * 30_000
+    else:
+        turn[3]["content"] += "x" * 30_000
+
+    snapshot = _bounded_background_parent_history(turn, context_length=4_096)
+    roles = [message["role"] for message in snapshot]
+    has_tool_call = any(message.get("tool_calls") for message in snapshot)
+    has_tool_result = "tool" in roles
+
+    assert roles[0] == "user"
+    assert roles[-1] == "assistant"
+    assert has_tool_call is has_tool_result
+    if has_tool_call:
+        assert snapshot == turn
+        assert snapshot is not turn
+        assert snapshot[0] is not turn[0]
+
 
 # ---------------------------------------------------------------------------
 # _run_background_task
@@ -114,11 +392,16 @@ class TestRunBackgroundTask:
     async def test_successful_task_sends_result(self):
         """When the agent completes successfully, the result is sent."""
         runner = _make_runner()
-        mock_adapter = AsyncMock()
+        mock_adapter = MagicMock()
         mock_adapter.send = AsyncMock()
         mock_adapter.extract_media = MagicMock(return_value=([], "Hello from background!"))
         mock_adapter.extract_images = MagicMock(return_value=([], "Hello from background!"))
         runner.adapters[Platform.TELEGRAM] = mock_adapter
+        parent_history = [
+            {"role": "user", "content": "Original parent request"},
+            {"role": "assistant", "content": "Original parent response"},
+        ]
+        child_history = [dict(message) for message in parent_history]
 
         source = SessionSource(
             platform=Platform.TELEGRAM,
@@ -139,14 +422,55 @@ class TestRunBackgroundTask:
         }
         with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
              patch("gateway.run._load_gateway_config", return_value=checkpoint_config), \
+             patch(
+                 "gateway.run._build_auto_skill_context",
+                 return_value=("ARBITRARY SKILL PAYLOAD", ["arbitrary-topic-skill"]),
+             ), \
+             patch(
+                 "gateway.run.build_session_context",
+                 return_value=MagicMock(),
+             ), \
+             patch(
+                 "gateway.run.build_session_context_prompt",
+                 return_value="ARBITRARY SOURCE CONTEXT",
+             ), \
+             patch.object(
+                 runner,
+                 "_get_system_prompt_for_channel",
+                 return_value="ARBITRARY CONFIGURED CHANNEL OVERRIDE",
+             ), \
              patch("run_agent.AIAgent") as MockAgent:
             mock_agent_instance = MagicMock()
             mock_agent_instance.shutdown_memory_provider = MagicMock()
             mock_agent_instance.close = MagicMock()
+            mock_agent_instance._session_db = MagicMock()
+            mock_agent_instance._session_db.get_messages_as_conversation.side_effect = [
+                [],
+                child_history,
+            ]
             mock_agent_instance.run_conversation.return_value = mock_result
             MockAgent.return_value = mock_agent_instance
 
-            await runner._run_background_task("say hello", source, "bg_test")
+            decision_after_old_limit = "APPROVE_THE_REPORT_AFTER_CHARACTER_500"
+            complete_reply = "q" * 700 + decision_after_old_limit
+            await runner._run_background_task(
+                "Ok, je valide pour Amandine",
+                source,
+                "bg_test",
+                parent_session_id="parent-session",
+                parent_session_key="telegram:67890",
+                parent_conversation_history=parent_history,
+                reply_to_text=complete_reply,
+                reply_to_is_own_message=True,
+                auto_skill=["arbitrary-topic-skill"],
+                channel_prompt="ARBITRARY TOPIC RULE",
+                internal_context={"channel_context": "SECONDARY TOPIC CONTEXT"},
+                origin={
+                    "execution_kind": "user_explicit_background",
+                    "user_initiated": True,
+                    "command": "/bg",
+                },
+            )
 
         # Should have sent the result
         mock_adapter.send.assert_called_once()
@@ -159,8 +483,569 @@ class TestRunBackgroundTask:
         assert agent_kwargs["checkpoint_max_snapshots"] == 8
         assert agent_kwargs["checkpoint_max_total_size_mb"] == 222
         assert agent_kwargs["checkpoint_max_file_size_mb"] == 3
+        assert agent_kwargs["parent_session_id"] == "parent-session"
+        assert agent_kwargs.get("gateway_session_key") is None
+        run_kwargs = mock_agent_instance.run_conversation.call_args.kwargs
+        assert run_kwargs["conversation_history"] == parent_history
+        assert run_kwargs["conversation_history"] is not parent_history
+        assert run_kwargs["conversation_history"][0] is not parent_history[0]
+        assert run_kwargs["current_user_text"] == "Ok, je valide pour Amandine"
+        assert run_kwargs["reply_to_text"] == complete_reply
+        assert run_kwargs["internal_context"] == {
+            "auto_skill": ["arbitrary-topic-skill"],
+            "channel_context": "SECONDARY TOPIC CONTEXT",
+        }
+        assert "ARBITRARY TOPIC RULE" in run_kwargs["system_message"]
+        assert run_kwargs["system_message"].endswith(
+            "ARBITRARY CONFIGURED CHANNEL OVERRIDE"
+        )
+        assert run_kwargs["user_message"].endswith("Ok, je valide pour Amandine")
+        assert all(
+            message.get("content") != "Ok, je valide pour Amandine"
+            for message in run_kwargs["conversation_history"]
+        )
+        assert "SECONDARY TOPIC CONTEXT\n\n[New message]" in run_kwargs["user_message"]
+        assert "ARBITRARY SKILL PAYLOAD" in run_kwargs["user_message"]
+        assert f'[Replying to your previous message: "{complete_reply}"]' in run_kwargs["user_message"]
+        assert decision_after_old_limit in run_kwargs["user_message"]
+        record_kwargs = mock_agent_instance.record_gateway_session_peer.call_args.kwargs
+        assert record_kwargs["routable"] is False
+        origin = record_kwargs["origin"]
+        assert origin["execution_kind"] == "user_explicit_background"
+        assert origin["user_initiated"] is True
+        assert origin["command"] == "/bg"
+        mock_agent_instance._session_db.append_messages_batch.assert_called_once_with(
+            "bg_test", parent_history
+        )
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_parent_tool_pair_survives_snapshot_reload_until_first_run(self, tmp_path):
+        from hermes_state import SessionDB
+
+        runner = _make_runner()
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.extract_media = MagicMock(return_value=([], "done"))
+        adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.TELEGRAM] = adapter
+        db = SessionDB(db_path=tmp_path / "state.db")
+        runner._session_db = db
+        task_id = "bg_tool_pair"
+        db.create_session("parent-session", source="telegram")
+        db.create_session(task_id, source="telegram", parent_session_id="parent-session")
+        tool_calls = [
+            {
+                "id": "call_weather_1",
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "arguments": '{"query":"weather Paris"}',
+                },
+            }
+        ]
+        parent_history = [
+            {"role": "user", "content": "Quel temps fait-il à Paris ?"},
+            {"role": "assistant", "content": "", "tool_calls": tool_calls},
+            {
+                "role": "tool",
+                "tool_call_id": "call_weather_1",
+                "name": "web_search",
+                "content": '{"temperature_c":21}',
+            },
+            {"role": "assistant", "content": "Il fait 21 °C à Paris."},
+        ]
+        agent = MagicMock()
+        agent._session_db = db
+        agent.run_conversation.return_value = {
+            "final_response": "done",
+            "messages": [],
+        }
+
+        try:
+            with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+                 patch("gateway.run._load_gateway_config", return_value={}), \
+                 patch("run_agent.AIAgent", return_value=agent):
+                await runner._run_background_task(
+                    "Résume la réponse précédente.",
+                    _make_event().source,
+                    task_id,
+                    parent_session_id="parent-session",
+                    parent_session_key="telegram:67890",
+                    parent_conversation_history=parent_history,
+                )
+
+            reloaded = agent.run_conversation.call_args.kwargs["conversation_history"]
+            assert [message["role"] for message in reloaded] == [
+                "user",
+                "assistant",
+                "tool",
+                "assistant",
+            ]
+            assert reloaded[1]["tool_calls"] == tool_calls
+            assert reloaded[2]["tool_call_id"] == tool_calls[0]["id"]
+            assert reloaded[2]["content"] == '{"temperature_c":21}'
+            assert agent.run_conversation.call_args.kwargs["user_message"].endswith(
+                "Résume la réponse précédente."
+            )
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_parent_context_available_without_session_search_and_new_instruction_wins(
+        self, tmp_path
+    ):
+        from hermes_state import SessionDB
+
+        runner = _make_runner()
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.extract_media = MagicMock(return_value=([], "done"))
+        adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.TELEGRAM] = adapter
+        db = SessionDB(db_path=tmp_path / "state.db")
+        runner._session_db = db
+        task_id = "bg_without_session_search"
+        db.create_session("parent-session", source="telegram")
+        db.create_session(task_id, source="telegram", parent_session_id="parent-session")
+        parent_sentinel = "PARENT_FACT_AVAILABLE_WITHOUT_SEARCH"
+        current_instruction = "CURRENT_CHILD_INSTRUCTION_WINS"
+        parent_history = [
+            {"role": "user", "content": "OLD_CONTRADICTORY_INSTRUCTION"},
+            {"role": "assistant", "content": parent_sentinel},
+            {"role": "user", "content": "unfinished parent input must be dropped"},
+        ]
+        agent = MagicMock()
+        agent._session_db = db
+        agent.context_compressor = MagicMock(context_length=8_192)
+        agent.run_conversation.return_value = {
+            "final_response": "done",
+            "messages": [],
+        }
+
+        try:
+            with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+                 patch("gateway.run._load_gateway_config", return_value={}), \
+                 patch.object(runner, "_resolve_enabled_toolsets_for_source", return_value=[]), \
+                 patch("run_agent.AIAgent", return_value=agent) as MockAgent:
+                await runner._run_background_task(
+                    current_instruction,
+                    _make_event().source,
+                    task_id,
+                    parent_session_id="parent-session",
+                    parent_session_key="telegram:67890",
+                    parent_conversation_history=parent_history,
+                )
+
+            run_kwargs = agent.run_conversation.call_args.kwargs
+            history = run_kwargs["conversation_history"]
+            assert MockAgent.call_args.kwargs["enabled_toolsets"] == []
+            assert parent_sentinel in json.dumps(history)
+            assert "unfinished parent input must be dropped" not in json.dumps(history)
+            assert history[-1]["role"] == "assistant"
+            assert current_instruction not in json.dumps(history)
+            assert run_kwargs["user_message"].count(current_instruction) == 1
+            assert run_kwargs["user_message"].endswith(current_instruction)
+            assert run_kwargs["current_user_text"] == current_instruction
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_parent_snapshot_persistence_is_idempotent_for_same_task_id(self, tmp_path):
+        from hermes_state import SessionDB
+
+        runner = _make_runner()
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.extract_media = MagicMock(return_value=([], "done"))
+        adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.TELEGRAM] = adapter
+        db = SessionDB(db_path=tmp_path / "state.db")
+        runner._session_db = db
+        task_id = "bg_redelivery"
+        db.create_session("parent-session", source="telegram")
+        db.create_session(task_id, source="telegram", parent_session_id="parent-session")
+        parent_history = [
+            {"role": "user", "content": "Parent request"},
+            {"role": "assistant", "content": "Parent response"},
+        ]
+        agent = MagicMock()
+        agent._session_db = db
+
+        def _persist_child_turn(**kwargs):
+            db.append_messages_batch(
+                task_id,
+                [
+                    {"role": "user", "content": kwargs["user_message"]},
+                    {"role": "assistant", "content": "done"},
+                ],
+            )
+            return {"final_response": "done", "messages": []}
+
+        agent.run_conversation.side_effect = _persist_child_turn
+
+        try:
+            with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+                 patch("gateway.run._load_gateway_config", return_value={}), \
+                 patch("run_agent.AIAgent", return_value=agent):
+                for _ in range(2):
+                    await runner._run_background_task(
+                        "Do the detached work",
+                        _make_event().source,
+                        task_id,
+                        parent_session_id="parent-session",
+                        parent_session_key="telegram:67890",
+                        parent_conversation_history=parent_history,
+                    )
+
+            persisted = db.get_messages_as_conversation(task_id)
+            persisted_contents = [message["content"] for message in persisted]
+            assert persisted_contents.count("Parent request") == 1
+            assert persisted_contents.count("Parent response") == 1
+            assert len(agent.run_conversation.call_args_list) == 2
+            second_history_contents = [
+                message["content"]
+                for message in agent.run_conversation.call_args_list[1].kwargs[
+                    "conversation_history"
+                ]
+            ]
+            assert second_history_contents.count("Parent request") == 1
+            assert second_history_contents.count("Parent response") == 1
+            assert second_history_contents.count("Do the detached work") == 1
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("message_type", "media_type", "path", "prepared_marker"),
+        [
+            (MessageType.AUDIO, "audio/mpeg", "/cache/user-song.mp3", "audio file attachment"),
+            (MessageType.DOCUMENT, "application/pdf", "/cache/report.pdf", "user sent a document"),
+        ],
+    )
+    async def test_background_non_image_media_reuses_normal_inbound_preprocessor(
+        self, message_type, media_type, path, prepared_marker
+    ):
+        runner = _make_runner()
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = adapter
+        source = _make_event().source
+        normal_preprocessor = runner._prepare_profile_scoped_inbound_message_text
+        runner._prepare_profile_scoped_inbound_message_text = AsyncMock(
+            wraps=normal_preprocessor
+        )
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            agent = MockAgent.return_value
+            agent.run_conversation.return_value = {"final_response": "done", "messages": []}
+            await runner._run_background_task(
+                "inspect attachment",
+                source,
+                "bg_media",
+                media_urls=[path],
+                media_types=[media_type],
+                message_type=message_type,
+            )
+
+        prepared_event = runner._prepare_profile_scoped_inbound_message_text.await_args.kwargs["event"]
+        assert prepared_event.media_urls == [path]
+        assert prepared_event.media_types == [media_type]
+        assert prepared_event.message_type == message_type
+        user_message = agent.run_conversation.call_args.kwargs["user_message"]
+        assert agent.run_conversation.call_args.kwargs["conversation_history"] is None
+        assert prepared_marker in user_message.lower()
+        assert path in user_message
+
+    @pytest.mark.asyncio
+    async def test_missing_declared_parent_fails_instead_of_starting_fresh(self):
+        runner = _make_runner()
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = adapter
+        runner._session_db = MagicMock()
+        runner._session_db._db = runner._session_db
+        runner._session_db.get_session.return_value = None
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            await runner._run_background_task(
+                "inspect parent context",
+                _make_event().source,
+                "bg_missing_parent",
+                parent_session_id="missing-parent",
+                parent_session_key="telegram:67890",
+            )
+
+        MockAgent.assert_not_called()
+        assert "parent context snapshot" in adapter.send.call_args.kwargs["content"].lower()
+
+    @pytest.mark.asyncio
+    async def test_generic_caller_supplies_its_own_provenance(self):
+        runner = _make_runner()
+        mock_adapter = MagicMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "done"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+        source = _make_event().source
+        caller_origin = {"execution_kind": "scheduled_background"}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            agent = MockAgent.return_value
+            agent._session_db = MagicMock()
+            agent._session_db.get_messages_as_conversation.return_value = []
+            agent.run_conversation.return_value = {"final_response": "done", "messages": []}
+            await runner._run_background_task(
+                "scheduled work",
+                source,
+                "bg_other",
+                parent_session_id="parent-session",
+                parent_session_key="telegram:67890",
+                parent_conversation_history=[],
+                origin=caller_origin,
+            )
+
+        assert agent.record_gateway_session_peer.call_args.kwargs == {
+            "origin": caller_origin,
+            "routable": False,
+        }
+        assert "command" not in caller_origin
+
+    @pytest.mark.asyncio
+    async def test_peer_record_failure_still_cleans_up_agent(self):
+        runner = _make_runner()
+        mock_adapter = MagicMock()
+        mock_adapter.send = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+        source = _make_event().source
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            agent = MockAgent.return_value
+            agent.record_gateway_session_peer.side_effect = RuntimeError(
+                "Session DB unavailable; gateway peer was not recorded"
+            )
+
+            await runner._run_background_task(
+                "scheduled work",
+                source,
+                "bg_failure",
+                parent_session_id="parent-session",
+                parent_session_key="telegram:67890",
+                parent_conversation_history=[],
+                origin={"execution_kind": "scheduled_background"},
+            )
+
+        agent.run_conversation.assert_not_called()
+        agent.shutdown_memory_provider.assert_called_once()
+        agent.close.assert_called_once()
+        assert "Session DB unavailable" in mock_adapter.send.call_args.kwargs["content"]
+
+
+class TestAIAgentGatewayPeerContract:
+    def test_records_peer_through_public_contract(self):
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        agent.session_id = "bg_test"
+        agent.platform = "telegram"
+        agent._session_db = MagicMock()
+        agent._ensure_db_session = MagicMock()
+        agent._user_id = "user"
+        agent._gateway_session_key = "telegram:chat"
+        agent._chat_id = "chat"
+        agent._chat_type = "group"
+        agent._thread_id = "topic"
+        agent._chat_name = "Test chat"
+        origin = {"execution_kind": "user_explicit_background"}
+
+        agent.record_gateway_session_peer(origin=origin)
+
+        agent._ensure_db_session.assert_called_once_with()
+        record_kwargs = agent._session_db.record_gateway_session_peer.call_args.kwargs
+        assert record_kwargs == {
+            "source": "telegram",
+            "user_id": "user",
+            "session_key": "telegram:chat",
+            "chat_id": "chat",
+            "chat_type": "group",
+            "thread_id": "topic",
+            "display_name": "Test chat",
+            "origin_json": json.dumps(origin),
+            "routable": True,
+        }
+        record_args = agent._session_db.record_gateway_session_peer.call_args.args
+        assert record_args == ("bg_test",)
+
+    def test_missing_session_db_fails_explicitly(self):
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        agent.session_id = "bg_test"
+        agent._session_db = None
+        agent._ensure_db_session = MagicMock()
+
+        with pytest.raises(RuntimeError, match="Session DB unavailable"):
+            agent.record_gateway_session_peer(origin={})
+
+    def test_missing_gateway_session_key_fails_explicitly(self):
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        agent.session_id = "bg_test"
+        agent._session_db = MagicMock()
+        agent._ensure_db_session = MagicMock()
+        agent._gateway_session_key = ""
+
+        with pytest.raises(RuntimeError, match="Gateway session key missing"):
+            agent.record_gateway_session_peer(origin={})
+
+        agent._session_db.record_gateway_session_peer.assert_not_called()
+
+    def test_unrouted_child_records_peer_without_a_routing_key(self):
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        agent.session_id = "bg_test"
+        agent.platform = "telegram"
+        agent._session_db = MagicMock()
+        agent._ensure_db_session = MagicMock()
+        agent._user_id = "user"
+        agent._gateway_session_key = None
+        agent._chat_id = "chat"
+        agent._chat_type = "private"
+        agent._thread_id = "topic"
+        agent._chat_name = "Test chat"
+
+        agent.record_gateway_session_peer(
+            origin={"execution_kind": "user_explicit_background"},
+            routable=False,
+        )
+
+        kwargs = agent._session_db.record_gateway_session_peer.call_args.kwargs
+        assert kwargs["session_key"] is None
+        assert kwargs["routable"] is False
+        assert kwargs["chat_id"] == "chat"
+        assert kwargs["thread_id"] == "topic"
+
+    def test_unrouted_child_cannot_replace_parent_in_gateway_recovery(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            peer = {
+                "source": "telegram",
+                "user_id": "user",
+                "chat_id": "chat",
+                "chat_type": "private",
+                "thread_id": "topic",
+                "display_name": "Test chat",
+            }
+            db.create_session("parent", source="telegram")
+            db.record_gateway_session_peer(
+                "parent",
+                session_key="telegram:chat:topic",
+                origin_json="{}",
+                **peer,
+            )
+            db.create_session(
+                "bg_child",
+                source="telegram",
+                parent_session_id="parent",
+            )
+            db.record_gateway_session_peer(
+                "bg_child",
+                session_key=None,
+                routable=False,
+                origin_json=json.dumps(
+                    {"execution_kind": "user_explicit_background"}
+                ),
+                **peer,
+            )
+
+            child = db.get_session("bg_child")
+            assert child is not None
+            assert child["parent_session_id"] == "parent"
+            assert child["chat_id"] == "chat"
+            assert child["thread_id"] == "topic"
+            assert json.loads(child["origin_json"])["execution_kind"] == "user_explicit_background"
+            db.append_message("parent", role="user", content="parent turn")
+            db.append_message("bg_child", role="user", content="newer detached turn")
+            db.end_session("bg_child", "session_reset")
+
+            recovered = db.find_latest_gateway_session_for_peer(
+                source="telegram",
+                user_id="user",
+                session_key="telegram:chat:topic",
+                chat_id="chat",
+                chat_type="private",
+                thread_id="topic",
+            )
+            assert recovered is not None
+            assert recovered["id"] == "parent"
+
+            fallback_recovered = db.find_latest_gateway_session_for_peer(
+                source="telegram",
+                user_id="user",
+                session_key="missing:exact:key",
+                chat_id="chat",
+                chat_type="private",
+                thread_id="topic",
+            )
+            assert fallback_recovered is not None
+            assert fallback_recovered["id"] == "parent"
+        finally:
+            db.close()
+
+
+@pytest.mark.asyncio
+async def test_immediate_voice_sets_normalized_current_user_text_from_spoken_words():
+    runner = _make_runner()
+    source = _make_event().source
+    event = MessageEvent(
+        text="",
+        source=source,
+        message_type=MessageType.VOICE,
+        media_urls=["/cache/voice.ogg"],
+        media_types=["audio/ogg"],
+        reply_to_message_id="42",
+        reply_to_text="INTERNAL REPLY CONTEXT",
+    )
+    runner._enrich_message_with_transcription = AsyncMock(
+        return_value=("[Voice transcription]: ship the report", ["ship the report"])
+    )
+
+    await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+
+    assert event._gateway_current_user_text == "ship the report"
+    assert "INTERNAL REPLY CONTEXT" not in event._gateway_current_user_text
+
+
+@pytest.mark.asyncio
+async def test_queued_voice_uses_cached_spoken_words_as_current_user_text():
+    runner = _make_runner()
+    source = _make_event().source
+    event = MessageEvent(
+        text="",
+        source=source,
+        message_type=MessageType.VOICE,
+        media_urls=["/cache/voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+    event._gateway_pending_stt_text = "[Voice transcription]: queue this report"
+    event._gateway_pending_stt_transcripts = ["queue this report"]
+
+    await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+
+    assert event._gateway_current_user_text == "queue this report"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -99,3 +99,28 @@ async def test_reply_prefix_still_injected_when_text_in_history():
     assert result.endswith("What's the best time to go?")
 
 
+@pytest.mark.asyncio
+async def test_reply_prefix_preserves_nonce_after_character_500():
+    """The complete explicitly replied-to message is model-visible."""
+    runner = _make_runner()
+    source = _source()
+    nonce = "FOREGROUND_NONCE_AFTER_CHARACTER_500"
+    quoted = "q" * 700 + nonce
+    event = MessageEvent(
+        text="Use the instruction I replied to.",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=quoted,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith(f'[Replying to: "{quoted}"]')
+    assert nonce in result
+
+


### PR DESCRIPTION
## Summary

- Preserve the complete explicit reply-to text while exposing `current_user_text`, `reply_to_text`, and `internal_context` separately to lifecycle hooks.
- For user-requested `/background`, resolve the exact current routing key and copy a bounded snapshot of completed parent turns into the detached child before its first turn.
- Persist that snapshot once per child task, so replay is idempotent and never duplicates the parent prefix.
- Keep the child instruction as the newest active user turn, with priority `current_user_text > reply_to > parent context`.
- Reuse existing gateway behavior for configured channel prompts, topic/channel auto-skills, image vision, non-image attachment preprocessing, multiplex profile scope, and provenance.
- Preserve parent lineage plus chat/topic/origin metadata while marking detached children durably unroutable, preventing foreground recovery from selecting them.

## Why `parent_session_id` is not enough

`parent_session_id` records lineage but does not hydrate the detached child's model conversation. The child therefore needs an automatic, immutable parent snapshot. The snapshot is bounded by message count and model-context budget, keeps only complete user-led turns ending in a final assistant response, never splits tool-call/tool-result pairs, and drops unfinished parent input.

## Ordering contract

The copied parent snapshot is passed as prior `conversation_history`. The explicit reply is composed into the child's new user message, and the current instruction remains last and is also available separately as `current_user_text`. This makes the operative priority explicit:

`current_user_text > reply_to > parent context`

## Verification

- Targeted wrapper run: `139 passed, 0 failed` across:
  - `tests/gateway/test_background_command.py`
  - `tests/gateway/test_reply_to_injection.py`
  - `tests/agent/test_api_content_sidecar.py`
  - `tests/cli/test_cli_background_busy_path.py`
  - `tests/hermes_cli/test_commands.py`
- `git diff --check`: clean.
- `tests/gateway/` was accepted by the wrapper but exceeded the bounded 420-second transport window; the orphaned pytest worker was terminated and no tracked file changed.
- Real Telegram canary without `session_search`: not claimed in this update. The available shell has no verified user-side Telegram emitter; Bot API output cannot simulate an inbound user command. Earlier live canaries used session search and therefore do not prove the new automatic snapshot path.

Head: `aa71aa90110f76a48da18dbd034869b8ce7f3916`
Base used for the bounded rebuild: `48a00349bd1c26ad3b71c2ac0fdbfefa5c1e96bb`.
