### PR TITLE
feat(tools): add native Claude Code delegation via GLM-5.2

### DIFF
--- a/tests/tools/test_claude_agent_tool.py
+++ b/tests/tools/test_claude_agent_tool.py
@@ -1,0 +1,510 @@
+"""Behavior-contract tests for delegate_claude_agent."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Reusable marker for tests that spawn a real (fake-binary) subprocess and
+# signal it. The conftest live-system guard allows signals inside the test's
+# own process subtree, so these do not need to bypass it — but we keep the
+# marker for clarity and in case a stricter guard is added later.
+_REAL_SUBPROC = pytest.mark.live_system_guard_bypass
+
+
+def _write_fake_binary(tmp_path: Path) -> Path:
+    """Write a fake claude-glm binary driven by FAKE_CLAUDE_* env vars."""
+    script = f"""#!{sys.executable}
+import json
+import os
+import sys
+import time
+
+mode = os.environ.get("FAKE_CLAUDE_MODE", "success")
+
+argv_out = os.environ.get("FAKE_CLAUDE_ARGV_OUT")
+if argv_out:
+    with open(argv_out, "w", encoding="utf-8") as fh:
+        json.dump(sys.argv, fh)
+
+env_out = os.environ.get("FAKE_CLAUDE_ENV_OUT")
+if env_out:
+    with open(env_out, "w", encoding="utf-8") as fh:
+        json.dump({{"HOME": os.environ.get("HOME"), "PATH": os.environ.get("PATH", "")}}, fh)
+
+if mode == "sleep":
+    try:
+        time.sleep(float(os.environ.get("FAKE_CLAUDE_SLEEP", "30")))
+    except Exception:
+        pass
+    sys.exit(0)
+
+if mode == "garbage":
+    sys.stdout.write("not json line 1\\nnot json line 2\\n")
+    sys.stdout.flush()
+    sys.exit(0)
+
+if mode == "empty":
+    sys.exit(0)
+
+if mode == "exitnonzero":
+    sys.stdout.write('{{"type":"result","subtype":"success","is_error":false,"result":"x"}}\\n')
+    sys.stdout.flush()
+    sys.exit(2)
+
+models_str = os.environ.get("FAKE_CLAUDE_MODELS", "glm-5.2")
+model_usage = {{}}
+for _name in models_str.split(","):
+    _name = _name.strip()
+    if _name:
+        model_usage[_name] = {{"input_tokens": 100, "output_tokens": 50}}
+
+result = {{
+    "type": "result",
+    "subtype": os.environ.get("FAKE_CLAUDE_SUBTYPE", "success"),
+    "is_error": os.environ.get("FAKE_CLAUDE_IS_ERROR", "false").lower() == "true",
+    "result": os.environ.get("FAKE_CLAUDE_RESULT_TEXT", "Done."),
+    "session_id": os.environ.get("FAKE_CLAUDE_SESSION_ID", "sess-claude-1"),
+    "num_turns": int(os.environ.get("FAKE_CLAUDE_NUM_TURNS", "3")),
+    "duration_ms": int(os.environ.get("FAKE_CLAUDE_DURATION_MS", "12345")),
+    "total_cost_usd": float(os.environ.get("FAKE_CLAUDE_COST", "0.0123")),
+    "modelUsage": model_usage,
+    "permission_denials": json.loads(os.environ.get("FAKE_CLAUDE_DENIALS", "[]")),
+}}
+sys.stdout.write(json.dumps(result) + "\\n")
+sys.stdout.flush()
+"""
+    binary = tmp_path / "claude-glm"
+    binary.write_text(script, encoding="utf-8")
+    binary.chmod(0o755)
+    return binary
+
+
+@pytest.fixture
+def fake_binary(tmp_path: Path) -> Path:
+    return _write_fake_binary(tmp_path)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    return workdir
+
+
+def _patch_binary(monkeypatch, binary: Path) -> None:
+    monkeypatch.setattr(
+        "tools.claude_agent_tool.resolve_claude_binary",
+        lambda: str(binary),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema + registration
+# ---------------------------------------------------------------------------
+
+def test_schema_registration():
+    import tools.claude_agent_tool  # noqa: F401
+    from tools.registry import registry
+
+    entry = registry.get_entry("delegate_claude_agent")
+    assert entry is not None
+    assert entry.toolset == "delegation"
+    assert entry.max_result_size_chars == 100_000
+
+    schema = entry.schema
+    required = set(schema["parameters"]["required"])
+    assert required == {"task", "workdir"}
+
+    props = schema["parameters"]["properties"]
+    assert props["model"]["default"] == "glm-5.2"
+    assert props["timeout_seconds"]["default"] == 1800
+    assert props["allowed_tools"]["default"] == "Read,Write,Edit,Glob,Grep,Bash"
+    assert props["permission_mode"]["default"] == "acceptEdits"
+    assert set(props["permission_mode"]["enum"]) == {"acceptEdits", "plan"}
+
+
+# ---------------------------------------------------------------------------
+# Binary resolution + gating
+# ---------------------------------------------------------------------------
+
+def test_check_fn_binary_found(monkeypatch, fake_binary):
+    from tools.claude_agent_tool import check_claude_agent_requirements
+
+    monkeypatch.setattr(
+        "tools.claude_agent_tool.resolve_claude_binary", lambda: str(fake_binary)
+    )
+    assert check_claude_agent_requirements() is True
+
+
+def test_check_fn_binary_missing(monkeypatch):
+    from tools.claude_agent_tool import check_claude_agent_requirements
+
+    monkeypatch.setattr("tools.claude_agent_tool.resolve_claude_binary", lambda: None)
+    assert check_claude_agent_requirements() is False
+
+
+def test_resolve_env_override(monkeypatch, fake_binary, tmp_path):
+    from tools.claude_agent_tool import resolve_claude_binary
+
+    monkeypatch.setenv("CLAUDE_GLM_BIN", str(fake_binary))
+    assert resolve_claude_binary() == str(fake_binary)
+
+
+def test_resolve_env_override_must_be_executable_file(monkeypatch, tmp_path):
+    from tools.claude_agent_tool import resolve_claude_binary
+
+    bogus = tmp_path / "nope"
+    monkeypatch.setenv("CLAUDE_GLM_BIN", str(bogus))
+    # Override points at a non-existent file → fall through to the rest.
+    monkeypatch.setattr("tools.claude_agent_tool.shutil.which", lambda name: None)
+    # A plain non-existent Path: is_file() is naturally False, exercising the
+    # real branch without the _flavour breakage a Path subclass would cause.
+    monkeypatch.setattr(
+        "tools.claude_agent_tool._local_bin_claude_glm_path",
+        lambda: Path("/nope/claude-glm"),
+    )
+    assert resolve_claude_binary() is None
+
+
+def test_resolve_local_bin(monkeypatch, fake_binary):
+    from tools.claude_agent_tool import resolve_claude_binary
+
+    monkeypatch.delenv("CLAUDE_GLM_BIN", raising=False)
+    monkeypatch.setattr("tools.claude_agent_tool.shutil.which", lambda name: None)
+    monkeypatch.setattr(
+        "tools.claude_agent_tool._local_bin_claude_glm_path", lambda: fake_binary
+    )
+    assert resolve_claude_binary() == str(fake_binary)
+
+
+def test_resolve_path_fallbacks(monkeypatch, tmp_path):
+    from tools.claude_agent_tool import resolve_claude_binary
+
+    monkeypatch.delenv("CLAUDE_GLM_BIN", raising=False)
+    monkeypatch.setattr(
+        "tools.claude_agent_tool._local_bin_claude_glm_path",
+        lambda: Path("/nope/claude-glm"),
+    )
+    # claude-glm on PATH wins over bare claude.
+    monkeypatch.setattr(
+        "tools.claude_agent_tool.shutil.which",
+        lambda name: "/usr/bin/claude-glm" if name == "claude-glm" else "/usr/bin/claude",
+    )
+    assert resolve_claude_binary() == "/usr/bin/claude-glm"
+
+    # Falls back to bare claude when claude-glm is absent.
+    monkeypatch.setattr(
+        "tools.claude_agent_tool.shutil.which",
+        lambda name: "/usr/bin/claude" if name == "claude" else None,
+    )
+    assert resolve_claude_binary() == "/usr/bin/claude"
+
+    # Nothing resolvable → None.
+    monkeypatch.setattr("tools.claude_agent_tool.shutil.which", lambda name: None)
+    assert resolve_claude_binary() is None
+
+
+# ---------------------------------------------------------------------------
+# Timeout clamping
+# ---------------------------------------------------------------------------
+
+def test_clamp_timeout_seconds():
+    from tools.claude_agent_tool import (
+        DEFAULT_TIMEOUT_SECONDS,
+        MAX_TIMEOUT_SECONDS,
+        MIN_TIMEOUT_SECONDS,
+        _clamp_timeout_seconds,
+    )
+
+    assert _clamp_timeout_seconds(59) == MIN_TIMEOUT_SECONDS
+    assert _clamp_timeout_seconds(3601) == MAX_TIMEOUT_SECONDS
+    assert _clamp_timeout_seconds("garbage") == DEFAULT_TIMEOUT_SECONDS
+    assert _clamp_timeout_seconds(None) == DEFAULT_TIMEOUT_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Log parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_result_extracts_fields():
+    from tools.claude_agent_tool import parse_claude_agent_log
+
+    line = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "All done.",
+            "session_id": "sess-1",
+            "num_turns": 4,
+            "duration_ms": 999,
+            "total_cost_usd": 0.05,
+            "modelUsage": {
+                "glm-5.2": {"input_tokens": 10},
+                "claude-haiku-4-5": {"input_tokens": 5},
+            },
+            "permission_denials": [{"tool": "Bash"}],
+        }
+    )
+    parsed = parse_claude_agent_log(line + "\n")
+    assert parsed["subtype"] == "success"
+    assert parsed["is_error"] is False
+    assert parsed["result"] == "All done."
+    assert parsed["session_id"] == "sess-1"
+    assert parsed["num_turns"] == 4
+    assert parsed["duration_ms"] == 999
+    assert parsed["total_cost_usd"] == 0.05
+    assert parsed["models_used"] == ["claude-haiku-4-5", "glm-5.2"]
+    assert parsed["permission_denials"] == [{"tool": "Bash"}]
+
+
+def test_parse_last_result_line_wins():
+    from tools.claude_agent_tool import parse_claude_agent_log
+
+    first = json.dumps({"type": "result", "subtype": "success", "result": "old"})
+    second = json.dumps({"type": "result", "subtype": "error", "is_error": True, "result": "new"})
+    parsed = parse_claude_agent_log("\n".join([first, second]))
+    assert parsed["result"] == "new"
+    assert parsed["subtype"] == "error"
+
+
+def test_parse_no_result_event_returns_empty():
+    from tools.claude_agent_tool import parse_claude_agent_log
+
+    assert parse_claude_agent_log("not json\n") == {}
+    assert parse_claude_agent_log("") == {}
+    assert parse_claude_agent_log('{"type":"assistant","message":{}}') == {}
+
+
+# ---------------------------------------------------------------------------
+# Validation paths (no subprocess spawned)
+# ---------------------------------------------------------------------------
+
+def test_validation_errors_use_full_result_shape(monkeypatch, tmp_path, fake_binary):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+
+    empty = json.loads(claude_agent_tool.delegate_claude_agent(task="", workdir=str(tmp_path)))
+    assert empty["success"] is False
+    assert empty["error"]
+    assert empty["log_path"] is None
+    assert "final_report" in empty
+    assert "models_used" in empty
+    assert "permission_denials" in empty
+
+    relative = json.loads(
+        claude_agent_tool.delegate_claude_agent(task="x", workdir="relative/path")
+    )
+    assert relative["success"] is False
+    assert "absolute path" in relative["error"]
+
+    missing = json.loads(
+        claude_agent_tool.delegate_claude_agent(
+            task="x",
+            workdir=str((tmp_path / "missing").resolve()),
+        )
+    )
+    assert missing["success"] is False
+    assert "does not exist" in missing["error"]
+
+
+def test_permission_mode_validation_rejects_unknown(monkeypatch, repo, fake_binary):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(
+            task="x",
+            workdir=str(repo),
+            permission_mode="yolo",
+        )
+    )
+    assert result["success"] is False
+    assert "permission_mode" in result["error"]
+    assert "acceptEdits" in result["error"]
+
+
+def test_binary_missing_returns_error(monkeypatch, repo):
+    from tools import claude_agent_tool
+
+    monkeypatch.setattr("tools.claude_agent_tool.resolve_claude_binary", lambda: None)
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(task="x", workdir=str(repo))
+    )
+    assert result["success"] is False
+    assert "not found" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Happy path + result parsing (real fake-binary subprocess)
+# ---------------------------------------------------------------------------
+
+@_REAL_SUBPROC
+def test_happy_path_e2e(monkeypatch, repo, fake_binary, tmp_path):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    monkeypatch.setenv("FAKE_CLAUDE_RESULT_TEXT", "Implemented feature.")
+    monkeypatch.setenv("FAKE_CLAUDE_SESSION_ID", "sess-claude-xyz")
+    monkeypatch.setenv("FAKE_CLAUDE_NUM_TURNS", "5")
+    monkeypatch.setenv("FAKE_CLAUDE_COST", "0.0775")
+    monkeypatch.setenv("FAKE_CLAUDE_MODELS", "glm-5.2,claude-haiku-4-5")
+    monkeypatch.setenv("FAKE_CLAUDE_DENIALS", '[{"tool":"Bash","reason":"nope"}]')
+    argv_out = tmp_path / "argv.json"
+    monkeypatch.setenv("FAKE_CLAUDE_ARGV_OUT", str(argv_out))
+
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(
+            task="implement feature",
+            workdir=str(repo),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["error"] is None
+    assert result["final_report"] == "Implemented feature."
+    assert result["session_id"] == "sess-claude-xyz"
+    assert result["num_turns"] == 5
+    assert result["cost_usd"] == 0.0775
+    assert result["models_used"] == ["claude-haiku-4-5", "glm-5.2"]
+    assert result["permission_denials"] == [{"tool": "Bash", "reason": "nope"}]
+    assert "claude-runs" in result["log_path"]
+    assert Path(result["log_path"]).is_file()
+
+    argv = json.loads(argv_out.read_text(encoding="utf-8"))
+    assert argv[0] == str(fake_binary)
+    assert "-p" in argv
+    assert "--model" in argv
+    assert argv[argv.index("--model") + 1] == "glm-5.2"
+    assert "--permission-mode" in argv
+    assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
+    assert "--allowedTools" in argv
+    assert argv[argv.index("--allowedTools") + 1] == "Read,Write,Edit,Glob,Grep,Bash"
+    assert "--output-format" in argv
+    assert argv[argv.index("--output-format") + 1] == "json"
+    assert argv[-1] == "implement feature"
+    # --dangerously-skip-permissions must never be passed (refused under root).
+    assert "--dangerously-skip-permissions" not in argv
+
+
+@_REAL_SUBPROC
+def test_plan_permission_mode_passed_through(monkeypatch, repo, fake_binary, tmp_path):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    argv_out = tmp_path / "argv.json"
+    monkeypatch.setenv("FAKE_CLAUDE_ARGV_OUT", str(argv_out))
+
+    claude_agent_tool.delegate_claude_agent(
+        task="plan something",
+        workdir=str(repo),
+        permission_mode="plan",
+    )
+    argv = json.loads(argv_out.read_text(encoding="utf-8"))
+    assert argv[argv.index("--permission-mode") + 1] == "plan"
+
+
+@_REAL_SUBPROC
+def test_is_error_path(monkeypatch, repo, fake_binary):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    monkeypatch.setenv("FAKE_CLAUDE_SUBTYPE", "error")
+    monkeypatch.setenv("FAKE_CLAUDE_IS_ERROR", "true")
+    monkeypatch.setenv("FAKE_CLAUDE_RESULT_TEXT", "Boom.")
+
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(task="x", workdir=str(repo))
+    )
+    assert result["success"] is False
+    assert result["final_report"] == "Boom."
+    assert "error" in result["error"] or "is_error" in result["error"]
+
+
+@_REAL_SUBPROC
+def test_malformed_output_no_result_event(monkeypatch, repo, fake_binary):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    monkeypatch.setenv("FAKE_CLAUDE_MODE", "garbage")
+
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(task="x", workdir=str(repo))
+    )
+    assert result["success"] is False
+    assert "no result event" in result["error"]
+    assert Path(result["log_path"]).is_file()
+
+
+@_REAL_SUBPROC
+def test_nonzero_exit_reports_failure(monkeypatch, repo, fake_binary):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    monkeypatch.setenv("FAKE_CLAUDE_MODE", "exitnonzero")
+
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(task="x", workdir=str(repo))
+    )
+    assert result["success"] is False
+    assert "exited with code 2" in result["error"]
+
+
+@_REAL_SUBPROC
+def test_timeout_kills_process_group(monkeypatch, repo, fake_binary):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    monkeypatch.setenv("FAKE_CLAUDE_MODE", "sleep")
+    monkeypatch.setenv("FAKE_CLAUDE_SLEEP", "30")
+
+    # Fake a fast wall-clock so timeout_seconds=60 trips within milliseconds.
+    start = time.monotonic()
+    calls = {"n": 0}
+
+    def _fake_monotonic():
+        calls["n"] += 1
+        return start + calls["n"] * 40
+
+    monkeypatch.setattr("tools.claude_agent_tool.time.monotonic", _fake_monotonic)
+    monkeypatch.setattr(claude_agent_tool, "STALL_WATCHDOG_SECONDS", 9999)
+    monkeypatch.setattr(claude_agent_tool, "_MONITOR_POLL_SECONDS", 0.001)
+
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(
+            task="timeout test",
+            workdir=str(repo),
+            timeout_seconds=60,
+        )
+    )
+    assert result["success"] is False
+    assert result["error"] == "timeout"
+
+
+@_REAL_SUBPROC
+def test_child_env_guarantees_home_and_local_bin(monkeypatch, repo, fake_binary, tmp_path):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    monkeypatch.delenv("HOME", raising=False)
+    env_out = tmp_path / "env.json"
+    monkeypatch.setenv("FAKE_CLAUDE_ENV_OUT", str(env_out))
+
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(task="x", workdir=str(repo))
+    )
+    assert result["success"] is True
+
+    captured = json.loads(env_out.read_text(encoding="utf-8"))
+    # HOME must be present and non-empty even though the caller env lacked it;
+    # the wrapper runs with `set -u` and dies on an unbound $HOME.
+    assert captured["HOME"] == str(Path.home())
+    # ~/.local/bin is prepended so binary resolution works under minimal PATH.
+    assert captured["PATH"].split(os.pathsep)[0] == str(Path.home() / ".local" / "bin")

--- a/tests/tools/test_claude_agent_tool.py
+++ b/tests/tools/test_claude_agent_tool.py
@@ -44,6 +44,13 @@ if mode == "sleep":
         pass
     sys.exit(0)
 
+if mode == "sleep_then_result":
+    try:
+        time.sleep(float(os.environ.get("FAKE_CLAUDE_SLEEP", "0.15")))
+    except Exception:
+        pass
+    # Fall through to emit the normal result event after the silent period.
+
 if mode == "garbage":
     sys.stdout.write("not json line 1\\nnot json line 2\\n")
     sys.stdout.flush()
@@ -56,6 +63,51 @@ if mode == "exitnonzero":
     sys.stdout.write('{{"type":"result","subtype":"success","is_error":false,"result":"x"}}\\n')
     sys.stdout.flush()
     sys.exit(2)
+
+if mode == "flood":
+    noise_line = '{{"type":"assistant","message":"noise"}}\\n'
+    target = int(os.environ.get("FAKE_CLAUDE_FLOOD_BYTES", str(3 * 1024 * 1024)))
+    written = 0
+    while written < target:
+        sys.stdout.write(noise_line)
+        written += len(noise_line.encode("utf-8"))
+    sys.stdout.flush()
+    # Fall through to emit the normal result event after the flood.
+
+if mode == "flood_giant_result":
+    pad = "x" * int(os.environ.get("FAKE_CLAUDE_GIANT_PAD", str(2 * 1024 * 1024)))
+    giant = {{
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": pad,
+        "session_id": "sess-giant",
+        "num_turns": 1,
+        "duration_ms": 1,
+        "total_cost_usd": 0.0,
+        "modelUsage": {{}},
+        "permission_denials": [],
+    }}
+    sys.stdout.write(json.dumps(giant) + "\\n")
+    sys.stdout.flush()
+    sys.exit(0)
+
+if mode == "early_result_then_flood":
+    early = {{
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": "not terminal",
+    }}
+    sys.stdout.write(json.dumps(early) + "\\n")
+    noise_line = '{{"type":"assistant","message":"trailing noise"}}\\n'
+    target = int(os.environ.get("FAKE_CLAUDE_FLOOD_BYTES", str(3 * 1024 * 1024)))
+    written = 0
+    while written < target:
+        sys.stdout.write(noise_line)
+        written += len(noise_line.encode("utf-8"))
+    sys.stdout.flush()
+    sys.exit(0)
 
 models_str = os.environ.get("FAKE_CLAUDE_MODELS", "glm-5.2")
 model_usage = {{}}
@@ -191,19 +243,18 @@ def test_resolve_path_fallbacks(monkeypatch, tmp_path):
         "tools.claude_agent_tool._local_bin_claude_glm_path",
         lambda: Path("/nope/claude-glm"),
     )
-    # claude-glm on PATH wins over bare claude.
     monkeypatch.setattr(
         "tools.claude_agent_tool.shutil.which",
-        lambda name: "/usr/bin/claude-glm" if name == "claude-glm" else "/usr/bin/claude",
+        lambda name: "/usr/bin/claude-glm" if name == "claude-glm" else None,
     )
     assert resolve_claude_binary() == "/usr/bin/claude-glm"
 
-    # Falls back to bare claude when claude-glm is absent.
+    # Bare `claude` on PATH must NOT resolve — GLM wrapper only.
     monkeypatch.setattr(
         "tools.claude_agent_tool.shutil.which",
         lambda name: "/usr/bin/claude" if name == "claude" else None,
     )
-    assert resolve_claude_binary() == "/usr/bin/claude"
+    assert resolve_claude_binary() is None
 
     # Nothing resolvable → None.
     monkeypatch.setattr("tools.claude_agent_tool.shutil.which", lambda name: None)
@@ -282,6 +333,94 @@ def test_parse_no_result_event_returns_empty():
     assert parse_claude_agent_log('{"type":"assistant","message":{}}') == {}
 
 
+def test_parse_adversarial_metadata_normalization():
+    from tools.claude_agent_tool import parse_claude_agent_log
+
+    line = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": {"nested": "report"},
+            "session_id": {"bad": "id"},
+            "num_turns": [1, 2],
+            "duration_ms": "123",
+            "total_cost_usd": {"usd": 1},
+            "modelUsage": {"glm-5.2": {}},
+            "permission_denials": "denied",
+        }
+    )
+    parsed = parse_claude_agent_log(line)
+    assert parsed["result"] == '{"nested": "report"}'
+    assert parsed["session_id"] is None
+    assert parsed["num_turns"] is None
+    assert parsed["duration_ms"] is None
+    assert parsed["total_cost_usd"] is None
+    assert parsed["models_used"] == ["glm-5.2"]
+    assert parsed["permission_denials"] == []
+
+
+@pytest.mark.parametrize(
+    "field_overrides,expected",
+    [
+        ({"num_turns": True}, {"num_turns": None, "success": True}),
+        ({"total_cost_usd": float("nan")}, {"total_cost_usd": None, "success": True}),
+        ({"total_cost_usd": float("inf")}, {"total_cost_usd": None, "success": True}),
+        ({"is_error": "false"}, {"success": False}),
+        ({"subtype": {"not": "string"}}, {"success": False}),
+    ],
+)
+def test_parse_adversarial_fail_closed_success(
+    field_overrides, expected, monkeypatch, repo, fake_binary
+):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    event = {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": "ok",
+        "session_id": "sess-1",
+        "num_turns": 3,
+        "duration_ms": 100,
+        "total_cost_usd": 0.01,
+        "modelUsage": {},
+        "permission_denials": [],
+    }
+    event.update(field_overrides)
+
+    def _fake_run(*_args, **_kwargs):
+        log_text = json.dumps(event) + "\n"
+        return None, "/tmp/fake.jsonl", log_text, log_text, 1.0, 0, False, 0
+
+    monkeypatch.setattr(claude_agent_tool, "_run_and_stream", _fake_run)
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(task="x", workdir=str(repo))
+    )
+    assert result["success"] is expected["success"]
+    if "num_turns" in expected:
+        assert result["num_turns"] is expected["num_turns"]
+    if "total_cost_usd" in expected:
+        assert result["cost_usd"] is expected["total_cost_usd"]
+
+
+def test_parse_coerces_integral_float_num_turns():
+    from tools.claude_agent_tool import parse_claude_agent_log
+
+    line = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "done",
+            "num_turns": 3.0,
+        }
+    )
+    parsed = parse_claude_agent_log(line)
+    assert parsed["num_turns"] == 3
+
+
 # ---------------------------------------------------------------------------
 # Validation paths (no subprocess spawned)
 # ---------------------------------------------------------------------------
@@ -297,7 +436,7 @@ def test_validation_errors_use_full_result_shape(monkeypatch, tmp_path, fake_bin
     assert empty["log_path"] is None
     assert "final_report" in empty
     assert "models_used" in empty
-    assert "permission_denials" in empty
+    assert empty["permission_denials"] == []
 
     relative = json.loads(
         claude_agent_tool.delegate_claude_agent(task="x", workdir="relative/path")
@@ -388,7 +527,8 @@ def test_happy_path_e2e(monkeypatch, repo, fake_binary, tmp_path):
     assert "--allowedTools" in argv
     assert argv[argv.index("--allowedTools") + 1] == "Read,Write,Edit,Glob,Grep,Bash"
     assert "--output-format" in argv
-    assert argv[argv.index("--output-format") + 1] == "json"
+    assert argv[argv.index("--output-format") + 1] == "stream-json"
+    assert "--verbose" in argv
     assert argv[-1] == "implement feature"
     # --dangerously-skip-permissions must never be passed (refused under root).
     assert "--dangerously-skip-permissions" not in argv
@@ -474,7 +614,6 @@ def test_timeout_kills_process_group(monkeypatch, repo, fake_binary):
         return start + calls["n"] * 40
 
     monkeypatch.setattr("tools.claude_agent_tool.time.monotonic", _fake_monotonic)
-    monkeypatch.setattr(claude_agent_tool, "STALL_WATCHDOG_SECONDS", 9999)
     monkeypatch.setattr(claude_agent_tool, "_MONITOR_POLL_SECONDS", 0.001)
 
     result = json.loads(
@@ -486,6 +625,45 @@ def test_timeout_kills_process_group(monkeypatch, repo, fake_binary):
     )
     assert result["success"] is False
     assert result["error"] == "timeout"
+
+
+@_REAL_SUBPROC
+def test_silent_period_then_final_result_not_stalled(monkeypatch, repo, fake_binary):
+    """Healthy runs that emit nothing until the final result must not die as stalled."""
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    monkeypatch.setenv("FAKE_CLAUDE_MODE", "sleep_then_result")
+    monkeypatch.setenv("FAKE_CLAUDE_SLEEP", "0.15")
+    monkeypatch.setenv("FAKE_CLAUDE_RESULT_TEXT", "Finished after quiet tool call.")
+
+    # Simulate >180s of stdout silence on the first monitor tick while the hard
+    # timeout (3600s) stays far away. Under the removed stall watchdog the run
+    # completes once the subprocess emits its final result line.
+    start = 1000.0
+    calls = {"n": 0}
+
+    def _fake_monotonic():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return start
+        if calls["n"] == 2:
+            return start + 200.0
+        return start + 200.0 + (calls["n"] - 2) * 0.01
+
+    monkeypatch.setattr("tools.claude_agent_tool.time.monotonic", _fake_monotonic)
+    monkeypatch.setattr(claude_agent_tool, "_MONITOR_POLL_SECONDS", 0.01)
+
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(
+            task="long quiet tool call",
+            workdir=str(repo),
+            timeout_seconds=3600,
+        )
+    )
+    assert result["success"] is True
+    assert result["error"] is None
+    assert result["final_report"] == "Finished after quiet tool call."
 
 
 @_REAL_SUBPROC
@@ -508,3 +686,74 @@ def test_child_env_guarantees_home_and_local_bin(monkeypatch, repo, fake_binary,
     assert captured["HOME"] == str(Path.home())
     # ~/.local/bin is prepended so binary resolution works under minimal PATH.
     assert captured["PATH"].split(os.pathsep)[0] == str(Path.home() / ".local" / "bin")
+
+
+@_REAL_SUBPROC
+def test_flood_output_bounded_and_parses_final_result(monkeypatch, repo, fake_binary):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    monkeypatch.setenv("FAKE_CLAUDE_MODE", "flood")
+    monkeypatch.setenv("FAKE_CLAUDE_FLOOD_BYTES", str(3 * 1024 * 1024))
+    monkeypatch.setenv("FAKE_CLAUDE_RESULT_TEXT", "Survived flood.")
+
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(task="flood test", workdir=str(repo))
+    )
+
+    assert result["success"] is True
+    assert result["final_report"] == "Survived flood."
+    assert result["log_truncated"] is True
+    assert result["log_bytes_dropped"] > 0
+
+    log_path = Path(result["log_path"])
+    assert log_path.stat().st_size <= claude_agent_tool.LOG_MAX_FILE_BYTES
+    log_text = log_path.read_text(encoding="utf-8", errors="replace")
+    assert "...[truncated " in log_text
+    assert "bytes]..." in log_text
+
+
+@_REAL_SUBPROC
+def test_giant_result_line_fails_closed(monkeypatch, repo, fake_binary):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    monkeypatch.setenv("FAKE_CLAUDE_MODE", "flood_giant_result")
+    giant_pad = claude_agent_tool.LOG_TAIL_BYTES + (512 * 1024)
+    monkeypatch.setenv("FAKE_CLAUDE_GIANT_PAD", str(giant_pad))
+
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(task="giant result", workdir=str(repo))
+    )
+
+    assert result["success"] is False
+    assert result["log_truncated"] is True
+    error = result["error"].lower()
+    assert "truncat" in error
+    log_path = Path(result["log_path"])
+    assert log_path.stat().st_size <= claude_agent_tool.LOG_MAX_FILE_BYTES
+
+
+@_REAL_SUBPROC
+def test_truncated_log_does_not_accept_early_head_result(
+    monkeypatch, repo, fake_binary
+):
+    from tools import claude_agent_tool
+
+    _patch_binary(monkeypatch, fake_binary)
+    monkeypatch.setenv("FAKE_CLAUDE_MODE", "early_result_then_flood")
+    monkeypatch.setenv("FAKE_CLAUDE_FLOOD_BYTES", str(3 * 1024 * 1024))
+
+    result = json.loads(
+        claude_agent_tool.delegate_claude_agent(
+            task="early result followed by trailing noise", workdir=str(repo)
+        )
+    )
+
+    assert result["success"] is False
+    assert result["final_report"] == ""
+    assert result["log_truncated"] is True
+    assert "result event missing" in result["error"]
+    assert Path(result["log_path"]).stat().st_size <= (
+        claude_agent_tool.LOG_MAX_FILE_BYTES
+    )

--- a/tools/claude_agent_tool.py
+++ b/tools/claude_agent_tool.py
@@ -1,0 +1,620 @@
+#!/usr/bin/env python3
+"""Delegate dev tasks to the Claude Code CLI (Alibaba GLM-5.2) as a subprocess.
+
+Gating
+------
+The tool registers only when the Claude Code GLM wrapper is resolvable —
+either via the ``CLAUDE_GLM_BIN`` env override, as an executable at
+``~/.local/bin/claude-glm``, or as ``claude-glm``/``claude`` on PATH.
+
+Credentials
+-----------
+The ``claude-glm`` wrapper injects the Alibaba coding-plan credentials at
+runtime from ``<HERMES_HOME>/.env`` itself (it ``execve``s the real Claude
+binary with ``ANTHROPIC_AUTH_TOKEN`` / ``ANTHROPIC_BASE_URL`` set). This tool
+therefore NEVER places credentials in argv or in env additions — it only
+guarantees ``HOME`` and a minimal ``PATH`` so the wrapper survives sparse
+environments (it runs with ``set -u`` and dies on an unbound ``$HOME``).
+``--dangerously-skip-permissions`` is deliberately NOT passed: it is refused
+when the process runs as root.
+
+Log format
+----------
+Stdout is streamed to ``<HERMES_HOME>/claude-runs/<timestamp>-<pid>.jsonl``.
+With ``--output-format json`` the CLI emits one JSON document per line; the
+handler scans for the last line that is valid JSON with ``"type": "result"``
+and extracts session metadata, cost, model usage, and permission denials
+from it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CLAUDE_MODEL = "glm-5.2"
+DEFAULT_TIMEOUT_SECONDS = 1800
+MIN_TIMEOUT_SECONDS = 60
+MAX_TIMEOUT_SECONDS = 3600
+STALL_WATCHDOG_SECONDS = 180
+
+DEFAULT_ALLOWED_TOOLS = "Read,Write,Edit,Glob,Grep,Bash"
+DEFAULT_PERMISSION_MODE = "acceptEdits"
+_ALLOWED_PERMISSION_MODES = ("acceptEdits", "plan")
+
+_MONITOR_POLL_SECONDS = 0.1
+_TERMINATE_GRACE_SECONDS = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Binary resolution + gating
+# ---------------------------------------------------------------------------
+
+def _local_bin_claude_glm_path() -> Path:
+    return Path.home() / ".local" / "bin" / "claude-glm"
+
+
+def resolve_claude_binary() -> Optional[str]:
+    """Return the Claude Code (GLM) wrapper path, or None if not found.
+
+    Search order:
+    1. ``CLAUDE_GLM_BIN`` env override (must be an executable file).
+    2. ``~/.local/bin/claude-glm``.
+    3. ``claude-glm`` on PATH.
+    4. bare ``claude`` on PATH.
+    """
+    try:
+        override = os.environ.get("CLAUDE_GLM_BIN")
+        if override:
+            override_path = Path(override).expanduser()
+            if override_path.is_file() and os.access(override_path, os.X_OK):
+                return str(override_path)
+
+        local = _local_bin_claude_glm_path()
+        if local.is_file() and os.access(local, os.X_OK):
+            return str(local)
+
+        found = shutil.which("claude-glm")
+        if found:
+            return found
+
+        found = shutil.which("claude")
+        if found:
+            return found
+    except Exception:
+        pass
+    return None
+
+
+def check_claude_agent_requirements() -> bool:
+    """Return True when the Claude Code (GLM) wrapper binary is available."""
+    try:
+        return resolve_claude_binary() is not None
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Result parsing
+# ---------------------------------------------------------------------------
+
+def parse_claude_agent_log(log_text: str) -> Dict[str, Any]:
+    """Parse a Claude Code json log for the final ``type=result`` event.
+
+    Scans every line for valid JSON; the last line whose parsed object has
+    ``"type": "result"`` wins. Returns an empty dict when no result event is
+    found (missing/malformed output).
+    """
+    result_event: Optional[Dict[str, Any]] = None
+    for raw_line in log_text.splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict) and event.get("type") == "result":
+            result_event = event
+
+    if not result_event:
+        return {}
+
+    model_usage = result_event.get("modelUsage")
+    models_used: List[str] = []
+    if isinstance(model_usage, dict):
+        models_used = sorted(str(key) for key in model_usage.keys())
+
+    permission_denials = result_event.get("permission_denials")
+    if permission_denials is None:
+        permission_denials = []
+
+    return {
+        "subtype": result_event.get("subtype"),
+        "is_error": result_event.get("is_error"),
+        "result": result_event.get("result"),
+        "session_id": result_event.get("session_id"),
+        "num_turns": result_event.get("num_turns"),
+        "duration_ms": result_event.get("duration_ms"),
+        "total_cost_usd": result_event.get("total_cost_usd"),
+        "models_used": models_used,
+        "permission_denials": permission_denials,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helpers
+# ---------------------------------------------------------------------------
+
+def _clamp_timeout_seconds(timeout_seconds: int) -> int:
+    try:
+        value = int(timeout_seconds)
+    except (TypeError, ValueError):
+        value = DEFAULT_TIMEOUT_SECONDS
+    return max(MIN_TIMEOUT_SECONDS, min(MAX_TIMEOUT_SECONDS, value))
+
+
+def _check_interrupted() -> bool:
+    try:
+        from tools.interrupt import is_interrupted
+
+        return is_interrupted()
+    except Exception:
+        return False
+
+
+def _signal_process_group(proc: subprocess.Popen, sig: signal.Signals) -> bool:
+    try:
+        os.killpg(os.getpgid(proc.pid), sig)
+        return True
+    except (OSError, ProcessLookupError, AttributeError):
+        return False
+
+
+def _signal_pgid(pgid: int, sig: signal.Signals) -> bool:
+    try:
+        os.killpg(pgid, sig)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+def _wait_pgid_reap(pgid: int, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return
+        except OSError as exc:
+            if getattr(exc, "errno", None) == 3:
+                return
+            return
+        time.sleep(0.05)
+
+
+def _terminate_process(proc: subprocess.Popen, pgid: Optional[int] = None) -> None:
+    if pgid is not None:
+        if not _signal_pgid(pgid, signal.SIGTERM):
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+    elif not _signal_process_group(proc, signal.SIGTERM):
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+
+    try:
+        proc.wait(timeout=_TERMINATE_GRACE_SECONDS)
+    except Exception:
+        pass
+
+    if pgid is not None:
+        _signal_pgid(pgid, signal.SIGKILL)
+        _wait_pgid_reap(pgid, _TERMINATE_GRACE_SECONDS)
+    elif not _signal_process_group(proc, signal.SIGKILL):
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+    try:
+        proc.wait(timeout=_TERMINATE_GRACE_SECONDS)
+    except Exception:
+        pass
+
+
+def _read_log_text(log_path: Path) -> str:
+    if not log_path.is_file():
+        return ""
+    return log_path.read_text(encoding="utf-8", errors="replace")
+
+
+def _run_and_stream(
+    cmd: List[str],
+    *,
+    workdir: str,
+    timeout_seconds: int,
+    log_dir: Path,
+    run_timestamp: str,
+) -> Tuple[Optional[str], str, str, float, Optional[int]]:
+    """Spawn the agent, stream stdout to a log file, enforce watchdogs.
+
+    Returns ``(error_code, log_path, log_text, duration_seconds, returncode)``.
+    """
+    start_mono = time.monotonic()
+    last_byte_mono = start_mono
+
+    # The wrapper runs with `set -u` and dies on an unbound $HOME in bare
+    # environments (transient systemd units, cron). Guarantee HOME so any
+    # sparse-env caller works, and prepend ~/.local/bin so binary resolution
+    # stays consistent when PATH is minimal. NO credentials are injected here
+    # — the wrapper pulls them from <HERMES_HOME>/.env at runtime.
+    env = os.environ.copy()
+    if not env.get("HOME"):
+        env["HOME"] = str(Path.home())
+    local_bin = str(Path.home() / ".local" / "bin")
+    env["PATH"] = local_bin + os.pathsep + env.get("PATH", "")
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=workdir,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        env=env,
+    )
+
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (OSError, ProcessLookupError):
+        pgid = None
+
+    log_path = log_dir / f"{run_timestamp}-{proc.pid}.jsonl"
+    reader_done = threading.Event()
+
+    def _reader() -> None:
+        nonlocal last_byte_mono
+        try:
+            assert proc.stdout is not None
+            with open(log_path, "wb") as log_file:
+                while True:
+                    try:
+                        chunk = proc.stdout.read1(4096)
+                    except (OSError, ValueError):
+                        break
+                    if not chunk:
+                        break
+                    log_file.write(chunk)
+                    log_file.flush()
+                    last_byte_mono = time.monotonic()
+        finally:
+            try:
+                if proc.stdout is not None:
+                    proc.stdout.close()
+            except Exception:
+                pass
+            reader_done.set()
+
+    reader_thread = threading.Thread(target=_reader, daemon=True)
+    reader_thread.start()
+
+    error_code: Optional[str] = None
+    while proc.poll() is None:
+        if _check_interrupted():
+            error_code = "interrupted"
+            break
+
+        now = time.monotonic()
+        elapsed = now - start_mono
+        if elapsed >= timeout_seconds:
+            error_code = "timeout"
+            break
+        if now - last_byte_mono >= STALL_WATCHDOG_SECONDS:
+            error_code = "stalled"
+            break
+        time.sleep(_MONITOR_POLL_SECONDS)
+
+    if error_code is not None:
+        _terminate_process(proc, pgid)
+
+    reader_thread.join(timeout=_TERMINATE_GRACE_SECONDS + 1.0)
+    duration = time.monotonic() - start_mono
+
+    if reader_thread.is_alive():
+        _terminate_process(proc, pgid)
+        return (
+            "incomplete_output",
+            str(log_path),
+            _read_log_text(log_path),
+            duration,
+            proc.poll() if proc.poll() is not None else -1,
+        )
+
+    log_text = _read_log_text(log_path)
+
+    returncode = proc.poll()
+    if returncode is None:
+        try:
+            returncode = proc.wait(timeout=_TERMINATE_GRACE_SECONDS)
+        except Exception:
+            returncode = -1
+
+    return error_code, str(log_path), log_text, duration, returncode
+
+
+def _make_result(
+    *,
+    success: bool,
+    final_report: str = "",
+    error: Optional[str] = None,
+    session_id: Optional[str] = None,
+    duration_seconds: float = 0.0,
+    num_turns: Optional[int] = None,
+    cost_usd: Optional[float] = None,
+    models_used: Optional[List[str]] = None,
+    permission_denials: Optional[List[Any]] = None,
+    log_path: Optional[str] = None,
+    **extra: Any,
+) -> str:
+    payload: Dict[str, Any] = {
+        "success": success,
+        "error": error,
+        "final_report": final_report,
+        "session_id": session_id,
+        "duration_seconds": duration_seconds,
+        "num_turns": num_turns,
+        "cost_usd": cost_usd,
+        "models_used": models_used or [],
+        "permission_denials": permission_denials,
+        "log_path": log_path,
+    }
+    payload.update(extra)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Tool implementation
+# ---------------------------------------------------------------------------
+
+def delegate_claude_agent(
+    task: str,
+    workdir: str,
+    model: str = DEFAULT_CLAUDE_MODEL,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    allowed_tools: str = DEFAULT_ALLOWED_TOOLS,
+    permission_mode: str = DEFAULT_PERMISSION_MODE,
+    task_id: str | None = None,
+) -> str:
+    del task_id  # reserved for future correlation; not used yet
+
+    if not task or not str(task).strip():
+        return _make_result(
+            success=False,
+            error="task is required for delegate_claude_agent",
+        )
+
+    workdir_path = Path(workdir)
+    if not workdir_path.is_absolute():
+        return _make_result(
+            success=False,
+            error="workdir must be an absolute path",
+        )
+    if not workdir_path.is_dir():
+        return _make_result(
+            success=False,
+            error=f"workdir does not exist or is not a directory: {workdir}",
+        )
+
+    mode = str(permission_mode or "").strip()
+    if mode not in _ALLOWED_PERMISSION_MODES:
+        return _make_result(
+            success=False,
+            error=(
+                "permission_mode must be one of "
+                f"{list(_ALLOWED_PERMISSION_MODES)}, got: {permission_mode!r}"
+            ),
+        )
+
+    binary = resolve_claude_binary()
+    if not binary:
+        return _make_result(
+            success=False,
+            error=(
+                "Claude Code (GLM) wrapper binary not found. Install the "
+                "`claude-glm` wrapper at ~/.local/bin/claude-glm (or set "
+                "CLAUDE_GLM_BIN), or place `claude-glm`/`claude` on PATH."
+            ),
+        )
+
+    clamped_timeout = _clamp_timeout_seconds(timeout_seconds)
+    model_name = str(model or "").strip() or DEFAULT_CLAUDE_MODEL
+    tools_arg = str(allowed_tools or "").strip() or DEFAULT_ALLOWED_TOOLS
+
+    log_dir = get_hermes_home() / "claude-runs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    run_timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+
+    # NOTE: --dangerously-skip-permissions is intentionally omitted — it is
+    # refused when running as root. The wrapper injects credentials itself.
+    cmd = [
+        binary,
+        "-p",
+        "--model",
+        model_name,
+        "--permission-mode",
+        mode,
+        "--allowedTools",
+        tools_arg,
+        "--output-format",
+        "json",
+        str(task).strip(),
+    ]
+
+    try:
+        watchdog_error, log_path, log_text, duration, returncode = _run_and_stream(
+            cmd,
+            workdir=str(workdir_path),
+            timeout_seconds=clamped_timeout,
+            log_dir=log_dir,
+            run_timestamp=run_timestamp,
+        )
+    except Exception as exc:
+        logger.error("delegate_claude_agent spawn failed: %s", exc, exc_info=True)
+        return _make_result(
+            success=False,
+            error=str(exc),
+            duration_seconds=0.0,
+        )
+
+    parsed = parse_claude_agent_log(log_text)
+    base_fields = {
+        "final_report": _coerce_str(parsed.get("result")) or "",
+        "session_id": parsed.get("session_id"),
+        "duration_seconds": round(duration, 3),
+        "num_turns": parsed.get("num_turns"),
+        "cost_usd": parsed.get("total_cost_usd"),
+        "models_used": parsed.get("models_used") or [],
+        "permission_denials": parsed.get("permission_denials") or [],
+        "log_path": log_path,
+    }
+
+    if watchdog_error:
+        return _make_result(
+            success=False,
+            error=watchdog_error,
+            **base_fields,
+        )
+
+    if returncode != 0:
+        tail = log_text.strip()[-2000:] if log_text.strip() else ""
+        return _make_result(
+            success=False,
+            error=f"Claude Code exited with code {returncode}" + (f": {tail}" if tail else ""),
+            **base_fields,
+        )
+
+    if not parsed:
+        return _make_result(
+            success=False,
+            error="no result event found in Claude Code output",
+            **base_fields,
+        )
+
+    is_error = parsed.get("is_error")
+    subtype = parsed.get("subtype")
+    success = is_error is False and subtype == "success"
+
+    return _make_result(
+        success=success,
+        error=None if success else (
+            f"Claude Code result subtype={subtype!r} is_error={is_error!r}"
+        ),
+        **base_fields,
+    )
+
+
+def _coerce_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+DELEGATE_CLAUDE_AGENT_SCHEMA = {
+    "name": "delegate_claude_agent",
+    "description": (
+        "Delegate a software development task to the Claude Code CLI running "
+        "against Alibaba GLM-5.2 via the local claude-glm wrapper. The CLI "
+        "performs code edits, terminal commands, and multi-step dev work "
+        "inside the specified repository directory. Stdout is captured as "
+        "JSON in a log under the Hermes home directory. Available only when "
+        "the claude-glm wrapper binary is installed."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task": {
+                "type": "string",
+                "description": "The coding task brief for Claude Code to perform.",
+            },
+            "workdir": {
+                "type": "string",
+                "description": "Absolute path to the target git repo/workspace.",
+            },
+            "model": {
+                "type": "string",
+                "description": "Model to use for the run (via the claude-glm wrapper).",
+                "default": DEFAULT_CLAUDE_MODEL,
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "description": (
+                    f"Maximum wall-clock seconds before the run is terminated "
+                    f"({MIN_TIMEOUT_SECONDS}–{MAX_TIMEOUT_SECONDS})."
+                ),
+                "default": DEFAULT_TIMEOUT_SECONDS,
+            },
+            "allowed_tools": {
+                "type": "string",
+                "description": (
+                    "Comma-separated list of tools Claude Code may use."
+                ),
+                "default": DEFAULT_ALLOWED_TOOLS,
+            },
+            "permission_mode": {
+                "type": "string",
+                "description": (
+                    "Claude Code permission mode. 'acceptEdits' auto-approves "
+                    "file edits; 'plan' only plans without writing."
+                ),
+                "default": DEFAULT_PERMISSION_MODE,
+                "enum": list(_ALLOWED_PERMISSION_MODES),
+            },
+        },
+        "required": ["task", "workdir"],
+    },
+}
+
+
+def _handle_delegate_claude_agent(args, **kw):
+    return delegate_claude_agent(
+        task=args.get("task", ""),
+        workdir=args.get("workdir", ""),
+        model=args.get("model", DEFAULT_CLAUDE_MODEL),
+        timeout_seconds=args.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS),
+        allowed_tools=args.get("allowed_tools", DEFAULT_ALLOWED_TOOLS),
+        permission_mode=args.get("permission_mode", DEFAULT_PERMISSION_MODE),
+        task_id=kw.get("task_id"),
+    )
+
+
+registry.register(
+    name="delegate_claude_agent",
+    toolset="delegation",
+    schema=DELEGATE_CLAUDE_AGENT_SCHEMA,
+    handler=_handle_delegate_claude_agent,
+    check_fn=check_claude_agent_requirements,
+    emoji="🤖",
+    max_result_size_chars=100_000,
+)

--- a/tools/claude_agent_tool.py
+++ b/tools/claude_agent_tool.py
@@ -5,7 +5,7 @@ Gating
 ------
 The tool registers only when the Claude Code GLM wrapper is resolvable —
 either via the ``CLAUDE_GLM_BIN`` env override, as an executable at
-``~/.local/bin/claude-glm``, or as ``claude-glm``/``claude`` on PATH.
+``~/.local/bin/claude-glm``, or as ``claude-glm`` on PATH.
 
 Credentials
 -----------
@@ -21,16 +21,19 @@ when the process runs as root.
 Log format
 ----------
 Stdout is streamed to ``<HERMES_HOME>/claude-runs/<timestamp>-<pid>.jsonl``.
-With ``--output-format json`` the CLI emits one JSON document per line; the
-handler scans for the last line that is valid JSON with ``"type": "result"``
-and extracts session metadata, cost, model usage, and permission denials
-from it.
+With ``--output-format stream-json`` (plus ``--verbose``) the CLI emits
+NDJSON event objects, one per line, as the run progresses. The handler scans
+every line for valid JSON and keeps the last object with ``"type": "result"``
+to extract session metadata, cost, model usage, and permission denials.
+Long quiet periods between events (e.g. during tool calls) are normal; only
+the caller's hard timeout bounds wall-clock run length.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import shutil
 import signal
@@ -50,7 +53,6 @@ DEFAULT_CLAUDE_MODEL = "glm-5.2"
 DEFAULT_TIMEOUT_SECONDS = 1800
 MIN_TIMEOUT_SECONDS = 60
 MAX_TIMEOUT_SECONDS = 3600
-STALL_WATCHDOG_SECONDS = 180
 
 DEFAULT_ALLOWED_TOOLS = "Read,Write,Edit,Glob,Grep,Bash"
 DEFAULT_PERMISSION_MODE = "acceptEdits"
@@ -58,6 +60,11 @@ _ALLOWED_PERMISSION_MODES = ("acceptEdits", "plan")
 
 _MONITOR_POLL_SECONDS = 0.1
 _TERMINATE_GRACE_SECONDS = 2.0
+
+LOG_HEAD_BYTES = 64 * 1024
+LOG_TAIL_BYTES = 1 * 1024 * 1024
+LOG_TRUNCATION_MARKER_OVERHEAD = 256
+LOG_MAX_FILE_BYTES = LOG_HEAD_BYTES + LOG_TAIL_BYTES + LOG_TRUNCATION_MARKER_OVERHEAD
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +82,6 @@ def resolve_claude_binary() -> Optional[str]:
     1. ``CLAUDE_GLM_BIN`` env override (must be an executable file).
     2. ``~/.local/bin/claude-glm``.
     3. ``claude-glm`` on PATH.
-    4. bare ``claude`` on PATH.
     """
     try:
         override = os.environ.get("CLAUDE_GLM_BIN")
@@ -89,10 +95,6 @@ def resolve_claude_binary() -> Optional[str]:
             return str(local)
 
         found = shutil.which("claude-glm")
-        if found:
-            return found
-
-        found = shutil.which("claude")
         if found:
             return found
     except Exception:
@@ -111,6 +113,52 @@ def check_claude_agent_requirements() -> bool:
 # ---------------------------------------------------------------------------
 # Result parsing
 # ---------------------------------------------------------------------------
+
+def _coerce_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _coerce_session_id(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _coerce_int_or_none(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if math.isfinite(value) and value.is_integer():
+            return int(value)
+        return None
+    return None
+
+
+def _coerce_finite_float_or_none(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        coerced = float(value)
+        if math.isfinite(coerced):
+            return coerced
+        return None
+    return None
+
+
+def _coerce_permission_denials(value: Any) -> List[Any]:
+    if isinstance(value, list):
+        return value
+    return []
+
 
 def parse_claude_agent_log(log_text: str) -> Dict[str, Any]:
     """Parse a Claude Code json log for the final ``type=result`` event.
@@ -138,20 +186,20 @@ def parse_claude_agent_log(log_text: str) -> Dict[str, Any]:
     if isinstance(model_usage, dict):
         models_used = sorted(str(key) for key in model_usage.keys())
 
-    permission_denials = result_event.get("permission_denials")
-    if permission_denials is None:
-        permission_denials = []
-
     return {
         "subtype": result_event.get("subtype"),
         "is_error": result_event.get("is_error"),
-        "result": result_event.get("result"),
-        "session_id": result_event.get("session_id"),
-        "num_turns": result_event.get("num_turns"),
-        "duration_ms": result_event.get("duration_ms"),
-        "total_cost_usd": result_event.get("total_cost_usd"),
+        "result": _coerce_str(result_event.get("result")),
+        "session_id": _coerce_session_id(result_event.get("session_id")),
+        "num_turns": _coerce_int_or_none(result_event.get("num_turns")),
+        "duration_ms": _coerce_finite_float_or_none(result_event.get("duration_ms")),
+        "total_cost_usd": _coerce_finite_float_or_none(
+            result_event.get("total_cost_usd")
+        ),
         "models_used": models_used,
-        "permission_denials": permission_denials,
+        "permission_denials": _coerce_permission_denials(
+            result_event.get("permission_denials")
+        ),
     }
 
 
@@ -242,7 +290,11 @@ def _terminate_process(proc: subprocess.Popen, pgid: Optional[int] = None) -> No
 def _read_log_text(log_path: Path) -> str:
     if not log_path.is_file():
         return ""
-    return log_path.read_text(encoding="utf-8", errors="replace")
+    with open(log_path, "rb") as log_file:
+        data = log_file.read(LOG_MAX_FILE_BYTES + 1)
+    if len(data) > LOG_MAX_FILE_BYTES:
+        data = data[:LOG_MAX_FILE_BYTES]
+    return data.decode("utf-8", errors="replace")
 
 
 def _run_and_stream(
@@ -252,13 +304,16 @@ def _run_and_stream(
     timeout_seconds: int,
     log_dir: Path,
     run_timestamp: str,
-) -> Tuple[Optional[str], str, str, float, Optional[int]]:
-    """Spawn the agent, stream stdout to a log file, enforce watchdogs.
+) -> Tuple[Optional[str], str, str, str, float, Optional[int], bool, int]:
+    """Spawn the agent, stream stdout to a log file, enforce hard timeout.
 
-    Returns ``(error_code, log_path, log_text, duration_seconds, returncode)``.
+    Returns
+    ``(error_code, log_path, log_text, result_parse_text, duration_seconds,
+    returncode, log_truncated, log_bytes_dropped)``. When output is truncated,
+    ``result_parse_text`` contains only the rolling tail so an early result in
+    the retained head cannot be mistaken for the terminal result.
     """
     start_mono = time.monotonic()
-    last_byte_mono = start_mono
 
     # The wrapper runs with `set -u` and dies on an unbound $HOME in bare
     # environments (transient systemd units, cron). Guarantee HOME so any
@@ -288,12 +343,50 @@ def _run_and_stream(
 
     log_path = log_dir / f"{run_timestamp}-{proc.pid}.jsonl"
     reader_done = threading.Event()
+    reader_state: Dict[str, Any] = {
+        "log_truncated": False,
+        "log_bytes_dropped": 0,
+        "result_parse_text": "",
+    }
+
+    def _append_tail(log_file, tail_buf: bytearray, bytes_dropped: int) -> None:
+        if bytes_dropped > 0:
+            marker = f"\n...[truncated {bytes_dropped} bytes]...\n".encode("utf-8")
+            reader_state["log_truncated"] = True
+            reader_state["log_bytes_dropped"] = bytes_dropped
+            reader_state["result_parse_text"] = bytes(tail_buf).decode(
+                "utf-8", errors="replace"
+            )
+        elif tail_buf:
+            marker = b""
+        else:
+            return
+
+        head_size = log_file.tell()
+        available = max(0, LOG_MAX_FILE_BYTES - head_size)
+        if not marker and not tail_buf:
+            return
+
+        payload = marker + bytes(tail_buf)
+        if len(payload) > available:
+            if len(marker) >= available:
+                log_file.write(marker[:available])
+            else:
+                tail_room = available - len(marker)
+                log_file.write(marker + bytes(tail_buf)[-tail_room:])
+        else:
+            log_file.write(payload)
+        log_file.flush()
 
     def _reader() -> None:
-        nonlocal last_byte_mono
         try:
             assert proc.stdout is not None
             with open(log_path, "wb") as log_file:
+                head_written = 0
+                tail_buf = bytearray()
+                bytes_dropped = 0
+                in_tail = False
+
                 while True:
                     try:
                         chunk = proc.stdout.read1(4096)
@@ -301,9 +394,31 @@ def _run_and_stream(
                         break
                     if not chunk:
                         break
-                    log_file.write(chunk)
-                    log_file.flush()
-                    last_byte_mono = time.monotonic()
+
+                    offset = 0
+                    while offset < len(chunk):
+                        if not in_tail:
+                            head_room = LOG_HEAD_BYTES - head_written
+                            if head_room <= 0:
+                                in_tail = True
+                                continue
+                            take = min(head_room, len(chunk) - offset)
+                            log_file.write(chunk[offset : offset + take])
+                            head_written += take
+                            offset += take
+                            if head_written >= LOG_HEAD_BYTES:
+                                in_tail = True
+                            continue
+
+                        take = len(chunk) - offset
+                        tail_buf.extend(chunk[offset : offset + take])
+                        offset += take
+                        if len(tail_buf) > LOG_TAIL_BYTES:
+                            excess = len(tail_buf) - LOG_TAIL_BYTES
+                            bytes_dropped += excess
+                            del tail_buf[:excess]
+
+                _append_tail(log_file, tail_buf, bytes_dropped)
         finally:
             try:
                 if proc.stdout is not None:
@@ -326,9 +441,6 @@ def _run_and_stream(
         if elapsed >= timeout_seconds:
             error_code = "timeout"
             break
-        if now - last_byte_mono >= STALL_WATCHDOG_SECONDS:
-            error_code = "stalled"
-            break
         time.sleep(_MONITOR_POLL_SECONDS)
 
     if error_code is not None:
@@ -339,15 +451,24 @@ def _run_and_stream(
 
     if reader_thread.is_alive():
         _terminate_process(proc, pgid)
+        incomplete_log_text = _read_log_text(log_path)
         return (
             "incomplete_output",
             str(log_path),
-            _read_log_text(log_path),
+            incomplete_log_text,
+            incomplete_log_text,
             duration,
             proc.poll() if proc.poll() is not None else -1,
+            reader_state["log_truncated"],
+            reader_state["log_bytes_dropped"],
         )
 
     log_text = _read_log_text(log_path)
+    result_parse_text = (
+        str(reader_state["result_parse_text"])
+        if reader_state["log_truncated"]
+        else log_text
+    )
 
     returncode = proc.poll()
     if returncode is None:
@@ -356,7 +477,16 @@ def _run_and_stream(
         except Exception:
             returncode = -1
 
-    return error_code, str(log_path), log_text, duration, returncode
+    return (
+        error_code,
+        str(log_path),
+        log_text,
+        result_parse_text,
+        duration,
+        returncode,
+        reader_state["log_truncated"],
+        reader_state["log_bytes_dropped"],
+    )
 
 
 def _make_result(
@@ -382,7 +512,7 @@ def _make_result(
         "num_turns": num_turns,
         "cost_usd": cost_usd,
         "models_used": models_used or [],
-        "permission_denials": permission_denials,
+        "permission_denials": permission_denials or [],
         "log_path": log_path,
     }
     payload.update(extra)
@@ -439,7 +569,7 @@ def delegate_claude_agent(
             error=(
                 "Claude Code (GLM) wrapper binary not found. Install the "
                 "`claude-glm` wrapper at ~/.local/bin/claude-glm (or set "
-                "CLAUDE_GLM_BIN), or place `claude-glm`/`claude` on PATH."
+                "CLAUDE_GLM_BIN), or place `claude-glm` on PATH."
             ),
         )
 
@@ -463,12 +593,22 @@ def delegate_claude_agent(
         "--allowedTools",
         tools_arg,
         "--output-format",
-        "json",
+        "stream-json",
+        "--verbose",
         str(task).strip(),
     ]
 
     try:
-        watchdog_error, log_path, log_text, duration, returncode = _run_and_stream(
+        (
+            run_error,
+            log_path,
+            log_text,
+            result_parse_text,
+            duration,
+            returncode,
+            log_truncated,
+            log_bytes_dropped,
+        ) = _run_and_stream(
             cmd,
             workdir=str(workdir_path),
             timeout_seconds=clamped_timeout,
@@ -483,9 +623,9 @@ def delegate_claude_agent(
             duration_seconds=0.0,
         )
 
-    parsed = parse_claude_agent_log(log_text)
-    base_fields = {
-        "final_report": _coerce_str(parsed.get("result")) or "",
+    parsed = parse_claude_agent_log(result_parse_text)
+    base_fields: Dict[str, Any] = {
+        "final_report": parsed.get("result") or "",
         "session_id": parsed.get("session_id"),
         "duration_seconds": round(duration, 3),
         "num_turns": parsed.get("num_turns"),
@@ -494,11 +634,14 @@ def delegate_claude_agent(
         "permission_denials": parsed.get("permission_denials") or [],
         "log_path": log_path,
     }
+    if log_truncated:
+        base_fields["log_truncated"] = True
+        base_fields["log_bytes_dropped"] = log_bytes_dropped
 
-    if watchdog_error:
+    if run_error:
         return _make_result(
             success=False,
-            error=watchdog_error,
+            error=run_error,
             **base_fields,
         )
 
@@ -511,6 +654,15 @@ def delegate_claude_agent(
         )
 
     if not parsed:
+        if log_truncated:
+            return _make_result(
+                success=False,
+                error=(
+                    "log truncated; result event missing or incomplete "
+                    f"({log_bytes_dropped} bytes dropped)"
+                ),
+                **base_fields,
+            )
         return _make_result(
             success=False,
             error="no result event found in Claude Code output",
@@ -530,17 +682,6 @@ def delegate_claude_agent(
     )
 
 
-def _coerce_str(value: Any) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value
-    try:
-        return json.dumps(value, ensure_ascii=False)
-    except (TypeError, ValueError):
-        return str(value)
-
-
 DELEGATE_CLAUDE_AGENT_SCHEMA = {
     "name": "delegate_claude_agent",
     "description": (
@@ -548,7 +689,7 @@ DELEGATE_CLAUDE_AGENT_SCHEMA = {
         "against Alibaba GLM-5.2 via the local claude-glm wrapper. The CLI "
         "performs code edits, terminal commands, and multi-step dev work "
         "inside the specified repository directory. Stdout is captured as "
-        "JSON in a log under the Hermes home directory. Available only when "
+        "NDJSON in a log under the Hermes home directory. Available only when "
         "the claude-glm wrapper binary is installed."
     ),
     "parameters": {

--- a/toolsets.py
+++ b/toolsets.py
@@ -72,6 +72,9 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # Claude Code CLI delegation via the claude-glm wrapper (gated via
+    # check_fn on the wrapper binary)
+    "delegate_claude_agent",
     # Cronjob management
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary

- add a gated `delegate_claude_agent` tool for oversized development tasks through Claude Code and the local `claude-glm` wrapper
- pin the default lane to Alibaba GLM-5.2 with bounded 60–3600 second execution, explicit permission modes, and configurable allowed tools
- stream Claude's realtime NDJSON output, preserve structured session/cost/model evidence, and keep the task as one argv item without credentials or dangerous permission bypasses
- register the tool in the delegation toolset only when the GLM wrapper is available

## Process and output safety

- retain hard timeout, interrupt handling, and POSIX process-group cleanup while allowing healthy quiet tool calls
- remove false bare-`claude` provider attribution; only `claude-glm` wrapper paths satisfy the gate
- normalize hostile result metadata into stable public field types and fail closed on malformed/error results
- bound stdout storage to a 64 KiB head plus 1 MiB rolling tail, with truncation evidence and a hard file cap
- parse terminal results from the rolling tail after truncation, so an early result followed by oversized trailing output cannot be accepted

## Verification

- `32 passed`:
  `python -m pytest tests/tools/test_claude_agent_tool.py -p no:cacheprovider`
- `64 passed`:
  `python -m pytest tests/test_toolsets.py tests/test_toolset_distributions.py tests/tools/test_delegate_toolset_scope.py tests/tools/test_delegate_composite_toolsets.py tests/hermes_cli/test_tools_config.py -p no:cacheprovider`
- `ruff check` passed for implementation, tests, and `toolsets.py`
- `git diff --check` passed
- fresh-context adversarial verifier: `PASS`, 0 blockers, exact reviewed tree `eeb8c6e1a9282bdcde574f9a6008ecaa9cb485fc`

## Untested scope

- a real read-only invocation reached `/root/.local/bin/claude-glm` and parsed stream-json, but the provider returned HTTP 429 because the weekly token-plan quota was exhausted. The tool returned `success=false`; external provider success is therefore not claimed.
- process-tree verification was performed on POSIX/Linux. Windows descendant behavior was not exercised.
