### PR TITLE
fix(tui): prepend Hermes venv and user-local bin to slash_worker PATH (#83845)

### DIFF
--- a/tests/gateway/test_tui_slash_worker_path.py
+++ b/tests/gateway/test_tui_slash_worker_path.py
@@ -1,0 +1,42 @@
+"""Regression test for slash_worker PATH construction (#83845).
+
+When the gateway is launched by the Desktop/Dashboard app it can inherit a
+minimal PATH (/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/sbin:/usr/sbin)
+that omits the Hermes venv bin dir and ~/.local/bin. The spawned
+tui_gateway.slash_worker then cannot resolve Hermes-managed CLIs such as
+browser-use/uvx via shutil.which, breaking browser_exec.
+
+`tui_gateway.server._prepend_tool_paths` prepends those two directories to
+the worker env PATH while preserving the inherited PATH.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from tui_gateway import server as tui_server
+
+
+class TestPrependToolPaths:
+    def test_prepends_venv_and_user_bin(self):
+        env = {"PATH": "/usr/bin"}
+        result = tui_server._prepend_tool_paths(env)
+
+        parts = result["PATH"].split(os.pathsep)
+        # venv bin first, then user-local bin, then the original PATH preserved
+        assert parts[0] == str(Path(sys.executable).parent)
+        assert str(Path.home() / ".local" / "bin") in parts
+        assert parts[-1] == "/usr/bin"
+
+    def test_preserves_existing_path_when_empty(self):
+        env = {}
+        result = tui_server._prepend_tool_paths(env)
+
+        parts = result["PATH"].split(os.pathsep)
+        assert parts[0] == str(Path(sys.executable).parent)
+        assert str(Path.home() / ".local" / "bin") in parts
+
+    def test_venv_bin_points_at_sys_executable_dir(self):
+        env = {"PATH": "/bin"}
+        result = tui_server._prepend_tool_paths(env)
+        assert result["PATH"].split(os.pathsep)[0] == str(Path(sys.executable).parent)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -329,6 +329,20 @@ _stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
 _detached_ws_transport = _DropTransport()
 
 
+def _prepend_tool_paths(env: dict[str, str]) -> dict[str, str]:
+    """Prepend the Hermes venv bin dir and the user-local bin dir to PATH
+    so slash_worker child processes can resolve Hermes-managed CLIs
+    (browser-use, uvx) even when the parent gateway was launched with a
+    minimal PATH (e.g. by the Desktop/Dashboard app)."""
+    venv_bin = str(Path(sys.executable).parent)  # <venv>/bin (POSIX) or <venv>/Scripts (Windows)
+    user_bin = str(Path.home() / ".local" / "bin")
+    existing = env.get("PATH") or ""
+    env["PATH"] = os.pathsep.join(
+        [p for p in (venv_bin, user_bin) if p] + ([existing] if existing else [])
+    )
+    return env
+
+
 class _SlashWorker:
     """Persistent HermesCLI subprocess for slash commands."""
 
@@ -365,6 +379,11 @@ class _SlashWorker:
             inherit_profile_home=False,  # base already carries the HOME contract
             extra={"HERMES_HOME": str(profile_home)} if profile_home else None,
         )
+        # Prepend the Hermes venv bin dir and the user-local bin dir to PATH so
+        # slash_worker child processes can resolve Hermes-managed CLIs
+        # (browser-use, uvx) even when the parent gateway was launched with a
+        # minimal PATH (e.g. by the Desktop/Dashboard app). See #83845.
+        env = _prepend_tool_paths(env)
 
         # start_new_session=True detaches the slash worker into its own
         # process group / session. Without this, the worker inherits the


### PR DESCRIPTION
## Summary

Fixes #83845: `browser_exec` (and any other tool that resolves Hermes-managed CLIs via `shutil.which`) fails in Dashboard/TUI sessions because the `tui_gateway.slash_worker` child process is spawned with a minimal PATH.

When the gateway is launched by the Desktop/Dashboard app, it can inherit a minimal PATH (`/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/sbin:/usr/sbin`) that omits both the Hermes venv bin dir and `~/.local/bin`. The slash worker inherits that PATH, so `shutil.which("browser-use")` / `shutil.which("uvx")` fail even when those CLIs are correctly installed in the Hermes venv.

## Root Cause

`SlashWorkerProcess.__init__` in `tui_gateway/server.py` builds the child environment with `build_subprocess_env(hermes_subprocess_env(...), ...)` and passes it straight to `subprocess.Popen`. `hermes_subprocess_env()` only copies the parent environment and strips secrets — it performs no PATH manipulation. The worker therefore inherits whatever (minimal) PATH the gateway process was launched with.

## Change

`tui_gateway/server.py` only (one file; the browser CLI tooling was refactored from `tools/browser_use_cli.py` into `tools/browser_tool.py` and needs no change):

- Added a module-level helper `_prepend_tool_paths(env)` that prepends the Hermes venv bin dir (`<sys.executable>/..`, i.e. `<venv>/bin` on POSIX or `<venv>/Scripts` on Windows) and the user-local bin dir (`~/.local/bin`) to `PATH`, preserving the existing PATH value at the end.
- `SlashWorkerProcess.__init__` now applies `env = _prepend_tool_paths(env)` right after building the environment and before `subprocess.Popen`.

Semantics: existing PATH entries are preserved; prepending is idempotent (duplicates are harmless) and non-existent `~/.local/bin` directories are harmless.

## Verification

Ran with the Hermes venv interpreter:

```
PYTHONPATH=<worktree> python3 -m pytest tests/gateway/test_tui_slash_worker_path.py tests/gateway/test_tui_approval_redaction.py -q
```

Result: `4 passed` (3 new regression tests for `_prepend_tool_paths` + 1 sanity test from `test_tui_approval_redaction.py`).

New tests cover:

- venv bin dir is prepended first, user-local bin present, and the original PATH preserved at the end;
- no `KeyError` when the env has no `PATH` key;
- first PATH element equals `str(Path(sys.executable).parent)`.

Closes #83845
