### PR TITLE
fix(search): keep grep fallback root searchable

### DIFF
--- a/tests/tools/test_search_hidden_dirs.py
+++ b/tests/tools/test_search_hidden_dirs.py
@@ -17,6 +17,9 @@ import subprocess
 
 import pytest
 
+from tools.file_operations import ShellFileOperations
+from tools.environments.local import LocalEnvironment
+
 
 @pytest.fixture
 def searchable_tree(tmp_path):
@@ -37,6 +40,12 @@ def searchable_tree(tmp_path):
     git_dir = tmp_path / "skills" / ".git" / "objects"
     git_dir.mkdir(parents=True)
     (git_dir / "pack-abc.idx").write_text("git internal data")
+
+    # An arbitrary hidden directory verifies the fallback is not limited to
+    # a hard-coded list of known cache names.
+    private_dir = tmp_path / "skills" / ".private-index"
+    private_dir.mkdir(parents=True)
+    (private_dir / "notes.txt").write_text("unlisted hidden content")
 
     return tmp_path / "skills"
 
@@ -64,25 +73,68 @@ class TestFindExcludesHiddenDirs:
 
 
 class TestGrepExcludesHiddenDirs:
-    """_search_with_grep should exclude hidden directories."""
+    """The real search_files grep fallback should search the default root."""
 
-    def test_grep_skips_hub_cache(self, searchable_tree):
-        """grep --exclude-dir should skip .hub/ directory."""
-        cmd = (
-            f"grep -rnHE --exclude-dir='.*' 'ignore' {searchable_tree}"
+    @staticmethod
+    def _grep_ops(searchable_tree, monkeypatch):
+        ops = ShellFileOperations(
+            LocalEnvironment(cwd=str(searchable_tree)),
+            cwd=str(searchable_tree),
         )
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-        # Should NOT find the injection text in .hub/index-cache/catalog.json
-        assert ".hub" not in result.stdout
-        assert "catalog.json" not in result.stdout
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+        return ops
 
-    def test_grep_still_finds_visible_content(self, searchable_tree):
-        """grep should still find content in visible directories."""
-        cmd = (
-            f"grep -rnHE --exclude-dir='.*' 'real skill' {searchable_tree}"
+    def test_grep_fallback_finds_visible_content(self, searchable_tree, monkeypatch):
+        """Searching ``.`` must not exclude the search root itself."""
+        result = self._grep_ops(searchable_tree, monkeypatch).search(
+            "real skill",
+            path=".",
+            target="content",
         )
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-        assert "SKILL.md" in result.stdout
+
+        assert result.error is None
+        assert result.total_count > 0
+        assert any("SKILL.md" in match.path for match in result.matches)
+
+    def test_grep_fallback_finds_dot_relative_subdirectory(
+        self, searchable_tree, monkeypatch
+    ):
+        """An explicit ``./directory`` root must remain searchable too."""
+        result = self._grep_ops(searchable_tree, monkeypatch).search(
+            "real skill",
+            path="./my-skill",
+            target="content",
+        )
+
+        assert result.error is None
+        assert result.total_count == 1
+        assert result.matches[0].path.endswith("SKILL.md")
+
+    def test_grep_fallback_skips_hub_cache(self, searchable_tree, monkeypatch):
+        """The fallback must not expose cached community skill content."""
+        result = self._grep_ops(searchable_tree, monkeypatch).search(
+            "ignore previous instructions",
+            path=".",
+            target="content",
+        )
+
+        assert result.error is None
+        assert result.total_count == 0
+        assert not result.matches
+
+    def test_grep_fallback_skips_arbitrary_hidden_directory(
+        self, searchable_tree, monkeypatch
+    ):
+        """Hidden-directory exclusion must not rely on a directory allowlist."""
+        result = self._grep_ops(searchable_tree, monkeypatch).search(
+            "unlisted hidden content",
+            path=".",
+            target="content",
+        )
+
+        assert result.error is None
+        assert result.total_count == 0
+        assert not result.matches
 
 
 class TestRipgrepAlreadyExcludesHidden:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3091,9 +3091,23 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")
         
-        # Add pattern and path
+        # Add pattern and path. grep applies --exclude-dir to the command-line
+        # search root too, so passing the default relative root ``.`` causes
+        # ``.*`` to exclude the entire search. Anchor relative paths at the
+        # shell's live cwd; quoting $PWD separately keeps user paths escaped
+        # while working across local, container, and remote backends.
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        is_absolute = path.startswith(("/", "\\\\")) or bool(
+            re.match(r"^[A-Za-z]:[\\/]", path)
+        )
+        if is_absolute:
+            search_root = self._escape_shell_arg(path)
+        else:
+            relative_path = path[2:] if path.startswith("./") else path
+            search_root = '"$PWD"'
+            if relative_path not in {"", "."}:
+                search_root += f"/{self._escape_shell_arg(relative_path)}"
+        cmd_parts.append(search_root)
         
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)


### PR DESCRIPTION
## What does this PR do?

Fixes the `search_files` grep fallback silently returning zero matches for its default `path="."` search.

The fallback intentionally passes `--exclude-dir='.*'` to match ripgrep's hidden-directory behavior. grep also applies that glob to the command-line search root, however, so a relative root such as `.` (or `./directory`) excludes itself before traversal begins.

This change anchors relative grep roots at the terminal backend's live, shell-quoted `$PWD`. It preserves the existing hidden-directory exclusion, avoids resolving remote/container paths on the host, and keeps the user-provided path component shell-escaped.

## Related Issue

N/A — searched open and closed issues/PRs for the error and `--exclude-dir` behavior; no duplicate found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Anchor relative roots passed by `ShellFileOperations._search_with_grep()` at the backend's live `$PWD`.
- Replace false-green handcrafted grep tests with production-API tests that force the real grep fallback.
- Cover the default `.`, an explicit `./directory`, the `.hub` prompt-injection cache, and an arbitrary hidden directory.

## How to Test

1. Run `python -m pytest tests/tools/test_search_hidden_dirs.py tests/tools/test_search_error_guard.py tests/tools/test_file_operations.py -q` (80 passed, 2 skipped on macOS 26.2).
2. Run the search-focused cross-suite selection (39 passed, 113 deselected).
3. Run `python -m ruff check tools/file_operations.py tests/tools/test_search_hidden_dirs.py` and `git diff --check`.
4. On Debian 12 with GNU grep, the old relative-root command returns exit 1 with zero lines; the anchored-root command returns the visible match and still excludes both named and arbitrary dot-directories.

The canonical full macOS run reached 29,484 passed / 306 skipped, with 22 unrelated platform/environment failures and one isolated test-file timeout; every touched and search-related suite passed. The PR's Ubuntu CI is the authoritative full-suite gate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (see macOS full-run note above; scoped suites are green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.2 (BSD grep) and Debian 12 arm64 container (GNU grep)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and covered by an inline rationale
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; public behavior is restored, not changed

## Screenshots / Logs

```text
# Regression mutation (old implementation)
1 failed: expected a visible match, got total_count == 0

# Fixed implementation
80 passed, 2 skipped

# Debian 12 / GNU grep
old_exit=1 old_lines=0 new_exit=0 new_lines=1
/work/my-skill/SKILL.md:2:This is a real skill.
```
