### PR TITLE
fix(accounting): carry the background review's tokens across the persistence boundary

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1663,6 +1663,13 @@ def init_agent(
     # background skill/memory review fork so its harness turn can't leak into
     # the user's real session and hijack the next live turn. Default False.
     agent._persist_disabled = False
+    # Narrow token-accounting channel. Normally None: an agent accounts on its own
+    # ``_session_db`` / ``session_id``. A persistence-isolated fork (background
+    # review) sets these to the OWNER's store + session id so its token counters —
+    # and only its counters, never a message — reach the session it shares an id
+    # with. See agent/conversation_loop.py's persist block.
+    agent._token_accounting_db = None
+    agent._token_accounting_session_id = None
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -854,6 +854,17 @@ def _run_review_in_thread(
             review_agent._persist_disabled = True
             review_agent._session_db = None
             review_agent._session_json_enabled = False
+            # ...but its TOKENS still belong to the session it shares an id with.
+            # The provider bills the review's calls and the observability backend
+            # files them under the parent's session_id, so leaving them out of
+            # state.db makes that session's own cost read low — measured at 10-15%
+            # of a gpt-5.4-mini pass and 27-29% of a claude-sonnet-4-6 one on a
+            # scheduled workload, against the provider's per-call usage as ground
+            # truth. This channel carries counters ONLY: `_persist_disabled` above
+            # still hard-stops every message/lazy-open path, so the curator-takeover
+            # isolation is untouched.
+            review_agent._token_accounting_db = getattr(agent, "_session_db", None)
+            review_agent._token_accounting_session_id = agent.session_id
             # Suppress all status/warning emits from the fork so the
             # user only sees the final successful-action summary.
             # Without this, mid-review "Iteration budget exhausted",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3780,7 +3780,22 @@ def run_conversation(
                     # is skipped or fails. Gateway/session-store writes use
                     # absolute totals, so they safely overwrite these per-call
                     # deltas instead of double-counting them.
-                    if agent._session_db and agent.session_id:
+                    # A persistence-isolated fork (the background review) has
+                    # ``_session_db = None`` on purpose — it must never write a
+                    # MESSAGE into the session it shares an id with. Its tokens are
+                    # a different matter: the provider bills them and the
+                    # observability backend attributes them to that same session, so
+                    # dropping them makes the session's own cost read low (measured
+                    # 10-27% on a scheduled workload). ``_token_accounting_db`` is
+                    # the narrow channel for exactly that: counters only, on a
+                    # session row somebody else owns and has already created.
+                    _acct_db = getattr(agent, "_token_accounting_db", None)
+                    _acct_session = getattr(agent, "_token_accounting_session_id", None)
+                    # Own store vs borrowed one. Only the owner may create the row.
+                    _acct_owned = _acct_db is None
+                    if _acct_owned:
+                        _acct_db, _acct_session = agent._session_db, agent.session_id
+                    if _acct_db and _acct_session:
                         try:
                             # Ensure the session row exists before attempting UPDATE.
                             # Under concurrent load (cron/kanban), the initial
@@ -3788,7 +3803,7 @@ def run_conversation(
                             # locking.  Retry here so per-call token deltas are
                             # not silently lost (UPDATE on a non-existent row
                             # affects 0 rows without error).
-                            if not agent._session_db_created:
+                            if _acct_owned and not agent._session_db_created:
                                 agent._ensure_db_session()
                             # Per-call cost delta = aggregator cost + MoA
                             # advisor cost (each priced at its own rate). Folded
@@ -3807,8 +3822,8 @@ def run_conversation(
                             # state.db UPDATE here stalled the tool loop for
                             # up to hundreds of ms per API call). Drained at
                             # turn finalize via _persist_session.
-                            agent._session_db.queue_token_counts(
-                                agent.session_id,
+                            _acct_db.queue_token_counts(
+                                _acct_session,
                                 input_tokens=canonical_usage.input_tokens,
                                 output_tokens=canonical_usage.output_tokens,
                                 cache_read_tokens=canonical_usage.cache_read_tokens,
@@ -3828,9 +3843,16 @@ def run_conversation(
                             # Log token persistence failures so they're
                             # visible in agent.log — silent loss here is
                             # the root cause of undercounted analytics.
-                            logger.debug(
+                            # WARNING, not debug: this comment was right about the
+                            # consequence and wrong about the level. At debug it is
+                            # invisible on a normal deployment, and a session store
+                            # closed out from under a still-running background review
+                            # swallowed every one of its writes for weeks while cost
+                            # analytics quietly ran low. An accounting write that
+                            # fails has to say so.
+                            logger.warning(
                                 "Token persistence failed (session=%s, tokens=%d): %s",
-                                agent.session_id, total_tokens, e,
+                                _acct_session, total_tokens, e,
                             )
                     
                     if agent.verbose_logging:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4707,6 +4707,25 @@ def run_job(
             exit_non_dispatcher_owned_context(_non_dispatcher_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
+        # The background skill/memory review is spawned when the turn ends and
+        # keeps calling the model — and writing — for another 40-100s. It accounts
+        # its tokens onto THIS SessionDB (see agent/background_review.py's
+        # _token_accounting_db), so closing below while it runs sets `_conn = None`
+        # under it and every one of its writes dies on `'NoneType' object has no
+        # attribute 'execute'`. That failure is caught per-call, so the only
+        # symptom is a cron pass under-reporting its own cost — measured at 10-15%
+        # (gpt-5.4-mini) to 27-29% (claude-sonnet-4-6). Wait for it first, so
+        # end_session()'s `ended_at` covers the whole pass and close() — which
+        # drains the token queue — is genuinely the last write.
+        if agent is not None:
+            try:
+                if not agent.wait_for_background_review():
+                    logger.warning(
+                        "Job '%s': background review still running after the wait; "
+                        "closing the session store anyway — its remaining token "
+                        "deltas will be lost.", job_id)
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': background review wait failed: %s", job_id, e)
         if _session_db:
             # Compression can rotate the live agent onto a continuation while
             # this run is in flight. Finalize that continuation, not the stale

--- a/run_agent.py
+++ b/run_agent.py
@@ -1833,7 +1833,28 @@ class AIAgent:
         t = threading.Thread(
             target=propagate_context_to_thread(target), daemon=True, name="bg-review"
         )
+        # Keep a handle. The review runs AFTER the turn ends and keeps writing
+        # (token counters, memory, skills), so an owner that disposes of shared
+        # per-run state at turn end — the cron runner closes the SQLite session
+        # store — needs to be able to WAIT for it. ``_background_review_agent``
+        # (added for cross-turn cancellation) can interrupt a review but gives no
+        # way to join one, and cancelling is the wrong move where the review's
+        # writes are wanted.
+        self._background_review_thread = t
         t.start()
+
+    def wait_for_background_review(self, timeout: float = 180.0) -> bool:
+        """Block until the background review thread finishes. True if it is done.
+
+        Call before disposing of anything the review shares with this agent — the
+        session store above all. Bounded, so a wedged review cannot hang a
+        scheduler; the caller decides what a False means.
+        """
+        t = getattr(self, "_background_review_thread", None)
+        if t is None or not t.is_alive():
+            return True
+        t.join(timeout)
+        return not t.is_alive()
 
     def _build_memory_write_metadata(
         self,

--- a/tests/run_agent/test_background_review_token_accounting.py
+++ b/tests/run_agent/test_background_review_token_accounting.py
@@ -1,0 +1,184 @@
+"""The background review's tokens must reach the session it shares an id with.
+
+The review fork is deliberately persistence-isolated (``_persist_disabled``,
+``_session_db = None``): it shares the parent's ``session_id`` for prompt-cache
+warmth, so letting it write MESSAGES there is the curator-takeover bug — see
+tests/test_background_review_session_isolation.py, which must keep passing.
+
+Its TOKENS are a different matter. The provider bills the review's calls and the
+observability backend files them under that same session id, so leaving them out
+of state.db makes the session's own cost read low (measured 10-15% of a
+gpt-5.4-mini pass, 27-29% of a claude-sonnet-4-6 one). ``_token_accounting_db``
+is the narrow channel that carries counters — and only counters — across the
+isolation boundary.
+
+Two things have to hold together, and these tests pin both:
+  * the fork accounts on the OWNER's store and session id, and
+  * nothing about that re-arms a message-write path.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+
+def _make_agent_stub(agent_cls, session_db=None):
+    """Minimal AIAgent-like object with just enough state for _spawn_background_review."""
+    agent = object.__new__(agent_cls)
+    agent.model = "test-model"
+    agent.platform = "test"
+    agent.provider = "openai"
+    agent.session_id = "sess-123"
+    agent.quiet_mode = True
+    agent._memory_store = None
+    agent._memory_enabled = True
+    agent._user_profile_enabled = False
+    agent._memory_nudge_interval = 5
+    agent._skill_nudge_interval = 5
+    agent.background_review_callback = None
+    agent.status_callback = None
+    agent._cached_system_prompt = None
+    agent._session_db = session_db
+    import datetime as _dt
+    agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
+    agent._MEMORY_REVIEW_PROMPT = "review memory"
+    agent._SKILL_REVIEW_PROMPT = "review skills"
+    agent._COMBINED_REVIEW_PROMPT = "review both"
+    agent.enabled_toolsets = ["memory", "skills"]
+    agent.disabled_toolsets = []
+    return agent
+
+
+class _SlowThread:
+    """Thread stand-in: runs the target on .start(), reports alive until joined."""
+
+    def __init__(self, *, target=None, daemon=None, name=None):
+        self._target = target
+        self._alive = False
+        self.name = name
+
+    def start(self):
+        self._alive = True
+        if self._target:
+            self._target()
+
+    def is_alive(self):
+        return self._alive
+
+    def join(self, timeout=None):
+        self._alive = False
+
+
+class TestAccountingChannelIsHonoured:
+    """conversation_loop must account on the borrowed store when one is set, and
+    must not try to CREATE a row it does not own."""
+
+    def test_defaults_to_the_agents_own_store(self):
+        import run_agent
+
+        agent = object.__new__(run_agent.AIAgent)
+        assert getattr(agent, "_token_accounting_db", None) is None, (
+            "the channel must default to unset so ordinary agents keep accounting "
+            "on their own _session_db / session_id"
+        )
+
+    def test_isolated_fork_keeps_message_writes_hard_stopped(self):
+        """The channel must not become a back door into the message log."""
+        import run_agent
+
+        db = MagicMock()
+        agent = object.__new__(run_agent.AIAgent)
+        agent._session_db = None
+        agent._persist_disabled = True
+        agent._token_accounting_db = db
+        agent._token_accounting_session_id = "sess-123"
+        agent.session_id = "sess-123"
+
+        agent._flush_messages_to_session_db([{"role": "user", "content": "hi"}], [])
+
+        db.append_message.assert_not_called()
+        db.create_session.assert_not_called()
+        db.queue_token_counts.assert_not_called()
+
+
+class TestForkWiring:
+    def test_fork_accounts_on_the_parents_store_and_session(self):
+        """Behavioural: run the real fork setup and read the attributes it set."""
+        import run_agent
+
+        parent_db = object()
+        agent = _make_agent_stub(run_agent.AIAgent, session_db=parent_db)
+        agent._credential_pool = None
+        agent._background_review_lock = threading.Lock()
+        agent._background_review_agent = None
+        agent._active_children_lock = threading.Lock()
+        agent._active_children = []
+
+        forks = []
+
+        def _fake_init(self, *args, **kwargs):
+            forks.append(self)
+
+        def _boom(self, *args, **kwargs):
+            raise RuntimeError("stop before the review actually runs")
+
+        with patch.object(run_agent.AIAgent, "__init__", _fake_init), \
+             patch.object(run_agent.AIAgent, "run_conversation", _boom), \
+             patch("threading.Thread", _SlowThread):
+            agent._spawn_background_review(messages_snapshot=[], review_memory=True,
+                                           review_skills=True)
+
+        assert forks, "the review fork was never constructed"
+        fork = forks[0]
+        assert fork._persist_disabled is True, "message isolation must survive"
+        assert fork._session_db is None, "the fork must not hold a message-writing store"
+        assert fork._token_accounting_db is parent_db, (
+            "the fork must account on the PARENT's store"
+        )
+        assert fork._token_accounting_session_id == agent.session_id, (
+            "and against the session id it shares, so the counters land on the "
+            "row the provider's billing is attributed to"
+        )
+
+
+class TestWaitForBackgroundReview:
+    def test_spawn_keeps_a_handle(self):
+        """Without a handle an owner tearing down shared state can only close blind."""
+        import run_agent
+
+        agent = _make_agent_stub(run_agent.AIAgent, session_db=object())
+
+        def _noop_init(self, *args, **kwargs):
+            raise RuntimeError("stop")
+
+        with patch.object(run_agent.AIAgent, "__init__", _noop_init), \
+             patch("threading.Thread", _SlowThread):
+            agent._spawn_background_review(messages_snapshot=[], review_memory=True,
+                                           review_skills=False)
+
+        t = getattr(agent, "_background_review_thread", None)
+        assert t is not None, "the review thread handle must be reachable from the agent"
+        assert t.name == "bg-review"
+
+    def test_wait_is_a_noop_when_there_is_no_review(self):
+        import run_agent
+
+        agent = object.__new__(run_agent.AIAgent)
+        assert agent.wait_for_background_review() is True
+
+    def test_wait_joins_a_running_review_and_is_bounded(self):
+        import run_agent
+
+        released = threading.Event()
+        agent = object.__new__(run_agent.AIAgent)
+        t = threading.Thread(target=released.wait, daemon=True)
+        t.start()
+        agent._background_review_thread = t
+        try:
+            assert agent.wait_for_background_review(timeout=0.2) is False, (
+                "a review still running must report False so the caller can decide "
+                "rather than block a scheduler forever")
+            released.set()
+            assert agent.wait_for_background_review(timeout=5) is True
+        finally:
+            released.set()
+            t.join(timeout=5)


### PR DESCRIPTION
> **Rewritten.** The first version of this PR gave the review fork the parent's `session_db` outright. That was wrong: it collided head-on with the `_persist_disabled` isolation added in `71435fa0e`/`#54937`, and would have reintroduced the curator-takeover bug. This version keeps that isolation completely intact and carries only the counters across it. Force-pushed onto current `main`.

## The bug

The background memory/skill review forks an `AIAgent` that shares the parent's `session_id` for prompt-cache warmth, and is deliberately persistence-isolated:

```python
review_agent._persist_disabled = True
review_agent._session_db = None
review_agent._session_json_enabled = False
```

That is right for **messages** — writing the harness turn into the user's real session is exactly the bug that isolation exists to stop.

It is wrong for **counters**. The provider bills the review's calls and the observability backend files them under that same `session_id`, so leaving them out of `state.db` makes the session's own cost read low. Nothing errors; the number is just quietly short.

## How short

Measured per call against OpenAI's own `GET /v1/responses/{id}` usage — ground truth, not an estimate — on a scheduled workload. The review is the **trailing 4-9 API calls of every pass**, and the session row came up short by *exactly* those calls: fresh input, cached input, output and reasoning all four matching to the token.

| model | provider calls / `api_call_count` | real cost | recorded | short by |
| -- | -- | -- | -- | -- |
| `gpt-5.4-mini` | 31 / 27 | $0.32134 | $0.28913 | 10.0% |
| `gpt-5.4-mini` | 28 / 22 | $0.47550 | $0.40507 | 14.8% |
| `claude-sonnet-4-6` | 27 / 18 | $1.07062 | $0.78134 | 27.0% |
| `claude-sonnet-4-6` | 31 / 20 | $1.02278 | $0.72405 | 29.2% |

Over 9 days on one workload: **−11.09%**, 54 of 56 passes affected, **257 of 1,740 calls** never recorded. The share is largest where the foreground turn is short, because the review re-sends the full conversation — each of its calls re-bills the whole prompt.

## The fix — counters only, across the boundary

`_token_accounting_db` / `_token_accounting_session_id`: a narrow channel set on the fork *in addition to* the isolation, never instead of it.

```python
review_agent._persist_disabled = True                          # unchanged
review_agent._session_db = None                                # unchanged
review_agent._token_accounting_db = agent._session_db          # counters only
review_agent._token_accounting_session_id = agent.session_id
```

`conversation_loop` accounts there when set, and **only the owner of a store may create its row** (`_acct_owned`) — a borrowed store is written to, never created on. `_persist_disabled` still hard-stops `_flush_messages_to_session_db`, `_ensure_db_session` and `_get_session_db_for_recall`, so no message path is re-armed. `tests/test_background_review_session_isolation.py` passes unchanged, and the new tests assert the isolation attributes right next to the accounting ones so the two cannot drift apart silently.

## Second half: the store is closed while the review is still writing

Even with the channel wired, the writes died — on a deployment they surfaced as:

```
Token persistence failed (session=cron_..., tokens=76750):
  'NoneType' object has no attribute 'execute'
```

`cron/scheduler.py` closes the shared `SessionDB` in its `finally`, right after `end_session()`. The review is spawned *when the turn ends* and keeps writing for another 40-100s, so `close()` sets `_conn = None` underneath a live thread. Caught per-call and logged at `debug` — invisible, so the only symptom was the under-count.

- `_spawn_background_review` keeps the thread handle; `wait_for_background_review()` joins it with a bound so a wedged review cannot hang a scheduler. `_background_review_agent` can *interrupt* a review but gives no way to *join* one, and cancelling is the wrong move where its writes are wanted — the two compose: cancel for live sessions, wait for batch ones.
- The cron runner waits before titling/ending/closing, so `ended_at` covers the whole pass and `close()` — which drains the token queue — is genuinely the last write. A timed-out wait warns and proceeds.
- `logger.debug("Token persistence failed…")` → `logger.warning`. Its own comment already said *"silent loss here is the root cause of undercounted analytics"* — right about the consequence, wrong about the level.

## Verified on a live cron

| | before | after |
| -- | -- | -- |
| provider calls / `api_call_count` | 28 / 22 | **47 / 47** |
| real cost | $0.47550 | $0.69394 |
| cost from `state.db` tokens | $0.40507 | **$0.693937** |
| gap | −14.81% | **−0.0004%** |

Same cron, eight hours apart. Downstream agrees too: the three rows the pass writes sum to $0.69394 on 3,636,830 tokens — exactly `state.db`.

*(That deployment runs an older build without `_persist_disabled`, so the shape verified there is the earlier one. The redesign here is verified by test, including upstream's own isolation suite; the measurements and the closed-store failure mode are unchanged by the reshaping.)*

## Tests

`tests/run_agent/test_background_review_token_accounting.py` — the fork accounts on the parent's store and session id (read off a real fork, not asserted against source text); the channel is not a back door into the message log; the handle exists and the wait is bounded. Each asserts the isolation attributes alongside the accounting ones.

Green: my tests + `tests/test_background_review_session_isolation.py` + `tests/run_agent/test_background_review.py` = 19 passed. `tests/cron` failure set byte-identical to `main` (6 pre-existing, 581 passed).

On the broad sweep (`tests/run_agent` + `tests/agent` + `hermes_state`, `-p no:randomly`) this venv has a lot of pre-existing environmental noise, so the number alone is meaningless — what matters is the comparison against a pristine `main` worktree with the identical command:

| | failed | passed |
| -- | -- | -- |
| `main` | 224 | 5,942 |
| this branch | **222** | 5,950 |

Zero failures unique to this branch; the two extras on `main` are concurrency/timing flakes.

## Note for other owners of per-run state

Anything that disposes of shared state at turn end has this race, not just cron — the review outlives the turn by design. `wait_for_background_review()` is the handle for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
