### PR TITLE
fix: fully redact Authorization in request dumps

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1852,12 +1852,6 @@ def dump_api_request_debug(
         body.pop("timeout", None)
         body = {k: v for k, v in body.items() if v is not None}
 
-        api_key = None
-        try:
-            api_key = getattr(agent.client, "api_key", None)
-        except Exception as e:
-            _ra().logger.debug("Could not extract API key for debug dump: %s", e)
-
         dump_payload: Dict[str, Any] = {
             "timestamp": datetime.now().isoformat(),
             "session_id": agent.session_id,
@@ -1866,7 +1860,7 @@ def dump_api_request_debug(
                 "method": "POST",
                 "url": f"{agent.base_url.rstrip('/')}{'/responses' if agent.api_mode == 'codex_responses' else '/chat/completions'}",
                 "headers": {
-                    "Authorization": f"Bearer {agent._mask_api_key_for_logs(api_key)}",
+                    "Authorization": "Bearer [REDACTED]",
                     "Content-Type": "application/json",
                 },
                 "body": body,

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1786,6 +1786,34 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
 
 
+def test_dump_api_request_debug_fully_redacts_authorization(monkeypatch, tmp_path):
+    """Request dump에는 API 키의 앞뒤 조각도 남기지 않는다."""
+    import json
+
+    _patch_agent_bootstrap(monkeypatch)
+    fake_secret = "sk-proj-abcdefghijklmno-qrstuvwxyz-12345678"
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key=fake_secret,
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.logs_dir = tmp_path
+
+    dump_file = agent._dump_api_request_debug(
+        _codex_request_kwargs(), reason="preflight"
+    )
+
+    dumped = dump_file.read_text(encoding="utf-8")
+    payload = json.loads(dumped)
+    assert payload["request"]["headers"]["Authorization"] == "Bearer [REDACTED]"
+    assert fake_secret[:8] not in dumped
+    assert fake_secret[-4:] not in dumped
+
+
 
 
 # --- Reasoning-only response tests (fix for empty content retry loop) ---


### PR DESCRIPTION
## Summary
- stop reading the client API key when generating request debug dumps
- write only `Bearer [REDACTED]` to the Authorization header
- add a regression test proving neither the first nor last key fragments survive

## Verification
- `pytest -q tests/run_agent/test_run_agent_codex_responses.py` (45 passed)
- `ruff check agent/agent_runtime_helpers.py tests/run_agent/test_run_agent_codex_responses.py`
- `git diff --check`

This prevents partial credential material from persisting in mode-0600 debug artifacts.