### PR TITLE
fix(cli): make status alias display provider-aware

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -124,22 +124,40 @@ def format_duration_compact(*args, **kwargs):
 # friendly names instead of full Palantir RIDs / long catalog IDs. Built
 # lazily on first call; cache is process-lifetime (config is read once at
 # session start, so further invalidation is unnecessary).
-_REVERSE_ALIAS_CACHE: dict[str, str] | None = None
+_REVERSE_ALIAS_CACHE: dict[str, dict[str, str]] | None = None
 
 
-def _reverse_alias_for_display(model_name: str) -> str:
+def _reverse_alias_for_display(model_name: str, provider: str | None = None) -> str:
     """Return the shortest configured alias for ``model_name``, or ``model_name``.
 
     Looks up both ``model_aliases:`` (dict-based, full DirectAlias entries)
     and ``model.aliases:`` (string-based, set via ``hermes config set``)
     from config.yaml. Multiple aliases pointing at the same model — the
-    shortest wins, so ``opus47`` beats ``palantir-claude47``.
+    shortest wins, so ``opus47`` beats ``palantir-claude47``. When the active
+    provider is known, only aliases for that provider are considered; this keeps
+    a same-model alias from another provider out of the status bar.
     """
     global _REVERSE_ALIAS_CACHE
     if not model_name:
         return model_name
+    provider_key = str(provider or "").strip()
+    if provider_key.lower() in {"auto", "default"}:
+        provider_key = ""
+
+    def _prefer_shortest(mapping: dict[str, str], key: str, alias: str) -> None:
+        alias = str(alias or "").strip()
+        if alias and (key not in mapping or len(alias) < len(mapping[key])):
+            mapping[key] = alias
+
+    def _split_provider_model(value: str) -> tuple[str | None, str]:
+        value = str(value or "").strip()
+        if "/" not in value:
+            return None, value
+        maybe_provider, model = value.split("/", 1)
+        return maybe_provider.strip() or None, model.strip()
+
     if _REVERSE_ALIAS_CACHE is None:
-        rmap: dict[str, str] = {}
+        rmap: dict[str, dict[str, str]] = {"provider_model": {}, "model": {}}
         try:
             from hermes_cli.config import load_config
             cfg = load_config() or {}
@@ -148,22 +166,38 @@ def _reverse_alias_for_display(model_name: str) -> str:
                 for alias, entry in ma.items():
                     if isinstance(entry, dict):
                         m = str(entry.get("model", "") or "").strip()
-                        if m and (m not in rmap or len(alias) < len(rmap[m])):
-                            rmap[m] = alias
+                        if not m:
+                            continue
+                        entry_provider = str(entry.get("provider", "") or "").strip()
+                        if not entry_provider:
+                            entry_provider, parsed_model = _split_provider_model(m)
+                            if parsed_model:
+                                m = parsed_model
+                        if entry_provider:
+                            _prefer_shortest(rmap["provider_model"], f"{entry_provider}/{m}", alias)
+                            _prefer_shortest(rmap["model"], m, alias)
+                        else:
+                            _prefer_shortest(rmap["model"], m, alias)
             mdl = cfg.get("model", {}) or {}
             if isinstance(mdl, dict):
                 simple = mdl.get("aliases")
                 if isinstance(simple, dict):
                     for alias, val in simple.items():
                         if isinstance(val, str) and val.strip():
-                            v = val.strip()
-                            m = v.split("/", 1)[1] if "/" in v else v
-                            if m and (m not in rmap or len(alias) < len(rmap[m])):
-                                rmap[m] = alias
+                            entry_provider, m = _split_provider_model(val)
+                            if not m:
+                                continue
+                            if entry_provider:
+                                _prefer_shortest(rmap["provider_model"], f"{entry_provider}/{m}", alias)
+                                _prefer_shortest(rmap["model"], m, alias)
+                            else:
+                                _prefer_shortest(rmap["model"], m, alias)
         except Exception:
             pass
         _REVERSE_ALIAS_CACHE = rmap
-    return _REVERSE_ALIAS_CACHE.get(model_name, model_name)
+    if provider_key:
+        return _REVERSE_ALIAS_CACHE["provider_model"].get(f"{provider_key}/{model_name}", model_name)
+    return _REVERSE_ALIAS_CACHE["model"].get(model_name, model_name)
 
 
 def format_token_count_compact(*args, **kwargs):
@@ -5303,11 +5337,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # _try_activate_fallback() switches provider/model.
         agent = getattr(self, "agent", None)
         model_name = (getattr(agent, "model", None) or self.model or "unknown")
+        provider_name = (
+            getattr(agent, "provider", None)
+            or getattr(self, "provider", None)
+            or getattr(self, "requested_provider", None)
+        )
         # Friendly display: prefer reverse-alias from config.yaml ``model_aliases:``
         # before slash/length truncation. This turns long Palantir RIDs like
         # ``ri.language-model-service..language-model.anthropic-claude-4-7-opus``
         # into the user's chosen short name (e.g. ``opus-4.7``) in the status bar.
-        model_short = _reverse_alias_for_display(model_name)
+        model_short = _reverse_alias_for_display(model_name, provider_name)
         if model_short == model_name:
             model_short = model_name.split("/")[-1] if "/" in model_name else model_name
             # Strip Palantir RID prefixes via the shared display formatter so

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -89,6 +89,24 @@ class TestCLIStatusBar:
 
         assert snapshot["model_short"] == "gpt-5.6-sol"
 
+    def test_status_bar_unmatched_provider_does_not_use_model_only_fallback(self):
+        cli_mod._REVERSE_ALIAS_CACHE = None
+        cli_obj = _make_cli(model="gpt-5.6-sol")
+        cli_obj.agent = SimpleNamespace(model="gpt-5.6-sol", provider="openai-codex-beta")
+
+        config = {
+            "model": {
+                "aliases": {
+                    "local-gpt56": "local-sub2api/gpt-5.6-sol",
+                    "codex-gpt56": "openai-codex/gpt-5.6-sol",
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["model_short"] == "gpt-5.6-sol"
+
     def test_reverse_alias_keeps_model_only_fallback_without_provider(self):
         cli_mod._REVERSE_ALIAS_CACHE = None
         config = {

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -54,6 +54,65 @@ def _attach_agent(
 
 
 class TestCLIStatusBar:
+    def test_status_bar_alias_respects_active_provider(self):
+        cli_mod._REVERSE_ALIAS_CACHE = None
+        cli_obj = _make_cli(model="gpt-5.6-sol")
+        cli_obj.agent = SimpleNamespace(model="gpt-5.6-sol", provider="openai-codex")
+
+        config = {
+            "model": {
+                "aliases": {
+                    "local-gpt56": "local-sub2api/gpt-5.6-sol",
+                    "codex-gpt56": "openai-codex/gpt-5.6-sol",
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["model_short"] == "codex-gpt56"
+
+    def test_status_bar_does_not_use_alias_from_other_provider(self):
+        cli_mod._REVERSE_ALIAS_CACHE = None
+        cli_obj = _make_cli(model="gpt-5.6-sol")
+        cli_obj.agent = SimpleNamespace(model="gpt-5.6-sol", provider="openai-codex")
+
+        config = {
+            "model": {
+                "aliases": {
+                    "local-gpt56": "local-sub2api/gpt-5.6-sol",
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["model_short"] == "gpt-5.6-sol"
+
+    def test_reverse_alias_keeps_model_only_fallback_without_provider(self):
+        cli_mod._REVERSE_ALIAS_CACHE = None
+        config = {
+            "model": {
+                "aliases": {
+                    "local-gpt56": "local-sub2api/gpt-5.6-sol",
+                    "longer-gpt56": "other-provider/gpt-5.6-sol",
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            assert cli_mod._reverse_alias_for_display("gpt-5.6-sol") == "local-gpt56"
+
+    def test_reverse_alias_treats_auto_provider_as_unknown(self):
+        cli_mod._REVERSE_ALIAS_CACHE = None
+        config = {
+            "model_aliases": {
+                "local-gpt56": {"model": "local-sub2api/gpt-5.6-sol"},
+                "longer-gpt56": {"provider": "other-provider", "model": "gpt-5.6-sol"},
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            assert cli_mod._reverse_alias_for_display("gpt-5.6-sol", "auto") == "local-gpt56"
+
     def test_session_title_is_right_aligned_after_it_is_queued(self):
         cli_obj = _make_cli()
         cli_obj._pending_title = "weekly-digest"
@@ -350,5 +409,3 @@ class TestIdleSinceLastTurn:
         cli_obj._prompt_duration = 5.0
         snapshot = cli_obj._get_status_bar_snapshot()
         assert snapshot["idle_since"].startswith("✓ ")
-
-


### PR DESCRIPTION
## Summary
- Fixes the classic CLI status bar alias display for same-model collisions across providers.
- `_reverse_alias_for_display()` now keeps provider-specific alias entries separately from model-only compatibility entries.
- `_get_status_bar_snapshot()` passes the live agent provider first, so fallback/provider changes do not leave a stale alias label.
- Keeps the old model-only alias fallback when provider information is unavailable, including `auto`.

## Validation
- `scripts/run_tests.sh tests/cli/test_cli_status_bar.py` passed, 24 passed.
- `scripts/run_tests.sh tests/cli/test_cli_status_bar.py tests/cli/test_cli_init.py tests/cli/test_cli_status_command.py tests/cli/test_cli_status_bar_goal.py tests/cli/test_cli_background_status_indicator.py` passed, 71 passed, 1 skipped.
- `python -m ruff check cli.py tests/cli/test_cli_status_bar.py` passed.
- `python scripts/check-windows-footguns.py --all` passed, 944 files scanned.
- `git diff --check upstream/main...HEAD` passed.
- Signed commit check passed: `55c374a8d8 G Deepak Jain <deepujain@gmail.com> fix(cli): make status alias display provider-aware`.

## Risk
- Display-only change. Runtime model/provider routing is not changed.
- Provider-specific aliases are used only when the active provider is known; otherwise the prior model-only fallback remains.

Fixes #83665
