### PR TITLE
perf(cron): bound lifecycle guard scan work

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -89,17 +89,22 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 # also means a real multi-line shell invocation split across continuation
 # lines (e.g. `launchctl submit \` / `  -l ai.hermes.gateway-... \` / `  -- ...`,
 # the exact reported shape in #62891) would otherwise slip past. Collapse
-# continuations to a single space before matching, mirroring what the shell
-# itself does, rather than loosening `[^\n]*` and risking false positives
-# across genuinely separate lines.
-_SHELL_LINE_CONTINUATION = re.compile(r"\\\r?\n[ \t]*")
+# the continuation pair before matching, mirroring what the shell itself does,
+# rather than loosening `[^\n]*` and risking false positives across genuinely
+# separate lines.  Indentation after the newline remains ordinary whitespace.
+_SHELL_LINE_CONTINUATION = re.compile(r"\\\r?\n")
+
+
+def _normalize_shell_line_continuations(text: str) -> str:
+    """Apply POSIX backslash-newline joining for both LF and CRLF input."""
+    return _SHELL_LINE_CONTINUATION.sub("", text)
 
 
 def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
-    normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
+    normalized = _normalize_shell_line_continuations(text)
     return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
 
 
@@ -107,6 +112,19 @@ _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
+# Whole-walk work limits.  The per-file byte cap and recursion depth above are
+# not enough: one command can reference arbitrarily many files, and shlex is
+# especially expensive on either thousands of short lines (one lexer is built
+# per line) or one enormous token.  In production that unbounded breadth held
+# the GIL for minutes on every gateway terminal call (#78398).
+#
+# These limits are deliberately fail-closed.  A normal shell-wrapper graph is
+# tiny; if a command exceeds the generous aggregate envelope, the guard blocks
+# it rather than allowing an unscanned lifecycle action through.
+_MAX_LIFECYCLE_SCAN_BYTES = 256 * 1024
+_MAX_LIFECYCLE_SCAN_LINES = 4096
+_MAX_LIFECYCLE_SCAN_LINE_BYTES = 32 * 1024
+_MAX_LIFECYCLE_SCAN_PATHS = 32
 _CONTROL_CHARS = frozenset(";&|()")
 
 # Executables whose arguments are DATA, not commands: search patterns, SQL
@@ -151,9 +169,76 @@ _BINARY_SNIFF_BYTES = 4096
 _ReadRemoteScriptFn = Callable[[str], Optional[str]]
 
 
+class _LifecycleScanBudget:
+    """Shared work budget for one complete referenced-script walk."""
+
+    __slots__ = (
+        "bytes_remaining",
+        "line_bytes_limit",
+        "lines_remaining",
+        "paths_remaining",
+    )
+
+    def __init__(self) -> None:
+        # Read module constants at construction time so tests and deployments
+        # can lower them without defaults capturing stale values at import.
+        self.bytes_remaining = _MAX_LIFECYCLE_SCAN_BYTES
+        self.lines_remaining = _MAX_LIFECYCLE_SCAN_LINES
+        self.line_bytes_limit = _MAX_LIFECYCLE_SCAN_LINE_BYTES
+        self.paths_remaining = _MAX_LIFECYCLE_SCAN_PATHS
+
+    def consume_text(self, text: str) -> bool:
+        """Charge text before tokenization; return False on exhaustion."""
+        # UTF-8 is at least one byte per code point.  This cheap check avoids
+        # allocating an encoded copy of an already-oversized adversarial input.
+        if len(text) > self.bytes_remaining:
+            return False
+        encoded_size = len(text.encode("utf-8", errors="replace"))
+        if encoded_size > self.bytes_remaining:
+            return False
+
+        # Match _iter_command_segments' physical-line accounting.  Check both
+        # character and encoded lengths so one huge token never reaches shlex's
+        # quadratic string accumulation, including for multibyte input.
+        # Use the same LF/CRLF continuation semantics as the direct-scan
+        # masker: either form can join multiple physical lines before shlex.
+        normalized = _normalize_shell_line_continuations(text)
+        lines = normalized.splitlines() or [normalized]
+        if len(lines) > self.lines_remaining:
+            return False
+        for line in lines:
+            if len(line) > self.line_bytes_limit:
+                return False
+            if len(line.encode("utf-8", errors="replace")) > self.line_bytes_limit:
+                return False
+
+        self.bytes_remaining -= encoded_size
+        self.lines_remaining -= len(lines)
+        return True
+
+    def consume_path(self) -> bool:
+        """Charge one unique referenced path before any local/remote read."""
+        if self.paths_remaining <= 0:
+            return False
+        self.paths_remaining -= 1
+        return True
+
+
+def lifecycle_scan_root_within_budget(text: str) -> bool:
+    """Return whether root text may safely enter an optional tokenizer pass.
+
+    ``False`` is not a safe/unsafe command verdict: callers must still run the
+    full lifecycle guard, which fails closed when this preflight is exhausted.
+    """
+    try:
+        return _LifecycleScanBudget().consume_text(text)
+    except Exception:
+        return False
+
+
 def _iter_command_segments(command: str) -> Iterator[list[str]]:
     """Yield shell-tokenized command segments, honoring quotes and comments."""
-    normalized = command.replace("\\\n", "")
+    normalized = _normalize_shell_line_continuations(command)
     for line in normalized.splitlines() or [normalized]:
         try:
             lexer = shlex.shlex(
@@ -294,7 +379,7 @@ def _lifecycle_command_scan_with_data_exemption(text: str) -> bool:
     """
     if not contains_gateway_lifecycle_command(text):
         return False
-    normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
+    normalized = _normalize_shell_line_continuations(text)
     return contains_gateway_lifecycle_command(_mask_data_sink_arguments(normalized))
 
 
@@ -425,8 +510,15 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
     return None
 
 
-def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
+def _read_referenced_script(
+    path: Path,
+    *,
+    max_bytes: Optional[int] = None,
+) -> tuple[Optional[str], bool]:
     """Return ``(text, unsafe)`` using bounded, regular-file-only reads."""
+    byte_limit = _MAX_REFERENCED_SCRIPT_BYTES
+    if max_bytes is not None:
+        byte_limit = min(byte_limit, max(0, int(max_bytes)))
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
@@ -449,12 +541,12 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         data = os.read(descriptor, _BINARY_SNIFF_BYTES)
         if data.startswith(_BINARY_MAGIC_PREFIXES) or b"\x00" in data:
             return None, False
+        if metadata.st_size > byte_limit:
+            return None, True
         # Read the remainder (bounded). Loop because os.read may return
         # short for non-regular-file-backed descriptors.
-        while len(data) <= _MAX_REFERENCED_SCRIPT_BYTES:
-            chunk = os.read(
-                descriptor, _MAX_REFERENCED_SCRIPT_BYTES + 1 - len(data)
-            )
+        while len(data) <= byte_limit:
+            chunk = os.read(descriptor, byte_limit + 1 - len(data))
             if not chunk:
                 break
             data += chunk
@@ -470,12 +562,16 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     # executed by the user is not a referenced *shell script*.
     if b"\x00" in data:
         return None, False
-    if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
+    if len(data) > byte_limit:
         return None, True
     return data.decode("utf-8", errors="replace"), False
 
 
-def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bool]:
+def _sanitize_remote_script_text(
+    text: Optional[str],
+    *,
+    max_bytes: Optional[int] = None,
+) -> tuple[Optional[str], bool]:
     """Apply the local-read contract to text from a ``read_remote_script`` callback.
 
     The recursion boundary must not trust its callbacks: any backend (SSH,
@@ -496,7 +592,12 @@ def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bo
         return None, False
     if "\x00" in text:
         return None, False
-    if len(text.encode("utf-8", errors="replace")) > _MAX_REFERENCED_SCRIPT_BYTES:
+    byte_limit = _MAX_REFERENCED_SCRIPT_BYTES
+    if max_bytes is not None:
+        byte_limit = min(byte_limit, max(0, int(max_bytes)))
+    if len(text) > byte_limit:
+        return None, True
+    if len(text.encode("utf-8", errors="replace")) > byte_limit:
         return None, True
     return text, False
 
@@ -507,8 +608,14 @@ def _contains_unsafe_gateway_action(
     cwd: Optional[str],
     depth: int,
     visited: set[Path],
+    budget: _LifecycleScanBudget,
     read_remote_script: Optional[_ReadRemoteScriptFn] = None,
 ) -> bool:
+    # Charge all text, including the depth-zero command, BEFORE any direct scan:
+    # contains_launchctl_submit_command and both reference iterators tokenize
+    # with shlex, so checking afterwards would preserve the CPU spike.
+    if not budget.consume_text(command):
+        return True
     if _direct_lifecycle_scan(command):
         return True
     if depth >= _MAX_REFERENCED_SCRIPT_DEPTH:
@@ -520,6 +627,7 @@ def _contains_unsafe_gateway_action(
             cwd=cwd,
             depth=depth + 1,
             visited=visited,
+            budget=budget,
             read_remote_script=read_remote_script,
         ):
             return True
@@ -534,8 +642,15 @@ def _contains_unsafe_gateway_action(
             resolved = script_path
         if resolved in visited:
             continue
+        if not budget.consume_path():
+            return True
         visited.add(resolved)
-        script_text, unsafe = _read_referenced_script(script_path)
+        if budget.bytes_remaining <= 0 or budget.lines_remaining <= 0:
+            return True
+        script_text, unsafe = _read_referenced_script(
+            script_path,
+            max_bytes=budget.bytes_remaining,
+        )
         if unsafe:
             return True
         if script_text is None and read_remote_script is not None:
@@ -544,7 +659,8 @@ def _contains_unsafe_gateway_action(
             # local read — sanitize it identically before it enters the
             # recursion (binary skip + size fail-closed).
             script_text, unsafe = _sanitize_remote_script_text(
-                read_remote_script(str(script_path))
+                read_remote_script(str(script_path)),
+                max_bytes=budget.bytes_remaining,
             )
             if unsafe:
                 return True
@@ -558,6 +674,7 @@ def _contains_unsafe_gateway_action(
             cwd=script_dir,
             depth=depth + 1,
             visited=visited,
+            budget=budget,
             read_remote_script=read_remote_script,
         ):
             return True
@@ -592,6 +709,7 @@ def contains_gateway_lifecycle_command_or_referenced_script(
             cwd=cwd,
             depth=0,
             visited=set(),
+            budget=_LifecycleScanBudget(),
             read_remote_script=read_remote_script,
         )
     except Exception:
@@ -618,7 +736,7 @@ def _resolve_script_path(script_path: str) -> Optional[Path]:
     """Resolve a cron ``script`` value the same way the scheduler does.
 
     The scheduler (``cron.scheduler``) resolves a bare/relative script path
-    under ``<HERMES_HOME>/scripts/`` and only accepts absolute paths as-is.
+    under ``<HERMES_HOME>/scripts/`` and canonicalizes the execution target.
     We MUST mirror that here so the guard scans the file that will actually
     run — otherwise a job whose script lives at the scheduler's real location
     (``~/.hermes/scripts/restart.sh``) but is passed as the bare name
@@ -635,14 +753,17 @@ def _resolve_script_path(script_path: str) -> Optional[Path]:
     raw = _expand_candidate_path(script_path)
     if raw is None:
         return None
-    if raw.is_absolute():
-        return raw
     try:
-        return get_hermes_home() / "scripts" / raw
-    except (RuntimeError, OSError):
+        path = raw if raw.is_absolute() else get_hermes_home() / "scripts" / raw
+        # Match cron.scheduler: interpreter selection and shell-relative
+        # references use the resolved execution target, not a symlink's name
+        # or parent directory.
+        return path.resolve(strict=False)
+    except (RuntimeError, OSError, ValueError):
         # get_hermes_home() falls back to Path.home(), which raises when
         # neither HERMES_HOME nor HOME is resolvable (launchd/systemd
-        # environments) — same ingestion contract: nothing to scan.
+        # environments). Path resolution can also fail on malformed paths or
+        # symlink loops. Same ingestion contract: nothing executable to scan.
         return None
 
 
@@ -678,14 +799,20 @@ def check_gateway_lifecycle(
     fail with a ``ValueError``-shaped error (the agent's ``cronjob`` tool
     surfaces this as a tool error; the CLI prints it in red and exits 1).
     """
-    combined = prompt or ""
+    prompt_text = prompt or ""
+    combined = prompt_text
+    script_text = ""
+    resolved_script: Optional[Path] = None
     python_script = False
     if script:
         resolved_script = _resolve_script_path(script)
-        python_script = resolved_script is not None and resolved_script.suffix == ".py"
+        python_script = (
+            resolved_script is not None
+            and resolved_script.suffix.lower() not in {".sh", ".bash"}
+        )
         script_text = _read_script_for_scanning(script)
         if script_text:
-            combined = f"{combined}\n{script_text}"
+            combined = "\n".join(part for part in (combined, script_text) if part)
 
     if python_script:
         # Python is executed by the interpreter, never through a POSIX
@@ -694,10 +821,31 @@ def check_gateway_lifecycle(
         # the filesystem root and trips the regular-file check, blocking
         # every innocent .py cron script, #77131). The direct command
         # regex below still scans the full text, so a literal
-        # `hermes gateway restart` embedded in a .py script is still
+        # `hermes gateway restart` embedded in a Python script is still
         # blocked. Non-regular/oversized script files still fail closed
         # via the lifecycle-shaped sentinel in _read_script_for_scanning.
-        unsafe = _lifecycle_command_scan_with_data_exemption(combined)
+        # Charge the combined root before scanning, just like the shell path.
+        budget = _LifecycleScanBudget()
+        if not budget.consume_text(combined):
+            unsafe = True
+        else:
+            # Preserve prompt data-argument exemptions without ever sending
+            # Python source through shlex. The final verdict remains a direct
+            # lifecycle-regex scan over the prompt plus source text.
+            prompt_for_scan = prompt_text
+            if contains_gateway_lifecycle_command(combined):
+                prompt_for_scan = _mask_data_sink_arguments(
+                    _normalize_shell_line_continuations(prompt_for_scan)
+                )
+            python_scan_text = "\n".join(
+                part for part in (prompt_for_scan, script_text) if part
+            )
+            # The execution-aware launchctl scan is label-independent, but it
+            # must only tokenize the shell-like prompt, never Python source.
+            unsafe = (
+                contains_launchctl_submit_command(prompt_text)
+                or contains_gateway_lifecycle_command(python_scan_text)
+            )
     else:
         script_dir = _resolve_script_directory(script) if script else None
         unsafe = contains_gateway_lifecycle_command_or_referenced_script(

--- a/tests/cron/test_lifecycle_guard_budget.py
+++ b/tests/cron/test_lifecycle_guard_budget.py
@@ -1,0 +1,340 @@
+"""Work-budget regressions for the gateway lifecycle guard (#78398).
+
+The referenced-script walk is security-sensitive, so exhausting a budget must
+fail closed.  These tests keep the limits tiny and deterministic; production
+limits remain generous enough for ordinary wrapper chains.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import cron.lifecycle_guard as lifecycle_guard
+
+
+def _remote_command(*paths: str) -> str:
+    return "\n".join(f"sh {path}" for path in paths)
+
+
+def test_unique_path_budget_bounds_remote_reads_and_fails_closed(monkeypatch):
+    """A wide script graph must not trigger an unbounded number of reads."""
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_PATHS",
+        3,
+        raising=False,
+    )
+    paths = tuple(f"/remote/safe-{index}.sh" for index in range(10))
+    reads: list[str] = []
+
+    def read_remote_script(path: str) -> str:
+        reads.append(path)
+        return "printf 'safe\\n'\n"
+
+    verdict = lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+        _remote_command(*paths),
+        read_remote_script=read_remote_script,
+    )
+
+    assert verdict is True
+    assert reads == list(paths[:3])
+
+
+def test_repeated_path_does_not_spend_unique_path_budget(monkeypatch):
+    """The existing visited-set dedupe stays effective under the new budget."""
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_PATHS",
+        1,
+        raising=False,
+    )
+    path = "/remote/reused-safe.sh"
+    reads: list[str] = []
+
+    def read_remote_script(candidate: str) -> str:
+        reads.append(candidate)
+        return "printf 'safe\\n'\n"
+
+    verdict = lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+        _remote_command(*(path for _ in range(10))),
+        read_remote_script=read_remote_script,
+    )
+
+    assert verdict is False
+    assert reads == [path]
+
+
+def test_cumulative_text_budget_bounds_recursive_scan(monkeypatch):
+    """Safe files cannot cumulatively feed unlimited text back into shlex."""
+    paths = ("/r/a", "/r/b", "/r/c")
+    command = _remote_command(*paths)
+    script = "printf 'one bounded script\\n'\n"
+    # Exactly enough for the root command and one remote script. The second
+    # referenced path must fail closed before another remote read is attempted.
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_BYTES",
+        len(command.encode("utf-8")) + len(script.encode("utf-8")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_PATHS",
+        10,
+        raising=False,
+    )
+    reads: list[str] = []
+
+    def read_remote_script(path: str) -> str:
+        reads.append(path)
+        return script
+
+    verdict = lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+        command,
+        read_remote_script=read_remote_script,
+    )
+
+    assert verdict is True
+    assert reads == [paths[0]]
+
+
+def test_line_budget_fails_closed_before_tokenizing_every_line(monkeypatch):
+    """Thousands of short lines were the one-lexer-per-line CPU blow-up."""
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_LINES",
+        2,
+        raising=False,
+    )
+
+    verdict = lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+        "sh /remote/many-lines.sh",
+        read_remote_script=lambda _path: "printf one\nprintf two\nprintf three",
+    )
+
+    assert verdict is True
+
+
+def test_depth_zero_byte_and_line_byte_limits_allow_exact_and_reject_plus_one(
+    monkeypatch,
+):
+    """The root is bounded before shlex, with inclusive byte limits."""
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_LINE_BYTES",
+        8,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_BYTES",
+        8,
+        raising=False,
+    )
+
+    assert (
+        lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script("x" * 8)
+        is False
+    )
+
+    def fail_if_scanned(_command: str) -> bool:
+        raise AssertionError("over-budget root reached the direct scanner")
+
+    monkeypatch.setattr(lifecycle_guard, "_direct_lifecycle_scan", fail_if_scanned)
+    assert (
+        lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script("x" * 9)
+        is True
+    )
+
+
+def test_depth_zero_line_limit_allows_exact_and_rejects_plus_one(monkeypatch):
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_LINES",
+        2,
+        raising=False,
+    )
+
+    assert (
+        lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+            "one\ntwo"
+        )
+        is False
+    )
+    assert (
+        lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+            "one\ntwo\nthree"
+        )
+        is True
+    )
+
+
+def test_crlf_continuation_line_budget_blocks_before_shlex(monkeypatch):
+    """CRLF continuations cannot join compliant lines into one huge token."""
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_LINE_BYTES",
+        8,
+        raising=False,
+    )
+
+    def fail_if_tokenized(*_args, **_kwargs):
+        raise AssertionError("over-budget CRLF continuation reached shlex")
+
+    monkeypatch.setattr(lifecycle_guard.shlex, "shlex", fail_if_tokenized)
+    assert (
+        lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+            "xxxxx\\\r\nxxxx"
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "hermes gate\\\nway restart",
+        "hermes gate\\\r\nway restart",
+        "launchctl sub\\\r\nmit -l com.foo -- /tmp/helper",
+    ],
+)
+def test_lf_and_crlf_continuations_cannot_split_blocked_keywords(command):
+    assert (
+        lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(command)
+        is True
+    )
+
+
+def test_depth_zero_budget_counts_utf8_bytes(monkeypatch):
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_BYTES",
+        4,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_LINE_BYTES",
+        4,
+        raising=False,
+    )
+
+    assert (
+        lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script("éé")
+        is False
+    )
+    assert (
+        lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script("ééé")
+        is True
+    )
+
+
+def test_empty_prompt_does_not_spend_a_synthetic_delimiter_byte(
+    monkeypatch,
+    tmp_path,
+):
+    """A script exactly at the root limit is allowed; one extra byte blocks."""
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_BYTES",
+        8,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_LINE_BYTES",
+        8,
+        raising=False,
+    )
+    script = tmp_path / "long-line.sh"
+    script.write_text("x" * 8, encoding="utf-8")
+
+    lifecycle_guard.check_gateway_lifecycle("", str(script))
+
+    script.write_text("x" * 9, encoding="utf-8")
+
+    with pytest.raises(lifecycle_guard.GatewayLifecycleBlocked):
+        lifecycle_guard.check_gateway_lifecycle("", str(script))
+
+
+@pytest.mark.parametrize("name", ["job.PY", "job"])
+def test_scheduler_python_classification_skips_shell_walk_and_is_bounded(
+    monkeypatch,
+    tmp_path,
+    name,
+):
+    """Uppercase and extensionless scripts use the bounded direct-regex path."""
+    (tmp_path / "child.sh").write_text(
+        "hermes gateway restart\n",
+        encoding="utf-8",
+    )
+    script = tmp_path / name
+    source = '"./child.sh"\n'
+    script.write_text(source, encoding="utf-8")
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_BYTES",
+        len(source.encode("utf-8")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_MAX_LIFECYCLE_SCAN_LINE_BYTES",
+        len(source.encode("utf-8")),
+        raising=False,
+    )
+
+    lifecycle_guard.check_gateway_lifecycle("", str(script))
+
+    script.write_text(f"{source}x", encoding="utf-8")
+    with pytest.raises(lifecycle_guard.GatewayLifecycleBlocked):
+        lifecycle_guard.check_gateway_lifecycle("", str(script))
+
+
+@pytest.mark.parametrize("name", ["job.PY", "job"])
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "launchctl submit -l com.foo -- /tmp/helper",
+        "launchctl bootstrap gui/501 /tmp/com.foo.plist",
+    ],
+)
+def test_python_classified_script_blocks_prompt_launchctl_without_scanning_source(
+    monkeypatch,
+    tmp_path,
+    name,
+    prompt,
+):
+    script = tmp_path / name
+    script.write_text("print('safe')\n", encoding="utf-8")
+    scanned: list[str] = []
+    original_scan = lifecycle_guard.contains_launchctl_submit_command
+
+    def track_launchctl_scan(text: str) -> bool:
+        scanned.append(text)
+        return original_scan(text)
+
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "contains_launchctl_submit_command",
+        track_launchctl_scan,
+    )
+
+    with pytest.raises(lifecycle_guard.GatewayLifecycleBlocked):
+        lifecycle_guard.check_gateway_lifecycle(prompt, str(script))
+
+    assert scanned == [prompt]
+
+
+@pytest.mark.parametrize("name", ["job.SH", "job.BASH"])
+def test_scheduler_shell_classification_is_case_insensitive_and_walks_child(
+    tmp_path,
+    name,
+):
+    child = tmp_path / "child.sh"
+    child.write_text("hermes gateway restart\n", encoding="utf-8")
+    script = tmp_path / name
+    script.write_text("./child.sh\n", encoding="utf-8")
+
+    with pytest.raises(lifecycle_guard.GatewayLifecycleBlocked):
+        lifecycle_guard.check_gateway_lifecycle("clean prompt", str(script))

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -327,6 +327,31 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 1
         assert "KeepAlive" in result["error"]
 
+    def test_oversized_root_skips_launchctl_prescan_and_fails_closed(
+        self, monkeypatch
+    ):
+        import cron.lifecycle_guard as lifecycle_guard
+        import tools.terminal_tool as tt
+
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+        monkeypatch.setattr(
+            lifecycle_guard, "_MAX_LIFECYCLE_SCAN_BYTES", 8, raising=False
+        )
+        monkeypatch.setattr(
+            lifecycle_guard, "_MAX_LIFECYCLE_SCAN_LINE_BYTES", 8, raising=False
+        )
+
+        def explode_if_tokenized(*args, **kwargs):
+            raise AssertionError("over-budget root reached shlex")
+
+        monkeypatch.setattr(lifecycle_guard.shlex, "shlex", explode_if_tokenized)
+
+        result = json.loads(tt.terminal_tool(command="x" * 9))
+
+        assert result["exit_code"] == 1
+        assert "command or referenced script" in result["error"]
+        assert "KeepAlive" not in result["error"]
+
     @pytest.mark.parametrize("command", [
         # Neutral, non-hermes label: label-independent detection is the point
         # (#62891 second reproduction used `ai.hermes.svc-reload-tmp`).
@@ -675,6 +700,28 @@ class TestLifecycleGuardModule:
         script.write_text('import os\nos.system("hermes gateway restart")\n', encoding="utf-8")
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("clean prompt", str(script))
+
+    def test_symlink_named_python_to_shell_uses_target_suffix_and_parent(
+        self, tmp_path
+    ):
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+        child = target_dir / "child.sh"
+        child.write_text("hermes gateway restart\n", encoding="utf-8")
+        wrapper = target_dir / "wrapper.sh"
+        wrapper.write_text("./child.sh\n", encoding="utf-8")
+        link_dir = tmp_path / "links"
+        link_dir.mkdir()
+        link = link_dir / "job.py"
+        try:
+            link.symlink_to(wrapper)
+        except (NotImplementedError, OSError) as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("clean prompt", str(link))
 
     def test_absolute_path_binary_does_not_crash_guard(self):
         """#76762: a terminal command invoking a binary by absolute path
@@ -1167,6 +1214,23 @@ class TestLifecycleGuardDataArgumentExemption:
             "WHERE msg LIKE '%systemctl restart hermes-gateway%'\""
         )
         check_gateway_lifecycle(prompt, str(script))
+
+    def test_python_combined_match_masks_prompt_data_arguments(self, tmp_path):
+        from cron.lifecycle_guard import check_gateway_lifecycle
+
+        script = tmp_path / "report.py"
+        script.write_text("restart = False\n", encoding="utf-8")
+
+        check_gateway_lifecycle("grep hermes gateway", str(script))
+
+    def test_python_combined_real_split_command_still_blocks(self, tmp_path):
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+
+        script = tmp_path / "restart.py"
+        script.write_text("restart = True\n", encoding="utf-8")
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("hermes gateway", str(script))
 
 
 class TestLifecycleGuardNeverRaises:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2777,8 +2777,15 @@ def terminal_tool(
                 _MAX_REFERENCED_SCRIPT_BYTES,
                 contains_gateway_lifecycle_command_or_referenced_script,
                 contains_launchctl_submit_command,
+                lifecycle_scan_root_within_budget,
             )
-            if contains_launchctl_submit_command(command):
+            # Keep the specific launchctl diagnostic when this optional
+            # pre-scan fits the budget.  The full fail-closed guard below still
+            # runs when it does not, so oversized roots never reach shlex here.
+            if (
+                lifecycle_scan_root_within_budget(command)
+                and contains_launchctl_submit_command(command)
+            ):
                 return json.dumps({
                     "output": "",
                     "exit_code": 1,


### PR DESCRIPTION
## Summary

- add a shared work budget to the lifecycle guard's complete scan: 256 KiB of UTF-8 text, 4,096 logical lines, 32 KiB per joined line, and 32 unique referenced paths
- enforce the budget before every root/recursive `shlex` path and before additional local/remote reads; exhaustion fails closed
- budget the terminal's optional `launchctl` pre-scan while preserving its specific diagnostic, and canonicalize LF/CRLF shell continuations consistently across regex, budget, lexer, and masker paths
- keep Python cron source out of `shlex`, classify cron scripts from the resolved scheduler target, and preserve label-independent prompt protection

## Problem

The guard already capped each file at 1 MiB and recursion depth at 8, but `N files × 1 MiB` remained unbounded. Each scanned text can be tokenized up to three times, and `_iter_command_segments` constructs one `shlex` per line. A single terminal call could therefore hold the GIL for minutes and create multi-gigabyte transient allocations.

The new budget is shared by the complete walk, including the root command, nested `sh -c` payloads, and referenced scripts. Repeated canonical paths still use the existing `visited` dedupe and do not spend additional path budget.

## Benchmark

One-shot comparison against `origin/main` (`c0106e50e`) on Linux / Python 3.11 through the public guard API:

| case | `origin/main` | patched | result |
|---|---:|---:|---|
| top-level 64 KiB token | 0.4570 s | 0.0002 s | 2,484× faster; fails closed before `shlex` |
| local script, one 64 KiB token | 0.3489 s | 0.0006 s | 628× faster; fails closed before recursive `shlex` |
| local script, 5,000 short lines | 0.7408 s | 0.0014 s | 515× faster; avoids per-line lexer construction |
| 100 unique remote script paths | 0.0596 s / 100 reads | 0.0226 s / 32 reads | deterministic breadth cap |

The timing rows intentionally exceed production work limits. The stable contract is bounded work, not a timing threshold.

## Safety and compatibility

- budget exhaustion returns the existing unsafe verdict; unscanned lifecycle actions are never allowed through
- byte accounting uses UTF-8 size, and LF/CRLF continuations are joined with POSIX semantics before line-length checks or tokenization
- local reads honor the shared remaining-byte budget; remote callback text is sanitized against the same remaining budget
- ordinary launchctl submissions that fit the budget retain the specific KeepAlive diagnostic; oversized roots skip the optional pre-scan and are blocked by the full guard
- cron interpreter classification mirrors the scheduler's resolved target (`.sh`/`.bash`, case-insensitive, versus Python), while Python source remains outside `shlex`

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py tests/cron/test_lifecycle_guard_budget.py tests/cron/test_jobs.py -q` — **218 passed**
- sabotage runs against `origin/main` — budget, root pre-scan, symlink-target, and LF/CRLF continuation regressions all fail without the patch
- `ruff check` on all changed Python files — passed
- `ruff format --check tests/cron/test_lifecycle_guard_budget.py` — passed (`cron/lifecycle_guard.py` has pre-existing formatter drift on `origin/main`; no unrelated reformatting included)
- `python -m py_compile ...` — passed
- `python scripts/check-windows-footguns.py ...` — passed
- independent fail-closed review — approved with no introduced security or logic defects
- full-suite attempt exposed one unrelated local-environment failure in `tests/agent/test_auxiliary_transport_autodetect.py` because the isolated venv lacks the optional `anthropic` package; the same 15-pass/1-fail result reproduces on a clean `origin/main` worktree

Closes #78398
Related: #77931
