### PR TITLE
docs(api): document API server key requirements

### DIFF
--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -524,7 +524,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `WEBHOOK_PORT` | HTTP server port for receiving webhooks (default: `8644`) |
 | `WEBHOOK_SECRET` | Global HMAC secret for webhook signature validation (used as fallback when routes don't specify their own) |
 | `API_SERVER_ENABLED` | Enable the OpenAI-compatible API server (`true`/`false`). Runs alongside other platforms. |
-| `API_SERVER_KEY` | Bearer token for API server authentication. Required whenever the API server is enabled. |
+| `API_SERVER_KEY` | Bearer token for API server authentication. Required whenever the API server is enabled; must be at least 16 characters and not a placeholder value. |
 | `API_SERVER_CORS_ORIGINS` | Comma-separated browser origins allowed to call the API server directly (for example `http://localhost:3000,http://127.0.0.1:3000`). Default: disabled. |
 | `API_SERVER_PORT` | Port for the API server (default: `8642`) |
 | `API_SERVER_HOST` | Host/bind address for the API server (default: `127.0.0.1`). `API_SERVER_KEY` is still required on loopback; use a narrow `API_SERVER_CORS_ORIGINS` allowlist for browser access. |

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -82,7 +82,7 @@ tool_loop_guardrails:
 ```
 :::
 
-Note: the API server is gated on `API_SERVER_ENABLED=true`. To expose it beyond `127.0.0.1` inside the container, also set `API_SERVER_HOST=0.0.0.0` and an `API_SERVER_KEY` (minimum 8 characters — generate one with `openssl rand -hex 32`). Example:
+Note: the API server is gated on `API_SERVER_ENABLED=true`. To expose it beyond `127.0.0.1` inside the container, also set `API_SERVER_HOST=0.0.0.0` and an `API_SERVER_KEY` (at least 16 characters and not a placeholder — generate one with `openssl rand -hex 32`). Example:
 
 ```sh
 docker run -d \

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -22,7 +22,8 @@ Add to `~/.hermes/.env`:
 
 ```bash
 API_SERVER_ENABLED=true
-API_SERVER_KEY=change-me-local-dev
+# Run `openssl rand -hex 32`, then paste its output after the equals sign.
+API_SERVER_KEY=
 # Optional: only if a browser must call Hermes directly
 # API_SERVER_CORS_ORIGINS=http://localhost:3000
 ```
@@ -634,13 +635,13 @@ hermes profile create bob
 cat >> ~/.hermes/profiles/alice/.env <<EOF
 API_SERVER_ENABLED=true
 API_SERVER_PORT=8643
-API_SERVER_KEY=alice-secret
+API_SERVER_KEY=$(openssl rand -hex 32)
 EOF
 
 cat >> ~/.hermes/profiles/bob/.env <<EOF
 API_SERVER_ENABLED=true
 API_SERVER_PORT=8644
-API_SERVER_KEY=bob-secret
+API_SERVER_KEY=$(openssl rand -hex 32)
 EOF
 
 # Start each profile's gateway

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -751,12 +751,13 @@ Add to `~/.hermes/.env`:
 
 ```bash
 API_SERVER_ENABLED=true
-API_SERVER_KEY=your-secret-key-here
+# Run `openssl rand -hex 32`, then paste its output after the equals sign.
+API_SERVER_KEY=
 API_SERVER_HOST=0.0.0.0
 ```
 
 - `API_SERVER_HOST=0.0.0.0` binds to all interfaces so the Docker container can reach it.
-- `API_SERVER_KEY` is required for non-loopback binding. Pick a strong random string.
+- `API_SERVER_KEY` is required for every deployment, including the default loopback bind. Generate a strong random value.
 - The API server runs on port 8642 by default (change with `API_SERVER_PORT` if needed).
 
 Start the gateway:

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -34,7 +34,7 @@ Open WebUI talks to Hermes server-to-server, so you do not need `API_SERVER_CORS
 
 ```bash
 hermes config set API_SERVER_ENABLED true
-hermes config set API_SERVER_KEY your-secret-key
+hermes config set API_SERVER_KEY "$(openssl rand -hex 32)"
 ```
 
 `hermes config set` auto-routes the flag to `config.yaml` and the secret to `~/.hermes/.env`. If the gateway is already running, restart it so the change takes effect:
@@ -244,14 +244,14 @@ hermes profile create alice
 cat >> ~/.hermes/profiles/alice/.env <<EOF
 API_SERVER_ENABLED=true
 API_SERVER_PORT=8650
-API_SERVER_KEY=alice-secret
+API_SERVER_KEY=$(openssl rand -hex 32)
 EOF
 
 hermes profile create bob
 cat >> ~/.hermes/profiles/bob/.env <<EOF
 API_SERVER_ENABLED=true
 API_SERVER_PORT=8651
-API_SERVER_KEY=bob-secret
+API_SERVER_KEY=$(openssl rand -hex 32)
 EOF
 ```
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -409,7 +409,7 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `WEBHOOK_PORT` | 接收 webhook 的 HTTP 服务器端口（默认：`8644`） |
 | `WEBHOOK_SECRET` | webhook 签名验证的全局 HMAC 密钥（当路由未指定自己的密钥时作为回退） |
 | `API_SERVER_ENABLED` | 启用 OpenAI 兼容 API 服务器（`true`/`false`）。与其他平台并行运行。 |
-| `API_SERVER_KEY` | API 服务器认证的 Bearer token。非回环绑定时强制执行。 |
+| `API_SERVER_KEY` | API 服务器认证的 Bearer token。API 服务器启用时必填；至少 16 个字符且不能是占位符。 |
 | `API_SERVER_CORS_ORIGINS` | 允许直接调用 API 服务器的逗号分隔浏览器来源（例如 `http://localhost:3000,http://127.0.0.1:3000`）。默认：禁用。 |
 | `API_SERVER_PORT` | API 服务器端口（默认：`8642`） |
 | `API_SERVER_HOST` | API 服务器主机/绑定地址（默认：`127.0.0.1`）。使用 `0.0.0.0` 开放网络访问——需要 `API_SERVER_KEY` 和严格的 `API_SERVER_CORS_ORIGINS` 白名单。 |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/docker.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/docker.md
@@ -41,7 +41,7 @@ docker run -d \
 
 端口 8642 暴露 gateway 的 [OpenAI 兼容 API 服务器](./features/api-server.md)和健康检查端点。如果你只使用聊天平台（Telegram、Discord 等），该端口是可选的；但如果你希望 dashboard 或外部工具访问 gateway，则必须开放。
 
-注意：API 服务器需设置 `API_SERVER_ENABLED=true` 才会启用。若要在容器内将其暴露至 `127.0.0.1` 以外，还需设置 `API_SERVER_HOST=0.0.0.0` 和 `API_SERVER_KEY`（最少 8 个字符——可用 `openssl rand -hex 32` 生成）。示例：
+注意：API 服务器需设置 `API_SERVER_ENABLED=true` 才会启用。若要在容器内将其暴露至 `127.0.0.1` 以外，还需设置 `API_SERVER_HOST=0.0.0.0` 和 `API_SERVER_KEY`（至少 16 个字符，且不能是占位符——可用 `openssl rand -hex 32` 生成）。示例：
 
 ```sh
 docker run -d \

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/api-server.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/api-server.md
@@ -22,7 +22,8 @@ Hermes 本身需要配置好 provider（提供商）和工具后端，API 服务
 
 ```bash
 API_SERVER_ENABLED=true
-API_SERVER_KEY=change-me-local-dev
+# 运行 `openssl rand -hex 32`，然后将输出粘贴在等号后面。
+API_SERVER_KEY=
 # 可选：仅当浏览器需要直接调用 Hermes 时
 # API_SERVER_CORS_ORIGINS=http://localhost:3000
 ```
@@ -332,7 +333,7 @@ Authorization: Bearer ***
 通过 `API_SERVER_KEY` 环境变量配置密钥。如果需要浏览器直接调用 Hermes，还需将 `API_SERVER_CORS_ORIGINS` 设置为明确的允许列表。
 
 :::warning 安全
-API 服务器提供对 hermes-agent 工具集的完整访问权限，**包括终端命令**。当绑定到非回环地址（如 `0.0.0.0`）时，**必须**设置 `API_SERVER_KEY`。同时保持 `API_SERVER_CORS_ORIGINS` 范围尽量小，以控制浏览器访问。
+API 服务器提供对 hermes-agent 工具集的完整访问权限，**包括终端命令**。`API_SERVER_KEY` 对每种部署方式都为**必填项**，包括默认的 `127.0.0.1` 回环绑定。仅在明确允许浏览器调用时，才使用范围尽量小的 `API_SERVER_CORS_ORIGINS` 来控制浏览器访问。
 
 默认绑定地址（`127.0.0.1`）仅供本地使用。浏览器访问默认禁用；仅为明确的可信来源启用。
 :::
@@ -422,13 +423,13 @@ hermes profile create bob
 cat >> ~/.hermes/profiles/alice/.env <<EOF
 API_SERVER_ENABLED=true
 API_SERVER_PORT=8643
-API_SERVER_KEY=alice-secret
+API_SERVER_KEY=$(openssl rand -hex 32)
 EOF
 
 cat >> ~/.hermes/profiles/bob/.env <<EOF
 API_SERVER_ENABLED=true
 API_SERVER_PORT=8644
-API_SERVER_KEY=bob-secret
+API_SERVER_KEY=$(openssl rand -hex 32)
 EOF
 
 # 启动每个 profile 的 gateway

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
@@ -537,12 +537,13 @@ Docker 容器仅处理 Matrix 协议和 E2EE。消息到达时，容器解密消
 
 ```bash
 API_SERVER_ENABLED=true
-API_SERVER_KEY=your-secret-key-here
+# 运行 `openssl rand -hex 32`，然后将输出粘贴在等号后面。
+API_SERVER_KEY=
 API_SERVER_HOST=0.0.0.0
 ```
 
 - `API_SERVER_HOST=0.0.0.0` 绑定到所有接口，使 Docker 容器可以访问。
-- `API_SERVER_KEY` 是非回环绑定的必填项。请选择一个强随机字符串。
+- `API_SERVER_KEY` 适用于每种部署方式（包括默认的回环绑定），均为必填项。请生成一个强随机值。
 - API 服务器默认运行在端口 8642（如需更改，使用 `API_SERVER_PORT`）。
 
 启动 gateway：

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/open-webui.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/open-webui.md
@@ -34,7 +34,7 @@ Open WebUI 与 Hermes 之间是服务器到服务器的通信，因此此集成�
 
 ```bash
 hermes config set API_SERVER_ENABLED true
-hermes config set API_SERVER_KEY your-secret-key
+hermes config set API_SERVER_KEY "$(openssl rand -hex 32)"
 ```
 
 `hermes config set` 会自动将标志路由到 `config.yaml`，将密钥路由到 `~/.hermes/.env`。如果 gateway 已在运行，请重启以使更改生效：
@@ -244,14 +244,14 @@ hermes profile create alice
 cat >> ~/.hermes/profiles/alice/.env <<EOF
 API_SERVER_ENABLED=true
 API_SERVER_PORT=8650
-API_SERVER_KEY=alice-secret
+API_SERVER_KEY=$(openssl rand -hex 32)
 EOF
 
 hermes profile create bob
 cat >> ~/.hermes/profiles/bob/.env <<EOF
 API_SERVER_ENABLED=true
 API_SERVER_PORT=8651
-API_SERVER_KEY=bob-secret
+API_SERVER_KEY=$(openssl rand -hex 32)
 EOF
 ```
 


### PR DESCRIPTION
## Summary
- Document the API server's key requirements and safe key-generation workflow.
- Replace copyable static API-key examples with generated values in English and Simplified Chinese docs.

## Problem / rationale
- Issue #83750 used `API_SERVER_KEY=apikey`; current `main` correctly rejects that short key.
- Documentation was inconsistent: some pages stated an 8-character minimum, several examples used predictable values accepted by the current length check, and some pages implied that loopback deployments did not require a key.

## Changes
- State that `API_SERVER_KEY` is required for every deployment, including the default loopback bind; it must be at least 16 characters and not a placeholder.
- Use `openssl rand -hex 32` in shell and profile setup examples.
- Leave `.env` examples empty with an explicit generation instruction rather than displaying reusable static keys.
- Keep English and Simplified Chinese API-server, Docker, Open WebUI, Matrix, and environment-variable documentation aligned.

## Validation
- The canonical suite completed for predecessor docs-only SHA `44e293b13d01f126b38d93df421da6bcf9f8c7a4` with exactly two independently reproduced upstream-baseline failures:
  - `tests/gateway/test_multiplex_busy_input_mode.py::test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries`
  - `tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries`
- This docs-only successor uses explicitly authorized derived evidence: current-SHA targeted API-server credential guards passed 16/16, and deterministic website-wide documentation invariants passed.
- Manual/E2E validation: an isolated temporary-home gateway starts with a 16+ character key; `/health` and authenticated `/v1/models` return 200; the short issue key is rejected.
- Platforms: Linux verified. This is a documentation-only change; macOS and Windows were not separately exercised.

## Upstream context
- Related issue: #83750
