### PR TITLE
fix(terminal): don't fail-closed directory path tokens as gateway scripts

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -440,6 +440,15 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     try:
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
+            # Directories are not shell scripts. Path tokens from Python
+            # sources (e.g. Path('/home/user/.hermes').rglob(...)) are often
+            # mis-yielded as "referenced scripts"; fail-closing them blocks
+            # innocent terminal/cron work with a misleading gateway-restart
+            # error. Skip dirs as nothing-to-scan. Keep fail-closed for other
+            # non-regular nodes (devices/FIFOs/sockets) which are never
+            # legitimate script payloads.
+            if stat.S_ISDIR(metadata.st_mode):
+                return None, False
             return None, True
         # Sniff a small prefix first: files that are clearly compiled
         # binaries (executable magic, or NUL bytes in the head) are never

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,54 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_python_path_to_hermes_home_directory_not_blocked(self, tmp_path):
+        """Directory path tokens in Python must not fail-closed as lifecycle.
+
+        Agents commonly write Path('/home/…/.hermes').rglob(...) inside
+        terminal python -c / heredocs. The referenced-script walk yields the
+        absolute directory path (token contains '/'); pre-fix that was
+        fail-closed as unsafe and blocked the whole command with a misleading
+        gateway-restart error.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+            _read_referenced_script,
+        )
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        text, unsafe = _read_referenced_script(hermes_home)
+        assert text is None
+        assert unsafe is False
+
+        cmd = (
+            "python3 -c "
+            f"\"from pathlib import Path; list(Path('{hermes_home}').rglob('*models*'))\""
+        )
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            cmd, cwd=str(tmp_path)
+        ) is False
+
+        # Heredoc shape that previously tripped Desktop/gateway agents.
+        heredoc = (
+            "python3 <<'PY'\n"
+            "from pathlib import Path\n"
+            f"list(Path('{hermes_home}').rglob('*models*'))\n"
+            "PY"
+        )
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            heredoc, cwd=str(tmp_path)
+        ) is False
+
+    def test_directory_read_is_nothing_to_scan_device_still_unsafe(self, tmp_path):
+        from pathlib import Path as P
+        from cron.lifecycle_guard import _read_referenced_script
+
+        text, unsafe = _read_referenced_script(tmp_path)
+        assert text is None and unsafe is False
+        text2, unsafe2 = _read_referenced_script(P("/dev/null"))
+        assert text2 is None and unsafe2 is True
+
     def test_nul_byte_in_path_token_does_not_crash_guard(self):
         """Residual #76762 class: when a NUL byte survives into the *path
         token itself* (tokenized binary-adjacent command text), ``os.open``
@@ -1204,10 +1252,12 @@ class TestLifecycleGuardNeverRaises:
         weird.write_bytes(b"\xff\xfe\x00\x01 not really a script")
         assert self._scan(f"bash {weird}") is False
 
-    def test_directory_and_dev_null_fail_closed_not_crash(self, tmp_path):
-        # Non-regular files are suspicious (fail closed = blocked), but the
-        # important contract is: verdict, not exception.
-        assert self._scan(f"bash {tmp_path}") is True
+    def test_directory_skipped_dev_null_fail_closed_not_crash(self, tmp_path):
+        # Directories are common path tokens from Python sources
+        # (Path('/home/user/.hermes')) — nothing to scan, not blocked.
+        # Other non-regular nodes (devices) stay fail-closed. Contract: verdict,
+        # never exception.
+        assert self._scan(f"bash {tmp_path}") is False
         assert self._scan("bash /dev/null") is True
 
     def test_magic_prefix_binaries_skipped_without_full_read(self, tmp_path):
@@ -1236,8 +1286,8 @@ class TestLifecycleGuardNeverRaises:
         )
         binary = tmp_path / "prog"
         binary.write_bytes(b"\x7fELF" + bytes(128))
-        for value in ("nul\x00byte.sh", str(binary), "/nonexistent/x.sh"):
+        for value in ("nul\x00byte.sh", str(binary), "/nonexistent/x.sh", str(tmp_path)):
             check_gateway_lifecycle("clean prompt", value)  # must not raise
-        for value in ("/dev/null", str(tmp_path)):
-            with pytest.raises(GatewayLifecycleBlocked):
-                check_gateway_lifecycle("clean prompt", value)
+        # Directories are nothing-to-scan; device nodes stay fail-closed.
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("clean prompt", "/dev/null")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1077,6 +1077,7 @@ import sys
 TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
 
 Do NOT use cat/head/tail (use read_file), grep/rg/find/ls (use search_files), sed/awk (use patch), or echo/heredoc file creation (use write_file). Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
+Prefer execute_code, or write_file + python /path/script.py, over multiline python -c / python <<heredoc (quoting and approval friction). Short single-line python -c '…' is fine for one-expression checks.
 Environment state persists: activate a virtualenv or export variables once per session, not before every command.
 
 Foreground (default): returns INSTANTLY when the command finishes, even with a high timeout — set timeout generously for long builds.


### PR DESCRIPTION
## Summary

- Referenced-script walk in the gateway lifecycle guard yields absolute path tokens from command text (any token containing `/`). Python sources commonly include directory paths like `Path('/home/user/.hermes').rglob(...)`.
- Pre-fix, `_read_referenced_script` treated **all** non-regular files as `unsafe=True`, so opening a **directory** fail-closed and blocked the entire terminal command with a misleading *"cannot restart or stop the gateway"* error.
- Fix: directories → nothing-to-scan (`unsafe=False`). Keep fail-closed for devices/FIFOs/sockets.
- Also: one-line steer on the `terminal` tool description — prefer `execute_code` or `write_file` + script path over multiline `python -c` / `python <<heredoc`.

## Repro (before)

```bash
python3 -c "from pathlib import Path; list(Path.home().joinpath('.hermes').rglob('*models*'))"
# or a heredoc that mentions Path('/home/.../.hermes')
```

Under gateway/Desktop terminal: blocked with gateway-restart message even though no restart was attempted.

## Test plan

- [x] `pytest tests/hermes_cli/test_gateway_restart_loop.py` — 127 passed
- [x] New: directory path in python -c / heredoc not blocked
- [x] New: directory read is nothing-to-scan; `/dev/null` still fail-closed
- [x] Updated: cron script=directory no longer raises lifecycle block; `/dev/null` still does