### PR TITLE
feat(skills): add radicale-calendar skill

### DIFF
--- a/optional-skills/productivity/radicale-calendar/SKILL.md
+++ b/optional-skills/productivity/radicale-calendar/SKILL.md
@@ -5,8 +5,6 @@ version: 1.0.0
 author: joost (KoenradusXLVIII), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
-prerequisites:
-  env_vars: [RADICALE_URL, RADICALE_USERNAME, RADICALE_PASSWORD]
 required_environment_variables:
   - name: RADICALE_URL
     prompt: Base URL of your Radicale server (e.g. https://calendar.example.com/)
@@ -46,7 +44,8 @@ Requires the `caldav` package. Standard installs get it via `hermes-agent[caldav
 too if running this script outside the main Hermes environment.
 
 Set `RADICALE_URL` / `RADICALE_USERNAME` / `RADICALE_PASSWORD` (see frontmatter
-above - Hermes prompts for these securely on first load if any are missing).
+above - Hermes prompts for these securely on first load if any are missing,
+storing them in `~/.hermes/.env`, which is what this script reads from).
 
 ## How to Run
 

--- a/optional-skills/productivity/radicale-calendar/SKILL.md
+++ b/optional-skills/productivity/radicale-calendar/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: radicale-calendar
+description: Manage appointments on a self-hosted Radicale calendar.
+version: 1.0.0
+author: joost (KoenradusXLVIII), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+prerequisites:
+  env_vars: [RADICALE_URL, RADICALE_USERNAME, RADICALE_PASSWORD]
+required_environment_variables:
+  - name: RADICALE_URL
+    prompt: Base URL of your Radicale server (e.g. https://calendar.example.com/)
+    help: "The CalDAV root URL Radicale serves from - same one you'd enter in any CalDAV client."
+  - name: RADICALE_USERNAME
+    prompt: Radicale account username
+  - name: RADICALE_PASSWORD
+    prompt: Radicale account password
+    help: "Basic auth password (or an app password, if Radicale sits behind a reverse proxy that enforces one)."
+metadata:
+  hermes:
+    tags: [Calendar, CalDAV, Radicale, Scheduling]
+    related_skills: [google-workspace]
+    homepage: https://radicale.org
+---
+
+# Radicale Calendar
+
+Check, create, reschedule, and delete appointments on a self-hosted
+[Radicale](https://radicale.org) CalDAV calendar via a small CLI wrapper
+(`scripts/radicale_cli.py`) around the `caldav` Python library. Talks
+directly to your own Radicale server - no OAuth flow, just a URL and
+basic auth.
+
+## When to Use
+
+- "What's on my calendar [today / this week / on X date]?"
+- "Do I have anything on [date/time]?" (check for conflicts before agreeing to something)
+- "Add an appointment for..." / "Schedule a meeting..."
+- "Move my [X] appointment to..." / "Reschedule..."
+- "Cancel my [X] appointment"
+
+## Prerequisites
+
+Requires the `caldav` package. Standard installs get it via `hermes-agent[caldav]`
+(`uv sync --extra caldav` in a dev checkout); `pip install caldav==3.2.1` works
+too if running this script outside the main Hermes environment.
+
+Set `RADICALE_URL` / `RADICALE_USERNAME` / `RADICALE_PASSWORD` (see frontmatter
+above - Hermes prompts for these securely on first load if any are missing).
+
+## How to Run
+
+Invoke the CLI with the `terminal` tool:
+
+```bash
+python scripts/radicale_cli.py <command> [args]
+```
+
+All commands return JSON on stdout. Parse it, don't eyeball raw text.
+
+## Quick Reference
+
+| Command | Purpose |
+|---|---|
+| `list-calendars` | List available calendars |
+| `list-events [--start] [--end]` | List events (defaults to next 7 days) |
+| `create-event --summary --start --end [--location] [--description] [--all-day] [--recur yearly]` | Create an event |
+| `reschedule-event --uid --start --end [--all-day]` | Change when an event happens |
+| `update-event --uid [--summary] [--location] [--description]` | Change fields other than the time |
+| `delete-event --uid` | Delete an event |
+
+## Procedure
+
+### List events
+
+```bash
+python scripts/radicale_cli.py list-events
+python scripts/radicale_cli.py list-events --start 2026-08-12T00:00:00 --end 2026-08-19T00:00:00
+```
+
+Returns `[{uid, summary, start, end, location, description, calendar}]`.
+
+### Create an event
+
+```bash
+python scripts/radicale_cli.py create-event \
+  --summary "Dentist" --start 2026-08-15T14:00:00 --end 2026-08-15T15:00:00 \
+  --location "Downtown Clinic" --description "Check-up"
+```
+
+Returns `{status: "created", uid, summary, start, end, ...}` - the `uid` is
+needed for rescheduling/updating/deleting later.
+
+### Create an all-day / recurring event (e.g. a birthday)
+
+```bash
+python scripts/radicale_cli.py create-event \
+  --summary "Someone's Birthday" --start 1990-04-13 --all-day --recur yearly
+```
+
+`--all-day` takes a bare `YYYY-MM-DD` and produces a whole-day event
+(`DTSTART;VALUE=DATE`), not a timed one. `--end` defaults to the day after
+`--start` if omitted (iCal's DTEND is exclusive). `--recur yearly` adds
+`RRULE:FREQ=YEARLY` - `list-events` expands it into future years without
+re-creating the event annually.
+
+### Reschedule an event
+
+```bash
+python scripts/radicale_cli.py reschedule-event \
+  --uid <uid> --start 2026-08-16T14:00:00 --end 2026-08-16T15:00:00
+```
+
+Named `reschedule-event`, not `move-event`, deliberately - other CalDAV
+tools use "move" to mean transferring an event to a *different calendar*.
+This changes date/time only.
+
+### Update other fields
+
+```bash
+python scripts/radicale_cli.py update-event --uid <uid> --location "New location"
+```
+
+Pass an empty string (`--location ""`) to clear a field entirely.
+
+### Delete an event
+
+```bash
+python scripts/radicale_cli.py delete-event --uid <uid>
+```
+
+## Pitfalls
+
+- **Never create, reschedule, or delete an event without confirming with
+  the user first.** Show what will change (summary, date/time, location)
+  and get explicit confirmation. Listing/checking needs no confirmation.
+- **Always resolve an explicit ISO 8601 date/time** before calling
+  anything - if the user gives a time without a date, check today's date
+  rather than guessing.
+- **Get `uid` from `list-events` or `create-event`'s own output** - never
+  guess or invent one.
+- **`--all-day` on `reschedule-event` matters** - omitting it on an
+  existing all-day event's reschedule assigns a `datetime` where a `date`
+  is expected, silently turning it into a timed event.
+- **Only one calendar exists** on a fresh Radicale instance, and commands
+  default to it. Once more than one exists, check `list-calendars` first
+  rather than assuming which one is meant.
+
+## Verification
+
+After any create/reschedule/update, re-run `list-events` (or search by the
+returned `uid`) and confirm the summary/start/end/location match what was
+requested before telling the user it succeeded.

--- a/optional-skills/productivity/radicale-calendar/scripts/radicale_cli.py
+++ b/optional-skills/productivity/radicale-calendar/scripts/radicale_cli.py
@@ -1,0 +1,300 @@
+"""Command-line wrapper around the `caldav` library for a self-hosted
+Radicale calendar. JSON output throughout, matching the output contract
+other Hermes calendar skills use (e.g. the bundled google-workspace
+skill's `calendar` subcommand) so results are easy to parse rather than
+eyeballed from plain text.
+
+Reads RADICALE_URL / RADICALE_USERNAME / RADICALE_PASSWORD from a .env file
+next to this script by default (override with --env-path).
+
+Deliberately named `reschedule-event` rather than `move-event` - other
+CalDAV tools use "move" to mean transferring an event to a *different
+calendar*, not changing its date/time. Avoid that ambiguity here:
+`reschedule-event` changes when an event happens, nothing else does
+calendar-to-calendar transfer (not needed yet - add it if it ever comes
+up).
+
+Run: python radicale_cli.py <command> [args]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import caldav
+
+DEFAULT_ENV_PATH = str(Path(__file__).resolve().parent.parent / ".env")
+
+
+def _load_dotenv(env_path: str) -> None:
+    import os
+
+    if not env_path or not os.path.exists(env_path):
+        return
+    with open(env_path, encoding="utf-8") as env_file:
+        for raw_line in env_file:
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip()
+            value = value.strip().strip("'\"")
+            if key and key not in os.environ:
+                os.environ[key] = value
+
+
+def _client(env_path: str) -> caldav.DAVClient:
+    import os
+
+    _load_dotenv(env_path)
+    for var in ("RADICALE_URL", "RADICALE_USERNAME", "RADICALE_PASSWORD"):
+        if var not in os.environ:
+            _fail(f"Missing {var} - check .env or pass --env-path")
+    return caldav.DAVClient(
+        url=os.environ["RADICALE_URL"],
+        username=os.environ["RADICALE_USERNAME"],
+        password=os.environ["RADICALE_PASSWORD"],
+    )
+
+
+def _fail(message: str) -> None:
+    print(json.dumps({"error": message}), file=sys.stderr)
+    sys.exit(1)
+
+
+def _get_calendar(principal, name: str | None):
+    calendars = principal.calendars()
+    if not calendars:
+        _fail("No calendars exist yet - create one first (e.g. via a real CalDAV client)")
+    if name is None:
+        return calendars[0]
+    for cal in calendars:
+        if cal.get_display_name() == name:
+            return cal
+    available = ", ".join(c.get_display_name() or "(unnamed)" for c in calendars)
+    _fail(f"No calendar named '{name}'. Available: {available}")
+
+
+def _parse_dt(value: str) -> datetime:
+    # Accept both a bare "Z" suffix and explicit offsets.
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _parse_date(value: str) -> date:
+    # Plain YYYY-MM-DD, no time component - for --all-day events. A date
+    # (not datetime) object is what makes icalendar emit DTSTART;VALUE=DATE
+    # instead of a timed DTSTART - confirmed live against Radicale
+    # (2026-08-11) rather than assumed from the RFC.
+    return date.fromisoformat(value)
+
+
+def _event_json(event) -> dict:
+    comp = event.icalendar_component
+    dtstart = comp.get("dtstart")
+    dtend = comp.get("dtend")
+    rrule = comp.get("rrule")
+    return {
+        "uid": str(comp.get("uid")),
+        "summary": str(comp.get("summary", "")),
+        # .dt is a `date` for --all-day events, `datetime` otherwise - both
+        # have .isoformat(), so this stays correct either way (a bare
+        # "YYYY-MM-DD" for all-day, full timestamp for timed events).
+        "start": dtstart.dt.isoformat() if dtstart else None,
+        "end": dtend.dt.isoformat() if dtend else None,
+        "location": str(comp.get("location", "")) or None,
+        "description": str(comp.get("description", "")) or None,
+        "calendar": event.parent.get_display_name(),
+        "all_day": bool(dtstart and not isinstance(dtstart.dt, datetime)),
+        "recurring": rrule.to_ical().decode() if rrule else None,
+    }
+
+
+def cmd_list_calendars(client: caldav.DAVClient, args) -> None:
+    principal = client.principal()
+    result = [{"name": c.get_display_name(), "url": str(c.url)} for c in principal.calendars()]
+    print(json.dumps(result, indent=2))
+
+
+def cmd_list_events(client: caldav.DAVClient, args) -> None:
+    principal = client.principal()
+    cal = _get_calendar(principal, args.calendar)
+    start = _parse_dt(args.start) if args.start else datetime.now()
+    end = _parse_dt(args.end) if args.end else start + timedelta(days=7)
+    events = cal.search(start=start, end=end, event=True, expand=True)
+    print(json.dumps([_event_json(e) for e in events], indent=2))
+
+
+def cmd_create_event(client: caldav.DAVClient, args) -> None:
+    principal = client.principal()
+    cal = _get_calendar(principal, args.calendar)
+    if args.all_day:
+        start = _parse_date(args.start)
+        # DTEND is exclusive in iCalendar - a single-day all-day event's
+        # end is the NEXT day, not the same day. Default to that unless an
+        # explicit --end was given (e.g. for a multi-day all-day event).
+        end = _parse_date(args.end) if args.end else start + timedelta(days=1)
+    else:
+        if not args.end:
+            _fail("--end is required unless --all-day is set")
+        start = _parse_dt(args.start)
+        end = _parse_dt(args.end)
+    kwargs = {"dtstart": start, "dtend": end, "summary": args.summary}
+    if args.location:
+        kwargs["location"] = args.location
+    if args.description:
+        kwargs["description"] = args.description
+    if args.recur == "yearly":
+        kwargs["rrule"] = {"FREQ": "YEARLY"}
+    event = cal.add_event(**kwargs)
+    print(json.dumps({"status": "created", **_event_json(event)}, indent=2))
+
+
+def cmd_reschedule_event(client: caldav.DAVClient, args) -> None:
+    principal = client.principal()
+    cal = _get_calendar(principal, args.calendar)
+    event = cal.event_by_uid(args.uid)
+    if event is None:
+        _fail(f"No event with uid '{args.uid}'")
+    old = _event_json(event)
+    ical = event.icalendar_component
+    if args.all_day:
+        # Preserve all-day-ness - assigning a `datetime` here (via
+        # _parse_dt) would silently turn an all-day event into a timed one.
+        start = _parse_date(args.start)
+        end = _parse_date(args.end) if args.end else start + timedelta(days=1)
+    else:
+        if not args.end:
+            _fail("--end is required unless --all-day is set")
+        start = _parse_dt(args.start)
+        end = _parse_dt(args.end)
+    ical["dtstart"].dt = start
+    ical["dtend"].dt = end
+    event.save()
+    print(
+        json.dumps(
+            {
+                "status": "rescheduled",
+                "old_start": old["start"],
+                "old_end": old["end"],
+                **_event_json(event),
+            },
+            indent=2,
+        )
+    )
+
+
+def _set_or_clear(ical, field: str, value: str | None) -> None:
+    # None (flag not passed) means leave alone. Empty string means clear -
+    # delete the property entirely rather than leaving an empty one behind
+    # (an empty DESCRIPTION: line is different, and uglier, than no
+    # DESCRIPTION property at all).
+    if value is None:
+        return
+    if value == "":
+        if field in ical:
+            del ical[field]
+        return
+    ical[field] = value
+
+
+def cmd_update_event(client: caldav.DAVClient, args) -> None:
+    principal = client.principal()
+    cal = _get_calendar(principal, args.calendar)
+    event = cal.event_by_uid(args.uid)
+    if event is None:
+        _fail(f"No event with uid '{args.uid}'")
+    ical = event.icalendar_component
+    _set_or_clear(ical, "summary", args.summary)
+    _set_or_clear(ical, "location", args.location)
+    _set_or_clear(ical, "description", args.description)
+    event.save()
+    print(json.dumps({"status": "updated", **_event_json(event)}, indent=2))
+
+
+def cmd_delete_event(client: caldav.DAVClient, args) -> None:
+    principal = client.principal()
+    cal = _get_calendar(principal, args.calendar)
+    event = cal.event_by_uid(args.uid)
+    if event is None:
+        _fail(f"No event with uid '{args.uid}'")
+    summary = str(event.icalendar_component.get("summary", ""))
+    event.delete()
+    print(json.dumps({"status": "deleted", "uid": args.uid, "summary": summary}, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="radicale", description="Control a self-hosted Radicale calendar."
+    )
+    parser.add_argument("--env-path", default=DEFAULT_ENV_PATH)
+    parser.add_argument(
+        "--calendar", default=None, help="Calendar name (default: the first/only one)"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list-calendars").set_defaults(func=cmd_list_calendars)
+
+    p_list = sub.add_parser("list-events", help="Defaults to the next 7 days")
+    p_list.add_argument("--start", help="ISO 8601, e.g. 2026-08-12T00:00:00")
+    p_list.add_argument("--end", help="ISO 8601")
+    p_list.set_defaults(func=cmd_list_events)
+
+    p_create = sub.add_parser("create-event")
+    p_create.add_argument("--summary", required=True)
+    p_create.add_argument(
+        "--start", required=True, help="ISO 8601 datetime, or YYYY-MM-DD with --all-day"
+    )
+    p_create.add_argument(
+        "--end",
+        help="ISO 8601, or YYYY-MM-DD with --all-day. Required unless --all-day "
+        "(defaults to the day after --start)",
+    )
+    p_create.add_argument("--location")
+    p_create.add_argument("--description")
+    p_create.add_argument(
+        "--all-day",
+        action="store_true",
+        help="Whole-day event (e.g. a birthday) - no specific time",
+    )
+    p_create.add_argument(
+        "--recur",
+        choices=["yearly"],
+        help="Recurrence rule. 'yearly' for annually-repeating events like birthdays",
+    )
+    p_create.set_defaults(func=cmd_create_event)
+
+    p_resched = sub.add_parser("reschedule-event", help="Change an event's start/end time")
+    p_resched.add_argument("--uid", required=True)
+    p_resched.add_argument("--start", required=True, help="ISO 8601, or YYYY-MM-DD with --all-day")
+    p_resched.add_argument(
+        "--end", help="ISO 8601, or YYYY-MM-DD with --all-day. Required unless --all-day"
+    )
+    p_resched.add_argument(
+        "--all-day", action="store_true", help="Keep/make this an all-day event, not a timed one"
+    )
+    p_resched.set_defaults(func=cmd_reschedule_event)
+
+    p_update = sub.add_parser(
+        "update-event", help="Change summary/location/description, not the time"
+    )
+    p_update.add_argument("--uid", required=True)
+    p_update.add_argument("--summary", help="Pass an empty string to clear")
+    p_update.add_argument("--location", help="Pass an empty string to clear")
+    p_update.add_argument("--description", help="Pass an empty string to clear")
+    p_update.set_defaults(func=cmd_update_event)
+
+    p_delete = sub.add_parser("delete-event")
+    p_delete.add_argument("--uid", required=True)
+    p_delete.set_defaults(func=cmd_delete_event)
+
+    args = parser.parse_args()
+    client = _client(args.env_path)
+    args.func(client, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/productivity/radicale-calendar/scripts/radicale_cli.py
+++ b/optional-skills/productivity/radicale-calendar/scripts/radicale_cli.py
@@ -4,8 +4,11 @@ other Hermes calendar skills use (e.g. the bundled google-workspace
 skill's `calendar` subcommand) so results are easy to parse rather than
 eyeballed from plain text.
 
-Reads RADICALE_URL / RADICALE_USERNAME / RADICALE_PASSWORD from a .env file
-next to this script by default (override with --env-path).
+Reads RADICALE_URL / RADICALE_USERNAME / RADICALE_PASSWORD from the process
+environment first, then from `~/.hermes/.env` (where Hermes's secure
+setup-on-load prompt actually stores them) and a `.env` in the current
+directory, in that order. Pass --env-path to load one specific file instead
+(e.g. running this script outside the main Hermes environment).
 
 Deliberately named `reschedule-event` rather than `move-event` - other
 CalDAV tools use "move" to mean transferring an event to a *different
@@ -21,43 +24,76 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
 import caldav
 
-DEFAULT_ENV_PATH = str(Path(__file__).resolve().parent.parent / ".env")
+
+def _hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
 
 
-def _load_dotenv(env_path: str) -> None:
-    import os
+def _dotenv_paths(env_path: str | None) -> list[Path]:
+    # An explicit --env-path loads only that file (standalone/outside-Hermes
+    # use). Otherwise fall back to the same locations Hermes itself uses -
+    # notably ~/.hermes/.env, where the secure setup-on-load prompt actually
+    # writes RADICALE_PASSWORD. A skill-local .env is deliberately not part
+    # of this list: it would be a second, unmanaged plaintext secret store
+    # outside Hermes's own, contradicting the "prompts securely" story.
+    if env_path:
+        return [Path(env_path)]
+    paths = []
+    project_env = Path.cwd() / ".env"
+    if project_env.exists():
+        paths.append(project_env)
+    user_env = _hermes_home() / ".env"
+    if user_env.exists():
+        paths.append(user_env)
+    return paths
 
-    if not env_path or not os.path.exists(env_path):
-        return
-    with open(env_path, encoding="utf-8") as env_file:
-        for raw_line in env_file:
-            line = raw_line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            key = key.strip()
-            value = value.strip().strip("'\"")
-            if key and key not in os.environ:
-                os.environ[key] = value
+
+def _load_dotenv_values(env_path: str | None) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for path in _dotenv_paths(env_path):
+        if not path.exists():
+            continue
+        with open(path, encoding="utf-8") as env_file:
+            for raw_line in env_file:
+                line = raw_line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                key = key.strip()
+                value = value.strip().strip("'\"")
+                if key:
+                    values[key] = value
+    return values
 
 
-def _client(env_path: str) -> caldav.DAVClient:
-    import os
+def _env_lookup(key: str, dotenv_values: dict[str, str]) -> str | None:
+    # Process environment wins over any dotenv file - lets a caller override
+    # without editing a file on disk.
+    return os.environ.get(key) or dotenv_values.get(key)
 
-    _load_dotenv(env_path)
+
+def _client(env_path: str | None) -> caldav.DAVClient:
+    dotenv_values = _load_dotenv_values(env_path)
+    creds = {}
     for var in ("RADICALE_URL", "RADICALE_USERNAME", "RADICALE_PASSWORD"):
-        if var not in os.environ:
-            _fail(f"Missing {var} - check .env or pass --env-path")
+        value = _env_lookup(var, dotenv_values)
+        if not value:
+            _fail(
+                f"Missing {var} - set it via `hermes setup`, "
+                f"{_hermes_home() / '.env'}, or --env-path"
+            )
+        creds[var] = value
     return caldav.DAVClient(
-        url=os.environ["RADICALE_URL"],
-        username=os.environ["RADICALE_USERNAME"],
-        password=os.environ["RADICALE_PASSWORD"],
+        url=creds["RADICALE_URL"],
+        username=creds["RADICALE_USERNAME"],
+        password=creds["RADICALE_PASSWORD"],
     )
 
 
@@ -82,6 +118,15 @@ def _get_calendar(principal, name: str | None):
 def _parse_dt(value: str) -> datetime:
     # Accept both a bare "Z" suffix and explicit offsets.
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _now_local() -> datetime:
+    # Timezone-aware, not naive - cal.search(..., expand=True) hands back
+    # events with aware dtstart/dtend once recurrence expansion kicks in, and
+    # comparing those against a naive default silently misses matches (or
+    # raises TypeError: can't compare offset-naive and offset-aware
+    # datetimes) instead of failing loudly.
+    return datetime.now().astimezone()
 
 
 def _parse_date(value: str) -> date:
@@ -122,7 +167,7 @@ def cmd_list_calendars(client: caldav.DAVClient, args) -> None:
 def cmd_list_events(client: caldav.DAVClient, args) -> None:
     principal = client.principal()
     cal = _get_calendar(principal, args.calendar)
-    start = _parse_dt(args.start) if args.start else datetime.now()
+    start = _parse_dt(args.start) if args.start else _now_local()
     end = _parse_dt(args.end) if args.end else start + timedelta(days=7)
     events = cal.search(start=start, end=end, event=True, expand=True)
     print(json.dumps([_event_json(e) for e in events], indent=2))
@@ -230,7 +275,11 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         prog="radicale", description="Control a self-hosted Radicale calendar."
     )
-    parser.add_argument("--env-path", default=DEFAULT_ENV_PATH)
+    parser.add_argument(
+        "--env-path",
+        default=None,
+        help="Load env vars from this file only, instead of ~/.hermes/.env / ./.env",
+    )
     parser.add_argument(
         "--calendar", default=None, help="Calendar name (default: the first/only one)"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,7 +322,7 @@ youtube = [
 ]
 # Required by optional-skills/productivity/radicale-calendar (CalDAV
 # client for a self-hosted Radicale calendar).
-caldav = ["caldav==3.2.1"]
+caldav = ["caldav>=3.2.1,<4"]
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
 # starlette==1.3.1 pinned for CVE-2026-48710 (BadHost) — fastapi pulls Starlette
 # transitively and pre-1.0.1 is the vulnerable range. See the mcp extra above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,6 +320,9 @@ youtube = [
   # at first invocation with ModuleNotFoundError (issue #22243).
   "youtube-transcript-api==1.2.4",
 ]
+# Required by optional-skills/productivity/radicale-calendar (CalDAV
+# client for a self-hosted Radicale calendar).
+caldav = ["caldav==3.2.1"]
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
 # starlette==1.3.1 pinned for CVE-2026-48710 (BadHost) — fastapi pulls Starlette
 # transitively and pre-1.0.1 is the vulnerable range. See the mcp extra above.

--- a/tests/skills/test_radicale_calendar_skill.py
+++ b/tests/skills/test_radicale_calendar_skill.py
@@ -86,6 +86,47 @@ def test_event_json_timed_event():
     assert result["recurring"] is None
 
 
+def test_now_local_is_timezone_aware():
+    assert rc._now_local().tzinfo is not None
+
+
+def test_load_dotenv_values_reads_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)  # no stray cwd .env to pick up instead
+    user_env = tmp_path / ".env"
+    user_env.write_text("RADICALE_URL=https://example.com\n", encoding="utf-8")
+
+    values = rc._load_dotenv_values(None)
+
+    assert values["RADICALE_URL"] == "https://example.com"
+
+
+def test_load_dotenv_values_explicit_path_ignores_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    user_env = tmp_path / ".env"
+    user_env.write_text("RADICALE_URL=https://wrong.example.com\n", encoding="utf-8")
+    explicit = tmp_path / "other.env"
+    explicit.write_text("RADICALE_URL=https://right.example.com\n", encoding="utf-8")
+
+    values = rc._load_dotenv_values(str(explicit))
+
+    assert values["RADICALE_URL"] == "https://right.example.com"
+
+
+def test_env_lookup_prefers_process_environment(monkeypatch):
+    monkeypatch.setenv("RADICALE_USERNAME", "from-process-env")
+    assert (
+        rc._env_lookup("RADICALE_USERNAME", {"RADICALE_USERNAME": "from-dotenv"})
+        == "from-process-env"
+    )
+
+
+def test_env_lookup_falls_back_to_dotenv_values(monkeypatch):
+    monkeypatch.delenv("RADICALE_PASSWORD", raising=False)
+    dotenv_values = {"RADICALE_PASSWORD": "secret"}
+    assert rc._env_lookup("RADICALE_PASSWORD", dotenv_values) == "secret"
+
+
 def test_event_json_all_day_recurring_event():
     comp = {
         "uid": "bday-1",

--- a/tests/skills/test_radicale_calendar_skill.py
+++ b/tests/skills/test_radicale_calendar_skill.py
@@ -1,0 +1,108 @@
+"""Tests for optional-skills/productivity/radicale-calendar's CLI helpers.
+
+Pure logic only (date/datetime parsing, event JSON shaping, field-clear
+semantics) - no live network calls, no real caldav server.
+"""
+
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# radicale_cli.py imports the `caldav` package at module scope. That's an
+# opt-in extra (`hermes-agent[caldav]`), not part of [dev]/[all], so skip
+# cleanly rather than erroring out test collection where it isn't installed.
+pytest.importorskip("caldav")
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "productivity"
+    / "radicale-calendar"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import radicale_cli as rc  # noqa: E402
+
+
+def test_parse_dt_accepts_z_suffix():
+    assert rc._parse_dt("2026-08-15T14:00:00Z") == datetime.fromisoformat(
+        "2026-08-15T14:00:00+00:00"
+    )
+
+
+def test_parse_dt_accepts_explicit_offset():
+    assert rc._parse_dt("2026-08-15T14:00:00+02:00") == datetime.fromisoformat(
+        "2026-08-15T14:00:00+02:00"
+    )
+
+
+def test_parse_date_bare_iso():
+    assert rc._parse_date("2026-08-15") == date(2026, 8, 15)
+
+
+def test_set_or_clear_none_leaves_field_untouched():
+    ical = {"summary": "Original"}
+    rc._set_or_clear(ical, "summary", None)
+    assert ical["summary"] == "Original"
+
+
+def test_set_or_clear_empty_string_deletes_field():
+    ical = {"summary": "Original"}
+    rc._set_or_clear(ical, "summary", "")
+    assert "summary" not in ical
+
+
+def test_set_or_clear_value_sets_field():
+    ical = {}
+    rc._set_or_clear(ical, "location", "New Place")
+    assert ical["location"] == "New Place"
+
+
+def test_event_json_timed_event():
+    comp = {
+        "uid": "abc-123",
+        "summary": "Dentist",
+        "dtstart": MagicMock(dt=datetime(2026, 8, 15, 14, 0)),
+        "dtend": MagicMock(dt=datetime(2026, 8, 15, 15, 0)),
+        "location": "Clinic",
+        "description": "Check-up",
+        "rrule": None,
+    }
+    event = MagicMock()
+    event.icalendar_component = comp
+    event.parent.get_display_name.return_value = "default"
+
+    result = rc._event_json(event)
+
+    assert result["uid"] == "abc-123"
+    assert result["summary"] == "Dentist"
+    assert result["start"] == "2026-08-15T14:00:00"
+    assert result["end"] == "2026-08-15T15:00:00"
+    assert result["all_day"] is False
+    assert result["recurring"] is None
+
+
+def test_event_json_all_day_recurring_event():
+    comp = {
+        "uid": "bday-1",
+        "summary": "Birthday",
+        "dtstart": MagicMock(dt=date(2026, 4, 13)),
+        "dtend": MagicMock(dt=date(2026, 4, 14)),
+        "location": "",
+        "description": "",
+        "rrule": MagicMock(to_ical=lambda: b"FREQ=YEARLY"),
+    }
+    event = MagicMock()
+    event.icalendar_component = comp
+    event.parent.get_display_name.return_value = "default"
+
+    result = rc._event_json(event)
+
+    assert result["all_day"] is True
+    assert result["recurring"] == "FREQ=YEARLY"
+    assert result["location"] is None
+    assert result["description"] is None


### PR DESCRIPTION
## What

Adds `radicale-calendar`, a skill for checking, creating, rescheduling, and deleting appointments on a self-hosted [Radicale](https://radicale.org) CalDAV calendar via a thin CLI wrapper (`scripts/radicale_cli.py`) around the `caldav` Python library. No OAuth flow - just a URL and basic auth against your own server.

Placed under `optional-skills/productivity/` (niche self-hosted integration, not a default-on skill), alongside `shopify`/`siyuan`.

## Why

Built and used daily against a real Radicale instance (list/create/reschedule/update/delete, all-day events, `RRULE:FREQ=YEARLY` recurrence for birthdays/anniversaries). Generalized from that private deployment for this PR - no personal URLs, paths, or account details remain.

## Changes

- `optional-skills/productivity/radicale-calendar/SKILL.md` - frontmatter (`required_environment_variables` for `RADICALE_URL`/`RADICALE_USERNAME`/`RADICALE_PASSWORD`, `prerequisites.env_vars`, `related_skills: [google-workspace]`), body following the title → intro → When to Use → Prerequisites → How to Run → Quick Reference → Procedure → Pitfalls → Verification order from CONTRIBUTING.md. Description is 55 chars, one sentence, no marketing language.
- `optional-skills/productivity/radicale-calendar/scripts/radicale_cli.py` - the CLI itself (argparse subcommands, JSON output, stdlib-only apart from `caldav`).
- `pyproject.toml` - new `caldav = ["caldav==3.2.1"]` extra (pinned to current PyPI latest), mirroring the `youtube`/`google` extras' "required by skill X" pattern. Deliberately **not** added to `[all]`, matching how `dingtalk`/`feishu` stay opt-in for niche integrations.
- `tests/skills/test_radicale_calendar_skill.py` - 8 stdlib+pytest+`unittest.mock` tests covering date/datetime parsing, the field-clear-on-empty-string semantics, and all-day vs. timed event JSON shaping. No live network calls. Guarded with `pytest.importorskip("caldav")` since the extra isn't in `[dev]`/`[all]`.

## Testing

- `pytest tests/skills/test_radicale_calendar_skill.py -v` - 8/8 passed, run against a real venv with `caldav==3.2.1` installed.
- `ruff check --select PLW1514 --preview` on both new Python files - clean.
- Exercised the CLI itself (list/create/reschedule/update/delete, all-day, yearly recurrence) live against a real Radicale server prior to genericizing.

One thing I'd appreciate a second pair of eyes on: I inferred the `required_environment_variables` frontmatter shape (`name`/`prompt`/`help`) from `optional-skills/productivity/shopify` and `optional-skills/productivity/siyuan`'s existing usage rather than from a schema doc, since I couldn't find one - happy to adjust if I got a field wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)