### PR TITLE
fix(tools): detect native Windows screenshot paths in browser_exec

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -510,6 +510,18 @@ class TestNativeScreenshots:
         out = f"step one saved {a}\nthen saved {b}\n"
         assert bu_cli._find_screenshot(out, since=time.time() - 5) == b
 
+    def test_find_screenshot_matches_native_windows_path(self, monkeypatch):
+        # A Windows-style path is not a leading-slash path; it must still be
+        # recognised. The file doesn't exist on this (POSIX) host, so stub the
+        # fs checks to accept it.
+        win = r"C:\Users\alice\AppData\Local\Temp\browser_use\shot.png"
+        monkeypatch.setattr(bu_cli.os.path, "isfile", lambda p: p == win)
+        monkeypatch.setattr(
+            bu_cli.os.path, "getmtime", lambda p: time.time() if p == win else 0
+        )
+        out = f"screenshot saved to {win}\n"
+        assert bu_cli._find_screenshot(out, since=time.time() - 5) == win
+
     def test_find_screenshot_rejects_stale_and_missing(self, tmp_path):
         stale = self._shot(tmp_path)
         os.utime(stale, (time.time() - 900, time.time() - 900))

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -31,8 +31,13 @@ _STDERR_CAP_CHARS = 4000
 # Filesystem-safe task ids for per-task workspace dirs.
 _TASK_ID_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
-# Screenshot paths printed by capture_screenshot() in the exec output
-_IMAGE_PATH_RE = re.compile(r"(/[^\s\"']+?\.(?:png|jpe?g|webp))", re.IGNORECASE)
+# Screenshot paths printed by capture_screenshot() in the exec output.
+# Match both POSIX paths (/tmp/.../shot.png) and native Windows paths
+# (C:\Users\...\shot.png) — a drive-letter prefix is not a leading slash.
+_IMAGE_PATH_RE = re.compile(
+    r"((?:/[^\s\"']+?|[A-Za-z]:\\[^\s\"']+?)\.(?:png|jpe?g|webp))",
+    re.IGNORECASE,
+)
 
 # http(s) URL literals in exec code checked against browser_navigate's policy
 _URL_RE = re.compile(r"https?://[^\s'\"\\)]+", re.IGNORECASE)


### PR DESCRIPTION
Fixes #83884

## Problem

On Windows, `browser_exec` fails to detect native Windows screenshot paths emitted by Browser Use. The parser in `tools/browser_use_cli.py` only matches image paths beginning with `/`, so a path like `C:\Users\alice\AppData\Local\Temp\browser_use\shot.png` is ignored. `browser_exec` then returns a result without `screenshot_path`, and the multimodal flow never receives the image.

## Root cause

`_find_screenshot` matches against:

```python
_IMAGE_PATH_RE = re.compile(r"(/[^\s"']+?\.(?:png|jpe?g|webp))", re.IGNORECASE)
```

The regex only accepts a leading-slash (POSIX) path. A Windows drive-letter path (`C:\...`) has no leading slash, so `findall` never captures it — `_find_screenshot` returns `None` even though the file exists and is fresh. The subsequent fs checks (`os.path.isfile` / `getmtime`) were already path-agnostic; only the regex was wrong.

## Fix

Extend `_IMAGE_PATH_RE` to also accept a drive-letter prefix (`[A-Za-z]:\`) alongside the leading slash:

```python
_IMAGE_PATH_RE = re.compile(
    r"((?:/[^\s"']+?|[A-Za-z]:\\[^\s"']+?)\.(?:png|jpe?g|webp))",
    re.IGNORECASE,
)
```

Both `C:\Users\...\shot.png` (native Windows) and `/tmp/.../shot.png` (POSIX) are now recognised. No change to `_find_screenshot`'s fs checks — they already accept any valid path.

## Tests

Added `test_find_screenshot_matches_native_windows_path` to `tests/tools/test_browser_use_cli.py` — feeds a `C:\Users\...\shot.png` path through the parser with the fs checks stubbed (the file can't exist on the POSIX CI host), and asserts it is returned. The existing POSIX-path and stale/missing-path tests still pass.

Full file: 68 passed, ruff clean.
