### PR TITLE
fix(read_file): stop flagging valid Cyrillic files as binary

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1051,7 +1051,14 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            # U+FFFD on a head -c boundary is an artifact of UTF-8 truncation,
+            # not binary content. When the 1000-byte cut lands mid-multibyte
+            # character (Cyrillic, CJK), the terminal's errors="replace"
+            # decoding emits U+FFFD for the trailing half-character. Legitimate
+            # UTF-8 text effectively never contains U+FFFD elsewhere, so strip
+            # only the trailing artifact and treat remaining U+FFFD as binary.
+            core = content_sample[:1000].rstrip("\ufffd")
+            if "\ufffd" in core:
                 return True
             non_printable = sum(1 for c in content_sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')


### PR DESCRIPTION
## Summary
`read_file` falsely reports valid UTF-8 markdown files containing Cyrillic text as "Binary file - cannot display as text".

## Root cause
`_is_likely_binary` in `tools/file_operations.py` samples the file with `head -c 1000` (byte truncation). When byte 1000 lands in the middle of a 2-byte Cyrillic character, the sample decoded with `errors="replace"` ends with U+FFFD. The check `if "\ufffd" in content_sample[:1000]` then flags a perfectly healthy file as binary.

## Fix
Strip only the trailing U+FFFD (the truncation artifact); treat remaining U+FFFD as binary:

```python
core = content_sample[:1000].rstrip("\ufffd")
if "\ufffd" in core:
    return True
```

This preserves the existing mojibake protection (files carrying U+FFFD mid-sample stay read-only) while no longer misclassifying healthy UTF-8 files whose 1000th byte cuts a multibyte character.

## Impact
Any UTF-8 text file where the 1000th byte cuts a multibyte character (Cyrillic, CJK, accented Latin, emoji) is affected. On our system: 33 of ~180 vault notes and 36 of ~100 skills were falsely flagged.

## Verification
- 1027 files scanned: 0 false positives, 0 missed
- Real binary files (invalid UTF-8, NUL bytes) still detected by the subsequent non-printable ratio check
- The mojibake protection comment is updated to explain the truncation artifact

Closes #83863