### PR TITLE
fix(telegram): restore log messages and redact error in polling error_callback

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4158,12 +4158,18 @@ class TelegramAdapter(BasePlatformAdapter):
                         self._background_tasks.add(self._polling_error_task)
                         self._polling_error_task.add_done_callback(self._background_tasks.discard)
                     elif self._looks_like_network_error(error):
-                        logger.warning("[%s] Telegram network _redact_telegram_error_text(error), scheduling reconnect: %s", self.name, error)
+                        logger.warning(
+                            "[%s] Telegram network error, scheduling reconnect: %s",
+                            self.name, _redact_telegram_error_text(error),
+                        )
                         self._polling_error_task = loop.create_task(self._handle_polling_network_error(error))
                         self._background_tasks.add(self._polling_error_task)
                         self._polling_error_task.add_done_callback(self._background_tasks.discard)
                     else:
-                        logger.error("[%s] Telegram polling _redact_telegram_error_text(error): %s", self.name, error, exc_info=True)
+                        logger.error(
+                            "[%s] Telegram polling error: %s",
+                            self.name, _redact_telegram_error_text(error), exc_info=True,
+                        )
 
                 # Store reference for retry use in _handle_polling_conflict
                 self._polling_error_callback_ref = _polling_error_callback


### PR DESCRIPTION
## What does this PR do?

Fixes two corrupted log statements in the Telegram polling `error_callback`. In both, the word `error` inside the message string was literally replaced by the name of the redaction helper, so the log emitted:

```
WARNING [Telegram] Telegram network _redact_telegram_error_text(error), scheduling reconnect: httpx.ReadError:
```

Beyond the unreadable text, the formatted argument was the **raw** `error` object — bypassing the very redaction the string was meant to invoke. Every other error-logging site in this adapter routes through `_redact_telegram_error_text()` precisely because Telegram network exceptions can carry the Bot API URL, and that URL embeds the bot token. These two call sites are on the hot path for transient network failures (`httpx.ReadError`, `TimedOut`, `Bad Gateway`), so they fire routinely in normal operation.

Both now pass the exception through `_redact_telegram_error_text()` and carry their intended message text.

## Related Issue

No existing issue — the bug is self-evident from the log output above.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (unredacted error text could surface the bot token in logs)

## Changes Made

- `plugins/platforms/telegram/adapter.py` — `_polling_error_callback`, network-error branch: message restored to `"Telegram network error, scheduling reconnect: %s"`; argument now `_redact_telegram_error_text(error)`.
- `plugins/platforms/telegram/adapter.py` — same callback, fallback `else` branch: message restored to `"Telegram polling error: %s"`; argument now `_redact_telegram_error_text(error)`.

No behavioral change: the reconnect ladder, task bookkeeping, and `exc_info=True` are untouched. Logging only.

## How to Test

1. Run a gateway with the Telegram platform in polling mode and induce a transient network failure (drop egress to `api.telegram.org` briefly, or suspend/resume the host).
2. Before this change, `gateway.log` shows `Telegram network _redact_telegram_error_text(error), scheduling reconnect: <raw error>`.
3. After this change, the same event logs `Telegram network error, scheduling reconnect: <redacted error>`, and the reconnect ladder proceeds identically (`Telegram network error (attempt N/10)` → `Telegram polling restarted after network error`).

Observed on a live gateway (Ubuntu 24.04, Python 3.11, systemd): the corrupted lines appeared during real Telegram outages on 2026-08-09 and 2026-08-11; after the fix and a gateway restart, startup and polling are clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(telegram): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single commit, one file, two statements)
- [ ] I've run `pytest tests/ -q` — **not run**: `pytest` is not installed in this deployment's venv and I did not want to mutate a running production environment to add it. Happy to run the suite if a maintainer prefers.
- [ ] I've added tests for my changes — **not added**: the change is a log-message string and an argument passed to an existing, already-tested redaction helper. I can add a `caplog` assertion on the two callback branches if you'd like that coverage.
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Before (real output from a production gateway):

```
2026-08-11 01:11:02 WARNING [Telegram] Telegram network _redact_telegram_error_text(error), scheduling reconnect: Bad Gateway
2026-08-11 01:11:02 WARNING [Telegram] Telegram network error (attempt 1/10), reconnecting in 5s. Error: Bad Gateway
2026-08-11 01:11:09 WARNING [Telegram] Telegram polling reconnect failed: Bad Gateway
2026-08-11 01:13:00 INFO    [Telegram] Telegram polling restarted after network error (attempt 4)
```

After, the first line reads:

```
WARNING [Telegram] Telegram network error, scheduling reconnect: Bad Gateway
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
