### PR TITLE
fix(context-compressor): stop priming models to abbreviate their own tool-call arguments

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1148,6 +1148,27 @@ def _strip_image_parts_from_parts(parts: Any) -> Any:
     return out if had_image else None
 
 
+# #83714 — the shrunk value is replayed back to the model as its OWN past
+# tool call on every subsequent turn. A bare, prose-shaped marker like
+# "...[truncated]" is exactly the kind of terse ellipsis abbreviation a
+# model is already inclined to produce, so a model conditioned on seeing
+# itself "get away with" that pattern in its own history will imitate it in
+# a *new* tool call — writing the literal marker into a file instead of the
+# real content (observed with deepseek-v4-pro; see PR #83752 for the
+# resulting file-corruption guard). This marker is deliberately NOT
+# prose-shaped: distinctive non-ASCII delimiters that don't occur in normal
+# code/text, an explicit "not real content" disclaimer, and a per-instance
+# character count that won't match the next omission point even if copied
+# verbatim — all raise the bar against a model treating this as a stylistic
+# convention worth reusing.
+_COMPRESSION_MARKER_TEMPLATE = (
+    "⟪HERMES-CONTEXT-COMPRESSION: {omitted:,} of {total:,} chars omitted here "
+    "by Hermes's context compressor. This is NOT part of the original tool "
+    "call and must never be reproduced in new output — always write full, "
+    "untruncated content.⟫"
+)
+
+
 def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
     """Shrink long string values inside a tool-call arguments JSON blob while
     preserving JSON validity.
@@ -1172,6 +1193,12 @@ def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
     to begin with — some model backends use non-JSON tool arguments — the
     original string is returned unchanged rather than replaced with
     something neither we nor the backend can parse.
+
+    The shrunk value stays a plain string (never a nested object) so the
+    JSON *shape* is unchanged from the original — only #83714's marker text
+    changed, not the #11762 valid-JSON-and-matching-shape contract. See
+    ``_COMPRESSION_MARKER_TEMPLATE`` for why the marker itself looks nothing
+    like ``"...[truncated]"`` anymore.
     """
     try:
         parsed = json.loads(args)
@@ -1181,7 +1208,10 @@ def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
     def _shrink(obj: Any) -> Any:
         if isinstance(obj, str):
             if len(obj) > head_chars:
-                return obj[:head_chars] + "...[truncated]"
+                marker = _COMPRESSION_MARKER_TEMPLATE.format(
+                    omitted=len(obj) - head_chars, total=len(obj)
+                )
+                return obj[:head_chars] + marker
             return obj
         if isinstance(obj, dict):
             return {k: _shrink(v) for k, v in obj.items()}

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2106,7 +2106,7 @@ class TestTruncateToolCallArgsJson:
         shrunk = shrink(original)
         parsed = _json.loads(shrunk)  # must not raise
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
-        assert parsed["content"].endswith("...[truncated]")
+        assert "HERMES-CONTEXT-COMPRESSION" in parsed["content"]
         assert len(shrunk) < len(original)
 
 
@@ -2127,7 +2127,7 @@ class TestTruncateToolCallArgsJson:
         assert parsed["enabled"] is True
         assert parsed["timeout"] is None
         assert parsed["items"] == [1, 2, 3]
-        assert parsed["note"].endswith("...[truncated]")
+        assert "HERMES-CONTEXT-COMPRESSION" in parsed["note"]
 
 
 
@@ -2165,7 +2165,87 @@ class TestTruncateToolCallArgsJson:
         # Must parse — otherwise downstream provider returns 400
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
-        assert parsed["content"].endswith("...[truncated]")
+        assert "HERMES-CONTEXT-COMPRESSION" in parsed["content"]
+
+
+class TestTruncationMarkerNotImitable:
+    """Regression tests for #83714.
+
+    A model replayed its own history containing the bare
+    ``"...[truncated]"`` marker and, in a later turn, imitated it —
+    writing the literal marker into a *new* tool call's ``new_string``
+    instead of real content, which the file tools then wrote straight to
+    disk (see PR #83752's write_file/patch_tool guard, the safety net for
+    when this still slips through). The compressor-side fix is to stop
+    injecting a marker that looks like something the model itself would
+    plausibly write.
+    """
+
+    def _helper(self):
+        from agent.context_compressor import _truncate_tool_call_args_json
+        return _truncate_tool_call_args_json
+
+    def test_old_bare_marker_no_longer_produced(self):
+        """The exact literal that caused #83714 must never come out of the
+        shrink helper again, in isolation or as a suffix."""
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({"path": "/f.py", "new_string": "y" * 600})
+        shrunk = _json.loads(shrink(payload))["new_string"]
+        assert "...[truncated]" not in shrunk
+        assert not shrunk.endswith("...[truncated]")
+
+    def test_marker_uses_distinctive_non_ascii_delimiters(self):
+        """The marker must be visually/structurally unlike prose a model
+        would naturally continue with — distinctive delimiters are one of
+        the deliberate anti-imitation properties (see
+        ``_COMPRESSION_MARKER_TEMPLATE``'s docstring)."""
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({"content": "x" * 1000})
+        shrunk = _json.loads(shrink(payload))["content"]
+        assert "⟪" in shrunk and "⟫" in shrunk
+
+    def test_marker_states_it_is_not_original_content(self):
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({"content": "x" * 1000})
+        shrunk = _json.loads(shrink(payload))["content"]
+        assert "NOT part of the original" in shrunk
+
+    def test_marker_carries_a_per_instance_char_count(self):
+        """The omitted/total counts vary per call, so a model that copies
+        the marker verbatim into an unrelated new tool call produces an
+        internally inconsistent (and thus more obviously wrong) string,
+        rather than a plausible-looking universal abbreviation token."""
+        import json as _json
+        shrink = self._helper()
+        # head_chars=200: a 300-char input omits 100, a 3000-char input omits 2800.
+        shrunk_short = _json.loads(shrink(_json.dumps({"c": "x" * 300})))["c"]
+        shrunk_long = _json.loads(shrink(_json.dumps({"c": "x" * 3000})))["c"]
+        assert shrunk_short != shrunk_long
+        assert "100 of 300 chars omitted" in shrunk_short
+        assert "2,800 of 3,000 chars omitted" in shrunk_long
+
+    def test_string_below_threshold_is_untouched(self):
+        """Strings at or under head_chars never get a marker at all — the
+        char-count check above only applies once shrinking actually kicks in."""
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({"c": "x" * 150})
+        parsed = _json.loads(shrink(payload))
+        assert parsed["c"] == "x" * 150
+
+    def test_shrunk_value_stays_a_plain_string(self):
+        """#11762 established that the shrunk JSON shape must match the
+        original (string leaf stays a string leaf) so strict providers
+        don't 400 on a type mismatch when the history is replayed. The
+        #83714 marker-text fix must not regress that invariant."""
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({"new_string": "z" * 500})
+        parsed = _json.loads(shrink(payload))
+        assert isinstance(parsed["new_string"], str)
 
 
 class TestLazyContextResolution:


### PR DESCRIPTION
## Summary

Root-cause fix for #83714.

During context compression, `_truncate_tool_call_args_json()` shrinks long string values inside **past assistant** `tool_calls[].function.arguments` — content that is later replayed to the model as its own prior output. The old suffix was a bare `...[truncated]`, which is easy for a model to imitate in a *new* tool call (and then write to disk).

This is the same marker family that previously caused #11762 (invalid JSON after raw-string slicing). That fix kept JSON valid but left the imitable marker text.

## Change

Replace the bare marker with a deliberately non-prose-shaped disclaimer:

```text
⟪HERMES-CONTEXT-COMPRESSION: {omitted} of {total} chars omitted here
by Hermes's context compressor. This is NOT part of the original tool
call and must never be reproduced in new output — always write full,
untruncated content.⟫
```

- Distinctive delimiters (`⟪⟫`)
- Explicit “not original tool call” wording
- Per-instance counts (copy-paste into a new call looks inconsistent)
- Value stays a **plain string** (preserves the #11762 shape/JSON-validity contract)

Other `...[truncated]` sites in the compressor (summarizer input, fallback recap, user-only paths) are left alone — they are not replayed as assistant tool-call args.

## Suggested landing order

1. **This PR** (#83843) — stop minting the bad primer  
2. **#83752** — fail closed on the write path if any residual imitation still happens (tool-result markers, already-compacted history, etc.)

## Testing

- Updated existing `TestTruncateToolCallArgsJson` expectations for the new marker
- Added `TestTruncationMarkerNotImitable` coverage
- `pytest tests/agent/test_context_compressor.py tests/test_trajectory_compressor.py -q` — green on the PR branch

## Related

- Issue: #83714  
- Companion guard: #83752  
- Prior art / overlapping write-guard ideas: #68512 (thanks @ygd58 — especially count-based original-vs-content comparison)  
- Earlier marker incident: #11762  

Happy to take review feedback or split further if useful.