### PR TITLE
fix(model-switch): pass current_api_key when probing current custom endpoint

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2934,7 +2934,7 @@ def list_authenticated_providers(
             from hermes_cli.models import cached_fetch_api_models
 
             _live_models = cached_fetch_api_models(
-                "",
+                current_api_key,
                 str(current_base_url).strip().rstrip("/"),
                 timeout=1.5 if for_picker else 5.0,  # picker: fail fast on a slow current endpoint
                 cache_only=not _probe_live,


### PR DESCRIPTION
## Summary

Section 3b of `list_authenticated_providers` probes the user's current custom endpoint to discover live models for the desktop model picker. It passes an **empty string** for `api_key` to `cached_fetch_api_models()`, causing authenticated custom endpoints to return 401. The probe silently fails and the picker falls back to showing only the single configured default model.

## Root Cause

`hermes_cli/model_switch.py` line 2937 hardcodes `""` instead of passing `current_api_key`:

```python
# Before (broken):
_live_models = cached_fetch_api_models(
    "",   # ← empty, gets 401 from authenticated endpoints
    ...
)

# After (fixed):
_live_models = cached_fetch_api_models(
    current_api_key,  # ← threads the active api_key
    ...
)
```

The `current_api_key` parameter is already available in the function signature (line 1292) and is used correctly by the adjacent section 3 (line 2862) and section 4 (line 3205) calls. Section 3b was the only call site missing it.

## Verification

- `ast.parse()` confirms syntax is valid
- Only 1 line changed (empty string → variable reference)
- No behavioral change for unauthenticated endpoints (empty string is the default)

Fixes #83837