### PR TITLE
feat(tui): add configurable left padding for streamed response text

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2508,9 +2508,10 @@ def _prune_orphaned_branches(repo_root: str) -> None:
 _ACCENT_ANSI_DEFAULT = "\033[1;38;2;255;215;0m"  # True-color #FFD700 bold — fallback
 _BOLD = "\033[1m"
 _RST = "\033[0m"
-_STREAM_PAD = ""  # No indent for streamed response text — leading whitespace pollutes
-# terminal copy/paste (every selected line carried 4 spaces).  Matches the
-# response Panel's flush-left padding.
+# Left padding for streamed response text. 0 = flush-left (default, best for
+# copy/paste).  Configurable via display.tui_padding in config.yaml (0-8).
+_pad_count = int(CLI_CONFIG.get("display", {}).get("tui_padding", 0))
+_STREAM_PAD = " " * max(0, min(_pad_count, 8))
 _STREAM_PARTIAL_PREVIEW_LEN = 60  # tail of an unfinished logical line mirrored
 # into the spinner while streaming (TTFT perception without hard-wrapping)
 
@@ -2970,13 +2971,12 @@ def _preserve_windows_dot_segments_for_markdown(text: str) -> str:
 def _terminal_width_for_streaming() -> int:
     """Display cells available inside the streamed response box.
 
-    The streaming path prefixes every line with ``_STREAM_PAD`` (now
-    empty — flush-left so copy/paste stays clean) inside an open
-    response panel.  The realigner uses this number as its budget when
-    deciding whether to keep a horizontal table or fall back to
-    vertical key-value rendering.  We subtract a small safety margin
-    so terminal-resize races don't push a borderline table into
-    mid-cell soft-wrap.
+    The streaming path prefixes every line with ``_STREAM_PAD`` (configurable
+    via display.tui_padding, default flush-left) inside an open response panel.
+    The realigner uses this number as its budget when deciding whether to keep
+    a horizontal table or fall back to vertical key-value rendering.  We subtract
+    a small safety margin so terminal-resize races don't push a borderline table
+    into mid-cell soft-wrap.
     """
 
     try:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1184,6 +1184,10 @@ DEFAULT_CONFIG = {
         # Per-platform overrides via display.platforms.<platform>.memory_notifications.
         "memory_notifications": "on",
         "streaming": False,
+        # Left padding (in spaces) for streamed response text in the CLI.
+        # 0 = flush-left (default, best for copy/paste). Set to 2-4 for
+        # visual breathing room. Clamped to 0-8 at runtime.
+        "tui_padding": 0,
         "timestamps": False,      # Show timestamp on user and assistant labels
         "timestamp_format": "%H:%M",  # strftime format for timestamps (e.g. "%b-%d %H:%M")
         "final_response_markdown": "strip",  # render | strip | raw


### PR DESCRIPTION
Title: feat(tui): add configurable left padding for streamed CLI response text

Body:

After updating to v0.20.0, the streamed response text sits flush-left with no visual breathing room. This adds a display.tui_padding config option (0-8 spaces, default 0) so users can opt-in to left padding for better readability while preserving the copy/paste-friendly flush-left default.

Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

Changes Made

- hermes_cli/config_defaults.py — added display.tui_padding: 0 config option with docstring
- cli.py — reads display.tui_padding from config, computes _STREAM_PAD with clamping (0-8), updated docstrings

How to Test

1. Default (no padding): hermes chat -q "hello" — text should be flush-left as before
2. Set padding: hermes config set display.tui_padding 2 then hermes chat -q "hello" — text should have 2-space indent
3. Test clamping: hermes config set display.tui_padding 10 — should clamp to 8 spaces max
4. Test negative: hermes config set display.tui_padding -1 — should fall back to 0

Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've tested on my platform: Windows 10

Documentation & Housekeeping

- [x] I've updated relevant docstrings
- [x] I've considered cross-platform impact — N/A (string multiplication is platform-independent)

Screenshots / Logs
Before
<img width="581" height="101" alt="image" src="https://github.com/user-attachments/assets/d8af7998-2af0-4539-96b6-30fddf5f5254" />
After
<img width="1898" height="242" alt="image" src="https://github.com/user-attachments/assets/743de833-e6c4-4137-96f8-232f4c2d5d37" />

