### PR TITLE
fix(prompt-builder): survive an unreadable working directory

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2326,13 +2326,26 @@ def build_context_files_prompt(
         )
         project_context = ""
     else:
-        # Priority-based project context: first match wins
-        project_context = (
-            _load_hermes_md(cwd_path, context_length)
-            or _load_agents_md(cwd_path, context_length)
-            or _load_claude_md(cwd_path, context_length)
-            or _load_cursorrules(cwd_path, context_length)
-        )
+        # Priority-based project context: first match wins. Project context is
+        # optional, but a cwd the process cannot read is not: a resumed session
+        # or a service invoked from another user's directory makes even
+        # Path.exists() raise PermissionError, which aborts the whole system
+        # prompt and kills the turn. Degrade to no project context instead.
+        try:
+            project_context = (
+                _load_hermes_md(cwd_path, context_length)
+                or _load_agents_md(cwd_path, context_length)
+                or _load_claude_md(cwd_path, context_length)
+                or _load_cursorrules(cwd_path, context_length)
+            )
+        except OSError as exc:
+            logger.warning(
+                "skipping project-context discovery: working directory %s is "
+                "not readable (%s)",
+                cwd_path,
+                exc,
+            )
+            project_context = ""
     if project_context:
         sections.append(project_context)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -514,6 +515,28 @@ class TestBuildContextFilesPrompt:
         from agent.prompt_builder import _load_agents_md
 
         assert _load_agents_md(sub) == ""
+
+    def test_unreadable_cwd_does_not_abort_prompt_build(self, tmp_path, monkeypatch):
+        """An unreadable cwd must degrade to no project context, not raise.
+
+        A resumed session or a service started from another user's directory
+        makes even Path.exists() raise PermissionError; that must not abort
+        construction of the system prompt.
+        """
+        blocked_cwd = tmp_path / "other-user-home"
+        blocked_cwd.mkdir()
+        original_exists = Path.exists
+
+        def permission_denied_for_blocked_tree(path):
+            if path == blocked_cwd or blocked_cwd in path.parents:
+                raise PermissionError(13, "Permission denied", str(path))
+            return original_exists(path)
+
+        monkeypatch.setattr(Path, "exists", permission_denied_for_blocked_tree)
+
+        result = build_context_files_prompt(cwd=str(blocked_cwd), skip_soul=True)
+
+        assert result == ""
 
     def test_skips_agents_md_in_install_tree_on_fallback(self, monkeypatch, tmp_path):
         # A backend that FALLS BACK into the install tree (cwd=None → getcwd,


### PR DESCRIPTION
## What does this PR do?

Stops an unreadable working directory from killing the whole turn.

`build_context_files_prompt()` treats project context as optional, but not the readability of the cwd. `_find_git_root()` walks the directory calling `Path.exists()`, and on a directory the process cannot read that **raises `PermissionError` instead of returning `False`** — so the exception escapes and aborts construction of the entire system prompt.

Reproduction on Linux, as a non-root user whose cwd is `/root`:

```
$ hermes -z 'reply OK'
hermes -z: agent failed: [Errno 13] Permission denied: '/root/.git'
```

Any surface that inherits a cwd it cannot read hits this: a resumed session whose recorded cwd now belongs to another user, a service or cron invoked from a privileged directory, or `sudo -u` keeping the caller's cwd. The error names `.git`, which sends you looking at git rather than at the real cause.

Project context is best-effort, so this degrades to no project context and logs a warning — matching how the install-tree fallback immediately above already handles its own bail-out, including its `logger.warning` + `project_context = ""` shape.

## Related Issue

No existing issue — I searched open and merged issues and PRs first (`PermissionError project context`, `unreadable working directory`, `prompt_builder PermissionError`, `unreadable cwd`) and found no duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py` — wrap the priority-based project-context lookup in `try/except OSError`, log a warning naming the directory and the underlying error, and fall back to no project context.
- `tests/agent/test_prompt_builder.py` — regression test that makes `Path.exists()` raise `PermissionError` for a blocked subtree and asserts the prompt still builds.

## How to Test

1. **The new test fails without the fix.** Stash only the `prompt_builder.py` hunk and run `pytest tests/agent/test_prompt_builder.py -k unreadable_cwd` — it fails with `PermissionError: ... /other-user-home/.git`.
2. **It passes with the fix.** Restore and re-run: `1 passed`.
3. **No regressions:** `pytest tests/agent/test_prompt_builder.py` → `62 passed`.
4. **Real-world reproduction.** As a non-root user, with the patched tree first on `sys.path`:
   ```python
   import agent.prompt_builder as pb
   pb.build_context_files_prompt(cwd='/root', skip_soul=True)
   ```
   Before: `PermissionError: [Errno 13] Permission denied: '/root/.git'`.
   After: returns `''` and logs
   `skipping project-context discovery: working directory /root is not readable ([Errno 13] Permission denied: '/root/.git')`.

## Checklist

- [x] I've tested on my platform: Ubuntu 24.04.4 LTS, Python 3.11.15, Hermes v0.20.0 (2026.8.3)
- [x] `ruff check` passes on both files. `ruff format --check` reports drift, but it is **pre-existing on `main`** in unrelated regions (lines ~132, ~235, ~339) — my hunks are format-clean, so I have not reformatted files beyond the change.

### Documentation & Housekeeping

- [x] Documentation — N/A (internal error handling, no user-facing config or behaviour change beyond not crashing)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact considered: `PermissionError` is a subclass of `OSError`, so catching `OSError` also covers the Windows path where an unreadable directory surfaces as `OSError`/`WinError`. No platform-specific code added.
- [x] Tool descriptions/schemas — N/A
