### PR TITLE
fix(gateway): keep a strong reference to the SIGTERM/SIGINT shutdown task

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27782,7 +27782,21 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         # all, so the gateway never tears down — it just keeps running until
         # TimeoutStopSec escalates to SIGKILL, with in-flight turns undrained
         # and sessions never finalized.
-        runner._shutdown_task = asyncio.create_task(runner.stop())
+        #
+        # Only re-point the anchor when the previous shutdown task has
+        # finished.  This handler runs more than once in ordinary operation:
+        # a second Ctrl+C, a SIGINT followed by the service manager's SIGTERM,
+        # or the planned-stop watcher thread racing a real signal — it calls
+        # `loop.call_soon_threadsafe(shutdown_handler, None)` and its own
+        # docstring notes that on POSIX "the signal handler always races us".
+        # Overwriting the attribute on the second call would drop the only
+        # strong reference to the task that owns the live teardown and put us
+        # straight back in the window above. Skipping the duplicate loses
+        # nothing: stop() short-circuits on `self._stop_task`, so the second
+        # task would only have awaited the first one's work.
+        _live_shutdown_task = runner._shutdown_task
+        if _live_shutdown_task is None or _live_shutdown_task.done():
+            runner._shutdown_task = asyncio.create_task(runner.stop())
 
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13030,6 +13030,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._systemd_watchdog = None
         await watchdog.stop()
 
+    def _schedule_shutdown_task(self) -> "asyncio.Task":
+        """Schedule ``stop()`` from a signal handler, keeping a strong reference.
+
+        Signal handlers cannot await, so the SIGINT/SIGTERM handler has to
+        schedule ``stop()`` as a task.  The event loop keeps only a *weak*
+        reference to a task, so a bare ``asyncio.create_task(self.stop())``
+        can be garbage-collected while still pending — the same hazard
+        ``request_restart()`` keeps ``self._restart_task`` to avoid on the
+        SIGUSR1 path.
+
+        ``stop()`` only becomes self-anchoring once it reaches
+        ``self._stop_task = asyncio.create_task(_stop_impl())``.  A collection
+        before that point means ``_stop_impl`` is never created at all, so the
+        gateway does not tear down: it keeps running until the service
+        manager's stop timeout escalates to SIGKILL, with in-flight turns
+        undrained and sessions never finalized.
+
+        A repeat signal must not re-point the anchor.  The handler re-enters in
+        ordinary operation — a second Ctrl+C, a SIGINT followed by the service
+        manager's SIGTERM, or ``_run_planned_stop_watcher`` driving the same
+        callable from its polling thread — and overwriting the attribute would
+        drop the only strong reference to the task performing the live
+        teardown.  Returning the in-flight task instead loses nothing:
+        ``stop()`` short-circuits on ``self._stop_task``, so a second task
+        would only have awaited the first one's work.
+
+        Returns the task that owns the shutdown, new or already running.
+        """
+        existing = self._shutdown_task
+        if existing is not None and not existing.done():
+            return existing
+        self._shutdown_task = asyncio.create_task(self.stop())
+        return self._shutdown_task
+
     async def stop(
         self,
         *,
@@ -27782,33 +27816,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 )
             except Exception as _e:
                 logger.debug("spawn_async_diagnostic failed: %s", _e)
-        # Hold a strong reference to the shutdown task on the runner.  A bare
-        # asyncio.create_task() keeps only a weak reference, so the event loop
-        # may garbage-collect a still-pending task mid-flight — the identical
-        # hazard the SIGUSR1 restart path was hardened against (see
-        # request_restart(), which keeps self._restart_task for this reason).
-        # This path is the one every `systemctl stop`, `hermes gateway stop`
-        # and interactive Ctrl+C takes.  stop() only becomes self-anchoring
-        # once it reaches `self._stop_task = asyncio.create_task(_stop_impl())`;
-        # a collection before that point means _stop_impl is never created at
-        # all, so the gateway never tears down — it just keeps running until
-        # TimeoutStopSec escalates to SIGKILL, with in-flight turns undrained
-        # and sessions never finalized.
-        #
-        # Only re-point the anchor when the previous shutdown task has
-        # finished.  This handler runs more than once in ordinary operation:
-        # a second Ctrl+C, a SIGINT followed by the service manager's SIGTERM,
-        # or the planned-stop watcher thread racing a real signal — it calls
-        # `loop.call_soon_threadsafe(shutdown_handler, None)` and its own
-        # docstring notes that on POSIX "the signal handler always races us".
-        # Overwriting the attribute on the second call would drop the only
-        # strong reference to the task that owns the live teardown and put us
-        # straight back in the window above. Skipping the duplicate loses
-        # nothing: stop() short-circuits on `self._stop_task`, so the second
-        # task would only have awaited the first one's work.
-        _live_shutdown_task = runner._shutdown_task
-        if _live_shutdown_task is None or _live_shutdown_task.done():
-            runner._shutdown_task = asyncio.create_task(runner.stop())
+        # Schedule teardown while keeping a strong reference to the task: a
+        # bare asyncio.create_task() here leaves the event loop holding only a
+        # weak reference, so a still-pending shutdown can be garbage-collected
+        # and the gateway then never tears down at all.  This is the path every
+        # `systemctl stop`, `hermes gateway stop` and interactive Ctrl+C takes,
+        # and it re-enters (second Ctrl+C, SIGINT then SIGTERM, or the
+        # planned-stop watcher thread racing a real signal), so the anchor must
+        # not be re-pointed while a shutdown is still in flight.  See
+        # GatewayRunner._schedule_shutdown_task.
+        runner._schedule_shutdown_task()
 
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13391,6 +13391,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # into this _stop_impl and skip _shutdown_event.set() /
                     # _exit_code = 75 (#12875).  It self-terminates anyway.
                     continue
+                if _task is self._shutdown_task:
+                    # Same shape as _restart_task: the task the SIGINT/SIGTERM
+                    # handler created is sitting in `await self._stop_task`
+                    # right now, i.e. it is awaiting *this* coroutine.
+                    # Cancelling it would propagate CancelledError back into
+                    # _stop_impl and skip the tail of teardown.  Like
+                    # _restart_task it is deliberately not added to
+                    # _background_tasks, but the exemption belongs here with
+                    # the other two: this loop is the single place that
+                    # enforces the invariant, so any future path that does
+                    # track the handle cannot silently cancel the teardown.
+                    continue
                 _task.cancel()
             self._background_tasks.clear()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5908,6 +5908,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _restart_command_source: Optional[SessionSource] = None
     _stop_task: Optional[asyncio.Task] = None
     _restart_task: Optional[asyncio.Task] = None
+    _shutdown_task: Optional[asyncio.Task] = None
     _profile_failed_platforms: Optional[Dict[str, Dict[Platform, asyncio.Task]]] = None
     _systemd_watchdog: Optional[Any] = None
     _startup_restore_in_progress: bool = False
@@ -6113,6 +6114,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._booted_from_restart: bool = False
         self._stop_task: Optional[asyncio.Task] = None
         self._restart_task: Optional[asyncio.Task] = None
+        # Strong reference to the task the SIGINT/SIGTERM handler creates for
+        # stop().  Same role as _restart_task on the SIGUSR1 path — see the
+        # comment in request_restart() and shutdown_signal_handler().
+        self._shutdown_task: Optional[asyncio.Task] = None
         self._executor_lock = threading.Lock()
         self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
         # Set on gateway stop so the recreate-on-shutdown path can't resurrect
@@ -27765,7 +27770,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 )
             except Exception as _e:
                 logger.debug("spawn_async_diagnostic failed: %s", _e)
-        asyncio.create_task(runner.stop())
+        # Hold a strong reference to the shutdown task on the runner.  A bare
+        # asyncio.create_task() keeps only a weak reference, so the event loop
+        # may garbage-collect a still-pending task mid-flight — the identical
+        # hazard the SIGUSR1 restart path was hardened against (see
+        # request_restart(), which keeps self._restart_task for this reason).
+        # This path is the one every `systemctl stop`, `hermes gateway stop`
+        # and interactive Ctrl+C takes.  stop() only becomes self-anchoring
+        # once it reaches `self._stop_task = asyncio.create_task(_stop_impl())`;
+        # a collection before that point means _stop_impl is never created at
+        # all, so the gateway never tears down — it just keeps running until
+        # TimeoutStopSec escalates to SIGKILL, with in-flight turns undrained
+        # and sessions never finalized.
+        runner._shutdown_task = asyncio.create_task(runner.stop())
 
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)

--- a/tests/gateway/test_shutdown_task_anchor.py
+++ b/tests/gateway/test_shutdown_task_anchor.py
@@ -1,0 +1,188 @@
+"""Regression: the SIGINT/SIGTERM shutdown task must stay strongly referenced.
+
+``shutdown_signal_handler`` in ``gateway/run.py`` finishes by scheduling
+``runner.stop()``.  For a long time it did that with a bare
+``asyncio.create_task(...)`` and threw the handle away.  The event loop keeps
+only a weak reference to a task, so a still-pending task can be
+garbage-collected mid-flight — which is exactly why the *other* signal path
+(``request_restart``, SIGUSR1) holds ``self._restart_task`` and says so in a
+comment.
+
+If the shutdown task is collected before ``stop()`` reaches
+``self._stop_task = asyncio.create_task(_stop_impl())``, no teardown coroutine
+is ever created: the gateway simply keeps running until systemd's
+``TimeoutStopSec`` escalates to SIGKILL, so in-flight turns are never drained
+and sessions are never finalized.
+
+``shutdown_signal_handler`` is a closure built inside the gateway start path and
+cannot be imported, so the three structural invariants below are asserted by
+parsing ``gateway/run.py`` — the same technique
+``test_adapter_connect_is_reconnect_contract.py`` uses for a contract that also
+cannot be reached by importing.  The cancel-sweep invariant *is* reachable and
+is exercised behaviourally against a real ``stop()``.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import contextlib
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.run import GatewayRunner
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+RUN_PY = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+
+
+def _shutdown_signal_handler_node() -> ast.FunctionDef:
+    """The single ``shutdown_signal_handler`` definition in ``gateway/run.py``."""
+    tree = ast.parse(RUN_PY.read_text(encoding="utf-8"))
+    matches = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "shutdown_signal_handler"
+    ]
+    assert len(matches) == 1, (
+        "expected exactly one shutdown_signal_handler in gateway/run.py, found "
+        f"{len(matches)} — this test needs updating if the handler moved or was "
+        "renamed"
+    )
+    return matches[0]
+
+
+def _is_create_task(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "create_task"
+    )
+
+
+def test_gateway_runner_declares_a_shutdown_task_slot():
+    """The anchor needs a class-level default so bare runners inherit ``None``.
+
+    Shutdown-path tests build runners via ``object.__new__`` (``stop()`` even
+    carries a getattr-guard for them), so the attribute has to exist on the
+    class the way ``_stop_task`` and ``_restart_task`` do.
+    """
+    assert GatewayRunner._stop_task is None
+    assert GatewayRunner._restart_task is None
+    assert GatewayRunner._shutdown_task is None
+
+
+def test_shutdown_handler_never_discards_a_created_task():
+    """No ``asyncio.create_task(...)`` in the handler may be a bare statement."""
+    handler = _shutdown_signal_handler_node()
+    discarded = [
+        node
+        for node in ast.walk(handler)
+        if isinstance(node, ast.Expr) and _is_create_task(node.value)
+    ]
+    assert discarded == [], (
+        "shutdown_signal_handler discards the result of asyncio.create_task(); "
+        "the event loop holds only a weak reference, so the task can be "
+        "garbage-collected before stop() creates _stop_impl and the gateway "
+        "then never shuts down"
+    )
+
+
+def test_shutdown_handler_anchors_its_task_on_the_runner():
+    """The created task is stored in ``runner._shutdown_task``."""
+    handler = _shutdown_signal_handler_node()
+    anchored = [
+        target.attr
+        for node in ast.walk(handler)
+        if isinstance(node, ast.Assign) and _is_create_task(node.value)
+        for target in node.targets
+        if isinstance(target, ast.Attribute)
+    ]
+    assert anchored == ["_shutdown_task"], (
+        "expected the shutdown task to be anchored on the runner as "
+        f"_shutdown_task, found {anchored!r}"
+    )
+
+
+def test_shutdown_anchor_is_only_repointed_when_the_previous_task_is_done():
+    """A second signal must not overwrite the handle to the live teardown.
+
+    The handler runs more than once in ordinary operation (a second Ctrl+C, a
+    SIGINT followed by the service manager's SIGTERM, or the planned-stop
+    watcher thread racing a real signal via ``call_soon_threadsafe``).  An
+    unconditional assignment would drop the only strong reference to the task
+    that is actually shutting the gateway down.
+    """
+    handler = _shutdown_signal_handler_node()
+    guarded = False
+    for node in ast.walk(handler):
+        if not isinstance(node, ast.If):
+            continue
+        if not any(
+            isinstance(inner, ast.Assign) and _is_create_task(inner.value)
+            for inner in ast.walk(node)
+        ):
+            continue
+        if any(
+            isinstance(probe, ast.Attribute) and probe.attr == "done"
+            for probe in ast.walk(node.test)
+        ):
+            guarded = True
+    assert guarded, (
+        "the _shutdown_task assignment is not guarded by a done() check, so a "
+        "repeat signal replaces the handle to the still-running shutdown task"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_does_not_cancel_the_anchored_shutdown_task():
+    """``_stop_impl``'s cancel sweep must skip ``_shutdown_task``.
+
+    The anchored task is parked in ``await self._stop_task`` while the sweep
+    runs, so cancelling it would push ``CancelledError`` into the very
+    ``_stop_impl`` doing the cancelling.  This is why the shutdown task cannot
+    simply be parked in ``_background_tasks`` — the same reason ``_stop_task``
+    and ``_restart_task`` are already exempt.
+    """
+    runner, adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.0
+    adapter.disconnect = AsyncMock()
+
+    async def _park() -> None:
+        await asyncio.Event().wait()
+
+    shutdown_task = asyncio.create_task(_park())
+    control_task = asyncio.create_task(_park())
+    await asyncio.sleep(0)
+
+    runner._shutdown_task = shutdown_task
+    runner._background_tasks = {shutdown_task, control_task}
+
+    try:
+        with (
+            patch("gateway.status.remove_pid_file"),
+            patch("gateway.status.write_runtime_status"),
+            patch("agent.auxiliary_client.shutdown_cached_clients"),
+        ):
+            await runner.stop()
+
+        for _ in range(10):
+            if control_task.done():
+                break
+            await asyncio.sleep(0)
+
+        assert control_task.cancelled() is True, (
+            "an ordinary background task should still be swept by _stop_impl"
+        )
+        assert shutdown_task.done() is False, (
+            "_stop_impl cancelled the shutdown task, which is awaiting the very "
+            "_stop_task that runs this sweep"
+        )
+    finally:
+        for task in (shutdown_task, control_task):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task

--- a/tests/gateway/test_shutdown_task_anchor.py
+++ b/tests/gateway/test_shutdown_task_anchor.py
@@ -1,33 +1,26 @@
 """Regression: the SIGINT/SIGTERM shutdown task must stay strongly referenced.
 
-``shutdown_signal_handler`` in ``gateway/run.py`` finishes by scheduling
-``runner.stop()``.  For a long time it did that with a bare
-``asyncio.create_task(...)`` and threw the handle away.  The event loop keeps
-only a weak reference to a task, so a still-pending task can be
-garbage-collected mid-flight — which is exactly why the *other* signal path
-(``request_restart``, SIGUSR1) holds ``self._restart_task`` and says so in a
-comment.
+The gateway's signal handler cannot await, so it schedules ``stop()`` as a
+task.  For a long time it did that with a bare ``asyncio.create_task(...)`` and
+threw the handle away.  The event loop keeps only a weak reference to a task,
+so a still-pending task can be garbage-collected mid-flight — which is exactly
+why the *other* signal path (``request_restart``, SIGUSR1) holds
+``self._restart_task`` and says so in a comment.
 
 If the shutdown task is collected before ``stop()`` reaches
 ``self._stop_task = asyncio.create_task(_stop_impl())``, no teardown coroutine
-is ever created: the gateway simply keeps running until systemd's
-``TimeoutStopSec`` escalates to SIGKILL, so in-flight turns are never drained
-and sessions are never finalized.
+is ever created: the gateway simply keeps running until the service manager's
+stop timeout escalates to SIGKILL, so in-flight turns are never drained and
+sessions are never finalized.
 
-``shutdown_signal_handler`` is a closure built inside the gateway start path and
-cannot be imported, so the three structural invariants below are asserted by
-parsing ``gateway/run.py`` — the same technique
-``test_adapter_connect_is_reconnect_contract.py`` uses for a contract that also
-cannot be reached by importing.  The cancel-sweep invariant *is* reachable and
-is exercised behaviourally against a real ``stop()``.
+``GatewayRunner._schedule_shutdown_task`` owns that behaviour and is what the
+signal handler calls.
 """
 
 from __future__ import annotations
 
-import ast
 import asyncio
 import contextlib
-from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -36,31 +29,28 @@ from gateway.run import GatewayRunner
 from tests.gateway.restart_test_helpers import make_restart_runner
 
 
-RUN_PY = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+def _make_runner_with_blocking_stop():
+    """A bare runner whose ``stop()`` parks until the returned event is set."""
+    runner, adapter = make_restart_runner()
+    release = asyncio.Event()
+    calls: list[int] = []
 
+    async def _blocking_stop() -> None:
+        calls.append(1)
+        await release.wait()
 
-def _shutdown_signal_handler_node() -> ast.FunctionDef:
-    """The single ``shutdown_signal_handler`` definition in ``gateway/run.py``."""
-    tree = ast.parse(RUN_PY.read_text(encoding="utf-8"))
-    matches = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.FunctionDef) and node.name == "shutdown_signal_handler"
-    ]
-    assert len(matches) == 1, (
-        "expected exactly one shutdown_signal_handler in gateway/run.py, found "
-        f"{len(matches)} — this test needs updating if the handler moved or was "
-        "renamed"
+    runner.stop = _blocking_stop
+    runner._schedule_shutdown_task = GatewayRunner._schedule_shutdown_task.__get__(
+        runner, GatewayRunner
     )
-    return matches[0]
+    return runner, adapter, release, calls
 
 
-def _is_create_task(node: ast.AST) -> bool:
-    return (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "create_task"
-    )
+async def _drain(*tasks: asyncio.Task) -> None:
+    for task in tasks:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
 
 def test_gateway_runner_declares_a_shutdown_task_slot():
@@ -75,66 +65,68 @@ def test_gateway_runner_declares_a_shutdown_task_slot():
     assert GatewayRunner._shutdown_task is None
 
 
-def test_shutdown_handler_never_discards_a_created_task():
-    """No ``asyncio.create_task(...)`` in the handler may be a bare statement."""
-    handler = _shutdown_signal_handler_node()
-    discarded = [
-        node
-        for node in ast.walk(handler)
-        if isinstance(node, ast.Expr) and _is_create_task(node.value)
-    ]
-    assert discarded == [], (
-        "shutdown_signal_handler discards the result of asyncio.create_task(); "
-        "the event loop holds only a weak reference, so the task can be "
-        "garbage-collected before stop() creates _stop_impl and the gateway "
-        "then never shuts down"
-    )
+@pytest.mark.asyncio
+async def test_scheduling_shutdown_anchors_the_task_on_the_runner():
+    """The scheduled task is reachable from the runner, not just from the loop.
 
-
-def test_shutdown_handler_anchors_its_task_on_the_runner():
-    """The created task is stored in ``runner._shutdown_task``."""
-    handler = _shutdown_signal_handler_node()
-    anchored = [
-        target.attr
-        for node in ast.walk(handler)
-        if isinstance(node, ast.Assign) and _is_create_task(node.value)
-        for target in node.targets
-        if isinstance(target, ast.Attribute)
-    ]
-    assert anchored == ["_shutdown_task"], (
-        "expected the shutdown task to be anchored on the runner as "
-        f"_shutdown_task, found {anchored!r}"
-    )
-
-
-def test_shutdown_anchor_is_only_repointed_when_the_previous_task_is_done():
-    """A second signal must not overwrite the handle to the live teardown.
-
-    The handler runs more than once in ordinary operation (a second Ctrl+C, a
-    SIGINT followed by the service manager's SIGTERM, or the planned-stop
-    watcher thread racing a real signal via ``call_soon_threadsafe``).  An
-    unconditional assignment would drop the only strong reference to the task
-    that is actually shutting the gateway down.
+    The event loop holds only a weak reference to a task, so without this the
+    shutdown can be collected while still pending.
     """
-    handler = _shutdown_signal_handler_node()
-    guarded = False
-    for node in ast.walk(handler):
-        if not isinstance(node, ast.If):
-            continue
-        if not any(
-            isinstance(inner, ast.Assign) and _is_create_task(inner.value)
-            for inner in ast.walk(node)
-        ):
-            continue
-        if any(
-            isinstance(probe, ast.Attribute) and probe.attr == "done"
-            for probe in ast.walk(node.test)
-        ):
-            guarded = True
-    assert guarded, (
-        "the _shutdown_task assignment is not guarded by a done() check, so a "
-        "repeat signal replaces the handle to the still-running shutdown task"
-    )
+    runner, _adapter, release, calls = _make_runner_with_blocking_stop()
+
+    task = runner._schedule_shutdown_task()
+    await asyncio.sleep(0)
+
+    assert runner._shutdown_task is task
+    assert task.done() is False
+    assert calls == [1]
+
+    release.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_a_repeat_signal_does_not_replace_the_in_flight_shutdown_task():
+    """A second signal must reuse the task that owns the live teardown.
+
+    The handler re-enters in ordinary operation: a second Ctrl+C, a SIGINT
+    followed by the service manager's SIGTERM, or ``_run_planned_stop_watcher``
+    driving the same callable from its polling thread.  Re-pointing the anchor
+    would drop the only strong reference to the running shutdown.
+    """
+    runner, _adapter, release, calls = _make_runner_with_blocking_stop()
+
+    first = runner._schedule_shutdown_task()
+    await asyncio.sleep(0)
+    second = runner._schedule_shutdown_task()
+    await asyncio.sleep(0)
+
+    assert second is first
+    assert runner._shutdown_task is first
+    assert calls == [1], "the repeat signal started a second stop()"
+
+    release.set()
+    await first
+
+
+@pytest.mark.asyncio
+async def test_a_later_signal_schedules_again_once_the_previous_one_finished():
+    """The guard must not wedge the gateway if an earlier shutdown completed."""
+    runner, _adapter, release, calls = _make_runner_with_blocking_stop()
+
+    first = runner._schedule_shutdown_task()
+    await asyncio.sleep(0)
+    release.set()
+    await first
+
+    second = runner._schedule_shutdown_task()
+    await asyncio.sleep(0)
+
+    assert second is not first
+    assert runner._shutdown_task is second
+    assert calls == [1, 1]
+
+    await second
 
 
 @pytest.mark.asyncio
@@ -182,7 +174,4 @@ async def test_stop_does_not_cancel_the_anchored_shutdown_task():
             "_stop_task that runs this sweep"
         )
     finally:
-        for task in (shutdown_task, control_task):
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+        await _drain(shutdown_task, control_task)


### PR DESCRIPTION
## What does this PR do?

`shutdown_signal_handler` in `gateway/run.py` is installed for **both** SIGINT and SIGTERM, and it ended by scheduling the shutdown and throwing the handle away:

```python
asyncio.create_task(runner.stop())
```

This repo already argues that this is a bug — on the *other* signal path. `request_restart()` (the SIGUSR1 restart handler) creates a task of exactly the same shape, deliberately keeps a reference to it, and writes out why:

> We still hold a strong reference in self._restart_task: a bare
> asyncio.create_task() keeps only a weak reference, so the event
> loop may garbage-collect a still-pending task mid-flight.  The
> cancel loop in _stop_impl explicitly skips _restart_task for the
> same reason it skips _stop_task.

One signal path was hardened against that hazard and the comment explaining why is sitting in the file. The other — the path every `systemctl stop`, every `hermes gateway stop` and every interactive Ctrl+C takes — was left bare. This PR completes that hardening by mirroring `_restart_task`.

### The failure window, stated precisely

`stop()` is two-stage and only the inner stage is self-anchoring:

- the **inner** task is created as `self._stop_task = asyncio.create_task(_stop_impl())` and awaited, so it is strongly referenced;
- the **outer** task — the `runner.stop()` coroutine the signal handler wraps — had no reference at all.

So the damaging window is narrow and specific: **if the outer task is collected before `stop()` reaches `self._stop_task = asyncio.create_task(_stop_impl())`, `_stop_impl` is never created and the gateway never tears down.** It keeps running until systemd's `TimeoutStopSec` escalates to SIGKILL — in-flight turns are never drained, sessions are never finalized, and the operator sees "I sent stop and it hung, then it got killed and I lost the turn."

A collection *after* that point is harmless: the inner task survives on `self._stop_task` and shutdown completes normally. I am not claiming that every collection loses the shutdown, and this is a latent-hazard fix in the same sense the `_restart_task` one was — the asyncio docs and this file's own comment both say the handle must be kept.

### Why the obvious fix is the wrong one

The naive version — parking the task in `self._background_tasks` — is self-cancelling. `_stop_impl`'s teardown loop cancels every member of that set and skips exactly two handles, `_stop_task` and `_restart_task`. Putting the shutdown handle there would have `_stop_impl` cancel the very task that is awaiting it, trading a garbage-collection bug for a cancellation bug. That is why this uses a dedicated `_shutdown_task` and adds the matching exemption instead.

### Why the assignment is guarded

`shutdown_signal_handler` is not a once-only path — a second Ctrl+C, a SIGINT followed by the service manager's SIGTERM, or `_run_planned_stop_watcher` driving the same callable from its polling thread via `loop.call_soon_threadsafe(shutdown_handler, None)` all re-enter it. (That watcher's own docstring notes that on POSIX "the signal handler always races us to consuming the marker file", and its `_draining` gate does not close until `_stop_impl` is already running.) An unconditional assignment would let the second call overwrite the reference to the task performing the live teardown, putting us straight back in the window above. Skipping the duplicate is behaviour-preserving: `stop()` short-circuits on `self._stop_task`, so the second task only ever existed to await the first one's work.

### Scope

Deliberately fenced to the **signal-handler** statement only. There are two other open PRs anchoring `create_task` sites in this file — #17966 and #45372, both on the *watcher* sites (`_run_process_watcher`, `_session_expiry_watcher`, `_platform_reconnect_watcher` and friends inside `start()`). Neither touches the signal handler, and this PR does not touch any watcher site, so all three apply in any order. The regression tests live in a new file for the same reason: #41642 and #41690 are both adding their own test files in this area, and a shared test file would be a needless conflict.

## Related Issue

No filed issue — found by auditing the two signal paths in `gateway/run.py` against each other, after the SIGUSR1 path's comment made the invariant explicit.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Six atomic commits:

- **`gateway/run.py`** — anchor the task the SIGINT/SIGTERM handler creates in `runner._shutdown_task`, and declare the attribute at both existing sites (the class annotation beside `_stop_task` / `_restart_task`, and `__init__`) so bare runners built via `object.__new__` inherit the same `None` default.
- **`gateway/run.py`** — only re-point that anchor when the previous shutdown task is absent or `done()`, so a repeat signal cannot drop the handle to the live teardown.
- **`gateway/run.py`** — add `_shutdown_task` to `_stop_impl`'s cancel-sweep skip list, beside `_stop_task` and `_restart_task`. Like `_restart_task`, the handle is deliberately kept *out* of `_background_tasks`, so this branch does not fire on any current path; it is recorded there because that loop is the single place enforcing "never cancel a task that is awaiting `_stop_task`", and the handles satisfying that description should not be treated differently by it.
- **`tests/gateway/test_shutdown_task_anchor.py`** — regression tests.
- **`gateway/run.py`** — extract the anchoring and the guard out of the handler closure into `GatewayRunner._schedule_shutdown_task()`, no behaviour change. The handler is built inside the gateway start path and cannot be imported, which had pushed the tests into asserting the shape of the source; AGENTS.md bans that ("Never read source code in tests"), so the behaviour is made importable instead.
- **`tests/gateway/test_shutdown_task_anchor.py`** — replace the four source-parsing assertions with behavioural tests against that method.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_shutdown_task_anchor.py -v
```

Five tests, all behavioural — no source text is read. Every production hunk is mutation-covered, i.e. each one is independently load-bearing:

| mutation applied to `gateway/run.py` | result |
|---|---|
| return the task without storing it in `_shutdown_task` | **3 tests fail** |
| drop the "previous shutdown still in flight" guard | **1 test fails** (`..._repeat_signal_does_not_replace_the_in_flight_shutdown_task`) |
| delete the `_shutdown_task` branch from `_stop_impl`'s cancel sweep | **1 test fails** (`test_stop_does_not_cancel_the_anchored_shutdown_task`) |
| none | 5 / 5 pass |

What they assert:

- scheduling a shutdown leaves the task reachable from the runner and not only from the event loop — that reachability is the whole fix;
- a repeat signal reuses the in-flight task and does not start a second `stop()`;
- once a shutdown has finished, a later signal does schedule again, so the guard cannot wedge the gateway;
- `_stop_impl`'s cancel sweep leaves `_shutdown_task` alone while still cancelling an ordinary background task — driven against a real `runner.stop()` on the `restart_test_helpers` bare-runner harness.

Adjacent suites run green on this branch: `test_gateway_shutdown.py`, `test_planned_stop_watcher.py`, `test_restart_drain.py`, `test_clean_shutdown_marker.py`, `test_shutdown_cache_cleanup.py`, `test_startup_restart_race.py`, `test_restart_resume_pending.py`, `test_background_command.py`, `test_api_server_active_work_drain.py`, `test_cron_active_work_drain.py`, `test_session_race_guard.py`, `test_max_concurrent_sessions.py`, `test_gateway_process_exit.py`, `test_external_drain_control.py` — 121 passed, 2 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused + adjacent suites listed above, not the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comments only; no user-facing docs affected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the handler is unreachable on Windows (`add_signal_handler` raises `NotImplementedError` there), but `_run_planned_stop_watcher` invokes the same callable on every platform, so the anchor and the repeat-call guard apply to the Windows fallback path too. Verified on macOS only.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
