### PR TITLE
fix(desktop): refresh selected custom provider models

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -29,7 +29,7 @@ let profileSwitchHandler: (() => void) | null = null
 
 vi.mock('@/hermes', () => ({
   getGlobalModelInfo: () => getGlobalModelInfo(),
-  getGlobalModelOptions: () => getGlobalModelOptions(),
+  getGlobalModelOptions: (opts?: unknown) => getGlobalModelOptions(opts),
   getAuxiliaryModels: () => getAuxiliaryModels(),
   getMoaModels: () => getMoaModels(),
   setModelAssignment: (body: unknown) => setModelAssignment(body),
@@ -213,7 +213,7 @@ describe('ModelSettings', () => {
   })
 
   it('preserves a user-defined provider endpoint when applying the main model', async () => {
-    getGlobalModelOptions.mockResolvedValueOnce({
+    getGlobalModelOptions.mockResolvedValue({
       providers: [
         {
           name: 'Nous',
@@ -257,6 +257,192 @@ describe('ModelSettings', () => {
         base_url: 'http://localhost:11434/v1'
       })
     )
+  })
+
+  it('refreshes a selected custom provider without carrying over the previous model', async () => {
+    getGlobalModelInfo.mockResolvedValueOnce({ provider: 'openai-codex', model: 'gpt-5.6-luna' })
+    getGlobalModelOptions
+      .mockResolvedValueOnce({
+        providers: [
+          {
+            name: 'OpenAI Codex',
+            slug: 'openai-codex',
+            models: ['gpt-5.6-luna'],
+            authenticated: true
+          },
+          {
+            name: 'Alibaba Personal Token Plan',
+            slug: 'alibaba-token-plan',
+            models: ['qwen3.8-max-preview'],
+            authenticated: true,
+            is_user_defined: true
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        providers: [
+          {
+            name: 'OpenAI Codex',
+            slug: 'openai-codex',
+            models: ['gpt-5.6-luna'],
+            authenticated: true
+          },
+          {
+            name: 'Alibaba Personal Token Plan',
+            slug: 'alibaba-token-plan',
+            models: ['qwen3.8-max', 'qwen3.7-max'],
+            authenticated: true,
+            is_user_defined: true
+          }
+        ]
+      })
+
+    await renderModelSettings()
+
+    const providerSelect = (await screen.findAllByRole('combobox'))[0]
+    fireEvent.click(providerSelect)
+    fireEvent.click(await screen.findByRole('option', { name: 'Alibaba Personal Token Plan' }))
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenLastCalledWith({ refresh: true }))
+
+    const modelSelect = (await screen.findAllByRole('combobox'))[1]
+    expect(modelSelect.textContent).not.toContain('gpt-5.6-luna')
+    fireEvent.click(modelSelect)
+    expect(await screen.findByRole('option', { name: 'qwen3.8-max' })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: 'gpt-5.6-luna' })).toBeNull()
+  })
+
+  it('clears the previous model on a built-in provider switch without refreshing discovery', async () => {
+    getGlobalModelOptions.mockResolvedValueOnce({
+      providers: [
+        {
+          name: 'Nous',
+          slug: 'nous',
+          models: ['hermes-4'],
+          authenticated: true
+        },
+        {
+          name: 'OpenAI Codex',
+          slug: 'openai-codex',
+          models: ['gpt-5.6-luna'],
+          authenticated: true
+        }
+      ]
+    })
+
+    await renderModelSettings()
+
+    const providerSelect = (await screen.findAllByRole('combobox'))[0]
+    fireEvent.click(providerSelect)
+    fireEvent.click(await screen.findByRole('option', { name: 'OpenAI Codex' }))
+
+    const modelSelect = (await screen.findAllByRole('combobox'))[1]
+    expect(modelSelect.textContent).not.toContain('hermes-4')
+    expect(getGlobalModelOptions).toHaveBeenCalledTimes(1)
+  })
+
+  it('discards a stale custom-provider refresh after a newer provider selection', async () => {
+    let resolveFirstRefresh!: (value: { providers: Array<Record<string, unknown>> }) => void
+
+    const firstRefresh = new Promise<{ providers: Array<Record<string, unknown>> }>(resolve => {
+      resolveFirstRefresh = resolve
+    })
+
+    getGlobalModelOptions
+      .mockResolvedValueOnce({
+        providers: [
+          { name: 'Nous', slug: 'nous', models: ['hermes-4'], authenticated: true },
+          { name: 'Custom A', slug: 'custom-a', models: ['a-old'], authenticated: true, is_user_defined: true },
+          { name: 'Custom B', slug: 'custom-b', models: ['b-old'], authenticated: true, is_user_defined: true }
+        ]
+      })
+      .mockReturnValueOnce(firstRefresh)
+      .mockResolvedValueOnce({
+        providers: [
+          { name: 'Nous', slug: 'nous', models: ['hermes-4'], authenticated: true },
+          { name: 'Custom A', slug: 'custom-a', models: ['a-old'], authenticated: true, is_user_defined: true },
+          { name: 'Custom B', slug: 'custom-b', models: ['b-fresh'], authenticated: true, is_user_defined: true }
+        ]
+      })
+
+    await renderModelSettings()
+
+    const providerSelect = (await screen.findAllByRole('combobox'))[0]
+    fireEvent.click(providerSelect)
+    fireEvent.click(await screen.findByRole('option', { name: 'Custom A' }))
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalledTimes(2))
+
+    fireEvent.click(providerSelect)
+    fireEvent.click(await screen.findByRole('option', { name: 'Custom B' }))
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalledTimes(3))
+
+    const modelSelect = (await screen.findAllByRole('combobox'))[1]
+    fireEvent.click(modelSelect)
+    expect(await screen.findByRole('option', { name: 'b-fresh' })).toBeTruthy()
+
+    await act(async () => {
+      resolveFirstRefresh({
+        providers: [
+          { name: 'Nous', slug: 'nous', models: ['hermes-4'], authenticated: true },
+          { name: 'Custom A', slug: 'custom-a', models: ['a-stale'], authenticated: true, is_user_defined: true },
+          { name: 'Custom B', slug: 'custom-b', models: ['b-old'], authenticated: true, is_user_defined: true }
+        ]
+      })
+      await firstRefresh
+    })
+
+    expect(screen.queryByRole('option', { name: 'a-stale' })).toBeNull()
+    expect(screen.getByRole('option', { name: 'b-fresh' })).toBeTruthy()
+  })
+
+  it('discards a custom-provider refresh after the active profile changes', async () => {
+    let resolveOldProfileRefresh!: (value: { providers: Array<Record<string, unknown>> }) => void
+
+    const oldProfileRefresh = new Promise<{ providers: Array<Record<string, unknown>> }>(resolve => {
+      resolveOldProfileRefresh = resolve
+    })
+
+    getGlobalModelInfo
+      .mockResolvedValueOnce({ provider: 'nous', model: 'hermes-4' })
+      .mockResolvedValueOnce({ provider: 'openai-codex', model: 'gpt-5.6-luna' })
+    getGlobalModelOptions
+      .mockResolvedValueOnce({
+        providers: [
+          { name: 'Nous', slug: 'nous', models: ['hermes-4'], authenticated: true },
+          { name: 'Custom A', slug: 'custom-a', models: ['a-old'], authenticated: true, is_user_defined: true }
+        ]
+      })
+      .mockReturnValueOnce(oldProfileRefresh)
+      .mockResolvedValueOnce({
+        providers: [
+          { name: 'OpenAI Codex', slug: 'openai-codex', models: ['gpt-5.6-luna'], authenticated: true }
+        ]
+      })
+
+    await renderModelSettings()
+
+    const providerSelect = (await screen.findAllByRole('combobox'))[0]
+    fireEvent.click(providerSelect)
+    fireEvent.click(await screen.findByRole('option', { name: 'Custom A' }))
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      profileSwitchHandler?.()
+    })
+    await waitFor(() => expect(providerSelect.textContent).toContain('OpenAI Codex'))
+
+    await act(async () => {
+      resolveOldProfileRefresh({
+        providers: [
+          { name: 'Nous', slug: 'nous', models: ['hermes-4'], authenticated: true },
+          { name: 'Custom A', slug: 'custom-a', models: ['a-stale'], authenticated: true, is_user_defined: true }
+        ]
+      })
+      await oldProfileRefresh
+    })
+
+    expect(providerSelect.textContent).toContain('OpenAI Codex')
+    expect(providerSelect.textContent).not.toContain('Custom A')
   })
 
   it('writes the profile default speed (service_tier) when the fast switch is toggled', async () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -222,6 +222,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   // so a request in flight when the user switches profiles can't paint profile
   // A's models/providers into profile B (or fire onMainModelChanged for A).
   const profileEpoch = useRef(0)
+  const providerRefreshGeneration = useRef(0)
 
   const refresh = useCallback(async ({ replaceSelection = false }: { replaceSelection?: boolean } = {}) => {
     const epoch = profileEpoch.current
@@ -313,6 +314,44 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   )
 
   const selectedProviderModels = selectedProviderRow?.models ?? []
+
+  const selectMainProvider = useCallback(
+    async (provider: string) => {
+      const epoch = profileEpoch.current
+      const generation = providerRefreshGeneration.current + 1
+      providerRefreshGeneration.current = generation
+
+      setSelectedProvider(provider)
+      // A model is scoped to its provider. Clear it before the new provider's
+      // inventory is rendered so withActive-style fallback behavior cannot
+      // surface an impossible provider/model pair.
+      setSelectedModel('')
+
+      const row = providers.find(entry => entry.slug === provider)
+
+      // Normal Settings loads avoid probing every saved custom endpoint. An
+      // explicit user selection is the right time to refresh that endpoint's
+      // discovered catalog.
+      if (!row?.is_user_defined) {
+        return
+      }
+
+      try {
+        const options = await getGlobalModelOptions({ refresh: true })
+
+        if (profileEpoch.current !== epoch || providerRefreshGeneration.current !== generation) {
+          return
+        }
+
+        setProviders(options.providers || [])
+      } catch (err) {
+        if (profileEpoch.current === epoch && providerRefreshGeneration.current === generation) {
+          setError(err instanceof Error ? err.message : String(err))
+        }
+      }
+    },
+    [providers]
+  )
 
   // An unconfigured provider was picked: no credentials yet, so there are no
   // models to choose. `api_key` providers can be activated inline (paste key);
@@ -759,7 +798,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       <section>
         <p className="mb-3 text-xs text-muted-foreground">{m.appliesDesc}</p>
         <div className="flex flex-wrap items-center gap-2">
-          <Select onValueChange={setSelectedProvider} value={selectedProvider}>
+          <Select onValueChange={value => void selectMainProvider(value)} value={selectedProvider}>
             <SelectTrigger className={cn('min-w-40', CONTROL_TEXT)}>
               <SelectValue placeholder={m.provider} />
             </SelectTrigger>
@@ -808,7 +847,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                   <SelectValue placeholder={m.model} />
                 </SelectTrigger>
                 <SelectContent>
-                  {withActive(selectedProviderModels, selectedModel).map(model => (
+                  {selectedProviderModels.map(model => (
                     <SelectItem key={model} value={model}>
                       {model}
                     </SelectItem>


### PR DESCRIPTION
## What changed\n\n- Clear the selected model whenever the main provider changes.\n- Refresh discovered models only when the newly selected provider is user-defined.\n- Ignore stale custom-provider refresh results after a newer provider selection or profile switch.\n- Stop injecting a previous provider's model into the new provider's main-model list.\n- Preserve auxiliary, MoA, and slot model behavior.\n\n## Why\n\nThe Desktop Settings model picker could carry a model from the previous provider into a newly selected custom provider. Its initial catalog was also stale unless another surface had already refreshed discovery, producing impossible provider/model pairs and hiding current custom-provider models.\n\n## Validation\n\n- Focused UI Vitest: 24/24 passed\n- Desktop renderer, Electron, and E2E TypeScript checks passed\n- Touched-file ESLint passed\n-  passed\n- Independent Hermes Qwen 3.8 review: PASS\n\n## Release boundary\n\nThis PR changes source and tests only. It does not sign, notarize, install, or release a Desktop build.