### PR TITLE
fix: don't flag valid UTF-8 as binary when the 1KB sample splits a multibyte char

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,21 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_trailing_replacement_char_from_sample_truncation_not_binary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # read_file samples the first 1000 *bytes* with head -c 1000. A
+        # multibyte UTF-8 character split at that boundary decodes to a
+        # trailing U+FFFD even in perfectly valid Japanese/CJK text. That
+        # truncation artifact appears only at the very end of the sample and
+        # must not trigger the binary guard (mid-sample U+FFFD still does).
+        sample = "正しい日本語テキスト\n" * 50 + "\ufffd"
+        assert ops._is_likely_binary("notes.txt", sample) is False
+
+    def test_mid_sample_replacement_char_still_binary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # U+FFFD embedded mid-sample (real corruption / non-UTF-8 bytes)
+        # must still be flagged binary even when the sample also ends with
+        # a trailing replacement char.
+        sample = "start\ufffdmiddle\ufffd\n"
+        assert ops._is_likely_binary("notes.txt", sample) is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -899,6 +899,7 @@ class ShellFileOperations(FileOperations):
         
         # Content analysis: >30% non-printable chars = binary
         if content_sample:
+            sample = content_sample[:1000]
             # Undecodable bytes: the terminal env decodes stdout with
             # errors="replace", so any non-UTF-8 byte arrives here already
             # turned into U+FFFD. That char is "printable" (ord 65533), so the
@@ -908,11 +909,18 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            #
+            # Exception: head -c 1000 samples *bytes*, so a multibyte UTF-8
+            # character split at the 1000-byte boundary decodes to a trailing
+            # U+FFFD even in perfectly valid Japanese/CJK text. That artifact
+            # appears only at the very end of the sample — strip the trailing
+            # run before the check so valid UTF-8 isn't misclassified as
+            # binary. Mid-sample U+FFFD still means binary/corrupt.
+            if sample.rstrip("\ufffd").count("\ufffd") > 0:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in sample
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
+            return non_printable / min(len(sample), 1000) > 0.30
         
         return False
     


### PR DESCRIPTION
## Problem

`read_file` misclassifies valid Japanese/CJK UTF-8 files as binary ("Binary file - cannot display as text"), intermittently.

## Root cause

`read_file` samples the first **1000 bytes** with `head -c 1000`, and the terminal env decodes that chunk with `errors="replace"`. A multibyte UTF-8 character split at the 1000-byte boundary decodes to a trailing `U+FFFD` (replacement char). `_is_likely_binary` treated *any* `U+FFFD` in the sample as evidence of a binary file, so perfectly valid Japanese/CJK text was flagged binary. ASCII files never hit this because single-byte characters cannot be split.

Verified reproduction: `head -c 1000 <japanese.md>` → `decode error: unexpected end of data` at position 999, exactly one `U+FFFD`, at the tail only.

## Fix

In `ShellFileOperations._is_likely_binary`, strip a **trailing** run of `U+FFFD` before the binary check. A truncation artifact from byte-boundary sampling appears only at the very end of the sample; mid-sample `U+FFFD` (genuine corruption / non-UTF-8 bytes) still flags the file as binary, preserving the read-only guard that prevents read→edit→write mojibake corruption.

## Tests

Added to `tests/tools/test_file_operations.py::TestReadNonUtf8IsBinary`:

- `test_trailing_replacement_char_from_sample_truncation_not_binary` — trailing-only U+FFFD is not binary (the regression)
- `test_mid_sample_replacement_char_still_binary` — mid-sample U+FFFD still binary (guard preserved)

`48 passed` in `tests/tools/test_file_operations.py`.
