### PR TITLE
fix(truncation): combine compressor marker + write guard (#83714)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1148,6 +1148,27 @@ def _strip_image_parts_from_parts(parts: Any) -> Any:
     return out if had_image else None
 
 
+# #83714 — the shrunk value is replayed back to the model as its OWN past
+# tool call on every subsequent turn. A bare, prose-shaped marker like
+# "...[truncated]" is exactly the kind of terse ellipsis abbreviation a
+# model is already inclined to produce, so a model conditioned on seeing
+# itself "get away with" that pattern in its own history will imitate it in
+# a *new* tool call — writing the literal marker into a file instead of the
+# real content (observed with deepseek-v4-pro; see PR #83752 for the
+# resulting file-corruption guard). This marker is deliberately NOT
+# prose-shaped: distinctive non-ASCII delimiters that don't occur in normal
+# code/text, an explicit "not real content" disclaimer, and a per-instance
+# character count that won't match the next omission point even if copied
+# verbatim — all raise the bar against a model treating this as a stylistic
+# convention worth reusing.
+_COMPRESSION_MARKER_TEMPLATE = (
+    "⟪HERMES-CONTEXT-COMPRESSION: {omitted:,} of {total:,} chars omitted here "
+    "by Hermes's context compressor. This is NOT part of the original tool "
+    "call and must never be reproduced in new output — always write full, "
+    "untruncated content.⟫"
+)
+
+
 def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
     """Shrink long string values inside a tool-call arguments JSON blob while
     preserving JSON validity.
@@ -1172,6 +1193,12 @@ def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
     to begin with — some model backends use non-JSON tool arguments — the
     original string is returned unchanged rather than replaced with
     something neither we nor the backend can parse.
+
+    The shrunk value stays a plain string (never a nested object) so the
+    JSON *shape* is unchanged from the original — only #83714's marker text
+    changed, not the #11762 valid-JSON-and-matching-shape contract. See
+    ``_COMPRESSION_MARKER_TEMPLATE`` for why the marker itself looks nothing
+    like ``"...[truncated]"`` anymore.
     """
     try:
         parsed = json.loads(args)
@@ -1181,7 +1208,10 @@ def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
     def _shrink(obj: Any) -> Any:
         if isinstance(obj, str):
             if len(obj) > head_chars:
-                return obj[:head_chars] + "...[truncated]"
+                marker = _COMPRESSION_MARKER_TEMPLATE.format(
+                    omitted=len(obj) - head_chars, total=len(obj)
+                )
+                return obj[:head_chars] + marker
             return obj
         if isinstance(obj, dict):
             return {k: _shrink(v) for k, v in obj.items()}

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1148,24 +1148,12 @@ def _strip_image_parts_from_parts(parts: Any) -> Any:
     return out if had_image else None
 
 
-# #83714 — the shrunk value is replayed back to the model as its OWN past
-# tool call on every subsequent turn. A bare, prose-shaped marker like
-# "...[truncated]" is exactly the kind of terse ellipsis abbreviation a
-# model is already inclined to produce, so a model conditioned on seeing
-# itself "get away with" that pattern in its own history will imitate it in
-# a *new* tool call — writing the literal marker into a file instead of the
-# real content (observed with deepseek-v4-pro; see PR #83752 for the
-# resulting file-corruption guard). This marker is deliberately NOT
-# prose-shaped: distinctive non-ASCII delimiters that don't occur in normal
-# code/text, an explicit "not real content" disclaimer, and a per-instance
-# character count that won't match the next omission point even if copied
-# verbatim — all raise the bar against a model treating this as a stylistic
-# convention worth reusing.
-_COMPRESSION_MARKER_TEMPLATE = (
-    "⟪HERMES-CONTEXT-COMPRESSION: {omitted:,} of {total:,} chars omitted here "
-    "by Hermes's context compressor. This is NOT part of the original tool "
-    "call and must never be reproduced in new output — always write full, "
-    "untruncated content.⟫"
+# #83714 — shrunk tool-call args are replayed as the model's OWN past output.
+# Marker text lives in tools.truncation_markers so the write/patch guard can
+# refuse the same token if a model ever copies it (#83752 / #83843).
+from tools.truncation_markers import (
+    COMPRESSION_MARKER_TEMPLATE as _COMPRESSION_MARKER_TEMPLATE,
+    format_compression_marker as _format_compression_marker,
 )
 
 
@@ -1208,7 +1196,7 @@ def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
     def _shrink(obj: Any) -> Any:
         if isinstance(obj, str):
             if len(obj) > head_chars:
-                marker = _COMPRESSION_MARKER_TEMPLATE.format(
+                marker = _format_compression_marker(
                     omitted=len(obj) - head_chars, total=len(obj)
                 )
                 return obj[:head_chars] + marker

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2106,7 +2106,7 @@ class TestTruncateToolCallArgsJson:
         shrunk = shrink(original)
         parsed = _json.loads(shrunk)  # must not raise
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
-        assert parsed["content"].endswith("...[truncated]")
+        assert "HERMES-CONTEXT-COMPRESSION" in parsed["content"]
         assert len(shrunk) < len(original)
 
 
@@ -2127,7 +2127,7 @@ class TestTruncateToolCallArgsJson:
         assert parsed["enabled"] is True
         assert parsed["timeout"] is None
         assert parsed["items"] == [1, 2, 3]
-        assert parsed["note"].endswith("...[truncated]")
+        assert "HERMES-CONTEXT-COMPRESSION" in parsed["note"]
 
 
 
@@ -2165,7 +2165,87 @@ class TestTruncateToolCallArgsJson:
         # Must parse — otherwise downstream provider returns 400
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
-        assert parsed["content"].endswith("...[truncated]")
+        assert "HERMES-CONTEXT-COMPRESSION" in parsed["content"]
+
+
+class TestTruncationMarkerNotImitable:
+    """Regression tests for #83714.
+
+    A model replayed its own history containing the bare
+    ``"...[truncated]"`` marker and, in a later turn, imitated it —
+    writing the literal marker into a *new* tool call's ``new_string``
+    instead of real content, which the file tools then wrote straight to
+    disk (see PR #83752's write_file/patch_tool guard, the safety net for
+    when this still slips through). The compressor-side fix is to stop
+    injecting a marker that looks like something the model itself would
+    plausibly write.
+    """
+
+    def _helper(self):
+        from agent.context_compressor import _truncate_tool_call_args_json
+        return _truncate_tool_call_args_json
+
+    def test_old_bare_marker_no_longer_produced(self):
+        """The exact literal that caused #83714 must never come out of the
+        shrink helper again, in isolation or as a suffix."""
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({"path": "/f.py", "new_string": "y" * 600})
+        shrunk = _json.loads(shrink(payload))["new_string"]
+        assert "...[truncated]" not in shrunk
+        assert not shrunk.endswith("...[truncated]")
+
+    def test_marker_uses_distinctive_non_ascii_delimiters(self):
+        """The marker must be visually/structurally unlike prose a model
+        would naturally continue with — distinctive delimiters are one of
+        the deliberate anti-imitation properties (see
+        ``_COMPRESSION_MARKER_TEMPLATE``'s docstring)."""
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({"content": "x" * 1000})
+        shrunk = _json.loads(shrink(payload))["content"]
+        assert "⟪" in shrunk and "⟫" in shrunk
+
+    def test_marker_states_it_is_not_original_content(self):
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({"content": "x" * 1000})
+        shrunk = _json.loads(shrink(payload))["content"]
+        assert "NOT part of the original" in shrunk
+
+    def test_marker_carries_a_per_instance_char_count(self):
+        """The omitted/total counts vary per call, so a model that copies
+        the marker verbatim into an unrelated new tool call produces an
+        internally inconsistent (and thus more obviously wrong) string,
+        rather than a plausible-looking universal abbreviation token."""
+        import json as _json
+        shrink = self._helper()
+        # head_chars=200: a 300-char input omits 100, a 3000-char input omits 2800.
+        shrunk_short = _json.loads(shrink(_json.dumps({"c": "x" * 300})))["c"]
+        shrunk_long = _json.loads(shrink(_json.dumps({"c": "x" * 3000})))["c"]
+        assert shrunk_short != shrunk_long
+        assert "100 of 300 chars omitted" in shrunk_short
+        assert "2,800 of 3,000 chars omitted" in shrunk_long
+
+    def test_string_below_threshold_is_untouched(self):
+        """Strings at or under head_chars never get a marker at all — the
+        char-count check above only applies once shrinking actually kicks in."""
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({"c": "x" * 150})
+        parsed = _json.loads(shrink(payload))
+        assert parsed["c"] == "x" * 150
+
+    def test_shrunk_value_stays_a_plain_string(self):
+        """#11762 established that the shrunk JSON shape must match the
+        original (string leaf stays a string leaf) so strict providers
+        don't 400 on a type mismatch when the history is replayed. The
+        #83714 marker-text fix must not regress that invariant."""
+        import json as _json
+        shrink = self._helper()
+        payload = _json.dumps({"new_string": "z" * 500})
+        parsed = _json.loads(shrink(payload))
+        assert isinstance(parsed["new_string"], str)
 
 
 class TestLazyContextResolution:

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -1011,12 +1011,33 @@ class TestTruncationPlaceholderGuard:
         from tools.file_tools import _find_truncation_placeholder
 
         assert _find_truncation_placeholder("hello ...[truncated]") == "...[truncated]"
-        assert _find_truncation_placeholder("hello … [truncated] world") == "… [truncated]"
+        assert _find_truncation_placeholder("hello … [truncated] world")
         assert _find_truncation_placeholder("plain [truncated] marker") == "[truncated]"
         assert _find_truncation_placeholder("// ... unchanged ...\ndef f(): pass")
+        assert _find_truncation_placeholder("# ... rest of file ...\npass")
+        assert "HERMES-CONTEXT-COMPRESSION" in (
+            _find_truncation_placeholder(
+                "x" * 10
+                + "⟪HERMES-CONTEXT-COMPRESSION: 1 of 2 chars omitted here "
+                + "by Hermes's context compressor. This is NOT part of the original tool "
+                + "call and must never be reproduced in new output — always write full, "
+                + "untruncated content.⟫"
+            )
+            or ""
+        )
         assert _find_truncation_placeholder("normal content, nothing odd here") is None
         assert _find_truncation_placeholder("") is None
         assert _find_truncation_placeholder(None) is None
+
+    def test_find_truncation_placeholder_count_based_vs_original(self):
+        """#68512: pre-existing one occurrence is ok; adding a second is not."""
+        from tools.file_tools import _find_truncation_placeholder
+
+        original = "def foo():\n    // ... unchanged ...\n    pass\n"
+        same = original + "def bar():\n    return 1\n"
+        assert _find_truncation_placeholder(same, original) is None
+        doubled = original + "def bar():\n    // ... unchanged ...\n    pass\n"
+        assert _find_truncation_placeholder(doubled, original) is not None
 
     @patch("tools.file_tools._get_file_ops")
     def test_write_file_rejects_truncation_placeholder(self, mock_get):
@@ -1132,3 +1153,14 @@ class TestTruncationPlaceholderGuard:
 
         garbage = "not a real v4a patch at all"
         assert _extract_v4a_added_content(garbage) == garbage
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_file_rejects_hermes_compression_marker(self, mock_get):
+        from tools.file_tools import write_file_tool
+        from tools.truncation_markers import format_compression_marker
+
+        content = "line one\n" + format_compression_marker(omitted=100, total=300) + "\n"
+        result = json.loads(write_file_tool("/tmp/corrupt.py", content))
+        assert "error" in result
+        assert "truncation placeholder" in result["error"].lower()
+        mock_get.assert_not_called()

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -999,3 +999,136 @@ class TestNotFoundCache:
         assert _check_not_found_cache("read", "/tmp/never-exists-notify", tid) is None, (
             "notify_other_tool_call must clear cached misses"
         )
+
+
+class TestTruncationPlaceholderGuard:
+    """Regression tests for #83714 — the ``patch``/``write_file`` tools must
+    refuse to persist a truncation-placeholder marker (e.g. ``...[truncated]``)
+    instead of writing it literally into the target file.
+    """
+
+    def test_find_truncation_placeholder_detects_known_markers(self):
+        from tools.file_tools import _find_truncation_placeholder
+
+        assert _find_truncation_placeholder("hello ...[truncated]") == "...[truncated]"
+        assert _find_truncation_placeholder("hello … [truncated] world") == "… [truncated]"
+        assert _find_truncation_placeholder("plain [truncated] marker") == "[truncated]"
+        assert _find_truncation_placeholder("// ... unchanged ...\ndef f(): pass")
+        assert _find_truncation_placeholder("normal content, nothing odd here") is None
+        assert _find_truncation_placeholder("") is None
+        assert _find_truncation_placeholder(None) is None
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_file_rejects_truncation_placeholder(self, mock_get):
+        from tools.file_tools import write_file_tool
+
+        content = "line one\nline two\n...[truncated]\nline four\n"
+        result = json.loads(write_file_tool("/tmp/corrupt.py", content))
+
+        assert "error" in result
+        assert "truncation placeholder" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_replace_rejects_truncation_placeholder_in_new_string(self, mock_get):
+        from tools.file_tools import patch_tool
+
+        result = json.loads(patch_tool(
+            mode="replace",
+            path="/tmp/f.py",
+            old_string="def foo():\n    pass\n",
+            new_string="def foo():\n    do_thing()\n...[truncated]\n",
+        ))
+
+        assert "error" in result
+        assert "truncation placeholder" in result["error"].lower()
+        mock_get.return_value.patch_replace.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_replace_allows_marker_already_present_in_old_string(self, mock_get):
+        """A legitimate edit to text that already mentions the marker (e.g.
+        this very test file, or docs about the bug) must not be blocked —
+        only NEW occurrences introduced by new_string are suspicious."""
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok"}
+        mock_ops.patch_replace.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import patch_tool
+        marker_text = "marker = '...[truncated]'\n"
+        result = json.loads(patch_tool(
+            mode="replace",
+            path="/tmp/f.py",
+            old_string=marker_text,
+            new_string="marker = '...[truncated]'  # renamed\n",
+        ))
+        assert result["status"] == "ok"
+        mock_ops.patch_replace.assert_called_once()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_v4a_rejects_truncation_placeholder_in_added_line(self, mock_get):
+        from tools.file_tools import patch_tool
+
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Update File: /tmp/f.py\n"
+            "@@ def foo():\n"
+            "-    pass\n"
+            "+    do_thing()\n"
+            "+    ...[truncated]\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(patch_tool(mode="patch", patch=patch_text))
+
+        assert "error" in result
+        assert "truncation placeholder" in result["error"].lower()
+        mock_get.return_value.patch_v4a.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_v4a_allows_marker_on_removed_or_context_line(self, mock_get):
+        """The marker must only be checked against ADDED content — a patch
+        that removes a line containing it, or merely has it as unchanged
+        context, is not the model truncating its own output."""
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok"}
+        mock_ops.patch_v4a.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import patch_tool
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Update File: /tmp/f.py\n"
+            "@@ def foo():\n"
+            " marker = '...[truncated]'\n"
+            "-    old_call()\n"
+            "+    new_call()\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(patch_tool(mode="patch", patch=patch_text))
+        assert result["status"] == "ok"
+        mock_ops.patch_v4a.assert_called_once()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_v4a_add_file_rejects_truncation_placeholder(self, mock_get):
+        from tools.file_tools import patch_tool
+
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Add File: /tmp/new_module.py\n"
+            "+def foo():\n"
+            "+    ...[truncated]\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(patch_tool(mode="patch", patch=patch_text))
+
+        assert "error" in result
+        assert "truncation placeholder" in result["error"].lower()
+        mock_get.return_value.patch_v4a.assert_not_called()
+
+    def test_extract_v4a_added_content_falls_back_to_raw_text_on_parse_failure(self):
+        from tools.file_tools import _extract_v4a_added_content
+
+        garbage = "not a real v4a patch at all"
+        assert _extract_v4a_added_content(garbage) == garbage

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1333,44 +1333,13 @@ def _is_internal_file_tool_content(content: str) -> bool:
     )
 
 
-# #83714 — models occasionally emit a truncation-placeholder marker in a
-# ``write_file``/``patch`` string argument instead of the full content it
-# was supposed to replace (observed with deepseek-v4-pro via the deepseek
-# provider). Hermes itself uses this exact marker to signal truncated tool
-# *output* elsewhere (todo_tool.py, file_operations.py's per-line cap,
-# mcp_tool.py) — the leading theory is the model is imitating a pattern it
-# has seen in its own context rather than Hermes truncating the argument
-# in transit (no length-based slicing of ``content``/``new_string`` exists
-# anywhere between JSON-parsing the tool call and the write/patch below).
-# Whatever the mechanism, writing the marker literally corrupts the file,
-# so it's caught here and refused before any bytes touch disk.
-_TRUNCATION_PLACEHOLDER_PATTERNS = [
-    re.compile(r'\.\.\.\s*\[truncated\]', re.IGNORECASE),
-    re.compile(r'…\s*\[truncated\]', re.IGNORECASE),  # "… [truncated]"
-    re.compile(r'\[truncated\]', re.IGNORECASE),
-    re.compile(r'//\s*\.\.\.\s*(?:rest\s+)?unchanged\s*\.\.\.', re.IGNORECASE),
-    re.compile(r'/\*\s*\.\.\.\s*(?:rest\s+)?unchanged\s*\.\.\.\s*\*/', re.IGNORECASE),
-]
-
-
-def _find_truncation_placeholder(text: str | None) -> str | None:
-    """Return the matched placeholder substring if ``text`` contains a
-    truncation-placeholder marker, else None.
-
-    These markers are legitimate in Hermes's own tool *output* (truncated
-    reads, search results) but never legitimate in the content a model is
-    asking to *write* — a real file that happens to contain the literal
-    string ``[truncated]`` is vanishingly unlikely, and the cost of a false
-    positive (a clear error asking the model to retry) is far lower than
-    the cost of a false negative (silent file corruption).
-    """
-    if not text:
-        return None
-    for pattern in _TRUNCATION_PLACEHOLDER_PATTERNS:
-        match = pattern.search(text)
-        if match:
-            return match.group(0)
-    return None
+# #83714 / #68512 / #83843 — refuse AI truncation placeholders and Hermes
+# compressor markers on the write path. Detection lives in
+# tools.truncation_markers (shared with the context compressor) and uses
+# count-based comparison when an original baseline is available so
+# pre-existing docs/tests that mention markers are not blocked, but adding
+# a NEW occurrence still is.
+from tools.truncation_markers import find_new_truncation_placeholder as _find_truncation_placeholder
 
 
 def _extract_v4a_added_content(patch_content: str) -> str:
@@ -2383,12 +2352,11 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     return tool_error("path required")
                 if old_string is None or new_string is None:
                     return tool_error("old_string and new_string required")
-                # #83714 — only flag a marker that's new to new_string. If
-                # old_string already contains the same literal text (e.g. a
-                # legitimate edit to a docstring that mentions "[truncated]"),
-                # this is not the model abbreviating its own output.
-                _placeholder = _find_truncation_placeholder(new_string)
-                if _placeholder and _placeholder.lower() not in (old_string or "").lower():
+                # #83714 / #68512 — count-based: only flag markers that are
+                # NEW relative to old_string (adding a second truncated stub
+                # still fails even if one already existed).
+                _placeholder = _find_truncation_placeholder(new_string, old_string)
+                if _placeholder:
                     return tool_error(
                         _truncation_placeholder_error("new_string", _placeholder)
                     )

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import posixpath
+import re
 import sys
 import threading
 from pathlib import Path, PurePosixPath
@@ -1332,6 +1333,81 @@ def _is_internal_file_tool_content(content: str) -> bool:
     )
 
 
+# #83714 — models occasionally emit a truncation-placeholder marker in a
+# ``write_file``/``patch`` string argument instead of the full content it
+# was supposed to replace (observed with deepseek-v4-pro via the deepseek
+# provider). Hermes itself uses this exact marker to signal truncated tool
+# *output* elsewhere (todo_tool.py, file_operations.py's per-line cap,
+# mcp_tool.py) — the leading theory is the model is imitating a pattern it
+# has seen in its own context rather than Hermes truncating the argument
+# in transit (no length-based slicing of ``content``/``new_string`` exists
+# anywhere between JSON-parsing the tool call and the write/patch below).
+# Whatever the mechanism, writing the marker literally corrupts the file,
+# so it's caught here and refused before any bytes touch disk.
+_TRUNCATION_PLACEHOLDER_PATTERNS = [
+    re.compile(r'\.\.\.\s*\[truncated\]', re.IGNORECASE),
+    re.compile(r'…\s*\[truncated\]', re.IGNORECASE),  # "… [truncated]"
+    re.compile(r'\[truncated\]', re.IGNORECASE),
+    re.compile(r'//\s*\.\.\.\s*(?:rest\s+)?unchanged\s*\.\.\.', re.IGNORECASE),
+    re.compile(r'/\*\s*\.\.\.\s*(?:rest\s+)?unchanged\s*\.\.\.\s*\*/', re.IGNORECASE),
+]
+
+
+def _find_truncation_placeholder(text: str | None) -> str | None:
+    """Return the matched placeholder substring if ``text`` contains a
+    truncation-placeholder marker, else None.
+
+    These markers are legitimate in Hermes's own tool *output* (truncated
+    reads, search results) but never legitimate in the content a model is
+    asking to *write* — a real file that happens to contain the literal
+    string ``[truncated]`` is vanishingly unlikely, and the cost of a false
+    positive (a clear error asking the model to retry) is far lower than
+    the cost of a false negative (silent file corruption).
+    """
+    if not text:
+        return None
+    for pattern in _TRUNCATION_PLACEHOLDER_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return match.group(0)
+    return None
+
+
+def _extract_v4a_added_content(patch_content: str) -> str:
+    """Return only the text a V4A patch is ADDING: '+' hunk lines and full
+    Add-File bodies. Falls back to the raw patch text if it fails to parse
+    so detection degrades gracefully instead of silently skipping — a
+    malformed patch is exactly the kind of thing worth double-checking.
+    """
+    try:
+        from tools.patch_parser import parse_v4a_patch, OperationType
+        operations, parse_error = parse_v4a_patch(patch_content)
+        if parse_error or not operations:
+            return patch_content
+        chunks: list[str] = []
+        for op in operations:
+            if op.operation == OperationType.ADD and op.content:
+                chunks.append(op.content)
+            for hunk in op.hunks:
+                for line in hunk.lines:
+                    if line.prefix == '+':
+                        chunks.append(line.content)
+        return "\n".join(chunks)
+    except Exception:
+        return patch_content
+
+
+def _truncation_placeholder_error(where: str, marker: str) -> str:
+    return (
+        f"Refusing to write {where}: it contains what looks like a "
+        f"truncation placeholder ({marker!r}) instead of the actual "
+        "content. This usually means the content was abbreviated rather "
+        "than written out in full. Emit the complete text with no "
+        "'...[truncated]'-style markers, then retry. The file was NOT "
+        "modified."
+    )
+
+
 def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     """Get or create ShellFileOperations for a terminal environment.
 
@@ -2127,6 +2203,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             "Strip read_file line-number prefixes or reconstruct the intended "
             "file contents before writing."
         )
+    _placeholder = _find_truncation_placeholder(content)
+    if _placeholder:
+        return tool_error(_truncation_placeholder_error(f"{path!r}", _placeholder))
     try:
         # Resolve once for the registry lock + stale check.  Failures here
         # fall back to the legacy path — write proceeds, per-task staleness
@@ -2304,6 +2383,15 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     return tool_error("path required")
                 if old_string is None or new_string is None:
                     return tool_error("old_string and new_string required")
+                # #83714 — only flag a marker that's new to new_string. If
+                # old_string already contains the same literal text (e.g. a
+                # legitimate edit to a docstring that mentions "[truncated]"),
+                # this is not the model abbreviating its own output.
+                _placeholder = _find_truncation_placeholder(new_string)
+                if _placeholder and _placeholder.lower() not in (old_string or "").lower():
+                    return tool_error(
+                        _truncation_placeholder_error("new_string", _placeholder)
+                    )
                 # Pass the resolved ABSOLUTE path to the shell layer so it
                 # operates on the exact file the tool layer resolved — the
                 # shell's own cwd may differ (worktree-cwd bug), and a relative
@@ -2314,6 +2402,17 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
+                # #83714 — scan only the content the model is actually ADDING
+                # (V4A '+' hunk lines and full Add-File bodies), not the whole
+                # patch text. Scanning the whole patch would false-positive on
+                # a legitimate edit that removes, or merely anchors context
+                # on, a pre-existing placeholder-like literal.
+                _added = _extract_v4a_added_content(patch)
+                _placeholder = _find_truncation_placeholder(_added)
+                if _placeholder:
+                    return tool_error(
+                        _truncation_placeholder_error("patch content", _placeholder)
+                    )
                 # Rewrite V4A headers to the resolved absolute paths so the
                 # shell layer patches the exact files the tool layer resolved
                 # (locked/reported). Without this a relative header re-resolves

--- a/tools/truncation_markers.py
+++ b/tools/truncation_markers.py
@@ -1,0 +1,110 @@
+"""Shared truncation / context-compression markers.
+
+Used by:
+- ``agent.context_compressor`` when shrinking past assistant tool-call args
+  (must NOT look like model-authored prose — see #83714 / #83843).
+- ``tools.file_tools`` write/patch guards so any imitation of those markers
+  (old bare ``...[truncated]``, AI "unchanged" stubs, or the new Hermes
+  compression disclaimer) fails closed before touching disk (#83752, #68512).
+
+Keep this module dependency-light so both agent and tools layers can import it
+without circular imports.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Marker injected into compressed tool-call argument strings. Deliberately
+# non-prose-shaped so models do not treat it as a reusable abbreviation.
+COMPRESSION_MARKER_NEEDLE = "HERMES-CONTEXT-COMPRESSION"
+COMPRESSION_MARKER_TEMPLATE = (
+    "⟪HERMES-CONTEXT-COMPRESSION: {omitted:,} of {total:,} chars omitted here "
+    "by Hermes's context compressor. This is NOT part of the original tool "
+    "call and must never be reproduced in new output — always write full, "
+    "untruncated content.⟫"
+)
+
+# Literal AI "I omitted the rest" stubs (from #68512 / issue #20805).
+# Matched case-insensitively via count comparison against original content.
+LITERAL_TRUNCATION_SIGNATURES: tuple[str, ...] = (
+    "/* ... full function ... */",
+    "/* ... unchanged ... */",
+    "// ... unchanged ...",
+    "// ... rest of file ...",
+    "# ... rest of file ...",
+    "# ... unchanged ...",
+    "/* ... rest unchanged ... */",
+    "... (rest of file unchanged)",
+    "... (unchanged)",
+    "<!-- ... unchanged ... -->",
+    "# ... (rest of the function remains the same)",
+    "// ... (rest of the function remains the same)",
+)
+
+# Regex family for Hermes-style truncation markers and the new compressor tag.
+# Applied with occurrence-count comparison when an original baseline is given.
+_REGEX_TRUNCATION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\.+\s*\[truncated\]", re.IGNORECASE),
+    re.compile(r"…\s*\[truncated\]", re.IGNORECASE),
+    re.compile(r"\[truncated\]", re.IGNORECASE),
+    re.compile(r"//\s*\.+\s*(?:rest\s+)?unchanged\s*\.+", re.IGNORECASE),
+    re.compile(r"/\*\s*\.+\s*(?:rest\s+)?unchanged\s*\.+\s*\*/", re.IGNORECASE),
+    # New compressor marker (#83843) — refuse if model copies it into writes.
+    re.compile(
+        r"⟪\s*HERMES-CONTEXT-COMPRESSION:.*?⟫",
+        re.IGNORECASE | re.DOTALL,
+    ),
+    re.compile(r"HERMES-CONTEXT-COMPRESSION\s*:", re.IGNORECASE),
+)
+
+
+def format_compression_marker(*, omitted: int, total: int) -> str:
+    """Build the per-instance compressor marker text."""
+    return COMPRESSION_MARKER_TEMPLATE.format(omitted=omitted, total=total)
+
+
+def find_new_truncation_placeholder(
+    content: str | None,
+    original: str | None = None,
+) -> str | None:
+    """Return a matched placeholder if *content* introduces more than *original*.
+
+    When ``original`` is None, any match is treated as new (unconditional
+    write_file path). When provided, only signatures whose occurrence count
+    in ``content`` exceeds the count in ``original`` are flagged — so
+    legitimate pre-existing docs/tests that mention markers are not blocked,
+    but adding a second truncated stub still is (#68512 count-based fix).
+    """
+    if not content:
+        return None
+
+    content_lower = content.lower()
+    original_lower = original.lower() if original is not None else None
+
+    for sig in LITERAL_TRUNCATION_SIGNATURES:
+        sig_lower = sig.lower()
+        content_count = content_lower.count(sig_lower)
+        if content_count == 0:
+            continue
+        original_count = (
+            original_lower.count(sig_lower) if original_lower is not None else 0
+        )
+        if content_count > original_count:
+            return sig
+
+    for pattern in _REGEX_TRUNCATION_PATTERNS:
+        content_matches = pattern.findall(content)
+        if not content_matches:
+            continue
+        original_count = (
+            len(pattern.findall(original)) if original is not None else 0
+        )
+        if len(content_matches) > original_count:
+            # findall may return tuples for groups; normalize to a string.
+            hit = content_matches[0]
+            if isinstance(hit, tuple):
+                hit = next((p for p in hit if p), str(hit))
+            return str(hit)
+
+    return None


### PR DESCRIPTION
## Summary
Combined local-deploy stack for #83714 that merges:

1. **#83843** — stop priming models via bare `...[truncated]` in compressed assistant tool_call args
2. **#83752** — fail-closed write/patch guard
3. **Clearly-better pieces of #68512** — count-based signature comparison + AI \"unchanged\"/\"rest of file\" stubs
4. **Review follow-up** — shared `tools/truncation_markers.py` so compressor marker text and write-guard detection cannot drift; refuse `⟪HERMES-CONTEXT-COMPRESSION…⟫` on write

## Why a combined PR
The two independent PRs are still valid and MERGEABLE on their own. This PR is the integration branch we deployed locally (plus the shared-constant follow-up requested after review). Maintainers can land the split PRs or this combined one.

## Tests
`pytest tests/tools/test_file_tools.py tests/agent/test_context_compressor.py tests/test_trajectory_compressor.py -q`
→ **216 passed**, 2 skipped, 2 pre-existing macOS `/tmp` vs `/private/tmp` mock failures (unrelated).

## Relationship
- Supersedes needing to land #68512 separately for the count-based + stub-signature coverage (that PR remains CONFLICTING).
- #83752 / #83843 can close as superseded if this lands, or this can close if those two land and the shared-module follow-up is cherry-picked.

Refs: #83714, #83752, #83843, #68512, #11762, #20805