### PR TITLE
fix(kanban): refuse session claims of dispatcher-managed tasks (#83736)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -562,6 +562,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_claim.add_argument("task_id")
     p_claim.add_argument("--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS,
                          help="Claim TTL in seconds (default: 900)")
+    p_claim.add_argument(
+        "--allow-session",
+        action="store_true",
+        help="Allow claiming a dispatcher-managed task from a session context "
+             "(no heartbeat; the claim will be reclaimed once the TTL expires - "
+             "only use for short tasks that finish inside the lease)",
+    )
 
     # --- comment / complete / block / unblock / archive ---
     p_comment = sub.add_parser("comment", help="Append a comment")
@@ -2063,6 +2070,30 @@ def _cmd_unlink(args: argparse.Namespace) -> int:
 
 
 def _cmd_claim(args: argparse.Namespace) -> int:
+    # Session claims have no heartbeat and cannot be terminated on reclaim,
+    # so claiming a dispatcher-managed task (assignee is a real profile)
+    # risks two concurrent writers once the TTL expires (#83736). Refuse
+    # unless the caller opts in via --allow-session. Dispatcher workers
+    # carry HERMES_KANBAN_RUN_ID, and control-plane lanes (assignee not a
+    # profile) are pulled by terminals by design - both stay claimable.
+    if not args.allow_session and not os.environ.get("HERMES_KANBAN_RUN_ID"):
+        with kb.connect_closing() as conn:
+            existing = kb.get_task(conn, args.task_id)
+        if existing is not None and existing.assignee:
+            from hermes_cli.profiles import profile_exists
+
+            if profile_exists(existing.assignee):
+                print(
+                    f"cannot claim {args.task_id}: task is dispatcher-managed "
+                    f"(assignee profile '{existing.assignee}'). Session claims have no "
+                    "heartbeat and cannot be terminated on reclaim, so the dispatcher "
+                    "would spawn a second worker into the same workspace once the TTL "
+                    "expires. Create the task and let the dispatcher own execution, or "
+                    "pass --allow-session for short tasks guaranteed to finish inside "
+                    f"the lease ({args.ttl}s).",
+                    file=sys.stderr,
+                )
+                return 1
     with kb.connect_closing() as conn:
         task = kb.claim_task(conn, args.task_id, ttl_seconds=args.ttl)
         if task is None:

--- a/tests/hermes_cli/test_83736_session_claim_gate.py
+++ b/tests/hermes_cli/test_83736_session_claim_gate.py
@@ -1,0 +1,81 @@
+"""Tests for session-claim refusal of dispatcher-managed tasks (#83736).
+
+A session-side ``kanban claim`` has no heartbeat: once the claim TTL
+expires the dispatcher reclaims the task (it cannot terminate the
+session's executor) and spawns a worker into the same workspace - two
+concurrent writers, silent file clobbering. The CLI refuses that
+combination unless the caller opts in with ``--allow-session``.
+Dispatcher-owned workers carry ``HERMES_KANBAN_RUN_ID``, and control-plane
+lanes (assignee is not a real Hermes profile) are pulled by terminals by
+design - both stay claimable.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    kb.init_db()
+    return home
+
+
+def _create_task(title: str, assignee: str) -> str:
+    with kb.connect() as conn:
+        return kb.create_task(conn, title=title, assignee=assignee)
+
+
+class TestSessionClaimGate:
+    def test_refuses_dispatcher_managed_task_from_session(self, kanban_home):
+        tid = _create_task("dispatcher task", assignee="alice")
+        with patch("hermes_cli.profiles.profile_exists", return_value=True):
+            out = kc.run_slash(f"claim {tid}")
+        assert "dispatcher-managed" in out
+        assert "--allow-session" in out
+        # Task unchanged - still ready, unclaimed.
+        with kb.connect() as conn:
+            row = kb.get_task(conn, tid)
+        assert row.status == "ready"
+        assert row.claim_lock is None
+
+    def test_allow_session_flag_claims_anyway(self, kanban_home):
+        tid = _create_task("dispatcher task", assignee="alice")
+        with patch("hermes_cli.profiles.profile_exists", return_value=True):
+            out = kc.run_slash(f"claim {tid} --allow-session")
+        assert "Claimed" in out
+        with kb.connect() as conn:
+            row = kb.get_task(conn, tid)
+        assert row.status == "running"
+
+    def test_control_plane_lane_stays_claimable(self, kanban_home):
+        """Assignee that is not a real profile (e.g. orion-cc) is pulled by
+        terminals by design and must not be refused."""
+        tid = _create_task("lane task", assignee="orion-cc")
+        with patch("hermes_cli.profiles.profile_exists", return_value=False):
+            out = kc.run_slash(f"claim {tid}")
+        assert "Claimed" in out
+
+    def test_dispatcher_worker_env_bypasses_gate(self, kanban_home, monkeypatch):
+        """A spawned worker carries HERMES_KANBAN_RUN_ID (heartbeat +
+        termination semantics) and may claim."""
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+        tid = _create_task("worker task", assignee="alice")
+        with patch("hermes_cli.profiles.profile_exists", return_value=True):
+            out = kc.run_slash(f"claim {tid}")
+        assert "Claimed" in out
+
+    def test_missing_task_still_reports_no_such_task(self, kanban_home):
+        out = kc.run_slash("claim t_missing")
+        assert "no such task" in out


### PR DESCRIPTION
## Summary

Fixes #83736 — a session-side `kanban claim` can produce **two concurrent writers on one task workspace**.

### The bug

`hermes kanban claim` was permitted from any context. A Desktop/CLI session claim has **no heartbeat**, so once the claim TTL expires (default 900s) the dispatcher reclaims the task — but it **cannot terminate the session's executor** (not a dispatcher-owned process) — and spawns a real Worker into the same workspace. Two unsynchronized writers, silent file clobbering (the issue documents a real incident: 5 files overwritten, manual reconciliation).

### The fix

`_cmd_claim` now refuses that combination:

- **Refused** when the caller is a session (no `HERMES_KANBAN_RUN_ID`) **and** the task's assignee is a real Hermes profile (spawnable by the dispatcher) — with an actionable message.
- **`--allow-session` opt-in** for short tasks guaranteed to finish inside the lease (the issue's option A explicitly permits this escape hatch; it preserves the legitimate "operator claims a card and executes it in-session" workflow).
- **Preserved**: dispatcher-owned workers carry `HERMES_KANBAN_RUN_ID` (set in `_build_worker_env`) so they bypass the gate — they have heartbeat + termination semantics. **Control-plane lanes** (assignee is not a real profile, e.g. `orion-cc`, pulled by terminals via `claim_task` by design) stay claimable — the dispatcher never spawns for them (`has_spawnable_ready` + the dispatcher lane-skip).

The gate is at the CLI (`_cmd_claim`), the only session claim path — `kanban_tools` has no claim verb, and `claim_task` API callers (terminals pulling lanes) are intentionally exempt per the issue's design.

## Tests

5 new tests in `tests/hermes_cli/test_83736_session_claim_gate.py`:
- refusal of dispatcher-managed task from session (message + task unchanged)
- `--allow-session` claims anyway
- control-plane lane (non-profile assignee) stays claimable
- `HERMES_KANBAN_RUN_ID` worker env bypasses the gate
- missing task still reports "no such task"

All pass against real SQLite + temp HERMES_HOME; RED verified (2 fail on pre-fix code). Two-axis code review findings (broad except, duplicated rationale) incorporated before submission.
