### PR TITLE
fix(desktop): prefer installer shim in Linux desktop entry Exec

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -57,13 +57,32 @@ def icon_path(project_root: Path) -> Path:
     return project_root / "apps" / "desktop" / "assets" / "icon.png"
 
 
+def installer_shim_path() -> Optional[str]:
+    """The installer's bash shim (``~/.local/bin/hermes``), if executable.
+
+    GUI launchers run the entry without the user's shell environment, and
+    some (e.g. Deepin's app-launch-helper) even force-run Python scripts
+    with the system interpreter, losing the venv dependencies. The shim
+    sanitizes the env and execs the venv interpreter explicitly, so it
+    survives every launcher.
+    """
+    shim = Path.home() / ".local" / "bin" / "hermes"
+    if shim.is_file() and os.access(shim, os.X_OK):
+        return str(shim)
+    return None
+
+
 def resolve_exec_command() -> str:
     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
 
-    Prefer the real ``hermes`` executable (argv[0] or PATH). When Hermes
-    runs as a module with no launcher installed, use the current
-    interpreter, also absolute.
+    Prefer the installer shim when present (see ``installer_shim_path``).
+    Fall back to the real ``hermes`` executable (argv[0] or PATH), then the
+    current interpreter, also absolute.
     """
+    shim = installer_shim_path()
+    if shim:
+        return " ".join(_quote_exec_arg(a) for a in (shim, "desktop"))
+
     from hermes_cli.relaunch import resolve_hermes_bin
 
     bin_path = resolve_hermes_bin()

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -15,6 +15,9 @@ def xdg_home(tmp_path, monkeypatch) -> Path:
     data_home = tmp_path / "xdg-data"
     monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
     monkeypatch.setattr(lde.sys, "platform", "linux")
+    # Deterministic resolution: the real machine may have the installer
+    # shim present; tests exercise the fallback chain, not the host env.
+    monkeypatch.setattr(lde, "installer_shim_path", lambda: None)
     return data_home
 
 
@@ -74,6 +77,25 @@ def test_installed_entry_is_executable(tmp_path, xdg_home, monkeypatch):
     entry = lde.install_desktop_entry(root)
 
     assert entry.stat().st_mode & stat.S_IXUSR
+
+
+def test_exec_prefers_installer_shim(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    shim = tmp_path / "shim" / "hermes"
+    shim.parent.mkdir()
+    shim.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(lde, "installer_shim_path", lambda: str(shim))
+    # The fallback chain must not be consulted when the shim exists.
+    monkeypatch.setattr(
+        "hermes_cli.relaunch.resolve_hermes_bin",
+        lambda: pytest.fail("resolve_hermes_bin must not run when the shim wins"),
+    )
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{shim} desktop"
 
 
 def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Summary

On Linux, the generated `hermes.desktop` entry's `Exec` line points at the checkout's `hermes` launcher script (`resolve_hermes_bin()` → `argv[0]`). That script's `#!/usr/bin/env python3` shebang resolves to the **system** interpreter when a desktop launcher runs the entry without the user's shell environment — and the CLI's dependencies (`rich`, etc.) live in the venv. Result: clicking the Hermes icon silently does nothing.

Observed on Deepin 25, whose `app-launch-helper` even force-runs `.py` scripts with `/usr/bin/python3` explicitly — but the failure mode is generic: the entry only ever worked when the session happened to export the venv `PYTHONPATH` (terminals do, GUI launchers don't).

## Evidence

journalctl from the icon click:

```
app-launch-helper[32143]: after encode: /home/RHM/.hermes/hermes-agent/hermes
hermes[32144]: [DEBUG] Automatically add interpreter /usr/bin/python3 to launch app.
hermes[32144]:   File ".../hermes_cli/secrets_cli.py", line 22, in <module>
hermes[32144]:     from rich.console import Console
hermes[32144]: ModuleNotFoundError: No module named 'rich'
systemd[4936]: app-DDE-hermes@....service: Failed with result 'exit-code'.
```

Reproduced without any desktop environment involved:

```bash
# shell env (PYTHONPATH exported): works
/usr/bin/python3 -c "import sys; sys.path.insert(0, '<repo>'); from hermes_cli import secrets_cli"  # OK

# GUI-like minimal env: fails exactly as in the journal
env -i HOME=$HOME PATH=/usr/bin:/bin /usr/bin/python3 -c "...same..."  # ModuleNotFoundError: rich
```

## Fix

`resolve_exec_command()` now prefers the installer's bash shim (`~/.local/bin/hermes`) when present and executable. The shim unsets `PYTHONPATH`/`PYTHONHOME` and execs the venv interpreter by absolute path, so it is robust under any launcher environment. The existing `argv[0]` → PATH → `sys.executable -m hermes_cli.main` fallback chain is unchanged for installs without the shim.

The shim lookup is extracted into `installer_shim_path()` so tests can isolate it from the host machine.

## Tests

- `xdg_home` fixture now stubs `installer_shim_path` to `None` — previously the fallback-chain tests depended on the shim being absent on the host (fails on any dev machine with Hermes installed).
- New `test_exec_prefers_installer_shim` pins the precedence and asserts the fallback chain is not consulted when the shim exists.
- `scripts/run_tests.sh tests/hermes_cli/test_linux_desktop_entry.py tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_gui_uninstall.py` → **28 passed, 0 failed, 6 skipped** (skips are platform markers), run against current `origin/main`.
- End-to-end on the affected machine: after the fix, the regenerated entry carries `Exec=/home/RHM/.local/bin/hermes desktop` and the icon cold-starts the app successfully.
