### PR TITLE
fix(agent): distinguish signed zero in token memo

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3096,12 +3096,13 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
 #     stored in the cache entry). While the entry lives, that id cannot be
 #     reused by another object, so id-equality implies object-equality —
 #     strings are immutable, so value-equality too (no #50372-style aliasing).
-#   * ints/floats/bools/None are fingerprinted by value.
+#   * ints/bools/None are fingerprinted by value. Floats use their repr because
+#     numerically equal signed zeros render differently in ``str(shadow)``.
 #   * dicts/lists recurse structurally, preserving key order — ``str(shadow)``
 #     depends on insertion order, so order is part of the key.
 #   * any other type aborts the memo and falls through to a direct compute.
-# Equal fingerprints therefore imply deep-equal messages built from identical
-# immutable leaves ⇒ identical ``str(shadow)`` bytes ⇒ identical estimate.
+# Equal fingerprints therefore imply identical structure and leaf renderings,
+# hence identical ``str(shadow)`` bytes and an identical estimate.
 #
 # Because the api_messages build shallow-copies history dicts each iteration,
 # the copies share the same content strings — so unchanged history messages
@@ -3117,8 +3118,10 @@ def _msg_fingerprint(value: Any, pins: list) -> Any:
     if t is str:
         pins.append(value)
         return ("s", id(value))
-    if t is int or t is float:
-        return ("n", t.__name__, value)
+    if t is int:
+        return ("n", "int", value)
+    if t is float:
+        return ("n", "float", repr(value))
     if t is dict:
         return ("d", tuple(
             (_msg_fingerprint(k, pins), _msg_fingerprint(v, pins))

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -144,6 +144,23 @@ class TestEstimateMessagesTokensRough:
         # Raw base64 would be ~100K tokens; the flat per-image model is ~1.5K.
         assert estimate_messages_tokens_rough([msg]) < 5_000
 
+    def test_signed_zero_values_do_not_alias_in_message_cache(self, monkeypatch):
+        """Values with different wire representations need distinct memo entries."""
+        import agent.model_metadata as mm
+
+        monkeypatch.setattr(mm, "_MSG_TOKENS_CACHE", {})
+        positive = {"role": "user", "content": "xxx", "value": 0.0}
+        negative = {"role": "user", "content": "xxx", "value": -0.0}
+
+        positive_fresh = estimate_messages_tokens_rough([positive])
+        mm._MSG_TOKENS_CACHE.clear()
+        negative_fresh = estimate_messages_tokens_rough([negative])
+        assert positive_fresh != negative_fresh
+
+        mm._MSG_TOKENS_CACHE.clear()
+        assert estimate_messages_tokens_rough([positive]) == positive_fresh
+        assert estimate_messages_tokens_rough([negative]) == negative_fresh
+
 
 
 class TestEstimateRequestTokensRough:


### PR DESCRIPTION
## What does this PR do?

Keeps the rough-token per-message memo exact when message structures contain signed-zero float leaves.

Python considers `0.0` and `-0.0` equal and gives them the same hash, but they render differently inside `str(shadow)`. The estimator is based on that rendered shadow, so caching one signed zero under the other can return a different token estimate. Exact float leaves are now fingerprinted by `repr(value)`, while integer keys remain unchanged.

This is intentionally limited to cache correctness. It does not implement the separately evaluated flat-message fingerprint fast path.

## Related Issue

Follow-up correctness fix for the token memo introduced in #74231. No issue filed; reproduced on current `main` at `c0106e50e7ecedb3ce34e785d949725dc4e0e457`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `agent/model_metadata.py` so exact `float` leaves use their representation in `_msg_fingerprint`; this distinguishes `0.0` from `-0.0` while safely deduplicating float values that render identically for the estimator.
- Clarify the fingerprint soundness argument in the adjacent comments.
- Add a public-path regression test in `tests/agent/test_model_metadata.py` that compares fresh estimates with both signed-zero values after cache population.

## How to Test

1. On baseline `main`, run:
   ```bash
   scripts/run_tests.sh tests/agent/test_model_metadata.py -q -k signed_zero_values_do_not_alias_in_message_cache
   ```
   It fails because the cached `-0.0` estimate is `12` while its fresh estimate is `13`.
2. Run the same command on this branch; it passes.
3. Run the 14 directly and indirectly related test files; `254 passed`.
4. Optional edge probe: exercise every cache order for finite floats, signed zeros, infinities and signed NaNs as nested values and dict keys; all 128 pairwise cases match direct computation.

A deliberately float-heavy 500-message fingerprint benchmark measured 1.859 ms before vs 1.906 ms after (median, pinned CPU), a 0.047 ms worst-case increase. Normal messages rarely contain float leaves.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full repository suite not run; 254 relevant tests pass via `scripts/run_tests.sh`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — adjacent fingerprint design comments updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python; Windows footgun scan passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused baseline failure:

```text
AssertionError: assert 12 == 13
```

Focused patched result:

```text
1 passed, 0 failed
```

Relevant canonical suite:

```text
14 files, 254 tests passed, 0 failed
```

Additional gates: full-repository `ruff check .`, `py_compile`, `git diff --check`, Windows footgun scan, and added-line static security scan passed.

`ruff format --check` reports broad pre-existing formatting drift in both touched files on `main`; this focused fix intentionally does not include an unrelated whole-file reformat.
