### PR TITLE
feat(agent): recover tool calls from Muse-Glimmer's native ATEM markup

### DIFF
--- a/agent/atem_dialect.py
+++ b/agent/atem_dialect.py
@@ -1,0 +1,179 @@
+"""Recovers OpenAI-style tool calls from Muse-Glimmer's native ATEM markup.
+
+Muse-Glimmer-30B (``meta-models/Muse-Glimmer-30B``) doesn't speak the OpenAI
+tool-calling wire format and its chat template emits no ``<tool_call>`` JSON.
+It writes a call like this instead::
+
+    <atem:function_calls>
+      <atem:invoke name="terminal">
+        <atem:parameter name="command">ls logs/</atem:parameter>
+      </atem:invoke>
+    </atem:function_calls>
+
+Served behind a standard OpenAI-compatible ``/chat/completions`` endpoint
+(vLLM or similar), the serving stack applies the model's own chat template
+on the way in — so Hermes still sends ordinary OpenAI-shaped ``tools`` and
+``messages`` — but nothing on the way out turns this markup into
+``message.tool_calls``. It arrives as literal text in ``message.content``,
+indistinguishable (to every existing code path) from a model that simply
+chose not to call a tool.
+
+This module is the parse side only. There is no render side: because a
+template-aware server sits between Hermes and the model, replaying a prior
+ATEM call back to the model is the server's job (it re-applies the chat
+template to whatever ``tool_calls`` Hermes sends, OpenAI-shaped, in
+conversation history) — not something Hermes constructs itself, the way
+``agent/copilot_acp_client.py`` must when it owns the raw prompt.
+
+## Argument types are not recovered here
+
+One JSON object per call becomes one XML element per *parameter*, and a
+parameter's value is text. The template writes booleans bare (``true``),
+``None`` as ``null``, and structured values through ``tojson`` — with
+nothing on the wire marking which happened, so a value reading ``true`` is
+indistinguishable from the string ``"true"``. Recovering that requires the
+tool's declared JSON Schema, which isn't available at the point
+``normalize_response`` runs (it sees only the raw API response, not the
+``tools`` list the request was built with). Every extracted argument is
+therefore left as a JSON string value — a safe under-recovery: most tool
+parameters (paths, commands, queries) are strings already, so this is a
+no-op for them, and a caller that needs the richer types can add
+schema-aware coercion as a follow-up without changing this module's
+contract.
+
+## Failure classes
+
+There's no arguments object, so there's no JSON syntax error to make — a
+whole class of malformed call cannot happen here. Two others can, and both
+would otherwise resolve to silent "no calls found":
+
+* an opened block, never closed — the likeliest break under a token limit,
+  since an ATEM call is several times longer than the JSON equivalent it
+  replaces.
+* an unterminated ``<atem:parameter>``, whose value swallows the rest of
+  the invoke. The parameters that *did* parse look like a complete call,
+  which is exactly why staying silent about it would be misleading.
+
+Both are reported in the returned ``malformed`` list rather than dropped.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+CALLS_OPEN = "<atem:function_calls>"
+CALLS_CLOSE = "</atem:function_calls>"
+
+_BLOCK_RE = re.compile(re.escape(CALLS_OPEN) + r"(.*?)" + re.escape(CALLS_CLOSE), re.DOTALL)
+_INVOKE_RE = re.compile(r'<atem:invoke\s+name="([^"]*)"\s*>(.*?)</atem:invoke>', re.DOTALL)
+_PARAM_RE = re.compile(r'<atem:parameter\s+name="([^"]*)"\s*>(.*?)</atem:parameter>', re.DOTALL)
+
+# Tag-shaped and not the tag: a namespace typo, a missing close, an unquoted name. Looked for
+# only after the real blocks are removed, so a near miss is reported rather than read as
+# silence — a correct call itself contains ``<atem:invoke>``, which is loose-tag-shaped too.
+_LOOSE_RE = re.compile(
+    r"<\s*/?\s*atem\s*:\s*(?:function_calls|invoke|parameter)\b[^>]*>?|<\s*/?\s*function_calls\b[^>]*>?",
+    re.IGNORECASE,
+)
+
+# An opened block with no matching close anywhere after it.
+_UNCLOSED_RE = re.compile(re.escape(CALLS_OPEN) + r"(?!.*" + re.escape(CALLS_CLOSE) + r")", re.DOTALL)
+
+
+def is_muse_glimmer_model(model: str | None) -> bool:
+    """True for any Muse-Glimmer model slug, bare or aggregator/path-prefixed.
+
+    Matches bare names (``muse-glimmer-30b``) and prefixed slugs
+    (``meta-models/Muse-Glimmer-30B``, ``openrouter/meta-models/muse-glimmer-30b``),
+    the same way :func:`agent.moonshot_schema.is_moonshot_model` covers aggregator
+    prefixes for Kimi.
+    """
+    if not model:
+        return False
+    tail = model.strip().lower().rsplit("/", 1)[-1]
+    return tail.startswith("muse-glimmer") or tail.startswith("museglimmer")
+
+
+def extract_atem_tool_calls(
+    text: str, *, call_id_prefix: str = "atem_call"
+) -> tuple[list[tuple[str, str, str]], str, list[str]]:
+    """Pull ``<atem:function_calls>`` blocks out of raw completion text.
+
+    Returns ``(calls, content, malformed)``:
+
+    * ``calls`` — one ``(call_id, name, arguments_json)`` tuple per
+      ``<atem:invoke>``, in document order. ``arguments_json`` is a JSON
+      object string (``json.dumps`` of the parsed parameters), matching the
+      shape ``ToolCall.arguments`` / ``Function.arguments`` already expect
+      elsewhere in this codebase — every value inside it is a string (see
+      module docstring).
+    * ``content`` — ``text`` with every well-formed call block, and any
+      malformed near-miss markup, removed. What's left is what the user
+      would actually see.
+    * ``malformed`` — human-readable diagnostics for call-shaped markup that
+      didn't parse (see module docstring). Empty when nothing looked broken.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return [], (text or ""), []
+
+    calls: list[tuple[str, str, str]] = []
+    malformed: list[str] = []
+    spans: list[tuple[int, int]] = []
+
+    for block in _BLOCK_RE.finditer(text):
+        spans.append(block.span())
+        body = block.group(1)
+        invokes = list(_INVOKE_RE.finditer(body))
+        if not invokes:
+            malformed.append(
+                f"{CALLS_OPEN} block contains no <atem:invoke>; the model opened a call "
+                "block and wrote nothing callable in it"
+            )
+            continue
+        for invoke in invokes:
+            name = invoke.group(1).strip()
+            if not name:
+                malformed.append("<atem:invoke> has an empty name attribute")
+                continue
+            raw_params = {p.group(1).strip(): p.group(2) for p in _PARAM_RE.finditer(invoke.group(2))}
+            leftover = _PARAM_RE.sub("", invoke.group(2)).strip()
+            if leftover and "<atem:parameter" in leftover:
+                # An unterminated parameter: its value swallowed the rest of the invoke.
+                malformed.append(
+                    f"{name}: an <atem:parameter> is not closed, so its value ran to the end "
+                    "of the call"
+                )
+                continue
+            call_id = f"{call_id_prefix}_{len(calls) + 1}"
+            calls.append((call_id, name, json.dumps(raw_params, ensure_ascii=False)))
+
+    remainder = _strip_spans(text, spans)
+
+    if _UNCLOSED_RE.search(remainder):
+        malformed.append(
+            f"{CALLS_OPEN} was opened and never closed, so the call is truncated. An ATEM "
+            "call is several times longer than the JSON equivalent, which makes this the "
+            "likeliest way a turn breaks under a token limit."
+        )
+    for loose in _LOOSE_RE.finditer(remainder):
+        malformed.append(
+            f"{loose.group(0)[:40]!r} is call-shaped but not a call. The namespace prefix is "
+            "part of the tag: `<function_calls>` and `<atem :invoke>` are both unparseable."
+        )
+
+    cleaned = _LOOSE_RE.sub("", _UNCLOSED_RE.sub("", remainder)).strip()
+    return calls, cleaned, malformed
+
+
+def _strip_spans(text: str, spans: list[tuple[int, int]]) -> str:
+    out: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        out.append(text[cursor:start])
+        cursor = end
+    out.append(text[cursor:])
+    return "".join(out)
+
+
+__all__ = ["CALLS_CLOSE", "CALLS_OPEN", "extract_atem_tool_calls", "is_muse_glimmer_model"]

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -12,6 +12,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 import json
 from typing import Any, Dict
 
+from agent.atem_dialect import extract_atem_tool_calls, is_muse_glimmer_model
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
@@ -835,6 +836,23 @@ class ChatCompletionsTransport(ProviderTransport):
         # loop's refusal handler surfaces it clearly and stops. ``refusal`` is
         # ``None`` for normal responses, so this is a no-op in the common case.
         content = msg.content
+
+        # Muse-Glimmer (and any future ATEM-speaking model) never populates
+        # ``msg.tool_calls`` — its chat template writes calls as inline
+        # ``<atem:function_calls>`` markup in ``content`` instead (see
+        # ``agent/atem_dialect.py``). Recover them here, before the refusal
+        # check below, so a real ATEM call isn't mistaken for an empty response.
+        if not tool_calls and is_muse_glimmer_model(getattr(response, "model", None)):
+            atem_calls, atem_content, atem_malformed = extract_atem_tool_calls(content or "")
+            if atem_calls:
+                tool_calls = [
+                    ToolCall(id=call_id, name=name, arguments=arguments)
+                    for call_id, name, arguments in atem_calls
+                ]
+                content = atem_content
+            if atem_malformed:
+                provider_data["atem_malformed"] = atem_malformed
+
         refusal = getattr(msg, "refusal", None)
         if refusal is None and hasattr(msg, "model_extra"):
             _msg_extra = getattr(msg, "model_extra", None) or {}

--- a/tests/agent/test_atem_dialect.py
+++ b/tests/agent/test_atem_dialect.py
@@ -1,0 +1,235 @@
+"""Tests for the ATEM dialect parser (Muse-Glimmer-30B's native tool-call markup).
+
+Covers ``agent/atem_dialect.py`` in isolation: model-name detection and
+parsing well-formed / malformed ``<atem:function_calls>`` markup out of raw
+completion text.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.atem_dialect import extract_atem_tool_calls, is_muse_glimmer_model
+
+
+class TestMuseGlimmerModelDetection:
+    """is_muse_glimmer_model() must match across aggregator/path prefixes."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "muse-glimmer-30b",
+            "Muse-Glimmer-30B",
+            "MUSE-GLIMMER-30B",
+            "meta-models/Muse-Glimmer-30B",
+            "openrouter/meta-models/muse-glimmer-30b",
+            "museglimmer-30b",
+        ],
+    )
+    def test_positive_matches(self, model):
+        assert is_muse_glimmer_model(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "",
+            None,
+            "kimi-k2.6",
+            "anthropic/claude-sonnet-4.6",
+            "openai/gpt-5.4",
+            "google/gemini-3-flash-preview",
+            "glimmer",
+            "muse",
+        ],
+    )
+    def test_negative_matches(self, model):
+        assert is_muse_glimmer_model(model) is False
+
+
+class TestExtractAtemToolCalls:
+    def test_empty_text(self):
+        calls, content, malformed = extract_atem_tool_calls("")
+        assert calls == []
+        assert content == ""
+        assert malformed == []
+
+    def test_none_like_text_returns_original(self):
+        calls, content, malformed = extract_atem_tool_calls("   ")
+        assert calls == []
+        assert content == "   "
+        assert malformed == []
+
+    def test_plain_text_no_calls(self):
+        calls, content, malformed = extract_atem_tool_calls("Sure, here's the answer.")
+        assert calls == []
+        assert content == "Sure, here's the answer."
+        assert malformed == []
+
+    def test_single_call(self):
+        text = (
+            "<atem:function_calls>\n"
+            '<atem:invoke name="terminal">\n'
+            '<atem:parameter name="command">ls logs/</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        calls, content, malformed = extract_atem_tool_calls(text)
+        assert malformed == []
+        assert content == ""
+        assert len(calls) == 1
+        call_id, name, arguments = calls[0]
+        assert call_id == "atem_call_1"
+        assert name == "terminal"
+        assert json.loads(arguments) == {"command": "ls logs/"}
+
+    def test_call_with_multiple_parameters_preserves_order(self):
+        text = (
+            "<atem:function_calls>\n"
+            '<atem:invoke name="search">\n'
+            '<atem:parameter name="query">weather</atem:parameter>\n'
+            '<atem:parameter name="limit">5</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        calls, _content, malformed = extract_atem_tool_calls(text)
+        assert malformed == []
+        _, _, arguments = calls[0]
+        assert list(json.loads(arguments).keys()) == ["query", "limit"]
+
+    def test_argument_values_stay_strings(self):
+        """No tool schema is available at parse time, so types aren't recovered."""
+        text = (
+            "<atem:function_calls>\n"
+            '<atem:invoke name="toggle">\n'
+            '<atem:parameter name="enabled">true</atem:parameter>\n'
+            '<atem:parameter name="count">5</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        calls, _content, _malformed = extract_atem_tool_calls(text)
+        arguments = json.loads(calls[0][2])
+        assert arguments == {"enabled": "true", "count": "5"}
+        assert isinstance(arguments["enabled"], str)
+        assert isinstance(arguments["count"], str)
+
+    def test_prose_around_a_call_is_preserved(self):
+        text = (
+            "Let me check that.\n"
+            "<atem:function_calls>\n"
+            '<atem:invoke name="terminal">\n'
+            '<atem:parameter name="command">pwd</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>\n"
+            "One moment."
+        )
+        calls, content, malformed = extract_atem_tool_calls(text)
+        assert len(calls) == 1
+        assert malformed == []
+        assert content == "Let me check that.\n\nOne moment."
+
+    def test_multiple_calls_in_document_order(self):
+        text = (
+            "<atem:function_calls>\n"
+            '<atem:invoke name="first">\n'
+            '<atem:parameter name="x">1</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>\n"
+            "<atem:function_calls>\n"
+            '<atem:invoke name="second">\n'
+            '<atem:parameter name="y">2</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        calls, _content, malformed = extract_atem_tool_calls(text)
+        assert malformed == []
+        assert [name for _id, name, _args in calls] == ["first", "second"]
+        assert [call_id for call_id, _name, _args in calls] == ["atem_call_1", "atem_call_2"]
+
+    def test_call_with_no_parameters(self):
+        text = (
+            "<atem:function_calls>\n"
+            '<atem:invoke name="list_files">\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        calls, _content, malformed = extract_atem_tool_calls(text)
+        assert malformed == []
+        assert json.loads(calls[0][2]) == {}
+
+    def test_empty_block_is_reported_not_silent(self):
+        text = "<atem:function_calls>\n</atem:function_calls>"
+        calls, content, malformed = extract_atem_tool_calls(text)
+        assert calls == []
+        assert content == ""
+        assert len(malformed) == 1
+        assert "no <atem:invoke>" in malformed[0]
+
+    def test_empty_invoke_name_is_reported(self):
+        text = (
+            "<atem:function_calls>\n"
+            '<atem:invoke name="">\n'
+            '<atem:parameter name="x">1</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        calls, _content, malformed = extract_atem_tool_calls(text)
+        assert calls == []
+        assert any("empty name attribute" in m for m in malformed)
+
+    def test_unclosed_call_block_is_reported(self):
+        """The likeliest truncation failure: an opened block never closed."""
+        text = (
+            "I'll check that.\n"
+            "<atem:function_calls>\n"
+            '<atem:invoke name="terminal">\n'
+            '<atem:parameter name="command">ls'
+        )
+        calls, content, malformed = extract_atem_tool_calls(text)
+        assert calls == []
+        assert "never closed" in " ".join(malformed)
+        assert "<atem:function_calls>" not in content
+
+    def test_unterminated_parameter_is_reported_not_silently_dropped(self):
+        text = (
+            "<atem:function_calls>\n"
+            '<atem:invoke name="terminal">\n'
+            '<atem:parameter name="command">ls logs/\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        calls, _content, malformed = extract_atem_tool_calls(text)
+        assert calls == []
+        assert any("is not closed" in m for m in malformed)
+
+    def test_loose_tag_shaped_text_outside_real_blocks_is_reported(self):
+        text = "Here's a call: <atem:invoke name=\"x\"> but no block around it."
+        calls, content, malformed = extract_atem_tool_calls(text)
+        assert calls == []
+        assert any("call-shaped but not a call" in m for m in malformed)
+        assert "<atem:invoke" not in content
+
+    def test_real_call_does_not_trigger_loose_tag_false_positive(self):
+        """A correct call contains <atem:invoke>, which is itself loose-tag-shaped;
+        it must not also be reported as a near miss."""
+        text = (
+            "<atem:function_calls>\n"
+            '<atem:invoke name="terminal">\n'
+            '<atem:parameter name="command">ls</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        _calls, _content, malformed = extract_atem_tool_calls(text)
+        assert malformed == []
+
+    def test_custom_call_id_prefix(self):
+        text = (
+            "<atem:function_calls>\n"
+            '<atem:invoke name="terminal">\n'
+            '<atem:parameter name="command">ls</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        calls, _content, _malformed = extract_atem_tool_calls(text, call_id_prefix="turn7")
+        assert calls[0][0] == "turn7_1"

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -776,3 +776,82 @@ class TestPromptCacheKeyCapability:
             provider_profile=profile,
         )
         assert "prompt_cache_key" not in kwargs
+
+
+class TestChatCompletionsNormalizeAtem:
+    """Muse-Glimmer never populates ``message.tool_calls`` — its chat template
+    writes calls as inline ``<atem:function_calls>`` markup in ``content``
+    instead (see ``agent/atem_dialect.py``). ``normalize_response`` must
+    recover them from a model whose ``response.model`` identifies it as
+    Muse-Glimmer, and must leave every other model untouched.
+    """
+
+    def _atem_response(self, content, *, model="meta-models/Muse-Glimmer-30B", tool_calls=None):
+        return SimpleNamespace(
+            model=model,
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=tool_calls, reasoning_content=None),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+    def test_atem_call_recovered_from_content(self, transport):
+        content = (
+            "<atem:function_calls>\n"
+            '<atem:invoke name="terminal">\n'
+            '<atem:parameter name="command">ls logs/</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        nr = transport.normalize_response(self._atem_response(content))
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "terminal"
+        assert json.loads(nr.tool_calls[0].arguments) == {"command": "ls logs/"}
+        assert nr.content == ""
+
+    def test_atem_call_with_surrounding_prose_keeps_visible_text(self, transport):
+        content = (
+            "One moment.\n"
+            "<atem:function_calls>\n"
+            '<atem:invoke name="terminal">\n'
+            '<atem:parameter name="command">pwd</atem:parameter>\n'
+            "</atem:invoke>\n"
+            "</atem:function_calls>"
+        )
+        nr = transport.normalize_response(self._atem_response(content))
+        assert len(nr.tool_calls) == 1
+        assert nr.content == "One moment."
+
+    def test_non_atem_model_content_is_left_alone(self, transport):
+        """A model whose slug doesn't match Muse-Glimmer must never have its
+        content parsed for ATEM markup, even if it happens to contain similar
+        text (e.g. discussing the format, or quoting it)."""
+        content = "<atem:function_calls>not really a call</atem:function_calls>"
+        nr = transport.normalize_response(self._atem_response(content, model="gpt-5.4"))
+        assert nr.tool_calls is None
+        assert nr.content == content
+
+    def test_atem_model_with_no_call_markup_is_plain_text(self, transport):
+        nr = transport.normalize_response(self._atem_response("Just an answer, no tool needed."))
+        assert nr.tool_calls is None
+        assert nr.content == "Just an answer, no tool needed."
+
+    def test_structured_tool_calls_take_precedence_over_atem_parsing(self, transport):
+        """If a Muse-Glimmer-labeled response somehow already carries real
+        OpenAI-shaped tool_calls, they must win — ATEM parsing only runs when
+        ``msg.tool_calls`` is empty."""
+        tc = SimpleNamespace(id="call_1", function=SimpleNamespace(name="real", arguments="{}"))
+        nr = transport.normalize_response(self._atem_response("ignored", tool_calls=[tc]))
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "real"
+        assert nr.content == "ignored"
+
+    def test_malformed_atem_call_surfaces_in_provider_data(self, transport):
+        """An unclosed call block (the likeliest truncation failure) must be
+        reported rather than silently read as an empty response."""
+        content = 'I\'ll check.\n<atem:function_calls>\n<atem:invoke name="terminal">'
+        nr = transport.normalize_response(self._atem_response(content))
+        assert nr.tool_calls is None
+        assert nr.provider_data is not None
+        assert any("never closed" in m for m in nr.provider_data["atem_malformed"])


### PR DESCRIPTION
## What does this PR do?

Adds support for **ATEM**, the native tool-calling markup used by `meta-models/Muse-Glimmer-30B`, so Hermes can actually use tools when talking to that model (or any future model sharing the same wire format).

Muse-Glimmer doesn't speak OpenAI's tool-calling wire format — its chat template has no `<tool_call>` JSON. Tool calls come out looking like this instead, as literal text in the assistant message:

```
<atem:function_calls>
  <atem:invoke name="terminal">
    <atem:parameter name="command">ls logs/</atem:parameter>
  </atem:invoke>
</atem:function_calls>
```

Because the model is served behind a standard OpenAI-compatible `/chat/completions` endpoint, this text lands in `message.content` with `message.tool_calls` empty — every existing code path reads that as the model simply choosing not to call a tool. This PR recovers the real call.

**Why this approach:** Muse-Glimmer is served behind a template-aware serving stack (vLLM or similar), so Hermes still sends ordinary OpenAI-shaped `tools`/`messages` on the way in — only the way *out* needs translating. That made this a **parse-only** change scoped to response normalization, rather than a full client facade like `agent/copilot_acp_client.py` (which owns raw prompt construction because it talks to a subprocess with no template layer of its own). There's deliberately no render side here: replaying a prior ATEM call back to the model is the server's job, re-applying its own chat template to whatever `tool_calls` Hermes sends in history.

## Related Issue

No existing issue for this specific format — I searched issues/PRs for "atem", "glimmer", and "muse" first (per the Contributing Guide) and found nothing that overlaps. #80591 ("meta model provider support") is adjacent — a request for a *provider*/endpoint integration for the same model family — but it's a different piece of work; this PR doesn't touch provider/endpoint config, so I'm not claiming it closes that issue.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **`agent/atem_dialect.py`** (new) — `is_muse_glimmer_model(model)` for bare/aggregator-prefixed slug detection (mirrors `agent/moonshot_schema.py`'s `is_moonshot_model` pattern), and `extract_atem_tool_calls(text)` which parses `<atem:function_calls>` blocks into `(call_id, name, arguments_json)` tuples plus cleaned visible content. Two failure classes are surfaced explicitly instead of silently resolving to "no calls found":
  - an opened call block never closed (the likely truncation failure — an ATEM call runs several times longer than the JSON equivalent it replaces, so there's more of it for a token limit to cut off)
  - an unterminated `<atem:parameter>`, whose value swallows the rest of the invoke
- **`agent/transports/chat_completions.py`** — in `normalize_response`, when a response has no structured `tool_calls` and `response.model` identifies it as Muse-Glimmer, parse `content` for ATEM markup before the refusal-detection check runs (so a genuine tool call is never mistaken for an empty/refused response). Malformed-call diagnostics are attached to `provider_data["atem_malformed"]` for visibility.
- **`tests/agent/test_atem_dialect.py`** (new) — unit tests for both functions: model-name detection (positive/negative, mirroring `test_moonshot_schema.py`'s parametrize style), well-formed single/multi-call parsing, argument ordering, prose preservation, and both malformed-call classes.
- **`tests/agent/transports/test_chat_completions.py`** — integration tests on `normalize_response`: ATEM call recovery, non-ATEM models are left untouched even with lookalike text, structured `tool_calls` take precedence when present, and malformed calls surface in `provider_data`.

**Known scope limit** (called out honestly rather than silently): extracted argument values are left as strings. ATEM's wire format has no types of its own — the template writes bare `true`/`false`/numbers with nothing marking what they are — so recovering real types needs the tool's declared JSON Schema, which isn't available inside `normalize_response` (it only sees the raw API response, not the request's `tools` list). Left-as-string is a safe under-recovery: most tool parameters (paths, commands, queries) are strings already, so this is a no-op for them, and schema-aware coercion can be added later as a follow-up without changing this module's contract.

## How to Test

1. `pytest tests/agent/test_atem_dialect.py tests/agent/transports/test_chat_completions.py -q` — 82 tests, all passing.
2. Broader regression check: `scripts/run_tests.sh tests/agent/transports/ tests/agent/test_atem_dialect.py tests/providers/` — 326 tests, all passing, nothing else affected.
3. Manual repro (illustrative — see the module docstring for the exact markup shape): point Hermes at a Muse-Glimmer-30B endpoint and ask it to run a tool; `agent/atem_dialect.py`'s docstring documents why no render side is needed for this to work end-to-end via a template-aware server.

I don't have GPU/serving infrastructure to stand up a live Muse-Glimmer endpoint for this PR, so verification here is at the parse-logic level (unit + integration tests against realistic captured markup) rather than a live end-to-end run.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(agent):`)
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` (scoped run, see above — full suite is large; ran the affected directories plus the new tests, all green) and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — no GPU/serving infra available to stand up a live Muse-Glimmer endpoint; verified at the parse-logic level instead (see "How to Test")

### Documentation & Housekeeping

- [x] N/A — no config keys added, no architecture/workflow changes, no tool schemas changed
- [ ] Documentation (README/docs) — not updated; happy to add a short mention under model/provider docs if maintainers want it before merge
