### PR TITLE
perf(agent): skip surrogate regex for ASCII text

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -35,7 +35,7 @@ def _sanitize_surrogates(text: str) -> str:
     Surrogates are invalid in UTF-8 and will crash ``json.dumps()`` inside the
     OpenAI SDK.  This is a fast no-op when the text contains no surrogates.
     """
-    if _SURROGATE_RE.search(text):
+    if not str.isascii(text) and _SURROGATE_RE.search(text):
         return _SURROGATE_RE.sub('\ufffd', text)
     return text
 
@@ -55,7 +55,7 @@ def _sanitize_structure_surrogates(payload: Any) -> bool:
         if isinstance(node, dict):
             for key, value in node.items():
                 if isinstance(value, str):
-                    if _SURROGATE_RE.search(value):
+                    if not str.isascii(value) and _SURROGATE_RE.search(value):
                         node[key] = _SURROGATE_RE.sub('\ufffd', value)
                         found = True
                 elif isinstance(value, (dict, list)):
@@ -63,7 +63,7 @@ def _sanitize_structure_surrogates(payload: Any) -> bool:
         elif isinstance(node, list):
             for idx, value in enumerate(node):
                 if isinstance(value, str):
-                    if _SURROGATE_RE.search(value):
+                    if not str.isascii(value) and _SURROGATE_RE.search(value):
                         node[idx] = _SURROGATE_RE.sub('\ufffd', value)
                         found = True
                 elif isinstance(value, (dict, list)):
@@ -90,18 +90,26 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
         if not isinstance(msg, dict):
             continue
         content = msg.get("content")
-        if isinstance(content, str) and _SURROGATE_RE.search(content):
+        if (
+            isinstance(content, str)
+            and not str.isascii(content)
+            and _SURROGATE_RE.search(content)
+        ):
             msg["content"] = _SURROGATE_RE.sub('\ufffd', content)
             found = True
         elif isinstance(content, list):
             for part in content:
                 if isinstance(part, dict):
                     text = part.get("text")
-                    if isinstance(text, str) and _SURROGATE_RE.search(text):
+                    if (
+                        isinstance(text, str)
+                        and not str.isascii(text)
+                        and _SURROGATE_RE.search(text)
+                    ):
                         part["text"] = _SURROGATE_RE.sub('\ufffd', text)
                         found = True
         name = msg.get("name")
-        if isinstance(name, str) and _SURROGATE_RE.search(name):
+        if isinstance(name, str) and not str.isascii(name) and _SURROGATE_RE.search(name):
             msg["name"] = _SURROGATE_RE.sub('\ufffd', name)
             found = True
         tool_calls = msg.get("tool_calls")
@@ -110,17 +118,29 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
                 if not isinstance(tc, dict):
                     continue
                 tc_id = tc.get("id")
-                if isinstance(tc_id, str) and _SURROGATE_RE.search(tc_id):
+                if (
+                    isinstance(tc_id, str)
+                    and not str.isascii(tc_id)
+                    and _SURROGATE_RE.search(tc_id)
+                ):
                     tc["id"] = _SURROGATE_RE.sub('\ufffd', tc_id)
                     found = True
                 fn = tc.get("function")
                 if isinstance(fn, dict):
                     fn_name = fn.get("name")
-                    if isinstance(fn_name, str) and _SURROGATE_RE.search(fn_name):
+                    if (
+                        isinstance(fn_name, str)
+                        and not str.isascii(fn_name)
+                        and _SURROGATE_RE.search(fn_name)
+                    ):
                         fn["name"] = _SURROGATE_RE.sub('\ufffd', fn_name)
                         found = True
                     fn_args = fn.get("arguments")
-                    if isinstance(fn_args, str) and _SURROGATE_RE.search(fn_args):
+                    if (
+                        isinstance(fn_args, str)
+                        and not str.isascii(fn_args)
+                        and _SURROGATE_RE.search(fn_args)
+                    ):
                         fn["arguments"] = _SURROGATE_RE.sub('\ufffd', fn_args)
                         found = True
         # Walk any additional string / nested fields (reasoning,
@@ -132,7 +152,7 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
             if key in {"content", "name", "tool_calls", "role"}:
                 continue
             if isinstance(value, str):
-                if _SURROGATE_RE.search(value):
+                if not str.isascii(value) and _SURROGATE_RE.search(value):
                     msg[key] = _SURROGATE_RE.sub('\ufffd', value)
                     found = True
             elif isinstance(value, (dict, list)):

--- a/tests/agent/test_surrogate_chokepoints.py
+++ b/tests/agent/test_surrogate_chokepoints.py
@@ -18,12 +18,15 @@ The fix is owned at chokepoints, not leaf sites:
 """
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import json
 
 import pytest
 
+import agent.message_sanitization as message_sanitization
 from agent.message_sanitization import (
+    _sanitize_messages_surrogates,
     _sanitize_structure_surrogates,
     _sanitize_surrogates,
 )
@@ -186,6 +189,80 @@ def test_conversation_loop_sanitizes_api_kwargs_after_build():
 # ---------------------------------------------------------------------------
 # Helper semantics shared by every chokepoint
 # ---------------------------------------------------------------------------
+
+
+def test_sanitize_surrogates_skips_regex_for_ascii_text(monkeypatch):
+    regex_spy = MagicMock(wraps=message_sanitization._SURROGATE_RE)
+    monkeypatch.setattr(message_sanitization, "_SURROGATE_RE", regex_spy)
+
+    text = "plain ASCII request text"
+    assert _sanitize_surrogates(text) is text
+    regex_spy.search.assert_not_called()
+
+
+def test_structure_sanitizer_skips_regex_for_ascii_leaves(monkeypatch):
+    regex_spy = MagicMock(wraps=message_sanitization._SURROGATE_RE)
+    monkeypatch.setattr(message_sanitization, "_SURROGATE_RE", regex_spy)
+    payload = {
+        "messages": [{"role": "user", "content": "plain request"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run a shell command",
+                    "parameters": {
+                        "type": "object",
+                        "required": ["command"],
+                    },
+                },
+            }
+        ],
+    }
+
+    assert _sanitize_structure_surrogates(payload) is False
+    regex_spy.search.assert_not_called()
+
+
+def test_message_sanitizer_skips_regex_for_ascii_leaves(monkeypatch):
+    regex_spy = MagicMock(wraps=message_sanitization._SURROGATE_RE)
+    monkeypatch.setattr(message_sanitization, "_SURROGATE_RE", regex_spy)
+    messages = [
+        {"role": "user", "content": "plain request", "name": "user"},
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "plain response"}],
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {"name": "terminal", "arguments": '{"command":"pwd"}'},
+                }
+            ],
+            "reasoning_content": "plain reasoning",
+            "reasoning_details": [{"summary": "plain summary"}],
+        },
+        {"role": "tool", "content": "plain result", "tool_call_id": "call_1"},
+    ]
+
+    assert _sanitize_messages_surrogates(messages) is False
+    regex_spy.search.assert_not_called()
+
+
+def test_str_subclass_cannot_bypass_surrogate_checks():
+    class MisreportingStr(str):
+        def isascii(self):
+            return True
+
+    dirty = MisreportingStr(f"dirty {LONE_HIGH} text")
+    assert _sanitize_surrogates(dirty) == "dirty \ufffd text"
+
+    payload = {"nested": [dirty]}
+    assert _sanitize_structure_surrogates(payload) is True
+    assert payload == {"nested": ["dirty \ufffd text"]}
+
+    messages = [{"role": "user", "content": dirty}]
+    assert _sanitize_messages_surrogates(messages) is True
+    assert messages == [{"role": "user", "content": "dirty \ufffd text"}]
 
 
 def test_sanitize_surrogates_preserves_valid_astral_pairs():


### PR DESCRIPTION
## Summary

- skip the surrogate regex for strings that are provably ASCII in the scalar, message-list, and nested-structure sanitizers
- preserve both outbound request chokepoints and all existing mutation/return semantics
- add deterministic tests proving all-ASCII scalar, tool-rich message, and full request payload paths never invoke the regex

## Problem

`run_conversation` sanitizes outbound messages and then walks the fully built `api_kwargs`, including the same messages plus every tool schema. On clean requests, every string leaf currently enters `_SURROGATE_RE.search()`, even though normal histories and schemas are overwhelmingly ASCII.

ASCII cannot contain U+D800–U+DFFF, so the built-in `str.isascii(value)`
descriptor is an exact rejection gate. Using the descriptor rather than dynamic
`value.isascii()` dispatch also prevents a `str` subclass override from bypassing
the sanitizer. Non-ASCII strings—including valid Unicode and lone high/low
surrogates—continue through the existing regex unchanged.

## Benchmark

Linux, Python 3.11.14, pinned CPU, interleaved baseline/patched samples in one process. Each case measures the real combined clean path:

```python
_sanitize_messages_surrogates(messages)
_sanitize_structure_surrogates(api_kwargs)
```

The payload includes 80 tool schemas and unique 512-character message bodies.
Representative medians from 31 batched samples are below; repeated runs kept the
speedup ratio between 8.3× and 9.4× under concurrent system load:

| messages | `origin/main` | patched | speedup |
|---:|---:|---:|---:|
| 100 | 3.100 ms | 0.374 ms | 8.30× |
| 500 | 8.547 ms | 0.972 ms | 8.79× |
| 2,000 | 29.049 ms | 3.329 ms | 8.73× |

A mixed nested payload containing valid Unicode plus lone high and low surrogates produced an identical sanitized structure on `origin/main` and this patch.
The corresponding 500-message valid-Unicode path was also neutral-to-faster
(8.925 ms → 8.559 ms, 1.04×), so the ASCII gate does not buy the common case
by penalizing multilingual requests.

## Safety and scope

- every `_SURROGATE_RE.search()` in `agent/message_sanitization.py` remains reachable for every non-ASCII string
- built-in descriptor dispatch preserves sanitization for `str` subclasses that override `isascii()`
- valid Unicode is still scanned and preserved; lone surrogates are still replaced with U+FFFD
- no sanitizer pass, field-coverage rule, function signature, or call site is removed or reordered
- the change is limited to the existing sanitization module and focused chokepoint tests

## Validation

- three fast-path regressions fail on `origin/main` (1, 7, and 10 regex calls) and pass with the patch (zero calls)
- a separate regression proves a misreporting `str` subclass cannot bypass scalar, nested-structure, or message sanitization
- unified direct/indirect surrogate suite (10 files: sanitizer, cache parity, multimodal, codec recovery, prompt caching, history isolation, CLI and tool surfaces) — **94 passed**
- `ruff check agent/message_sanitization.py tests/agent/test_surrogate_chokepoints.py` — passed
- `python -m py_compile ...` — passed
- `python scripts/check-windows-footguns.py ...` — passed
- `git diff --check` and added-line security scan — passed

`ruff format --check` reports pre-existing formatting drift in both touched legacy files; this PR intentionally avoids unrelated whole-file reformatting.
