### PR TITLE
fix(gateway): stop /refine cold-cache false emptiness

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3791,7 +3791,9 @@ class SessionStore:
             logger.debug("Failed to rewrite transcript in DB: %s", e)
             return False
 
-    def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
+    def load_transcript(
+        self, session_id: str, *, raise_on_error: bool = False
+    ) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
 
         state.db is the canonical store. The legacy JSONL fallback was removed
@@ -3804,6 +3806,9 @@ class SessionStore:
         chain while reads queried the stale id directly — the transcript
         "vanished" (disk=0) even though every message sat healthy under the
         child session.
+
+        Set ``raise_on_error`` for callers that must distinguish an unreadable
+        transcript from a genuinely empty one.
         """
         if not self._db:
             return []
@@ -3839,6 +3844,8 @@ class SessionStore:
                 "downstream must not treat this as data loss): %s",
                 session_id, e,
             )
+            if raise_on_error:
+                raise
             return []
 
     def rewind_session(self, session_id: str, n: int = 1) -> Optional[Dict[str, Any]]:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3811,6 +3811,8 @@ class SessionStore:
         transcript from a genuinely empty one.
         """
         if not self._db:
+            if raise_on_error:
+                raise RuntimeError("Session database is unavailable")
             return []
         # Follow the write-side reroute chain (cycle-guarded, same shape as
         # append_to_transcript).
@@ -3826,6 +3828,8 @@ class SessionStore:
             if tip:
                 session_id = tip
         except Exception:
+            if raise_on_error:
+                raise
             pass
         try:
             # repair_alternation: this load feeds LIVE REPLAY. A durable

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2849,24 +2849,20 @@ class GatewaySlashCommandsMixin:
         )
 
     async def _load_refine_persisted_transcript(
-        self, event: "MessageEvent"
+        self, session_key: str
     ) -> tuple[Optional[list], Optional[str]]:
-        """Load the durable transcript for /refine.
+        """Load the durable transcript for /refine without creating a session.
 
         Returns ``(history, None)`` on success (history may be empty), or
         ``(None, error_message)`` when the transcript cannot be read. A read
         failure must NOT be treated as zero turns — that reintroduces the
         cold-cache false-emptiness claim.
         """
-        if event.source is None:
-            return [], None
         try:
-            session_entry = await self.async_session_store.get_or_create_session(
-                event.source
-            )
-            history = await self.async_session_store.load_transcript(
-                session_entry.session_id
-            )
+            session_id = await self.async_session_store.peek_session_id(session_key)
+            if not session_id:
+                return [], None
+            history = await self.async_session_store.load_transcript(session_id)
         except Exception:
             logger.debug(
                 "failed to load persisted /refine transcript", exc_info=True
@@ -2911,13 +2907,13 @@ class GatewaySlashCommandsMixin:
                 cached = self._agent_cache.get(quick_key)
                 agent = cached[0] if isinstance(cached, tuple) else cached if cached else None
         if agent is None:
-            history, read_err = await self._load_refine_persisted_transcript(event)
+            history, read_err = await self._load_refine_persisted_transcript(quick_key)
             if read_err:
                 return read_err
             n = self._count_refine_persisted_turns(history or [])
             if n > 0:
                 return (
-                    f"This session has {n} persisted messages, but the live "
+                    f"This session has {n} persisted user/assistant messages, but the live "
                     "agent isn't cached. Send a message (or /resume) to wake "
                     "the session first, then /refine."
                 )
@@ -2925,7 +2921,7 @@ class GatewaySlashCommandsMixin:
 
         snapshot = list(getattr(agent, "_session_messages", None) or [])
         if not snapshot:
-            history, read_err = await self._load_refine_persisted_transcript(event)
+            history, read_err = await self._load_refine_persisted_transcript(quick_key)
             if read_err:
                 return read_err
             if self._count_refine_persisted_turns(history or []) > 0:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2862,7 +2862,9 @@ class GatewaySlashCommandsMixin:
             session_id = await self.async_session_store.peek_session_id(session_key)
             if not session_id:
                 return [], None
-            history = await self.async_session_store.load_transcript(session_id)
+            history = await self.async_session_store.load_transcript(
+                session_id, raise_on_error=True
+            )
         except Exception:
             logger.debug(
                 "failed to load persisted /refine transcript", exc_info=True

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2848,6 +2848,40 @@ class GatewaySlashCommandsMixin:
             "elapsed. Lives while the gateway runs — use `hermes cron` for durable schedules."
         )
 
+    async def _load_refine_persisted_transcript(
+        self, event: "MessageEvent"
+    ) -> tuple[Optional[list], Optional[str]]:
+        """Load the durable transcript for /refine.
+
+        Returns ``(history, None)`` on success (history may be empty), or
+        ``(None, error_message)`` when the transcript cannot be read. A read
+        failure must NOT be treated as zero turns — that reintroduces the
+        cold-cache false-emptiness claim.
+        """
+        if event.source is None:
+            return [], None
+        try:
+            session_entry = await self.async_session_store.get_or_create_session(
+                event.source
+            )
+            history = await self.async_session_store.load_transcript(
+                session_entry.session_id
+            )
+        except Exception:
+            logger.debug(
+                "failed to load persisted /refine transcript", exc_info=True
+            )
+            return (
+                None,
+                "Couldn't read the persisted conversation for /refine — "
+                "try again, or send a message to resume the session.",
+            )
+        return list(history or []), None
+
+    @staticmethod
+    def _count_refine_persisted_turns(history: list) -> int:
+        return sum(1 for m in history if m.get("role") in {"user", "assistant"})
+
     async def _handle_refine_command(self, event: "MessageEvent") -> str:
         """Handle /refine — run the memory/skill review fork on demand.
 
@@ -2855,6 +2889,13 @@ class GatewaySlashCommandsMixin:
         ``_agent_cache``). The review runs in a daemon thread against a
         snapshot of the conversation; the live session and prompt cache are
         untouched. Requires the session to have at least one completed turn.
+
+        A cold ``_agent_cache`` is not the same as an empty conversation: when
+        the agent is absent we consult the persisted transcript and tell the
+        user to resume first if durable turns exist, rather than claiming
+        there is nothing to refine. When the agent is cached but
+        ``_session_messages`` is empty, fall back to the persisted transcript
+        and run the review against that snapshot.
         """
         args = (event.get_command_args() or "").strip()
         quick_key = self._session_key_for_source(event.source) if event.source else None
@@ -2870,11 +2911,27 @@ class GatewaySlashCommandsMixin:
                 cached = self._agent_cache.get(quick_key)
                 agent = cached[0] if isinstance(cached, tuple) else cached if cached else None
         if agent is None:
+            history, read_err = await self._load_refine_persisted_transcript(event)
+            if read_err:
+                return read_err
+            n = self._count_refine_persisted_turns(history or [])
+            if n > 0:
+                return (
+                    f"This session has {n} persisted messages, but the live "
+                    "agent isn't cached. Send a message (or /resume) to wake "
+                    "the session first, then /refine."
+                )
             return "Nothing to refine yet — send a message first."
 
         snapshot = list(getattr(agent, "_session_messages", None) or [])
         if not snapshot:
-            return "Nothing to refine yet — the conversation is empty."
+            history, read_err = await self._load_refine_persisted_transcript(event)
+            if read_err:
+                return read_err
+            if self._count_refine_persisted_turns(history or []) > 0:
+                snapshot = list(history or [])
+            else:
+                return "Nothing to refine yet — the conversation is empty."
 
         review_skills = "skill_manage" in getattr(agent, "valid_tool_names", set())
         try:

--- a/tests/gateway/test_refine_command.py
+++ b/tests/gateway/test_refine_command.py
@@ -9,7 +9,7 @@ import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
-from gateway.session import SessionEntry, SessionSource, build_session_key
+from gateway.session import SessionEntry, SessionSource, SessionStore, build_session_key
 
 
 def _make_source(platform: Platform = Platform.TELEGRAM) -> SessionSource:
@@ -77,7 +77,9 @@ async def test_refine_cold_cache_with_persisted_turns_asks_to_resume():
     assert "2 persisted user/assistant messages" in result
     assert "resume" in result.lower() or "wake the session first" in result
     assert "Nothing to refine yet" not in result
-    runner.session_store.load_transcript.assert_called_once_with(entry.session_id)
+    runner.session_store.load_transcript.assert_called_once_with(
+        entry.session_id, raise_on_error=True
+    )
 
 
 @pytest.mark.asyncio
@@ -114,6 +116,22 @@ async def test_refine_cold_cache_transcript_read_failure_is_distinct():
 
     assert "Couldn't read the persisted conversation" in result
     assert "Nothing to refine yet" not in result
+
+
+def test_refine_strict_transcript_read_propagates_store_failure():
+    class _FailingDB:
+        def get_compression_tip(self, _session_id):
+            return None
+
+        def get_messages_as_conversation(self, _session_id, **_kwargs):
+            raise RuntimeError("db down")
+
+    store = object.__new__(SessionStore)
+    store._db = _FailingDB()
+    store._transcript_reroutes = {}
+
+    with pytest.raises(RuntimeError, match="db down"):
+        store.load_transcript("sess-refine-1", raise_on_error=True)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_refine_command.py
+++ b/tests/gateway/test_refine_command.py
@@ -41,6 +41,7 @@ def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.T
     runner.hooks = SimpleNamespace(emit=MagicMock(), loaded_hooks=False)
     runner.session_store = MagicMock()
     runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.peek_session_id.return_value = session_entry.session_id
     runner.session_store.load_transcript.return_value = []
     runner._running_agents = {}
     runner._agent_cache = {}
@@ -73,10 +74,23 @@ async def test_refine_cold_cache_with_persisted_turns_asks_to_resume():
 
     result = await runner._handle_refine_command(_make_event("/refine"))
 
-    assert "2 persisted messages" in result
+    assert "2 persisted user/assistant messages" in result
     assert "resume" in result.lower() or "wake the session first" in result
     assert "Nothing to refine yet" not in result
     runner.session_store.load_transcript.assert_called_once_with(entry.session_id)
+
+
+@pytest.mark.asyncio
+async def test_refine_cold_cache_unknown_session_does_not_create_one():
+    entry = _session_entry()
+    runner = _make_runner(entry)
+    runner.session_store.peek_session_id.return_value = None
+
+    result = await runner._handle_refine_command(_make_event())
+
+    assert result == "Nothing to refine yet — send a message first."
+    runner.session_store.get_or_create_session.assert_not_called()
+    runner.session_store.load_transcript.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_refine_command.py
+++ b/tests/gateway/test_refine_command.py
@@ -134,6 +134,27 @@ def test_refine_strict_transcript_read_propagates_store_failure():
         store.load_transcript("sess-refine-1", raise_on_error=True)
 
 
+def test_refine_strict_transcript_read_rejects_unavailable_database():
+    store = object.__new__(SessionStore)
+    store._db = None
+
+    with pytest.raises(RuntimeError, match="database is unavailable"):
+        store.load_transcript("sess-refine-1", raise_on_error=True)
+
+
+def test_refine_strict_transcript_read_propagates_tip_lookup_failure():
+    class _FailingTipDB:
+        def get_compression_tip(self, _session_id):
+            raise RuntimeError("tip lookup failed")
+
+    store = object.__new__(SessionStore)
+    store._db = _FailingTipDB()
+    store._transcript_reroutes = {}
+
+    with pytest.raises(RuntimeError, match="tip lookup failed"):
+        store.load_transcript("sess-refine-1", raise_on_error=True)
+
+
 @pytest.mark.asyncio
 async def test_refine_cached_agent_uses_persisted_transcript_when_messages_empty():
     entry = _session_entry()

--- a/tests/gateway/test_refine_command.py
+++ b/tests/gateway/test_refine_command.py
@@ -1,0 +1,169 @@
+"""Tests for gateway /refine cold-cache and persisted-transcript handling."""
+
+from datetime import datetime
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source(platform: Platform = Platform.TELEGRAM) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str = "/refine", *, platform: Platform = Platform.TELEGRAM) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=_make_source(platform),
+        message_id="m1",
+    )
+
+
+def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.TELEGRAM):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {}
+    runner.hooks = SimpleNamespace(emit=MagicMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    return runner
+
+
+def _session_entry(source=None) -> SessionEntry:
+    source = source or _make_source()
+    return SessionEntry(
+        session_key=build_session_key(source),
+        session_id="sess-refine-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=source.platform,
+        chat_type=source.chat_type or "dm",
+    )
+
+
+@pytest.mark.asyncio
+async def test_refine_cold_cache_with_persisted_turns_asks_to_resume():
+    """Cold _agent_cache must not claim an empty conversation when transcript has turns."""
+    entry = _session_entry()
+    runner = _make_runner(entry)
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "tool", "content": "ignored for count"},
+    ]
+
+    result = await runner._handle_refine_command(_make_event("/refine"))
+
+    assert "2 persisted messages" in result
+    assert "resume" in result.lower() or "wake the session first" in result
+    assert "Nothing to refine yet" not in result
+    runner.session_store.load_transcript.assert_called_once_with(entry.session_id)
+
+
+@pytest.mark.asyncio
+async def test_refine_cold_cache_truly_empty_keeps_nothing_to_refine():
+    entry = _session_entry()
+    runner = _make_runner(entry)
+    runner.session_store.load_transcript.return_value = []
+
+    result = await runner._handle_refine_command(_make_event())
+
+    assert result == "Nothing to refine yet — send a message first."
+
+
+@pytest.mark.asyncio
+async def test_refine_cold_cache_transcript_read_failure_is_distinct():
+    entry = _session_entry()
+    runner = _make_runner(entry)
+    runner.session_store.load_transcript.side_effect = RuntimeError("db down")
+
+    result = await runner._handle_refine_command(_make_event())
+
+    assert "Couldn't read the persisted conversation" in result
+    assert "Nothing to refine yet" not in result
+
+
+@pytest.mark.asyncio
+async def test_refine_cached_agent_uses_persisted_transcript_when_messages_empty():
+    entry = _session_entry()
+    runner = _make_runner(entry)
+    captured = {}
+
+    class _Agent:
+        valid_tool_names = {"memory", "skill_manage"}
+        _session_messages = []
+
+        def _spawn_background_review(self, **kwargs):
+            captured.update(kwargs)
+
+    source = _make_source()
+    session_key = build_session_key(source)
+    runner._agent_cache[session_key] = (_Agent(), "sig")
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "persisted question"},
+        {"role": "assistant", "content": "persisted answer"},
+        {"role": "tool", "content": "tool output"},
+    ]
+
+    result = await runner._handle_refine_command(_make_event("/refine save workflow"))
+
+    assert "Reviewing this conversation" in result
+    assert captured["focus"] == "save workflow"
+    assert captured["review_memory"] is True
+    assert captured["review_skills"] is True
+    assert captured["messages_snapshot"] == [
+        {"role": "user", "content": "persisted question"},
+        {"role": "assistant", "content": "persisted answer"},
+        {"role": "tool", "content": "tool output"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refine_cached_agent_prefers_in_memory_messages():
+    entry = _session_entry()
+    runner = _make_runner(entry)
+    captured = {}
+
+    class _Agent:
+        valid_tool_names = {"memory"}
+        _session_messages = [
+            {"role": "user", "content": "live question"},
+            {"role": "assistant", "content": "live answer"},
+        ]
+
+        def _spawn_background_review(self, **kwargs):
+            captured.update(kwargs)
+
+    source = _make_source()
+    runner._agent_cache[build_session_key(source)] = (_Agent(), "sig")
+    runner.session_store.load_transcript.side_effect = AssertionError(
+        "must not load transcript when in-memory messages exist"
+    )
+
+    result = await runner._handle_refine_command(_make_event())
+
+    assert "Reviewing this conversation" in result
+    assert captured["messages_snapshot"] == [
+        {"role": "user", "content": "live question"},
+        {"role": "assistant", "content": "live answer"},
+    ]
+    assert captured["review_skills"] is False


### PR DESCRIPTION
## What does this PR do?

On messaging platforms, `/refine` no longer treats a cold `_agent_cache` as an empty conversation. When the live agent is missing, the handler loads the persisted transcript off the event loop and reports that durable turns exist so the user can resume first. When the agent is cached but `_session_messages` is empty, it falls back to that transcript and starts the review. Transcript read failures return a distinct error instead of looking like emptiness.

### Symptom

`/refine` on Telegram/Discord/etc. can return `Nothing to refine yet - send a message first.` after completed turns once the idle agent has left `_agent_cache`.

### Impact

Messaging users cannot refine an existing conversation, or get a false empty-conversation claim, even though the session store still has usable turns.

### Bug Cause

**Trigger:** `gateway/slash_commands.py::_handle_refine_command` with a cold `_agent_cache`

**Causal chain:**
1. Messaging `/refine` looks up the session agent only in `_agent_cache`.
2. A missing cache entry returns the same "Nothing to refine yet" response used for a genuinely empty conversation.
3. The handler never consults `session_store.load_transcript`, so durable turns are ignored.

**Why it is wrong:** Cache absence is not emptiness. The Desktop/TUI path already fixed the sibling false claim in #83520; messaging still had the cold-cache branch.

**Working sibling / contrast:** #83520 loads persisted history and runs refine for Desktop/TUI. This PR covers the messaging gateway path called out as complementary on #83455.

**Ruled out:** A truly empty transcript still returns the original empty-conversation messages.

### Fix

Resolve the session entry, load the transcript via `async_session_store` (already offloaded with `asyncio.to_thread`), count `user`/`assistant` rows, and:
- cold cache + N > 0 -> ask to resume/wake first
- transcript read failure -> distinct "couldn't read" answer
- cached agent + empty `_session_messages` + durable turns -> run review against the persisted snapshot

## Related Issue

Fixes #83871

Related: #83455, #83520

## Type of Change

- [x] Bug fix

## Changes Made

- `gateway/slash_commands.py` - consult persisted transcript for cold-cache and empty in-memory `/refine` paths
- `tests/gateway/test_refine_command.py` - cover resume prompt, true empty, read failure, and persisted-snapshot review

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_refine_command.py
```

Results: 5 passed on Windows with the project venv.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's test entry on relevant tests
- [x] I've added regression tests for this bug fix
- [x] I've tested on Windows

### Documentation & Housekeeping

- [x] Documentation update - N/A (behavior fix only)
- [x] cli-config.yaml.example - N/A
- [x] CONTRIBUTING.md / AGENTS.md - N/A
- [x] Cross-platform impact considered (async offload via existing AsyncSessionStore)
- [x] Tool descriptions/schemas - N/A
