### PR TITLE
fix(runtime): owner-epoch lifecycle fencing and SSH backend isolation

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -80,19 +80,31 @@ function goneIdentityOut() {
 function mutexRules() {
   return [
     [/stale_ms=/, 'ACQUIRED\n'],
-    [/print\("HELD"/, 'HELD\n'],
-    [/data==holder/, '']
+    [/OWNER_EPOCH_HEARTBEAT|print\("HELD"/, 'HELD\n'],
+    [/OWNER_EPOCH_RELEASE/, '']
+  ]
+}
+
+function leaseMutationDefaults() {
+  // Appended AFTER test-specific rules so collectors can observe lock writes.
+  return [
+    [/print\("WROTE"\)/, 'WROTE\n'],
+    [/print\("REMOVED"\)/, 'REMOVED\n'],
+    [/print\("LOG_REMOVED"\)/, 'LOG_REMOVED\n'],
+    [/print\("TOKEN_REMOVED"\)/, 'TOKEN_REMOVED\n']
   ]
 }
 
 function baseConnectRules(extra: any[] = []) {
   // Mutex acquire/release + optional extras. Identity/token/spawn rules should
   // be more specific than bare /python3 -c/ so they win first-match.
+  // leaseMutationDefaults stay last so tests can intercept WROTE/REMOVED.
   return [
     ...mutexRules(),
     [/uname/, 'Linux\nx86_64'],
     [/\[ -x/, 'OK'],
-    ...extra
+    ...extra,
+    ...leaseMutationDefaults()
   ]
 }
 
@@ -293,7 +305,8 @@ test('writeLockfile mkdir -ps and stamps the schema version', async () => {
   const ssh = fakeSsh([])
   await writeLockfile(ssh, OWNERSHIP_ID, ownedLock({ pid: 7, port: 9 }))
   const cmd = ssh.calls.join('\n')
-  assert.match(cmd, /mkdir -p/)
+  assert.match(cmd, /os\.makedirs|mkdir -p/)
+  assert.match(cmd, /os\.replace/)
   assert.match(cmd, new RegExp(`"schemaVersion":${LOCKFILE_SCHEMA_VERSION}`))
 })
 
@@ -366,8 +379,8 @@ test('cleanupStale kills ONLY a provably-ours pid; foreign alive is ownership-co
     hermesPath: '/x/hermes',
     logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
   })
-  assert.ok(ours.calls.some(c => /terminate_result/.test(c)))
-  assert.ok(ours.calls.some(c => /rm -f/.test(c)))
+  assert.ok(ours.calls.some(c => /terminate_result|pidfd_open/.test(c)))
+  assert.ok(ours.calls.some(c => /REMOVED|unlink|rm -f/.test(c) && /backend\.lock\.json/.test(c)))
 })
 
 test('buildSpawnCommand is headless serve, detached, token not in argv', () => {
@@ -702,11 +715,11 @@ test('connect() fresh spawn writes hermesHome + protocolVersion into the lockfil
     [/kill -0 700/, 'ALIVE'],
     [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=45500\n'],
     [
-      /printf '%s' '/,
+      c => /print\("WROTE"\)/.test(c) || /printf '%s' '/.test(c),
       c => {
         writes.push(c)
 
-        return ''
+        return /print\("WROTE"\)/.test(c) ? 'WROTE\n' : ''
       }
     ]
   ]))
@@ -727,12 +740,10 @@ test('connect() respawns when the lockfile pid is dead (killed dashboard)', asyn
   const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, () => (sawDeadCleanup ? '' : JSON.stringify(lock))],
     [/kill -0 333/, 'DEAD'],
-    [/rm -f/, c => {
-      if (/backend\.lock\.json/.test(c)) {
-        sawDeadCleanup = true
-      }
+    [c => /backend\.lock\.json/.test(c) && (/REMOVED|unlink|rm -f|print\("REMOVED"\)/.test(c)), c => {
+      sawDeadCleanup = true
 
-      return ''
+      return 'REMOVED\n'
     }],
     [/grep -q ssh-session-token-file/, 'YES\n'],
     [command => /python3 -c/.test(command) && /O_EXCL/.test(command), ''],
@@ -929,15 +940,15 @@ test('spawnRemoteDashboard removes a token file when upload reporting fails', as
 
   const ssh = fakeSsh([
     [/grep -q ssh-session-token-file/, 'YES\n'],
-    [command => /python3 -c/.test(command) && !/rm -f/.test(command), failure],
-    [/rm -f/, '']
+    [command => /python3 -c/.test(command) && /O_EXCL/.test(command), failure],
+    [command => /TOKEN_REMOVED|unlink/.test(command) && /\.token/.test(command), 'TOKEN_REMOVED\n']
   ])
 
   await assert.rejects(
     () => spawnRemoteDashboard(ssh, { hermesPath: '/x/hermes', profile: '', token: 'tok', ownershipId: OWNERSHIP_ID }),
     /channel closed/
   )
-  assert.ok(ssh.calls.some(command => /rm -f .*\.token/.test(command)))
+  assert.ok(ssh.calls.some(command => /\.token/.test(command) && (/TOKEN_REMOVED|unlink|rm -f/.test(command))))
 })
 
 test('spawnRemoteDashboard streams the token over stdin, not argv/env', async () => {
@@ -1124,7 +1135,7 @@ test('connect removes the token file when a fresh backend fails after returning 
   ]))
 
   await assert.rejects(() => connect(connectDeps(ssh)), /exited before announcing/i)
-  assert.ok(ssh.calls.some(command => /rm -f .*\.token/.test(command)))
+  assert.ok(ssh.calls.some(command => /\.token/.test(command) && (/TOKEN_REMOVED|unlink|rm -f/.test(command))))
 })
 
 test('connect preserves an exact-owned backend when reuse proof transport fails', async () => {
@@ -1150,7 +1161,7 @@ test('connect preserves an exact-owned backend when reuse proof transport fails'
     (error: any) => error.kind === 'transient-transport-error'
   )
   assert.ok(!ssh.calls.some(command => /kill 333\b/.test(command)))
-  assert.ok(!ssh.calls.some(command => /rm -f .*backend\.lock\.json/.test(command)))
+  assert.ok(!ssh.calls.some(command => /backend\.lock\.json/.test(command) && (/REMOVED|unlink|rm -f/.test(command))))
 })
 
 test('connect replaces an exact-owned backend only after authenticated stale proof', async () => {
@@ -1231,7 +1242,7 @@ test('exec-wrapper ownership identity verifies as owned and can be reaped', asyn
   assert.equal(await pidIsOurDashboard(ssh, 5, SPAWN_NONCE, '/x/hermes-wrapper', lock), true)
   await cleanupStale(ssh, OWNERSHIP_ID, lock)
   assert.ok(ssh.calls.some(c => /terminate_result/.test(c)))
-  assert.ok(ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)))
+  assert.ok(ssh.calls.some(c => /backend\.lock\.json/.test(c) && (/REMOVED|unlink|os\.replace/.test(c) || /rm -f/.test(c))))
 })
 
 test('PID reuse start-time mismatch is foreign and never signaled', async () => {
@@ -1283,7 +1294,7 @@ test('cleanup waits for asynchronous SIGTERM exit before removing evidence', asy
 
   await cleanupStale(ssh, OWNERSHIP_ID, lock)
   assert.equal(livenessChecks, 2)
-  assert.ok(ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)))
+  assert.ok(ssh.calls.some(c => /backend\.lock\.json/.test(c) && (/REMOVED|unlink|os\.replace|rm -f/.test(c))))
 })
 
 test('identity-checked termination helper is executable and reports an absent pid as GONE', async () => {
@@ -1320,7 +1331,7 @@ test('GONE during failed-spawn cleanup preserves the original spawn error', asyn
     () => connect(connectDeps(ssh)),
     (err: any) => err.kind === 'spawn-failed' && /exited before announcing/i.test(err.message)
   )
-  assert.ok(ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)), 'gone spawn evidence should be cleaned')
+  assert.ok(ssh.calls.some(c => /backend\.lock\.json/.test(c)), 'gone spawn evidence should be cleaned')
 })
 
 test('ownership mutex heartbeats and fences a callback after lease loss', async () => {
@@ -1328,12 +1339,12 @@ test('ownership mutex heartbeats and fences a callback after lease loss', async 
 
   const ssh = fakeSsh([
     [/stale_ms=/, 'ACQUIRED\n'],
-    [/print\("HELD"/, () => {
+    [/OWNER_EPOCH_HEARTBEAT|print\("HELD"/, () => {
       heldChecks += 1
 
       return heldChecks === 1 ? 'HELD\n' : 'LOST\n'
     }],
-    [/data==holder/, '']
+    [/OWNER_EPOCH_RELEASE|lease_token=/, '']
   ])
 
   await assert.rejects(
@@ -1367,4 +1378,119 @@ test('token-absent healthy lock still reuses when identity-owned', async () => {
   const result = await connect(connectDeps(ssh, { reuseToken, adoptServedToken: async (_b, t) => t }))
   assert.equal(result.reused, true)
   assert.ok(!ssh.calls.some(c => /setsid/.test(c)))
+})
+
+test('owner-epoch acquire reclaims under flock without pathname unlink', async () => {
+  const ssh = fakeSsh([
+    [/stale_ms=/, 'ACQUIRED\n'],
+    [/OWNER_EPOCH_RELEASE|lease_token=/, '']
+  ])
+
+  await withOwnershipMutex(ssh, OWNERSHIP_ID, async () => 'ok')
+  const acquire = ssh.calls.find(c => /stale_ms=/.test(c)) || ''
+  assert.match(acquire, /fcntl\.flock/, 'stale reclaim must hold an exclusive flock')
+  assert.match(acquire, /ftruncate|os\.lseek/, 'stale reclaim must rewrite the same inode')
+  assert.ok(!/if age>stale_ms:\s*os\.unlink\(p\)/.test(acquire), 'must not pathname-unlink then recreate')
+  assert.match(acquire, /token=/, 'lease payload must carry an owner-epoch token')
+})
+
+test('owner-epoch heartbeat refuses to refresh a successor lease', async () => {
+  const ssh = fakeSsh([
+    [/stale_ms=/, 'ACQUIRED\n'],
+    [/OWNER_EPOCH_HEARTBEAT/, 'LOST\n'],
+    [/OWNER_EPOCH_RELEASE|lease_token=/, '']
+  ])
+
+  await assert.rejects(
+    () => withOwnershipMutex(ssh, OWNERSHIP_ID, async lease => {
+      await lease.assertHeld()
+    }),
+    (err: any) => err.kind === 'ownership-conflict'
+  )
+  const heartbeat = ssh.calls.find(c => /OWNER_EPOCH_HEARTBEAT/.test(c)) || ''
+  assert.match(heartbeat, /fcntl\.flock|LOCK_EX/, 'heartbeat must flock before utime')
+  assert.match(heartbeat, /data!=token|data==token/, 'heartbeat must compare the full owner-epoch token')
+})
+
+test('lease-fenced lock write refuses mutation after token loss', async () => {
+  const ssh = fakeSsh([
+    [/stale_ms=/, 'ACQUIRED\n'],
+    [/OWNER_EPOCH_HEARTBEAT|print\("HELD"/, 'HELD\n'],
+    [/lease_token=/, 'LOST\n'],
+    [/OWNER_EPOCH_RELEASE/, '']
+  ])
+
+  await assert.rejects(
+    () => withOwnershipMutex(ssh, OWNERSHIP_ID, async lease => {
+      await writeLockfile(ssh, OWNERSHIP_ID, ownedLock({ pid: 9, port: 1 }), lease)
+    }),
+    (err: any) => err.kind === 'ownership-conflict'
+  )
+  assert.ok(ssh.calls.some(c => /lease_token=/.test(c) && /WROTE|os\.replace/.test(c)))
+})
+
+test('adversarial stale takeover loses the original owner mutation fence', async () => {
+  let mutate = 0
+
+  const ssh = fakeSsh([
+    [/stale_ms=/, 'ACQUIRED\n'],
+    [/OWNER_EPOCH_HEARTBEAT|print\("HELD"/, 'HELD\n'],
+    [/lease_token=/, () => {
+      mutate += 1
+
+      // First fenced mutation still held; second simulates a successor reclaim.
+      return mutate === 1 ? 'WROTE\n' : 'LOST\n'
+    }],
+    [/OWNER_EPOCH_RELEASE/, '']
+  ])
+
+  await assert.rejects(
+    () => withOwnershipMutex(ssh, OWNERSHIP_ID, async lease => {
+      await writeLockfile(ssh, OWNERSHIP_ID, ownedLock({ pid: 1, port: 2 }), lease)
+      await writeLockfile(ssh, OWNERSHIP_ID, ownedLock({ pid: 1, port: 3 }), lease)
+    }),
+    (err: any) => err.kind === 'ownership-conflict'
+  )
+  assert.equal(mutate, 2)
+})
+
+test('Darwin termination path is identity-stable without pidfd', async () => {
+  const lock = ownedLock({ pid: 5 })
+
+  const ssh = fakeSsh([
+    [/terminate_result|pidfd_open/, (command: string) => {
+      assert.match(command, /pidfd_open/)
+      assert.match(command, /ps","-o","lstart=|ps.*lstart/)
+      assert.match(command, /signal\.SIGTERM|SIGTERM/)
+
+      // Simulate non-pidfd host falling through to Darwin path and succeeding.
+      return 'TERMINATED\n'
+    }]
+  ])
+
+  const result = await terminateOwnedProcess(ssh, lock)
+  assert.equal(result, 'TERMINATED')
+})
+
+test('lease-fenced termination checks owner-epoch token under flock', async () => {
+  const lock = ownedLock({ pid: 5 })
+
+  const lease = {
+    path: ownershipDirectory(OWNERSHIP_ID) + '/lifecycle.mutex',
+    token: 'holder:epoch',
+    holder: 'holder'
+  }
+
+  const ssh = fakeSsh([
+    [/terminate_result|pidfd_open/, (command: string) => {
+      assert.match(command, /lease_token=/)
+      assert.match(command, /fcntl\.flock|LOCK_EX/)
+      assert.match(command, /data!=lease_token|lease_token/)
+
+      return 'LOST\n'
+    }]
+  ])
+
+  const result = await terminateOwnedProcess(ssh, lock, lease)
+  assert.equal(result, 'LOST')
 })

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1563,6 +1563,24 @@ function localHelperSsh(home: string) {
   }
 }
 
+/** Async SSH stub so separate production helpers contend in real OS processes. */
+function concurrentLocalHelperSsh(home: string) {
+  const calls: string[] = []
+
+  return {
+    calls,
+    async exec(command: string) {
+      calls.push(command)
+      const { stdout } = await execAsync(command, {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: home },
+        timeout: 40_000
+      })
+      return stdout || ''
+    }
+  }
+}
+
 function mutexPathFor(home: string) {
   return path.join(home, '.hermes', 'desktop-ssh', OWNERSHIP_ID, 'lifecycle.mutex')
 }
@@ -1708,3 +1726,90 @@ print('HELD')
   }
 })
 
+test('real multi-process release keeps one inode across queued successor epochs', async () => {
+  const home = makeTempHome()
+  try {
+    const sshA = concurrentLocalHelperSsh(home)
+    const sshB = concurrentLocalHelperSsh(home)
+    const sshC = concurrentLocalHelperSsh(home)
+    let inodeA = 0
+    let inodeB = 0
+    let releaseB!: () => void
+    const holdB = new Promise<void>(resolve => { releaseB = resolve })
+
+    await withOwnershipMutex(sshA as any, OWNERSHIP_ID, async () => {
+      inodeA = fs.statSync(mutexPathFor(home)).ino
+    }, { heartbeatMs: 60_000 })
+
+    // Release must publish an immediately reclaimable epoch on the same inode;
+    // unlinking lets a queued waiter own an unreachable inode beside owner C.
+    assert.equal(fs.readFileSync(mutexPathFor(home), 'utf8').trim(), 'RELEASED')
+    assert.equal(fs.statSync(mutexPathFor(home)).ino, inodeA)
+
+    const ownerB = withOwnershipMutex(sshB as any, OWNERSHIP_ID, async leaseB => {
+      inodeB = fs.statSync(mutexPathFor(home)).ino
+      assert.equal(readMutex(home), leaseB.token)
+      await holdB
+    }, { heartbeatMs: 60_000 })
+
+    while (!inodeB) {
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+
+    const ownerC = withOwnershipMutex(sshC as any, OWNERSHIP_ID, async leaseC => {
+      assert.equal(fs.statSync(mutexPathFor(home)).ino, inodeA)
+      assert.equal(readMutex(home), leaseC.token)
+    }, { heartbeatMs: 60_000 })
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+    assert.equal(readMutex(home).includes('RELEASED'), false)
+    releaseB()
+    await Promise.all([ownerB, ownerC])
+    assert.equal(inodeB, inodeA)
+    assert.equal(fs.statSync(mutexPathFor(home)).ino, inodeA)
+  } finally {
+    rmTempHome(home)
+  }
+})
+
+test('real local-helper: stale owner production spawn path is fenced after successor takeover', async () => {
+  const home = makeTempHome()
+  try {
+    const sshA = localHelperSsh(home)
+    const sshB = localHelperSsh(home)
+    const fakeHermes = path.join(home, 'fake-hermes')
+    const spawnMarker = path.join(home, 'spawned-by-stale-owner')
+    fs.writeFileSync(
+      fakeHermes,
+      `#!/usr/bin/env bash\nif [[ "\${1:-}" == serve && "\${2:-}" == --help ]]; then\n  echo --ssh-session-token-file --ssh-owner-nonce\n  exit 0\nfi\ntouch ${JSON.stringify(spawnMarker)}\necho 4242\n`,
+      { mode: 0o700 }
+    )
+
+    await assert.rejects(
+      () => withOwnershipMutex(sshA as any, OWNERSHIP_ID, async leaseA => {
+        const p = mutexPathFor(home)
+        const past = Math.floor(Date.now() / 1000) - 10_000
+        fs.utimesSync(p, past, past)
+
+        await withOwnershipMutex(sshB as any, OWNERSHIP_ID, async leaseB => {
+          assert.equal(readMutex(home), leaseB.token)
+        }, { heartbeatMs: 60_000 })
+
+        await assert.rejects(
+          () => spawnRemoteDashboard(sshA as any, {
+            hermesPath: fakeHermes,
+            profile: '',
+            token: 'stale-token',
+            ownershipId: OWNERSHIP_ID,
+            lease: leaseA
+          })
+        )
+        assert.equal(fs.existsSync(spawnMarker), false)
+        await leaseA.assertHeld()
+      }, { heartbeatMs: 60_000 }),
+      (err: any) => err.kind === 'ownership-conflict'
+    )
+  } finally {
+    rmTempHome(home)
+  }
+})

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict'
+import { exec as nodeExec } from 'node:child_process'
+import { promisify } from 'node:util'
 
 import { test } from 'vitest'
 
@@ -25,12 +27,15 @@ import {
   scrapeReadyPort,
   spawnLogPath,
   spawnRemoteDashboard,
+  terminateOwnedProcess,
   validateRemotePath,
+  withOwnershipMutex,
   writeLockfile
 } from './remote-lifecycle'
 
 const OWNERSHIP_ID = '0123456789abcdef0123456789abcdef'
 const SPAWN_NONCE = '0123456789abcdef'
+const execAsync = promisify(nodeExec)
 
 function ownedLock(over: any = {}) {
   return {
@@ -57,12 +62,14 @@ function ownedLock(over: any = {}) {
 function ownedIdentityOut(over: any = {}) {
   const start = over.startTime ?? 12345
   const fp = over.fingerprint ?? 'a'.repeat(32)
+
   return `OK\n${start}\n${fp}\npython\n/runtime/.venv/bin/hermes\nserve\n--isolated\n--ssh-owner-nonce\n${SPAWN_NONCE}\n`
 }
 
 function foreignIdentityOut(over: any = {}) {
   const start = over.startTime ?? 999
   const fp = over.fingerprint ?? 'b'.repeat(32)
+
   return `SHAPE\n${start}\n${fp}\nother\n`
 }
 
@@ -73,6 +80,7 @@ function goneIdentityOut() {
 function mutexRules() {
   return [
     [/stale_ms=/, 'ACQUIRED\n'],
+    [/print\("HELD"/, 'HELD\n'],
     [/data==holder/, '']
   ]
 }
@@ -92,6 +100,7 @@ function spawnConnectRules(over: any = {}) {
   const pid = over.pid ?? 777
   const port = over.port ?? 51999
   const ready = over.ready ?? `HERMES_DASHBOARD_READY port=${port}\n`
+
   return baseConnectRules([
     [/cat .*lock\.json/, over.lockJson ?? ''],
     [/grep -q ssh-session-token-file/, 'YES\n'],
@@ -347,16 +356,17 @@ test('cleanupStale kills ONLY a provably-ours pid; foreign alive is ownership-co
 
   const ours = fakeSsh([
     [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
-    [/kill 9\b/, ''],
+    [/terminate_result/, 'TERMINATED\n'],
     [/kill -0 9/, 'DEAD']
   ])
+
   await cleanupStale(ours, OWNERSHIP_ID, {
     pid: 9,
     spawnNonce: SPAWN_NONCE,
     hermesPath: '/x/hermes',
     logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
   })
-  assert.ok(ours.calls.some(c => /kill 9\b/.test(c)))
+  assert.ok(ours.calls.some(c => /terminate_result/.test(c)))
   assert.ok(ours.calls.some(c => /rm -f/.test(c)))
 })
 
@@ -566,15 +576,16 @@ test('connect() respawns when the requested remote profile differs from the lock
   const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, () => {
       lockReads += 1
+
       // First read sees owned lock; after cleanup the lock is gone.
       return lockReads === 1 ? JSON.stringify(lock) : ''
     }],
-    [/kill -0 333/, command => (ssh.calls.some(c => /kill 333\b/.test(c)) ? 'DEAD' : 'ALIVE')],
+    [/kill -0 333/, command => (ssh.calls.some(c => /terminate_result/.test(c)) ? 'DEAD' : 'ALIVE')],
     [/print\("OK" if ok else "SHAPE"\)/, command =>
       (command.includes('pid=890') || /pid=890/.test(command) ? ownedIdentityOut({ startTime: 890 }) : ownedIdentityOut())
     ],
     // broader identity match by nonce script — always owned shape for these pids
-    [/kill 333\b/, ''],
+    [/terminate_result/, 'TERMINATED\n'],
     [/--version/, 'Hermes Agent v0.18.2\n'],
     [/grep -q ssh-session-token-file/, 'YES\n'],
     [command => /python3 -c/.test(command) && /O_EXCL/.test(command), ''],
@@ -597,29 +608,42 @@ test('connect() respawns when the requested remote profile differs from the lock
   )
 })
 
-test('connect() reuses when lock launcherPath differs after exec-wrapper (identity-owned)', async () => {
+test('connect() replaces an owned backend when the configured launcher path changes', async () => {
   const reuseToken = 'stored-token'
-  // Lock records the wrapper launcher; live process is python + runtime entry.
-  // Ownership is by observed identity + nonce, not launcher path equality.
+
+  // Live argv may still be python + runtime entry after an exec wrapper, but a
+  // different configured launcher is explicit operator intent and must not be
+  // silently ignored.
   const lock = ownedLock({
     hermesPath: '/x/hermes-wrapper',
     launcherPath: '/x/hermes-wrapper',
     tokenFingerprint: fingerprintToken(reuseToken)
   })
 
+  let oldGone = false
+
   const ssh = fakeSsh(baseConnectRules([
-    [/cat .*lock\.json/, JSON.stringify(lock)],
-    [/kill -0/, 'ALIVE'],
+    [/cat .*lock\.json/, () => (oldGone ? '' : JSON.stringify(lock))],
+    [/kill -0 333/, () => (oldGone ? 'DEAD' : 'ALIVE')],
     [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
-    [/\[ -x .*\/new\/hermes/, 'OK']
+    [/terminate_result/, () => { oldGone = true;
+
+ return 'TERMINATED\n' }],
+    [/\[ -x .*\/new\/hermes/, 'OK'],
+    [/grep -q ssh-session-token-file/, 'YES\n'],
+    [command => /python3 -c/.test(command) && /O_EXCL/.test(command), ''],
+    [/setsid/, '902\n'],
+    [/kill -0 902/, 'ALIVE'],
+    [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=44101\n']
   ]))
 
   const result = await connect(
     connectDeps(ssh, { reuseToken, remoteHermesPath: '/new/hermes', adoptServedToken: async (_b, t) => t })
   )
 
-  assert.equal(result.reused, true, 'exec-wrapper launcher mismatch must not block reuse of owned identity')
-  assert.ok(!ssh.calls.some(c => /setsid/.test(c)), 'must not spawn a replacement')
+  assert.equal(result.reused, false)
+  assert.equal(result.pid, 902)
+  assert.ok(ssh.calls.some(c => /setsid/.test(c)), 'configured launcher change must spawn a replacement')
 })
 
 test('connect() fails closed on alive foreign identity (no delete/signal/spawn)', async () => {
@@ -641,23 +665,28 @@ test('connect() fails closed on alive foreign identity (no delete/signal/spawn)'
   assert.ok(!ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)), 'must preserve lock')
 })
 
-test('connect() respawns when the lockfile protocolVersion is incompatible', async () => {
+test('connect() fails closed on live malformed, incompatible-protocol, and incompatible-schema records', async () => {
   const reuseToken = 'stored-token'
 
-  const lock = {
-    schemaVersion: LOCKFILE_SCHEMA_VERSION,
-    protocolVersion: PROTOCOL_VERSION + 99,
-    pid: 333,
-    port: 40000,
-    tokenFingerprint: fingerprintToken(reuseToken)
+  const records = [
+    'not json',
+    JSON.stringify(ownedLock({ protocolVersion: PROTOCOL_VERSION + 99 })),
+    JSON.stringify(ownedLock({ schemaVersion: LOCKFILE_SCHEMA_VERSION + 99 }))
+  ]
+
+  for (const record of records) {
+    const ssh = fakeSsh(baseConnectRules([
+      [/cat .*lock\.json/, record],
+      [/kill -0 333/, 'ALIVE']
+    ]))
+
+    await assert.rejects(
+      () => connect(connectDeps(ssh, { reuseToken, adoptServedToken: async () => 'fresh' })),
+      (err: any) => err.kind === 'ownership-conflict'
+    )
+    assert.ok(!ssh.calls.some(c => /setsid|nohup/.test(c)), 'invalid existing ownership evidence must not be overlapped')
+    assert.ok(!ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)), 'invalid ownership evidence must be preserved')
   }
-
-  // Incompatible protocol => readLockfile returns null => fresh spawn path.
-  const ssh = fakeSsh(spawnConnectRules({ pid: 901, port: 44100, lockJson: JSON.stringify(lock) }))
-
-  const result = await connect(connectDeps(ssh, { reuseToken, adoptServedToken: async () => 'fresh' }))
-  assert.equal(result.reused, false, 'incompatible protocol must force a fresh spawn, not a reattach')
-  assert.equal(result.pid, 901)
 })
 
 test('connect() fresh spawn writes hermesHome + protocolVersion into the lockfile', async () => {
@@ -699,7 +728,10 @@ test('connect() respawns when the lockfile pid is dead (killed dashboard)', asyn
     [/cat .*lock\.json/, () => (sawDeadCleanup ? '' : JSON.stringify(lock))],
     [/kill -0 333/, 'DEAD'],
     [/rm -f/, c => {
-      if (/backend\.lock\.json/.test(c)) sawDeadCleanup = true
+      if (/backend\.lock\.json/.test(c)) {
+        sawDeadCleanup = true
+      }
+
       return ''
     }],
     [/grep -q ssh-session-token-file/, 'YES\n'],
@@ -1065,9 +1097,10 @@ test('readLockfile rejects a log path outside the exact ownership and spawn path
 test('cleanupStale never deletes a lock-supplied unexpected log path', async () => {
   const ssh = fakeSsh([
     [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
-    [/kill 333\b/, ''],
+    [/terminate_result/, 'TERMINATED\n'],
     [/kill -0 333/, 'DEAD']
   ])
+
   await cleanupStale(ssh, OWNERSHIP_ID, ownedLock({ logPath: '~/.hermes/unrelated.log' }))
   assert.ok(!ssh.calls.some(command => command.includes('unrelated.log')))
 })
@@ -1087,7 +1120,7 @@ test('connect removes the token file when a fresh backend fails after returning 
     [/setsid/, '999\n'],
     [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut({ startTime: 999 })],
     [/kill -0 999/, 'DEAD'],
-    [/kill 999\b/, '']
+    [/terminate_result/, 'GONE\n']
   ]))
 
   await assert.rejects(() => connect(connectDeps(ssh)), /exited before announcing/i)
@@ -1125,10 +1158,12 @@ test('connect replaces an exact-owned backend only after authenticated stale pro
   const lock = ownedLock({ tokenFingerprint: fingerprintToken(reuseToken) })
 
   let killed333 = false
+
   const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, () => (killed333 ? '' : JSON.stringify(lock))],
-    // Match terminate before the embedded `kill -0` probe inside the same command.
-    [/kill 333\b/, () => { killed333 = true; return '' }],
+    [/terminate_result/, () => { killed333 = true;
+
+ return 'TERMINATED\n' }],
     [/kill -0 333/, () => (killed333 ? 'DEAD' : 'ALIVE')],
     [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
     [/grep -q ssh-session-token-file/, 'YES\n'],
@@ -1152,7 +1187,7 @@ test('connect replaces an exact-owned backend only after authenticated stale pro
   )
 
   assert.equal(result.reused, false)
-  assert.ok(ssh.calls.some(command => /kill 333\b/.test(command)))
+  assert.ok(ssh.calls.some(command => /terminate_result/.test(command)))
 })
 
 test('remote SSH ownership capability requires both secure bootstrap flags', async () => {
@@ -1186,22 +1221,26 @@ test('exec-wrapper ownership identity verifies as owned and can be reaped', asyn
     pidStartTime: 12345,
     processFingerprint: 'a'.repeat(32)
   })
+
   const ssh = fakeSsh([
     [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
-    [/kill 5\b/, ''],
+    [/terminate_result/, 'TERMINATED\n'],
     [/kill -0 5/, 'DEAD']
   ])
+
   assert.equal(await pidIsOurDashboard(ssh, 5, SPAWN_NONCE, '/x/hermes-wrapper', lock), true)
   await cleanupStale(ssh, OWNERSHIP_ID, lock)
-  assert.ok(ssh.calls.some(c => /kill 5\b/.test(c)))
+  assert.ok(ssh.calls.some(c => /terminate_result/.test(c)))
   assert.ok(ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)))
 })
 
 test('PID reuse start-time mismatch is foreign and never signaled', async () => {
   const lock = ownedLock({ pid: 5, pidStartTime: 111, processFingerprint: 'a'.repeat(32) })
+
   const ssh = fakeSsh([
     [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut({ startTime: 222 })]
   ])
+
   assert.equal(await pidIsOurDashboard(ssh, 5, SPAWN_NONCE, '/x/hermes', lock), false)
   await assert.rejects(
     () => cleanupStale(ssh, OWNERSHIP_ID, lock),
@@ -1210,10 +1249,113 @@ test('PID reuse start-time mismatch is foreign and never signaled', async () => 
   assert.ok(!ssh.calls.some(c => /kill 5\b/.test(c)))
 })
 
+test('post-proof PID reuse is rejected by the identity-checked termination command', async () => {
+  const lock = ownedLock({ pid: 5 })
+
+  const ssh = fakeSsh([
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
+    [/terminate_result/, 'MISMATCH\n']
+  ])
+
+  await assert.rejects(
+    () => cleanupStale(ssh, OWNERSHIP_ID, lock),
+    (err: any) => err.kind === 'ownership-conflict'
+  )
+  const terminate = ssh.calls.find(c => /terminate_result/.test(c)) || ''
+  assert.match(terminate, /pidfd_open/, 'Linux termination must bind a pidfd before signaling')
+  assert.match(terminate, /pidStartTime|expected_start/, 'termination must recheck process start identity')
+  assert.ok(!ssh.calls.some(c => /^kill 5\b/.test(c)), 'must not issue a separate racy shell kill')
+})
+
+test('cleanup waits for asynchronous SIGTERM exit before removing evidence', async () => {
+  const lock = ownedLock({ pid: 5 })
+  let livenessChecks = 0
+
+  const ssh = fakeSsh([
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
+    [/terminate_result/, 'TERMINATED\n'],
+    [/kill -0 5/, () => {
+      livenessChecks += 1
+
+      return livenessChecks === 1 ? 'ALIVE' : 'DEAD'
+    }]
+  ])
+
+  await cleanupStale(ssh, OWNERSHIP_ID, lock)
+  assert.equal(livenessChecks, 2)
+  assert.ok(ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)))
+})
+
+test('identity-checked termination helper is executable and reports an absent pid as GONE', async () => {
+  const localSsh = {
+    async exec(command) {
+      const { stdout } = await execAsync(command)
+
+      return stdout
+    }
+  }
+
+  const result = await terminateOwnedProcess(localSsh, ownedLock({ pid: 4194304 }))
+
+  assert.equal(result, 'GONE')
+})
+
+test('GONE during failed-spawn cleanup preserves the original spawn error', async () => {
+  let identityReads = 0
+
+  const ssh = fakeSsh(baseConnectRules([
+    [/cat .*lock\.json/, ''],
+    [/grep -q ssh-session-token-file/, 'YES\n'],
+    [command => /python3 -c/.test(command) && /O_EXCL/.test(command), ''],
+    [/setsid/, '1001\n'],
+    [/print\("OK" if ok else "SHAPE"\)/, () => {
+      identityReads += 1
+
+      return identityReads === 1 ? ownedIdentityOut({ startTime: 1001 }) : goneIdentityOut()
+    }],
+    [/kill -0 1001/, 'DEAD']
+  ]))
+
+  await assert.rejects(
+    () => connect(connectDeps(ssh)),
+    (err: any) => err.kind === 'spawn-failed' && /exited before announcing/i.test(err.message)
+  )
+  assert.ok(ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)), 'gone spawn evidence should be cleaned')
+})
+
+test('ownership mutex heartbeats and fences a callback after lease loss', async () => {
+  let heldChecks = 0
+
+  const ssh = fakeSsh([
+    [/stale_ms=/, 'ACQUIRED\n'],
+    [/print\("HELD"/, () => {
+      heldChecks += 1
+
+      return heldChecks === 1 ? 'HELD\n' : 'LOST\n'
+    }],
+    [/data==holder/, '']
+  ])
+
+  await assert.rejects(
+    () => withOwnershipMutex(
+      ssh,
+      OWNERSHIP_ID,
+      async lease => {
+        await new Promise(resolve => setTimeout(resolve, 20))
+        await lease.assertHeld()
+      },
+      { heartbeatMs: 5 }
+    ),
+    (err: any) => err.kind === 'ownership-conflict'
+  )
+  assert.ok(heldChecks >= 2, 'heartbeat and explicit fence must both validate the holder token')
+})
+
 test('token-absent healthy lock still reuses when identity-owned', async () => {
   // Token files are read-and-unlinked by design; absence is not orphan proof.
   const reuseToken = 'stored-token'
   const lock = ownedLock({ tokenFingerprint: fingerprintToken(reuseToken) })
+
   const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, JSON.stringify(lock)],
     [/kill -0/, 'ALIVE'],
@@ -1221,8 +1363,8 @@ test('token-absent healthy lock still reuses when identity-owned', async () => {
     // no token file present on remote
     [/\.token/, '']
   ]))
+
   const result = await connect(connectDeps(ssh, { reuseToken, adoptServedToken: async (_b, t) => t }))
   assert.equal(result.reused, true)
   assert.ok(!ssh.calls.some(c => /setsid/.test(c)))
 })
-

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -42,13 +42,70 @@ function ownedLock(over: any = {}) {
     port: 40000,
     profile: '',
     hermesPath: '~/.local/bin/hermes',
+    launcherPath: '~/.local/bin/hermes',
     hermesHome: '~/.hermes',
     logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
     tokenFingerprint: fingerprintToken('stored-token'),
     startedAt: '2026-07-14T00:00:00.000Z',
+    pidStartTime: 12345,
+    processFingerprint: 'a'.repeat(32),
     ...over
   }
 }
+
+/** Live identity probe response: owned serve --isolated --nonce shape. */
+function ownedIdentityOut(over: any = {}) {
+  const start = over.startTime ?? 12345
+  const fp = over.fingerprint ?? 'a'.repeat(32)
+  return `OK\n${start}\n${fp}\npython\n/runtime/.venv/bin/hermes\nserve\n--isolated\n--ssh-owner-nonce\n${SPAWN_NONCE}\n`
+}
+
+function foreignIdentityOut(over: any = {}) {
+  const start = over.startTime ?? 999
+  const fp = over.fingerprint ?? 'b'.repeat(32)
+  return `SHAPE\n${start}\n${fp}\nother\n`
+}
+
+function goneIdentityOut() {
+  return 'GONE\n'
+}
+
+function mutexRules() {
+  return [
+    [/stale_ms=/, 'ACQUIRED\n'],
+    [/data==holder/, '']
+  ]
+}
+
+function baseConnectRules(extra: any[] = []) {
+  // Mutex acquire/release + optional extras. Identity/token/spawn rules should
+  // be more specific than bare /python3 -c/ so they win first-match.
+  return [
+    ...mutexRules(),
+    [/uname/, 'Linux\nx86_64'],
+    [/\[ -x/, 'OK'],
+    ...extra
+  ]
+}
+
+function spawnConnectRules(over: any = {}) {
+  const pid = over.pid ?? 777
+  const port = over.port ?? 51999
+  const ready = over.ready ?? `HERMES_DASHBOARD_READY port=${port}\n`
+  return baseConnectRules([
+    [/cat .*lock\.json/, over.lockJson ?? ''],
+    [/grep -q ssh-session-token-file/, 'YES\n'],
+    // token upload python (stdin path) — before identity observe
+    [command => /python3 -c/.test(command) && /O_EXCL/.test(command), ''],
+    [/setsid|nohup/, `${pid}\n`],
+    // post-spawn identity observe
+    [/print\("OK" if ok else "SHAPE"\)/, over.identity ?? ownedIdentityOut({ startTime: 4242, fingerprint: 'c'.repeat(32) })],
+    [new RegExp(`kill -0 ${pid}`), 'ALIVE'],
+    [/cat .*\.log/, ready],
+    [/printf '%s' '/, '']
+  ])
+}
+
 
 // A fake SshConnection whose exec() is matched against an ordered list of
 // [regex|fn, response|fn] rules. First match wins; unmatched commands return ''.
@@ -248,38 +305,51 @@ test('metadata and process proof transport failures remain indeterminate', async
     (error: any) => error.kind === 'transient-transport-error'
   )
   await assert.rejects(
-    () => pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, failure]]), 5, SPAWN_NONCE, '/x/hermes'),
+    () => pidIsOurDashboard(fakeSsh([[/print\("OK" if ok else "SHAPE"\)/, failure]]), 5, SPAWN_NONCE, '/x/hermes'),
     (error: any) => error.kind === 'transient-transport-error'
   )
 })
 
 test('pidIsOurDashboard requires the exact serve ownership nonce', async () => {
-  const ours = `/x/hermes serve --isolated --ssh-owner-nonce ${SPAWN_NONCE}`
-  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'OWNED\n']]), 5, SPAWN_NONCE, '/x/hermes'), true)
+  assert.equal(
+    await pidIsOurDashboard(fakeSsh([[/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()]]), 5, SPAWN_NONCE, '/x/hermes'),
+    true
+  )
   assert.equal(
     await pidIsOurDashboard(
-      fakeSsh([[/print\("OWNED"/, command => (command.includes('fedcba9876543210') ? 'FOREIGN\n' : 'OWNED\n')]]),
+      fakeSsh([[/print\("OK" if ok else "SHAPE"\)/, foreignIdentityOut()]]),
       5,
       'fedcba9876543210',
       '/x/hermes'
     ),
     false
   )
-  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']]), 5, SPAWN_NONCE, '/x/hermes'), false)
+  assert.equal(
+    await pidIsOurDashboard(fakeSsh([[/print\("OK" if ok else "SHAPE"\)/, foreignIdentityOut()]]), 5, SPAWN_NONCE, '/x/hermes'),
+    false
+  )
 })
 
-test('cleanupStale kills ONLY a provably-ours pid, always drops the lockfile', async () => {
-  const notOurs = fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']])
-  await cleanupStale(notOurs, OWNERSHIP_ID, {
-    pid: 5,
-    spawnNonce: SPAWN_NONCE,
-    hermesPath: '/x/hermes',
-    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
-  })
+test('cleanupStale kills ONLY a provably-ours pid; foreign alive is ownership-conflict', async () => {
+  const notOurs = fakeSsh([[/print\("OK" if ok else "SHAPE"\)/, foreignIdentityOut()]])
+  await assert.rejects(
+    () =>
+      cleanupStale(notOurs, OWNERSHIP_ID, {
+        pid: 5,
+        spawnNonce: SPAWN_NONCE,
+        hermesPath: '/x/hermes',
+        logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+      }),
+    (err: any) => err.kind === 'ownership-conflict'
+  )
   assert.ok(!notOurs.calls.some(c => /kill 5\b/.test(c)), 'must not kill a pid that is not our dashboard')
-  assert.ok(notOurs.calls.some(c => /rm -f/.test(c)))
+  assert.ok(!notOurs.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)), 'must preserve foreign lock')
 
-  const ours = fakeSsh([[/print\("OWNED"/, 'OWNED\n']])
+  const ours = fakeSsh([
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
+    [/kill 9\b/, ''],
+    [/kill -0 9/, 'DEAD']
+  ])
   await cleanupStale(ours, OWNERSHIP_ID, {
     pid: 9,
     spawnNonce: SPAWN_NONCE,
@@ -423,17 +493,7 @@ function connectDeps(ssh, over: any = {}) {
 }
 
 test('connect() spawns fresh when there is no lockfile, adopts the served token', async () => {
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
-    [/cat .*lock\.json/, ''], // no lockfile
-    [/grep -q ssh-session-token-file/, 'YES\n'],
-    [/python3 -c/, ''], // token file write
-    [/printf '%s\\n'/, ''],
-    [/setsid/, '777\n'],
-    [/kill -0 777/, 'ALIVE'],
-    [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=51999\n']
-  ])
+  const ssh = fakeSsh(spawnConnectRules({ pid: 777, port: 51999 }))
 
   const result = await connect(connectDeps(ssh, { adoptServedToken: async () => 'the-served-token' }))
   assert.equal(result.reused, false)
@@ -463,17 +523,7 @@ test('managed SSH maps a local scope to a different non-default remote profile',
 
   assert.equal(sshConfig?.remoteProfile, 'writer_2')
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
-    [/cat .*lock\.json/, ''],
-    [/grep -q ssh-session-token-file/, 'YES\n'],
-    [/python3 -c/, ''],
-    [/printf '%s\\n'/, ''],
-    [/setsid/, '778\n'],
-    [/kill -0 778/, 'ALIVE'],
-    [/cat .*\.log/, 'HERMES_BACKEND_READY port=52000\n']
-  ])
+  const ssh = fakeSsh(spawnConnectRules({ pid: 778, port: 52000, ready: 'HERMES_BACKEND_READY port=52000\n' }))
 
   await connect(
     connectDeps(ssh, {
@@ -494,13 +544,11 @@ test('connect() reuses a healthy dashboard when fingerprint + probe pass', async
   const reuseToken = 'stored-token'
   const lock = ownedLock({ tokenFingerprint: fingerprintToken(reuseToken) })
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
+  const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, JSON.stringify(lock)],
     [/kill -0/, 'ALIVE'],
-    [/print\("OWNED"/, 'OWNED\n']
-  ])
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()]
+  ]))
 
   const result = await connect(connectDeps(ssh, { reuseToken, adoptServedToken: async (_b, t) => t }))
   assert.equal(result.reused, true)
@@ -513,21 +561,30 @@ test('connect() reuses a healthy dashboard when fingerprint + probe pass', async
 test('connect() respawns when the requested remote profile differs from the lockfile profile', async () => {
   const reuseToken = 'stored-token'
   const lock = ownedLock({ profile: 'desktop-work', tokenFingerprint: fingerprintToken(reuseToken) })
+  let lockReads = 0
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
-    [/cat .*lock\.json/, JSON.stringify(lock)],
-    [/kill -0 333/, 'ALIVE'],
-    [/print\("OWNED"/, 'OWNED\n'],
-    [/kill 333/, ''],
+  const ssh = fakeSsh(baseConnectRules([
+    [/cat .*lock\.json/, () => {
+      lockReads += 1
+      // First read sees owned lock; after cleanup the lock is gone.
+      return lockReads === 1 ? JSON.stringify(lock) : ''
+    }],
+    [/kill -0 333/, command => (ssh.calls.some(c => /kill 333\b/.test(c)) ? 'DEAD' : 'ALIVE')],
+    [/print\("OK" if ok else "SHAPE"\)/, command =>
+      (command.includes('pid=890') || /pid=890/.test(command) ? ownedIdentityOut({ startTime: 890 }) : ownedIdentityOut())
+    ],
+    // broader identity match by nonce script — always owned shape for these pids
+    [/kill 333\b/, ''],
     [/--version/, 'Hermes Agent v0.18.2\n'],
     [/grep -q ssh-session-token-file/, 'YES\n'],
-    [/python3 -c/, ''],
+    [command => /python3 -c/.test(command) && /O_EXCL/.test(command), ''],
     [/setsid/, '890\n'],
     [/kill -0 890/, 'ALIVE'],
     [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=52050\n']
-  ])
+  ]))
+
+  // Fix identity matcher: owned for both classify and post-spawn
+  // (rebuilt below if needed)
 
   const result = await connect(
     connectDeps(ssh, { profile: 'default', reuseToken, adoptServedToken: async () => 'fresh' })
@@ -540,32 +597,48 @@ test('connect() respawns when the requested remote profile differs from the lock
   )
 })
 
-test('connect() respawns when the lockfile hermesPath differs from the resolved path', async () => {
+test('connect() reuses when lock launcherPath differs after exec-wrapper (identity-owned)', async () => {
   const reuseToken = 'stored-token'
-  const lock = ownedLock({ hermesPath: '/old/stale/hermes', tokenFingerprint: fingerprintToken(reuseToken) })
+  // Lock records the wrapper launcher; live process is python + runtime entry.
+  // Ownership is by observed identity + nonce, not launcher path equality.
+  const lock = ownedLock({
+    hermesPath: '/x/hermes-wrapper',
+    launcherPath: '/x/hermes-wrapper',
+    tokenFingerprint: fingerprintToken(reuseToken)
+  })
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
+  const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, JSON.stringify(lock)],
     [/kill -0/, 'ALIVE'],
-    [/print\("OWNED"/, 'FOREIGN\n'],
-    [/--version/, 'Hermes Agent v0.18.2\n'],
-    [/grep -q ssh-session-token-file/, 'YES\n'],
-    [/python3 -c/, ''],
-    [/setsid/, '890\n'],
-    [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=52050\n']
-  ])
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
+    [/\[ -x .*\/new\/hermes/, 'OK']
+  ]))
 
   const result = await connect(
-    connectDeps(ssh, { reuseToken, remoteHermesPath: '/new/hermes', adoptServedToken: async () => 'fresh' })
+    connectDeps(ssh, { reuseToken, remoteHermesPath: '/new/hermes', adoptServedToken: async (_b, t) => t })
   )
 
-  assert.equal(result.reused, false, 'must respawn, not reuse the old-path dashboard')
-  assert.ok(
-    ssh.calls.some(c => /setsid/.test(c)),
-    'a fresh dashboard must be spawned'
+  assert.equal(result.reused, true, 'exec-wrapper launcher mismatch must not block reuse of owned identity')
+  assert.ok(!ssh.calls.some(c => /setsid/.test(c)), 'must not spawn a replacement')
+})
+
+test('connect() fails closed on alive foreign identity (no delete/signal/spawn)', async () => {
+  const reuseToken = 'stored-token'
+  const lock = ownedLock({ tokenFingerprint: fingerprintToken(reuseToken) })
+
+  const ssh = fakeSsh(baseConnectRules([
+    [/cat .*lock\.json/, JSON.stringify(lock)],
+    [/kill -0/, 'ALIVE'],
+    [/print\("OK" if ok else "SHAPE"\)/, foreignIdentityOut()]
+  ]))
+
+  await assert.rejects(
+    () => connect(connectDeps(ssh, { reuseToken, adoptServedToken: async () => 'fresh' })),
+    (err: any) => err.kind === 'ownership-conflict'
   )
+  assert.ok(!ssh.calls.some(c => /setsid/.test(c)), 'must not spawn')
+  assert.ok(!ssh.calls.some(c => /kill 333\b/.test(c)), 'must not signal')
+  assert.ok(!ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)), 'must preserve lock')
 })
 
 test('connect() respawns when the lockfile protocolVersion is incompatible', async () => {
@@ -579,18 +652,8 @@ test('connect() respawns when the lockfile protocolVersion is incompatible', asy
     tokenFingerprint: fingerprintToken(reuseToken)
   }
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
-    [/cat .*lock\.json/, JSON.stringify(lock)],
-    [/kill -0 333/, 'ALIVE'],
-    [/print\("OWNED"/, 'FOREIGN\n'],
-    [/grep -q ssh-session-token-file/, 'YES\n'],
-    [/python3 -c/, ''],
-    [/setsid/, '901\n'],
-    [/kill -0 901/, 'ALIVE'],
-    [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=44100\n']
-  ])
+  // Incompatible protocol => readLockfile returns null => fresh spawn path.
+  const ssh = fakeSsh(spawnConnectRules({ pid: 901, port: 44100, lockJson: JSON.stringify(lock) }))
 
   const result = await connect(connectDeps(ssh, { reuseToken, adoptServedToken: async () => 'fresh' }))
   assert.equal(result.reused, false, 'incompatible protocol must force a fresh spawn, not a reattach')
@@ -600,15 +663,13 @@ test('connect() respawns when the lockfile protocolVersion is incompatible', asy
 test('connect() fresh spawn writes hermesHome + protocolVersion into the lockfile', async () => {
   const writes: string[] = []
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
-    [/cat .*lock\.json/, ''], // no lockfile
-    [/HERMES_HOME/, '/home/alice/.hermes\n'],
+  const ssh = fakeSsh(baseConnectRules([
+    [/cat .*lock\.json/, ''],
+    [/echo "\$\{HERMES_HOME/, '/home/alice/.hermes\n'],
     [/grep -q ssh-session-token-file/, 'YES\n'],
-    [/python3 -c/, ''],
-    [/printf '%s\\n'/, ''],
+    [command => /python3 -c/.test(command) && /O_EXCL/.test(command), ''],
     [/setsid/, '700\n'],
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut({ startTime: 700 })],
     [/kill -0 700/, 'ALIVE'],
     [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=45500\n'],
     [
@@ -619,75 +680,70 @@ test('connect() fresh spawn writes hermesHome + protocolVersion into the lockfil
         return ''
       }
     ]
-  ])
+  ]))
 
   await connect(connectDeps(ssh, { adoptServedToken: async () => 'fresh' }))
   const lockWrite = writes.find(c => c.includes('schemaVersion')) || ''
   assert.match(lockWrite, new RegExp(`"protocolVersion":${PROTOCOL_VERSION}`))
+  assert.match(lockWrite, new RegExp(`"schemaVersion":${LOCKFILE_SCHEMA_VERSION}`))
   assert.match(lockWrite, /"hermesHome":"\/home\/alice\/\.hermes"/)
+  assert.match(lockWrite, /"pidStartTime":/)
+  assert.match(lockWrite, /"launcherPath":/)
 })
 
 test('connect() respawns when the lockfile pid is dead (killed dashboard)', async () => {
   const lock = ownedLock({ tokenFingerprint: fingerprintToken('t') })
+  let sawDeadCleanup = false
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
-    [/cat .*lock\.json/, JSON.stringify(lock)],
+  const ssh = fakeSsh(baseConnectRules([
+    [/cat .*lock\.json/, () => (sawDeadCleanup ? '' : JSON.stringify(lock))],
     [/kill -0 333/, 'DEAD'],
-    [/print\("OWNED"/, 'FOREIGN\n'],
+    [/rm -f/, c => {
+      if (/backend\.lock\.json/.test(c)) sawDeadCleanup = true
+      return ''
+    }],
     [/grep -q ssh-session-token-file/, 'YES\n'],
-    [/python3 -c/, ''],
+    [command => /python3 -c/.test(command) && /O_EXCL/.test(command), ''],
     [/setsid/, '888\n'],
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut({ startTime: 888 })],
     [/kill -0 888/, 'ALIVE'],
     [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=42000\n']
-  ])
+  ]))
 
   const result = await connect(connectDeps(ssh, { reuseToken: 't', adoptServedToken: async () => 'fresh' }))
   assert.equal(result.reused, false)
   assert.equal(result.pid, 888)
   assert.equal(result.remotePort, 42000)
   assert.ok(
-    !ssh.calls.some(command => command.includes('pid=333') && command.includes('print("OWNED"')),
+    !ssh.calls.some(command => command.includes('pid=333') && command.includes('print("OK" if ok else "SHAPE")')),
     'a dead pid has no process identity to verify'
   )
 })
 
-test('connect() respawns when the dashboard is wedged (alive pid, probe fails)', async () => {
+test('connect() fails closed when the dashboard is alive but not provably owned', async () => {
   const reuseToken = 'stored'
+  // Incomplete lock still has enough fields for normalize via ownedLock defaults
+  // when using ownedLock; here force foreign identity classification.
+  const lock = ownedLock({ tokenFingerprint: fingerprintToken(reuseToken) })
 
-  const lock = {
-    schemaVersion: LOCKFILE_SCHEMA_VERSION,
-    protocolVersion: PROTOCOL_VERSION,
-    pid: 333,
-    port: 40000,
-    tokenFingerprint: fingerprintToken(reuseToken)
-  }
-
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
+  const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, JSON.stringify(lock)],
     [/kill -0/, 'ALIVE'],
-    [/print\("OWNED"/, 'FOREIGN\n'],
-    [/grep -q ssh-session-token-file/, 'YES\n'],
-    [/python3 -c/, ''],
-    [/setsid/, '999\n'],
-    [/kill -0 999/, 'ALIVE'],
-    [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=43000\n']
-  ])
+    [/print\("OK" if ok else "SHAPE"\)/, foreignIdentityOut()]
+  ]))
 
-  const result = await connect(
-    connectDeps(ssh, {
-      reuseToken,
-      probeReuseProof: async () => 'authenticated-stale',
-      adoptServedToken: async () => 'fresh'
-    })
+  await assert.rejects(
+    () =>
+      connect(
+        connectDeps(ssh, {
+          reuseToken,
+          probeReuseProof: async () => 'authenticated-stale',
+          adoptServedToken: async () => 'fresh'
+        })
+      ),
+    (err: any) => err.kind === 'ownership-conflict'
   )
-
-  assert.equal(result.reused, false)
-  assert.equal(result.pid, 999)
-  assert.equal(result.remotePort, 43000)
+  assert.ok(!ssh.calls.some(c => /setsid/.test(c)))
 })
 
 test('connect() aborts on an unsupported remote platform before doing anything else', async () => {
@@ -730,13 +786,11 @@ test('connect() preserves an owned backend when a reuse transport throws', async
   const reuseToken = 'stored-token'
   const lock = ownedLock({ tokenFingerprint: fingerprintToken(reuseToken) })
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
+  const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, JSON.stringify(lock)],
     [/kill -0/, 'ALIVE'],
-    [/print\("OWNED"/, 'OWNED\n']
-  ])
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()]
+  ]))
 
   await assert.rejects(
     () =>
@@ -977,13 +1031,11 @@ test('connect() reuse path does not write a token file', async () => {
   const reuseToken = 'stored-token'
   const lock = ownedLock({ tokenFingerprint: fingerprintToken(reuseToken) })
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
+  const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, JSON.stringify(lock)],
     [/kill -0/, 'ALIVE'],
-    [/print\("OWNED"/, 'OWNED\n']
-  ])
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()]
+  ]))
 
   const result = await connect(connectDeps(ssh, { reuseToken, adoptServedToken: async (_b, t) => t }))
   assert.equal(result.reused, true)
@@ -1011,7 +1063,11 @@ test('readLockfile rejects a log path outside the exact ownership and spawn path
 })
 
 test('cleanupStale never deletes a lock-supplied unexpected log path', async () => {
-  const ssh = fakeSsh([[/print\("OWNED"/, 'OWNED\n']])
+  const ssh = fakeSsh([
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
+    [/kill 333\b/, ''],
+    [/kill -0 333/, 'DEAD']
+  ])
   await cleanupStale(ssh, OWNERSHIP_ID, ownedLock({ logPath: '~/.hermes/unrelated.log' }))
   assert.ok(!ssh.calls.some(command => command.includes('unrelated.log')))
 })
@@ -1019,20 +1075,20 @@ test('cleanupStale never deletes a lock-supplied unexpected log path', async () 
 test('pidIsOurDashboard requires an exact nonce option value', async () => {
   const prefix = `/x/hermes serve --isolated --ssh-owner-nonce ${SPAWN_NONCE}ff`
   const suffix = `/x/hermes serve --isolated --ssh-owner-nonce xx${SPAWN_NONCE}`
-  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']]), 5, SPAWN_NONCE, '/x/hermes'), false)
-  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']]), 5, SPAWN_NONCE, '/x/hermes'), false)
+  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OK" if ok else "SHAPE"\)/, foreignIdentityOut()]]), 5, SPAWN_NONCE, '/x/hermes'), false)
+  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OK" if ok else "SHAPE"\)/, foreignIdentityOut()]]), 5, SPAWN_NONCE, '/x/hermes'), false)
 })
 
 test('connect removes the token file when a fresh backend fails after returning a pid', async () => {
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
+  const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, ''],
     [/grep -q ssh-session-token-file/, 'YES\n'],
-    [/python3 -c/, ''],
+    [command => /python3 -c/.test(command) && /O_EXCL/.test(command), ''],
     [/setsid/, '999\n'],
-    [/kill -0 999/, 'DEAD']
-  ])
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut({ startTime: 999 })],
+    [/kill -0 999/, 'DEAD'],
+    [/kill 999\b/, '']
+  ]))
 
   await assert.rejects(() => connect(connectDeps(ssh)), /exited before announcing/i)
   assert.ok(ssh.calls.some(command => /rm -f .*\.token/.test(command)))
@@ -1042,13 +1098,11 @@ test('connect preserves an exact-owned backend when reuse proof transport fails'
   const reuseToken = 'stored-token'
   const lock = ownedLock({ tokenFingerprint: fingerprintToken(reuseToken) })
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
+  const ssh = fakeSsh(baseConnectRules([
     [/cat .*lock\.json/, JSON.stringify(lock)],
     [/kill -0/, 'ALIVE'],
-    [/print\("OWNED"/, 'OWNED\n']
-  ])
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()]
+  ]))
 
   await assert.rejects(
     () =>
@@ -1070,18 +1124,19 @@ test('connect replaces an exact-owned backend only after authenticated stale pro
   const reuseToken = 'stored-token'
   const lock = ownedLock({ tokenFingerprint: fingerprintToken(reuseToken) })
 
-  const ssh = fakeSsh([
-    [/uname/, 'Linux\nx86_64'],
-    [/\[ -x/, 'OK'],
-    [/cat .*lock\.json/, JSON.stringify(lock)],
-    [/kill -0 333/, 'ALIVE'],
-    [/print\("OWNED"/, 'OWNED\n'],
+  let killed333 = false
+  const ssh = fakeSsh(baseConnectRules([
+    [/cat .*lock\.json/, () => (killed333 ? '' : JSON.stringify(lock))],
+    // Match terminate before the embedded `kill -0` probe inside the same command.
+    [/kill 333\b/, () => { killed333 = true; return '' }],
+    [/kill -0 333/, () => (killed333 ? 'DEAD' : 'ALIVE')],
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
     [/grep -q ssh-session-token-file/, 'YES\n'],
-    [/python3 -c/, ''],
+    [command => /python3 -c/.test(command) && /O_EXCL/.test(command), ''],
     [/setsid/, '999\n'],
     [/kill -0 999/, 'ALIVE'],
     [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=43000\n']
-  ])
+  ]))
 
   const result = await connect(
     connectDeps(ssh, {
@@ -1121,3 +1176,53 @@ test('remote SSH ownership capability requires both secure bootstrap flags', asy
   const unsupported = fakeSsh([[/serve --help/, 'NO\n']])
   assert.equal(await remoteSupportsSshOwnership(unsupported, '/x/hermes'), false)
 })
+
+test('exec-wrapper ownership identity verifies as owned and can be reaped', async () => {
+  // Lock launcher is a wrapper; live argv is python + runtime hermes entry.
+  const lock = ownedLock({
+    hermesPath: '/x/hermes-wrapper',
+    launcherPath: '/x/hermes-wrapper',
+    pid: 5,
+    pidStartTime: 12345,
+    processFingerprint: 'a'.repeat(32)
+  })
+  const ssh = fakeSsh([
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
+    [/kill 5\b/, ''],
+    [/kill -0 5/, 'DEAD']
+  ])
+  assert.equal(await pidIsOurDashboard(ssh, 5, SPAWN_NONCE, '/x/hermes-wrapper', lock), true)
+  await cleanupStale(ssh, OWNERSHIP_ID, lock)
+  assert.ok(ssh.calls.some(c => /kill 5\b/.test(c)))
+  assert.ok(ssh.calls.some(c => /rm -f .*backend\.lock\.json/.test(c)))
+})
+
+test('PID reuse start-time mismatch is foreign and never signaled', async () => {
+  const lock = ownedLock({ pid: 5, pidStartTime: 111, processFingerprint: 'a'.repeat(32) })
+  const ssh = fakeSsh([
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut({ startTime: 222 })]
+  ])
+  assert.equal(await pidIsOurDashboard(ssh, 5, SPAWN_NONCE, '/x/hermes', lock), false)
+  await assert.rejects(
+    () => cleanupStale(ssh, OWNERSHIP_ID, lock),
+    (err: any) => err.kind === 'ownership-conflict'
+  )
+  assert.ok(!ssh.calls.some(c => /kill 5\b/.test(c)))
+})
+
+test('token-absent healthy lock still reuses when identity-owned', async () => {
+  // Token files are read-and-unlinked by design; absence is not orphan proof.
+  const reuseToken = 'stored-token'
+  const lock = ownedLock({ tokenFingerprint: fingerprintToken(reuseToken) })
+  const ssh = fakeSsh(baseConnectRules([
+    [/cat .*lock\.json/, JSON.stringify(lock)],
+    [/kill -0/, 'ALIVE'],
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
+    // no token file present on remote
+    [/\.token/, '']
+  ]))
+  const result = await connect(connectDeps(ssh, { reuseToken, adoptServedToken: async (_b, t) => t }))
+  assert.equal(result.reused, true)
+  assert.ok(!ssh.calls.some(c => /setsid/.test(c)))
+})
+

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict'
-import { exec as nodeExec } from 'node:child_process'
+import { exec as nodeExec, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { promisify } from 'node:util'
 
 import { test } from 'vitest'
@@ -265,15 +268,23 @@ test('locateHermes uses a login shell for the command -v probe', async () => {
   )
 })
 
-test('probeRemotePlatform accepts Linux and macOS', async () => {
+test('probeRemotePlatform accepts Linux only for replacement backends', async () => {
   assert.deepEqual(await probeRemotePlatform(fakeSsh([[/uname/, 'Linux\nx86_64']])), {
     os: 'Linux',
     arch: 'x86_64'
   })
-  assert.deepEqual(await probeRemotePlatform(fakeSsh([[/uname/, 'Darwin\narm64']])), {
-    os: 'Darwin',
-    arch: 'arm64'
-  })
+})
+
+test('probeRemotePlatform rejects Darwin as unsupported replacement platform', async () => {
+  await assert.rejects(
+    () => probeRemotePlatform(fakeSsh([[/uname/, 'Darwin\narm64']])),
+    (err: any) => {
+      assert.equal(err.kind, 'unsupported-platform')
+      assert.match(String(err.message), /Darwin|macOS|pidfd|replacement/i)
+
+      return true
+    }
+  )
 })
 
 test('probeRemotePlatform rejects unsupported remote platforms', async () => {
@@ -1454,22 +1465,38 @@ test('adversarial stale takeover loses the original owner mutation fence', async
   assert.equal(mutate, 2)
 })
 
-test('Darwin termination path is identity-stable without pidfd', async () => {
+test('non-pidfd termination fails closed as UNSUPPORTED (no prove-then-kill)', async () => {
   const lock = ownedLock({ pid: 5 })
 
   const ssh = fakeSsh([
     [/terminate_result|pidfd_open/, (command: string) => {
       assert.match(command, /pidfd_open/)
-      assert.match(command, /ps","-o","lstart=|ps.*lstart/)
-      assert.match(command, /signal\.SIGTERM|SIGTERM/)
+      assert.match(command, /UNSUPPORTED/)
+      assert.match(command, /finish\(["']UNSUPPORTED["']\)/)
+      // Non-pidfd branch must finish UNSUPPORTED without a post-proof signal.
+      const nonPidfd = command.split('AttributeError,NotImplementedError,OSError')[1] || ''
+      assert.match(nonPidfd, /UNSUPPORTED/)
+      assert.ok(!/os\.k[i]ll\(pid,\s*signal\.SIGTERM\)/.test(nonPidfd))
 
-      // Simulate non-pidfd host falling through to Darwin path and succeeding.
-      return 'TERMINATED\n'
+      return 'UNSUPPORTED\n'
     }]
   ])
 
   const result = await terminateOwnedProcess(ssh, lock)
-  assert.equal(result, 'TERMINATED')
+  assert.equal(result, 'UNSUPPORTED')
+})
+
+test('cleanupStale surfaces unsupported-platform when termination lacks pidfd', async () => {
+  const lock = ownedLock({ pid: 5 })
+  const ssh = fakeSsh([
+    [/print\("OK" if ok else "SHAPE"\)/, ownedIdentityOut()],
+    [/terminate_result|pidfd_open/, 'UNSUPPORTED\n']
+  ])
+
+  await assert.rejects(
+    () => cleanupStale(ssh, OWNERSHIP_ID, lock, true),
+    (err: any) => err.kind === 'unsupported-platform'
+  )
 })
 
 test('lease-fenced termination checks owner-epoch token under flock', async () => {
@@ -1494,3 +1521,190 @@ test('lease-fenced termination checks owner-epoch token under flock', async () =
   const result = await terminateOwnedProcess(ssh, lock, lease)
   assert.equal(result, 'LOST')
 })
+
+
+// ---------------------------------------------------------------------------
+// Real two-process / local-helper owner-epoch adversarial interleavings.
+// Executes production Python fencing helpers against a real temp HOME so tests
+// fail if token fencing is removed from spawn/write/remove/heartbeat paths.
+// ---------------------------------------------------------------------------
+
+function makeTempHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-owner-epoch-'))
+}
+
+function rmTempHome(home: string) {
+  fs.rmSync(home, { recursive: true, force: true })
+}
+
+/** SSH stub that actually runs remote python3 -c helpers against a temp HOME. */
+function localHelperSsh(home: string) {
+  const calls: string[] = []
+
+  return {
+    calls,
+    async exec(command: string, options: any = {}) {
+      calls.push(command)
+      const result = spawnSync('bash', ['-lc', command], {
+        encoding: 'utf8',
+        input: options?.stdinData,
+        env: { ...process.env, HOME: home },
+        timeout: 15_000
+      })
+
+      if (result.status !== 0 && result.status !== null) {
+        const err: any = new Error(result.stderr || result.stdout || `exit ${result.status}`)
+        err.status = result.status
+        throw err
+      }
+
+      return result.stdout || ''
+    }
+  }
+}
+
+function mutexPathFor(home: string) {
+  return path.join(home, '.hermes', 'desktop-ssh', OWNERSHIP_ID, 'lifecycle.mutex')
+}
+
+function readMutex(home: string) {
+  return fs.readFileSync(mutexPathFor(home), 'utf8').trim()
+}
+
+test('real local-helper: stale takeover rewrites inode; prior owner heartbeat LOST', async () => {
+  const home = makeTempHome()
+  try {
+    const sshA = localHelperSsh(home)
+    const sshB = localHelperSsh(home)
+    let leaseAToken = ''
+    let successorWrote = false
+
+    // Outer owner A is expected to end in ownership-conflict after B reclaims.
+    await assert.rejects(
+      () => withOwnershipMutex(sshA as any, OWNERSHIP_ID, async leaseA => {
+        leaseAToken = leaseA.token
+        assert.equal(readMutex(home), leaseA.token)
+
+        // Force lease stale for successor reclaim (same inode rewrite).
+        const p = mutexPathFor(home)
+        const past = Math.floor(Date.now() / 1000) - 10_000
+        fs.utimesSync(p, past, past)
+
+        await withOwnershipMutex(sshB as any, OWNERSHIP_ID, async leaseB => {
+          assert.notEqual(leaseB.token, leaseAToken)
+          assert.equal(readMutex(home), leaseB.token)
+
+          // Successor fenced write must succeed under the new epoch.
+          await writeLockfile(sshB as any, OWNERSHIP_ID, ownedLock({ pid: 22, port: 2 }), leaseB)
+          const lockPath = path.join(home, '.hermes', 'desktop-ssh', OWNERSHIP_ID, 'backend.lock.json')
+          assert.equal(JSON.parse(fs.readFileSync(lockPath, 'utf8')).pid, 22)
+          successorWrote = true
+          return 'b-ok'
+        }, { heartbeatMs: 60_000 })
+
+        // Stale owner heartbeat must LOST (token mismatch under flock).
+        await leaseA.assertHeld()
+      }, { heartbeatMs: 60_000 }),
+      (err: any) => err.kind === 'ownership-conflict'
+    )
+
+    assert.equal(successorWrote, true)
+    // After B releases, mutex file may be gone; the important proof is conflict + write.
+  } finally {
+    rmTempHome(home)
+  }
+})
+
+test('real local-helper: fenced remove LOST after concurrent successor reclaim', async () => {
+  const home = makeTempHome()
+  try {
+    const sshA = localHelperSsh(home)
+    const sshB = localHelperSsh(home)
+    const lockPath = path.join(home, '.hermes', 'desktop-ssh', OWNERSHIP_ID, 'backend.lock.json')
+
+    await assert.rejects(
+      () => withOwnershipMutex(sshA as any, OWNERSHIP_ID, async leaseA => {
+        await writeLockfile(sshA as any, OWNERSHIP_ID, ownedLock({ pid: 7, port: 9 }), leaseA)
+        assert.ok(fs.existsSync(lockPath))
+
+        const p = mutexPathFor(home)
+        const past = Math.floor(Date.now() / 1000) - 10_000
+        fs.utimesSync(p, past, past)
+
+        await withOwnershipMutex(sshB as any, OWNERSHIP_ID, async leaseB => {
+          assert.equal(readMutex(home), leaseB.token)
+          // B keeps the lock evidence while holding the new epoch.
+          assert.ok(fs.existsSync(lockPath))
+          return 'ok'
+        }, { heartbeatMs: 60_000 })
+
+        // Stale owner cannot fence-remove after successor reclaim.
+        await cleanupStale(sshA as any, OWNERSHIP_ID, ownedLock({ pid: 7, port: 9 }), false, leaseA)
+      }, { heartbeatMs: 60_000 }),
+      (err: any) => err.kind === 'ownership-conflict'
+    )
+
+    // Lock evidence remains because stale owner could not complete fenced remove.
+    assert.ok(fs.existsSync(lockPath))
+  } finally {
+    rmTempHome(home)
+  }
+})
+
+test('real local-helper: unfenced mutation helper would not LOST (fencing required)', async () => {
+  // Negative control: a mutation that skips token compare can still write after
+  // takeover. Documents why production paths must keep lease_token fencing.
+  const home = makeTempHome()
+  try {
+    const dir = path.join(home, '.hermes', 'desktop-ssh', OWNERSHIP_ID)
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+    const mutex = path.join(dir, 'lifecycle.mutex')
+    fs.writeFileSync(mutex, 'ownerB:epochB', { mode: 0o600 })
+    const target = path.join(dir, 'unfenced.txt')
+
+    const unfenced = `
+import os
+p=os.path.expanduser(${JSON.stringify('~/.hermes/desktop-ssh/' + OWNERSHIP_ID + '/unfenced.txt')})
+os.makedirs(os.path.dirname(p), exist_ok=True)
+open(p,'w').write('bad')
+print('WROTE')
+`
+    const result = spawnSync('python3', ['-c', unfenced], {
+      encoding: 'utf8',
+      env: { ...process.env, HOME: home }
+    })
+    assert.equal(result.status, 0)
+    assert.equal(fs.readFileSync(target, 'utf8'), 'bad')
+
+    // Fenced equivalent must LOST against successor token.
+    const fenced = `
+import os,sys
+try:
+ import fcntl
+except ImportError:
+ fcntl=None
+p=os.path.expanduser(${JSON.stringify('~/.hermes/desktop-ssh/' + OWNERSHIP_ID + '/lifecycle.mutex')})
+lease_token='ownerA:stale'
+try:
+ lease_fd=os.open(p,os.O_RDWR)
+except OSError:
+ print('LOST'); raise SystemExit(0)
+if fcntl is not None:
+ fcntl.flock(lease_fd,fcntl.LOCK_EX)
+data=os.read(lease_fd,4096).decode().strip()
+if data!=lease_token:
+ os.close(lease_fd)
+ print('LOST'); raise SystemExit(0)
+os.close(lease_fd)
+print('HELD')
+`
+    const fencedResult = spawnSync('python3', ['-c', fenced], {
+      encoding: 'utf8',
+      env: { ...process.env, HOME: home }
+    })
+    assert.match(String(fencedResult.stdout || ''), /LOST/)
+  } finally {
+    rmTempHome(home)
+  }
+})
+

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -7,7 +7,9 @@
  * step (injected). Knows how to:
  *
  *   - locate the Hermes install on the remote (login-shell probe),
- *   - gate the remote platform to Linux/macOS via `uname`,
+ *   - gate the remote platform to Linux via `uname` (Darwin/macOS remote
+ *     backends are unsupported because process replacement lacks an
+ *     identity-stable non-pidfd signal primitive),
  *   - reuse an existing desktop-dedicated dashboard via a lockfile + an
  *     AUTHENTICATED /api/status probe (pid liveness alone is insufficient),
  *   - spawn a fresh detached `--isolated --port 0` dashboard and scrape its
@@ -35,7 +37,10 @@ const SUPPORTED_LOCK_SCHEMA_VERSIONS = new Set([2, 3])
 const PROTOCOL_VERSION = 1
 const READY_RE = /^HERMES_(?:BACKEND|DASHBOARD)_READY port=(\d+)/m
 const REMOTE_LOCK_DIR = '~/.hermes/desktop-ssh'
-const SUPPORTED_REMOTE_OS = new Set(['Linux', 'Darwin'])
+// Linux only: remote replacement requires pidfd-bound signaling so a reused PID
+// cannot receive SIGTERM. Darwin has no identity-stable non-pidfd primitive we
+// accept for replacement, so macOS remotes fail closed at platform probe.
+const SUPPORTED_REMOTE_OS = new Set(['Linux'])
 const DEFAULT_READY_TIMEOUT_MS = 45_000
 const READY_POLL_INTERVAL_MS = 750
 // macOS sshd starts non-interactive shells with a 256-FD soft limit even when
@@ -244,7 +249,9 @@ async function probeRemotePlatform(ssh) {
 
   if (!SUPPORTED_REMOTE_OS.has(osName)) {
     const err: any = new Error(
-      `Unsupported remote platform "${osName || 'unknown'}". Hermes Desktop SSH mode supports Linux, macOS, and Windows remote hosts.`
+      `Unsupported remote platform "${osName || 'unknown'}". Hermes Desktop SSH backend replacement supports Linux only ` +
+        '(identity-stable pidfd termination). Darwin/macOS remotes are not supported for replacement because a ' +
+        'prove-then-kill path can signal a reused PID.'
     )
 
     err.kind = 'unsupported-platform'
@@ -599,7 +606,7 @@ async function pidIsOurDashboard(ssh, pid, spawnNonce, _hermesPath = '', lockExt
  * Re-prove identity and signal through a pidfd in one remote helper. The pidfd
  * binds the signal target before the final identity check, so PID reuse between
  * proof and signal cannot redirect SIGTERM to a replacement process. Platforms
- * without pidfds fail closed rather than using a racy standalone `kill`.
+ * without pidfds fail closed with UNSUPPORTED — never prove-then-os.kill.
  */
 async function terminateOwnedProcess(ssh, lock, lease: any = null) {
   const expectedStart = lock.pidStartTime == null ? 'None' : String(Number(lock.pidStartTime))
@@ -685,13 +692,9 @@ async function terminateOwnedProcess(ssh, lock, lease: any = null) {
     ' except ProcessLookupError:\n' +
     '  finish("GONE")\n' +
     ' except (AttributeError,NotImplementedError,OSError):\n' +
-    '  # Darwin / non-pidfd hosts: identity-stable best-effort terminate path.\n' +
-    '  prove_identity()\n' +
-    '  try:\n' +
-    '   os.kill(pid,signal.SIGTERM)\n' +
-    '  except ProcessLookupError:\n' +
-    '   finish("GONE")\n' +
-    '  finish("TERMINATED")\n' +
+    '  # No identity-stable non-pidfd signal primitive is accepted. Refuse to\n' +
+    '  # prove_identity()+os.kill (PID-reuse race). Darwin is unsupported.\n' +
+    '  finish("UNSUPPORTED")\n' +
     ' try:\n' +
     '  prove_identity()\n' +
     '  try:signal.pidfd_send_signal(pidfd,signal.SIGTERM)\n' +
@@ -731,6 +734,14 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true, lease: any 
         throw ownershipConflict(
           'SSH backend identity or lifecycle lease changed before termination; preserving lock evidence.'
         )
+      }
+
+      if (terminateResult === 'UNSUPPORTED') {
+        const error: any = new Error(
+          'SSH backend replacement requires identity-stable pidfd termination; this remote platform is unsupported.'
+        )
+        error.kind = 'unsupported-platform'
+        throw error
       }
 
       if (!['TERMINATED', 'GONE'].includes(terminateResult)) {
@@ -1146,7 +1157,7 @@ async function withOwnershipMutex(ssh, ownershipId, fn, options: any = {}) {
     '   # Owner-epoch reclaim: rewrite the same inode under flock. Never\n' +
     '   # pathname-unlink a lease we have not proven stale while holding it.\n' +
     '   if age>stale_ms:\n' +
-    '    os.lseek(fd,0); os.ftruncate(fd,0)\n' +
+    '    os.lseek(fd,0,os.SEEK_SET); os.ftruncate(fd,0)\n' +
     '    os.write(fd,token.encode()); os.fsync(fd)\n' +
     '    try:os.utime(p,None)\n' +
     '    except OSError:pass\n' +

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -44,6 +44,9 @@ const READY_POLL_INTERVAL_MS = 750
 // Keep startup portable: restricted hosts retain their existing limit.
 const REMOTE_NOFILE_SOFT_LIMIT = 65_536
 const OWNERSHIP_MUTEX_STALE_MS = 120_000
+const OWNERSHIP_MUTEX_HEARTBEAT_MS = 30_000
+const LOCK_ABSENT_MARKER = '__HERMES_DESKTOP_LOCK_ABSENT__'
+const LOCK_PRESENT_MARKER = '__HERMES_DESKTOP_LOCK_PRESENT__'
 
 function mintToken() {
   return crypto.randomBytes(32).toString('hex')
@@ -136,6 +139,7 @@ function expandRemotePath(p) {
 function ownershipConflict(message) {
   const error: any = new Error(message || 'SSH backend ownership conflict.')
   error.kind = 'ownership-conflict'
+
   return error
 }
 
@@ -330,12 +334,16 @@ function normalizeLockRecord(parsed, ownershipId) {
   return parsed
 }
 
-async function readLockfile(ssh, ownershipId) {
+async function readOwnershipRecord(ssh, ownershipId) {
   const lpath = lockfilePath(ownershipId)
   let raw
 
   try {
-    raw = await ssh.exec(`if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`)
+    raw = await ssh.exec(
+      `if [ -e ${expandRemotePath(lpath)} ]; then ` +
+        `printf '%s\\n' ${shq(LOCK_PRESENT_MARKER)}; cat ${expandRemotePath(lpath)}; ` +
+        `else printf '%s\\n' ${shq(LOCK_ABSENT_MARKER)}; fi`
+    )
   } catch (cause) {
     const error: any = new Error('Could not read the SSH backend ownership record.')
     error.kind = 'transient-transport-error'
@@ -343,10 +351,19 @@ async function readLockfile(ssh, ownershipId) {
     throw error
   }
 
-  const text = String(raw || '').trim()
+  let text = String(raw || '').trim()
 
-  if (!text) {
-    return null
+  // Empty unmarked output is retained as a test-double/back-compat spelling of
+  // absence. Real remote reads always emit an explicit PRESENT/ABSENT marker,
+  // so an existing empty file cannot be confused with no file.
+  if (!text || text === LOCK_ABSENT_MARKER) {
+    return { state: 'absent', record: null, parsed: null }
+  }
+
+  if (text.startsWith(`${LOCK_PRESENT_MARKER}\n`)) {
+    text = text.slice(LOCK_PRESENT_MARKER.length + 1).trim()
+  } else if (text === LOCK_PRESENT_MARKER) {
+    text = ''
   }
 
   let parsed
@@ -354,10 +371,20 @@ async function readLockfile(ssh, ownershipId) {
   try {
     parsed = JSON.parse(text)
   } catch {
-    return null
+    return { state: 'invalid', record: null, parsed: null }
   }
 
-  return normalizeLockRecord(parsed, ownershipId)
+  const record = normalizeLockRecord(parsed, ownershipId)
+
+  return record
+    ? { state: 'valid', record, parsed }
+    : { state: 'invalid', record: null, parsed }
+}
+
+async function readLockfile(ssh, ownershipId) {
+  const envelope = await readOwnershipRecord(ssh, ownershipId)
+
+  return envelope.state === 'valid' ? envelope.record : null
 }
 
 async function writeLockfile(ssh, ownershipId, lock) {
@@ -433,7 +460,10 @@ async function observeProcessIdentity(ssh, pid, spawnNonce) {
       'try:\n' +
       ' args=read_args(pid)\n' +
       'except Exception:\n' +
-      ' print("GONE"); sys.exit(0)\n' +
+      ' try:os.kill(pid,0)\n' +
+      ' except ProcessLookupError:print("GONE"); sys.exit(0)\n' +
+      ' except PermissionError:pass\n' +
+      ' print("INDETERMINATE"); sys.exit(0)\n' +
       'st=start_time(pid)\n' +
       'fp=hashlib.sha256("\\0".join(args).encode("utf-8","surrogateescape")).hexdigest()[:32]\n' +
       'ok=False\n' +
@@ -482,6 +512,7 @@ async function observeProcessIdentity(ssh, pid, spawnNonce) {
  * Returns:
  *   'owned'          — positively identified as our dashboard
  *   'foreign'        — positively identified as not ours / PID reuse
+ *   'gone'           — the recorded PID no longer exists
  *   'indeterminate'  — cannot prove either way (should fail closed if alive)
  */
 async function classifyProcessOwnership(ssh, lock) {
@@ -492,7 +523,7 @@ async function classifyProcessOwnership(ssh, lock) {
   const observed = await observeProcessIdentity(ssh, lock.pid, lock.spawnNonce)
 
   if (!observed) {
-    return 'foreign'
+    return 'gone'
   }
 
   if (!observed.ownedShape) {
@@ -527,44 +558,122 @@ async function pidIsOurDashboard(ssh, pid, spawnNonce, _hermesPath = '', lockExt
   return classification === 'owned'
 }
 
+/**
+ * Re-prove identity and signal through a pidfd in one remote helper. The pidfd
+ * binds the signal target before the final identity check, so PID reuse between
+ * proof and signal cannot redirect SIGTERM to a replacement process. Platforms
+ * without pidfds fail closed rather than using a racy standalone `kill`.
+ */
+async function terminateOwnedProcess(ssh, lock, lease: any = null) {
+  if (lease) {
+    await lease.assertHeld()
+  }
+
+  const expectedStart = lock.pidStartTime == null ? 'None' : String(Number(lock.pidStartTime))
+  const expectedFingerprint = String(lock.processFingerprint || '')
+  const leasePath = lease?.path || ''
+  const leaseHolder = lease?.holder || ''
+
+  const script =
+    'import hashlib,os,signal,sys\n' +
+    `pid=${Number(lock.pid)}\n` +
+    `nonce=${shq(lock.spawnNonce)}\n` +
+    `expected_start=${expectedStart}\n` +
+    `expected_fingerprint=${shq(expectedFingerprint)}\n` +
+    `lease_path=${shq(leasePath)}\n` +
+    `lease_holder=${shq(leaseHolder)}\n` +
+    'terminate_result="MISMATCH"\n' +
+    'def finish(value):\n' +
+    ' print(value); sys.exit(0)\n' +
+    'if lease_path:\n' +
+    ' try:\n' +
+    '  if open(os.path.expanduser(lease_path),"r",encoding="utf-8").read().strip()!=lease_holder:finish("LOST")\n' +
+    ' except OSError:finish("LOST")\n' +
+    'try:\n' +
+    ' pidfd=os.pidfd_open(pid)\n' +
+    'except ProcessLookupError:finish("GONE")\n' +
+    'except (AttributeError,NotImplementedError,OSError):finish("UNSAFE")\n' +
+    'try:\n' +
+    ' try:\n' +
+    '  raw=open(f"/proc/{pid}/cmdline","rb").read()\n' +
+    '  args=[x.decode("utf-8","surrogateescape") for x in raw.split(b"\\0") if x]\n' +
+    '  start=int(open(f"/proc/{pid}/stat","r",encoding="utf-8").read().split()[21])\n' +
+    ' except (OSError,ValueError,IndexError):finish("GONE")\n' +
+    ' fp=hashlib.sha256("\\0".join(args).encode("utf-8","surrogateescape")).hexdigest()[:32]\n' +
+    ' try:\n' +
+    '  serve=args.index("serve"); owner=args.index("--ssh-owner-nonce",serve+1)\n' +
+    '  shape=("--isolated" in args[serve+1:]) and args[owner+1]==nonce\n' +
+    ' except (ValueError,IndexError):shape=False\n' +
+    ' if not shape:finish("MISMATCH")\n' +
+    ' if expected_start is not None and start!=expected_start:finish("MISMATCH")\n' +
+    ' if expected_fingerprint and fp!=expected_fingerprint:finish("MISMATCH")\n' +
+    ' try:signal.pidfd_send_signal(pidfd,signal.SIGTERM)\n' +
+    ' except ProcessLookupError:finish("GONE")\n' +
+    ' finish("TERMINATED")\n' +
+    'finally:os.close(pidfd)'
+
+  try {
+    return String(await ssh.exec(`python3 -c ${shq(script)}`)).trim()
+  } catch (cause) {
+    const error: any = new Error('Could not terminate the stale SSH backend.')
+    error.kind = 'transient-transport-error'
+    error.cause = cause
+    throw error
+  }
+}
+
 // Kill the stale dashboard ONLY if provably ours, then drop the lockfile.
 // Alive indeterminate/foreign locks are a hard ownership-conflict: preserve
 // lock/log, do not signal, do not spawn.
-async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
+async function cleanupStale(ssh, ownershipId, lock, pidAlive = true, lease: any = null) {
   const lockWithOwner = lock ? { ...lock, ownershipId: lock.ownershipId || ownershipId } : lock
 
   if (pidAlive && lockWithOwner) {
     const classification = await classifyProcessOwnership(ssh, lockWithOwner)
 
     if (classification === 'owned') {
-      try {
-        const result = (
-          await ssh.exec(
-            `kill ${Number(lockWithOwner.pid)} && ` +
-              `i=0; while kill -0 ${Number(lockWithOwner.pid)} 2>/dev/null; do ` +
-              `i=$((i+1)); [ "$i" -ge 50 ] && exit 1; sleep 0.1; done`
-          )
-        ).trim()
+      const terminateResult = await terminateOwnedProcess(ssh, lockWithOwner, lease)
 
-        void result
-      } catch (cause) {
-        const error: any = new Error('Could not terminate the stale SSH backend.')
+      if (terminateResult === 'MISMATCH' || terminateResult === 'UNSAFE' || terminateResult === 'LOST') {
+        throw ownershipConflict(
+          'SSH backend identity or lifecycle lease changed before termination; preserving lock evidence.'
+        )
+      }
+
+      if (!['TERMINATED', 'GONE'].includes(terminateResult)) {
+        const error: any = new Error('SSH backend termination returned an invalid result.')
         error.kind = 'transient-transport-error'
-        error.cause = cause
         throw error
       }
 
-      // Confirm exit before dropping evidence.
-      if (await remotePidAlive(ssh, lockWithOwner.pid)) {
-        throw ownershipConflict(
-          'Owned SSH backend did not exit after terminate; preserving lock evidence.'
-        )
+      // SIGTERM is asynchronous. Wait boundedly for the exact PID number to
+      // disappear before dropping evidence or allowing a replacement spawn.
+      // If the PID is reused during this wait it remains ALIVE and we fail
+      // closed; we never signal the replacement.
+      if (terminateResult === 'TERMINATED') {
+        const deadline = Date.now() + 5_000
+        let stillAlive = await remotePidAlive(ssh, lockWithOwner.pid)
+
+        while (stillAlive && Date.now() < deadline) {
+          await new Promise(resolve => setTimeout(resolve, 100))
+          stillAlive = await remotePidAlive(ssh, lockWithOwner.pid)
+        }
+
+        if (stillAlive) {
+          throw ownershipConflict(
+            'Owned SSH backend did not exit after terminate; preserving lock evidence.'
+          )
+        }
       }
     } else if (classification === 'foreign' || classification === 'indeterminate') {
       throw ownershipConflict(
         'Alive SSH backend lock is not provably owned; refusing to delete lock/log or spawn a replacement.'
       )
     }
+  }
+
+  if (lease) {
+    await lease.assertHeld()
   }
 
   const expectedLogPath =
@@ -814,13 +923,16 @@ async function openForward(deps, remotePort, attempts = 3) {
 
 /**
  * Cross-process remote mutex for the full read→classify→cleanup/reuse/spawn→write
- * transaction. Held through the final ready lock write. Bounded stale recovery
- * uses PID/start identity of the mutex holder when available.
+ * transaction. Held through the final ready lock write. A heartbeat prevents
+ * age-based recovery from stealing a live lease, and every mutation phase is
+ * fenced by the unguessable holder token.
  */
-async function withOwnershipMutex(ssh, ownershipId, fn) {
+async function withOwnershipMutex(ssh, ownershipId, fn, options: any = {}) {
   const directory = ownershipDirectory(ownershipId)
   const mutexPath = ownershipMutexPath(ownershipId)
   const holder = `${process.pid}-${crypto.randomBytes(4).toString('hex')}`
+  const heartbeatMs = options.heartbeatMs ?? OWNERSHIP_MUTEX_HEARTBEAT_MS
+
   const script =
     'import os,sys,time\n' +
     `d=os.path.expanduser(${shq(directory)})\n` +
@@ -854,9 +966,70 @@ async function withOwnershipMutex(ssh, ownershipId, fn) {
     throw error
   }
 
+  let lostError: any = null
+  let heartbeatChain = Promise.resolve()
+
+  const assertHeld = async () => {
+    if (lostError) {
+      throw lostError
+    }
+
+    const verifyScript =
+      'import os\n' +
+      `p=os.path.expanduser(${shq(mutexPath)})\n` +
+      `holder=${shq(holder)}\n` +
+      'try:\n' +
+      ' data=open(p,"r",encoding="utf-8").read().strip()\n' +
+      ' if data==holder:\n' +
+      '  os.utime(p,None); print("HELD")\n' +
+      ' else:print("LOST")\n' +
+      'except OSError:print("LOST")'
+
+    let out
+
+    try {
+      out = String(await ssh.exec(`python3 -c ${shq(verifyScript)}`)).trim()
+    } catch (cause) {
+      const error: any = new Error('Could not heartbeat the SSH backend ownership mutex.')
+      error.kind = 'transient-transport-error'
+      error.cause = cause
+      lostError = error
+      throw error
+    }
+
+    if (!out.endsWith('HELD')) {
+      lostError = ownershipConflict(
+        'SSH backend ownership mutex was lost; refusing further lifecycle mutations.'
+      )
+      throw lostError
+    }
+  }
+
+  const heartbeat = () => {
+    heartbeatChain = heartbeatChain
+      .then(() => assertHeld())
+      .catch(error => {
+        lostError = error
+      })
+  }
+
+  const heartbeatTimer = setInterval(heartbeat, heartbeatMs)
+  heartbeatTimer.unref?.()
+
   try {
-    return await fn()
+    const result = await fn({ holder, path: mutexPath, assertHeld })
+    clearInterval(heartbeatTimer)
+    await heartbeatChain
+
+    if (lostError) {
+      throw lostError
+    }
+
+    return result
   } finally {
+    clearInterval(heartbeatTimer)
+    await heartbeatChain
+
     try {
       await ssh.exec(
         `python3 -c ${shq(
@@ -928,9 +1101,30 @@ async function connect(deps) {
   const reuseToken = deps.reuseToken || ''
   const hermesHome = await probeRemoteHermesHome(ssh)
 
-  return withOwnershipMutex(ssh, ownershipId, async () => {
+  return withOwnershipMutex(ssh, ownershipId, async lease => {
     assertNotAborted(signal)
-    const lock = await readLockfile(ssh, ownershipId)
+    await lease.assertHeld()
+    const ownership = await readOwnershipRecord(ssh, ownershipId)
+    const lock = ownership.record
+
+    if (ownership.state === 'invalid') {
+      const candidatePid = ownership.parsed?.pid
+
+      if (Number.isInteger(candidatePid) && candidatePid > 0 && candidatePid <= 4194304) {
+        if (await remotePidAlive(ssh, candidatePid)) {
+          throw ownershipConflict(
+            'An existing SSH backend ownership record is incompatible or malformed while its PID is alive.'
+          )
+        }
+
+        await lease.assertHeld()
+        await removeLockfile(ssh, ownershipId)
+      } else {
+        throw ownershipConflict(
+          'An existing SSH backend ownership record is malformed and cannot be proven stale.'
+        )
+      }
+    }
 
     if (lock) {
       const pidAlive = await remotePidAlive(ssh, lock.pid)
@@ -955,8 +1149,10 @@ async function connect(deps) {
         lock.profile === profile &&
         Boolean(reuseToken) &&
         lock.tokenFingerprint === fingerprintToken(reuseToken) &&
-        // launcherPath/hermesPath are metadata — do not require equality after
-        // exec wrappers. hermesHome still scopes the state store.
+        // The configured launcher is explicit runtime intent. It remains a
+        // metadata comparison (not a live argv invariant), so exec wrappers
+        // are still supported while a settings change forces replacement.
+        (lock.launcherPath || lock.hermesPath) === hermesPath &&
         lock.hermesHome === hermesHome
 
       if (reusable) {
@@ -979,7 +1175,7 @@ async function connect(deps) {
           if (reuseClassification === 'authenticated-stale') {
             assertNotAborted(signal)
             await cancelForwardSafe(deps, localPort, lock.port)
-            await cleanupStale(ssh, ownershipId, lock)
+            await cleanupStale(ssh, ownershipId, lock, true, lease)
           } else if (reuseClassification === 'authenticated-ok') {
             const token = await adoptOwnedServedToken(
               adoptServedToken,
@@ -1021,15 +1217,16 @@ async function connect(deps) {
         // Owned but not reusable (profile/token/port mismatch): terminate exact
         // identity, wait until gone, then spawn. Never overlap two owners.
         assertNotAborted(signal)
-        await cleanupStale(ssh, ownershipId, lock, pidAlive)
+        await cleanupStale(ssh, ownershipId, lock, pidAlive, lease)
       } else {
         // Dead pid: drop lock evidence and continue to spawn.
         assertNotAborted(signal)
-        await cleanupStale(ssh, ownershipId, lock, false)
+        await cleanupStale(ssh, ownershipId, lock, false, lease)
       }
     }
 
     assertNotAborted(signal)
+    await lease.assertHeld()
     const spawnToken = mintToken()
 
     const { pid, spawnNonce, logPath, tokenFilePath, pidStartTime, processFingerprint } =
@@ -1068,6 +1265,7 @@ async function connect(deps) {
       // lockless orphan — the next connect reaps it by exact ownership via this
       // record. Inside the try: if this write itself fails, the catch still
       // kills the just-spawned process via the in-memory record.
+      await lease.assertHeld()
       await writeLockfile(ssh, ownershipId, ownedSpawn)
       remotePort = await scrapeReadyPort(ssh, logPath, {
         timeoutMs: readyTimeoutMs,
@@ -1087,6 +1285,7 @@ async function connect(deps) {
 
       assertNotAborted(signal)
       const tokenFingerprint = fingerprintToken(token)
+      await lease.assertHeld()
       await writeLockfile(ssh, ownershipId, { ...ownedSpawn, port: remotePort, tokenFingerprint })
       assertNotAborted(signal)
 
@@ -1116,7 +1315,7 @@ async function connect(deps) {
         void 0
       }
 
-      await cleanupStale(ssh, ownershipId, ownedSpawn)
+      await cleanupStale(ssh, ownershipId, ownedSpawn, true, lease)
       throw error
     }
   })
@@ -1157,6 +1356,7 @@ export {
   spawnLogPath,
   spawnRemoteDashboard,
   SUPPORTED_REMOTE_OS,
+  terminateOwnedProcess,
   validateRemotePath,
   withOwnershipMutex,
   writeLockfile

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -387,25 +387,62 @@ async function readLockfile(ssh, ownershipId) {
   return envelope.state === 'valid' ? envelope.record : null
 }
 
-async function writeLockfile(ssh, ownershipId, lock) {
+async function writeLockfile(ssh, ownershipId, lock, lease: any = null) {
   const directory = ownershipDirectory(ownershipId)
   const lpath = lockfilePath(ownershipId)
   const temporaryPath = `${directory}/.${crypto.randomBytes(8).toString('hex')}.lock.tmp`
   const json = JSON.stringify({ ...lock, schemaVersion: LOCKFILE_SCHEMA_VERSION })
-  await ssh.exec(
-    `umask 077 && mkdir -p ${expandRemotePath(directory)} && ` +
-      `printf '%s' ${shq(json)} > ${expandRemotePath(temporaryPath)} && ` +
-      `mv -f ${expandRemotePath(temporaryPath)} ${expandRemotePath(lpath)}`
-  )
+
+  const body =
+    'import os\n' +
+    `d=os.path.expanduser(${shq(directory)})\n` +
+    `tmp=os.path.expanduser(${shq(temporaryPath)})\n` +
+    `dst=os.path.expanduser(${shq(lpath)})\n` +
+    `payload=${shq(json)}\n` +
+    'os.makedirs(d,mode=0o700,exist_ok=True)\n' +
+    'fd=os.open(tmp,os.O_WRONLY|os.O_CREAT|os.O_TRUNC,0o600)\n' +
+    'try:os.write(fd,payload.encode())\n' +
+    'finally:os.close(fd)\n' +
+    'os.replace(tmp,dst)\n' +
+    'print("WROTE")'
+
+  if (lease) {
+    const out = String(await lease.runHeld(body)).trim()
+
+    if (!out.endsWith('WROTE')) {
+      const error: any = new Error('Could not write the SSH backend ownership record under the lifecycle lease.')
+      error.kind = 'transient-transport-error'
+      throw error
+    }
+
+    return
+  }
+
+  await ssh.exec(`python3 -c ${shq(body)}`)
 }
 
-async function removeLockfile(ssh, ownershipId) {
+async function removeLockfile(ssh, ownershipId, lease: any = null) {
   const lpath = lockfilePath(ownershipId)
 
+  const body =
+    'import os\n' +
+    `p=os.path.expanduser(${shq(lpath)})\n` +
+    'try:os.unlink(p)\n' +
+    'except FileNotFoundError:pass\n' +
+    'print("REMOVED")'
+
   try {
-    await ssh.exec(`rm -f ${expandRemotePath(lpath)}`)
-  } catch {
-    // best effort
+    if (lease) {
+      await lease.runHeld(body)
+
+      return
+    }
+
+    await ssh.exec(`python3 -c ${shq(body)}`)
+  } catch (error) {
+    if (lease) {
+      throw error
+    }
   }
 }
 
@@ -565,52 +602,108 @@ async function pidIsOurDashboard(ssh, pid, spawnNonce, _hermesPath = '', lockExt
  * without pidfds fail closed rather than using a racy standalone `kill`.
  */
 async function terminateOwnedProcess(ssh, lock, lease: any = null) {
-  if (lease) {
-    await lease.assertHeld()
-  }
-
   const expectedStart = lock.pidStartTime == null ? 'None' : String(Number(lock.pidStartTime))
   const expectedFingerprint = String(lock.processFingerprint || '')
   const leasePath = lease?.path || ''
-  const leaseHolder = lease?.holder || ''
+  const leaseToken = lease?.token || lease?.holder || ''
 
   const script =
-    'import hashlib,os,signal,sys\n' +
+    'import hashlib,os,signal,sys,shlex,subprocess\n' +
+    'try:\n' +
+    ' import fcntl\n' +
+    'except ImportError:\n' +
+    ' fcntl=None\n' +
     `pid=${Number(lock.pid)}\n` +
     `nonce=${shq(lock.spawnNonce)}\n` +
     `expected_start=${expectedStart}\n` +
     `expected_fingerprint=${shq(expectedFingerprint)}\n` +
     `lease_path=${shq(leasePath)}\n` +
-    `lease_holder=${shq(leaseHolder)}\n` +
+    `lease_token=${shq(leaseToken)}\n` +
     'terminate_result="MISMATCH"\n' +
     'def finish(value):\n' +
     ' print(value); sys.exit(0)\n' +
-    'if lease_path:\n' +
+    'def fence_lease():\n' +
+    ' if not lease_path:\n' +
+    '  return None\n' +
+    ' p=os.path.expanduser(lease_path)\n' +
     ' try:\n' +
-    '  if open(os.path.expanduser(lease_path),"r",encoding="utf-8").read().strip()!=lease_holder:finish("LOST")\n' +
-    ' except OSError:finish("LOST")\n' +
-    'try:\n' +
-    ' pidfd=os.pidfd_open(pid)\n' +
-    'except ProcessLookupError:finish("GONE")\n' +
-    'except (AttributeError,NotImplementedError,OSError):finish("UNSAFE")\n' +
-    'try:\n' +
+    '  fd=os.open(p,os.O_RDWR)\n' +
+    ' except OSError:\n' +
+    '  finish("LOST")\n' +
     ' try:\n' +
-    '  raw=open(f"/proc/{pid}/cmdline","rb").read()\n' +
-    '  args=[x.decode("utf-8","surrogateescape") for x in raw.split(b"\\0") if x]\n' +
-    '  start=int(open(f"/proc/{pid}/stat","r",encoding="utf-8").read().split()[21])\n' +
-    ' except (OSError,ValueError,IndexError):finish("GONE")\n' +
+    '  if fcntl is not None:\n' +
+    '   fcntl.flock(fd,fcntl.LOCK_EX)\n' +
+    '  data=os.read(fd,4096).decode().strip()\n' +
+    '  if data!=lease_token:\n' +
+    '   finish("LOST")\n' +
+    '  try:os.utime(p,None)\n' +
+    '  except OSError:pass\n' +
+    '  return fd\n' +
+    ' except Exception:\n' +
+    '  try:os.close(fd)\n' +
+    '  except OSError:pass\n' +
+    '  raise\n' +
+    'def read_args(p):\n' +
+    ' try:\n' +
+    '  raw=open(f"/proc/{p}/cmdline","rb").read()\n' +
+    '  return [x.decode("utf-8","surrogateescape") for x in raw.split(b"\\0") if x], "proc"\n' +
+    ' except OSError:\n' +
+    '  line=subprocess.check_output(["ps","-o","command=","-p",str(p)],text=True).strip()\n' +
+    '  return shlex.split(line), "ps"\n' +
+    'def start_time(p):\n' +
+    ' try:\n' +
+    '  return int(open(f"/proc/{p}/stat","r",encoding="utf-8").read().split()[21]), "proc"\n' +
+    ' except Exception:\n' +
+    '  out=subprocess.check_output(["ps","-o","lstart=","-p",str(p)],text=True).strip()\n' +
+    '  return int(hashlib.sha256(out.encode()).hexdigest()[:15],16), "ps"\n' +
+    'def prove_identity():\n' +
+    ' try:\n' +
+    '  args, _src=read_args(pid)\n' +
+    ' except Exception:\n' +
+    '  try:os.kill(pid,0)\n' +
+    '  except ProcessLookupError:finish("GONE")\n' +
+    '  except PermissionError:finish("UNSAFE")\n' +
+    '  finish("UNSAFE")\n' +
+    ' try:\n' +
+    '  start,_=start_time(pid)\n' +
+    ' except Exception:\n' +
+    '  finish("GONE")\n' +
     ' fp=hashlib.sha256("\\0".join(args).encode("utf-8","surrogateescape")).hexdigest()[:32]\n' +
     ' try:\n' +
     '  serve=args.index("serve"); owner=args.index("--ssh-owner-nonce",serve+1)\n' +
     '  shape=("--isolated" in args[serve+1:]) and args[owner+1]==nonce\n' +
-    ' except (ValueError,IndexError):shape=False\n' +
+    ' except (ValueError,IndexError):\n' +
+    '  shape=False\n' +
     ' if not shape:finish("MISMATCH")\n' +
     ' if expected_start is not None and start!=expected_start:finish("MISMATCH")\n' +
     ' if expected_fingerprint and fp!=expected_fingerprint:finish("MISMATCH")\n' +
-    ' try:signal.pidfd_send_signal(pidfd,signal.SIGTERM)\n' +
-    ' except ProcessLookupError:finish("GONE")\n' +
-    ' finish("TERMINATED")\n' +
-    'finally:os.close(pidfd)'
+    ' return args,start,fp\n' +
+    'lease_fd=fence_lease()\n' +
+    'try:\n' +
+    ' try:\n' +
+    '  pidfd=os.pidfd_open(pid)\n' +
+    ' except ProcessLookupError:\n' +
+    '  finish("GONE")\n' +
+    ' except (AttributeError,NotImplementedError,OSError):\n' +
+    '  # Darwin / non-pidfd hosts: identity-stable best-effort terminate path.\n' +
+    '  prove_identity()\n' +
+    '  try:\n' +
+    '   os.kill(pid,signal.SIGTERM)\n' +
+    '  except ProcessLookupError:\n' +
+    '   finish("GONE")\n' +
+    '  finish("TERMINATED")\n' +
+    ' try:\n' +
+    '  prove_identity()\n' +
+    '  try:signal.pidfd_send_signal(pidfd,signal.SIGTERM)\n' +
+    '  except ProcessLookupError:finish("GONE")\n' +
+    '  finish("TERMINATED")\n' +
+    ' finally:\n' +
+    '  try:os.close(pidfd)\n' +
+    '  except Exception:pass\n' +
+    'finally:\n' +
+    ' if lease_fd is not None:\n' +
+    '  try:os.close(lease_fd)\n' +
+    '  except OSError:pass'
 
   try {
     return String(await ssh.exec(`python3 -c ${shq(script)}`)).trim()
@@ -672,22 +765,29 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true, lease: any 
     }
   }
 
-  if (lease) {
-    await lease.assertHeld()
-  }
-
   const expectedLogPath =
     lockWithOwner?.spawnNonce ? spawnLogPath(ownershipId, lockWithOwner.spawnNonce) : ''
 
   if (lockWithOwner?.logPath && lockWithOwner.logPath === expectedLogPath) {
+    const logBody =
+      'import os\n' +
+      `p=os.path.expanduser(${shq(lockWithOwner.logPath)})\n` +
+      'try:os.unlink(p)\n' +
+      'except FileNotFoundError:pass\n' +
+      'print("LOG_REMOVED")'
+
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(lockWithOwner.logPath)}`)
+      if (lease) {
+        await lease.runHeld(logBody)
+      } else {
+        await ssh.exec(`python3 -c ${shq(logBody)}`)
+      }
     } catch {
       void 0
     }
   }
 
-  await removeLockfile(ssh, ownershipId)
+  await removeLockfile(ssh, ownershipId, lease)
 }
 
 // Detach so the backend survives the SSH channel closing: setsid (Linux)
@@ -761,7 +861,44 @@ async function scrapeReadyPort(ssh, logPath, { timeoutMs = DEFAULT_READY_TIMEOUT
   throw err
 }
 
-async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownershipId }) {
+function indentPython(source, levels = 1) {
+  const pad = ' '.repeat(levels)
+
+  return String(source || '')
+    .split('\n')
+    .map(line => (line.length ? pad + line : line))
+    .join('\n')
+}
+
+/**
+ * Python preamble that opens the lifecycle mutex, takes an exclusive flock when
+ * available, and verifies the owner-epoch token before any mutation body runs.
+ * Leaves `lease_fd` open for the caller to close.
+ */
+function buildLeaseFenceOpen(lease) {
+  return (
+    'try:\n' +
+    ' import fcntl\n' +
+    'except ImportError:\n' +
+    ' fcntl=None\n' +
+    `p=os.path.expanduser(${shq(lease.path)})\n` +
+    `lease_token=${shq(lease.token)}\n` +
+    'try:\n' +
+    ' lease_fd=os.open(p,os.O_RDWR)\n' +
+    'except OSError:\n' +
+    ' print("LOST"); raise SystemExit(0)\n' +
+    'if fcntl is not None:\n' +
+    ' fcntl.flock(lease_fd,fcntl.LOCK_EX)\n' +
+    'data=os.read(lease_fd,4096).decode().strip()\n' +
+    'if data!=lease_token:\n' +
+    ' os.close(lease_fd)\n' +
+    ' print("LOST"); raise SystemExit(0)\n' +
+    'try:os.utime(p,None)\n' +
+    'except OSError:pass\n'
+  )
+}
+
+async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownershipId, lease = null }) {
   if (!(await remoteSupportsSshOwnership(ssh, hermesPath))) {
     const err: any = new Error(
       'The remote Hermes install does not support --ssh-session-token-file and --ssh-owner-nonce. ' +
@@ -807,29 +944,67 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
     ' finally:os.close(fd)\n' +
     'finally:os.close(dd)'
 
-  try {
-    await ssh.exec(`python3 -c ${shq(tokenUploadPy)}`, { stdinData: token })
-  } catch (error) {
+  const cleanupToken = async () => {
+    const body =
+      'import os\n' +
+      `p=os.path.expanduser(${shq(tokenFilePath)})\n` +
+      'try:os.unlink(p)\n' +
+      'except FileNotFoundError:pass\n' +
+      'print("TOKEN_REMOVED")'
+
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      if (lease) {
+        await lease.runHeld(body)
+      } else {
+        await ssh.exec(`python3 -c ${shq(body)}`)
+      }
     } catch {
       void 0
     }
+  }
 
+  try {
+    if (lease) {
+      // Token bytes still stream over stdin; fence the filesystem mutation only.
+      const fencedUpload =
+        'import os,sys\n' +
+        buildLeaseFenceOpen(lease) +
+        'try:\n' +
+        indentPython(tokenUploadPy, 1) +
+        '\n finally:\n' +
+        '  os.close(lease_fd)\n'
+
+      await ssh.exec(`python3 -c ${shq(fencedUpload)}`, { stdinData: token })
+    } else {
+      await ssh.exec(`python3 -c ${shq(tokenUploadPy)}`, { stdinData: token })
+    }
+  } catch (error) {
+    await cleanupToken()
     throw error
   }
 
   let out
 
   try {
-    out = await ssh.exec(buildSpawnCommand(hermesPath, profile, { spawnNonce, tokenFilePath, logPath }))
-  } catch (error) {
-    try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
-    } catch {
-      void 0
-    }
+    const spawnCmd = buildSpawnCommand(hermesPath, profile, { spawnNonce, tokenFilePath, logPath })
 
+    if (lease) {
+      const fencedSpawn =
+        'import os,subprocess,sys\n' +
+        buildLeaseFenceOpen(lease) +
+        'try:\n' +
+        ` cmd=${shq(spawnCmd)}\n` +
+        ' out=subprocess.check_output(cmd,shell=True,text=True,stderr=subprocess.STDOUT)\n' +
+        ' sys.stdout.write(out if out.endswith("\\n") else out+"\\n")\n' +
+        'finally:\n' +
+        ' os.close(lease_fd)\n'
+
+      out = await ssh.exec(`python3 -c ${shq(fencedSpawn)}`)
+    } else {
+      out = await ssh.exec(spawnCmd)
+    }
+  } catch (error) {
+    await cleanupToken()
     throw error
   }
 
@@ -842,11 +1017,7 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
   )
 
   if (!Number.isInteger(pid) || pid <= 0) {
-    try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
-    } catch {
-      void 0
-    }
+    await cleanupToken()
 
     const err: any = new Error('Failed to launch the remote dashboard (no pid returned).')
     err.kind = 'spawn-failed'
@@ -923,44 +1094,71 @@ async function openForward(deps, remotePort, attempts = 3) {
 
 /**
  * Cross-process remote mutex for the full read→classify→cleanup/reuse/spawn→write
- * transaction. Held through the final ready lock write. A heartbeat prevents
- * age-based recovery from stealing a live lease, and every mutation phase is
- * fenced by the unguessable holder token.
+ * transaction. Held through the final ready lock write.
+ *
+ * Owner-epoch protocol:
+ *   - lease payload is `${holder}:${epoch}` (unguessable holder + unique epoch)
+ *   - stale takeover reclaims in-place under flock (no stat-then-unlink race)
+ *   - heartbeat refreshes mtime only while flock-holding the matching token
+ *   - every spawn/write/remove mutation validates the token inside the same
+ *     remote helper that performs the filesystem/process mutation
  */
 async function withOwnershipMutex(ssh, ownershipId, fn, options: any = {}) {
   const directory = ownershipDirectory(ownershipId)
   const mutexPath = ownershipMutexPath(ownershipId)
   const holder = `${process.pid}-${crypto.randomBytes(4).toString('hex')}`
+  const epoch = `${Date.now().toString(16)}-${crypto.randomBytes(4).toString('hex')}`
+  const token = `${holder}:${epoch}`
   const heartbeatMs = options.heartbeatMs ?? OWNERSHIP_MUTEX_HEARTBEAT_MS
 
   const script =
     'import os,sys,time\n' +
+    'try:\n' +
+    ' import fcntl\n' +
+    'except ImportError:\n' +
+    ' fcntl=None\n' +
     `d=os.path.expanduser(${shq(directory)})\n` +
     `p=os.path.expanduser(${shq(mutexPath)})\n` +
-    `holder=${shq(holder)}\n` +
+    `token=${shq(token)}\n` +
     `stale_ms=${OWNERSHIP_MUTEX_STALE_MS}\n` +
     'os.makedirs(d,mode=0o700,exist_ok=True)\n' +
     'deadline=time.time()+30\n' +
     'while time.time()<deadline:\n' +
     ' try:\n' +
-    '  fd=os.open(p,os.O_CREAT|os.O_EXCL|os.O_WRONLY,0o600)\n' +
-    '  try:os.write(fd,holder.encode())\n' +
-    '  finally:os.close(fd)\n' +
+    '  fd=os.open(p,os.O_CREAT|os.O_EXCL|os.O_RDWR,0o600)\n' +
+    '  try:\n' +
+    '   os.write(fd,token.encode()); os.fsync(fd)\n' +
+    '  finally:\n' +
+    '   os.close(fd)\n' +
     '  print("ACQUIRED"); sys.exit(0)\n' +
     ' except FileExistsError:\n' +
     '  try:\n' +
-    '   age=(time.time()-os.stat(p).st_mtime)*1000\n' +
-    '   if age>stale_ms:\n' +
-    '    os.unlink(p)\n' +
-    '    continue\n' +
+    '   fd=os.open(p,os.O_RDWR)\n' +
+    '  except FileNotFoundError:\n' +
+    '   continue\n' +
     '  except OSError:\n' +
-    '   pass\n' +
+    '   time.sleep(0.05); continue\n' +
+    '  try:\n' +
+    '   if fcntl is not None:\n' +
+    '    fcntl.flock(fd,fcntl.LOCK_EX)\n' +
+    '   st=os.fstat(fd)\n' +
+    '   age=(time.time()-st.st_mtime)*1000\n' +
+    '   # Owner-epoch reclaim: rewrite the same inode under flock. Never\n' +
+    '   # pathname-unlink a lease we have not proven stale while holding it.\n' +
+    '   if age>stale_ms:\n' +
+    '    os.lseek(fd,0); os.ftruncate(fd,0)\n' +
+    '    os.write(fd,token.encode()); os.fsync(fd)\n' +
+    '    try:os.utime(p,None)\n' +
+    '    except OSError:pass\n' +
+    '    print("ACQUIRED"); sys.exit(0)\n' +
+    '  finally:\n' +
+    '   os.close(fd)\n' +
     '  time.sleep(0.05)\n' +
     'print("TIMEOUT"); sys.exit(2)'
 
   const acquireOut = String(await ssh.exec(`python3 -c ${shq(script)}`)).trim()
 
-  if (!acquireOut.endsWith('ACQUIRED')) {
+  if (!(acquireOut === 'ACQUIRED' || acquireOut.endsWith('\nACQUIRED') || acquireOut.endsWith('ACQUIRED'))) {
     const error: any = new Error('Could not acquire the SSH backend ownership mutex.')
     error.kind = 'transient-transport-error'
     throw error
@@ -969,21 +1167,78 @@ async function withOwnershipMutex(ssh, ownershipId, fn, options: any = {}) {
   let lostError: any = null
   let heartbeatChain = Promise.resolve()
 
+  const markLost = error => {
+    lostError = error
+
+    return error
+  }
+
+  const runHeld = async bodyPython => {
+    if (lostError) {
+      throw lostError
+    }
+
+    const scriptBody =
+      'import os,sys\n' +
+      buildLeaseFenceOpen({ path: mutexPath, token }) +
+      'try:\n' +
+      indentPython(bodyPython, 1) +
+      '\nfinally:\n' +
+      ' os.close(lease_fd)\n'
+
+    let out
+
+    try {
+      out = String(await ssh.exec(`python3 -c ${shq(scriptBody)}`))
+    } catch (cause) {
+      const error: any = new Error('Could not run a lease-fenced SSH lifecycle mutation.')
+      error.kind = 'transient-transport-error'
+      error.cause = cause
+      throw markLost(error)
+    }
+
+    const lines = out.trim().split('\n').map(line => line.trim()).filter(Boolean)
+
+    if (lines[0] === 'LOST') {
+      throw markLost(
+        ownershipConflict(
+          'SSH backend ownership mutex was lost; refusing further lifecycle mutations.'
+        )
+      )
+    }
+
+    return out
+  }
+
   const assertHeld = async () => {
     if (lostError) {
       throw lostError
     }
 
     const verifyScript =
-      'import os\n' +
-      `p=os.path.expanduser(${shq(mutexPath)})\n` +
-      `holder=${shq(holder)}\n` +
+      'import os,sys\n' +
       'try:\n' +
-      ' data=open(p,"r",encoding="utf-8").read().strip()\n' +
-      ' if data==holder:\n' +
-      '  os.utime(p,None); print("HELD")\n' +
-      ' else:print("LOST")\n' +
-      'except OSError:print("LOST")'
+      ' import fcntl\n' +
+      'except ImportError:\n' +
+      ' fcntl=None\n' +
+      `p=os.path.expanduser(${shq(mutexPath)})\n` +
+      `token=${shq(token)}\n` +
+      'OWNER_EPOCH_HEARTBEAT=1\n' +
+      'try:\n' +
+      ' fd=os.open(p,os.O_RDWR)\n' +
+      'except OSError:\n' +
+      ' print("LOST"); sys.exit(0)\n' +
+      'try:\n' +
+      ' if fcntl is not None:\n' +
+      '  fcntl.flock(fd,fcntl.LOCK_EX)\n' +
+      ' data=os.read(fd,4096).decode().strip()\n' +
+      ' if data!=token:\n' +
+      '  print("LOST"); sys.exit(0)\n' +
+      ' try:os.utime(p,None)\n' +
+      ' except OSError:pass\n' +
+      ' print("HELD")\n' +
+      'finally:\n' +
+      ' os.close(fd)'
 
     let out
 
@@ -993,15 +1248,15 @@ async function withOwnershipMutex(ssh, ownershipId, fn, options: any = {}) {
       const error: any = new Error('Could not heartbeat the SSH backend ownership mutex.')
       error.kind = 'transient-transport-error'
       error.cause = cause
-      lostError = error
-      throw error
+      throw markLost(error)
     }
 
     if (!out.endsWith('HELD')) {
-      lostError = ownershipConflict(
-        'SSH backend ownership mutex was lost; refusing further lifecycle mutations.'
+      throw markLost(
+        ownershipConflict(
+          'SSH backend ownership mutex was lost; refusing further lifecycle mutations.'
+        )
       )
-      throw lostError
     }
   }
 
@@ -1016,8 +1271,17 @@ async function withOwnershipMutex(ssh, ownershipId, fn, options: any = {}) {
   const heartbeatTimer = setInterval(heartbeat, heartbeatMs)
   heartbeatTimer.unref?.()
 
+  const lease = {
+    holder,
+    epoch,
+    token,
+    path: mutexPath,
+    assertHeld,
+    runHeld
+  }
+
   try {
-    const result = await fn({ holder, path: mutexPath, assertHeld })
+    const result = await fn(lease)
     clearInterval(heartbeatTimer)
     await heartbeatChain
 
@@ -1034,12 +1298,31 @@ async function withOwnershipMutex(ssh, ownershipId, fn, options: any = {}) {
       await ssh.exec(
         `python3 -c ${shq(
           'import os\n' +
-            `p=os.path.expanduser(${shq(mutexPath)})\n` +
-            `holder=${shq(holder)}\n` +
             'try:\n' +
-            ' data=open(p,"r",encoding="utf-8").read().strip()\n' +
-            ' if data==holder:os.unlink(p)\n' +
-            'except OSError:pass'
+            ' import fcntl\n' +
+            'except ImportError:\n' +
+            ' fcntl=None\n' +
+            `p=os.path.expanduser(${shq(mutexPath)})\n` +
+            `token=${shq(token)}\n` +
+            'OWNER_EPOCH_RELEASE=1\n' +
+            'try:\n' +
+            ' fd=os.open(p,os.O_RDWR)\n' +
+            'except OSError:\n' +
+            ' pass\n' +
+            'else:\n' +
+            ' try:\n' +
+            '  if fcntl is not None:\n' +
+            '   fcntl.flock(fd,fcntl.LOCK_EX)\n' +
+            '  data=os.read(fd,4096).decode().strip()\n' +
+            '  if data==token:\n' +
+            '   os.close(fd)\n' +
+            '   try:os.unlink(p)\n' +
+            '   except OSError:pass\n' +
+            '  else:\n' +
+            '   os.close(fd)\n' +
+            ' except Exception:\n' +
+            '  try:os.close(fd)\n' +
+            '  except OSError:pass'
         )}`
       )
     } catch {
@@ -1117,8 +1400,7 @@ async function connect(deps) {
           )
         }
 
-        await lease.assertHeld()
-        await removeLockfile(ssh, ownershipId)
+        await removeLockfile(ssh, ownershipId, lease)
       } else {
         throw ownershipConflict(
           'An existing SSH backend ownership record is malformed and cannot be proven stale.'
@@ -1226,7 +1508,6 @@ async function connect(deps) {
     }
 
     assertNotAborted(signal)
-    await lease.assertHeld()
     const spawnToken = mintToken()
 
     const { pid, spawnNonce, logPath, tokenFilePath, pidStartTime, processFingerprint } =
@@ -1234,7 +1515,8 @@ async function connect(deps) {
         hermesPath,
         profile,
         token: spawnToken,
-        ownershipId
+        ownershipId,
+        lease
       })
 
     log(`spawned remote dashboard pid=${pid}`)
@@ -1265,8 +1547,7 @@ async function connect(deps) {
       // lockless orphan — the next connect reaps it by exact ownership via this
       // record. Inside the try: if this write itself fails, the catch still
       // kills the just-spawned process via the in-memory record.
-      await lease.assertHeld()
-      await writeLockfile(ssh, ownershipId, ownedSpawn)
+      await writeLockfile(ssh, ownershipId, ownedSpawn, lease)
       remotePort = await scrapeReadyPort(ssh, logPath, {
         timeoutMs: readyTimeoutMs,
         isAlive: () => remotePidAlive(ssh, pid),
@@ -1285,8 +1566,7 @@ async function connect(deps) {
 
       assertNotAborted(signal)
       const tokenFingerprint = fingerprintToken(token)
-      await lease.assertHeld()
-      await writeLockfile(ssh, ownershipId, { ...ownedSpawn, port: remotePort, tokenFingerprint })
+      await writeLockfile(ssh, ownershipId, { ...ownedSpawn, port: remotePort, tokenFingerprint }, lease)
       assertNotAborted(signal)
 
       return {
@@ -1310,7 +1590,13 @@ async function connect(deps) {
       }
 
       try {
-        await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+        await lease.runHeld(
+          'import os\n' +
+            `p=os.path.expanduser(${shq(tokenFilePath)})\n` +
+            'try:os.unlink(p)\n' +
+            'except FileNotFoundError:pass\n' +
+            'print("TOKEN_REMOVED")'
+        )
       } catch {
         void 0
       }

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -1154,9 +1154,11 @@ async function withOwnershipMutex(ssh, ownershipId, fn, options: any = {}) {
     '    fcntl.flock(fd,fcntl.LOCK_EX)\n' +
     '   st=os.fstat(fd)\n' +
     '   age=(time.time()-st.st_mtime)*1000\n' +
+    '   os.lseek(fd,0,os.SEEK_SET)\n' +
+    '   previous=os.read(fd,4096).decode().strip()\n' +
     '   # Owner-epoch reclaim: rewrite the same inode under flock. Never\n' +
     '   # pathname-unlink a lease we have not proven stale while holding it.\n' +
-    '   if age>stale_ms:\n' +
+    '   if previous=="RELEASED" or age>stale_ms:\n' +
     '    os.lseek(fd,0,os.SEEK_SET); os.ftruncate(fd,0)\n' +
     '    os.write(fd,token.encode()); os.fsync(fd)\n' +
     '    try:os.utime(p,None)\n' +
@@ -1326,11 +1328,14 @@ async function withOwnershipMutex(ssh, ownershipId, fn, options: any = {}) {
             '   fcntl.flock(fd,fcntl.LOCK_EX)\n' +
             '  data=os.read(fd,4096).decode().strip()\n' +
             '  if data==token:\n' +
-            '   os.close(fd)\n' +
-            '   try:os.unlink(p)\n' +
+            '   # Publish a reclaimable epoch on the same inode. Unlinking after\n' +
+            '   # unlock lets a queued waiter rewrite the old inode while a third\n' +
+            '   # owner creates the pathname, producing two concurrent owners.\n' +
+            '   os.lseek(fd,0,os.SEEK_SET); os.ftruncate(fd,0)\n' +
+            '   os.write(fd,b"RELEASED"); os.fsync(fd)\n' +
+            '   try:os.utime(p,(0,0))\n' +
             '   except OSError:pass\n' +
-            '  else:\n' +
-            '   os.close(fd)\n' +
+            '  os.close(fd)\n' +
             ' except Exception:\n' +
             '  try:os.close(fd)\n' +
             '  except OSError:pass'

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -11,23 +11,24 @@
  *   - reuse an existing desktop-dedicated dashboard via a lockfile + an
  *     AUTHENTICATED /api/status probe (pid liveness alone is insufficient),
  *   - spawn a fresh detached `--isolated --port 0` dashboard and scrape its
- *     `HERMES_DASHBOARD_READY port=<n>` readiness line,
+ *     readiness line,
  *   - adopt the token the dashboard actually serves (served-token adoption),
- *   - clean up a stale dashboard only when it is provably ours.
+ *   - clean up a stale dashboard only when it is provably ours,
+ *   - fail closed on alive indeterminate/foreign locks (no delete/signal/spawn),
+ *   - serialize the full remote lifecycle transaction with a per-ownership mutex.
+ *
+ * Lock schema v3 persists spawn-observed process identity (pid, kernel start
+ * time, argv fingerprint). The launcher path is metadata only after exec
+ * wrappers — ownership never requires argv[0]/argv[1] to equal the launcher.
  *
  * No `import 'electron'` so it's unit-testable with `node --test`. main.ts wires
  * the real SshConnection, fetch, adoptServedDashboardToken, and waitForHermes in.
- *
- * The minted HERMES_DASHBOARD_SESSION_TOKEN is the SPAWN credential. After
- * readiness the caller runs served-token adoption against the tunneled baseUrl
- * and the SERVED token's fingerprint is what lands in the lockfile — so the
- * reuse probe checks the credential that actually authenticates /api/ws, not
- * the minted one (which the dashboard may regen).
  */
 
 import crypto from 'node:crypto'
 
-const LOCKFILE_SCHEMA_VERSION = 2
+const LOCKFILE_SCHEMA_VERSION = 3
+const SUPPORTED_LOCK_SCHEMA_VERSIONS = new Set([2, 3])
 // Bumped when the desktop<->dashboard reuse contract changes in a way that makes
 // an old running dashboard unsafe to reattach to (token handling, readiness/spawn
 // args, served-token reconciliation). A mismatch forces a clean respawn.
@@ -42,6 +43,7 @@ const READY_POLL_INTERVAL_MS = 750
 // while serving several profiles/tools, so raise only the child process limit.
 // Keep startup portable: restricted hosts retain their existing limit.
 const REMOTE_NOFILE_SOFT_LIMIT = 65_536
+const OWNERSHIP_MUTEX_STALE_MS = 120_000
 
 function mintToken() {
   return crypto.randomBytes(32).toString('hex')
@@ -85,6 +87,10 @@ function lockfilePath(ownershipId) {
   return `${ownershipDirectory(ownershipId)}/backend.lock.json`
 }
 
+function ownershipMutexPath(ownershipId) {
+  return `${ownershipDirectory(ownershipId)}/lifecycle.mutex`
+}
+
 function spawnLogPath(ownershipId, spawnNonce) {
   return `${ownershipDirectory(ownershipId)}/${validateSpawnNonce(spawnNonce)}.log`
 }
@@ -125,6 +131,12 @@ function expandRemotePath(p) {
   }
 
   return shq(p)
+}
+
+function ownershipConflict(message) {
+  const error: any = new Error(message || 'SSH backend ownership conflict.')
+  error.kind = 'ownership-conflict'
+  return error
 }
 
 // Resolve the remote hermes executable. An EXPLICIT path is honored strictly
@@ -254,34 +266,8 @@ async function probeRemoteHermesHome(ssh) {
   }
 }
 
-async function readLockfile(ssh, ownershipId) {
-  const lpath = lockfilePath(ownershipId)
-  let raw
-
-  try {
-    raw = await ssh.exec(`if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`)
-  } catch (cause) {
-    const error: any = new Error('Could not read the SSH backend ownership record.')
-    error.kind = 'transient-transport-error'
-    error.cause = cause
-    throw error
-  }
-
-  const text = String(raw || '').trim()
-
-  if (!text) {
-    return null
-  }
-
-  let parsed
-
-  try {
-    parsed = JSON.parse(text)
-  } catch {
-    return null
-  }
-
-  if (!parsed || parsed.schemaVersion !== LOCKFILE_SCHEMA_VERSION) {
+function normalizeLockRecord(parsed, ownershipId) {
+  if (!parsed || !SUPPORTED_LOCK_SCHEMA_VERSIONS.has(parsed.schemaVersion)) {
     return null
   }
 
@@ -320,7 +306,58 @@ async function readLockfile(ssh, ownershipId) {
     }
   }
 
+  // launcherPath is optional metadata (v3); fall back to hermesPath.
+  if (parsed.launcherPath != null) {
+    if (typeof parsed.launcherPath !== 'string' || parsed.launcherPath.length > 1024) {
+      return null
+    }
+  } else {
+    parsed.launcherPath = parsed.hermesPath
+  }
+
+  if (parsed.pidStartTime != null) {
+    if (!Number.isInteger(parsed.pidStartTime) || parsed.pidStartTime < 0) {
+      return null
+    }
+  }
+
+  if (parsed.processFingerprint != null) {
+    if (typeof parsed.processFingerprint !== 'string' || !/^[0-9a-f]{16,128}$/.test(parsed.processFingerprint)) {
+      return null
+    }
+  }
+
   return parsed
+}
+
+async function readLockfile(ssh, ownershipId) {
+  const lpath = lockfilePath(ownershipId)
+  let raw
+
+  try {
+    raw = await ssh.exec(`if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`)
+  } catch (cause) {
+    const error: any = new Error('Could not read the SSH backend ownership record.')
+    error.kind = 'transient-transport-error'
+    error.cause = cause
+    throw error
+  }
+
+  const text = String(raw || '').trim()
+
+  if (!text) {
+    return null
+  }
+
+  let parsed
+
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return null
+  }
+
+  return normalizeLockRecord(parsed, ownershipId)
 }
 
 async function writeLockfile(ssh, ownershipId, lock) {
@@ -362,72 +399,180 @@ async function remotePidAlive(ssh, pid) {
   }
 }
 
-// A pid is "provably ours" only if its remote cmdline carries our dashboard
-// args — never kill a pid we can't positively identify as our dashboard.
-async function pidIsOurDashboard(ssh, pid, spawnNonce, hermesPath = '') {
-  if (!pid || !/^[0-9a-f]{16}$/.test(String(spawnNonce || '')) || !hermesPath) {
-    return false
+/**
+ * Observe the live process identity for a remote PID.
+ * Returns { startTime, fingerprint, ownedShape } or null when the PID is gone.
+ * Transport failures raise transient-transport-error.
+ */
+async function observeProcessIdentity(ssh, pid, spawnNonce) {
+  if (!pid || !/^[0-9a-f]{16}$/.test(String(spawnNonce || ''))) {
+    return null
   }
 
   try {
     const script =
-      'import os,shlex,subprocess,sys\n' +
+      'import hashlib,os,shlex,subprocess,sys\n' +
       `pid=${Number(pid)}\n` +
-      `expected=os.path.expanduser(${shq(hermesPath)})\n` +
       `nonce=${shq(spawnNonce)}\n` +
+      'def read_args(p):\n' +
+      ' try:\n' +
+      '  raw=open(f"/proc/{p}/cmdline","rb").read()\n' +
+      '  return [x.decode("utf-8","surrogateescape") for x in raw.split(b"\\0") if x]\n' +
+      ' except OSError:\n' +
+      '  line=subprocess.check_output(["ps","-o","command=","-p",str(p)],text=True).strip()\n' +
+      '  return shlex.split(line)\n' +
+      'def start_time(p):\n' +
+      ' try:\n' +
+      '  return int(open(f"/proc/{p}/stat","r",encoding="utf-8").read().split()[21])\n' +
+      ' except Exception:\n' +
+      '  try:\n' +
+      '   out=subprocess.check_output(["ps","-o","lstart=","-p",str(p)],text=True).strip()\n' +
+      '   return int(hashlib.sha256(out.encode()).hexdigest()[:15],16)\n' +
+      '  except Exception:\n' +
+      '   return None\n' +
       'try:\n' +
-      ' raw=open(f"/proc/{pid}/cmdline","rb").read()\n' +
-      ' args=[x.decode("utf-8","surrogateescape") for x in raw.split(b"\\0") if x]\n' +
-      'except OSError:\n' +
-      ' line=subprocess.check_output(["ps","-o","command=","-p",str(pid)],text=True).strip()\n' +
-      ' args=shlex.split(line)\n' +
+      ' args=read_args(pid)\n' +
+      'except Exception:\n' +
+      ' print("GONE"); sys.exit(0)\n' +
+      'st=start_time(pid)\n' +
+      'fp=hashlib.sha256("\\0".join(args).encode("utf-8","surrogateescape")).hexdigest()[:32]\n' +
       'ok=False\n' +
       'try:\n' +
       ' serve=args.index("serve")\n' +
       ' owner=args.index("--ssh-owner-nonce",serve+1)\n' +
-      ' direct=args[0]==expected\n' +
-      ' python_entry=len(args)>1 and args[1]==expected and os.path.basename(args[0]).startswith("python")\n' +
-      ' ok=(direct or python_entry) and "--isolated" in args[serve+1:] and args[owner+1]==nonce\n' +
-      'except (ValueError,IndexError):pass\n' +
-      'print("OWNED" if ok else "FOREIGN")'
+      ' ok=("--isolated" in args[serve+1:]) and args[owner+1]==nonce\n' +
+      'except (ValueError,IndexError):\n' +
+      ' ok=False\n' +
+      'print("OK" if ok else "SHAPE")\n' +
+      'print(st if st is not None else "")\n' +
+      'print(fp)\n' +
+      'print("\\0".join(args))'
 
-    const out = await ssh.exec(`python3 -c ${shq(script)}`)
+    const out = String(await ssh.exec(`python3 -c ${shq(script)}`)).trim()
+    const lines = out.split('\n')
+    const status = (lines[0] || '').trim()
 
-    return String(out || '').trim() === 'OWNED'
+    if (status === 'GONE' || !status) {
+      return null
+    }
+
+    const startRaw = (lines[1] || '').trim()
+    const fingerprint = (lines[2] || '').trim()
+    const startTime = startRaw === '' ? null : Number(startRaw)
+
+    return {
+      startTime: Number.isInteger(startTime) ? startTime : null,
+      fingerprint: /^[0-9a-f]{16,128}$/.test(fingerprint) ? fingerprint : '',
+      ownedShape: status === 'OK'
+    }
   } catch (cause) {
-    const error: any = new Error('Could not verify SSH backend process ownership.')
+    const error: any = new Error('Could not observe SSH backend process identity.')
     error.kind = 'transient-transport-error'
     error.cause = cause
     throw error
   }
 }
 
-// Kill the stale dashboard ONLY if provably ours, then drop the lockfile.
-async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
-  if (pidAlive && lock && (await pidIsOurDashboard(ssh, lock.pid, lock.spawnNonce, lock.hermesPath))) {
-    try {
-      const result = (
-        await ssh.exec(
-          `kill ${Number(lock.pid)} && ` +
-            `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
-            `i=$((i+1)); [ "$i" -ge 50 ] && exit 1; sleep 0.1; done`
-        )
-      ).trim()
+/**
+ * A pid is "provably ours" only when the live process carries the exact serve
+ * ownership shape and matches any spawn-observed identity recorded in the lock.
+ * The launcher path is metadata after exec wrappers — never an ownership
+ * invariant.
+ *
+ * Returns:
+ *   'owned'          — positively identified as our dashboard
+ *   'foreign'        — positively identified as not ours / PID reuse
+ *   'indeterminate'  — cannot prove either way (should fail closed if alive)
+ */
+async function classifyProcessOwnership(ssh, lock) {
+  if (!lock || !lock.pid || !/^[0-9a-f]{16}$/.test(String(lock.spawnNonce || ''))) {
+    return 'indeterminate'
+  }
 
-      void result
-    } catch (cause) {
-      const error: any = new Error('Could not terminate the stale SSH backend.')
-      error.kind = 'transient-transport-error'
-      error.cause = cause
-      throw error
+  const observed = await observeProcessIdentity(ssh, lock.pid, lock.spawnNonce)
+
+  if (!observed) {
+    return 'foreign'
+  }
+
+  if (!observed.ownedShape) {
+    return 'foreign'
+  }
+
+  if (lock.pidStartTime != null && observed.startTime != null && lock.pidStartTime !== observed.startTime) {
+    // Same PID number, different start time => PID reuse. Never signal it.
+    return 'foreign'
+  }
+
+  if (
+    lock.processFingerprint &&
+    observed.fingerprint &&
+    lock.processFingerprint !== observed.fingerprint
+  ) {
+    return 'foreign'
+  }
+
+  return 'owned'
+}
+
+// Back-compat predicate used by tests and callers that want a boolean.
+async function pidIsOurDashboard(ssh, pid, spawnNonce, _hermesPath = '', lockExtras: any = {}) {
+  const classification = await classifyProcessOwnership(ssh, {
+    pid,
+    spawnNonce,
+    pidStartTime: lockExtras.pidStartTime,
+    processFingerprint: lockExtras.processFingerprint
+  })
+
+  return classification === 'owned'
+}
+
+// Kill the stale dashboard ONLY if provably ours, then drop the lockfile.
+// Alive indeterminate/foreign locks are a hard ownership-conflict: preserve
+// lock/log, do not signal, do not spawn.
+async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
+  const lockWithOwner = lock ? { ...lock, ownershipId: lock.ownershipId || ownershipId } : lock
+
+  if (pidAlive && lockWithOwner) {
+    const classification = await classifyProcessOwnership(ssh, lockWithOwner)
+
+    if (classification === 'owned') {
+      try {
+        const result = (
+          await ssh.exec(
+            `kill ${Number(lockWithOwner.pid)} && ` +
+              `i=0; while kill -0 ${Number(lockWithOwner.pid)} 2>/dev/null; do ` +
+              `i=$((i+1)); [ "$i" -ge 50 ] && exit 1; sleep 0.1; done`
+          )
+        ).trim()
+
+        void result
+      } catch (cause) {
+        const error: any = new Error('Could not terminate the stale SSH backend.')
+        error.kind = 'transient-transport-error'
+        error.cause = cause
+        throw error
+      }
+
+      // Confirm exit before dropping evidence.
+      if (await remotePidAlive(ssh, lockWithOwner.pid)) {
+        throw ownershipConflict(
+          'Owned SSH backend did not exit after terminate; preserving lock evidence.'
+        )
+      }
+    } else if (classification === 'foreign' || classification === 'indeterminate') {
+      throw ownershipConflict(
+        'Alive SSH backend lock is not provably owned; refusing to delete lock/log or spawn a replacement.'
+      )
     }
   }
 
-  const expectedLogPath = lock?.spawnNonce ? spawnLogPath(ownershipId, lock.spawnNonce) : ''
+  const expectedLogPath =
+    lockWithOwner?.spawnNonce ? spawnLogPath(ownershipId, lockWithOwner.spawnNonce) : ''
 
-  if (lock?.logPath === expectedLogPath) {
+  if (lockWithOwner?.logPath && lockWithOwner.logPath === expectedLogPath) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(lock.logPath)}`)
+      await ssh.exec(`rm -f ${expandRemotePath(lockWithOwner.logPath)}`)
     } catch {
       void 0
     }
@@ -599,7 +744,24 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
     throw err
   }
 
-  return { pid, spawnNonce, logPath, tokenFilePath }
+  // Capture spawn-observed identity immediately after spawn. Launcher path is
+  // metadata only; ownership uses this observed identity + nonce.
+  let pidStartTime = null
+  let processFingerprint = ''
+
+  try {
+    const observed = await observeProcessIdentity(ssh, pid, spawnNonce)
+
+    if (observed) {
+      pidStartTime = observed.startTime
+      processFingerprint = observed.fingerprint || ''
+    }
+  } catch {
+    // Observation failure is non-fatal at spawn; later classification may still
+    // prove ownership via live serve --isolated --ssh-owner-nonce shape.
+  }
+
+  return { pid, spawnNonce, logPath, tokenFilePath, pidStartTime, processFingerprint }
 }
 
 // Best-effort forward teardown when a reuse attempt fails mid-flight, so we
@@ -648,6 +810,69 @@ async function openForward(deps, remotePort, attempts = 3) {
   }
 
   throw lastError
+}
+
+/**
+ * Cross-process remote mutex for the full read→classify→cleanup/reuse/spawn→write
+ * transaction. Held through the final ready lock write. Bounded stale recovery
+ * uses PID/start identity of the mutex holder when available.
+ */
+async function withOwnershipMutex(ssh, ownershipId, fn) {
+  const directory = ownershipDirectory(ownershipId)
+  const mutexPath = ownershipMutexPath(ownershipId)
+  const holder = `${process.pid}-${crypto.randomBytes(4).toString('hex')}`
+  const script =
+    'import os,sys,time\n' +
+    `d=os.path.expanduser(${shq(directory)})\n` +
+    `p=os.path.expanduser(${shq(mutexPath)})\n` +
+    `holder=${shq(holder)}\n` +
+    `stale_ms=${OWNERSHIP_MUTEX_STALE_MS}\n` +
+    'os.makedirs(d,mode=0o700,exist_ok=True)\n' +
+    'deadline=time.time()+30\n' +
+    'while time.time()<deadline:\n' +
+    ' try:\n' +
+    '  fd=os.open(p,os.O_CREAT|os.O_EXCL|os.O_WRONLY,0o600)\n' +
+    '  try:os.write(fd,holder.encode())\n' +
+    '  finally:os.close(fd)\n' +
+    '  print("ACQUIRED"); sys.exit(0)\n' +
+    ' except FileExistsError:\n' +
+    '  try:\n' +
+    '   age=(time.time()-os.stat(p).st_mtime)*1000\n' +
+    '   if age>stale_ms:\n' +
+    '    os.unlink(p)\n' +
+    '    continue\n' +
+    '  except OSError:\n' +
+    '   pass\n' +
+    '  time.sleep(0.05)\n' +
+    'print("TIMEOUT"); sys.exit(2)'
+
+  const acquireOut = String(await ssh.exec(`python3 -c ${shq(script)}`)).trim()
+
+  if (!acquireOut.endsWith('ACQUIRED')) {
+    const error: any = new Error('Could not acquire the SSH backend ownership mutex.')
+    error.kind = 'transient-transport-error'
+    throw error
+  }
+
+  try {
+    return await fn()
+  } finally {
+    try {
+      await ssh.exec(
+        `python3 -c ${shq(
+          'import os\n' +
+            `p=os.path.expanduser(${shq(mutexPath)})\n` +
+            `holder=${shq(holder)}\n` +
+            'try:\n' +
+            ' data=open(p,"r",encoding="utf-8").read().strip()\n' +
+            ' if data==holder:os.unlink(p)\n' +
+            'except OSError:pass'
+        )}`
+      )
+    } catch {
+      void 0
+    }
+  }
 }
 
 /**
@@ -702,177 +927,205 @@ async function connect(deps) {
 
   const reuseToken = deps.reuseToken || ''
   const hermesHome = await probeRemoteHermesHome(ssh)
-  const lock = await readLockfile(ssh, ownershipId)
 
-  if (lock) {
-    const pidAlive = await remotePidAlive(ssh, lock.pid)
-    const owned = pidAlive && (await pidIsOurDashboard(ssh, lock.pid, lock.spawnNonce, lock.hermesPath))
+  return withOwnershipMutex(ssh, ownershipId, async () => {
+    assertNotAborted(signal)
+    const lock = await readLockfile(ssh, ownershipId)
 
-    const reusable =
-      pidAlive &&
-      owned &&
-      lock.port > 0 &&
-      lock.profile === profile &&
-      Boolean(reuseToken) &&
-      lock.tokenFingerprint === fingerprintToken(reuseToken) &&
-      lock.hermesPath === hermesPath &&
-      lock.hermesHome === hermesHome
+    if (lock) {
+      const pidAlive = await remotePidAlive(ssh, lock.pid)
+      let classification = 'foreign'
 
-    if (reusable) {
-      assertNotAborted(signal)
-      const localPort = await openForward(deps, lock.port)
+      if (pidAlive) {
+        classification = await classifyProcessOwnership(ssh, { ...lock, ownershipId })
+      }
 
-      try {
-        const baseUrl = `http://127.0.0.1:${localPort}`
-        let reuseClassification
+      const owned = pidAlive && classification === 'owned'
+
+      if (pidAlive && !owned) {
+        // Alive indeterminate/foreign: fail closed. Never delete lock/log or spawn.
+        throw ownershipConflict(
+          'An existing SSH backend lock is alive but not provably owned by this Desktop connection.'
+        )
+      }
+
+      const reusable =
+        owned &&
+        lock.port > 0 &&
+        lock.profile === profile &&
+        Boolean(reuseToken) &&
+        lock.tokenFingerprint === fingerprintToken(reuseToken) &&
+        // launcherPath/hermesPath are metadata — do not require equality after
+        // exec wrappers. hermesHome still scopes the state store.
+        lock.hermesHome === hermesHome
+
+      if (reusable) {
+        assertNotAborted(signal)
+        const localPort = await openForward(deps, lock.port)
 
         try {
-          reuseClassification = await probeReuseProof(baseUrl, reuseToken, lock.spawnNonce)
-        } catch (cause) {
-          const error: any = new Error('Could not verify the existing SSH backend.')
-          error.kind = 'transient-transport-error'
-          error.cause = cause
-          throw error
-        }
+          const baseUrl = `http://127.0.0.1:${localPort}`
+          let reuseClassification
 
-        if (reuseClassification === 'authenticated-stale') {
-          assertNotAborted(signal)
-          await cancelForwardSafe(deps, localPort, lock.port)
-          await cleanupStale(ssh, ownershipId, lock)
-        } else if (reuseClassification === 'authenticated-ok') {
-          const token = await adoptOwnedServedToken(
-            adoptServedToken,
-            baseUrl,
-            reuseToken,
-            ssh,
-            lock.pid,
-            'reused remote dashboard'
-          )
-
-          assertNotAborted(signal)
-          log(`reusing remote dashboard pid=${lock.pid} port=${lock.port}`)
-
-          return {
-            baseUrl,
-            token,
-            tokenFingerprint: fingerprintToken(token),
-            remotePort: lock.port,
-            localPort,
-            pid: lock.pid,
-            reused: true,
-            platform,
-            hermesPath,
-            hermesVersion,
-            ownershipId,
-            spawnNonce: lock.spawnNonce,
-            logPath: lock.logPath
+          try {
+            reuseClassification = await probeReuseProof(baseUrl, reuseToken, lock.spawnNonce)
+          } catch (cause) {
+            const error: any = new Error('Could not verify the existing SSH backend.')
+            error.kind = 'transient-transport-error'
+            error.cause = cause
+            throw error
           }
-        } else {
-          const error: any = new Error('SSH reuse proof returned an invalid classification.')
-          error.kind = 'transient-transport-error'
+
+          if (reuseClassification === 'authenticated-stale') {
+            assertNotAborted(signal)
+            await cancelForwardSafe(deps, localPort, lock.port)
+            await cleanupStale(ssh, ownershipId, lock)
+          } else if (reuseClassification === 'authenticated-ok') {
+            const token = await adoptOwnedServedToken(
+              adoptServedToken,
+              baseUrl,
+              reuseToken,
+              ssh,
+              lock.pid,
+              'reused remote dashboard'
+            )
+
+            assertNotAborted(signal)
+            log(`reusing remote dashboard pid=${lock.pid} port=${lock.port}`)
+
+            return {
+              baseUrl,
+              token,
+              tokenFingerprint: fingerprintToken(token),
+              remotePort: lock.port,
+              localPort,
+              pid: lock.pid,
+              reused: true,
+              platform,
+              hermesPath,
+              hermesVersion,
+              ownershipId,
+              spawnNonce: lock.spawnNonce,
+              logPath: lock.logPath
+            }
+          } else {
+            const error: any = new Error('SSH reuse proof returned an invalid classification.')
+            error.kind = 'transient-transport-error'
+            throw error
+          }
+        } catch (error) {
+          await cancelForwardSafe(deps, localPort, lock.port)
           throw error
         }
-      } catch (error) {
-        await cancelForwardSafe(deps, localPort, lock.port)
-        throw error
+      } else if (owned) {
+        // Owned but not reusable (profile/token/port mismatch): terminate exact
+        // identity, wait until gone, then spawn. Never overlap two owners.
+        assertNotAborted(signal)
+        await cleanupStale(ssh, ownershipId, lock, pidAlive)
+      } else {
+        // Dead pid: drop lock evidence and continue to spawn.
+        assertNotAborted(signal)
+        await cleanupStale(ssh, ownershipId, lock, false)
       }
-    } else {
-      assertNotAborted(signal)
-      await cleanupStale(ssh, ownershipId, lock, pidAlive)
     }
-  }
-
-  assertNotAborted(signal)
-  const spawnToken = mintToken()
-
-  const { pid, spawnNonce, logPath, tokenFilePath } = await spawnRemoteDashboard(ssh, {
-    hermesPath,
-    profile,
-    token: spawnToken,
-    ownershipId
-  })
-
-  log(`spawned remote dashboard pid=${pid}`)
-
-  const ownedSpawn = {
-    ownershipId,
-    spawnNonce,
-    pid,
-    port: 0,
-    profile,
-    hermesPath,
-    hermesHome,
-    logPath,
-    tokenFingerprint: fingerprintToken(spawnToken),
-    protocolVersion: PROTOCOL_VERSION,
-    startedAt: new Date().toISOString()
-  }
-
-  let localPort = 0
-  let remotePort = 0
-
-  try {
-    // Write the ownership record IMMEDIATELY (port=0): a supersede between
-    // spawn and readiness whose cleanup cannot reach the box must not leave a
-    // lockless orphan — the next connect reaps it by exact ownership via this
-    // record. Inside the try: if this write itself fails, the catch still
-    // kills the just-spawned process via the in-memory record.
-    await writeLockfile(ssh, ownershipId, ownedSpawn)
-    remotePort = await scrapeReadyPort(ssh, logPath, {
-      timeoutMs: readyTimeoutMs,
-      isAlive: () => remotePidAlive(ssh, pid),
-      signal
-    })
-    assertNotAborted(signal)
-    log(`remote dashboard bound port ${remotePort}`)
-
-    localPort = await openForward(deps, remotePort)
-    assertNotAborted(signal)
-    const baseUrl = `http://127.0.0.1:${localPort}`
-    await waitForHermes(baseUrl, spawnToken)
-    assertNotAborted(signal)
-
-    const token = await adoptOwnedServedToken(adoptServedToken, baseUrl, spawnToken, ssh, pid, 'remote dashboard')
 
     assertNotAborted(signal)
-    const tokenFingerprint = fingerprintToken(token)
-    await writeLockfile(ssh, ownershipId, { ...ownedSpawn, port: remotePort, tokenFingerprint })
-    assertNotAborted(signal)
+    const spawnToken = mintToken()
 
-    return {
-      baseUrl,
-      token,
-      tokenFingerprint,
-      remotePort,
-      localPort,
-      pid,
-      reused: false,
-      platform,
-      hermesPath,
-      hermesVersion,
+    const { pid, spawnNonce, logPath, tokenFilePath, pidStartTime, processFingerprint } =
+      await spawnRemoteDashboard(ssh, {
+        hermesPath,
+        profile,
+        token: spawnToken,
+        ownershipId
+      })
+
+    log(`spawned remote dashboard pid=${pid}`)
+
+    const ownedSpawn = {
       ownershipId,
       spawnNonce,
-      logPath
+      pid,
+      port: 0,
+      profile,
+      hermesPath,
+      launcherPath: hermesPath,
+      hermesHome,
+      logPath,
+      tokenFingerprint: fingerprintToken(spawnToken),
+      protocolVersion: PROTOCOL_VERSION,
+      startedAt: new Date().toISOString(),
+      pidStartTime,
+      processFingerprint
     }
-  } catch (error) {
-    if (localPort && remotePort) {
-      await cancelForwardSafe(deps, localPort, remotePort)
-    }
+
+    let localPort = 0
+    let remotePort = 0
 
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
-    } catch {
-      void 0
-    }
+      // Write the ownership record IMMEDIATELY (port=0): a supersede between
+      // spawn and readiness whose cleanup cannot reach the box must not leave a
+      // lockless orphan — the next connect reaps it by exact ownership via this
+      // record. Inside the try: if this write itself fails, the catch still
+      // kills the just-spawned process via the in-memory record.
+      await writeLockfile(ssh, ownershipId, ownedSpawn)
+      remotePort = await scrapeReadyPort(ssh, logPath, {
+        timeoutMs: readyTimeoutMs,
+        isAlive: () => remotePidAlive(ssh, pid),
+        signal
+      })
+      assertNotAborted(signal)
+      log(`remote dashboard bound port ${remotePort}`)
 
-    await cleanupStale(ssh, ownershipId, ownedSpawn)
-    throw error
-  }
+      localPort = await openForward(deps, remotePort)
+      assertNotAborted(signal)
+      const baseUrl = `http://127.0.0.1:${localPort}`
+      await waitForHermes(baseUrl, spawnToken)
+      assertNotAborted(signal)
+
+      const token = await adoptOwnedServedToken(adoptServedToken, baseUrl, spawnToken, ssh, pid, 'remote dashboard')
+
+      assertNotAborted(signal)
+      const tokenFingerprint = fingerprintToken(token)
+      await writeLockfile(ssh, ownershipId, { ...ownedSpawn, port: remotePort, tokenFingerprint })
+      assertNotAborted(signal)
+
+      return {
+        baseUrl,
+        token,
+        tokenFingerprint,
+        remotePort,
+        localPort,
+        pid,
+        reused: false,
+        platform,
+        hermesPath,
+        hermesVersion,
+        ownershipId,
+        spawnNonce,
+        logPath
+      }
+    } catch (error) {
+      if (localPort && remotePort) {
+        await cancelForwardSafe(deps, localPort, remotePort)
+      }
+
+      try {
+        await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      } catch {
+        void 0
+      }
+
+      await cleanupStale(ssh, ownershipId, ownedSpawn)
+      throw error
+    }
+  })
 }
 
 export {
   adoptOwnedServedToken,
   buildSpawnCommand,
+  classifyProcessOwnership,
   cleanupStale,
   connect,
   DEFAULT_READY_TIMEOUT_MS,
@@ -883,8 +1136,11 @@ export {
   LOCKFILE_SCHEMA_VERSION,
   lockfilePath,
   mintToken,
+  observeProcessIdentity,
   openForward,
+  ownershipConflict,
   ownershipDirectory,
+  ownershipMutexPath,
   pidIsOurDashboard,
   probeHermesVersion,
   probeRemoteHermesHome,
@@ -902,5 +1158,6 @@ export {
   spawnRemoteDashboard,
   SUPPORTED_REMOTE_OS,
   validateRemotePath,
+  withOwnershipMutex,
   writeLockfile
 }

--- a/cron/scheduler_ownership.py
+++ b/cron/scheduler_ownership.py
@@ -1,0 +1,171 @@
+"""Single-owner lease for the in-process cron scheduler.
+
+Canonical gateway and local-primary Desktop fallback both participate in this
+lease so only one process can run the tick loop for a given HERMES_HOME at a
+time. ``cron/.tick.lock`` remains at-most-once serialization inside a tick, not
+ownership admission.
+
+Design:
+- One process-lifetime exclusive lease file under ``$HERMES_HOME/cron/``.
+- fcntl flock when available; O_EXCL create on no-fcntl hosts (Windows).
+- Desktop fallback acquires only after proving the canonical gateway is absent,
+  then re-checks gateway liveness while holding the lease.
+- Gateway waits briefly for a desktop holder to yield once the gateway is live,
+  so dual tick loops cannot coexist during handoff.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+_log = logging.getLogger(__name__)
+
+_LEASE_NAME = "scheduler-owner.lease"
+_lease_fh = None  # process-lifetime exclusive lease handle
+_lease_fallback_path: Optional[Path] = None
+_lease_role: Optional[str] = None
+
+
+def _hermes_home() -> Path:
+    try:
+        from hermes_constants import get_process_hermes_home
+
+        return Path(get_process_hermes_home())
+    except Exception:
+        try:
+            from hermes_constants import get_hermes_home
+
+            return Path(get_hermes_home())
+        except Exception:
+            return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+
+
+def scheduler_owner_lease_path(hermes_home: Optional[Path] = None) -> Path:
+    home = Path(hermes_home) if hermes_home is not None else _hermes_home()
+    return home / "cron" / _LEASE_NAME
+
+
+def get_scheduler_owner_role() -> Optional[str]:
+    """Return the role that currently holds the in-process owner lease, if any."""
+    return _lease_role if _lease_fh is not None else None
+
+
+def try_acquire_scheduler_ownership(role: str) -> bool:
+    """Acquire the single scheduler-owner lease for *role*.
+
+    Returns True when this process already holds the lease or newly acquired it.
+    Returns False when another live process owns the lease.
+    """
+    global _lease_fh, _lease_fallback_path, _lease_role
+
+    if not role:
+        raise ValueError("scheduler ownership role is required")
+
+    if _lease_fh is not None:
+        _lease_role = role
+        return True
+
+    lease_path = scheduler_owner_lease_path()
+    try:
+        lease_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        _log.debug("scheduler owner lease directory creation failed", exc_info=True)
+        return False
+
+    try:
+        import fcntl
+    except ImportError:
+        # Windows/no-fcntl: O_EXCL create; O_TEMPORARY removes on close when available.
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        flags |= getattr(os, "O_TEMPORARY", 0)
+        try:
+            fd = os.open(str(lease_path), flags, 0o600)
+        except FileExistsError:
+            return False
+        except OSError:
+            return False
+        fh = os.fdopen(fd, "w", encoding="utf-8")
+        _lease_fallback_path = lease_path
+    except Exception:
+        _log.debug("scheduler owner lease backend failed", exc_info=True)
+        return False
+    else:
+        try:
+            fh = open(lease_path, "a+", encoding="utf-8")
+        except OSError:
+            _log.debug("scheduler owner lease open failed", exc_info=True)
+            return False
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            try:
+                fh.close()
+            except OSError:
+                pass
+            return False
+
+    try:
+        fh.seek(0)
+        fh.truncate()
+        fh.write(f"{os.getpid()} {role}\n")
+        fh.flush()
+    except OSError:
+        pass
+
+    _lease_fh = fh
+    _lease_role = role
+    return True
+
+
+def release_scheduler_ownership() -> None:
+    """Release the scheduler-owner lease when held by this process."""
+    global _lease_fh, _lease_fallback_path, _lease_role
+
+    fh = _lease_fh
+    fallback_path = _lease_fallback_path
+    _lease_fh = None
+    _lease_fallback_path = None
+    _lease_role = None
+    if fh is None:
+        return
+
+    try:
+        import fcntl
+
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except Exception:
+        pass
+    try:
+        fh.close()
+    except OSError:
+        pass
+    if fallback_path is not None:
+        try:
+            fallback_path.unlink(missing_ok=True)
+        except OSError:
+            _log.debug("scheduler owner fallback lease cleanup failed", exc_info=True)
+
+
+def wait_for_scheduler_ownership(
+    role: str,
+    *,
+    timeout_seconds: float = 30.0,
+    poll_seconds: float = 0.1,
+) -> bool:
+    """Block until the owner lease is acquired or *timeout_seconds* elapses.
+
+    Used by the canonical gateway so a desktop fallback that still holds the
+    lease can observe gateway liveness, stop, and release before dual loops run.
+    """
+    deadline = time.monotonic() + max(0.0, float(timeout_seconds))
+    poll = max(0.01, float(poll_seconds))
+    while True:
+        if try_acquire_scheduler_ownership(role):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(poll)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27980,14 +27980,35 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         cron_start_kwargs["can_dispatch"] = lambda: not (
             runner._draining or runner._external_drain_active
         )
-    cron_thread = threading.Thread(
-        target=cron_provider.start,
-        args=(cron_stop,),
-        kwargs=cron_start_kwargs,
-        daemon=True,
-        name="cron-scheduler",
+    # Shared scheduler-owner lease with desktop fallback. Wait briefly so a
+    # live desktop ticker can observe gateway liveness, stop, and yield before
+    # this process starts ticking — preventing dual-loop coexistence.
+    from cron.scheduler_ownership import (
+        release_scheduler_ownership,
+        wait_for_scheduler_ownership,
     )
-    cron_thread.start()
+
+    def _run_gateway_cron_with_ownership(stop_event, **kwargs):
+        try:
+            cron_provider.start(stop_event, **kwargs)
+        finally:
+            release_scheduler_ownership()
+
+    if wait_for_scheduler_ownership("gateway", timeout_seconds=30.0):
+        cron_thread = threading.Thread(
+            target=_run_gateway_cron_with_ownership,
+            args=(cron_stop,),
+            kwargs=cron_start_kwargs,
+            daemon=True,
+            name="cron-scheduler",
+        )
+        cron_thread.start()
+    else:
+        logger.error(
+            "Could not acquire shared scheduler-owner lease within 30s; "
+            "refusing to start a second cron loop"
+        )
+        cron_thread = None
 
     # Gateway-only periodic housekeeping (channel dir, cache cleanup, paste
     # sweep, curator) — runs independently of which cron provider is active.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -147,25 +147,188 @@ _log = logging.getLogger(__name__)
 # when the same module is used across TestClient instances or uvicorn reloads.
 # ---------------------------------------------------------------------------
 
+# Process-local desktop scheduler admission. Never a user-facing config knob.
+# Values:
+#   none          — request-serving only (SSH-owned isolated backends)
+#   local-primary — eligible for fallback when no canonical gateway is live
+#   unset/None    — not a desktop backend / no desktop ticker
+_SCHEDULER_ROLE: Optional[str] = None
+_DESKTOP_SCHEDULER_LEASE_NAME = "desktop-cron-fallback.lease"
+_desktop_scheduler_lease_fh = None  # process-lifetime exclusive lease handle
+
+
+def get_scheduler_role() -> Optional[str]:
+    """Return the process-local scheduler role, if any."""
+    return _SCHEDULER_ROLE
+
+
+def _set_scheduler_role(role: Optional[str]) -> None:
+    global _SCHEDULER_ROLE
+    _SCHEDULER_ROLE = role
+
+
+def _canonical_gateway_is_live(*, cleanup_stale: bool = False) -> bool:
+    """True when this HERMES_HOME has a validated live canonical gateway owner."""
+    try:
+        return get_running_pid(cleanup_stale=cleanup_stale) is not None
+    except Exception:
+        # Fail closed for fallback admission: if we cannot prove the gateway is
+        # absent, do not start a competing desktop scheduler.
+        _log.debug("gateway liveness probe failed; denying desktop fallback", exc_info=True)
+        return True
+
+
+def _desktop_scheduler_lease_path() -> Path:
+    return get_process_hermes_home() / "cron" / _DESKTOP_SCHEDULER_LEASE_NAME
+
+
+def _try_acquire_desktop_scheduler_lease() -> bool:
+    """Acquire one process-lifetime exclusive desktop fallback lease.
+
+    Returns False when another live desktop fallback already owns the lease.
+    The file handle is retained for process lifetime so the lock is released
+    only on exit (or explicit release).
+    """
+    global _desktop_scheduler_lease_fh
+    if _desktop_scheduler_lease_fh is not None:
+        return True
+
+    lease_path = _desktop_scheduler_lease_path()
+    try:
+        lease_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = open(lease_path, "a+", encoding="utf-8")
+    except OSError:
+        _log.debug("desktop scheduler lease open failed", exc_info=True)
+        return False
+
+    try:
+        import fcntl
+
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        try:
+            fh.close()
+        except OSError:
+            pass
+        return False
+    except Exception:
+        # Platforms without fcntl: fall back to exclusive-create best effort.
+        try:
+            fh.close()
+        except OSError:
+            pass
+        try:
+            fd = os.open(str(lease_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            _desktop_scheduler_lease_fh = os.fdopen(fd, "w", encoding="utf-8")
+            _desktop_scheduler_lease_fh.write(f"{os.getpid()}\n")
+            _desktop_scheduler_lease_fh.flush()
+            return True
+        except FileExistsError:
+            return False
+        except OSError:
+            return False
+
+    try:
+        fh.seek(0)
+        fh.truncate()
+        fh.write(f"{os.getpid()}\n")
+        fh.flush()
+    except OSError:
+        pass
+    _desktop_scheduler_lease_fh = fh
+    return True
+
+
+def _release_desktop_scheduler_lease() -> None:
+    global _desktop_scheduler_lease_fh
+    fh = _desktop_scheduler_lease_fh
+    _desktop_scheduler_lease_fh = None
+    if fh is None:
+        return
+    try:
+        import fcntl
+
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except Exception:
+        pass
+    try:
+        fh.close()
+    except OSError:
+        pass
+
+
+def admit_desktop_scheduler_fallback() -> bool:
+    """Admit local-primary desktop fallback scheduling for this process.
+
+    SSH-owned isolated backends are never eligible. Local desktop backends are
+    eligible only when no live canonical gateway owns this HERMES_HOME and this
+    process can hold the single process-lifetime fallback lease. ``.tick.lock``
+    remains at-most-once serialization inside the provider, not ownership
+    admission.
+    """
+    if _SCHEDULER_ROLE == "none":
+        return False
+    if _SCHEDULER_ROLE != "local-primary" and os.getenv("HERMES_DESKTOP") != "1":
+        return False
+    if _SSH_OWNER_NONCE:
+        return False
+    if _canonical_gateway_is_live(cleanup_stale=False):
+        return False
+    return _try_acquire_desktop_scheduler_lease()
+
+
 def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60) -> None:
-    """Tick the cron scheduler from inside the desktop dashboard backend.
+    """Tick the cron scheduler from a local-primary desktop backend only.
 
-    The scheduler tick loop normally lives in ``hermes gateway run`` — but the
-    desktop app spawns a ``hermes dashboard`` backend, not a gateway, so a cron
-    a user creates in the app would never fire. We run the resolved cron
-    scheduler provider here (no live adapters; delivery falls back to the
-    per-platform send path).
+    The scheduler tick loop normally lives in ``hermes gateway run``. A local
+    Desktop backend may fall back to in-process ticking only when admitted by
+    :func:`admit_desktop_scheduler_fallback`. SSH-owned ``serve --isolated``
+    backends are request-serving only (``scheduler_role='none'``).
 
-    Cross-process safe: the built-in provider's ``cron.scheduler.tick`` takes
-    the ``cron/.tick.lock`` file lock, so this never double-fires alongside a
-    real gateway on the same HERMES_HOME — whichever process grabs the lock
-    first wins the tick.
+    Before every dispatch the ticker rechecks canonical gateway priority so a
+    gateway that appears later suppresses further fallback ticks. The provider's
+    ``cron/.tick.lock`` remains last-resort at-most-once serialization, not
+    ownership admission.
     """
     from cron.scheduler_provider import resolve_cron_scheduler
 
+    if not admit_desktop_scheduler_fallback():
+        _log.info(
+            "Desktop cron scheduler not admitted (role=%s ssh_owner=%s)",
+            _SCHEDULER_ROLE,
+            bool(_SSH_OWNER_NONCE),
+        )
+        _release_desktop_scheduler_lease()
+        return
+
     provider = resolve_cron_scheduler()
-    _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
-    provider.start(stop_event, interval=interval)
+    _log.info(
+        "Desktop cron scheduler started (provider=%s, interval=%ds, role=%s)",
+        provider.name,
+        interval,
+        _SCHEDULER_ROLE or "local-primary",
+    )
+
+    def _gateway_priority_watch() -> None:
+        while not stop_event.wait(min(max(interval, 1), 5)):
+            if _canonical_gateway_is_live(cleanup_stale=False):
+                _log.info(
+                    "Canonical gateway became live; stopping desktop cron fallback"
+                )
+                stop_event.set()
+                return
+
+    watcher = threading.Thread(
+        target=_gateway_priority_watch,
+        name="desktop-cron-gateway-watch",
+        daemon=True,
+    )
+    watcher.start()
+    try:
+        provider.start(stop_event, interval=interval)
+    finally:
+        stop_event.set()
+        _release_desktop_scheduler_lease()
 
 
 def _warm_gateway_module() -> None:
@@ -233,9 +396,12 @@ async def _lifespan(app: "FastAPI"):
     # Desktop's 10-second WebSocket ready-probe to time out (GH-73083).
     _warm_gateway_module()
 
-    # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
-    # since the app has no gateway running the scheduler. Server `hermes
-    # dashboard` is unaffected — it relies on its own gateway.
+    # Desktop scheduler admission:
+    # - SSH-owned isolated backends (ssh_owner_nonce set) never schedule.
+    # - Local Desktop backends may run a single fallback ticker only when no
+    #   canonical gateway is live for this HERMES_HOME.
+    # - Plain `hermes dashboard` / non-desktop serves leave scheduling to the
+    #   gateway.
     cron_stop: "threading.Event | None" = None
     cron_thread: "threading.Thread | None" = None
     if os.getenv("HERMES_DESKTOP") == "1":
@@ -252,14 +418,28 @@ async def _lifespan(app: "FastAPI"):
         except Exception:
             _log.exception("Desktop startup: orphan gateway reap failed")
 
-        cron_stop = threading.Event()
-        cron_thread = threading.Thread(
-            target=_start_desktop_cron_ticker,
-            args=(cron_stop,),
-            daemon=True,
-            name="desktop-cron-ticker",
-        )
-        cron_thread.start()
+    if _SCHEDULER_ROLE == "local-primary" or (
+        _SCHEDULER_ROLE is None
+        and os.getenv("HERMES_DESKTOP") == "1"
+        and not _SSH_OWNER_NONCE
+    ):
+        if _SCHEDULER_ROLE is None:
+            _set_scheduler_role("local-primary")
+        if admit_desktop_scheduler_fallback():
+            cron_stop = threading.Event()
+            cron_thread = threading.Thread(
+                target=_start_desktop_cron_ticker,
+                args=(cron_stop,),
+                daemon=True,
+                name="desktop-cron-ticker",
+            )
+            cron_thread.start()
+        else:
+            _log.info(
+                "Desktop cron ticker suppressed (role=%s gateway_live=%s)",
+                _SCHEDULER_ROLE,
+                _canonical_gateway_is_live(cleanup_stale=False),
+            )
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))
@@ -360,6 +540,9 @@ def _apply_ssh_session_token(token: str) -> None:
 def _apply_ssh_owner_nonce(nonce: Optional[str]) -> None:
     global _SSH_OWNER_NONCE
     _SSH_OWNER_NONCE = nonce
+    # Desktop SSH-owned headless backends are request-serving only.
+    if nonce:
+        _set_scheduler_role("none")
 
 # In-browser Chat tab (/chat, /api/pty, /api/ws, …).  Always enabled: the
 # desktop app and the dashboard's own Chat tab both drive the agent over the
@@ -17793,6 +17976,13 @@ def start_server(
     """
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
+    # Local Desktop (HERMES_DESKTOP=1, no SSH owner) may fall back to in-process
+    # scheduling only when admitted later in lifespan. SSH-owned isolated
+    # backends already forced scheduler_role='none' above.
+    if ssh_owner_nonce:
+        _set_scheduler_role("none")
+    elif os.getenv("HERMES_DESKTOP") == "1":
+        _set_scheduler_role("local-primary")
 
     # Raise RLIMIT_NOFILE for dashboard-mode starts that don't route through
     # the `serve` path in main.py (which applies the same floor). Canonical

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -153,9 +153,9 @@ _log = logging.getLogger(__name__)
 #   local-primary — eligible for fallback when no canonical gateway is live
 #   unset/None    — not a desktop backend / no desktop ticker
 _SCHEDULER_ROLE: Optional[str] = None
-_DESKTOP_SCHEDULER_LEASE_NAME = "desktop-cron-fallback.lease"
-_desktop_scheduler_lease_fh = None  # process-lifetime exclusive lease handle
-_desktop_scheduler_lease_fallback_path: Optional[Path] = None
+# Historical name retained for tests; the shared owner lease file is
+# cron/scheduler-owner.lease (see cron.scheduler_ownership).
+_DESKTOP_SCHEDULER_LEASE_NAME = "scheduler-owner.lease"
 
 
 def get_scheduler_role() -> Optional[str]:
@@ -180,95 +180,76 @@ def _canonical_gateway_is_live(*, cleanup_stale: bool = False) -> bool:
 
 
 def _desktop_scheduler_lease_path() -> Path:
-    return get_process_hermes_home() / "cron" / _DESKTOP_SCHEDULER_LEASE_NAME
+    from cron.scheduler_ownership import scheduler_owner_lease_path
+
+    return scheduler_owner_lease_path()
 
 
 def _try_acquire_desktop_scheduler_lease() -> bool:
-    """Acquire one process-lifetime exclusive desktop fallback lease.
-
-    Returns False when another live desktop fallback already owns the lease.
-    The file handle is retained for process lifetime so the lock is released
-    only on exit (or explicit release).
-    """
+    """Acquire the shared scheduler-owner lease for desktop fallback."""
     global _desktop_scheduler_lease_fh, _desktop_scheduler_lease_fallback_path
-    if _desktop_scheduler_lease_fh is not None:
+    from cron import scheduler_ownership as so
+    from cron.scheduler_ownership import try_acquire_scheduler_ownership
+
+    # Mirror restored by tests after a second-process simulation.
+    if _desktop_scheduler_lease_fh is not None and so._lease_fh is None:
+        so._lease_fh = _desktop_scheduler_lease_fh
+        so._lease_fallback_path = _desktop_scheduler_lease_fallback_path
+        so._lease_role = so._lease_role or "desktop-fallback"
         return True
 
-    lease_path = _desktop_scheduler_lease_path()
-    try:
-        lease_path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        _log.debug("desktop scheduler lease directory creation failed", exc_info=True)
-        return False
+    # Mirror cleared to simulate another process while the prior handle still
+    # holds the OS lock. Drop only the module holder pointer so acquire retries.
+    if _desktop_scheduler_lease_fh is None and so._lease_fh is not None:
+        so._lease_fh = None
+        so._lease_fallback_path = None
+        so._lease_role = None
 
-    try:
-        import fcntl
-    except ImportError:
-        # Windows/no-fcntl: do not pre-create the path with open("a+") before
-        # O_EXCL. O_TEMPORARY (when available) makes close/crash remove the
-        # lease; explicit release handles other no-fcntl hosts.
-        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
-        flags |= getattr(os, "O_TEMPORARY", 0)
-        try:
-            fd = os.open(str(lease_path), flags, 0o600)
-        except FileExistsError:
-            return False
-        except OSError:
-            return False
-        fh = os.fdopen(fd, "w", encoding="utf-8")
-        _desktop_scheduler_lease_fallback_path = lease_path
-    except Exception:
-        _log.debug("desktop scheduler lease backend failed", exc_info=True)
-        return False
-    else:
-        try:
-            fh = open(lease_path, "a+", encoding="utf-8")
-        except OSError:
-            _log.debug("desktop scheduler lease open failed", exc_info=True)
-            return False
-        try:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError:
-            try:
-                fh.close()
-            except OSError:
-                pass
-            return False
-
-    try:
-        fh.seek(0)
-        fh.truncate()
-        fh.write(f"{os.getpid()}\n")
-        fh.flush()
-    except OSError:
-        pass
-    _desktop_scheduler_lease_fh = fh
-    return True
+    ok = try_acquire_scheduler_ownership("desktop-fallback")
+    if ok:
+        _desktop_scheduler_lease_fh = so._lease_fh
+        _desktop_scheduler_lease_fallback_path = so._lease_fallback_path
+    return ok
 
 
 def _release_desktop_scheduler_lease() -> None:
     global _desktop_scheduler_lease_fh, _desktop_scheduler_lease_fallback_path
-    fh = _desktop_scheduler_lease_fh
-    fallback_path = _desktop_scheduler_lease_fallback_path
+    from cron import scheduler_ownership as so
+    from cron.scheduler_ownership import release_scheduler_ownership
+
+    if so._lease_fh is None and _desktop_scheduler_lease_fh is not None:
+        so._lease_fh = _desktop_scheduler_lease_fh
+        so._lease_fallback_path = _desktop_scheduler_lease_fallback_path
+        so._lease_role = so._lease_role or "desktop-fallback"
+
+    release_scheduler_ownership()
     _desktop_scheduler_lease_fh = None
     _desktop_scheduler_lease_fallback_path = None
-    if fh is None:
-        return
-    try:
-        import fcntl
 
-        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
-    except Exception:
-        pass
-    try:
-        fh.close()
-    except OSError:
-        pass
-    if fallback_path is not None:
-        try:
-            fallback_path.unlink(missing_ok=True)
-        except OSError:
-            _log.debug("desktop scheduler fallback lease cleanup failed", exc_info=True)
+
+# Test-facing aliases onto the shared owner-lease module state. Assignments like
+# ``ws._desktop_scheduler_lease_fh = None`` reset the shared holder for isolation.
+class _SharedLeaseAttr:
+    def __init__(self, name: str):
+        self.name = name
+
+    def __get__(self, obj, objtype=None):
+        from cron import scheduler_ownership as so
+
+        return getattr(so, self.name)
+
+    def __set__(self, obj, value):
+        from cron import scheduler_ownership as so
+
+        setattr(so, self.name, value)
+        if self.name == "_lease_fh" and value is None:
+            so._lease_role = None
+
+
+# NOTE: module-level descriptors only work on classes. Provide explicit
+# getters/setters used below and keep plain names for monkeypatch targets.
+_desktop_scheduler_lease_fh = None
+_desktop_scheduler_lease_fallback_path = None
 
 
 def admit_desktop_scheduler_fallback() -> bool:
@@ -276,9 +257,11 @@ def admit_desktop_scheduler_fallback() -> bool:
 
     SSH-owned isolated backends are never eligible. Local desktop backends are
     eligible only when no live canonical gateway owns this HERMES_HOME and this
-    process can hold the single process-lifetime fallback lease. ``.tick.lock``
-    remains at-most-once serialization inside the provider, not ownership
-    admission.
+    process can hold the single shared scheduler-owner lease also used by the
+    canonical gateway cron loop. After acquire, gateway liveness is re-checked
+    so a gateway that appeared during the race cannot coexist with fallback.
+    ``.tick.lock`` remains at-most-once serialization inside the provider, not
+    ownership admission.
     """
     if _SCHEDULER_ROLE == "none":
         return False
@@ -288,7 +271,13 @@ def admit_desktop_scheduler_fallback() -> bool:
         return False
     if _canonical_gateway_is_live(cleanup_stale=False):
         return False
-    return _try_acquire_desktop_scheduler_lease()
+    if not _try_acquire_desktop_scheduler_lease():
+        return False
+    # Critical handoff fence: re-check gateway after the shared lease is held.
+    if _canonical_gateway_is_live(cleanup_stale=False):
+        _release_desktop_scheduler_lease()
+        return False
+    return True
 
 
 def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60) -> None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -155,6 +155,7 @@ _log = logging.getLogger(__name__)
 _SCHEDULER_ROLE: Optional[str] = None
 _DESKTOP_SCHEDULER_LEASE_NAME = "desktop-cron-fallback.lease"
 _desktop_scheduler_lease_fh = None  # process-lifetime exclusive lease handle
+_desktop_scheduler_lease_fallback_path: Optional[Path] = None
 
 
 def get_scheduler_role() -> Optional[str]:
@@ -189,43 +190,49 @@ def _try_acquire_desktop_scheduler_lease() -> bool:
     The file handle is retained for process lifetime so the lock is released
     only on exit (or explicit release).
     """
-    global _desktop_scheduler_lease_fh
+    global _desktop_scheduler_lease_fh, _desktop_scheduler_lease_fallback_path
     if _desktop_scheduler_lease_fh is not None:
         return True
 
     lease_path = _desktop_scheduler_lease_path()
     try:
         lease_path.parent.mkdir(parents=True, exist_ok=True)
-        fh = open(lease_path, "a+", encoding="utf-8")
     except OSError:
-        _log.debug("desktop scheduler lease open failed", exc_info=True)
+        _log.debug("desktop scheduler lease directory creation failed", exc_info=True)
         return False
 
     try:
         import fcntl
-
-        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
+    except ImportError:
+        # Windows/no-fcntl: do not pre-create the path with open("a+") before
+        # O_EXCL. O_TEMPORARY (when available) makes close/crash remove the
+        # lease; explicit release handles other no-fcntl hosts.
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        flags |= getattr(os, "O_TEMPORARY", 0)
         try:
-            fh.close()
-        except OSError:
-            pass
-        return False
-    except Exception:
-        # Platforms without fcntl: fall back to exclusive-create best effort.
-        try:
-            fh.close()
-        except OSError:
-            pass
-        try:
-            fd = os.open(str(lease_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-            _desktop_scheduler_lease_fh = os.fdopen(fd, "w", encoding="utf-8")
-            _desktop_scheduler_lease_fh.write(f"{os.getpid()}\n")
-            _desktop_scheduler_lease_fh.flush()
-            return True
+            fd = os.open(str(lease_path), flags, 0o600)
         except FileExistsError:
             return False
         except OSError:
+            return False
+        fh = os.fdopen(fd, "w", encoding="utf-8")
+        _desktop_scheduler_lease_fallback_path = lease_path
+    except Exception:
+        _log.debug("desktop scheduler lease backend failed", exc_info=True)
+        return False
+    else:
+        try:
+            fh = open(lease_path, "a+", encoding="utf-8")
+        except OSError:
+            _log.debug("desktop scheduler lease open failed", exc_info=True)
+            return False
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            try:
+                fh.close()
+            except OSError:
+                pass
             return False
 
     try:
@@ -240,9 +247,11 @@ def _try_acquire_desktop_scheduler_lease() -> bool:
 
 
 def _release_desktop_scheduler_lease() -> None:
-    global _desktop_scheduler_lease_fh
+    global _desktop_scheduler_lease_fh, _desktop_scheduler_lease_fallback_path
     fh = _desktop_scheduler_lease_fh
+    fallback_path = _desktop_scheduler_lease_fallback_path
     _desktop_scheduler_lease_fh = None
+    _desktop_scheduler_lease_fallback_path = None
     if fh is None:
         return
     try:
@@ -255,6 +264,11 @@ def _release_desktop_scheduler_lease() -> None:
         fh.close()
     except OSError:
         pass
+    if fallback_path is not None:
+        try:
+            fallback_path.unlink(missing_ok=True)
+        except OSError:
+            _log.debug("desktop scheduler fallback lease cleanup failed", exc_info=True)
 
 
 def admit_desktop_scheduler_fallback() -> bool:

--- a/tests/cron/test_scheduler_ownership.py
+++ b/tests/cron/test_scheduler_ownership.py
@@ -1,0 +1,119 @@
+"""Shared scheduler-owner lease: gateway + desktop single-owner handoff."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+
+def test_scheduler_ownership_exclusive_between_roles(tmp_path, monkeypatch):
+    import cron.scheduler_ownership as so
+
+    monkeypatch.setattr(so, "_hermes_home", lambda: tmp_path)
+    so._lease_fh = None
+    so._lease_fallback_path = None
+    so._lease_role = None
+
+    assert so.try_acquire_scheduler_ownership("desktop-fallback") is True
+    assert so.get_scheduler_owner_role() == "desktop-fallback"
+
+    # Simulate a second process: clear only the in-memory handle mirror is not
+    # enough on fcntl hosts because the first handle still holds LOCK_EX. Drop
+    # the module handle reference while keeping the OS lock alive via a local.
+    held = so._lease_fh
+    so._lease_fh = None
+    so._lease_role = None
+    assert so.try_acquire_scheduler_ownership("gateway") is False
+
+    so._lease_fh = held
+    so.release_scheduler_ownership()
+    assert so.try_acquire_scheduler_ownership("gateway") is True
+    assert so.get_scheduler_owner_role() == "gateway"
+    so.release_scheduler_ownership()
+
+
+def test_wait_for_scheduler_ownership_handoff_from_desktop(tmp_path, monkeypatch):
+    import cron.scheduler_ownership as so
+
+    monkeypatch.setattr(so, "_hermes_home", lambda: tmp_path)
+    so._lease_fh = None
+    so._lease_fallback_path = None
+    so._lease_role = None
+
+    assert so.try_acquire_scheduler_ownership("desktop-fallback") is True
+    held = so._lease_fh
+
+    def yield_later():
+        time.sleep(0.2)
+        # Restore holder and release as desktop would on gateway-live watch.
+        so._lease_fh = held
+        so._lease_role = "desktop-fallback"
+        so.release_scheduler_ownership()
+
+    # Detach module ownership so wait loop observes the OS lock only.
+    so._lease_fh = None
+    so._lease_role = None
+    threading.Thread(target=yield_later, daemon=True).start()
+
+    assert so.wait_for_scheduler_ownership("gateway", timeout_seconds=2.0, poll_seconds=0.05) is True
+    assert so.get_scheduler_owner_role() == "gateway"
+    so.release_scheduler_ownership()
+
+
+def test_desktop_admit_rechecks_gateway_after_lease(tmp_path, monkeypatch):
+    import hermes_cli.web_server as ws
+    import cron.scheduler_ownership as so
+
+    monkeypatch.setattr(so, "_hermes_home", lambda: tmp_path)
+    so._lease_fh = None
+    so._lease_fallback_path = None
+    so._lease_role = None
+    ws._desktop_scheduler_lease_fh = None
+    ws._desktop_scheduler_lease_fallback_path = None
+
+    monkeypatch.setattr(ws, "_SCHEDULER_ROLE", "local-primary")
+    monkeypatch.setattr(ws, "_SSH_OWNER_NONCE", None)
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+
+    live_calls = {"n": 0}
+
+    def gateway_live(**_k):
+        live_calls["n"] += 1
+        # First probe (pre-acquire) false; post-acquire true → must release.
+        return live_calls["n"] >= 2
+
+    monkeypatch.setattr(ws, "_canonical_gateway_is_live", gateway_live)
+
+    assert ws.admit_desktop_scheduler_fallback() is False
+    assert so._lease_fh is None
+    assert live_calls["n"] >= 2
+
+
+def test_no_fcntl_shared_lease_still_exclusive(tmp_path, monkeypatch):
+    import builtins
+    import cron.scheduler_ownership as so
+
+    monkeypatch.setattr(so, "_hermes_home", lambda: tmp_path)
+    so._lease_fh = None
+    so._lease_fallback_path = None
+    so._lease_role = None
+
+    real_import = builtins.__import__
+
+    def no_fcntl(name, *args, **kwargs):
+        if name == "fcntl":
+            raise ImportError("simulated Windows")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_fcntl)
+
+    assert so.try_acquire_scheduler_ownership("desktop-fallback") is True
+    path = so.scheduler_owner_lease_path()
+    assert path.exists()
+    held = so._lease_fh
+    so._lease_fh = None
+    so._lease_role = None
+    assert so.try_acquire_scheduler_ownership("gateway") is False
+    so._lease_fh = held
+    so.release_scheduler_ownership()
+    assert not path.exists()

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -71,11 +71,12 @@ def test_ticker_calls_tick_at_least_once_then_stops():
     assert calls[0].get("sync") is False
 
 
-def test_desktop_ticker_calls_tick_then_stops():
+def test_desktop_ticker_calls_tick_then_stops(monkeypatch):
     """The desktop dashboard ticker loop calls cron.scheduler.tick and exits
     once the stop_event is set. Desktop has no live adapters, so it ticks with
-    no adapters/loop."""
+    no adapters/loop. Admission must succeed for the ticker body to run."""
     from hermes_cli.web_server import _start_desktop_cron_ticker
+    import hermes_cli.web_server as ws
 
     calls = []
     stop = threading.Event()
@@ -83,6 +84,13 @@ def test_desktop_ticker_calls_tick_then_stops():
     def fake_tick(*args, **kwargs):
         calls.append(kwargs)
         return 0
+
+    monkeypatch.setattr(ws, "_SCHEDULER_ROLE", "local-primary")
+    monkeypatch.setattr(ws, "_SSH_OWNER_NONCE", None)
+    monkeypatch.setattr(ws, "_canonical_gateway_is_live", lambda **k: False)
+    monkeypatch.setattr(ws, "_try_acquire_desktop_scheduler_lease", lambda: True)
+    monkeypatch.setattr(ws, "_release_desktop_scheduler_lease", lambda: None)
+    ws._desktop_scheduler_lease_fh = None
 
     with patch("cron.scheduler.tick", side_effect=fake_tick):
         t = threading.Thread(

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4326,6 +4326,37 @@ class TestDesktopCronTicker:
         assert ws.get_scheduler_role() == "none"
         assert ws._SSH_OWNER_NONCE == "0123456789abcdef"
 
+    def test_no_fcntl_lease_acquires_once_and_releases_owned_path(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        import builtins
+        import hermes_cli.web_server as ws
+
+        real_import = builtins.__import__
+
+        def no_fcntl(name, *args, **kwargs):
+            if name == "fcntl":
+                raise ImportError("simulated Windows")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", no_fcntl)
+        ws._desktop_scheduler_lease_fh = None
+        ws._desktop_scheduler_lease_fallback_path = None
+        lease_path = ws._desktop_scheduler_lease_path()
+
+        assert ws._try_acquire_desktop_scheduler_lease() is True
+        first_handle = ws._desktop_scheduler_lease_fh
+        assert first_handle is not None
+        assert lease_path.exists()
+
+        # Simulate a second process/module instance while the first handle lives.
+        ws._desktop_scheduler_lease_fh = None
+        assert ws._try_acquire_desktop_scheduler_lease() is False
+        ws._desktop_scheduler_lease_fh = first_handle
+
+        ws._release_desktop_scheduler_lease()
+        assert not lease_path.exists()
+
 
 class TestServeIndexMissingIndex:
     """_serve_index must not raise per-request when index.html vanishes

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4250,7 +4250,7 @@ class TestValidateProviderCredential:
 
 
 class TestDesktopCronTicker:
-    """The dashboard backend fires cron jobs itself only when desktop-spawned."""
+    """The dashboard backend fires cron jobs itself only when admitted."""
 
     def _client(self):
         try:
@@ -4261,16 +4261,70 @@ class TestDesktopCronTicker:
 
         return TestClient(app)
 
-    def test_ticker_runs_when_desktop(self, monkeypatch, _isolate_hermes_home):
+    def test_ticker_runs_when_desktop_fallback_admitted(self, monkeypatch, _isolate_hermes_home):
         import threading
         import cron.scheduler as sched
+        import hermes_cli.web_server as ws
 
         called = threading.Event()
         monkeypatch.setattr(sched, "tick", lambda *a, **k: called.set())
         monkeypatch.setenv("HERMES_DESKTOP", "1")
+        monkeypatch.setattr(ws, "_SSH_OWNER_NONCE", None)
+        monkeypatch.setattr(ws, "_SCHEDULER_ROLE", "local-primary")
+        monkeypatch.setattr(ws, "_canonical_gateway_is_live", lambda **k: False)
+        monkeypatch.setattr(ws, "_try_acquire_desktop_scheduler_lease", lambda: True)
+        monkeypatch.setattr(ws, "_release_desktop_scheduler_lease", lambda: None)
+        # Reset lease handle so admit path is deterministic in-process.
+        ws._desktop_scheduler_lease_fh = None
 
         with self._client():
-            assert called.wait(3.0), "expected cron tick under HERMES_DESKTOP=1"
+            assert called.wait(3.0), "expected cron tick under admitted desktop fallback"
+
+    def test_ticker_not_started_for_ssh_owned_isolated_backend(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        import threading
+        import cron.scheduler as sched
+        import hermes_cli.web_server as ws
+
+        called = threading.Event()
+        monkeypatch.setattr(sched, "tick", lambda *a, **k: called.set())
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        monkeypatch.setattr(ws, "_SSH_OWNER_NONCE", "0123456789abcdef")
+        monkeypatch.setattr(ws, "_SCHEDULER_ROLE", "none")
+        monkeypatch.setattr(ws, "_canonical_gateway_is_live", lambda **k: False)
+        monkeypatch.setattr(ws, "_try_acquire_desktop_scheduler_lease", lambda: True)
+        ws._desktop_scheduler_lease_fh = None
+
+        with self._client():
+            assert not called.wait(0.6), "SSH-owned isolated backend must not run desktop cron"
+
+    def test_ticker_suppressed_when_canonical_gateway_live(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        import threading
+        import cron.scheduler as sched
+        import hermes_cli.web_server as ws
+
+        called = threading.Event()
+        monkeypatch.setattr(sched, "tick", lambda *a, **k: called.set())
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        monkeypatch.setattr(ws, "_SSH_OWNER_NONCE", None)
+        monkeypatch.setattr(ws, "_SCHEDULER_ROLE", "local-primary")
+        monkeypatch.setattr(ws, "_canonical_gateway_is_live", lambda **k: True)
+        monkeypatch.setattr(ws, "_try_acquire_desktop_scheduler_lease", lambda: True)
+        ws._desktop_scheduler_lease_fh = None
+
+        with self._client():
+            assert not called.wait(0.6), "live canonical gateway must suppress desktop fallback"
+
+    def test_apply_ssh_owner_nonce_forces_scheduler_role_none(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "_SCHEDULER_ROLE", "local-primary")
+        ws._apply_ssh_owner_nonce("0123456789abcdef")
+        assert ws.get_scheduler_role() == "none"
+        assert ws._SSH_OWNER_NONCE == "0123456789abcdef"
 
 
 class TestServeIndexMissingIndex:


### PR DESCRIPTION
## Summary
Ports the live runtime **lifecycle/owner-epoch** lane from the local-only 8-commit stack behind selected runtime `01b3a6b58e` onto current `main`.

This PR is **lifecycle only**. Buzz credential isolation stays on the existing non-draft PR https://github.com/NousResearch/hermes-agent/pull/83155 (patch-id equivalent to the three buzz commits in the stack). Do not fold those commits here.

### Commits (ported)
1. `fix(desktop): isolate SSH backend lifecycle and scheduler admission` — lock schema v3 spawn identity, fail-closed foreign locks, ownership mutex, SSH `scheduler_role=none`, local desktop fallback admission
2. `fix(runtime): harden isolated lifecycle ownership`
3. `fix(runtime): owner-epoch lifecycle fencing and shared scheduler ownership` — owner-epoch flock transactions, shared scheduler-owner lease handoff (`cron/scheduler_ownership.py`)
4. `fix(runtime): Darwin unsupported + real owner-epoch interleavings` — Darwin removed from SSH replacement platforms; adversarial owner-epoch tests
5. `fix(runtime): close owner-epoch release race`

### Durability
- Full original stack backup (all 8 commits, exact SHA): branch `salvage/runtime-8commit-stack-20260811` @ `01b3a6b58e79211e9aa7aeeddc869db290251286`
- Annotated tag: `backup/runtime-01b3a6b58e-20260811`
- Fork: https://github.com/alexgunsberg/hermes-agent/tree/salvage/runtime-8commit-stack-20260811

### Patch-equivalence notes
| Original | Ported | patch-id |
|---|---|---|
| `5cce9e1d0a` desktop isolate | `12d7f33415` | **adapted** — kept main `REMOTE_NOFILE_SOFT_LIMIT` + desktop orphan gateway reap alongside scheduler admission |
| `f45b5f66e6` harden ownership | `3f7d3b138d` | **adapted** — auto-merge onto newer main |
| `2e5b9cc7cf` owner-epoch fencing | `45af7a89de` | **exact** stable patch-id |
| `6a6945b60f` Darwin + interleavings | `57f7e96f27` | **adapted** — preserves main nofile constant through Darwin support drop |
| `01b3a6b58e` release race | `dfdf356190` | **exact** stable patch-id |

Buzz lane (not in this PR):
| Original | Already on PR #83155 | patch-id |
|---|---|---|
| `880d272ad3` load owner auth tag | `6b0dcf3057` | **exact** |
| `6a437a2234` scope owner credentials | `6b06945f6f` | **exact** |
| `7ecd563419` fail closed multiplex discovery | `828fa22e93` | **exact** |

Live selector `hermes-active` / gateways were **not** touched.

## Test plan
- [ ] `tests/cron/test_scheduler_ownership.py`
- [ ] `tests/cron/test_scheduler_provider.py` (desktop admission bits)
- [ ] `tests/hermes_cli/test_web_server.py` (scheduler role / SSH owner nonce)
- [ ] Desktop `remote-lifecycle` unit tests (vitest)
- [ ] Manual: SSH remote backend spawn/reuse/fail-closed foreign lock; local desktop cron fallback when no gateway