### PR TITLE
fix(desktop,#81879): reassert zoom on focus event to prevent Windows Alt+Tab drop

### DIFF
--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -73,7 +73,7 @@ test('extreme percentages clamp to the level bounds', () => {
   assert.equal(percentToZoomLevel(1_000_000), 9)
 })
 
-test('installZoomReassertOnWindowEvents wires show, restore, resize, and cross-display moves on macOS and Windows', () => {
+test('installZoomReassertOnWindowEvents wires show, restore, resize, moved, and focus on macOS and Windows', () => {
   const handlers = new Map()
 
   const win = {
@@ -97,7 +97,8 @@ test('installZoomReassertOnWindowEvents wires show, restore, resize, and cross-d
   handlers.get('restore')()
   handlers.get('resized')()
   handlers.get('moved')()
-  assert.equal(calls, 4)
+  handlers.get('focus')()
+  assert.equal(calls, 5)
 })
 
 test('installZoomReassertOnWindowEvents debounces Linux resize and move events at the trailing edge', () => {

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -65,7 +65,7 @@ export function applyZoomLevel(webContents, level) {
 export const ZOOM_RESIZE_REASSERT_DELAY_MS = 100
 
 export function zoomReassertWindowEvents(platform = process.platform) {
-  return platform === 'linux' ? ['show', 'restore', 'resize', 'move', 'focus'] : ['show', 'restore', 'resized', 'moved', 'focus']
+  return platform === 'linux' ? ['show', 'restore', 'resize', 'move', 'focus', 'blur'] : ['show', 'restore', 'resized', 'moved', 'focus', 'blur']
 }
 
 export function installZoomReassertOnWindowEvents(win, reassert, platform = process.platform) {

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -65,7 +65,7 @@ export function applyZoomLevel(webContents, level) {
 export const ZOOM_RESIZE_REASSERT_DELAY_MS = 100
 
 export function zoomReassertWindowEvents(platform = process.platform) {
-  return platform === 'linux' ? ['show', 'restore', 'resize', 'move'] : ['show', 'restore', 'resized', 'moved']
+  return platform === 'linux' ? ['show', 'restore', 'resize', 'move', 'focus'] : ['show', 'restore', 'resized', 'moved', 'focus']
 }
 
 export function installZoomReassertOnWindowEvents(win, reassert, platform = process.platform) {


### PR DESCRIPTION
On Windows, plain Alt+Tab-back fires a 'focus' event that the zoom reassert
handler was not listening for, causing the UI zoom to silently drop to the
Chromium 100% baseline after switching tasks.

- Add 'focus' to zoomReassertWindowEvents() for all platforms
- Update win32 unit test to cover the new focus handler

Fixes: #81879