### PR TITLE
fix(skills): isolate OpenClaw external skill dirs

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -479,6 +479,40 @@ def _normalize_string_set(values) -> Set[str]:
     return {str(v).strip() for v in values if str(v).strip()}
 
 
+# -- Foreign app skill roots -------------------------------------------------
+
+_OPENCLAW_HOME_MARKERS = frozenset(("openclaw.json", "clawdbot.json", "moltbot.json"))
+
+
+def _is_openclaw_owned(path: Path) -> bool:
+    """Return True when *path* appears to belong to an OpenClaw home/tree."""
+    try:
+        resolved = Path(path).expanduser().resolve()
+    except (OSError, RuntimeError):
+        resolved = Path(path).expanduser().absolute()
+
+    if any(part.lower() == ".openclaw" for part in resolved.parts):
+        return True
+
+    home = Path.home()
+    for parent in (resolved, *resolved.parents):
+        if any((parent / marker).exists() for marker in _OPENCLAW_HOME_MARKERS):
+            return True
+        if parent == home:
+            break
+    return False
+
+
+def _openclaw_external_dirs_allowed(skills_cfg: Dict[str, Any]) -> bool:
+    """Whether config explicitly opts into indexing OpenClaw-owned skill roots."""
+    value = skills_cfg.get("allow_openclaw_external_dirs")
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
 # ── External skills directories ──────────────────────────────────────────
 
 # (config_path_str, mtime_ns) -> resolved external dirs list.  Keyed by
@@ -506,7 +540,8 @@ def get_external_skills_dirs() -> List[Path]:
     Cached in-process, keyed on ``config.yaml`` mtime — the function is
     called once per skill during banner / tool-registry scans, and YAML
     parsing a non-trivial config dominates ``hermes`` cold-start time
-    when the cache is absent.
+    when the cache is absent. OpenClaw-owned roots are skipped unless the
+    user explicitly opts in via ``skills.allow_openclaw_external_dirs``.
     """
     config_path = get_config_path()
     if not config_path.exists():
@@ -551,6 +586,7 @@ def get_external_skills_dirs() -> List[Path]:
     local_skills = get_skills_dir().resolve()
     seen: Set[Path] = set()
     result = []
+    allow_openclaw = _openclaw_external_dirs_allowed(skills_cfg)
 
     for entry in raw_dirs:
         entry = str(entry).strip()
@@ -567,6 +603,9 @@ def get_external_skills_dirs() -> List[Path]:
         if p == local_skills:
             continue
         if p in seen:
+            continue
+        if _is_openclaw_owned(p) and not allow_openclaw:
+            logger.warning("Skipping OpenClaw-owned external skills directory: %s", p)
             continue
         if p.is_dir():
             seen.add(p)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1859,6 +1859,10 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Keep Hermes/OpenClaw skills isolated by default. Set true only if you
+        # intentionally want Hermes to index an OpenClaw-owned skills directory
+        # such as ~/.openclaw/skills via external_dirs.
+        "allow_openclaw_external_dirs": False,
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/tests/agent/test_openclaw_external_skills_isolation.py
+++ b/tests/agent/test_openclaw_external_skills_isolation.py
@@ -1,0 +1,120 @@
+import importlib
+from pathlib import Path
+
+
+def _write_skill(root: Path, name: str) -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {name}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _write_config(hermes_home: Path, body: str) -> None:
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "skills").mkdir(exist_ok=True)
+    (hermes_home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def _reload_skill_utils(monkeypatch, hermes_home: Path):
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import agent.skill_utils as skill_utils
+
+    importlib.reload(skill_utils)
+    skill_utils._external_dirs_cache_clear()
+    return skill_utils
+
+
+def test_openclaw_external_skills_dir_skipped_by_default(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    openclaw_skills = tmp_path / ".openclaw" / "skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+    _write_config(
+        hermes_home,
+        "skills:\n"
+        "  external_dirs:\n"
+        f"    - {openclaw_skills}\n",
+    )
+
+    skill_utils = _reload_skill_utils(monkeypatch, hermes_home)
+
+    assert skill_utils.get_external_skills_dirs() == []
+
+
+def test_openclaw_external_skills_dir_allowed_by_config(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    openclaw_skills = tmp_path / ".openclaw" / "skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+    _write_config(
+        hermes_home,
+        "skills:\n"
+        "  allow_openclaw_external_dirs: true\n"
+        "  external_dirs:\n"
+        f"    - {openclaw_skills}\n",
+    )
+
+    skill_utils = _reload_skill_utils(monkeypatch, hermes_home)
+
+    assert skill_utils.get_external_skills_dirs() == [openclaw_skills.resolve()]
+
+
+def test_non_openclaw_external_skills_still_work(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    external_skills = tmp_path / "shared-skills"
+    _write_skill(external_skills, "legit-skill")
+    _write_config(
+        hermes_home,
+        "skills:\n"
+        "  external_dirs:\n"
+        f"    - {external_skills}\n",
+    )
+
+    skill_utils = _reload_skill_utils(monkeypatch, hermes_home)
+
+    assert skill_utils.get_external_skills_dirs() == [external_skills.resolve()]
+
+
+def test_mixed_external_dirs_skip_openclaw_but_keep_normal(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    openclaw_skills = tmp_path / ".openclaw" / "skills"
+    external_skills = tmp_path / "shared-skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+    _write_skill(external_skills, "legit-skill")
+    _write_config(
+        hermes_home,
+        "skills:\n"
+        "  external_dirs:\n"
+        f"    - {openclaw_skills}\n"
+        f"    - {external_skills}\n",
+    )
+
+    skill_utils = _reload_skill_utils(monkeypatch, hermes_home)
+
+    assert skill_utils.get_external_skills_dirs() == [external_skills.resolve()]
+
+
+def test_is_openclaw_owned_detects_marker_in_parent(tmp_path):
+    openclaw_home = tmp_path / "OpenClawHome"
+    (openclaw_home / "skills").mkdir(parents=True)
+    (openclaw_home / "openclaw.json").write_text("{}", encoding="utf-8")
+
+    from agent.skill_utils import _is_openclaw_owned
+
+    assert _is_openclaw_owned(openclaw_home / "skills")
+
+
+def test_is_openclaw_owned_does_not_walk_past_home(tmp_path, monkeypatch):
+    fake_root = tmp_path / "root"
+    home = fake_root / "home"
+    skill_dir = home / "project" / "skills"
+    skill_dir.mkdir(parents=True)
+    (fake_root / "openclaw.json").write_text("{}", encoding="utf-8")
+
+    from agent.skill_utils import _is_openclaw_owned
+
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    assert not _is_openclaw_owned(skill_dir)


### PR DESCRIPTION
## Summary

Fixes #17345 by preventing Hermes from indexing OpenClaw-owned external skill directories by default.

Hermes now skips configured `skills.external_dirs` entries that point to OpenClaw-owned paths such as `~/.openclaw/skills`, unless the user explicitly opts in with:

```yaml
skills:
  allow_openclaw_external_dirs: true
```

## Why

When Hermes and OpenClaw are installed on the same machine, Hermes can currently discover OpenClaw skills through configured external skill roots. This causes cross-app skill pollution: OpenClaw skills appear in Hermes prompts, `skills_list`, and related discovery surfaces even though they do not live under `~/.hermes/skills`.

## Notes

This PR intentionally preserves the existing `get_all_skills_dirs()` local-first contract. It only filters external skill directories and keeps non-OpenClaw external skills available.

It also avoids adding a behavior environment variable; the opt-in is config-only.

## Tests

- Added regression coverage for default OpenClaw external-dir filtering.
- Added config opt-in coverage.
- Added mixed-dir coverage to ensure valid external skills are not dropped when an OpenClaw external dir is present.
- Added marker-depth coverage for OpenClaw ownership detection.
