### PR TITLE
test(cli): guard setup pickers stay on curses radiolist

### DIFF
--- a/tests/hermes_cli/test_setup_menu_curses_migration.py
+++ b/tests/hermes_cli/test_setup_menu_curses_migration.py
@@ -1,0 +1,67 @@
+"""Regression tests confirming the setup model/provider/reasoning pickers route
+through the shared curses radiolist (ESC + arrow-key handling that works across
+terminals, incl. Ghostty) instead of simple_term_menu.
+
+Guards against silently regressing back to simple_term_menu, whose ESC/arrow
+handling was unreliable in `hermes setup` (the provider->model sub-menu).
+"""
+from unittest.mock import patch
+
+
+def test_prompt_model_selection_uses_curses_radiolist():
+    from hermes_cli.auth import _prompt_model_selection
+    from hermes_cli.curses_ui import radio_item_plain
+
+    seen = {}
+
+    def _fake(
+        title,
+        items,
+        *,
+        selected=0,
+        cancel_returns=None,
+        description=None,
+        searchable=False,
+        search_labels=None,
+    ):
+        seen["title"] = title
+        seen["items"] = items
+        seen["search_labels"] = search_labels
+        return 1  # pick second model
+
+    with patch("hermes_cli.curses_ui.curses_radiolist", side_effect=_fake), \
+         patch("builtins.print"):
+        result = _prompt_model_selection(["model-a", "model-b"])
+
+    assert result == "model-b"
+    assert seen["title"] == "Select default model:"
+    # Items are the models plus the custom/skip entries. Model rows may be
+    # rich (text, style) segments for sale chrome — compare the plain text.
+    plain = [radio_item_plain(item) for item in seen["items"]]
+    assert plain[:2] == ["model-a", "model-b"]
+    assert "Skip (keep current)" in plain
+    assert seen["search_labels"] is not None
+    assert len(seen["search_labels"]) == len(seen["items"])
+
+
+def test_prompt_model_selection_esc_cancels():
+    from hermes_cli.auth import _prompt_model_selection
+
+    # curses_radiolist returns the cancel sentinel (-1) on ESC.
+    with patch("hermes_cli.curses_ui.curses_radiolist", return_value=-1), \
+         patch("builtins.print"):
+        result = _prompt_model_selection(["model-a", "model-b"])
+
+    assert result is None
+
+
+def test_reasoning_effort_uses_curses_radiolist():
+    from hermes_cli.main import _prompt_reasoning_effort_selection
+
+    with patch("hermes_cli.curses_ui.curses_radiolist", return_value=2), \
+         patch("builtins.print"):
+        result = _prompt_reasoning_effort_selection(["low", "medium", "high"], current_effort="")
+
+    assert result == "high"
+
+


### PR DESCRIPTION
## Summary
Salvages one intentional unique file from the DGX hermes-agent staged-index audit (`edf2005c6e7` / tree `ebe6950d1404`) onto clean `main`.

Adds `tests/hermes_cli/test_setup_menu_curses_migration.py` to lock:
- `_prompt_model_selection` happy path uses `curses_radiolist` (with search labels)
- ESC cancel returns `None`
- reasoning-effort picker uses `curses_radiolist`

## Why
The dirty install tree has 692 staged paths. Classification showed almost all are residue (older snapshot mods/deletes vs live main). This test file is the only unique addition that is still valuable, safe, and green on current main.

Explicitly **not** recovered from the same snapshot:
- blender MCP/skill paths (security-removed on main via `bdbdfead041`)
- incomplete `inference-sh-cli` → `cli` rename
- PR screenshots, frozen achievements plugin docs, stale plan docs already superseded by shipped streaming/API work

## Test plan
- [x] `pytest tests/hermes_cli/test_setup_menu_curses_migration.py -q` → 3 passed on `origin/main`
- [ ] CI