### PR TITLE
fix(gateway): deliver reasoning block on streamed responses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18408,6 +18408,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if source.platform == Platform.MATTERMOST
                     else getattr(self, "_show_reasoning", False)
                 )
+            # When streaming already delivered the body, we can't prepend onto
+            # sent text; defer the reasoning block to a trailing send below.
+            _reasoning_pending = None
             if _show_reasoning_effective and response and not _intentional_silence:
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
@@ -18436,17 +18439,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _quoted = "\n".join(
                             f"-# {ln}" if ln else "-#" for ln in display_reasoning.splitlines()
                         )
-                        response = f"-# 💭 Reasoning\n{_quoted}\n\n{response}"
+                        _reasoning_block = f"-# 💭 Reasoning\n{_quoted}"
                     elif _reasoning_style == "blockquote":
                         _quoted = "\n".join(
                             f"> {ln}" if ln else ">" for ln in display_reasoning.splitlines()
                         )
-                        response = f"> 💭 **Reasoning:**\n{_quoted}\n\n{response}"
+                        _reasoning_block = f"> 💭 **Reasoning:**\n{_quoted}"
                     else:
                         # Escape ``` inside reasoning so inner fences don't
                         # break the outer code block used to render it.
                         display_reasoning = escape_code_fences_for_display(display_reasoning)
-                        response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+                        _reasoning_block = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```"
+                    # When streaming already delivered the body we can't prepend
+                    # onto the sent text, so hold the block back and deliver it
+                    # as a trailing message below (same pattern as the runtime
+                    # footer).  Otherwise prepend as before.
+                    if agent_result.get("already_sent"):
+                        _reasoning_pending = _reasoning_block
+                    else:
+                        response = f"{_reasoning_block}\n\n{response}"
 
             # Runtime-metadata footer — only on the FINAL message of the turn.
             # Off by default (display.runtime_footer.enabled=false).  When
@@ -18844,6 +18855,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
+                # Streaming already delivered the body text, but the reasoning
+                # block was held back (see the `already_sent` branch in the
+                # prepend above).  Send it now as its own small trailing message
+                # so streamed Telegram/Discord/etc. replies don't silently lose
+                # the thinking.
+                if _reasoning_pending:
+                    try:
+                        _reason_adapter = self._adapter_for_source(source)
+                        if _reason_adapter:
+                            await _reason_adapter.send(
+                                source.chat_id,
+                                _reasoning_pending,
+                                metadata=self._thread_metadata_for_source(source, self._reply_anchor_for_event(event)),
+                            )
+                    except Exception as _e:
+                        logger.debug("trailing reasoning send failed: %s", _e)
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
                 # Send it now as a small trailing message so Telegram/Discord/etc.


### PR DESCRIPTION
## Summary

Fixes the gate‑bʹreasoning display bug where the **`💭 **Reasoning:**`** block never reaches the user on **streamed** responses (Telegram/Discord DMs, and any platform using progressive edit/native‑draft transport).

## Root cause

1. The stream consumer transparently suppresses model `think` blocks as they stream, so reasoning is never part of the streamed body.
2. `last_reasoning` is only known once the turn completes, so the gateway builds the reasoning block into the final `response` string (`gateway/run.py`, reasoning-prepend block).
3. But on a streamed reply the body is already on screen, so the final message is marked `already_sent` and its send is **suppressed** — the reasoning block was computed and then silently discarded.

Net effect: reasoning appeared only on non‑streamed (one‑shot) sends; streamed replies lost it entirely.

## Change

- Build the rendered reasoning into its own `_reasoning_block` (same three `reasoning_style` outputs: code / blockquote / subtext).
- **Non‑streamed** (`not already_sent`): prepend to `response` — byte‑identical behavior to before.
- **Streamed** (`already_sent`): hold the block back and send it as a **separate trailing message**, mirroring the existing runtime‑footer pattern (`gateway/run.py` already does exactly this for the footer when streaming delivered the body).

## Test plan

- `python -m py_compile gateway/run.py` passes.
- Verified end‑to‑end on a live gateway: after the change, a streamed Telegram DM reply is followed by a separate `💭 **Reasoning:**` message.