### PR TITLE
fix(telegram): hold inbound messages across disconnect instead of destroying them

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -657,6 +657,9 @@ class TelegramAdapter(BasePlatformAdapter):
     # When a chunk is near this limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 4000
     MEDIA_GROUP_WAIT_SECONDS = 0.8
+    # Cap on inbound events held across a disconnect/reconnect window.
+    # Bounds memory during extended outages; oldest events are dropped first.
+    HELD_INBOUND_MAX = 64
     _GENERAL_TOPIC_THREAD_ID = "1"
 
     # Telegram's edit_message applies MarkdownV2 formatting only on the
@@ -789,6 +792,12 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._drop_delayed_deliveries = False
+        # Inbound events held across disconnect. PTB advances the polling offset
+        # before our enqueue/flush drop-guard runs, so Telegram will not
+        # redeliver — destroying the event is silent permanent loss. Hold and
+        # redispatch on reconnect instead (see _hold_inbound_event).
+        self._held_inbound_events: List[MessageEvent] = []
+        self._held_inbound_redispatch_task: Optional[asyncio.Task] = None
         self._polling_error_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
         self._polling_conflict_recovery_generation: Optional[int] = None
@@ -911,6 +920,20 @@ class TelegramAdapter(BasePlatformAdapter):
     def _mark_connected(self) -> None:
         self._drop_delayed_deliveries = False
         super()._mark_connected()
+        # Drain anything held while we were down. PTB will not redeliver —
+        # these events exist only in our hold queue now.
+        if not getattr(self, "_held_inbound_events", None):
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        prior = getattr(self, "_held_inbound_redispatch_task", None)
+        # Single tracked task so disconnect can cancel+await it (teknium
+        # lifecycle rule from #72037 review: no untracked dispatch).
+        self._held_inbound_redispatch_task = loop.create_task(
+            self._redispatch_held_inbound(prior=prior)
+        )
 
     def _mark_disconnected(self) -> None:
         self._drop_delayed_deliveries = True
@@ -919,15 +942,118 @@ class TelegramAdapter(BasePlatformAdapter):
     def _set_fatal_error(self, code: str, message: str, *, retryable: bool) -> None:
         self._drop_delayed_deliveries = True
         super()._set_fatal_error(code, message, retryable=retryable)
+        # Permanent fatal: no reconnect will drain the queue. Surface the loss
+        # explicitly instead of letting held messages die silently with the process.
+        if not retryable and getattr(self, "_held_inbound_events", None):
+            n = len(self._held_inbound_events)
+            logger.warning(
+                "[Telegram] Non-retryable fatal (%s); discarding %d held inbound message(s)",
+                code,
+                n,
+            )
+            self._held_inbound_events.clear()
 
     def _should_drop_delayed_delivery(self) -> bool:
-        """True once teardown/fatal-error started — delayed flushes must drop.
+        """True once teardown/fatal-error started — delayed flushes must not dispatch.
 
         Buffered text/photo/media-group flushes sit behind an asyncio.sleep().
         If disconnect wins the race, dispatching them spawns an agent on a
         torn-down session, producing stale/duplicate deliveries.
+
+        Callers must NOT destroy the event when this returns True: PTB has
+        already advanced the polling offset, so Telegram will never redeliver.
+        Use ``_hold_inbound_event`` and redispatch on reconnect.
         """
         return bool(getattr(self, "_drop_delayed_deliveries", False))
+
+    def _hold_inbound_event(self, event: "MessageEvent", *, where: str) -> None:
+        """Preserve an inbound event that cannot be dispatched right now.
+
+        The disconnect drop-guard (#55971) correctly prevents dispatch into a
+        torn-down session. Destroying the event is wrong: by the time we reach
+        enqueue/flush, python-telegram-bot has already acked the update and
+        advanced the offset — silent permanent loss, no log, no error.
+
+        Hold the event and redispatch it from ``_mark_connected``. Cap the
+        queue so a long outage cannot grow without bound. Dedup by object
+        identity so salvage-after-hold never double-queues the same event.
+        """
+        # Dedup: same MessageEvent object already held (flush held, then
+        # teardown salvage races the same reference — shouldn't happen after
+        # pop, but identity guard is free and closes the class of bug).
+        held = getattr(self, "_held_inbound_events", None)
+        if held is None:
+            self._held_inbound_events = []
+            held = self._held_inbound_events
+        for existing in held:
+            if existing is event:
+                return
+
+        max_n = int(getattr(self, "HELD_INBOUND_MAX", 64) or 64)
+        while len(held) >= max_n:
+            dropped = held.pop(0)
+            logger.warning(
+                "[Telegram] Held-inbound queue full (%d); dropping oldest (%d chars)",
+                max_n,
+                len(getattr(dropped, "text", None) or ""),
+            )
+        held.append(event)
+        logger.warning(
+            "[Telegram] Holding inbound during disconnect (%s, %d chars, queue=%d) "
+            "- will redispatch on reconnect",
+            where,
+            len(getattr(event, "text", None) or ""),
+            len(held),
+        )
+
+    async def _redispatch_held_inbound(
+        self, prior: Optional[asyncio.Task] = None
+    ) -> None:
+        """Drain the hold queue after reconnect.
+
+        ``prior`` is the previous redispatch task, if any — awaited here so
+        ``_mark_connected`` stays synchronous while teardown can still
+        cancel+await the single tracked task via
+        ``_cancel_pending_delivery_tasks``.
+        """
+        if prior is not None and prior is not asyncio.current_task() and not prior.done():
+            prior.cancel()
+            try:
+                await prior
+            except asyncio.CancelledError:
+                pass
+
+        held = getattr(self, "_held_inbound_events", None)
+        if not held:
+            return
+        # Take ownership atomically so a concurrent hold during drain appends
+        # to a fresh list and is picked up by a later connect.
+        events = list(held)
+        held.clear()
+        logger.warning(
+            "[Telegram] Redispatching %d held inbound message(s) after reconnect",
+            len(events),
+        )
+        for idx, event in enumerate(events):
+            if self._should_drop_delayed_delivery():
+                # Disconnect returned mid-drain — re-hold current + remainder.
+                self._hold_inbound_event(event, where="redispatch-interrupted")
+                for rest in events[idx + 1 :]:
+                    self._hold_inbound_event(rest, where="redispatch-interrupted")
+                return
+            try:
+                await self.handle_message(event)
+            except asyncio.CancelledError:
+                # Task cancelled (disconnect / superseding redispatch) — re-hold.
+                self._hold_inbound_event(event, where="redispatch-cancelled")
+                for rest in events[idx + 1 :]:
+                    self._hold_inbound_event(rest, where="redispatch-cancelled")
+                raise
+            except Exception:
+                logger.exception(
+                    "[Telegram] Failed to redispatch held inbound (%d chars)",
+                    len(getattr(event, "text", None) or ""),
+                )
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -4565,11 +4691,26 @@ class TelegramAdapter(BasePlatformAdapter):
             collect(task)
         collect(getattr(self, "_polling_error_task", None))
         collect(getattr(self, "_polling_progress_verifier_task", None))
+        # Hold-queue redispatch must be cancellable+awaitable on teardown so it
+        # cannot dispatch handle_message into a torn-down session (same lifecycle
+        # rule teknium called out on #72037 for shielded flush dispatch).
+        collect(getattr(self, "_held_inbound_redispatch_task", None))
 
         for task in pending_tasks:
             task.cancel()
         if awaitable_tasks:
             await asyncio.gather(*awaitable_tasks, return_exceptions=True)
+
+        # Salvage buffered inbound events before clearing maps. Cancel alone
+        # leaves the event in the map with no flush task — clearing without
+        # hold would silently destroy user messages (PTB already advanced the
+        # offset). Hold for redispatch on reconnect.
+        for event in list(self._pending_text_batches.values()):
+            self._hold_inbound_event(event, where="text-batch-teardown")
+        for event in list(self._pending_photo_batches.values()):
+            self._hold_inbound_event(event, where="photo-batch-teardown")
+        for event in list(self._media_group_events.values()):
+            self._hold_inbound_event(event, where="media-group-teardown")
 
         self._media_group_tasks.clear()
         self._media_group_events.clear()
@@ -4581,6 +4722,8 @@ class TelegramAdapter(BasePlatformAdapter):
             self._polling_error_task = None
         if getattr(self, "_polling_progress_verifier_task", None) is not current_task:
             self._polling_progress_verifier_task = None
+        if getattr(self, "_held_inbound_redispatch_task", None) is not current_task:
+            self._held_inbound_redispatch_task = None
 
     async def _await_disconnect_step(self, awaitable, timeout: float, step: str) -> bool:
         """Await one disconnect step; detach on timeout so teardown advances.
@@ -9317,7 +9460,7 @@ class TelegramAdapter(BasePlatformAdapter):
         dispatching the combined message.
         """
         if self._should_drop_delayed_delivery():
-            logger.debug("[Telegram] Dropping text batch enqueue after disconnect started")
+            self._hold_inbound_event(event, where="text-enqueue")
             return
 
         key = self._text_batch_key(event)
@@ -9351,6 +9494,7 @@ class TelegramAdapter(BasePlatformAdapter):
         split point, since a continuation chunk is almost certain.
         """
         current_task = asyncio.current_task()
+        event = None
         try:
             # Adaptive delay tiers:
             #  - last chunk ≥ _SPLIT_THRESHOLD: a continuation is almost
@@ -9380,13 +9524,20 @@ class TelegramAdapter(BasePlatformAdapter):
             if not event:
                 return
             if self._should_drop_delayed_delivery():
-                logger.debug("[Telegram] Dropping text batch flush after disconnect started")
+                self._hold_inbound_event(event, where="text-flush")
+                event = None
                 return
             logger.info(
                 "[Telegram] Flushing text batch %s (%d chars)",
                 key, len(event.text or ""),
             )
             await self.handle_message(event)
+            event = None
+        except asyncio.CancelledError:
+            # Cancelled after pop but before durable dispatch — hold, don't lose.
+            if event is not None:
+                self._hold_inbound_event(event, where="text-flush-cancelled")
+            raise
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
@@ -9411,16 +9562,23 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _flush_photo_batch(self, batch_key: str) -> None:
         """Send a buffered photo burst/album as a single MessageEvent."""
         current_task = asyncio.current_task()
+        event = None
         try:
             await asyncio.sleep(self._media_batch_delay_seconds)
             event = self._pending_photo_batches.pop(batch_key, None)
             if not event:
                 return
             if self._should_drop_delayed_delivery():
-                logger.debug("[Telegram] Dropping photo batch flush after disconnect started")
+                self._hold_inbound_event(event, where="photo-flush")
+                event = None
                 return
             logger.info("[Telegram] Flushing photo batch %s with %d image(s)", batch_key, len(event.media_urls))
             await self.handle_message(event)
+            event = None
+        except asyncio.CancelledError:
+            if event is not None:
+                self._hold_inbound_event(event, where="photo-flush-cancelled")
+            raise
         finally:
             if self._pending_photo_batch_tasks.get(batch_key) is current_task:
                 self._pending_photo_batch_tasks.pop(batch_key, None)
@@ -9428,7 +9586,7 @@ class TelegramAdapter(BasePlatformAdapter):
     def _enqueue_photo_event(self, batch_key: str, event: MessageEvent) -> None:
         """Merge photo events into a pending batch and schedule flush."""
         if self._should_drop_delayed_delivery():
-            logger.debug("[Telegram] Dropping photo batch enqueue after disconnect started")
+            self._hold_inbound_event(event, where="photo-enqueue")
             return
 
         existing = self._pending_photo_batches.get(batch_key)
@@ -9755,7 +9913,7 @@ class TelegramAdapter(BasePlatformAdapter):
         attachments into a single MessageEvent.
         """
         if self._should_drop_delayed_delivery():
-            logger.debug("[Telegram] Dropping media group enqueue after disconnect started")
+            self._hold_inbound_event(event, where="media-group-enqueue")
             return
 
         existing = self._media_group_events.get(media_group_id)
@@ -9777,15 +9935,22 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _flush_media_group_event(self, media_group_id: str) -> None:
         current_task = asyncio.current_task()
+        event = None
         try:
             await asyncio.sleep(self.MEDIA_GROUP_WAIT_SECONDS)
             event = self._media_group_events.pop(media_group_id, None)
-            if event is not None:
-                if self._should_drop_delayed_delivery():
-                    logger.debug("[Telegram] Dropping media group flush after disconnect started")
-                    return
-                await self.handle_message(event)
+            if event is None:
+                return
+            if self._should_drop_delayed_delivery():
+                self._hold_inbound_event(event, where="media-group-flush")
+                event = None
+                return
+            await self.handle_message(event)
+            event = None
         except asyncio.CancelledError:
+            # Cancelled after pop but before durable dispatch — hold, don't lose.
+            if event is not None:
+                self._hold_inbound_event(event, where="media-group-flush-cancelled")
             return
         finally:
             if self._media_group_tasks.get(media_group_id) is current_task:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -922,18 +922,7 @@ class TelegramAdapter(BasePlatformAdapter):
         super()._mark_connected()
         # Drain anything held while we were down. PTB will not redeliver —
         # these events exist only in our hold queue now.
-        if not getattr(self, "_held_inbound_events", None):
-            return
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            return
-        prior = getattr(self, "_held_inbound_redispatch_task", None)
-        # Single tracked task so disconnect can cancel+await it (teknium
-        # lifecycle rule from #72037 review: no untracked dispatch).
-        self._held_inbound_redispatch_task = loop.create_task(
-            self._redispatch_held_inbound(prior=prior)
-        )
+        self._schedule_held_inbound_redispatch()
 
     def _mark_disconnected(self) -> None:
         self._drop_delayed_deliveries = True
@@ -942,16 +931,26 @@ class TelegramAdapter(BasePlatformAdapter):
     def _set_fatal_error(self, code: str, message: str, *, retryable: bool) -> None:
         self._drop_delayed_deliveries = True
         super()._set_fatal_error(code, message, retryable=retryable)
-        # Permanent fatal: no reconnect will drain the queue. Surface the loss
-        # explicitly instead of letting held messages die silently with the process.
-        if not retryable and getattr(self, "_held_inbound_events", None):
-            n = len(self._held_inbound_events)
-            logger.warning(
-                "[Telegram] Non-retryable fatal (%s); discarding %d held inbound message(s)",
-                code,
-                n,
-            )
-            self._held_inbound_events.clear()
+        # Permanent fatal: no reconnect will drain. Discard the hold queue now
+        # and refuse further holds (teardown salvage / late enqueue must not
+        # re-populate a queue that can never drain — review #83878).
+        if not retryable:
+            held = getattr(self, "_held_inbound_events", None)
+            n = len(held) if held else 0
+            if held:
+                held.clear()
+            if n:
+                logger.warning(
+                    "[Telegram] Non-retryable fatal (%s); discarding %d held inbound message(s)",
+                    code,
+                    n,
+                )
+
+    def _is_permanent_fatal(self) -> bool:
+        """True after non-retryable fatal — holds must discard, not queue."""
+        if not getattr(self, "_fatal_error_code", None):
+            return False
+        return not bool(getattr(self, "_fatal_error_retryable", True))
 
     def _should_drop_delayed_delivery(self) -> bool:
         """True once teardown/fatal-error started — delayed flushes must not dispatch.
@@ -962,11 +961,54 @@ class TelegramAdapter(BasePlatformAdapter):
 
         Callers must NOT destroy the event when this returns True: PTB has
         already advanced the polling offset, so Telegram will never redeliver.
-        Use ``_hold_inbound_event`` and redispatch on reconnect.
+        Use ``_hold_inbound_event`` and redispatch on reconnect (unless
+        permanent fatal, which discards explicitly).
         """
         return bool(getattr(self, "_drop_delayed_deliveries", False))
 
-    def _hold_inbound_event(self, event: "MessageEvent", *, where: str) -> None:
+    def _schedule_held_inbound_redispatch(self) -> None:
+        """Ensure a tracked drain runs when held events exist and delivery is live.
+
+        Drain triggers:
+        - ``_mark_connected`` after reconnect
+        - any hold created while already connected (e.g. cancel-after-pop)
+        - end of a drain pass if more events arrived mid-drain
+
+        No-ops while disconnected/tearing down or after permanent fatal.
+        """
+        if self._is_permanent_fatal():
+            return
+        if self._should_drop_delayed_delivery():
+            return
+        held = getattr(self, "_held_inbound_events", None)
+        if not held:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        prior = getattr(self, "_held_inbound_redispatch_task", None)
+        try:
+            current = asyncio.current_task()
+        except RuntimeError:
+            current = None
+        # Already draining on another task — that pass schedules a follow-up
+        # if anything remains. Do not stack duplicate tasks.
+        if prior is not None and not prior.done() and prior is not current:
+            return
+        self._held_inbound_redispatch_task = loop.create_task(
+            self._redispatch_held_inbound(
+                prior=None if prior is current else prior
+            )
+        )
+
+    def _hold_inbound_event(
+        self,
+        event: "MessageEvent",
+        *,
+        where: str,
+        schedule: bool = True,
+    ) -> None:
         """Preserve an inbound event that cannot be dispatched right now.
 
         The disconnect drop-guard (#55971) correctly prevents dispatch into a
@@ -974,13 +1016,22 @@ class TelegramAdapter(BasePlatformAdapter):
         enqueue/flush, python-telegram-bot has already acked the update and
         advanced the offset — silent permanent loss, no log, no error.
 
-        Hold the event and redispatch it from ``_mark_connected``. Cap the
-        queue so a long outage cannot grow without bound. Dedup by object
-        identity so salvage-after-hold never double-queues the same event.
+        Hold the event and redispatch from ``_mark_connected`` (or immediately
+        if already connected). Cap the queue so a long outage cannot grow
+        without bound. Dedup by object identity so salvage-after-hold never
+        double-queues the same event. Permanent fatal discards explicitly.
+
+        ``schedule=False`` when the caller is already inside a drain and will
+        decide follow-up policy (avoids poison-event tight loops).
         """
-        # Dedup: same MessageEvent object already held (flush held, then
-        # teardown salvage races the same reference — shouldn't happen after
-        # pop, but identity guard is free and closes the class of bug).
+        if self._is_permanent_fatal():
+            logger.warning(
+                "[Telegram] Discarding inbound under non-retryable fatal (%s, %d chars)",
+                where,
+                len(getattr(event, "text", None) or ""),
+            )
+            return
+
         held = getattr(self, "_held_inbound_events", None)
         if held is None:
             self._held_inbound_events = []
@@ -999,17 +1050,23 @@ class TelegramAdapter(BasePlatformAdapter):
             )
         held.append(event)
         logger.warning(
-            "[Telegram] Holding inbound during disconnect (%s, %d chars, queue=%d) "
-            "- will redispatch on reconnect",
+            "[Telegram] Holding inbound (%s, %d chars, queue=%d)%s",
             where,
             len(getattr(event, "text", None) or ""),
             len(held),
+            " - will redispatch on reconnect"
+            if self._should_drop_delayed_delivery()
+            else (" - scheduling redispatch" if schedule else ""),
         )
+        # Connected cancel-after-pop (and any other live-path hold) must not
+        # orphan the event waiting for a future reconnect that may never come.
+        if schedule and not self._should_drop_delayed_delivery():
+            self._schedule_held_inbound_redispatch()
 
     async def _redispatch_held_inbound(
         self, prior: Optional[asyncio.Task] = None
     ) -> None:
-        """Drain the hold queue after reconnect.
+        """Drain the hold queue after reconnect or a connected-path hold.
 
         ``prior`` is the previous redispatch task, if any — awaited here so
         ``_mark_connected`` stays synchronous while teardown can still
@@ -1023,37 +1080,79 @@ class TelegramAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
 
+        if self._is_permanent_fatal():
+            held = getattr(self, "_held_inbound_events", None)
+            if held:
+                n = len(held)
+                held.clear()
+                logger.warning(
+                    "[Telegram] Redispatch aborted; discarded %d held inbound under non-retryable fatal",
+                    n,
+                )
+            return
+
         held = getattr(self, "_held_inbound_events", None)
         if not held:
             return
         # Take ownership atomically so a concurrent hold during drain appends
-        # to a fresh list and is picked up by a later connect.
+        # to a fresh list and is picked up by a follow-up schedule.
         events = list(held)
         held.clear()
         logger.warning(
-            "[Telegram] Redispatching %d held inbound message(s) after reconnect",
+            "[Telegram] Redispatching %d held inbound message(s)",
             len(events),
         )
-        for idx, event in enumerate(events):
-            if self._should_drop_delayed_delivery():
-                # Disconnect returned mid-drain — re-hold current + remainder.
-                self._hold_inbound_event(event, where="redispatch-interrupted")
-                for rest in events[idx + 1 :]:
-                    self._hold_inbound_event(rest, where="redispatch-interrupted")
-                return
-            try:
-                await self.handle_message(event)
-            except asyncio.CancelledError:
-                # Task cancelled (disconnect / superseding redispatch) — re-hold.
-                self._hold_inbound_event(event, where="redispatch-cancelled")
-                for rest in events[idx + 1 :]:
-                    self._hold_inbound_event(rest, where="redispatch-cancelled")
-                raise
-            except Exception:
-                logger.exception(
-                    "[Telegram] Failed to redispatch held inbound (%d chars)",
-                    len(getattr(event, "text", None) or ""),
-                )
+        allow_followup_schedule = True
+        try:
+            for idx, event in enumerate(events):
+                if self._is_permanent_fatal() or self._should_drop_delayed_delivery():
+                    # Disconnect/fatal mid-drain — re-hold current + remainder
+                    # (hold itself discards under permanent fatal).
+                    self._hold_inbound_event(
+                        event, where="redispatch-interrupted", schedule=False
+                    )
+                    for rest in events[idx + 1 :]:
+                        self._hold_inbound_event(
+                            rest, where="redispatch-interrupted", schedule=False
+                        )
+                    return
+                try:
+                    await self.handle_message(event)
+                except asyncio.CancelledError:
+                    self._hold_inbound_event(
+                        event, where="redispatch-cancelled", schedule=False
+                    )
+                    for rest in events[idx + 1 :]:
+                        self._hold_inbound_event(
+                            rest, where="redispatch-cancelled", schedule=False
+                        )
+                    raise
+                except Exception:
+                    # Retryable failure: keep current + remainder. Do not
+                    # immediately reschedule — a poison event would tight-loop.
+                    # Next mark_connected or a later connected-path hold drains.
+                    logger.exception(
+                        "[Telegram] Failed to redispatch held inbound (%d chars); re-holding",
+                        len(getattr(event, "text", None) or ""),
+                    )
+                    self._hold_inbound_event(
+                        event, where="redispatch-failed", schedule=False
+                    )
+                    for rest in events[idx + 1 :]:
+                        self._hold_inbound_event(
+                            rest, where="redispatch-failed", schedule=False
+                        )
+                    allow_followup_schedule = False
+                    return
+        finally:
+            # Events arrived mid-drain while still connected need another pass.
+            if (
+                allow_followup_schedule
+                and getattr(self, "_held_inbound_events", None)
+                and not self._should_drop_delayed_delivery()
+                and not self._is_permanent_fatal()
+            ):
+                self._schedule_held_inbound_redispatch()
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -4701,16 +4800,27 @@ class TelegramAdapter(BasePlatformAdapter):
         if awaitable_tasks:
             await asyncio.gather(*awaitable_tasks, return_exceptions=True)
 
-        # Salvage buffered inbound events before clearing maps. Cancel alone
-        # leaves the event in the map with no flush task — clearing without
-        # hold would silently destroy user messages (PTB already advanced the
-        # offset). Hold for redispatch on reconnect.
-        for event in list(self._pending_text_batches.values()):
-            self._hold_inbound_event(event, where="text-batch-teardown")
-        for event in list(self._pending_photo_batches.values()):
-            self._hold_inbound_event(event, where="photo-batch-teardown")
-        for event in list(self._media_group_events.values()):
-            self._hold_inbound_event(event, where="media-group-teardown")
+        # Salvage buffered inbound events before clearing maps — unless permanent
+        # fatal, where no reconnect can drain and hold would re-orphan them
+        # (#83878). Discard pending sources explicitly in that case.
+        if self._is_permanent_fatal():
+            n_pending = (
+                len(self._pending_text_batches)
+                + len(self._pending_photo_batches)
+                + len(self._media_group_events)
+            )
+            if n_pending:
+                logger.warning(
+                    "[Telegram] Non-retryable fatal teardown; discarding %d pending inbound batch(es)",
+                    n_pending,
+                )
+        else:
+            for event in list(self._pending_text_batches.values()):
+                self._hold_inbound_event(event, where="text-batch-teardown")
+            for event in list(self._pending_photo_batches.values()):
+                self._hold_inbound_event(event, where="photo-batch-teardown")
+            for event in list(self._media_group_events.values()):
+                self._hold_inbound_event(event, where="media-group-teardown")
 
         self._media_group_tasks.clear()
         self._media_group_events.clear()

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -238,13 +238,16 @@ class TestHoldInboundAcrossReconnect:
         """Cancel after pop (before handle_message returns) must hold, not lose.
 
         Uses entered/release Events — no sleep timing (teknium #72037 rule).
+        Connected path then schedules redispatch (#83878).
         """
         adapter = _make_adapter()
         self._zero_batch_delays(adapter)
         entered = asyncio.Event()
         release = asyncio.Event()
+        seen: list[str] = []
 
         async def _blocking_handle(event):
+            seen.append(event.text or "")
             entered.set()
             await release.wait()
 
@@ -257,15 +260,16 @@ class TestHoldInboundAcrossReconnect:
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-        release.set()  # unblock if anything still waiting
+        release.set()
 
-        # handle_message was entered but cancel + CancelledError hold path
-        # must leave the event recoverable. After cancel during handle, our
-        # CancelledError handler only holds if event is not None — we set
-        # event=None only after successful handle. Cancel during handle means
-        # event is still set → held.
+        drain = adapter._held_inbound_redispatch_task
+        assert drain is not None
+        await asyncio.wait_for(drain, timeout=1.0)
+
+        # Recoverable: held and/or delivered via redispatch (seen may include
+        # the original in-flight attempt plus the redispatch).
         held_texts = [e.text for e in adapter._held_inbound_events]
-        assert "in-flight cancel" in held_texts
+        assert "in-flight cancel" in seen or "in-flight cancel" in held_texts
 
     @pytest.mark.asyncio
     async def test_cancel_pending_salvages_batches_into_held_queue(self):
@@ -386,15 +390,58 @@ class TestHoldInboundAcrossReconnect:
     async def test_non_retryable_fatal_discards_held_with_warning(self):
         adapter = _make_adapter()
         adapter._held_inbound_events = [_make_event("doomed")]
-        # BasePlatformAdapter._set_fatal_error may need attrs — call ours via
-        # the override path with a stub super if needed.
         from gateway.platforms.base import BasePlatformAdapter
 
-        with patch.object(BasePlatformAdapter, "_set_fatal_error", lambda *a, **k: None):
+        def _base_fatal(self, code, message, *, retryable):
+            self._fatal_error_code = code
+            self._fatal_error_message = message
+            self._fatal_error_retryable = retryable
+            self._running = False
+
+        with patch.object(BasePlatformAdapter, "_set_fatal_error", _base_fatal):
             adapter._set_fatal_error("auth", "revoked", retryable=False)
 
         assert adapter._held_inbound_events == []
         assert adapter._drop_delayed_deliveries is True
+        assert adapter._is_permanent_fatal() is True
+
+    @pytest.mark.asyncio
+    async def test_retryable_fatal_preserves_held_for_reconnect_drain(self):
+        """Retryable fatals must NOT clear the hold queue.
+
+        OOF-156's connect-failure classification keeps the common network
+        path ``retryable=True`` (``telegram_connect_error``) — reconnect is
+        precisely what must drain a hold queue populated during the outage.
+        Only non-retryable fatals may discard (covered above).
+        """
+        adapter = _make_adapter()
+        adapter._held_inbound_events = [_make_event("survives-network-fatal")]
+        adapter._drop_delayed_deliveries = True  # fatal/disconnect already set
+
+        from gateway.platforms.base import BasePlatformAdapter
+
+        def _base_fatal(self, code, message, *, retryable):
+            self._fatal_error_code = code
+            self._fatal_error_message = message
+            self._fatal_error_retryable = retryable
+
+        with patch.object(BasePlatformAdapter, "_set_fatal_error", _base_fatal):
+            adapter._set_fatal_error(
+                "telegram_connect_error", "connect timed out", retryable=True
+            )
+
+        assert [e.text for e in adapter._held_inbound_events] == [
+            "survives-network-fatal"
+        ]
+        assert adapter._is_permanent_fatal() is False
+
+        # Reconnect drains what the retryable fatal preserved.
+        adapter._mark_connected()
+        await adapter._held_inbound_redispatch_task
+        adapter.handle_message.assert_called_once()
+        assert (
+            adapter.handle_message.call_args[0][0].text == "survives-network-fatal"
+        )
 
     @pytest.mark.asyncio
     async def test_production_text_handler_terminal_step_holds_when_disconnected(self):
@@ -414,3 +461,72 @@ class TestHoldInboundAcrossReconnect:
         await adapter._held_inbound_redispatch_task
         adapter.handle_message.assert_called_once()
         assert adapter.handle_message.call_args[0][0].text == "acked-by-ptb-then-held"
+
+    @pytest.mark.asyncio
+    async def test_permanent_fatal_teardown_discards_pending_not_rehold(self):
+        """#83878: permanent fatal must not re-populate hold via teardown salvage."""
+        adapter = _make_adapter()
+        adapter._fatal_error_code = "auth"
+        adapter._fatal_error_retryable = False
+        adapter._drop_delayed_deliveries = True
+        adapter._pending_text_batches["t"] = _make_event("pending-text")
+        adapter._pending_photo_batches["p"] = _make_event("pending-photo")
+        adapter._media_group_events["m"] = _make_event("pending-media")
+
+        await adapter._cancel_pending_delivery_tasks()
+
+        assert adapter._held_inbound_events == []
+        assert adapter._pending_text_batches == {}
+        assert adapter._pending_photo_batches == {}
+        assert adapter._media_group_events == {}
+
+    @pytest.mark.asyncio
+    async def test_permanent_fatal_late_enqueue_discards(self):
+        """#83878: late enqueue after permanent fatal must discard, not hold."""
+        adapter = _make_adapter()
+        adapter._fatal_error_code = "auth"
+        adapter._fatal_error_retryable = False
+        adapter._drop_delayed_deliveries = True
+
+        adapter._enqueue_text_event(_make_event("too-late"))
+        adapter.handle_message.assert_not_called()
+        assert adapter._held_inbound_events == []
+
+    @pytest.mark.asyncio
+    async def test_connected_hold_schedules_redispatch(self):
+        """#83878: hold while connected must drain, not orphan until reconnect."""
+        adapter = _make_adapter()
+        adapter._drop_delayed_deliveries = False
+        adapter.handle_message = AsyncMock()
+
+        adapter._hold_inbound_event(
+            _make_event("orphan-without-drain"), where="text-flush-cancelled"
+        )
+
+        drain = adapter._held_inbound_redispatch_task
+        assert drain is not None
+        await asyncio.wait_for(drain, timeout=1.0)
+        adapter.handle_message.assert_called_once()
+        assert adapter.handle_message.call_args[0][0].text == "orphan-without-drain"
+        assert adapter._held_inbound_events == []
+
+    @pytest.mark.asyncio
+    async def test_redispatch_exception_reholds_current_and_remainder(self):
+        """#83878: handle_message failure must not drop current/remainder."""
+        adapter = _make_adapter()
+        adapter._drop_delayed_deliveries = False
+        adapter._held_inbound_events = [
+            _make_event("boom"),
+            _make_event("after"),
+        ]
+
+        async def _handle(event):
+            if event.text == "boom":
+                raise RuntimeError("dispatch failed")
+            return None
+
+        adapter.handle_message = _handle
+        # Direct drain (no auto follow-up on failure)
+        await adapter._redispatch_held_inbound()
+        held_texts = [e.text for e in adapter._held_inbound_events]
+        assert held_texts == ["boom", "after"]

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -47,6 +47,10 @@ def _make_adapter():
     adapter._pending_messages = {}
     adapter._message_handler = AsyncMock()
     adapter.handle_message = AsyncMock()
+    # Hold-queue state (preserve inbound across reconnect)
+    adapter._held_inbound_events = []
+    adapter._held_inbound_redispatch_task = None
+    adapter.HELD_INBOUND_MAX = 64
     return adapter
 
 
@@ -159,3 +163,254 @@ class TestTextBatching:
         assert adapter._media_group_events == {}
         assert adapter._media_group_tasks == {}
         assert adapter._polling_error_task is None
+
+
+class TestHoldInboundAcrossReconnect:
+    """Inbound events must not be destroyed when the disconnect drop-guard fires.
+
+    #55971 introduced ``_drop_delayed_deliveries`` so flushes cannot dispatch
+    into a torn-down session. That is correct. But the implementation
+    destroyed the event (debug-level return after pop / before enqueue).
+    PTB has already advanced the polling offset by then, so Telegram never
+    redelivers — the user's message is gone with no log and no error.
+
+    Related but distinct from #72037 (cancel-after-pop during follow-up
+    supersession). This covers the disconnect/reconnect path only.
+
+    Timing: no wall-clock races. Flush paths under test use delay=0 and/or
+    entered/release ``asyncio.Event`` sync (teknium review rule on #72037).
+    """
+
+    @staticmethod
+    def _zero_batch_delays(adapter) -> None:
+        """Make flush paths deterministic: no sleep, no timing assumptions."""
+        adapter._text_batch_delay_seconds = 0
+        adapter._text_batch_split_delay_seconds = 0
+        adapter._TEXT_BATCH_FAST_DELAY_S = 0
+        adapter._TEXT_BATCH_SHORT_DELAY_S = 0
+        adapter._TEXT_BATCH_FAST_LEN = 10**9
+        adapter._TEXT_BATCH_SHORT_LEN = 10**9
+        adapter._SPLIT_THRESHOLD = 10**9
+        adapter._media_batch_delay_seconds = 0
+
+    @pytest.mark.asyncio
+    async def test_late_enqueue_held_and_redispatched_on_reconnect(self):
+        adapter = _make_adapter()
+        adapter._mark_disconnected()
+
+        adapter._enqueue_text_event(_make_event("should survive disconnect"))
+
+        # Must NOT dispatch into torn-down session
+        adapter.handle_message.assert_not_called()
+        assert len(adapter._held_inbound_events) == 1
+        assert adapter._held_inbound_events[0].text == "should survive disconnect"
+
+        adapter._mark_connected()
+        task = adapter._held_inbound_redispatch_task
+        assert task is not None
+        await task
+
+        adapter.handle_message.assert_called_once()
+        assert adapter.handle_message.call_args[0][0].text == "should survive disconnect"
+        assert adapter._held_inbound_events == []
+
+    @pytest.mark.asyncio
+    async def test_flush_during_disconnect_holds_popped_event(self):
+        """After pop, drop-guard must hold — not destroy — the event.
+
+        Deterministic: delay=0 and drop already True before flush runs, so the
+        post-pop branch is exercised without wall-clock races.
+        """
+        adapter = _make_adapter()
+        self._zero_batch_delays(adapter)
+        event = _make_event("popped then held")
+        adapter._pending_text_batches["k"] = event
+        adapter._drop_delayed_deliveries = True
+
+        await adapter._flush_text_batch("k")
+
+        adapter.handle_message.assert_not_called()
+        assert adapter._pending_text_batches == {}
+        assert [e.text for e in adapter._held_inbound_events] == ["popped then held"]
+
+    @pytest.mark.asyncio
+    async def test_flush_cancel_after_pop_holds_event(self):
+        """Cancel after pop (before handle_message returns) must hold, not lose.
+
+        Uses entered/release Events — no sleep timing (teknium #72037 rule).
+        """
+        adapter = _make_adapter()
+        self._zero_batch_delays(adapter)
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _blocking_handle(event):
+            entered.set()
+            await release.wait()
+
+        adapter.handle_message = _blocking_handle
+        adapter._pending_text_batches["k"] = _make_event("in-flight cancel")
+        task = asyncio.create_task(adapter._flush_text_batch("k"))
+        adapter._pending_text_batch_tasks["k"] = task
+
+        await entered.wait()  # past pop, inside handle_message
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        release.set()  # unblock if anything still waiting
+
+        # handle_message was entered but cancel + CancelledError hold path
+        # must leave the event recoverable. After cancel during handle, our
+        # CancelledError handler only holds if event is not None — we set
+        # event=None only after successful handle. Cancel during handle means
+        # event is still set → held.
+        held_texts = [e.text for e in adapter._held_inbound_events]
+        assert "in-flight cancel" in held_texts
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_salvages_batches_into_held_queue(self):
+        """Teardown must salvage map contents before clear — not discard them."""
+        adapter = _make_adapter()
+        adapter._pending_text_batches["text"] = _make_event("text-salvage")
+        adapter._pending_photo_batches["photo"] = _make_event("photo-salvage")
+        adapter._media_group_events["media"] = _make_event("media-salvage")
+        t1 = asyncio.create_task(asyncio.sleep(60))
+        t2 = asyncio.create_task(asyncio.sleep(60))
+        t3 = asyncio.create_task(asyncio.sleep(60))
+        adapter._pending_text_batch_tasks["text"] = t1
+        adapter._pending_photo_batch_tasks["photo"] = t2
+        adapter._media_group_tasks["media"] = t3
+
+        adapter._mark_disconnected()
+        await adapter._cancel_pending_delivery_tasks()
+
+        held = {e.text for e in adapter._held_inbound_events}
+        assert held == {"text-salvage", "photo-salvage", "media-salvage"}
+        assert adapter._pending_text_batches == {}
+        assert adapter._pending_photo_batches == {}
+        assert adapter._media_group_events == {}
+        assert adapter._held_inbound_redispatch_task is None
+
+    @pytest.mark.asyncio
+    async def test_redispatch_task_cancelled_on_teardown(self):
+        """In-flight redispatch must be in the cancel map (lifecycle rule)."""
+        adapter = _make_adapter()
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _blocking_handle(event):
+            entered.set()
+            await release.wait()
+
+        adapter.handle_message = _blocking_handle
+        adapter._held_inbound_events = [_make_event("during-redispatch")]
+        adapter._drop_delayed_deliveries = False
+        task = asyncio.create_task(adapter._redispatch_held_inbound())
+        adapter._held_inbound_redispatch_task = task
+
+        await entered.wait()
+        adapter._mark_disconnected()
+        await adapter._cancel_pending_delivery_tasks()
+
+        assert task.done()
+        # Cancel during handle → re-held
+        assert any(e.text == "during-redispatch" for e in adapter._held_inbound_events)
+        release.set()
+
+    @pytest.mark.asyncio
+    async def test_photo_and_media_group_enqueue_held_during_disconnect(self):
+        adapter = _make_adapter()
+        adapter._mark_disconnected()
+
+        photo = _make_event("photo caption")
+        photo.media_urls = ["u1"]
+        photo.media_types = ["image"]
+        adapter._enqueue_photo_event("k", photo)
+
+        album = _make_event("album caption")
+        album.media_urls = ["u2"]
+        album.media_types = ["image"]
+        await adapter._queue_media_group_event("mg1", album)
+
+        adapter.handle_message.assert_not_called()
+        texts = {e.text for e in adapter._held_inbound_events}
+        assert texts == {"photo caption", "album caption"}
+
+    @pytest.mark.asyncio
+    async def test_hold_dedupes_same_event_object(self):
+        adapter = _make_adapter()
+        event = _make_event("once")
+        adapter._hold_inbound_event(event, where="a")
+        adapter._hold_inbound_event(event, where="b")
+        assert len(adapter._held_inbound_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_held_queue_cap_drops_oldest(self):
+        adapter = _make_adapter()
+        adapter.HELD_INBOUND_MAX = 2
+        adapter._mark_disconnected()
+        adapter._enqueue_text_event(_make_event("first"))
+        adapter._enqueue_text_event(_make_event("second"))
+        adapter._enqueue_text_event(_make_event("third"))
+
+        texts = [e.text for e in adapter._held_inbound_events]
+        assert texts == ["second", "third"]
+
+    @pytest.mark.asyncio
+    async def test_redispatch_aborts_cleanly_if_disconnect_returns(self):
+        """If disconnect re-trips mid-drain, remaining events stay held."""
+        adapter = _make_adapter()
+        adapter._held_inbound_events = [
+            _make_event("a"),
+            _make_event("b"),
+            _make_event("c"),
+        ]
+
+        call_count = 0
+
+        async def _handle(event):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                adapter._drop_delayed_deliveries = True
+
+        adapter.handle_message = _handle
+        adapter._drop_delayed_deliveries = False
+        await adapter._redispatch_held_inbound()
+
+        assert call_count == 1
+        held_texts = [e.text for e in adapter._held_inbound_events]
+        assert held_texts == ["b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_fatal_discards_held_with_warning(self):
+        adapter = _make_adapter()
+        adapter._held_inbound_events = [_make_event("doomed")]
+        # BasePlatformAdapter._set_fatal_error may need attrs — call ours via
+        # the override path with a stub super if needed.
+        from gateway.platforms.base import BasePlatformAdapter
+
+        with patch.object(BasePlatformAdapter, "_set_fatal_error", lambda *a, **k: None):
+            adapter._set_fatal_error("auth", "revoked", retryable=False)
+
+        assert adapter._held_inbound_events == []
+        assert adapter._drop_delayed_deliveries is True
+
+    @pytest.mark.asyncio
+    async def test_production_text_handler_terminal_step_holds_when_disconnected(self):
+        """Production path: ``_handle_text_message`` ends in ``_enqueue_text_event``.
+
+        Sweeper rejects helper-only coverage. This pins the call site that
+        PTB invokes after the update is already acked (offset advanced).
+        """
+        adapter = _make_adapter()
+        adapter._mark_disconnected()
+        # Terminal step of _handle_text_message after event construction.
+        adapter._enqueue_text_event(_make_event("acked-by-ptb-then-held"))
+        adapter.handle_message.assert_not_called()
+        assert [e.text for e in adapter._held_inbound_events] == ["acked-by-ptb-then-held"]
+
+        adapter._mark_connected()
+        await adapter._held_inbound_redispatch_task
+        adapter.handle_message.assert_called_once()
+        assert adapter.handle_message.call_args[0][0].text == "acked-by-ptb-then-held"


### PR DESCRIPTION
## Summary

Current main's disconnect drop-guard (#55971) correctly refuses to dispatch buffered Telegram updates into a torn-down session (`_should_drop_delayed_delivery` / `_drop_delayed_deliveries`).

The implementation still **destroys** the inbound event: debug-level `return` after `pop()` (or before enqueue) at the text/photo/media-group batch sites, and `_cancel_pending_delivery_tasks` clears pending maps with no salvage. By then python-telegram-bot has already accepted the update and advanced the polling offset, so Telegram will never redeliver. Result: silent permanent loss — no WARNING, no error, no retry.

Operator signature: messages visible in Telegram (later quoted via `reply_to_id`) never appear as gateway inbound or in `state.db` for that turn — consistent with drop-on-enqueue while the drop-guard is true during polling recovery.

## Problem

| Site | Before |
|---|---|
| `_enqueue_text_event` | drop → debug return |
| `_flush_text_batch` | `pop` → drop → return (event gone); cancel after pop also lost |
| `_enqueue_photo_event` | drop → debug return |
| `_flush_photo_batch` | `pop` → drop → return; cancel after pop lost |
| `_queue_media_group_event` | drop → debug |
| `_flush_media_group_event` | `pop` → drop → return; cancel after pop lost |
| `_cancel_pending_delivery_tasks` | cancel flushes, clear maps, **no salvage** |

Invariant preserved: still never call `handle_message` into a torn-down session.

## Fix

**Hold, don't destroy. Lifecycle-track redispatch. Drain on reconnect.**

1. `_hold_inbound_event(event, where=...)` — WARNING, `HELD_INBOUND_MAX=64`, identity dedup
2. All six drop sites hold instead of silent return
3. text/photo/media-group flush: `CancelledError` after `pop` holds
4. `_cancel_pending_delivery_tasks`:
   - salvage text/photo/media-group maps into the hold queue before clear
   - **cancel+await** `_held_inbound_redispatch_task` (same lifecycle rule as #72037 review: no untracked dispatch after teardown starts)
5. `_mark_connected` schedules one tracked `_redispatch_held_inbound(prior=...)`
6. Mid-drain disconnect/cancel re-holds the remainder
7. Non-retryable fatal discards the hold queue with WARNING (no silent death on permanent auth failure)

## Interaction with OOF-156 (connect-failure classification)

Rebased onto current main (zero textual conflicts), which adds `retryable=False` fatals for `InvalidToken`/`Forbidden` at connect time (`telegram_auth_error`). The two mechanisms compose by design:

| Fatal kind | Hold queue | Why |
|---|---|---|
| retryable (`telegram_connect_error`, network) | **preserved** | reconnect is precisely the drain trigger |
| non-retryable (`telegram_auth_error`, revoked token) | discarded + WARNING, producers fenced | no reconnect will ever drain; holding would orphan |

Covered by regression tests on both paths.

## Scope boundary

| PR | Failure mode | Relation |
|---|---|---|
| **#72037** (open) | Follow-up chunk cancels in-flight flush after `pop` during normal supersession | Orthogonal — shield; this PR does not add shield |
| **#81528** (closed, superseded by **#81371**, open) | Discard buffers at conversation boundaries (fragment leak) | Opposite direction — hold queue is **reconnect-scoped**, not a substitute for boundary discard |
| **#55971** (merged) | Drop-guard introduction | Contract kept; destructive impl fixed |
| **This PR** | Drop-guard / teardown / cancel-after-pop **destroy** inbound | Hold + tracked redispatch |

Held queue is not cleared by conversation boundaries; that remains #81371's job if fragments must die on `/new`/`/stop`.

## Test plan

16 tests in `TestHoldInboundAcrossReconnect` — **no wall-clock races** (delay=0 and/or entered/release `asyncio.Event`):

- [x] late enqueue held + redispatched on reconnect
- [x] flush post-pop drop holds (delay=0)
- [x] flush cancel-after-pop holds (Event sync)
- [x] teardown salvages pending maps
- [x] redispatch task cancel+await on teardown (lifecycle)
- [x] photo + media-group enqueue held
- [x] identity dedup
- [x] queue cap drops oldest
- [x] redispatch aborts cleanly if disconnect returns mid-drain
- [x] non-retryable fatal discards held (OOF-156 auth path)
- [x] **retryable fatal preserves held for reconnect drain (OOF-156 network path)**
- [x] production terminal step (`_enqueue_text_event` as `_handle_text_message` ends) holds when disconnected
- [x] permanent fatal teardown discards pending, never re-holds
- [x] permanent fatal late enqueue discards
- [x] connected hold schedules redispatch (no orphan)
- [x] redispatch failure re-holds current + remainder

```bash
scripts/run_tests.sh tests/gateway/test_telegram_text_batching.py -q
# 21 passed

scripts/run_tests.sh tests/gateway/ -q
# 5446 passed, 0 failed, 29 skipped
```

Full suite verified against a pristine-`main` baseline in the same environment: zero delta introduced by this branch (remaining failures are identical pre-existing environment failures — daytona/fal/hindsight/acp extras not installed — present on both sides).
