### PR TITLE
fix(telegram): analyze animated sticker content via frame extraction

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9602,9 +9602,6 @@ class TelegramAdapter(BasePlatformAdapter):
 
             if image_bytes is None:
                 if metadata_description:
-                    cache_sticker_description(
-                        sticker.file_unique_id, metadata_description, emoji, set_name
-                    )
                     event.text = build_sticker_injection(
                         metadata_description, emoji, set_name
                     )
@@ -9631,12 +9628,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.text = build_sticker_injection(description, emoji, set_name)
             else:
                 if metadata_description:
-                    cache_sticker_description(
-                        sticker.file_unique_id,
-                        metadata_description,
-                        emoji,
-                        set_name,
-                    )
                     event.text = build_sticker_injection(
                         metadata_description, emoji, set_name
                     )
@@ -9652,9 +9643,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
             if metadata_description:
-                cache_sticker_description(
-                    sticker.file_unique_id, metadata_description, emoji, set_name
-                )
                 event.text = build_sticker_injection(
                     metadata_description, emoji, set_name
                 )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9524,9 +9524,9 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         Describe a Telegram sticker via vision analysis, with caching.
 
-        For static stickers (WEBP), we download, analyze with vision, and cache
-        the description by file_unique_id. For animated/video stickers, we inject
-        a placeholder noting the emoji.
+        Static stickers and Telegram-provided animated/video thumbnails are
+        analyzed with vision. TGS stickers additionally get local best-effort
+        frame extraction, with parsed animation metadata as a final fallback.
         """
         from gateway.sticker_cache import (
             get_cached_description,
@@ -9540,28 +9540,83 @@ class TelegramAdapter(BasePlatformAdapter):
         emoji = sticker.emoji or ""
         set_name = sticker.set_name or ""
 
-        # Animated and video stickers can't be analyzed as static images
-        if sticker.is_animated or sticker.is_video:
-            event.text = build_animated_sticker_injection(emoji)
-            return
-
         # Check the cache first
         cached = get_cached_description(sticker.file_unique_id)
         if cached:
             event.text = build_sticker_injection(
-                cached["description"], cached.get("emoji", emoji), cached.get("set_name", set_name)
+                cached["description"],
+                cached.get("emoji", emoji),
+                cached.get("set_name", set_name),
             )
             logger.info("[Telegram] Sticker cache hit: %s", sticker.file_unique_id)
             return
 
         # Cache miss -- download and analyze
+        metadata_description = None
         try:
-            file_obj = await sticker.get_file()
-            image_bytes = await file_obj.download_as_bytearray()
-            cached_path = cache_image_from_bytes(bytes(image_bytes), ext=".webp")
+            image_bytes = None
+            image_ext = ".webp"
+
+            if sticker.is_animated:
+                from plugins.platforms.telegram.tgs import extract_tgs_frame
+
+                try:
+                    file_obj = await sticker.get_file()
+                    tgs_bytes = bytes(await file_obj.download_as_bytearray())
+                    frame_result = await asyncio.to_thread(extract_tgs_frame, tgs_bytes)
+                except Exception as exc:
+                    logger.info(
+                        "[Telegram] TGS frame extraction unavailable: %s",
+                        _redact_telegram_error_text(exc),
+                    )
+                else:
+                    image_bytes = frame_result.image_bytes
+                    metadata_description = frame_result.metadata_description
+                    image_ext = ".png"
+
+            # Telegram exposes a WEBP/JPG thumbnail for animated and video
+            # stickers. It is the dependency-free representative-frame path.
+            if image_bytes is None and (sticker.is_animated or sticker.is_video):
+                thumbnail = getattr(sticker, "thumbnail", None)
+                if thumbnail is not None:
+                    try:
+                        thumbnail_file = await thumbnail.get_file()
+                        image_bytes = bytes(
+                            await thumbnail_file.download_as_bytearray()
+                        )
+                        if image_bytes.startswith(b"\xff\xd8\xff"):
+                            image_ext = ".jpg"
+                        elif image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+                            image_ext = ".png"
+                        else:
+                            image_ext = ".webp"
+                    except Exception as exc:
+                        logger.info(
+                            "[Telegram] Sticker thumbnail unavailable: %s",
+                            _redact_telegram_error_text(exc),
+                        )
+
+            if image_bytes is None and not (sticker.is_animated or sticker.is_video):
+                file_obj = await sticker.get_file()
+                image_bytes = bytes(await file_obj.download_as_bytearray())
+
+            if image_bytes is None:
+                if metadata_description:
+                    cache_sticker_description(
+                        sticker.file_unique_id, metadata_description, emoji, set_name
+                    )
+                    event.text = build_sticker_injection(
+                        metadata_description, emoji, set_name
+                    )
+                else:
+                    event.text = build_animated_sticker_injection(emoji)
+                return
+
+            cached_path = cache_image_from_bytes(image_bytes, ext=image_ext)
             logger.info("[Telegram] Analyzing sticker at %s", cached_path)
 
             from tools.vision_tools import vision_analyze_tool
+
             result_json = await vision_analyze_tool(
                 image_url=cached_path,
                 user_prompt=STICKER_VISION_PROMPT,
@@ -9570,20 +9625,47 @@ class TelegramAdapter(BasePlatformAdapter):
 
             if result.get("success"):
                 description = result.get("analysis", "a sticker")
-                cache_sticker_description(sticker.file_unique_id, description, emoji, set_name)
+                cache_sticker_description(
+                    sticker.file_unique_id, description, emoji, set_name
+                )
                 event.text = build_sticker_injection(description, emoji, set_name)
             else:
-                # Vision failed -- use emoji as fallback
+                if metadata_description:
+                    cache_sticker_description(
+                        sticker.file_unique_id,
+                        metadata_description,
+                        emoji,
+                        set_name,
+                    )
+                    event.text = build_sticker_injection(
+                        metadata_description, emoji, set_name
+                    )
+                elif sticker.is_animated or sticker.is_video:
+                    event.text = build_animated_sticker_injection(emoji)
+                else:
+                    fallback = f"a sticker with emoji {emoji}" if emoji else "a sticker"
+                    event.text = build_sticker_injection(fallback, emoji, set_name)
+        except Exception as e:
+            logger.warning(
+                "[Telegram] Sticker analysis error: %s",
+                _redact_telegram_error_text(e),
+                exc_info=True,
+            )
+            if metadata_description:
+                cache_sticker_description(
+                    sticker.file_unique_id, metadata_description, emoji, set_name
+                )
+                event.text = build_sticker_injection(
+                    metadata_description, emoji, set_name
+                )
+            elif sticker.is_animated or sticker.is_video:
+                event.text = build_animated_sticker_injection(emoji)
+            else:
                 event.text = build_sticker_injection(
                     f"a sticker with emoji {emoji}" if emoji else "a sticker",
-                    emoji, set_name,
+                    emoji,
+                    set_name,
                 )
-        except Exception as e:
-            logger.warning("[Telegram] Sticker analysis error: %s", _redact_telegram_error_text(e), exc_info=True)
-            event.text = build_sticker_injection(
-                f"a sticker with emoji {emoji}" if emoji else "a sticker",
-                emoji, set_name,
-            )
 
     def _reload_dm_topics_from_config(self) -> None:
         """Re-read dm_topics from config.yaml and load any new thread_ids into cache.

--- a/plugins/platforms/telegram/tgs.py
+++ b/plugins/platforms/telegram/tgs.py
@@ -1,0 +1,178 @@
+"""Safe, best-effort frame extraction for Telegram animated stickers."""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import math
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+TGS_MAGIC = b"\x1f\x8b"
+MAX_TGS_BYTES = 512 * 1024
+MAX_TGS_JSON_BYTES = 4 * 1024 * 1024
+MAX_RENDERED_FRAME_BYTES = 10 * 1024 * 1024
+MAX_RENDER_DIMENSION = 4096
+
+
+@dataclass(frozen=True)
+class TGSFrameResult:
+    """A rendered representative frame, or metadata for graceful fallback."""
+
+    image_bytes: Optional[bytes]
+    metadata_description: str
+
+
+def _read_tgs_json(data: bytes) -> dict[str, Any]:
+    """Decode a bounded gzip-compressed Lottie document."""
+    if not data.startswith(TGS_MAGIC):
+        raise ValueError("TGS data is not gzip-compressed")
+    if len(data) > MAX_TGS_BYTES:
+        raise ValueError("TGS file exceeds the safe compressed-size limit")
+
+    with gzip.GzipFile(fileobj=io.BytesIO(data)) as stream:
+        raw = stream.read(MAX_TGS_JSON_BYTES + 1)
+    if len(raw) > MAX_TGS_JSON_BYTES:
+        raise ValueError("TGS JSON exceeds the safe decompressed-size limit")
+
+    document = json.loads(raw.decode("utf-8"))
+    if not isinstance(document, dict):
+        raise ValueError("TGS document must be a JSON object")
+    if not isinstance(document.get("layers"), list):
+        raise ValueError("TGS document has no layer list")
+    return document
+
+
+def describe_tgs_metadata(document: dict[str, Any]) -> str:
+    """Build a concise description when no Lottie renderer is available."""
+    width = document.get("w")
+    height = document.get("h")
+    layers = document.get("layers", [])
+    frame_rate = document.get("fr")
+    in_point = document.get("ip")
+    out_point = document.get("op")
+
+    has_dimensions = (
+        isinstance(width, (int, float))
+        and not isinstance(width, bool)
+        and math.isfinite(width)
+        and isinstance(height, (int, float))
+        and not isinstance(height, bool)
+        and math.isfinite(height)
+    )
+    dimensions = f"{width}x{height}" if has_dimensions else "unknown dimensions"
+    duration = None
+    if (
+        isinstance(frame_rate, (int, float))
+        and not isinstance(frame_rate, bool)
+        and math.isfinite(frame_rate)
+        and frame_rate > 0
+        and isinstance(in_point, (int, float))
+        and not isinstance(in_point, bool)
+        and math.isfinite(in_point)
+        and isinstance(out_point, (int, float))
+        and not isinstance(out_point, bool)
+        and math.isfinite(out_point)
+    ):
+        duration = max(0.0, (out_point - in_point) / frame_rate)
+
+    animated_layers = sum(
+        1 for layer in layers if isinstance(layer, dict) and _contains_keyframes(layer)
+    )
+    layer_word = "layer" if len(layers) == 1 else "layers"
+    details = [
+        f"a {dimensions} animated sticker with {len(layers)} visual {layer_word}"
+    ]
+    if duration is not None:
+        details.append(f"lasting about {duration:.1f} seconds")
+    if animated_layers:
+        animated_layer_word = "layer" if animated_layers == 1 else "layers"
+        details.append(f"with motion in {animated_layers} {animated_layer_word}")
+    return ", ".join(details)
+
+
+def _contains_keyframes(value: Any) -> bool:
+    """Return whether a Lottie subtree contains an animated-property marker."""
+    if isinstance(value, dict):
+        if value.get("a") == 1 and isinstance(value.get("k"), list):
+            return True
+        return any(_contains_keyframes(child) for child in value.values())
+    if isinstance(value, list):
+        return any(_contains_keyframes(child) for child in value)
+    return False
+
+
+def _representative_frame(document: dict[str, Any]) -> int:
+    in_point = document.get("ip", 0)
+    out_point = document.get("op", in_point)
+    if (
+        not isinstance(in_point, (int, float))
+        or isinstance(in_point, bool)
+        or not math.isfinite(in_point)
+        or not isinstance(out_point, (int, float))
+        or isinstance(out_point, bool)
+        or not math.isfinite(out_point)
+    ):
+        return 0
+    return max(0, round((in_point + out_point) / 2))
+
+
+def _has_safe_dimensions(document: dict[str, Any]) -> bool:
+    return all(
+        isinstance(document.get(key), (int, float))
+        and not isinstance(document.get(key), bool)
+        and math.isfinite(document[key])
+        and 0 < document[key] <= MAX_RENDER_DIMENSION
+        for key in ("w", "h")
+    )
+
+
+def extract_tgs_frame(data: bytes) -> TGSFrameResult:
+    """Render a representative PNG using an installed python-lottie CLI.
+
+    Hermes intentionally does not add a renderer dependency for one platform.
+    If ``lottie_convert.py`` is unavailable or rejects the animation, callers
+    still receive bounded, parsed metadata suitable for a textual fallback.
+    """
+    document = _read_tgs_json(data)
+    metadata_description = describe_tgs_metadata(document)
+    converter = shutil.which("lottie_convert.py")
+    if converter is None or not _has_safe_dimensions(document):
+        return TGSFrameResult(None, metadata_description)
+
+    with tempfile.TemporaryDirectory(prefix="hermes-tgs-") as temp_dir:
+        input_path = Path(temp_dir) / "sticker.tgs"
+        output_path = Path(temp_dir) / "frame.png"
+        input_path.write_bytes(data)
+        try:
+            subprocess.run(
+                [
+                    converter,
+                    str(input_path),
+                    str(output_path),
+                    "--frame",
+                    str(_representative_frame(document)),
+                ],
+                cwd=temp_dir,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=15,
+            )
+            with output_path.open("rb") as stream:
+                frame = stream.read(MAX_RENDERED_FRAME_BYTES + 1)
+        except (OSError, subprocess.SubprocessError):
+            return TGSFrameResult(None, metadata_description)
+
+    if (
+        not frame.startswith(b"\x89PNG\r\n\x1a\n")
+        or len(frame) > MAX_RENDERED_FRAME_BYTES
+    ):
+        return TGSFrameResult(None, metadata_description)
+    return TGSFrameResult(frame, metadata_description)

--- a/tests/gateway/test_telegram_tgs.py
+++ b/tests/gateway/test_telegram_tgs.py
@@ -149,7 +149,87 @@ def test_animated_sticker_thumbnail_uses_vision_and_cache():
     assert 'It shows: "A cat waving hello"' in event.text
 
 
-def test_animated_sticker_metadata_fallback_is_cached():
+@pytest.mark.parametrize(
+    "vision_failure",
+    [json.dumps({"success": False}), RuntimeError("temporary vision outage")],
+)
+def test_animated_sticker_vision_failure_does_not_cache_metadata(
+    vision_failure, tmp_path
+):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    from plugins.platforms.telegram.tgs import TGSFrameResult
+
+    tgs_file = SimpleNamespace(
+        download_as_bytearray=AsyncMock(return_value=_tgs_bytes())
+    )
+    sticker = SimpleNamespace(
+        emoji="✨",
+        set_name="Sparkles",
+        file_unique_id="transient-vision-failure-uid",
+        is_animated=True,
+        is_video=False,
+        get_file=AsyncMock(return_value=tgs_file),
+        thumbnail=None,
+    )
+    event = SimpleNamespace(text="")
+    vision = AsyncMock(
+        side_effect=[
+            vision_failure,
+            json.dumps({"success": True, "analysis": "A sparkling star"}),
+        ]
+    )
+
+    with (
+        patch(
+            "gateway.sticker_cache.CACHE_PATH",
+            tmp_path / "sticker-cache.json",
+        ),
+        patch(
+            "plugins.platforms.telegram.tgs.extract_tgs_frame",
+            return_value=TGSFrameResult(
+                b"\x89PNG\r\n\x1a\nframe",
+                "a 512x512 animation with 2 layers",
+            ),
+        ) as extract_frame,
+        patch(
+            "plugins.platforms.telegram.adapter.cache_image_from_bytes",
+            return_value="/tmp/sticker.png",
+        ),
+        patch(
+            "tools.vision_tools.vision_analyze_tool",
+            new=vision,
+        ),
+    ):
+        asyncio.run(
+            TelegramAdapter._handle_sticker(
+                object.__new__(TelegramAdapter), SimpleNamespace(sticker=sticker), event
+            )
+        )
+        retry_event = SimpleNamespace(text="")
+        asyncio.run(
+            TelegramAdapter._handle_sticker(
+                object.__new__(TelegramAdapter),
+                SimpleNamespace(sticker=sticker),
+                retry_event,
+            )
+        )
+        cached_event = SimpleNamespace(text="")
+        asyncio.run(
+            TelegramAdapter._handle_sticker(
+                object.__new__(TelegramAdapter),
+                SimpleNamespace(sticker=sticker),
+                cached_event,
+            )
+        )
+
+    assert "a 512x512 animation with 2 layers" in event.text
+    assert vision.await_count == 2
+    assert extract_frame.call_count == 2
+    assert 'It shows: "A sparkling star"' in retry_event.text
+    assert 'It shows: "A sparkling star"' in cached_event.text
+
+
+def test_animated_sticker_metadata_fallback_is_not_cached(tmp_path):
     from plugins.platforms.telegram.adapter import TelegramAdapter
     from plugins.platforms.telegram.tgs import TGSFrameResult
 
@@ -168,23 +248,32 @@ def test_animated_sticker_metadata_fallback_is_cached():
     event = SimpleNamespace(text="")
 
     with (
-        patch("gateway.sticker_cache.get_cached_description", return_value=None),
-        patch("gateway.sticker_cache.cache_sticker_description") as cache_description,
+        patch(
+            "gateway.sticker_cache.CACHE_PATH",
+            tmp_path / "sticker-cache.json",
+        ),
         patch(
             "plugins.platforms.telegram.tgs.extract_tgs_frame",
             return_value=TGSFrameResult(None, "a 512x512 animation with 2 layers"),
-        ),
+        ) as extract_frame,
     ):
         asyncio.run(
             TelegramAdapter._handle_sticker(
                 object.__new__(TelegramAdapter), SimpleNamespace(sticker=sticker), event
             )
         )
+        retry_event = SimpleNamespace(text="")
+        asyncio.run(
+            TelegramAdapter._handle_sticker(
+                object.__new__(TelegramAdapter),
+                SimpleNamespace(sticker=sticker),
+                retry_event,
+            )
+        )
 
-    cache_description.assert_called_once_with(
-        "metadata-uid", "a 512x512 animation with 2 layers", "✨", "Sparkles"
-    )
+    assert extract_frame.call_count == 2
     assert "a 512x512 animation with 2 layers" in event.text
+    assert "a 512x512 animation with 2 layers" in retry_event.text
 
 
 def test_video_sticker_vision_failure_keeps_emoji_fallback():

--- a/tests/gateway/test_telegram_tgs.py
+++ b/tests/gateway/test_telegram_tgs.py
@@ -1,0 +1,224 @@
+"""Tests for bounded Telegram TGS parsing and representative-frame extraction."""
+
+import asyncio
+import gzip
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from plugins.platforms.telegram.tgs import (
+    MAX_TGS_JSON_BYTES,
+    _read_tgs_json,
+    extract_tgs_frame,
+)
+
+
+def _tgs_bytes(**overrides) -> bytes:
+    document = {
+        "v": "5.7.4",
+        "w": 512,
+        "h": 512,
+        "fr": 60,
+        "ip": 0,
+        "op": 120,
+        "layers": [
+            {"ty": 4, "ks": {"o": {"a": 1, "k": [{"t": 0}, {"t": 60}]}}},
+            {"ty": 4, "ks": {"o": {"a": 0, "k": 100}}},
+        ],
+    }
+    document.update(overrides)
+    return gzip.compress(json.dumps(document).encode())
+
+
+def test_extract_tgs_returns_metadata_without_optional_renderer(monkeypatch):
+    monkeypatch.setattr("plugins.platforms.telegram.tgs.shutil.which", lambda _: None)
+
+    result = extract_tgs_frame(_tgs_bytes())
+
+    assert result.image_bytes is None
+    assert result.metadata_description == (
+        "a 512x512 animated sticker with 2 visual layers, "
+        "lasting about 2.0 seconds, with motion in 1 layer"
+    )
+
+
+def test_extract_tgs_renders_representative_midpoint(monkeypatch):
+    png = b"\x89PNG\r\n\x1a\n" + b"frame"
+    observed = {}
+
+    def fake_run(args, **kwargs):
+        observed["args"] = args
+        Path(args[2]).write_bytes(png)
+
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.tgs.shutil.which",
+        lambda _: "/usr/local/bin/lottie_convert.py",
+    )
+    monkeypatch.setattr("plugins.platforms.telegram.tgs.subprocess.run", fake_run)
+
+    result = extract_tgs_frame(_tgs_bytes())
+
+    assert result.image_bytes == png
+    assert observed["args"][-2:] == ["--frame", "60"]
+
+
+def test_extract_tgs_does_not_render_unsafe_dimensions(monkeypatch):
+    run = Mock()
+    monkeypatch.setattr("plugins.platforms.telegram.tgs.subprocess.run", run)
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.tgs.shutil.which",
+        lambda _: "/usr/local/bin/lottie_convert.py",
+    )
+    result = extract_tgs_frame(_tgs_bytes(w=100_000))
+
+    assert result.image_bytes is None
+    run.assert_not_called()
+
+
+def test_extract_tgs_ignores_non_finite_metadata(monkeypatch):
+    monkeypatch.setattr("plugins.platforms.telegram.tgs.shutil.which", lambda _: None)
+
+    result = extract_tgs_frame(_tgs_bytes(w=float("inf"), fr=float("inf")))
+
+    assert "unknown dimensions" in result.metadata_description
+    assert "lasting about" not in result.metadata_description
+
+
+def test_read_tgs_rejects_non_gzip_input():
+    with pytest.raises(ValueError, match="gzip-compressed"):
+        _read_tgs_json(b'{"layers": []}')
+
+
+def test_read_tgs_bounds_decompressed_json():
+    oversized = gzip.compress(b" " * (MAX_TGS_JSON_BYTES + 1))
+
+    with pytest.raises(ValueError, match="decompressed-size"):
+        _read_tgs_json(oversized)
+
+
+def test_animated_sticker_thumbnail_uses_vision_and_cache():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    from plugins.platforms.telegram.tgs import TGSFrameResult
+
+    tgs_file = SimpleNamespace(
+        download_as_bytearray=AsyncMock(return_value=_tgs_bytes())
+    )
+    thumbnail_file = SimpleNamespace(
+        download_as_bytearray=AsyncMock(return_value=b"thumbnail-webp")
+    )
+    sticker = SimpleNamespace(
+        emoji="👋",
+        set_name="WavingPack",
+        file_unique_id="animated-uid",
+        is_animated=True,
+        is_video=False,
+        get_file=AsyncMock(return_value=tgs_file),
+        thumbnail=SimpleNamespace(get_file=AsyncMock(return_value=thumbnail_file)),
+    )
+    event = SimpleNamespace(text="")
+    vision = AsyncMock(
+        return_value=json.dumps({"success": True, "analysis": "A cat waving hello"})
+    )
+    with (
+        patch("gateway.sticker_cache.get_cached_description", return_value=None),
+        patch("gateway.sticker_cache.cache_sticker_description") as cache_description,
+        patch(
+            "plugins.platforms.telegram.tgs.extract_tgs_frame",
+            return_value=TGSFrameResult(None, "animation metadata"),
+        ),
+        patch(
+            "plugins.platforms.telegram.adapter.cache_image_from_bytes",
+            return_value="/tmp/sticker.webp",
+        ) as cache_image,
+        patch("tools.vision_tools.vision_analyze_tool", new=vision),
+    ):
+        asyncio.run(
+            TelegramAdapter._handle_sticker(
+                object.__new__(TelegramAdapter), SimpleNamespace(sticker=sticker), event
+            )
+        )
+
+    cache_image.assert_called_once_with(b"thumbnail-webp", ext=".webp")
+    vision.assert_awaited_once()
+    cache_description.assert_called_once_with(
+        "animated-uid", "A cat waving hello", "👋", "WavingPack"
+    )
+    assert 'It shows: "A cat waving hello"' in event.text
+
+
+def test_animated_sticker_metadata_fallback_is_cached():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    from plugins.platforms.telegram.tgs import TGSFrameResult
+
+    tgs_file = SimpleNamespace(
+        download_as_bytearray=AsyncMock(return_value=_tgs_bytes())
+    )
+    sticker = SimpleNamespace(
+        emoji="✨",
+        set_name="Sparkles",
+        file_unique_id="metadata-uid",
+        is_animated=True,
+        is_video=False,
+        get_file=AsyncMock(return_value=tgs_file),
+        thumbnail=None,
+    )
+    event = SimpleNamespace(text="")
+
+    with (
+        patch("gateway.sticker_cache.get_cached_description", return_value=None),
+        patch("gateway.sticker_cache.cache_sticker_description") as cache_description,
+        patch(
+            "plugins.platforms.telegram.tgs.extract_tgs_frame",
+            return_value=TGSFrameResult(None, "a 512x512 animation with 2 layers"),
+        ),
+    ):
+        asyncio.run(
+            TelegramAdapter._handle_sticker(
+                object.__new__(TelegramAdapter), SimpleNamespace(sticker=sticker), event
+            )
+        )
+
+    cache_description.assert_called_once_with(
+        "metadata-uid", "a 512x512 animation with 2 layers", "✨", "Sparkles"
+    )
+    assert "a 512x512 animation with 2 layers" in event.text
+
+
+def test_video_sticker_vision_failure_keeps_emoji_fallback():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    thumbnail_file = SimpleNamespace(
+        download_as_bytearray=AsyncMock(return_value=b"video-thumbnail")
+    )
+    sticker = SimpleNamespace(
+        emoji="🎬",
+        set_name="MoviePack",
+        file_unique_id="video-uid",
+        is_animated=False,
+        is_video=True,
+        thumbnail=SimpleNamespace(get_file=AsyncMock(return_value=thumbnail_file)),
+    )
+    event = SimpleNamespace(text="")
+
+    with (
+        patch("gateway.sticker_cache.get_cached_description", return_value=None),
+        patch(
+            "plugins.platforms.telegram.adapter.cache_image_from_bytes",
+            return_value="/tmp/video-sticker.webp",
+        ),
+        patch(
+            "tools.vision_tools.vision_analyze_tool",
+            new=AsyncMock(return_value=json.dumps({"success": False})),
+        ),
+    ):
+        asyncio.run(
+            TelegramAdapter._handle_sticker(
+                object.__new__(TelegramAdapter), SimpleNamespace(sticker=sticker), event
+            )
+        )
+
+    assert "animated sticker 🎬" in event.text
+    assert "emoji suggests: 🎬" in event.text


### PR DESCRIPTION
## What does this PR do?

Telegram animated and video stickers currently bypass vision analysis and produce only an emoji-based placeholder. This PR routes them through the existing sticker analysis and cache path:

- TGS stickers are decoded with compressed and decompressed size limits, then rendered at a representative midpoint frame when a usable `lottie_convert.py` PNG exporter from python-lottie is available.
- When local rendering is unavailable, Hermes analyzes Telegram's thumbnail when present.
- If vision is unavailable or fails, TGS metadata provides a bounded textual fallback before Hermes returns to the existing emoji placeholder.
- Successful vision descriptions are cached by `file_unique_id`; metadata fallbacks remain uncached so a later send retries vision after transient failures.

The implementation adds no dependency. It intentionally leaves sticker prompt framing unchanged because that work is already covered by #33650 and #6518.

## Related Issue

No matching issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py` downloads and analyzes rendered TGS frames or Telegram thumbnails, caches successful vision results, and preserves uncached metadata/emoji fallbacks.
- `plugins/platforms/telegram/tgs.py` safely parses bounded TGS payloads, summarizes animation metadata, and optionally renders a representative PNG frame.
- `tests/gateway/test_telegram_tgs.py` covers parser bounds, non-finite metadata, frame selection, thumbnail analysis, caching, and fallback behavior.

## How to Test

1. Run `pytest tests/gateway/test_sticker_cache.py tests/gateway/test_telegram_tgs.py -q` and confirm all 16 tests pass.
2. With a PNG-capable `lottie_convert.py` available on `PATH`, send the Telegram bot an animated TGS sticker and confirm the agent receives a vision description; send the same sticker again and confirm the cached description is reused.
3. Repeat without `lottie_convert.py` and confirm Hermes analyzes the Telegram thumbnail, or emits parsed TGS metadata when no thumbnail is available.
4. Send a video sticker and confirm its Telegram thumbnail is analyzed while the existing emoji placeholder remains the final fallback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and covered by docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `shutil.which`, `pathlib`, and `tempfile` are used; the Windows footgun scan passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changes

## Screenshots / Logs

- `pytest tests/gateway/test_sticker_cache.py tests/gateway/test_telegram_tgs.py -q`: 16 passed, 0 failed.
- `ruff check`, `ruff format --check`, and `ty check plugins/platforms/telegram/tgs.py`: passed.
- `python scripts/check-windows-footguns.py --diff origin/main`: passed.
