### PR TITLE
fix(gateway): scope multiplex context files by profile

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -52,7 +52,11 @@ from agent.turn_context import (
     reanchor_current_turn_user_idx,
 )
 from agent.turn_retry_state import TurnRetryState
-from agent.runtime_cwd import resolve_agent_cwd
+from agent.runtime_cwd import (
+    is_context_file_cwd_scoped,
+    resolve_agent_cwd,
+    resolve_context_cwd,
+)
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
     _repair_tool_call_arguments,
@@ -1234,10 +1238,11 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
         """Last matching line wins.
 
         Safe ONLY for fields emitted in the volatile tier at the very END of
-        the prompt (Model / Provider / Platform). User-supplied project
-        context (AGENTS.md / CLAUDE.md / .cursorrules) is embedded in the
-        middle context tier, so a last-match scan lets project prose shadow
-        any field emitted EARLIER — see ``host_info_value``.
+        the prompt (Model / Provider / Platform / Context files directory).
+        User-supplied project context (AGENTS.md / CLAUDE.md / .cursorrules)
+        is embedded in the middle context tier, so a last-match scan lets
+        project prose shadow any field emitted EARLIER — see
+        ``host_info_value``.
         """
         prefix = f"{label}:"
         value = ""
@@ -1291,6 +1296,26 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     if stored_cwd:
         if stored_cwd != str(resolve_agent_cwd()):
             return False
+
+    # Context-file discovery is independently scoped in multiplex mode. An old
+    # prompt without this marker, or a prompt from another profile, must rebuild
+    # once rather than retaining stale or cross-profile instructions.
+    #
+    # Compare in BOTH directions, mirroring the builder rather than the current
+    # scope. Gating this on is_context_file_cwd_scoped() checked only the safe
+    # half: a prompt built inside a profile scope and later resumed WITHOUT one
+    # kept its foreign marker and instructions, because the comparison never
+    # ran. An absent marker on either side is "", so an unscoped session with an
+    # unscoped prompt still matches and stays cache gold.
+    stored_context_cwd = line_value("Context files directory")
+    current_context_cwd = ""
+    if (
+        is_context_file_cwd_scoped()
+        and getattr(agent, "skip_context_files", False) is not True
+    ):
+        current_context_cwd = str(resolve_context_cwd() or "")
+    if stored_context_cwd != current_context_cwd:
+        return False
 
     # Detect runtime-surface drift: the stored prompt records which platform it
     # was built for (e.g. "desktop" vs "cli"). Reusing a desktop-built prompt on

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -1,13 +1,14 @@
-"""Single source of truth for the agent working directory.
+"""Single source of truth for agent execution and context-file directories.
 
 `TERMINAL_CWD` is the runtime carrier for the configured working directory
 (design #19214/#19242: `terminal.cwd` is bridged once to `TERMINAL_CWD` at
 gateway/cron startup). The local-CLI backend deliberately leaves it unset and
-relies on the launch dir. Reading it in one place keeps the system prompt, the
-tool surfaces, and context-file discovery agreeing on where the agent lives.
+relies on the launch dir. Reading it in one place keeps the system prompt and
+tool surfaces agreeing on where the agent executes.
 
-Multi-session gateways can pin a logical cwd via the `_SESSION_CWD`
-contextvar; CLI/cron fall through to `TERMINAL_CWD`/launch cwd.
+Multi-session gateways can pin a logical execution cwd via `_SESSION_CWD`.
+Multiplex gateways independently pin `_CONTEXT_FILE_CWD` to the routed
+profile home so profile instructions never follow a shared process cwd.
 """
 
 import logging
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 _UNSET: Any = object()
 
 _SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
+_CONTEXT_FILE_CWD: ContextVar = ContextVar("HERMES_CONTEXT_FILE_CWD", default=_UNSET)
 
 # The Python package/source root (this file lives at <root>/agent/runtime_cwd.py).
 # When a backend is launched from, or self-spawns into, this tree (the desktop
@@ -48,6 +50,16 @@ def set_session_cwd(cwd: str | None) -> Token:
 
 def clear_session_cwd() -> None:
     _SESSION_CWD.set("")
+
+
+def set_context_file_cwd(cwd: str | None) -> Token:
+    """Pin context-file discovery without changing the agent execution cwd."""
+    return _CONTEXT_FILE_CWD.set((cwd or "").strip())
+
+
+def reset_context_file_cwd(token: Token) -> None:
+    """Restore the context-file discovery override for a nested runtime scope."""
+    _CONTEXT_FILE_CWD.reset(token)
 
 
 def _session_cwd_override() -> str:
@@ -81,6 +93,17 @@ def scope_terminal_cwd() -> str:
     """
     return _terminal_cwd_env()
 
+def _context_file_cwd_override() -> str:
+    value = _CONTEXT_FILE_CWD.get()
+    if value is _UNSET:
+        return ""
+    return str(value).strip()
+
+
+def is_context_file_cwd_scoped() -> bool:
+    """Return whether instruction discovery has an independent context scope."""
+    return bool(_context_file_cwd_override())
+
 
 def resolve_agent_cwd() -> Path:
     override = _session_cwd_override()
@@ -107,6 +130,26 @@ def resolve_context_cwd() -> Path | None:
     # source tree itself, which is a legitimate workspace when the user is
     # developing Hermes (per-surface policy for fallback-picked directories
     # lives in build_context_files_prompt; see #64590).
+    context_override = _context_file_cwd_override()
+    if context_override:
+        p = Path(context_override).expanduser()
+        if not p.is_dir():
+            # Stay authoritative anyway. None here does NOT mean "no context
+            # files" — build_context_files_prompt reads it as "fall back to
+            # os.getcwd()", which under multiplex is the shared gateway launch
+            # directory, silently restoring the cross-profile leak this scope
+            # exists to prevent. Honouring the missing path instead makes
+            # discovery find nothing, which is the correct outcome, and the
+            # prompt still records the scope. Logged at error level because the
+            # same directory is simultaneously the HERMES_HOME override, so a
+            # misconfigured route must be visible rather than merely degraded.
+            logger.error(
+                "configured context-file directory does not exist: %s — "
+                "instruction discovery will find nothing (not falling back to "
+                "the execution cwd)",
+                context_override,
+            )
+        return p
     override = _session_cwd_override()
     if override:
         p = Path(override).expanduser()

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -52,7 +52,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_MODELS,
     drain_truncation_warnings,
 )
-from agent.runtime_cwd import resolve_context_cwd
+from agent.runtime_cwd import is_context_file_cwd_scoped, resolve_context_cwd
 from hermes_constants import get_default_hermes_root, get_hermes_home
 from pathlib import Path
 from utils import is_truthy_value
@@ -881,27 +881,31 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if system_message is not None:
         context_parts.append(system_message)
 
+    _context_cwd = None
+    _context_marker_cwd = ""
     if not agent.skip_context_files:
-        # Prefer the configured TERMINAL_CWD (gateway mode). When unset (local
-        # CLI), None lets build_context_files_prompt fall back to the launch
-        # dir — the user's real cwd there, but the install dir for the gateway
-        # daemon, which is why the gateway sets TERMINAL_CWD.
+        # Multiplex gateways provide a profile-specific context directory that
+        # is independent of the shared execution cwd. Standalone CLI/TUI runs
+        # still use TERMINAL_CWD when configured, or fall back to the launch
+        # directory when it is absent.
         #
         # allow_install_tree_fallback: for cli/tui the launch dir IS the
         # user's shell cwd, so an in-tree fallback is a deliberate choice
         # (developing Hermes). Every other surface (desktop chat panel,
         # gateway daemons) self-spawns into the install tree, where the
         # fallback would inject this repo's contributor AGENTS.md (#64590).
-        context_cwd = resolve_context_cwd()
+        _context_cwd = resolve_context_cwd()
         if getattr(agent, "_context_cwd_is_launch_artifact", False):
             # Desktop session creation pins the backend launch directory so
             # tools have a deterministic cwd even when the user picked no
             # workspace. Preserve that tool routing, but let context discovery
             # see it as the fallback it really is. The install-tree guard can
             # then reject Hermes's bundled contributor AGENTS.md (#97448).
-            context_cwd = None
+            _context_cwd = None
+        if is_context_file_cwd_scoped():
+            _context_marker_cwd = str(_context_cwd or "")
         context_files_prompt = _r.build_context_files_prompt(
-            cwd=context_cwd, skip_soul=_soul_loaded,
+            cwd=_context_cwd, skip_soul=_soul_loaded,
             context_length=_ctx_len,
             allow_install_tree_fallback=agent.platform in ("cli", "tui"),
             home_override=_agent_home(agent))
@@ -1024,6 +1028,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         timestamp_line += f"\nProvider: {agent.provider}"
     if agent.platform:
         timestamp_line += f"\nPlatform: {agent.platform}"
+    if _context_marker_cwd:
+        timestamp_line += f"\nContext files directory: {_context_marker_cwd}"
     volatile_parts.append(timestamp_line)
 
     return {

--- a/docs/profile-routing.md
+++ b/docs/profile-routing.md
@@ -102,16 +102,18 @@ If no route matches, the message uses the default/active profile.
 3. `_profile_name_for_source` runs the configured routes through `match_profile_route` and
    stamps `source.profile` with the winning route's profile (or leaves it unset).
 4. Downstream, `_resolve_profile_home_for_source` chooses the profile home directory
-   (`source.profile` → active profile → `default`) and the session is scoped per-profile, so
-   each routed community gets isolated memory and conversation state.
+   (`source.profile` → active profile → `default`). The per-profile runtime scope isolates
+   memory, conversation state, credentials, and context-file discovery. Tool execution keeps
+   the configured working directory; `AGENTS.md` and related instructions resolve from the
+   routed profile home instead.
 
 Because `gateway_runner` is injected for **all** adapters (declared on `BasePlatformAdapter`),
 every platform goes through this path — not just Discord.
 
 ## Relationship to multiplexing
 
-`profile_routes` requires `gateway.multiplex_profiles: true`. Multiplexing is what
-activates the per-profile runtime scope (per-profile `HERMES_HOME`, secret scope, and
-profile-namespaced session keys); routing is the decision layer that picks *which*
+`profile_routes` requires `gateway.multiplex_profiles: true`. Multiplexing activates the
+per-profile runtime scope: per-profile `HERMES_HOME`, secret scope, context-file directory,
+and profile-namespaced session keys. Routing is the decision layer that picks *which*
 profile a given guild/channel/thread lands in. With multiplexing off, `profile_routes`
 is ignored entirely — behavior is byte-identical to a single-profile gateway.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2618,27 +2618,31 @@ def _profile_runtime_scope(
     *,
     hydrate_secrets: bool = True,
 ):
-    """Scope config/skills/memory AND credentials to a profile for one turn.
+    """Scope profile state, credentials, and instruction discovery for one turn.
 
-    Combines the two seams the multiplexer needs:
+    Combines the three seams the multiplexer needs:
       1. ``set_hermes_home_override`` — redirects ``get_hermes_home()`` (config,
-         skills, memory, SOUL, sessions) to the profile's home. Contextvar, so
-         it propagates into the agent worker thread via ``copy_context()``.
+         skills, memory, SOUL, sessions) to the profile's home.
       2. ``set_secret_scope`` — installs the profile's ``.env`` secrets as the
-         authoritative credential source, so ``get_secret`` reads this profile's
-         keys and never the process-global ``os.environ`` (which in a
-         multiplexer may hold another profile's values).
+         authoritative credential source.
+      3. ``set_context_file_cwd`` — discovers AGENTS.md and related instruction
+         files from the routed profile home without changing the shared
+         execution cwd used by tools and subprocesses.
 
-    Only used on the multiplexed inbound path. Single-profile gateways never
-    enter this scope, so their behavior is unchanged. Loading the profile's
-    ``.env`` here does NOT mutate ``os.environ`` — ``build_profile_secret_scope``
-    returns an isolated dict — which is what keeps subprocesses (MCP, kanban)
-    from inheriting cross-profile secrets.
+    All three are context-local and propagate into the agent worker thread via
+    ``copy_context()``. Only the multiplexed inbound path enters this scope, so
+    single-profile gateways are unchanged. Loading the profile's ``.env`` here
+    does not mutate ``os.environ``; subprocesses cannot inherit another
+    profile's credentials.
     """
     from hermes_constants import set_hermes_home_override, reset_hermes_home_override
     from agent.secret_scope import (
         set_secret_scope,
         reset_secret_scope,
+    )
+    from agent.runtime_cwd import (
+        reset_context_file_cwd,
+        set_context_file_cwd,
     )
 
     home_token = set_hermes_home_override(str(profile_home))
@@ -2660,9 +2664,17 @@ def _profile_runtime_scope(
     from tools.terminal_scope import install_and_reset_profile_terminal_scope
 
     with install_and_reset_profile_terminal_scope(Path(profile_home)):
+        # Per-turn context-file cwd (fourth seam of the profile boundary): pins
+        # instruction discovery (AGENTS.md, etc.) to the routed profile home
+        # without changing the agent's execution cwd.
+        context_cwd_token = set_context_file_cwd(str(profile_home))
         try:
             yield
         finally:
+            # Every seam unwinds even when the turn raises: a leaked secret
+            # scope or HERMES_HOME override would hand the next routed turn
+            # another profile's credentials and home.
+            reset_context_file_cwd(context_cwd_token)
             reset_secret_scope(secret_token)
             reset_hermes_home_override(home_token)
 

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -67,7 +67,6 @@ class TestSessionCwdOverride:
         finally:
             rt._SESSION_CWD.reset(token)
 
-
     def test_clear_session_cwd_restores_terminal_cwd(self, monkeypatch, tmp_path):
         other = tmp_path / "other"
         other.mkdir()
@@ -78,4 +77,47 @@ class TestSessionCwdOverride:
             assert resolve_agent_cwd() == tmp_path
         finally:
             rt._SESSION_CWD.reset(token)
+
+
+class TestContextScopeSurvivesMissingDir:
+    """A pinned context scope must not silently degrade into the execution cwd.
+
+    Returning None here does NOT mean "no context files": build_context_files_prompt
+    treats None as "fall back to os.getcwd()", which in multiplex is the shared gateway
+    launch directory — exactly the cross-profile leak the scope exists to prevent. A
+    missing profile directory must therefore stay authoritative (discovery simply finds
+    nothing there) and say so loudly.
+    """
+
+    def test_missing_context_dir_stays_authoritative(self, monkeypatch, tmp_path, caplog):
+        import logging
+        import sys
+
+        # Set and read through ONE module object. Other suites in this directory
+        # reload sibling modules, and a duplicated agent.runtime_cwd would carry
+        # its own ContextVars — the setter would then write a scope the resolver
+        # cannot see, and this test would pass alone and fail in the full run.
+        mod = sys.modules["agent.runtime_cwd"]
+
+        launch_dir = tmp_path / "gateway-launch"
+        launch_dir.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(launch_dir))
+        missing = tmp_path / "profiles" / "never-created"
+
+        token = mod.set_context_file_cwd(str(missing))
+        try:
+            assert mod.is_context_file_cwd_scoped(), (
+                "scope did not take effect; module identity split "
+                f"(rt is sys.modules entry: {mod is rt})"
+            )
+            with caplog.at_level(logging.ERROR, logger="agent.runtime_cwd"):
+                resolved = mod.resolve_context_cwd()
+        finally:
+            mod.reset_context_file_cwd(token)
+
+        assert resolved == missing, "must not fall back to the shared execution cwd"
+        assert resolved != launch_dir
+        assert any("does not exist" in r.getMessage() for r in caplog.records)
+
+
 

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -110,6 +110,40 @@ class TestContextFileCwd:
 
         assert "chosen workspace instructions" in context
 
+    def test_profile_context_directory_is_recorded_in_prompt_tail(
+        self, monkeypatch, tmp_path
+    ):
+        # Build the prompt through a CALL-TIME import of agent.system_prompt so the
+        # writer (_profile_runtime_scope) and the reader share one agent.runtime_cwd.
+        # Several suites in tests/agent delete every `agent.*` entry from sys.modules
+        # (test_empty_tool_name_loop_dampening, test_verification_stop_caching,
+        # test_vision_routing_31179); the module-level binding used by the helpers
+        # below would otherwise read a superseded module's ContextVars, and the scope
+        # would look unset only in a full-directory run.
+        import importlib
+
+        from gateway.run import _profile_runtime_scope
+
+        system_prompt = importlib.import_module("agent.system_prompt")
+
+        execution_cwd = tmp_path / "shared-workdir"
+        execution_cwd.mkdir()
+        profile_home = tmp_path / "profiles" / "beta"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("TERMINAL_CWD", str(execution_cwd))
+
+        with _profile_runtime_scope(profile_home):
+            with (
+                patch("run_agent.load_soul_md", return_value=""),
+                patch("run_agent.build_environment_hints", return_value=""),
+                patch("run_agent.build_context_files_prompt", return_value=""),
+            ):
+                parts = system_prompt.build_system_prompt_parts(
+                    _make_agent(platform="discord")
+                )
+
+        assert f"Context files directory: {profile_home}" in parts["volatile"]
+
 
 def _stable_prompt(agent):
     with (

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -113,6 +113,92 @@ class TestStoredPromptReuse:
         )
         assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
 
+    @pytest.mark.parametrize("stored_context_line", [None, "Context files directory: /old/profile"])
+    def test_profile_context_change_rebuilds_stored_prompt(
+        self, stored_context_line, tmp_path, monkeypatch
+    ):
+        # Import the guard AND the scope together, at call time. Several suites in
+        # tests/agent delete every `agent.*` entry from sys.modules
+        # (test_empty_tool_name_loop_dampening, test_verification_stop_caching,
+        # test_vision_routing_31179), so a module-level binding here would read the
+        # ContextVars of a superseded agent.runtime_cwd while _profile_runtime_scope
+        # writes the current one — the scope would look unset and this test would
+        # pass alone and fail in a full-directory run.
+        import importlib
+
+        from gateway.run import _profile_runtime_scope
+
+        restore = importlib.import_module("agent.conversation_loop")._restore_or_build_system_prompt
+
+        execution_cwd = tmp_path / "shared-workdir"
+        execution_cwd.mkdir()
+        active_profile = tmp_path / "profiles" / "active"
+        active_profile.mkdir(parents=True)
+        monkeypatch.setenv("TERMINAL_CWD", str(execution_cwd))
+
+        lines = [
+            "Host: Linux",
+            f"User home directory: {tmp_path}",
+            f"Current working directory: {execution_cwd}",
+        ]
+        if stored_context_line:
+            lines.append(stored_context_line)
+        lines.extend(
+            [
+                "Conversation started: Tuesday, June 16, 2026",
+                "Model: test-model",
+                "Provider: openrouter",
+                "Platform: cli",
+            ]
+        )
+        stored = "\n".join(lines)
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db, prebuilt_prompt="PROFILE_PROMPT_REBUILT")
+
+        with _profile_runtime_scope(active_profile):
+            restore(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert agent._cached_system_prompt == "PROFILE_PROMPT_REBUILT"
+        agent._build_system_prompt.assert_called_once_with(None)
+        db.update_system_prompt.assert_called_once_with(
+            agent.session_id, "PROFILE_PROMPT_REBUILT"
+        )
+
+    def test_scoped_prompt_resumed_without_a_scope_rebuilds(self, tmp_path, monkeypatch):
+        """A prompt built INSIDE a profile scope must not survive resumption outside one.
+
+        The guard used to run only while currently scoped, which is the wrong half of
+        the comparison: the dangerous direction is a stored prompt that still carries
+        another profile's marker and instructions being reused by a session with no
+        scope at all. Compare whenever either side has a value.
+        """
+        execution_cwd = tmp_path / "shared-workdir"
+        execution_cwd.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(execution_cwd))
+
+        stored = "\n".join(
+            [
+                "Host: Linux",
+                f"User home directory: {tmp_path}",
+                f"Current working directory: {execution_cwd}",
+                "Context files directory: /profiles/other",
+                "Conversation started: Tuesday, June 16, 2026",
+                "Model: test-model",
+                "Provider: openrouter",
+                "Platform: cli",
+            ]
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db, prebuilt_prompt="UNSCOPED_PROMPT_REBUILT")
+
+        # No _profile_runtime_scope here: this is the resumed-outside-multiplex case.
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert agent._cached_system_prompt == "UNSCOPED_PROMPT_REBUILT"
+        agent._build_system_prompt.assert_called_once_with(None)
+
 
 # ---------------------------------------------------------------------------
 # Legitimate fresh-build paths (no history, no DB)

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -100,7 +100,13 @@ class TestProfilePathResolutionUnderMultiplexScope:
         (execution_cwd / "AGENTS.md").write_text(
             "ROOT_EXECUTION_MARKER", encoding="utf-8"
         )
-        monkeypatch.setenv("TERMINAL_CWD", str(execution_cwd))
+        # The execution cwd travels through each profile's OWN terminal policy,
+        # not ambient TERMINAL_CWD: since #68559 a routed turn installs the
+        # profile's complete terminal scope and never reads the launch
+        # process's TERMINAL_* vars. Every profile points at the same shared
+        # workdir, so execution stays put while instruction discovery follows
+        # the profile home.
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
 
         profile_names = ("default", "alpha", "beta", "gamma", "delta", "epsilon")
         profiles = {}
@@ -109,6 +115,9 @@ class TestProfilePathResolutionUnderMultiplexScope:
             home.mkdir(parents=True)
             marker = f"PROFILE_MARKER_{name.upper()}"
             (home / "AGENTS.md").write_text(marker, encoding="utf-8")
+            (home / "config.yaml").write_text(
+                f"terminal:\n  cwd: {execution_cwd}\n", encoding="utf-8"
+            )
             profiles[name] = (home, marker)
 
         for name, (home, marker) in profiles.items():
@@ -168,6 +177,38 @@ def test_turn_scoped_dotenv_reload_does_not_pollute_process_env(tmp_path, monkey
         assert "PROFILE_SCOPED_API_KEY" not in os.environ
         assert os.environ["DISCORD_ALLOWED_CHANNELS"] == "all-channels"
 
+def test_failing_turn_unwinds_every_profile_seam(tmp_path):
+    """A turn that raises must not leave a profile's scopes installed.
+
+    The three seams are entered in sequence, so an exception escaping the
+    ``yield`` has to unwind all of them.  Leaving the secret scope or the
+    HERMES_HOME override behind is exactly the cross-profile bleed this
+    context manager exists to prevent: the next routed turn would resolve
+    another profile's credentials and home.
+    """
+    from agent.runtime_cwd import is_context_file_cwd_scoped
+    from agent.secret_scope import get_secret
+    from gateway.run import _profile_runtime_scope
+    from hermes_constants import get_hermes_home
+
+    profile = tmp_path / "profiles" / "raiser"
+    profile.mkdir(parents=True)
+    (profile / ".env").write_text("PROFILE_SCOPED_API_KEY=secret-raiser\n", encoding="utf-8")
+    root_home = get_hermes_home()
+
+    ss.set_multiplex_active(True)
+    with pytest.raises(RuntimeError, match="turn exploded"):
+        with _profile_runtime_scope(profile):
+            assert get_secret("PROFILE_SCOPED_API_KEY") == "secret-raiser"
+            raise RuntimeError("turn exploded")
+
+    # With multiplexing on, an unscoped read fails closed — which is the
+    # strongest available proof that the profile's scope is gone rather than
+    # merely empty.
+    with pytest.raises(ss.UnscopedSecretError):
+        get_secret("PROFILE_SCOPED_API_KEY")
+    assert get_hermes_home() == root_home
+    assert is_context_file_cwd_scoped() is False
 
 def test_cold_profile_hydrates_external_source_without_global_env(
     tmp_path, monkeypatch

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -88,6 +88,39 @@ class TestProfilePathResolutionUnderMultiplexScope:
         assert b_seen == prof_b / "skills"
 
 
+    def test_context_files_follow_profile_without_changing_execution_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.prompt_builder import build_context_files_prompt
+        from agent.runtime_cwd import resolve_agent_cwd, resolve_context_cwd
+        from gateway.run import _profile_runtime_scope
+
+        execution_cwd = tmp_path / "shared-workdir"
+        execution_cwd.mkdir()
+        (execution_cwd / "AGENTS.md").write_text(
+            "ROOT_EXECUTION_MARKER", encoding="utf-8"
+        )
+        monkeypatch.setenv("TERMINAL_CWD", str(execution_cwd))
+
+        profile_names = ("default", "alpha", "beta", "gamma", "delta", "epsilon")
+        profiles = {}
+        for name in profile_names:
+            home = tmp_path / "profiles" / name
+            home.mkdir(parents=True)
+            marker = f"PROFILE_MARKER_{name.upper()}"
+            (home / "AGENTS.md").write_text(marker, encoding="utf-8")
+            profiles[name] = (home, marker)
+
+        for name, (home, marker) in profiles.items():
+            with _profile_runtime_scope(home):
+                prompt = build_context_files_prompt(cwd=resolve_context_cwd())
+                assert resolve_agent_cwd() == execution_cwd
+                assert marker in prompt
+                assert "ROOT_EXECUTION_MARKER" not in prompt
+                for other_name, (_, other_marker) in profiles.items():
+                    if other_name != name:
+                        assert other_marker not in prompt
+
 def test_turn_scoped_dotenv_reload_does_not_pollute_process_env(tmp_path, monkeypatch):
     """A routed profile reload must stay inside its context-local scope.
 


### PR DESCRIPTION
## What does this PR do?

Multiplex gateways already scope `HERMES_HOME`, secrets, skills, memory, SOUL, and sessions to the routed profile. Context-file discovery remained tied to the shared execution cwd, so routed profiles could miss their own `AGENTS.md` or inherit instructions from the gateway workdir.

This adds an independent, context-local context-file cwd to the existing multiplex profile scope. `AGENTS.md` and related files resolve from the routed profile home while terminal/file tools retain the configured execution cwd. It deliberately does **not** point every seat at the root `HERMES_HOME`, which could leak primary-profile instructions into public or quarantined profiles.

A short profile-directory marker is emitted only in multiplex-scoped prompts. Existing persisted multiplex prompts without the marker rebuild once after upgrade; subsequent turns reuse the stored bytes. Standalone CLI/TUI and single-profile prompt bytes/cache behavior remain unchanged.

## Related Issue

Addresses the multiplex profile-isolation variant of #11763. Related but not duplicate: #70600 changes routed tool execution cwd, while #78289 bridges routed `terminal.*` configuration; this PR intentionally leaves execution cwd and terminal environment unchanged.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `agent/runtime_cwd.py`: add a `ContextVar`-backed context-file cwd, separate from session/tool cwd.
- `gateway/run.py`: bind/reset that directory inside `_profile_runtime_scope`.
- `agent/system_prompt.py`: discover context files from the scoped directory and record a multiplex-only cache identity marker.
- `agent/conversation_loop.py`: rebuild persisted multiplex prompts once when that marker is absent or belongs to another profile.
- `tests/`: cover all six profile names, root/cross-profile negative markers, unchanged execution cwd, prompt-tail identity, and stale stored-prompt invalidation.
- `docs/profile-routing.md`: document instruction-discovery isolation versus execution cwd.

No config keys, dependencies, tool schemas, or tool behavior change.

## How to Test

1. Focused contract:
   ```bash
   uv run --extra dev pytest -q \
     tests/gateway/test_multiplex_credential_isolation.py::TestProfilePathResolutionUnderMultiplexScope::test_context_files_follow_profile_without_changing_execution_cwd \
     tests/agent/test_system_prompt.py::TestContextFileCwd \
     tests/agent/test_system_prompt_restore.py::TestStoredPromptReuse::test_profile_context_change_rebuilds_stored_prompt
   ```
   Result: **6 passed**.
2. Lint changed Python files:
   ```bash
   uv run --extra dev ruff check agent/runtime_cwd.py agent/system_prompt.py agent/conversation_loop.py gateway/run.py tests/agent/test_system_prompt.py tests/agent/test_system_prompt_restore.py tests/gateway/test_multiplex_credential_isolation.py
   ```
   Result: **passed**.
3. Full per-file isolated suite:
   ```bash
   scripts/run_tests.sh
   ```
   Patched result: **29,554 passed, 20 failed, 286 skipped**. Untouched `main` baseline in a detached worktree: **29,550 passed, the same 20 failed in the same 12 files, 286 skipped**. The four added regression cases account for the pass-count delta; no new failures. The baseline failures are host/environment contamination and current-main failures (including shared `/tmp` discovery, local Camofox/umask behavior, and unrelated verification/busy-mode tests), so the all-tests-pass checkbox below is intentionally left unchecked.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched open issues and PRs; #70600/#78289 have different execution-cwd/terminal-env contracts
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — baseline is already red as disclosed above
- [x] I've added tests for the bug
- [x] Tested on Ubuntu Linux

### Documentation & Housekeeping

- [x] Updated relevant documentation and docstrings
- [x] `cli-config.yaml.example`: N/A — no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no workflow changes
- [x] Considered cross-platform impact — stdlib `ContextVar`/`Path`, no platform-specific behavior
- [x] Tool descriptions/schemas: N/A — tool behavior is intentionally unchanged

## Screenshots / Logs

Fail-first evidence before implementation:
- six-profile context regression: failed because `PROFILE_MARKER_DEFAULT` was absent and the shared workdir marker was loaded;
- stored-prompt invalidation: both missing-marker and wrong-profile cases reused stale bytes.

Both contracts pass after the change.