### PR TITLE
fix(kanban): compose blocked idempotency backfill

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3157,13 +3157,27 @@ def create_task(
     # insert, at which point both rows exist but the next lookup stabilises.
     if idempotency_key:
         row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            "SELECT id, status FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived' "
             "ORDER BY created_at DESC LIMIT 1",
             (idempotency_key,),
         ).fetchone()
         if row:
-            return row["id"]
+            existing_id = row["id"]
+            if (
+                initial_status == "blocked"
+                and row["status"] == "blocked"
+                and not _has_sticky_block(conn, existing_id)
+            ):
+                with write_txn(conn, allow_nested=True):
+                    if not _has_sticky_block(conn, existing_id):
+                        _append_event(
+                            conn,
+                            existing_id,
+                            "blocked",
+                            {"reason": "initial_status=blocked", "kind": "needs_input"},
+                        )
+            return existing_id
 
     now = int(time.time())
 
@@ -3307,6 +3321,13 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if initial_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status=blocked", "kind": "needs_input"},
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -29,6 +29,7 @@ landed via #28754 / #28781 ahead of this fix.
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 
@@ -40,12 +41,37 @@ from hermes_cli import kanban_db as kb
 @pytest.fixture
 def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Isolated HERMES_HOME with an empty kanban DB."""
+    inherited_db = os.environ.get("HERMES_KANBAN_DB")
     home = tmp_path / ".hermes"
     home.mkdir()
+    disposable_db = tmp_path / "disposable-kanban.db"
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(disposable_db))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_WORKSPACES_ROOT", raising=False)
+    if inherited_db:
+        assert Path(inherited_db).expanduser() != disposable_db
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert kb.kanban_db_path() == disposable_db
     kb.init_db()
     return home
+
+
+def _event_kinds(conn, task_id: str) -> list[str]:
+    return [
+        row["kind"]
+        for row in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id ASC",
+            (task_id,),
+        ).fetchall()
+    ]
+
+
+def _task_status(conn, task_id: str) -> str:
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    return task.status
 
 
 # ---------------------------------------------------------------------------
@@ -66,14 +92,126 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             reason="review-required: please verify ACL change",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
-        assert kb.get_task(conn, tid).status == "blocked"
+        assert _task_status(conn, tid) == "blocked"
 
         # Hammer the promotion code — exactly the dispatcher loop's
         # behaviour, just compressed in time.
         for _ in range(5):
             promoted = kb.recompute_ready(conn)
             assert promoted == 0, "worker-blocked task must not auto-promote"
-            assert kb.get_task(conn, tid).status == "blocked"
+            assert _task_status(conn, tid) == "blocked"
+
+
+def test_create_time_blocked_parent_free_task_is_sticky(kanban_home: Path) -> None:
+    """``initial_status='blocked'`` is an explicit human-ops block.
+
+    Even with no parents, dispatcher recomputation must not silently
+    promote it to ready/claimable. The sticky marker must be durable and
+    ordered after the ``created`` event so notification cursors can inherit
+    both creation facts before they are caught up.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="parked for ops", initial_status="blocked")
+
+        assert _task_status(conn, tid) == "blocked"
+        assert _event_kinds(conn, tid) == ["created", "blocked"]
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.claim_task(conn, tid) is None
+        assert _task_status(conn, tid) == "blocked"
+
+
+def test_create_time_blocked_child_with_done_parent_is_sticky(kanban_home: Path) -> None:
+    """A blocked child must not become claimable when its parents are done."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="already reviewed parent")
+        assert kb.complete_task(conn, parent, summary="done")
+        child = kb.create_task(
+            conn,
+            title="child parked for ops",
+            parents=[parent],
+            initial_status="blocked",
+        )
+
+        assert _task_status(conn, child) == "blocked"
+        assert _event_kinds(conn, child)[:2] == ["created", "blocked"]
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.claim_task(conn, child) is None
+        assert _task_status(conn, child) == "blocked"
+
+
+def test_reused_still_blocked_idempotent_task_gets_sticky_marker_only_on_explicit_block_request(
+    kanban_home: Path,
+) -> None:
+    """Legacy idempotent rows may already be blocked without a marker.
+
+    Backfill the marker only when the retried creator again explicitly asks
+    for ``initial_status='blocked'``. Default idempotent reuse keeps the old
+    non-sticky auto-recover behavior.
+    """
+    with kb.connect() as conn:
+        non_explicit = kb.create_task(
+            conn, title="legacy default reuse", idempotency_key="default-reuse"
+        )
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (non_explicit,))
+        conn.commit()
+
+        assert (
+            kb.create_task(
+                conn, title="legacy default reuse", idempotency_key="default-reuse"
+            )
+            == non_explicit
+        )
+        assert _event_kinds(conn, non_explicit) == ["created"]
+        assert kb.recompute_ready(conn) == 1
+        assert _task_status(conn, non_explicit) == "ready"
+
+        explicit = kb.create_task(
+            conn, title="legacy blocked reuse", idempotency_key="blocked-reuse"
+        )
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (explicit,))
+        conn.commit()
+
+        assert (
+            kb.create_task(
+                conn,
+                title="legacy blocked reuse",
+                idempotency_key="blocked-reuse",
+                initial_status="blocked",
+            )
+            == explicit
+        )
+        assert _event_kinds(conn, explicit) == ["created", "blocked"]
+        assert kb.recompute_ready(conn) == 0
+        assert _task_status(conn, explicit) == "blocked"
+
+
+def test_reused_blocked_idempotent_task_gets_sticky_marker_inside_outer_write_txn(
+    kanban_home: Path,
+) -> None:
+    """Idempotent blocked reuse backfill composes under graph-builder writes."""
+    with kb.connect() as conn:
+        explicit = kb.create_task(
+            conn, title="legacy nested reuse", idempotency_key="nested-reuse"
+        )
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (explicit,))
+        conn.commit()
+
+        with kb.write_txn(conn):
+            assert (
+                kb.create_task(
+                    conn,
+                    title="legacy nested reuse",
+                    idempotency_key="nested-reuse",
+                    initial_status="blocked",
+                )
+                == explicit
+            )
+
+        assert _event_kinds(conn, explicit) == ["created", "blocked"]
+        assert kb.recompute_ready(conn) == 0
+        assert _task_status(conn, explicit) == "blocked"
 
 
 
@@ -123,11 +261,11 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
             reason="review-required: human eyes please",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
-        assert kb.get_task(conn, tid).status == "blocked"
+        assert _task_status(conn, tid) == "blocked"
 
         # First dispatcher tick — must NOT promote.
         assert kb.recompute_ready(conn) == 0
-        assert kb.get_task(conn, tid).status == "blocked"
+        assert _task_status(conn, tid) == "blocked"
 
         # Simulate the (hypothetical) protocol_violation + gave_up
         # entries that the dispatcher would have written if the bug
@@ -152,7 +290,7 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
         for _ in range(3):
             promoted = kb.recompute_ready(conn)
             assert promoted == 0
-            assert kb.get_task(conn, tid).status == "blocked"
+            assert _task_status(conn, tid) == "blocked"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Preserve create-time `initial_status="blocked"` as a sticky block by appending the blocked marker after task creation.
- Backfill the sticky marker on idempotent reuse only when the caller explicitly asks for `initial_status="blocked"` and the reused task is already blocked.
- Route that idempotent backfill through `write_txn(conn, allow_nested=True)` so it composes inside current-main graph-builder transactions.

## Test Plan
- `PYTHONPATH=. python ../manual_validate_sticky.py` — passes; covers create-time sticky block and nested outer `write_txn` idempotent blocked reuse.
- `python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py` — passes.
- `git diff --check` — passes.
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py -q` — blocked locally: no venv with pytest found; no install/package install performed per task constraints.

Successor/correction for PR #82488 against exact current main `c0106e50e7ecedb3ce34e785d949725dc4e0e457`.
