### PR TITLE
fix(gemini): fail malformed function call turns

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3193,6 +3193,31 @@ def run_conversation(
                         error_detail=_refusal_text or "model declined (content_filter)",
                     )
 
+                if finish_reason == "malformed_function_call":
+                    malformed_response = (
+                        "Gemini returned MALFORMED_FUNCTION_CALL, so the model's "
+                        "tool call payload could not be parsed or executed."
+                    )
+                    logger.warning(
+                        "%sGemini returned malformed function call. "
+                        "model=%s provider=%s",
+                        agent.log_prefix, agent.model, agent.provider,
+                    )
+                    agent._emit_status(
+                        "Gemini returned a malformed function call; stopping this turn."
+                    )
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": malformed_response,
+                            "finish_reason": finish_reason,
+                        }
+                    )
+                    final_response = malformed_response
+                    failed = True
+                    _turn_exit_reason = "malformed_function_call"
+                    break
+
                 if finish_reason == "length":
                     if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
                         agent._vprint(

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -575,6 +575,7 @@ def _map_gemini_finish_reason(reason: str) -> str:
         "MAX_TOKENS": "length",
         "SAFETY": "content_filter",
         "RECITATION": "content_filter",
+        "MALFORMED_FUNCTION_CALL": "malformed_function_call",
         "OTHER": "stop",
     }
     return mapping.get(str(reason or "").upper(), "stop")
@@ -652,7 +653,13 @@ def translate_gemini_response(resp: Dict[str, Any], model: str) -> SimpleNamespa
                 tool_call.extra_content = extra_content
             tool_calls.append(tool_call)
 
-    finish_reason = "tool_calls" if tool_calls else _map_gemini_finish_reason(str(cand.get("finishReason") or ""))
+    finish_reason_raw = str(cand.get("finishReason") or "")
+    mapped_finish_reason = _map_gemini_finish_reason(finish_reason_raw)
+    finish_reason = (
+        "tool_calls"
+        if tool_calls and mapped_finish_reason != "malformed_function_call"
+        else mapped_finish_reason
+    )
     usage_meta = resp.get("usageMetadata") or {}
     usage = SimpleNamespace(
         prompt_tokens=int(usage_meta.get("promptTokenCount") or 0),
@@ -820,7 +827,12 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
 
     finish_reason_raw = str(cand.get("finishReason") or "")
     if finish_reason_raw:
-        mapped = "tool_calls" if tool_call_indices else _map_gemini_finish_reason(finish_reason_raw)
+        mapped_finish_reason = _map_gemini_finish_reason(finish_reason_raw)
+        mapped = (
+            "tool_calls"
+            if tool_call_indices and mapped_finish_reason != "malformed_function_call"
+            else mapped_finish_reason
+        )
         finish_chunk = _make_stream_chunk(model=model, finish_reason=mapped)
         # Attach usage from this event's usageMetadata so the streaming
         # loop in run_agent.py can record token counts (mirrors the

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -67,6 +67,25 @@ def _drop_verification_continuation_scaffolding(messages) -> None:
     ]
 
 
+def _turn_completed_successfully(
+    *,
+    final_response,
+    failed: bool,
+    api_call_count: int,
+    max_iterations: int,
+    turn_exit_reason,
+) -> bool:
+    normal_text_response = str(turn_exit_reason).startswith("text_response(")
+    return (
+        final_response is not None
+        and not failed
+        and (
+            api_call_count < max_iterations
+            or normal_text_response
+        )
+    )
+
+
 def finalize_turn(
     agent,
     *,
@@ -192,14 +211,12 @@ def finalize_turn(
                 )
 
     # Determine if conversation completed successfully
-    normal_text_response = str(_turn_exit_reason).startswith("text_response(")
-    completed = (
-        final_response is not None
-        and not failed
-        and (
-            api_call_count < agent.max_iterations
-            or normal_text_response
-        )
+    completed = _turn_completed_successfully(
+        final_response=final_response,
+        failed=failed,
+        api_call_count=api_call_count,
+        max_iterations=agent.max_iterations,
+        turn_exit_reason=_turn_exit_reason,
     )
 
     # Preflight can seed the display count before the provider receives the

--- a/tests/test_gemini_native_adapter.py
+++ b/tests/test_gemini_native_adapter.py
@@ -1,0 +1,81 @@
+from agent.gemini_native_adapter import translate_gemini_response, translate_stream_event
+from agent.turn_finalizer import _turn_completed_successfully
+
+
+def test_gemini_malformed_function_call_finish_reason_is_preserved():
+    response = translate_gemini_response(
+        {
+            "candidates": [
+                {
+                    "content": {"parts": []},
+                    "finishReason": "MALFORMED_FUNCTION_CALL",
+                }
+            ]
+        },
+        model="gemini-2.5-pro",
+    )
+
+    assert response.choices[0].finish_reason == "malformed_function_call"
+
+
+def test_gemini_stream_malformed_function_call_finish_reason_is_preserved():
+    chunks = translate_stream_event(
+        {
+            "candidates": [
+                {
+                    "content": {"parts": []},
+                    "finishReason": "MALFORMED_FUNCTION_CALL",
+                }
+            ]
+        },
+        model="gemini-2.5-pro",
+        tool_call_indices={},
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].choices[0].finish_reason == "malformed_function_call"
+
+
+def test_gemini_malformed_function_call_overrides_parsed_tool_call():
+    response = translate_gemini_response(
+        {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "functionCall": {
+                                    "name": "run_shell",
+                                    "args": {"command": "echo hi"},
+                                }
+                            }
+                        ]
+                    },
+                    "finishReason": "MALFORMED_FUNCTION_CALL",
+                }
+            ]
+        },
+        model="gemini-2.5-pro",
+    )
+
+    assert response.choices[0].finish_reason == "malformed_function_call"
+
+
+def test_malformed_function_call_failed_turn_is_not_completed():
+    assert not _turn_completed_successfully(
+        final_response="Gemini returned MALFORMED_FUNCTION_CALL",
+        failed=True,
+        api_call_count=1,
+        max_iterations=5,
+        turn_exit_reason="malformed_function_call",
+    )
+
+
+def test_text_response_turn_still_completes_at_iteration_limit():
+    assert _turn_completed_successfully(
+        final_response="done",
+        failed=False,
+        api_call_count=5,
+        max_iterations=5,
+        turn_exit_reason="text_response(finish_reason=stop)",
+    )


### PR DESCRIPTION
## Summary

- preserve Gemini native `MALFORMED_FUNCTION_CALL` as a distinct `malformed_function_call` finish reason instead of normalizing it to `stop`
- stop malformed Gemini tool-call turns as failed turns before the empty-response retry path can turn them into `(empty)` successful completions
- keep `MALFORMED_FUNCTION_CALL` authoritative even if the response payload contains a parsed `functionCall`, so Hermes does not execute a tool call Gemini already marked malformed

## Root Cause

Gemini can return `finishReason: "MALFORMED_FUNCTION_CALL"` when the model emits an invalid function-call payload. The native Gemini adapter previously mapped any unrecognized finish reason to `stop`. That made the agent treat the response as a normal empty assistant message, retry until exhaustion, and then finalize with `(empty)` while `completed` could still be true. With trajectory saving enabled, that false terminal state could land in `trajectory_samples.jsonl` instead of the failed trajectory path.

## Behavior Change

`MALFORMED_FUNCTION_CALL` now terminates the turn as a failed malformed-function-call response. The user gets an explicit explanation, and trajectory/finalization code sees `failed=True`, so the turn is not recorded as a successful completion.

Normal text-response completion semantics are unchanged.

Fixes #83869

## Tests

- `./.venv/Scripts/python.exe -m pytest tests/test_gemini_native_adapter.py -q`
- `./.venv/Scripts/python.exe -m py_compile agent/gemini_native_adapter.py agent/conversation_loop.py agent/turn_finalizer.py tests/test_gemini_native_adapter.py`