### PR TITLE
fix(vision): enforce session-scoped media provenance

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1555,6 +1555,21 @@ def run_conversation(
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
+    # Trust is session-scoped and process-local. Rebuild it from prior user
+    # messages and grounded results from explicitly designated media producers,
+    # then register the current original user input. Arbitrary assistant text
+    # and unmatched/ordinary tool history must never re-trust a reference.
+    try:
+        from agent.media_provenance import (
+            register_user_media_references,
+            rehydrate_media_references,
+        )
+
+        rehydrate_media_references(agent.session_id, conversation_history)
+        register_user_media_references(agent.session_id, original_user_message)
+    except Exception:
+        logger.warning("Media provenance registration failed", exc_info=True)
+
     # Commentary deduplication spans all provider continuations and tool calls
     # within one user turn, but must not suppress the same phrase next turn.
     agent._delivered_interim_texts = set()

--- a/agent/media_provenance.py
+++ b/agent/media_provenance.py
@@ -1,0 +1,417 @@
+"""Session-scoped provenance registry for model-invoked media tools.
+
+The registry is deliberately independent of filesystem existence.  A path or
+URL is usable by ``vision_analyze`` only after a trusted boundary registered it
+for the same conversation session.  This prevents a model-generated reference
+from becoming trusted merely because it happens to resolve on the host.
+
+Registration is process-local and fail-closed.  Gateway attachments and the
+current user turn are registered before the agent loop; explicitly designated
+media-producing tools are registered after successful execution.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+import hashlib
+import json
+import ntpath
+from pathlib import Path
+import re
+import threading
+from typing import Any, Iterable, Iterator, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+
+_MAX_SESSIONS = 256
+_MAX_REFS_PER_SESSION = 512
+_MEDIA_EXTENSIONS = (
+    "avif", "bmp", "gif", "heic", "heif", "jpeg", "jpg", "png", "svg",
+    "tif", "tiff", "webp",
+)
+_URL_RE = re.compile(r"https?://[^\s<>\]\[{}\"']+", re.IGNORECASE)
+_FILE_URL_RE = re.compile(r"file://[^\s<>\]\[{}\"']+", re.IGNORECASE)
+_QUOTED_PATH_RE = re.compile(r"[`\"']([^`\"']+)[`\"']")
+_ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![\w.])((?:/[^\s<>`\"']+)|(?:[A-Za-z]:[\\/][^\s<>`\"']+))"
+)
+_POSIX_PATH_RE = re.compile(
+    rf"(?<![\w.])(/[^\n\r<>\"']+?\.(?:{'|'.join(_MEDIA_EXTENSIONS)}))"
+    r"(?=$|[\s,;:!?)}\]])",
+    re.IGNORECASE,
+)
+_WINDOWS_PATH_RE = re.compile(
+    rf"(?<![\w.])([A-Za-z]:[\\/][^\n\r<>\"']+?\.(?:{'|'.join(_MEDIA_EXTENSIONS)}))"
+    r"(?=$|[\s,;:!?)}\]])",
+    re.IGNORECASE,
+)
+_RELATIVE_PATH_RE = re.compile(
+    rf"(?<![\w./\\])((?:\.{1,2}[\\/])?[^\s<>\"']+\.(?:{'|'.join(_MEDIA_EXTENSIONS)}))"
+    r"(?=$|[\s,;:!?)}\]])",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class MediaProvenance:
+    """Audit-safe provenance metadata for one registered media reference."""
+
+    origin: str
+    producer: Optional[str] = None
+
+
+_lock = threading.RLock()
+_sessions: "OrderedDict[str, OrderedDict[str, MediaProvenance]]" = OrderedDict()
+
+
+def _session_key(session_id: Any) -> str:
+    return str(session_id or "").strip()
+
+
+def canonical_media_reference(reference: Any) -> Optional[str]:
+    """Return a stable, non-secret identity key for a media reference."""
+    if not isinstance(reference, str):
+        return None
+    value = reference.strip()
+    if not value:
+        return None
+
+    lowered = value.lower()
+    if lowered.startswith("data:"):
+        # Never retain a potentially multi-megabyte inline image in memory.
+        return "data:sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+    if lowered.startswith(("http://", "https://")):
+        try:
+            parsed = urlsplit(value)
+            if not parsed.netloc:
+                return None
+            host = (parsed.hostname or "").lower()
+            if parsed.port:
+                host = f"{host}:{parsed.port}"
+            if parsed.username:
+                # Userinfo is part of identity but never stored in clear.
+                userinfo = hashlib.sha256(
+                    f"{parsed.username}:{parsed.password or ''}".encode("utf-8")
+                ).hexdigest()[:16]
+                host = f"userinfo-sha256-{userinfo}@{host}"
+            identity = urlunsplit(
+                (parsed.scheme.lower(), host, parsed.path, parsed.query, "")
+            )
+            return "url:sha256:" + hashlib.sha256(
+                identity.encode("utf-8")
+            ).hexdigest()
+        except (TypeError, ValueError):
+            return None
+    if lowered.startswith("file://"):
+        value = value[7:]
+    if re.match(r"^[A-Za-z]:[\\/]", value):
+        normalized = ntpath.normcase(ntpath.normpath(value))
+        return "file:sha256:" + hashlib.sha256(
+            normalized.encode("utf-8")
+        ).hexdigest()
+    try:
+        normalized = str(Path(value).expanduser().resolve(strict=False))
+        return "file:sha256:" + hashlib.sha256(
+            normalized.encode("utf-8")
+        ).hexdigest()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def register_trusted_media(
+    session_id: Any,
+    references: Iterable[Any],
+    *,
+    origin: str,
+    producer: Optional[str] = None,
+) -> int:
+    """Register references for exactly one session, returning the new count."""
+    session = _session_key(session_id)
+    if not session:
+        return 0
+    keys = [canonical_media_reference(ref) for ref in references]
+    keys = [key for key in keys if key]
+    if not keys:
+        return 0
+
+    added = 0
+    with _lock:
+        bucket = _sessions.setdefault(session, OrderedDict())
+        _sessions.move_to_end(session)
+        for key in keys:
+            if key not in bucket:
+                added += 1
+            bucket[key] = MediaProvenance(origin=origin, producer=producer)
+            bucket.move_to_end(key)
+        while len(bucket) > _MAX_REFS_PER_SESSION:
+            bucket.popitem(last=False)
+        while len(_sessions) > _MAX_SESSIONS:
+            _sessions.popitem(last=False)
+    return added
+
+
+def trusted_media_provenance(
+    session_id: Any,
+    reference: Any,
+) -> Optional[MediaProvenance]:
+    """Return provenance only when *reference* belongs to *session_id*."""
+    session = _session_key(session_id)
+    key = canonical_media_reference(reference)
+    if not session or not key:
+        return None
+    with _lock:
+        bucket = _sessions.get(session)
+        if bucket is None:
+            return None
+        provenance = bucket.get(key)
+        if provenance is not None:
+            # Both caps use insertion order as LRU order. A reference that is
+            # actively reused should not be evicted ahead of dormant entries.
+            bucket.move_to_end(key)
+            _sessions.move_to_end(session)
+        return provenance
+
+
+def is_trusted_media(session_id: Any, reference: Any) -> bool:
+    return trusted_media_provenance(session_id, reference) is not None
+
+
+def clear_media_provenance(session_id: Any = None) -> None:
+    """Clear one session, or all sessions when called without an id (tests)."""
+    with _lock:
+        if session_id is None:
+            _sessions.clear()
+        else:
+            _sessions.pop(_session_key(session_id), None)
+
+
+def _strip_trailing_url_punctuation(value: str) -> str:
+    # Closing punctuation is commonly adjacent in prose.  Preserve URL query
+    # bytes; trim only characters which cannot safely identify the resource.
+    return value.rstrip(".,;:!?)]}")
+
+
+def _iter_content_references(content: Any) -> Iterator[str]:
+    if isinstance(content, str):
+        if content.lstrip().lower().startswith("data:image/"):
+            yield content.strip()
+            return
+        url_spans: list[tuple[int, int]] = []
+        for url_pattern in (_URL_RE, _FILE_URL_RE):
+            for match in url_pattern.finditer(content):
+                yield _strip_trailing_url_punctuation(match.group(0))
+                url_spans.append(match.span())
+        # Do not reinterpret a URL path as a local POSIX/relative path.
+        path_text = content
+        for start, end in reversed(url_spans):
+            path_text = path_text[:start] + (" " * (end - start)) + path_text[end:]
+        for match in _QUOTED_PATH_RE.finditer(path_text):
+            candidate = match.group(1).strip()
+            if candidate.startswith(("/", "./", "../")) or re.match(
+                r"^[A-Za-z]:[\\/]", candidate
+            ):
+                yield candidate
+        for pattern in (
+            _ABSOLUTE_PATH_RE,
+            _WINDOWS_PATH_RE,
+            _POSIX_PATH_RE,
+            _RELATIVE_PATH_RE,
+        ):
+            for match in pattern.finditer(path_text):
+                yield _strip_trailing_url_punctuation(match.group(1))
+        return
+    if isinstance(content, (list, tuple)):
+        for item in content:
+            yield from _iter_content_references(item)
+        return
+    if not isinstance(content, dict):
+        return
+
+    block_type = str(content.get("type") or "").lower()
+    if block_type in {"image", "image_url", "input_image"}:
+        for key in ("url", "path", "image_url", "file_path"):
+            value = content.get(key)
+            if isinstance(value, str):
+                yield value
+            elif isinstance(value, dict):
+                nested = value.get("url") or value.get("path")
+                if isinstance(nested, str):
+                    yield nested
+        source = content.get("source")
+        if isinstance(source, dict):
+            value = source.get("url") or source.get("path") or source.get("data")
+            if isinstance(value, str):
+                if source.get("type") == "base64" and not value.startswith("data:"):
+                    media_type = source.get("media_type") or "image/jpeg"
+                    value = f"data:{media_type};base64,{value}"
+                yield value
+        return
+
+    # Plain user-message dictionaries may wrap the actual content.
+    if "content" in content:
+        yield from _iter_content_references(content.get("content"))
+
+
+def register_user_media_references(session_id: Any, content: Any) -> int:
+    """Register media references explicitly present in the current user turn."""
+    return register_trusted_media(
+        session_id,
+        _iter_content_references(content),
+        origin="user_explicit",
+    )
+
+
+def rehydrate_media_references(session_id: Any, messages: Any) -> int:
+    """Rebuild trust from persisted user input and verified producer results.
+
+    A tool result is accepted only when its ``tool_call_id`` maps to a preceding
+    assistant call with the same tool name. The producer registry applies the
+    second allow-list check. Arbitrary assistant text, unmatched tool rows, and
+    ordinary tool results therefore remain untrusted after a restart.
+    """
+    if not isinstance(messages, (list, tuple)):
+        return 0
+    added = 0
+    pending_tool_names: dict[str, str] = {}
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        if role == "user":
+            pending_tool_names.clear()
+            added += register_user_media_references(
+                session_id, message.get("content")
+            )
+            continue
+        if role == "assistant":
+            # A tool result is grounded only in the immediately active
+            # assistant tool-call batch. A new assistant row closes any older
+            # incomplete batch instead of letting an ID match far later.
+            pending_tool_names.clear()
+            for tool_call in message.get("tool_calls") or []:
+                if not isinstance(tool_call, dict):
+                    continue
+                tool_call_id = tool_call.get("id")
+                function = tool_call.get("function")
+                tool_name = (
+                    function.get("name") if isinstance(function, dict) else None
+                )
+                if isinstance(tool_call_id, str) and isinstance(tool_name, str):
+                    pending_tool_names[tool_call_id] = tool_name
+            continue
+        if role != "tool":
+            pending_tool_names.clear()
+            continue
+        tool_call_id = message.get("tool_call_id")
+        tool_name = message.get("tool_name") or message.get("name")
+        if (
+            not isinstance(tool_call_id, str)
+            or not isinstance(tool_name, str)
+            or pending_tool_names.pop(tool_call_id, None) != tool_name
+        ):
+            continue
+        added += register_trusted_tool_result(
+            session_id, tool_name, message.get("content")
+        )
+    return added
+
+
+def _decoded_tool_payload(tool_name: str, result: Any) -> Any:
+    if isinstance(result, str):
+        candidate = result
+        # Session persistence replaces image parts in multimodal tool messages
+        # with this marker. Remove only the storage marker; never treat it as
+        # media provenance itself.
+        while candidate.endswith("\n[screenshot]"):
+            candidate = candidate[: -len("\n[screenshot]")]
+        try:
+            return json.loads(candidate)
+        except (TypeError, ValueError):
+            # High-risk browser results are persisted inside the exact
+            # untrusted-data envelope added by make_tool_result_message().
+            # Recover only a well-formed outer envelope whose source matches
+            # the verified tool call; embedded forged delimiters are already
+            # neutralized before persistence.
+            opening = f'<untrusted_tool_result source="{tool_name}">\n'
+            closing = "\n</untrusted_tool_result>"
+            if candidate.startswith(opening) and candidate.endswith(closing):
+                _, separator, payload = candidate.partition("\n\n")
+                if not separator:
+                    return None
+                candidate = payload[: -len(closing)]
+                try:
+                    return json.loads(candidate)
+                except (TypeError, ValueError):
+                    pass
+            return candidate
+    return result
+
+
+def _trusted_tool_references(tool_name: str, result: Any) -> list[str]:
+    payload = _decoded_tool_payload(tool_name, result)
+    if isinstance(payload, (list, tuple)):
+        return list(_iter_content_references(payload))
+    if isinstance(payload, str) and tool_name == "browser_vision":
+        # Native browser_vision results persist only their text summary. Hermes
+        # appends the real screenshot path at the very end; anchor there so a
+        # path-like string in page/vision text cannot gain provenance.
+        match = re.search(r"(?:^|\s)Screenshot path:\s*(.+?)\s*$", payload)
+        return [match.group(1)] if match else []
+    if not isinstance(payload, dict):
+        return []
+    if payload.get("success") is False and tool_name != "browser_vision":
+        return []
+
+    refs: list[str] = []
+    # Multimodal producers expose the exact image reference the main model saw.
+    # Register it without retaining the inline bytes (canonicalization hashes
+    # data URLs). This covers browser_vision and computer_use captures.
+    for block in payload.get("content") or []:
+        if not isinstance(block, dict) or block.get("type") != "image_url":
+            continue
+        image_url = block.get("image_url")
+        if isinstance(image_url, dict):
+            image_url = image_url.get("url")
+        if isinstance(image_url, str):
+            refs.append(image_url)
+    if tool_name == "image_generate":
+        refs.extend(
+            value for key in ("image", "host_image", "agent_visible_image")
+            if isinstance((value := payload.get(key)), str)
+        )
+    elif tool_name == "browser_get_images":
+        for item in payload.get("images") or []:
+            if isinstance(item, dict) and isinstance(item.get("src"), str):
+                refs.append(item["src"])
+    elif tool_name == "browser_vision":
+        for value in (
+            payload.get("screenshot_path"),
+            (payload.get("meta") or {}).get("screenshot_path")
+            if isinstance(payload.get("meta"), dict) else None,
+        ):
+            if isinstance(value, str):
+                refs.append(value)
+    return refs
+
+
+def register_trusted_tool_result(
+    session_id: Any,
+    tool_name: str,
+    result: Any,
+) -> int:
+    """Register media emitted by a registry-designated trusted producer."""
+    try:
+        from tools.registry import registry
+
+        entry = registry.get_entry(tool_name)
+        if entry is None or not entry.produces_trusted_media:
+            return 0
+    except Exception:
+        return 0
+    return register_trusted_media(
+        session_id,
+        _trusted_tool_references(tool_name, result),
+        origin="trusted_tool",
+        producer=tool_name,
+    )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -53,6 +53,22 @@ from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context
 logger = logging.getLogger(__name__)
 
 
+def _register_trusted_media_result(
+    agent: Any, tool_name: str, result: Any, *, blocked: bool,
+) -> None:
+    """Register a designated producer result before it enters model history."""
+    if blocked:
+        return
+    try:
+        from agent.media_provenance import register_trusted_tool_result
+
+        register_trusted_tool_result(getattr(agent, "session_id", None), tool_name, result)
+    except Exception:
+        # Bookkeeping must not fail a producer call; the downstream gate still
+        # fails closed if registration did not succeed.
+        logger.warning("Trusted media provenance registration failed for %s", tool_name, exc_info=True)
+
+
 def _ensure_file_checkpoint(
     agent,
     function_name: str,
@@ -1434,6 +1450,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if blocked:
                 effect_disposition = "none"
 
+            _register_trusted_media_result(
+                agent, function_name, function_result, blocked=blocked,
+            )
             if not blocked:
                 function_result = agent._append_guardrail_observation(
                     function_name,
@@ -2168,6 +2187,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             tool_duration = time.time() - tool_start_time
+
+        _register_trusted_media_result(
+            agent, function_name, function_result, blocked=_execution_blocked,
+        )
 
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2776,6 +2776,27 @@ def _event_media_is_image(event, index: int) -> bool:
     return getattr(event, "message_type", None) == MessageType.PHOTO
 
 
+def _register_gateway_media_paths(session_id: str, paths: List[str]) -> int:
+    """Trust inbound image attachments and their remote-backend aliases."""
+    try:
+        from agent.media_provenance import register_trusted_media
+        from tools.credential_files import to_agent_visible_cache_path
+
+        original_references = [path for path in paths if isinstance(path, str)]
+        aliases = [
+            to_agent_visible_cache_path(path)
+            for path in original_references
+            if not path.startswith(("http://", "https://", "data:"))
+        ]
+        references = original_references + aliases
+        return register_trusted_media(
+            session_id, references, origin="gateway_attachment",
+        )
+    except Exception:
+        logger.warning("Gateway media provenance registration failed", exc_info=True)
+        return 0
+
+
 def _event_media_is_audio(event, index: int) -> bool:
     """True if the attachment at *index* is audio (per-attachment MIME first)."""
     mtype = _event_media_type_at(event, index)
@@ -18151,6 +18172,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # attachments (documents, audio, etc.) are not sent to the vision
         # tool even when they appear in the same message.
         # -----------------------------------------------------------------
+        _register_gateway_media_paths(
+            session_entry.session_id,
+            [
+                path
+                for i, path in enumerate(getattr(event, "media_urls", None) or [])
+                if _event_media_is_image(event, i)
+            ],
+        )
         message_text = await self._prepare_profile_scoped_inbound_message_text(
             event=event,
             source=source,
@@ -20304,6 +20333,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         image_paths.append(path)
                 if image_paths:
                     try:
+                        _register_gateway_media_paths(task_id, image_paths)
                         enriched_prompt = await self._enrich_message_with_vision(
                             prompt, image_paths,
                         )
@@ -26775,6 +26805,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_key or "?",
                             exc_info=True,
                         )
+                    _register_gateway_media_paths(
+                        session_id,
+                        [
+                            path
+                            for i, path in enumerate(
+                                getattr(pending_event, "media_urls", None) or []
+                            )
+                            if _event_media_is_image(pending_event, i)
+                        ],
+                    )
                     next_message = await self._prepare_profile_scoped_inbound_message_text(
                         event=pending_event,
                         source=next_source,

--- a/tests/agent/test_auxiliary_config_bridge.py
+++ b/tests/agent/test_auxiliary_config_bridge.py
@@ -169,13 +169,15 @@ class TestVisionModelOverride:
     @pytest.mark.asyncio
     async def test_env_var_overrides_default(self, monkeypatch):
         monkeypatch.setenv("AUXILIARY_VISION_MODEL", "openai/gpt-4o")
+        from agent.media_provenance import register_user_media_references
         from tools.vision_tools import _handle_vision_analyze
+        register_user_media_references("test-session", "http://test.jpg")
         with (
             patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool,
             patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
         ):
             mock_tool.return_value = '{"success": true}'
-            await _handle_vision_analyze({"image_url": "http://test.jpg", "question": "test"})
+            await _handle_vision_analyze({"image_url": "http://test.jpg", "question": "test"}, session_id="test-session")
             call_args = mock_tool.call_args
             # 3rd positional arg = model
             assert call_args[0][2] == "openai/gpt-4o"
@@ -183,13 +185,15 @@ class TestVisionModelOverride:
     @pytest.mark.asyncio
     async def test_default_model_when_no_override(self, monkeypatch):
         monkeypatch.delenv("AUXILIARY_VISION_MODEL", raising=False)
+        from agent.media_provenance import register_user_media_references
         from tools.vision_tools import _handle_vision_analyze
+        register_user_media_references("test-session", "http://test.jpg")
         with (
             patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_tool,
             patch("tools.vision_tools._should_use_native_vision_fast_path", return_value=False),
         ):
             mock_tool.return_value = '{"success": true}'
-            await _handle_vision_analyze({"image_url": "http://test.jpg", "question": "test"})
+            await _handle_vision_analyze({"image_url": "http://test.jpg", "question": "test"}, session_id="test-session")
             call_args = mock_tool.call_args
             # With no AUXILIARY_VISION_MODEL env var, model should be None
             # (the centralized call_llm router picks the provider default)

--- a/tests/agent/test_media_provenance.py
+++ b/tests/agent/test_media_provenance.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.media_provenance import (
+    clear_media_provenance,
+    is_trusted_media,
+    register_trusted_media,
+    register_trusted_tool_result,
+    register_user_media_references,
+    rehydrate_media_references,
+)
+from tools import browser_tool as _browser_tool  # noqa: F401
+from tools import computer_use_tool as _computer_use_tool  # noqa: F401
+from tools import image_generation_tool as _image_generation_tool  # noqa: F401
+from tools import vision_tools
+
+
+@pytest.fixture(autouse=True)
+def clear_registry() -> None:
+    clear_media_provenance()
+    yield
+    clear_media_provenance()
+
+
+def call_vision(session_id: str, reference: str) -> dict:
+    raw = asyncio.run(vision_tools._handle_vision_analyze(
+        {"image_url": reference, "question": "inspect"},
+        session_id=session_id, task_id="test-task",
+    ))
+    return json.loads(raw)
+
+
+def test_unregistered_reference_is_blocked_before_native_or_auxiliary_vision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auxiliary = AsyncMock(return_value="must not run")
+    native = AsyncMock(return_value="must not run")
+    monkeypatch.setattr(vision_tools, "vision_analyze_tool", auxiliary)
+    monkeypatch.setattr(vision_tools, "_vision_analyze_native", native)
+
+    result = call_vision("session-a", "/tmp/invented.png")
+
+    assert result["error_type"] == "untrusted_media_reference"
+    auxiliary.assert_not_awaited()
+    native.assert_not_awaited()
+
+
+def test_user_reference_is_allowed_only_in_its_own_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference = "https://example.test/user-photo.png"
+    assert register_user_media_references("session-a", f"inspect {reference}") == 1
+
+    auxiliary = AsyncMock(return_value="trusted analysis")
+    monkeypatch.setattr(vision_tools, "vision_analyze_tool", auxiliary)
+    monkeypatch.setattr(vision_tools, "_should_use_native_vision_fast_path", lambda: False)
+
+    raw = asyncio.run(vision_tools._handle_vision_analyze(
+        {"image_url": reference, "question": "inspect"},
+        session_id="session-a", task_id="test-task",
+    ))
+    assert raw == "trusted analysis"
+    auxiliary.assert_awaited_once()
+
+    assert call_vision("session-b", reference)["error_type"] == "untrusted_media_reference"
+
+
+def test_registered_reference_reaches_native_vision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference = "/tmp/user-provided.png"
+    register_user_media_references("session-a", f"inspect {reference}")
+    native = AsyncMock(return_value={"_multimodal": True, "content": []})
+    auxiliary = AsyncMock(return_value="must not run")
+    monkeypatch.setattr(vision_tools, "_vision_analyze_native", native)
+    monkeypatch.setattr(vision_tools, "vision_analyze_tool", auxiliary)
+    monkeypatch.setattr(
+        vision_tools, "_should_use_native_vision_fast_path", lambda: True
+    )
+
+    result = asyncio.run(vision_tools._handle_vision_analyze(
+        {"image_url": reference, "question": "inspect"},
+        session_id="session-a",
+        task_id="test-task",
+    ))
+
+    assert result == {"_multimodal": True, "content": []}
+    native.assert_awaited_once()
+    auxiliary.assert_not_awaited()
+
+
+def test_user_extensionless_and_file_url_paths_are_registered() -> None:
+    extensionless = "/tmp/upload-without-extension"
+    file_url = "file:///tmp/photo.png"
+
+    register_user_media_references(
+        "session-a", f"inspect `{extensionless}` and {file_url}"
+    )
+
+    assert is_trusted_media("session-a", extensionless)
+    assert is_trusted_media("session-a", file_url)
+
+
+def test_existing_path_from_another_session_is_not_trusted() -> None:
+    reference = "/tmp/shared-cache-image.png"
+    register_trusted_media("session-a", [reference], origin="gateway_attachment")
+
+    assert call_vision("session-b", reference)["error_type"] == "untrusted_media_reference"
+
+
+def test_restart_rehydrates_only_grounded_user_and_producer_media() -> None:
+    from agent.tool_dispatch_helpers import make_tool_result_message
+
+    user_reference = "https://example.test/user-image.png"
+    model_reference = "/tmp/model-invented.png"
+    stale_reference = "/tmp/stale-tool-result.png"
+    generated_reference = "/tmp/historical-generated.png"
+    browser_reference = "https://example.test/historical-browser.jpg"
+    screenshot_reference = "/tmp/historical browser screenshot.png"
+    browser_result = make_tool_result_message(
+        "browser_get_images",
+        json.dumps({
+            "success": True,
+            "images": [{"src": browser_reference}],
+        }),
+        "call-browser",
+    )
+    browser_vision_summary = make_tool_result_message(
+        "browser_vision",
+        (
+            "A page analysis that mentions /tmp/untrusted.png but ends with "
+            f"the Hermes artifact. Screenshot path: {screenshot_reference}"
+        ),
+        "call-browser-vision",
+    )
+    browser_vision_summary["content"] += "\n[screenshot]"
+
+    assert rehydrate_media_references("session-a", [
+        {"role": "assistant", "content": f"inspect {model_reference}"},
+        {
+            "role": "tool",
+            "tool_name": "image_generate",
+            "tool_call_id": "unmatched",
+            "content": json.dumps({"success": True, "image": model_reference}),
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call-stale",
+                "function": {"name": "image_generate", "arguments": "{}"},
+            }],
+        },
+        {"role": "user", "content": f"inspect {user_reference}"},
+        {
+            "role": "tool",
+            "tool_name": "image_generate",
+            "tool_call_id": "call-stale",
+            "content": json.dumps({"success": True, "image": stale_reference}),
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call-generate",
+                "function": {"name": "image_generate", "arguments": "{}"},
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_name": "image_generate",
+            "tool_call_id": "call-generate",
+            "content": json.dumps({
+                "success": True,
+                "image": generated_reference,
+            }),
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call-browser",
+                "function": {"name": "browser_get_images", "arguments": "{}"},
+            }],
+        },
+        browser_result,
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call-browser-vision",
+                "function": {"name": "browser_vision", "arguments": "{}"},
+            }],
+        },
+        browser_vision_summary,
+    ]) == 4
+    assert is_trusted_media("session-a", user_reference)
+    assert is_trusted_media("session-a", generated_reference)
+    assert is_trusted_media("session-a", browser_reference)
+    assert is_trusted_media("session-a", screenshot_reference)
+    assert not is_trusted_media("session-a", "/tmp/untrusted.png")
+    assert not is_trusted_media("session-a", model_reference)
+    assert not is_trusted_media("session-a", stale_reference)
+
+
+def test_session_db_round_trip_rehydrates_grounded_producer_media(tmp_path) -> None:
+    from agent.tool_dispatch_helpers import make_tool_result_message
+    from hermes_state import SessionDB
+
+    session_id = "session-db-round-trip"
+    reference = "https://example.test/persisted-browser-image.jpg"
+    result = make_tool_result_message(
+        "browser_get_images",
+        json.dumps({
+            "success": True,
+            "images": [{"src": reference}],
+        }),
+        "call-browser",
+    )
+    database = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        database.create_session(session_id, source="cli")
+        database.append_messages_batch(session_id, [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call-browser",
+                    "type": "function",
+                    "function": {
+                        "name": "browser_get_images",
+                        "arguments": "{}",
+                    },
+                }],
+            },
+            result,
+        ])
+        persisted = database.get_messages_as_conversation(session_id)
+    finally:
+        database.close()
+
+    clear_media_provenance()
+    assert rehydrate_media_references(session_id, persisted) == 1
+    assert is_trusted_media(session_id, reference)
+
+
+def test_only_designated_producer_results_register_exact_media() -> None:
+    generated = "/tmp/generated.png"
+    browser_image = "https://example.test/page-image.jpg"
+    browser_screenshot = "/tmp/browser-screenshot.png"
+    computer_capture = "data:image/png;base64,Y2FwdHVyZQ=="
+    ordinary_path = "/tmp/read-file-output.png"
+
+    assert register_trusted_tool_result(
+        "session-a", "image_generate",
+        json.dumps({"success": True, "image": generated}),
+    ) == 1
+    assert register_trusted_tool_result(
+        "session-a", "browser_get_images",
+        json.dumps({"success": True, "images": [{"src": browser_image}]}),
+    ) == 1
+    assert register_trusted_tool_result(
+        "session-a", "read_file",
+        json.dumps({"success": True, "path": ordinary_path}),
+    ) == 0
+    assert register_trusted_tool_result(
+        "session-a", "browser_vision",
+        json.dumps({
+            "success": False,
+            "error": "auxiliary vision unavailable",
+            "screenshot_path": browser_screenshot,
+        }),
+    ) == 1
+    assert register_trusted_tool_result(
+        "session-a", "computer_use",
+        {
+            "_multimodal": True,
+            "content": [{
+                "type": "image_url",
+                "image_url": {"url": computer_capture},
+            }],
+        },
+    ) == 1
+    assert is_trusted_media("session-a", generated)
+    assert is_trusted_media("session-a", browser_image)
+    assert is_trusted_media("session-a", browser_screenshot)
+    assert is_trusted_media("session-a", computer_capture)
+    assert not is_trusted_media("session-a", ordinary_path)
+
+
+def test_executor_wiring_does_not_register_blocked_producer_result() -> None:
+    from agent.tool_executor import _register_trusted_media_result
+
+    agent = SimpleNamespace(session_id="session-a")
+    _register_trusted_media_result(
+        agent, "image_generate",
+        json.dumps({"success": True, "image": "/tmp/allowed.png"}),
+        blocked=False,
+    )
+    _register_trusted_media_result(
+        agent, "image_generate",
+        json.dumps({"success": True, "image": "/tmp/blocked.png"}),
+        blocked=True,
+    )
+    assert is_trusted_media("session-a", "/tmp/allowed.png")
+    assert not is_trusted_media("session-a", "/tmp/blocked.png")
+
+
+def test_full_dispatch_rejects_before_vision_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from model_tools import handle_function_call
+
+    auxiliary = AsyncMock(return_value="must not run")
+    monkeypatch.setattr(vision_tools, "vision_analyze_tool", auxiliary)
+
+    raw = handle_function_call(
+        "vision_analyze",
+        {"image_url": "/tmp/unregistered.png", "question": "inspect"},
+        task_id="test-task",
+        session_id="session-a",
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+        skip_tool_execution_middleware=True,
+    )
+
+    assert json.loads(raw)["error_type"] == "untrusted_media_reference"
+    auxiliary.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("backend", "agent_visible_path"),
+    [
+        ("docker", "/root/.hermes/cache/images/upload.png"),
+        ("ssh", "~/.hermes/cache/images/upload.png"),
+        ("local", None),
+    ],
+)
+def test_gateway_attachment_registers_real_backend_alias(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+    agent_visible_path: str | None,
+) -> None:
+    from gateway.run import _register_gateway_media_paths
+
+    hermes_home = tmp_path / ".hermes"
+    image_path = hermes_home / "cache" / "images" / "upload.png"
+    image_path.parent.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", backend)
+
+    _register_gateway_media_paths("session-a", [str(image_path)])
+
+    assert is_trusted_media("session-a", str(image_path))
+    if agent_visible_path is not None:
+        assert is_trusted_media("session-a", agent_visible_path)

--- a/tests/gateway/test_queued_native_image_session_key.py
+++ b/tests/gateway/test_queued_native_image_session_key.py
@@ -92,6 +92,9 @@ def _make_runner(adapter):
 
 @pytest.mark.asyncio
 async def test_queued_followup_uses_pending_event_session_key_for_native_images(monkeypatch, tmp_path):
+    from agent.media_provenance import clear_media_provenance, is_trusted_media
+
+    clear_media_provenance()
     CaptureQueuedNativeImageAgent.calls = []
 
     fake_dotenv = types.ModuleType("dotenv")
@@ -149,3 +152,4 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
     assert queued_message[0]["type"] == "text"
     assert queued_message[0]["text"].startswith("describe this")
     assert any(part.get("type") == "image_url" for part in queued_message)
+    assert is_trusted_media("sess-native-image-followup", str(image_path))

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -356,7 +356,10 @@ class TestVisionDispatchLoopSafety:
         """After dispatching vision_analyze via the registry, the event
         loop must remain open so cached async clients don't crash on GC."""
         from model_tools import _get_tool_loop
+        from agent.media_provenance import register_user_media_references
         from tools.registry import registry
+
+        register_user_media_references("test-session", "https://example.com/cat.png")
 
         fake_response = _mock_vision_response()
 
@@ -384,6 +387,7 @@ class TestVisionDispatchLoopSafety:
             result_json = registry.dispatch(
                 "vision_analyze",
                 {"image_url": "https://example.com/cat.png", "question": "What is this?"},
+                session_id="test-session",
             )
 
         result = json.loads(result_json)
@@ -401,7 +405,10 @@ class TestVisionDispatchLoopSafety:
         and share the same loop (simulates 'first call fails, second
         works' from the issue report)."""
         from model_tools import _get_tool_loop
+        from agent.media_provenance import register_user_media_references
         from tools.registry import registry
+
+        register_user_media_references("test-session", "https://example.com/cat.png")
 
         fake_response = _mock_vision_response()
 
@@ -428,10 +435,10 @@ class TestVisionDispatchLoopSafety:
         ):
             args = {"image_url": "https://example.com/cat.png", "question": "Describe"}
 
-            r1 = json.loads(registry.dispatch("vision_analyze", args))
+            r1 = json.loads(registry.dispatch("vision_analyze", args, session_id="test-session"))
             loop_after_first = _get_tool_loop()
 
-            r2 = json.loads(registry.dispatch("vision_analyze", args))
+            r2 = json.loads(registry.dispatch("vision_analyze", args, session_id="test-session"))
             loop_after_second = _get_tool_loop()
 
         assert r1.get("success") is True

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -13,6 +13,7 @@ import base64
 import json
 from unittest.mock import patch
 
+from agent.media_provenance import register_trusted_media
 
 from tools.vision_tools import (
     _build_native_vision_tool_result,
@@ -153,6 +154,7 @@ class TestHandleVisionAnalyzeFastPath:
         """Main model supports native vision → fast path returns multimodal."""
         img = tmp_path / "x.png"
         img.write_bytes(_TINY_PNG)
+        register_trusted_media("test-session", [str(img)], origin="user_explicit")
 
         # Set runtime override so the handler thinks we're on opus@openrouter
         from agent.auxiliary_client import set_runtime_main, clear_runtime_main
@@ -164,7 +166,7 @@ class TestHandleVisionAnalyzeFastPath:
                 "agent.image_routing.decide_image_input_mode",
                 return_value="native",
             ):
-                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
+                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"}, session_id="test-session")
                 result = asyncio.get_event_loop().run_until_complete(coro)
         finally:
             clear_runtime_main()
@@ -178,6 +180,7 @@ class TestHandleVisionAnalyzeFastPath:
         """Even with vision-capable model, unknown provider → fall through."""
         img = tmp_path / "x.png"
         img.write_bytes(_TINY_PNG)
+        register_trusted_media("test-session", [str(img)], origin="user_explicit")
 
         async def _aux_sentinel(*args, **kwargs):
             return '{"sentinel": "aux-path"}'
@@ -186,7 +189,7 @@ class TestHandleVisionAnalyzeFastPath:
         set_runtime_main("brand-new-provider", "anthropic/claude-opus-4.6")
         try:
             with patch("tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel):
-                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
+                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"}, session_id="test-session")
                 result = asyncio.get_event_loop().run_until_complete(coro)
         finally:
             clear_runtime_main()
@@ -198,6 +201,7 @@ class TestHandleVisionAnalyzeFastPath:
         """supports_vision=true enables the fast path on an unlisted provider."""
         img = tmp_path / "x.png"
         img.write_bytes(_TINY_PNG)
+        register_trusted_media("test-session", [str(img)], origin="user_explicit")
 
         async def _aux_sentinel(*args, **kwargs):
             return '{"sentinel": "aux-path"}'
@@ -211,7 +215,7 @@ class TestHandleVisionAnalyzeFastPath:
             ), patch(
                 "tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel,
             ) as mock_aux:
-                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
+                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"}, session_id="test-session")
                 result = asyncio.get_event_loop().run_until_complete(coro)
         finally:
             clear_runtime_main()
@@ -223,6 +227,7 @@ class TestHandleVisionAnalyzeFastPath:
         """Explicit text routing blocks the fast path even with supports_vision."""
         img = tmp_path / "x.png"
         img.write_bytes(_TINY_PNG)
+        register_trusted_media("test-session", [str(img)], origin="user_explicit")
 
         async def _aux_sentinel(*args, **kwargs):
             return '{"sentinel": "aux-path"}'
@@ -239,7 +244,7 @@ class TestHandleVisionAnalyzeFastPath:
             ), patch(
                 "tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel,
             ) as mock_aux:
-                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
+                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"}, session_id="test-session")
                 result = asyncio.get_event_loop().run_until_complete(coro)
         finally:
             clear_runtime_main()

--- a/tests/tools/test_vision_region.py
+++ b/tests/tools/test_vision_region.py
@@ -179,6 +179,8 @@ class TestSchemaAndHandler:
         from tools.vision_tools import _handle_vision_analyze
 
         src = _make_png(tmp_path / "img.png", 100, 50)
+        from agent.media_provenance import register_trusted_media
+        register_trusted_media("test-session", [str(src)], origin="user_explicit")
         seen = {}
 
         async def _fake_native(image_url, question, task_id=None, region=None):
@@ -191,7 +193,8 @@ class TestSchemaAndHandler:
         )
         asyncio.get_event_loop().run_until_complete(
             _handle_vision_analyze(
-                {"image_url": str(src), "question": "q", "region": [1, 2, 30, 40]}
+                {"image_url": str(src), "question": "q", "region": [1, 2, 30, 40]},
+                session_id="test-session",
             )
         )
         assert seen["region"] == [1, 2, 30, 40]

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -131,6 +131,7 @@ class TestHandleVisionAnalyze:
         then None, letting the centralized call_llm router pick the default."""
 
         async def resolve(config=None, env_model=None):
+            from agent.media_provenance import register_user_media_references
             with ExitStack() as st:
                 mock_tool = st.enter_context(
                     patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock)
@@ -149,8 +150,10 @@ class TestHandleVisionAnalyze:
                 else:
                     os.environ["AUXILIARY_VISION_MODEL"] = env_model
                 mock_tool.return_value = json.dumps({"result": "ok"})
+                register_user_media_references("test-session", "https://example.com/img.png")
                 await _handle_vision_analyze(
-                    {"image_url": "https://example.com/img.png", "question": "test"}
+                    {"image_url": "https://example.com/img.png", "question": "test"},
+                    session_id="test-session",
                 )
                 return mock_tool.call_args[0][2]  # third positional arg
 
@@ -976,10 +979,13 @@ class TestVisionCpuBurstCap:
             patch.object(vt, "_should_use_native_vision_fast_path", return_value=True),
             patch.object(vt, "_vision_analyze_native", side_effect=fake_native),
         ):
+            from agent.media_provenance import register_trusted_media
+            references = [f"https://example.com/frame_{i}.png" for i in range(N)]
+            register_trusted_media("test-session", references, origin="user_explicit")
             await asyncio.gather(*[
                 vt._handle_vision_analyze(
                     {"image_url": f"https://example.com/frame_{i}.png",
-                     "question": "what is this"}
+                     "question": "what is this"}, session_id="test-session"
                 )
                 for i in range(N)
             ])

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -5121,6 +5121,7 @@ registry.register(
     handler=lambda args, **kw: browser_get_images(task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="🖼️",
+    produces_trusted_media=True,
 )
 registry.register(
     name="browser_vision",
@@ -5129,6 +5130,7 @@ registry.register(
     handler=lambda args, **kw: browser_vision(question=args.get("question", ""), annotate=args.get("annotate", False), task_id=kw.get("task_id")),
     check_fn=check_browser_vision_requirements,
     emoji="👁️",
+    produces_trusted_media=True,
 )
 registry.register(
     name="browser_console",

--- a/tools/computer_use_tool.py
+++ b/tools/computer_use_tool.py
@@ -30,6 +30,7 @@ registry.register(
         "etc.). Background computer-use: does NOT steal the user's cursor "
         "or keyboard focus."
     ),
+    produces_trusted_media=True,
 )
 
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -1990,4 +1990,5 @@ registry.register(
     is_async=False,   # sync fal_client API to avoid "Event loop is closed" in gateway
     emoji="🎨",
     dynamic_schema_overrides=_build_dynamic_image_schema,
+    produces_trusted_media=True,
 )

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -205,11 +205,13 @@ class ToolEntry:
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
         "max_result_size_chars", "dynamic_schema_overrides",
+        "produces_trusted_media",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 produces_trusted_media=False):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -228,6 +230,7 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        self.produces_trusted_media = bool(produces_trusted_media)
 
 
 # ---------------------------------------------------------------------------
@@ -572,6 +575,7 @@ class ToolRegistry:
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
+        produces_trusted_media: bool = False,
         override: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file.
@@ -632,6 +636,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                produces_trusted_media=produces_trusted_media,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -31,6 +31,7 @@ Usage:
 import base64
 import contextlib
 import asyncio
+import hashlib
 import json
 from concurrent.futures import ThreadPoolExecutor
 import logging
@@ -1759,6 +1760,24 @@ async def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> str:
     question = args.get("question", "")
     region = args.get("region")
     task_id = kw.get("task_id")
+    session_id = kw.get("session_id")
+
+    # A reachable path does not prove that this conversation authorized it.
+    # Check before native routing, downloads, or an auxiliary model call.
+    from agent.media_provenance import is_trusted_media
+    if not is_trusted_media(session_id, image_url):
+        session_digest = hashlib.sha256(str(session_id or "").encode("utf-8")).hexdigest()[:12]
+        reference_digest = hashlib.sha256(str(image_url or "").encode("utf-8")).hexdigest()[:12]
+        logger.warning(
+            "vision_analyze provenance gate blocked unregistered media "
+            "(session_sha256=%s reference_sha256=%s)",
+            session_digest, reference_digest,
+        )
+        return tool_error(
+            "vision_analyze blocked: image_url is not registered as trusted media for this session. "
+            "Ask the user to attach it or explicitly provide the URL/path in the current conversation.",
+            error_type="untrusted_media_reference",
+        )
 
     # The fan-out cap lives inside the encode/resize step (offloaded to the
     # bounded _vision_cpu_executor), NOT around the whole analysis — so a


### PR DESCRIPTION
## What does this PR do?

  Fixes the media-provenance gap described in #83792.

  `vision_analyze` previously treated a resolvable path or URL as sufficient, even when that reference was absent from
  the current conversation. This PR adds a bounded, process-local, session-scoped provenance registry and validates
  references before native routing, source resolution, downloading, or auxiliary vision execution.

  The registry accepts only:

  - explicit media references from user turns;
  - structured gateway image attachments, including their actual backend-visible aliases;
  - exact outputs from designated media-producing tools: `image_generate`, `browser_get_images`, `browser_vision`, and
  `computer_use`;
  - persisted producer results on session resume only when grounded by an adjacent matching assistant `tool_call_id` and
  tool name.

  This preserves direct user path/URL support and legitimate same-session attachment reuse, while rejecting model-
  fabricated, cross-session, unmatched, stale, and ordinary tool-result references.

  The registry stores hashes rather than raw references or data URLs. No prompt content or model tool schema is changed.

  ## Related Issue

  Fixes #83792

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)
  - [ ] Performance improvement
  - [ ] Security fix

  ## Changes Made

  - Added `agent/media_provenance.py`, which maintains bounded, session-scoped trusted-media registrations.
  - Registered explicit user media references during conversation processing.
  - Registered exact outputs from designated media-producing tools.
  - Restored only structurally grounded producer outputs when resuming persisted sessions.
  - Registered structured gateway attachment paths together with their backend-visible aliases.
  - Added provenance validation to `vision_analyze` before any source resolution or auxiliary model call.
  - Propagated the active session context through tool execution paths.
  - Added deterministic regression and integration tests covering:
    - explicit user references;
    - legitimate attachment reuse;
    - media-producing tool outputs;
    - resumed sessions;
    - fabricated and unmatched references;
    - cross-session isolation;
    - Docker, SSH, and local path aliases;
    - bounded registry behavior.

  ## How to Test

  Run the focused provenance and credential-file tests:

  ```bash
  scripts/run_tests.sh \
    tests/agent/test_media_provenance.py \
    tests/tools/test_credential_files.py \
    --file-timeout 120 -q

  Run the registry and tool-executor regression tests:

  scripts/run_tests.sh \
    tests/tools/test_registry.py \
    tests/run_agent/test_tool_executor_contextvar_propagation.py \
    tests/agent/test_tool_executor_checkpoint_paths.py \
    --file-timeout 120 -q

  Run the auxiliary configuration bridge tests:

  scripts/run_tests.sh \
    tests/agent/test_auxiliary_config_bridge.py \
    --file-timeout 120 -q

  Expected result: all 110 focused tests pass.

  Additional validation performed:

  - git diff --check passes.
  - Affected Python modules compile successfully.
  - The new provenance suite exercises a real SessionDB round trip and real local/Docker/SSH path mapping.
  - Some broader legacy vision/async test processes exceeded the per-file teardown timeout; representative timeouts
    reproduced on the base commit. No assertion failure related to this change was observed.

  - The full repository test suite is therefore not claimed as passing locally.

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit message follows the conventional commit format
  - [x] I've searched existing PRs to avoid duplicates
  - [x] My changes only include files related to this fix
  - [ ] I've run pytest tests/ -q and all tests pass — focused validation completed as documented above; the full suite
    is not claimed

  - [x] I've added tests that prove the fix and protect against regression
  - [x] I've tested this on Ubuntu 24.04 under WSL2 with a Windows 11 host

  ### Documentation & Housekeeping

  - [x] User-facing documentation updated, or N/A — no user-facing workflow or configuration changed
  - [x] Configuration examples updated, or N/A — no configuration keys were added
  - [x] Contributor documentation updated, or N/A — no development workflow changed
  - [x] Cross-platform impact considered — local, Docker, SSH, POSIX, and Windows-style path handling is covered
  - [x] Tool descriptions and schemas updated, or N/A — validation is server-side and the existing vision_analyze input
    schema remains accurate

  ## Screenshots / Logs

  Not applicable. The reproduction and regression tests are deterministic and do not call a network service or real
  vision model.