### PR TITLE
fix(agent): fail Gemini MALFORMED_FUNCTION_CALL turns instead of empty success

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1460,6 +1460,33 @@ def _content_policy_blocked_result(
     }
 
 
+def _malformed_function_call_result(
+    messages: List[Dict],
+    api_call_count: int,
+    *,
+    final_response: str,
+    error_detail: str,
+) -> Dict[str, Any]:
+    """Build the terminal turn result for a provider-rejected tool call.
+
+    Native Gemini can return HTTP 200 with
+    ``finishReason=MALFORMED_FUNCTION_CALL`` (or ``UNEXPECTED_TOOL_CALL``)
+    and empty content. That is a rejection of the model's tool-call shape,
+    not a successful empty reply and not a safety refusal. The turn ends
+    here (no empty-content retries) as a failed, non-completed result so
+    trajectories are not saved as successes (#83869).
+    """
+    return {
+        "final_response": final_response,
+        "messages": messages,
+        "api_calls": api_call_count,
+        "completed": False,
+        "failed": True,
+        "error": f"malformed_function_call: {error_detail}",
+        "turn_exit_reason": "malformed_function_call",
+    }
+
+
 def _compression_deferred_result(
     agent,
     messages: List[Dict],
@@ -3691,6 +3718,93 @@ def run_conversation(
                         api_call_count,
                         final_response=_refusal_response,
                         error_detail=_refusal_text or "model declined (content_filter)",
+                    )
+
+                # ── Malformed function call (HTTP 200) ─────────────────
+                # Native Gemini returns ``finishReason=MALFORMED_FUNCTION_CALL``
+                # (and sometimes ``UNEXPECTED_TOOL_CALL``) with empty content
+                # when the model's tool-call shape is invalid. The adapter maps
+                # those to ``malformed_function_call``. Without this branch the
+                # empty payload falls through to empty-content retries and is
+                # saved as a successful ``(empty)`` trajectory (#83869).
+                # Not a safety refusal — do not route through content_filter.
+                if finish_reason == "malformed_function_call":
+                    _mfc_transport = agent._get_transport()
+                    _mfc_result = _mfc_transport.normalize_response(response)
+                    _mfc_text = (getattr(_mfc_result, "content", None) or "").strip()
+                    if not _mfc_text:
+                        _mfc_text = (agent._extract_reasoning(_mfc_result) or "").strip()
+
+                    agent._invoke_api_request_error_hook(
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        api_call_count=api_call_count,
+                        api_start_time=api_start_time,
+                        api_kwargs=api_kwargs,
+                        error_type="MalformedFunctionCall",
+                        error_message=_mfc_text or "provider rejected a malformed function call",
+                        status_code=None,
+                        retry_count=retry_count,
+                        max_retries=max_retries,
+                        retryable=False,
+                        reason="malformed_function_call",
+                    )
+
+                    if thinking_spinner:
+                        thinking_spinner.stop("")
+                        thinking_spinner = None
+                    if agent.thinking_callback:
+                        agent.thinking_callback("")
+
+                    # Deterministic for the unchanged prompt — never retry
+                    # empty-content. Try a configured fallback once (a
+                    # different model may emit a valid call); otherwise
+                    # surface the rejection terminally.
+                    if agent._has_pending_fallback():
+                        agent._buffer_status(
+                            "⚠️ Gemini rejected a malformed function call — trying fallback..."
+                        )
+                    if agent._try_activate_fallback():
+                        active_system_prompt = _sync_failover_system_message(
+                            agent, api_messages, active_system_prompt)
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        continue
+
+                    agent._flush_status_buffer()
+                    logger.warning(
+                        "%sProvider rejected a malformed function call "
+                        "(finish_reason=malformed_function_call). "
+                        "model=%s provider=%s",
+                        agent.log_prefix, agent.model, agent.provider,
+                    )
+                    agent._emit_status(
+                        "⚠️ Gemini rejected a malformed function call from the model."
+                    )
+
+                    _mfc_detail = (
+                        f"Provider message: {_mfc_text}"
+                        if _mfc_text
+                        else "The provider returned no explanation."
+                    )
+                    _mfc_response = (
+                        "⚠️  Gemini rejected a malformed function call "
+                        "from the model (not a Hermes/gateway failure).\n\n"
+                        f"{_mfc_detail}\n\n"
+                        "This is not a safety refusal. The model produced a "
+                        "tool call Gemini's API could not parse. Try again, "
+                        "or add a fallback provider with `hermes fallback add`."
+                    )
+
+                    agent._cleanup_task_resources(effective_task_id)
+                    agent._persist_session(messages, conversation_history)
+                    return _malformed_function_call_result(
+                        messages,
+                        api_call_count,
+                        final_response=_mfc_response,
+                        error_detail=_mfc_text or "provider rejected a malformed function call",
                     )
 
                 if finish_reason == "length":

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3771,7 +3771,11 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
-                        continue
+                        # Match content_filter failover: break out of the
+                        # retry loop so restart_with_rebuilt_messages re-runs
+                        # preflight against the fallback context window (#84733).
+                        _retry.restart_with_rebuilt_messages = True
+                        break
 
                     agent._flush_status_buffer()
                     logger.warning(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1065,6 +1065,33 @@ def _content_policy_blocked_result(
     }
 
 
+def _malformed_function_call_result(
+    messages: List[Dict],
+    api_call_count: int,
+    *,
+    final_response: str,
+    error_detail: str,
+) -> Dict[str, Any]:
+    """Build the terminal turn result for a provider-rejected tool call.
+
+    Native Gemini can return HTTP 200 with
+    ``finishReason=MALFORMED_FUNCTION_CALL`` (or ``UNEXPECTED_TOOL_CALL``)
+    and empty content. That is a rejection of the model's tool-call shape,
+    not a successful empty reply and not a safety refusal. The turn ends
+    here (no empty-content retries) as a failed, non-completed result so
+    trajectories are not saved as successes (#83869).
+    """
+    return {
+        "final_response": final_response,
+        "messages": messages,
+        "api_calls": api_call_count,
+        "completed": False,
+        "failed": True,
+        "error": f"malformed_function_call: {error_detail}",
+        "turn_exit_reason": "malformed_function_call",
+    }
+
+
 def _compression_deferred_result(
     agent,
     messages: List[Dict],
@@ -3191,6 +3218,93 @@ def run_conversation(
                         api_call_count,
                         final_response=_refusal_response,
                         error_detail=_refusal_text or "model declined (content_filter)",
+                    )
+
+                # ── Malformed function call (HTTP 200) ─────────────────
+                # Native Gemini returns ``finishReason=MALFORMED_FUNCTION_CALL``
+                # (and sometimes ``UNEXPECTED_TOOL_CALL``) with empty content
+                # when the model's tool-call shape is invalid. The adapter maps
+                # those to ``malformed_function_call``. Without this branch the
+                # empty payload falls through to empty-content retries and is
+                # saved as a successful ``(empty)`` trajectory (#83869).
+                # Not a safety refusal — do not route through content_filter.
+                if finish_reason == "malformed_function_call":
+                    _mfc_transport = agent._get_transport()
+                    _mfc_result = _mfc_transport.normalize_response(response)
+                    _mfc_text = (getattr(_mfc_result, "content", None) or "").strip()
+                    if not _mfc_text:
+                        _mfc_text = (agent._extract_reasoning(_mfc_result) or "").strip()
+
+                    agent._invoke_api_request_error_hook(
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        api_call_count=api_call_count,
+                        api_start_time=api_start_time,
+                        api_kwargs=api_kwargs,
+                        error_type="MalformedFunctionCall",
+                        error_message=_mfc_text or "provider rejected a malformed function call",
+                        status_code=None,
+                        retry_count=retry_count,
+                        max_retries=max_retries,
+                        retryable=False,
+                        reason="malformed_function_call",
+                    )
+
+                    if thinking_spinner:
+                        thinking_spinner.stop("")
+                        thinking_spinner = None
+                    if agent.thinking_callback:
+                        agent.thinking_callback("")
+
+                    # Deterministic for the unchanged prompt — never retry
+                    # empty-content. Try a configured fallback once (a
+                    # different model may emit a valid call); otherwise
+                    # surface the rejection terminally.
+                    if agent._has_pending_fallback():
+                        agent._buffer_status(
+                            "⚠️ Gemini rejected a malformed function call — trying fallback..."
+                        )
+                    if agent._try_activate_fallback():
+                        active_system_prompt = _sync_failover_system_message(
+                            agent, api_messages, active_system_prompt)
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        continue
+
+                    agent._flush_status_buffer()
+                    logger.warning(
+                        "%sProvider rejected a malformed function call "
+                        "(finish_reason=malformed_function_call). "
+                        "model=%s provider=%s",
+                        agent.log_prefix, agent.model, agent.provider,
+                    )
+                    agent._emit_status(
+                        "⚠️ Gemini rejected a malformed function call from the model."
+                    )
+
+                    _mfc_detail = (
+                        f"Provider message: {_mfc_text}"
+                        if _mfc_text
+                        else "The provider returned no explanation."
+                    )
+                    _mfc_response = (
+                        "⚠️  Gemini rejected a malformed function call "
+                        "from the model (not a Hermes/gateway failure).\n\n"
+                        f"{_mfc_detail}\n\n"
+                        "This is not a safety refusal. The model produced a "
+                        "tool call Gemini's API could not parse. Try again, "
+                        "or add a fallback provider with `hermes fallback add`."
+                    )
+
+                    agent._cleanup_task_resources(effective_task_id)
+                    agent._persist_session(messages, conversation_history)
+                    return _malformed_function_call_result(
+                        messages,
+                        api_call_count,
+                        final_response=_mfc_response,
+                        error_detail=_mfc_text or "provider rejected a malformed function call",
                     )
 
                 if finish_reason == "length":

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -713,6 +713,11 @@ def _map_gemini_finish_reason(reason: str) -> str:
         "MAX_TOKENS": "length",
         "SAFETY": "content_filter",
         "RECITATION": "content_filter",
+        # Provider rejected the model's tool-call shape — not a safety
+        # refusal. Dedicated finish_reason so the agent loop can fail the
+        # turn instead of treating empty content as a successful stop.
+        "MALFORMED_FUNCTION_CALL": "malformed_function_call",
+        "UNEXPECTED_TOOL_CALL": "malformed_function_call",
         "OTHER": "stop",
     }
     return mapping.get(str(reason or "").upper(), "stop")

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -575,6 +575,11 @@ def _map_gemini_finish_reason(reason: str) -> str:
         "MAX_TOKENS": "length",
         "SAFETY": "content_filter",
         "RECITATION": "content_filter",
+        # Provider rejected the model's tool-call shape — not a safety
+        # refusal. Dedicated finish_reason so the agent loop can fail the
+        # turn instead of treating empty content as a successful stop.
+        "MALFORMED_FUNCTION_CALL": "malformed_function_call",
+        "UNEXPECTED_TOOL_CALL": "malformed_function_call",
         "OTHER": "stop",
     }
     return mapping.get(str(reason or "").upper(), "stop")

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -273,6 +273,36 @@ def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     assert json.loads(choice.message.tool_calls[0].function.arguments) == {"q": "hermes"}
 
 
+@pytest.mark.parametrize(
+    "raw_reason",
+    ("MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL"),
+)
+def test_translate_malformed_function_call_is_not_stop(raw_reason):
+    """Gemini tool-call-shape rejections must not fall through to stop.
+
+    An empty MALFORMED_FUNCTION_CALL candidate used to map to finish_reason
+    ``stop``, which the conversation loop treated as a successful empty
+    reply (#83869). These reasons are also not safety refusals.
+    """
+    from agent.gemini_native_adapter import translate_gemini_response
+
+    payload = {
+        "candidates": [
+            {
+                "content": {"parts": []},
+                "finishReason": raw_reason,
+            }
+        ],
+    }
+
+    response = translate_gemini_response(payload, model="gemini-2.5-flash")
+    choice = response.choices[0]
+    assert choice.finish_reason == "malformed_function_call"
+    assert choice.finish_reason != "stop"
+    assert choice.finish_reason != "content_filter"
+    assert not choice.message.tool_calls
+
+
 def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatch):
     from agent.gemini_native_adapter import GeminiNativeClient
 
@@ -439,6 +469,30 @@ def test_build_gemini_request_does_not_raise_when_thinking_is_disabled():
 
     assert request["generationConfig"]["maxOutputTokens"] == 4096
     assert request["generationConfig"]["thinkingConfig"]["includeThoughts"] is False
+
+@pytest.mark.parametrize(
+    "raw_reason",
+    ("MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL"),
+)
+def test_stream_malformed_function_call_is_not_stop(raw_reason):
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {"parts": []},
+                "finishReason": raw_reason,
+            }
+        ],
+    }
+
+    chunks = translate_stream_event(
+        event, model="gemini-2.5-flash", tool_call_indices={}
+    )
+    assert chunks
+    assert chunks[-1].choices[0].finish_reason == "malformed_function_call"
+    assert chunks[-1].choices[0].finish_reason != "stop"
+    assert chunks[-1].choices[0].finish_reason != "content_filter"
 
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -163,6 +163,36 @@ def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     assert json.loads(choice.message.tool_calls[0].function.arguments) == {"q": "hermes"}
 
 
+@pytest.mark.parametrize(
+    "raw_reason",
+    ("MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL"),
+)
+def test_translate_malformed_function_call_is_not_stop(raw_reason):
+    """Gemini tool-call-shape rejections must not fall through to stop.
+
+    An empty MALFORMED_FUNCTION_CALL candidate used to map to finish_reason
+    ``stop``, which the conversation loop treated as a successful empty
+    reply (#83869). These reasons are also not safety refusals.
+    """
+    from agent.gemini_native_adapter import translate_gemini_response
+
+    payload = {
+        "candidates": [
+            {
+                "content": {"parts": []},
+                "finishReason": raw_reason,
+            }
+        ],
+    }
+
+    response = translate_gemini_response(payload, model="gemini-2.5-flash")
+    choice = response.choices[0]
+    assert choice.finish_reason == "malformed_function_call"
+    assert choice.finish_reason != "stop"
+    assert choice.finish_reason != "content_filter"
+    assert not choice.message.tool_calls
+
+
 def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatch):
     from agent.gemini_native_adapter import GeminiNativeClient
 
@@ -288,6 +318,31 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
     assert first[0].choices[0].delta.tool_calls[0].function.arguments == '{"q": "abc"}'
     assert second[0].choices[0].delta.tool_calls[0].function.arguments == ""
     assert first[-1].choices[0].finish_reason == "tool_calls"
+
+
+@pytest.mark.parametrize(
+    "raw_reason",
+    ("MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL"),
+)
+def test_stream_malformed_function_call_is_not_stop(raw_reason):
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {"parts": []},
+                "finishReason": raw_reason,
+            }
+        ],
+    }
+
+    chunks = translate_stream_event(
+        event, model="gemini-2.5-flash", tool_call_indices={}
+    )
+    assert chunks
+    assert chunks[-1].choices[0].finish_reason == "malformed_function_call"
+    assert chunks[-1].choices[0].finish_reason != "stop"
+    assert chunks[-1].choices[0].finish_reason != "content_filter"
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5169,6 +5169,72 @@ class TestRetryExhaustion:
         # exactly one API call, no empty-response retry loop.
         assert agent.client.chat.completions.create.call_count == 1
 
+    def test_malformed_function_call_surfaced_not_retried(self, agent):
+        """Gemini MALFORMED_FUNCTION_CALL must fail the turn, not succeed empty.
+
+        Regression #83869: native Gemini returns HTTP 200 with
+        ``finish_reason=malformed_function_call`` and empty content. That used
+        to fall through to empty-content retries and be saved as a successful
+        ``(empty)`` trajectory. Surface it as a failed, non-completed turn
+        without treating it as a safety refusal.
+        """
+        self._setup_agent(agent)
+        malformed_resp = _mock_response(
+            content=None, finish_reason="malformed_function_call",
+        )
+        agent.client.chat.completions.create.return_value = malformed_resp
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("please call a tool")
+        assert result.get("completed") is False
+        assert result.get("failed") is True
+        assert "malformed_function_call" in result.get("error", "")
+        assert result.get("turn_exit_reason") == "malformed_function_call"
+        final = result.get("final_response") or ""
+        assert "malformed function call" in final.lower()
+        assert "not a safety refusal" in final.lower()
+        assert "content_policy_blocked" not in result.get("error", "")
+        assert "(empty)" not in final
+        # Deterministic for the unchanged prompt — not retried as empty.
+        assert agent.client.chat.completions.create.call_count == 1
+
+    def test_malformed_function_call_tries_fallback_once(self, agent):
+        """A pending fallback may recover from a Gemini malformed tool call."""
+        self._setup_agent(agent)
+        agent._fallback_chain = [
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.7"},
+        ]
+        agent._fallback_index = 0
+        malformed_resp = _mock_response(
+            content=None, finish_reason="malformed_function_call",
+        )
+        fallback_resp = _mock_response(
+            content="Recovered on fallback", finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            malformed_resp, fallback_resp,
+        ]
+
+        def _fake_activate(reason=None):
+            agent._fallback_index = len(agent._fallback_chain)
+            return True
+
+        with (
+            patch.object(agent, "_try_activate_fallback", side_effect=_fake_activate) as mock_fallback,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("please call a tool")
+
+        assert result.get("completed") is True
+        assert result.get("final_response") == "Recovered on fallback"
+        mock_fallback.assert_called_once_with()
+        assert agent.client.chat.completions.create.call_count == 2
+
 
     def test_build_api_kwargs_error_no_unbound_local(self, agent):
         """When _build_api_kwargs raises, except handler must not crash with UnboundLocalError.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4685,6 +4685,72 @@ class TestRetryExhaustion:
         # exactly one API call, no empty-response retry loop.
         assert agent.client.chat.completions.create.call_count == 1
 
+    def test_malformed_function_call_surfaced_not_retried(self, agent):
+        """Gemini MALFORMED_FUNCTION_CALL must fail the turn, not succeed empty.
+
+        Regression #83869: native Gemini returns HTTP 200 with
+        ``finish_reason=malformed_function_call`` and empty content. That used
+        to fall through to empty-content retries and be saved as a successful
+        ``(empty)`` trajectory. Surface it as a failed, non-completed turn
+        without treating it as a safety refusal.
+        """
+        self._setup_agent(agent)
+        malformed_resp = _mock_response(
+            content=None, finish_reason="malformed_function_call",
+        )
+        agent.client.chat.completions.create.return_value = malformed_resp
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("please call a tool")
+        assert result.get("completed") is False
+        assert result.get("failed") is True
+        assert "malformed_function_call" in result.get("error", "")
+        assert result.get("turn_exit_reason") == "malformed_function_call"
+        final = result.get("final_response") or ""
+        assert "malformed function call" in final.lower()
+        assert "not a safety refusal" in final.lower()
+        assert "content_policy_blocked" not in result.get("error", "")
+        assert "(empty)" not in final
+        # Deterministic for the unchanged prompt — not retried as empty.
+        assert agent.client.chat.completions.create.call_count == 1
+
+    def test_malformed_function_call_tries_fallback_once(self, agent):
+        """A pending fallback may recover from a Gemini malformed tool call."""
+        self._setup_agent(agent)
+        agent._fallback_chain = [
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.7"},
+        ]
+        agent._fallback_index = 0
+        malformed_resp = _mock_response(
+            content=None, finish_reason="malformed_function_call",
+        )
+        fallback_resp = _mock_response(
+            content="Recovered on fallback", finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            malformed_resp, fallback_resp,
+        ]
+
+        def _fake_activate(reason=None):
+            agent._fallback_index = len(agent._fallback_chain)
+            return True
+
+        with (
+            patch.object(agent, "_try_activate_fallback", side_effect=_fake_activate) as mock_fallback,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("please call a tool")
+
+        assert result.get("completed") is True
+        assert result.get("final_response") == "Recovered on fallback"
+        mock_fallback.assert_called_once_with()
+        assert agent.client.chat.completions.create.call_count == 2
+
 
     def test_build_api_kwargs_error_no_unbound_local(self, agent):
         """When _build_api_kwargs raises, except handler must not crash with UnboundLocalError.


### PR DESCRIPTION
## Problem

When the native Gemini API returns HTTP 200 with `finishReason: "MALFORMED_FUNCTION_CALL"` (empty content), Hermes:

1. Retries as if the model returned a normal empty stop
2. Eventually surfaces `(empty)` / no reply
3. Saves the turn as `completed: true` in the successful trajectory file

Reporter evidence on #83869: successful trajectory contains `(empty)` after Gemini rejected its own function call. Related: #11171 (OpenAI-compat `function_call_filter` class). This PR is the **native** adapter + loop terminal path.

## Root cause

| Layer | Behavior on main |
|-------|------------------|
| `agent/gemini_native_adapter.py` `_map_gemini_finish_reason` | Unknown reasons (including `MALFORMED_FUNCTION_CALL`) default to `stop` |
| `agent/conversation_loop.py` | Empty `stop` → empty-content retries → terminal `(empty)` |
| `agent/turn_finalizer.py` | `completed = final_response is not None and not failed` → true for `(empty)` when `failed` stays false |

#63263 left `MALFORMED_FUNCTION_CALL` out of the content_filter map on purpose (not a safety refusal). #43478 and #11172 are different surfaces.

## Fix

1. Map `MALFORMED_FUNCTION_CALL` and `UNEXPECTED_TOOL_CALL` → `malformed_function_call` (not `stop`, not `content_filter`).
2. Early terminal in the conversation loop (sibling to content_filter): no empty retries; optional one fallback; otherwise `completed=False`, `failed=True` with a clear user message.

## Why it matters

False-success trajectories poison eval/training exports and SessionDB history. Empty retries also burn latency on a deterministic provider rejection of the tool-call shape.

## Test plan

```bash
scripts/run_tests.sh tests/agent/test_gemini_native_adapter.py tests/run_agent/test_run_agent.py \
  -k "malformed_function_call or stream_malformed or translate_malformed" -q
```

- [x] Adapter non-stream + stream mapping (not `stop` / not `content_filter`)
- [x] Loop: failed non-completed without empty retries; fallback can recover once
- [x] **6 passed** @ head `a25e9472` (macOS Mini)
- [ ] Full monorepo suite not run for this change (focused filter only)

## Risk / blast radius

- Fires only when finish_reason is `malformed_function_call` (set by the native Gemini mapper today).
- Does not change global empty_response_exhausted completed=true behavior.
- Does not use safety-refusal / content_filter UX.

## Closest existing work

- #63263 — policy-block map (orthogonal)
- #43478 — stream terminal finish reasons (orthogonal)
- #11172 — OpenAI-compat `function_call_filter` + delegate validation (different surface)
- **none found** that closes #83869 on current main with tests

Fixes #83869

### Acceptance retest (2026-08-18)
Rebased onto current `main`. Mini proof @ `5fc41efed`: gemini malformed adapter+loop — 6 passed.

## Acceptance retest (2026-08-18b)

- Head: `64f4446b9`
- MALFORMED fallback activation now sets restart_with_rebuilt_messages + break (matches content_filter / #84733). Mini: TestFailoverRestartsPreflight 2 + malformed 6 passed @ 64f4446b9.

## Mini retest (2026-08-24 acceptance)
- Head `1acbc9d3b7` · pytest -k "malformed_function_call or finish_reason" → 30 passed (+5 skip)
- Rebased onto current upstream `main` (force-with-lease, pre-review)
