### PR TITLE
fix: coerce dict-valued model/default config back to string across resolution paths

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2206,7 +2206,10 @@ def init_agent(
     # overrides consistent with them and let provider metadata resolve the
     # active model's window instead.
     if _config_context_length is not None and isinstance(_model_cfg, dict):
-        _configured_default_model = str(_model_cfg.get("default") or "").strip()
+        _default = _model_cfg.get("default")
+        if isinstance(_default, dict):
+            _default = str(_default.get("model") or _default.get("default") or "")
+        _configured_default_model = str(_default or "").strip()
         _configured_default_runtime_model = _configured_default_model
         _active_runtime_model = agent.model
         if _configured_default_model:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2156,6 +2156,9 @@ def anthropic_prompt_cache_policy(
             logger.debug("MoA aggregator cache-policy resolution failed: %s", _moa_exc)
         return False, False
 
+    if isinstance(eff_model, dict):
+        eff_model = eff_model.get('default') or eff_model.get('model') or ''
+    eff_model = eff_model if isinstance(eff_model, str) else str(eff_model or '')
     model_lower = eff_model.lower()
     provider_lower = eff_provider.lower()
     is_claude = "claude" in model_lower

--- a/cli.py
+++ b/cli.py
@@ -4246,6 +4246,26 @@ def _normalize_moa_model(model: Optional[str]) -> tuple[Optional[str], Optional[
                 return "moa", preset
     return None, model
 
+def _split_model_config_default(raw_default: Any) -> tuple[str, str]:
+    """Canonicalize a config ``model.default``/``model.model`` value.
+
+    A dict-valued default (``model.default: {provider: ..., model: ...}``)
+    pairs the model string with the provider it must be routed through. The
+    dict is flattened here at the shared boundary so both halves stay
+    together through ``HermesCLI`` construction: the model becomes a plain
+    string and the provider is returned explicitly instead of being lost to
+    the outer merged ``model.provider`` default (often ``"auto"``, which
+    runtime resolution treats as authoritative and would otherwise route the
+    model through the wrong active provider).
+
+    Returns ``(model, provider)``; both are ``""`` when nothing is usable.
+    """
+    if isinstance(raw_default, dict):
+        provider = str(raw_default.get("provider") or "").strip()
+        model = raw_default.get("model") or raw_default.get("default")
+        return (str(model or "").strip(), provider)
+    return (str(raw_default or "").strip(), "")
+
 
 class _VoiceInputMessage:
     """Sentinel wrapper for voice-transcribed messages in ``_pending_input``.
@@ -4429,10 +4449,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # env vars would stomp each other.
         _model_config = CLI_CONFIG.get("model", {})
         _raw_default = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
-        if isinstance(_raw_default, dict):
-            _config_model = str(_raw_default.get("model") or _raw_default.get("default") or _raw_default.get("provider") or "")
-        else:
-            _config_model = str(_raw_default or "")
+        # A dict-valued default (``model.default: {provider: ..., model: ...}``)
+        # carries its own provider; flatten it here so the nested provider is
+        # available when ``requested_provider`` is constructed below instead of
+        # being discarded and replaced by the outer merged ``model.provider``
+        # (typically ``"auto"``, which is authoritative at runtime resolution).
+        _config_model, _nested_provider = _split_model_config_default(_raw_default)
         _DEFAULT_CONFIG_MODEL = ""
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
         # A ``moa:<preset>`` model string selects the MoA virtual provider in
@@ -4478,6 +4500,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.requested_provider = (
             _moa_provider_override
             or provider
+            or _nested_provider
             or CLI_CONFIG["model"].get("provider")
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"
@@ -8479,10 +8502,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         )
         _model_config = CLI_CONFIG.get("model", {})
         _raw_default2 = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
-        if isinstance(_raw_default2, dict):
-            _config_model = str(_raw_default2.get("model") or _raw_default2.get("default") or _raw_default2.get("provider") or "")
-        else:
-            _config_model = str(_raw_default2 or "")
+        _config_model, _ = _split_model_config_default(_raw_default2)
         if _config_model and _config_model != getattr(self, "model", None):
             _config_provider = (
                 _model_config.get("provider", "")

--- a/cli.py
+++ b/cli.py
@@ -4428,7 +4428,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # authoritative.  This avoids conflicts in multi-agent setups where
         # env vars would stomp each other.
         _model_config = CLI_CONFIG.get("model", {})
-        _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
+        _raw_default = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
+        if isinstance(_raw_default, dict):
+            _config_model = str(_raw_default.get("model") or _raw_default.get("default") or _raw_default.get("provider") or "")
+        else:
+            _config_model = str(_raw_default or "")
         _DEFAULT_CONFIG_MODEL = ""
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
         # A ``moa:<preset>`` model string selects the MoA virtual provider in
@@ -6404,7 +6408,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def _normalize_model_for_provider(self, resolved_provider: str) -> bool:
         """Normalize provider-specific model IDs and routing."""
-        current_model = (self.model or "").strip()
+        current_model = str(self.model or "").strip()
+        if isinstance(self.model, dict):
+            _m_dict = self.model
+            current_model = str(_m_dict.get("model") or _m_dict.get("default") or _m_dict.get("provider") or "").strip()
         changed = False
 
         try:
@@ -8471,11 +8478,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             CLI_CONFIG["agent"].get("service_tier", "")
         )
         _model_config = CLI_CONFIG.get("model", {})
-        _config_model = (
-            (_model_config.get("default") or _model_config.get("model") or "")
-            if isinstance(_model_config, dict)
-            else (_model_config or "")
-        )
+        _raw_default2 = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
+        if isinstance(_raw_default2, dict):
+            _config_model = str(_raw_default2.get("model") or _raw_default2.get("default") or _raw_default2.get("provider") or "")
+        else:
+            _config_model = str(_raw_default2 or "")
         if _config_model and _config_model != getattr(self, "model", None):
             _config_provider = (
                 _model_config.get("provider", "")
@@ -14088,8 +14095,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 from hermes_cli.config import load_config
 
                 _img_mode = decide_image_input_mode(
-                    (self.provider or "").strip(),
-                    (self.model or "").strip(),
+                    str(self.provider or "").strip() if not isinstance(self.provider, dict) else str(self.provider.get("provider") or self.provider.get("default") or "").strip(),
+                    str(self.model or "").strip() if not isinstance(self.model, dict) else str(self.model.get("model") or self.model.get("default") or "").strip(),
                     load_config(),
                     requested_provider=(self.requested_provider or "").strip(),
                 )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2778,6 +2778,16 @@ def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
     # alias, or a model dict whose id lives under a non-canonical key.
     model_in = config.get("model")
     model_has_alias = isinstance(model_in, dict) and model_in.get("api_base")
+    # A dict-valued ``default``/``model`` (``{provider: ..., model: ...}``)
+    # must be flattened into ``default`` (string) + ``provider`` here at the
+    # single load/save chokepoint, so every reader (doctor, status, fallback
+    # picker, prompt-size, context-switch guard, …) sees plain strings instead
+    # of a nested dict that crashes ``.strip()``/``.lower()`` or routes the
+    # model through the wrong provider.
+    _has_nested_default = isinstance(model_in, dict) and (
+        isinstance(model_in.get("default"), dict)
+        or isinstance(model_in.get("model"), dict)
+    )
     # A model dict needs canonicalization if its id lives under a non-canonical
     # key (``model``/``name``) — either because ``default`` is empty (we must
     # promote the alias) or because ``default`` is set but a stale alias still
@@ -2788,7 +2798,7 @@ def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
     has_root = any(
         config.get(k) for k in ("provider", "base_url", "context_length", "api_base")
     )
-    if not has_root and not model_has_alias and not model_needs_canon:
+    if not has_root and not model_has_alias and not model_needs_canon and not _has_nested_default:
         return config
 
     config = dict(config)
@@ -2798,6 +2808,24 @@ def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
     else:
         model = dict(model)
     config["model"] = model
+
+    # Flatten a dict-valued ``model.default``/``model.model``:
+    # ``{provider: <p>, model: <m>}`` -> ``default: "<m>"`` and, when no
+    # explicit ``model.provider`` is set, ``provider: "<p>"``. The nested
+    # provider must win over the merged default ``"auto"`` (which runtime
+    # resolution treats as authoritative and would otherwise route the model
+    # through the wrong active provider), but never over an explicitly
+    # configured outer provider.
+    for _key in ("default", "model"):
+        _val = model.get(_key)
+        if isinstance(_val, dict):
+            _nested_model = _val.get("model") or _val.get("default")
+            _nested_provider = str(_val.get("provider") or "").strip()
+            model[_key] = str(_nested_model or "").strip()
+            if _nested_provider:
+                _outer_provider = str(model.get("provider") or "").strip()
+                if not _outer_provider or _outer_provider == "auto":
+                    model["provider"] = _nested_provider
 
     for key in ("provider", "base_url", "context_length"):
         root_val = config.get(key)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3482,7 +3482,18 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         # keys the managed layer pins — see docs/design/managed-scope.md §4.1.
         managed_config = managed_scope.load_managed_config()
         if managed_config:
-            managed_expanded = _expand_env_vars(managed_config)
+            # Normalize the managed overlay through the same canonicalization as
+            # the user config BEFORE merging (parity with
+            # managed_scope.apply_managed_overlay): a dict-valued
+            # ``model.default`` (``{provider: ..., model: ...}``) or a bare
+            # ``model: <string>`` must be flattened to a string ``default``
+            # paired with ``provider`` so the merged result never exposes a
+            # nested dict to status/fallback/runtime readers.
+            managed_normalized = _normalize_root_model_keys(managed_config)
+            if isinstance(managed_normalized.get("model"), str):
+                managed_normalized = dict(managed_normalized)
+                managed_normalized["model"] = {"default": managed_normalized["model"]}
+            managed_expanded = _expand_env_vars(managed_normalized)
             expanded = _deep_merge(expanded, managed_expanded)
         _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
         if cache_sig is not None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -973,7 +973,12 @@ def _has_any_provider_configured() -> bool:
     cfg = load_config()
     model_cfg = cfg.get("model")
     if isinstance(model_cfg, dict):
-        _model_name = (model_cfg.get("default") or "").strip()
+        _default = model_cfg.get("default")
+        if isinstance(_default, dict):
+            _model_name = (_default.get("model") or _default.get("provider") or "")
+        else:
+            _model_name = (_default or "")
+        _model_name = (str(_model_name) if not isinstance(_model_name, str) else _model_name).strip()
     elif isinstance(model_cfg, str):
         _model_name = model_cfg.strip()
     else:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -343,7 +343,11 @@ def _run_agent(
     if isinstance(model_cfg, str):
         cfg_model = model_cfg
     else:
-        cfg_model = model_cfg.get("default") or model_cfg.get("model") or ""
+        _raw = model_cfg.get("default") or model_cfg.get("model") or ""
+        if isinstance(_raw, dict):
+            cfg_model = str(_raw.get("model") or _raw.get("default") or _raw.get("provider") or "")
+        else:
+            cfg_model = str(_raw or "")
 
     env_model = os.getenv("HERMES_INFERENCE_MODEL", "").strip()
     effective_model = (model or "").strip() or env_model or cfg_model

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -322,7 +322,16 @@ def _get_model_config() -> Dict[str, Any]:
         # Accept "model" as alias for "default" (users intuitively write model.model)
         if not cfg.get("default") and cfg.get("model"):
             cfg["default"] = cfg["model"]
-        default = (cfg.get("default") or "").strip()
+        # Handle model.default being a dict {provider: ..., model: ...} rather than a string
+        _default = cfg.get("default")
+        if isinstance(_default, dict):
+            cfg_provider = str(_default.get("provider") or model_cfg.get("provider") or "")
+            cfg_model = str(_default.get("model") or _default.get("default") or "")
+            cfg["default"] = cfg_model
+            if cfg_provider and not cfg.get("provider"):
+                cfg["provider"] = cfg_provider
+            _default = cfg_model
+        default = (str(_default or "")).strip()
         base_url = (cfg.get("base_url") or "").strip()
         is_local = "localhost" in base_url or "127.0.0.1" in base_url
         is_fallback = not default

--- a/model_tools.py
+++ b/model_tools.py
@@ -638,7 +638,10 @@ def _resolve_active_context_length() -> int:
         model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
         if not isinstance(model_cfg, dict):
             model_cfg = {}
-        model_id = (model_cfg.get("model") or model_cfg.get("default") or "").strip()
+        _raw_model_id = model_cfg.get("model") or model_cfg.get("default") or ""
+        if isinstance(_raw_model_id, dict):
+            _raw_model_id = _raw_model_id.get("model") or _raw_model_id.get("provider") or ""
+        model_id = str(_raw_model_id).strip()
         if not model_id:
             return 0
         from agent.model_metadata import get_model_context_length

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -590,5 +590,73 @@ class TestRootLevelProviderOverride:
         assert "model" not in result["model"] and "name" not in result["model"]
 
 
+    # --- dict-valued model.default flattening (PR #83902 follow-up) --------
+    # ``model.default: {provider: ..., model: ...}`` must flatten into a string
+    # ``model.default`` plus ``model.provider`` at the load chokepoint so every
+    # reader (doctor, status, fallback picker, prompt-size, context-switch
+    # guard) sees plain strings instead of a nested dict that crashes
+    # ``.strip()``/``.lower()`` or routes the model through the wrong provider.
+
+    def test_nested_dict_default_flattens_model_and_provider(self):
+        """dict model.default -> string default + provider, no outer provider set."""
+        from hermes_cli.config import _normalize_root_model_keys
+
+        result = _normalize_root_model_keys({
+            "model": {
+                "default": {"provider": "nous", "model": "nested-default-model"},
+            },
+        })
+        assert result["model"]["default"] == "nested-default-model"
+        assert result["model"]["provider"] == "nous"
+
+    def test_nested_dict_default_provider_wins_over_auto(self):
+        """Nested provider replaces the merged default "auto"."""
+        from hermes_cli.config import _normalize_root_model_keys
+
+        result = _normalize_root_model_keys({
+            "model": {
+                "default": {"provider": "nous", "model": "nested-default-model"},
+                "provider": "auto",
+            },
+        })
+        assert result["model"]["default"] == "nested-default-model"
+        assert result["model"]["provider"] == "nous"
+
+    def test_nested_dict_default_never_overrides_explicit_provider(self):
+        """An explicitly configured model.provider beats the nested provider."""
+        from hermes_cli.config import _normalize_root_model_keys
+
+        result = _normalize_root_model_keys({
+            "model": {
+                "default": {"provider": "nous", "model": "nested-default-model"},
+                "provider": "anthropic",
+            },
+        })
+        assert result["model"]["default"] == "nested-default-model"
+        assert result["model"]["provider"] == "anthropic"
+
+    def test_nested_dict_model_alias_flattens_to_default(self):
+        """dict model.model alias also flattens (default > model > name)."""
+        from hermes_cli.config import _normalize_root_model_keys
+
+        result = _normalize_root_model_keys({
+            "model": {
+                "model": {"provider": "openai", "model": "nested-alias-model"},
+            },
+        })
+        assert result["model"]["default"] == "nested-alias-model"
+        assert result["model"]["provider"] == "openai"
+        assert "model" not in result["model"]
+
+    def test_flat_string_default_untouched(self):
+        """Plain string defaults keep existing behavior exactly."""
+        from hermes_cli.config import _normalize_root_model_keys
+
+        result = _normalize_root_model_keys({
+            "model": {"default": "flat-default-model", "provider": "auto"},
+        })
+        assert result["model"]["default"] == "flat-default-model"
+        assert result["model"]["provider"] == "auto"
+
 
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -372,6 +372,64 @@ class TestHistoryDisplay:
         )
 
 
+class TestNestedDictModelDefaultPairing:
+    """A dict-valued ``model.default`` must keep its nested provider paired.
+
+    ``model.default: {provider: ..., model: ...}`` canonicalizes to the string
+    model AND the nested provider, so ``HermesCLI`` routes the model through
+    that provider instead of discarding it and falling back to the outer
+    merged ``model.provider`` (``"auto"`` — authoritative at runtime
+    resolution, which would route the model through the wrong active
+    provider).
+    """
+
+    def test_nested_dict_default_keeps_provider_paired(self):
+        cli = _make_cli(config_overrides={
+            "model": {
+                "default": {"provider": "nous", "model": "nested-default-model"},
+                "provider": "auto",
+            },
+        })
+        assert cli.model == "nested-default-model"
+        assert cli.requested_provider == "nous"
+        assert cli.provider == "nous"
+
+    def test_nested_dict_model_alias_keeps_provider_paired(self):
+        cli = _make_cli(config_overrides={
+            "model": {
+                "model": {"provider": "openai", "model": "nested-alias-model"},
+                "provider": "auto",
+            },
+        })
+        assert cli.model == "nested-alias-model"
+        assert cli.requested_provider == "openai"
+        assert cli.provider == "openai"
+
+    def test_flat_string_default_still_uses_outer_provider(self):
+        cli = _make_cli(config_overrides={
+            "model": {
+                "default": "flat-default-model",
+                "provider": "auto",
+            },
+        })
+        assert cli.model == "flat-default-model"
+        assert cli.requested_provider == "auto"
+        assert cli.provider == "auto"
+
+    def test_nested_provider_does_not_override_explicit_provider_arg(self):
+        cli = _make_cli(
+            config_overrides={
+                "model": {
+                    "default": {"provider": "nous", "model": "nested-default-model"},
+                    "provider": "auto",
+                },
+            },
+            provider="anthropic",
+        )
+        assert cli.model == "nested-default-model"
+        assert cli.requested_provider == "anthropic"
+        assert cli.provider == "anthropic"
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""

--- a/tests/hermes_cli/test_managed_scope_config.py
+++ b/tests/hermes_cli/test_managed_scope_config.py
@@ -64,3 +64,40 @@ def test_user_cannot_shadow_managed_literal_via_envref(homes, monkeypatch):
     _write(home / "config.yaml", "model:\n  default: ${EVIL}\n")
     _write(managed / "config.yaml", "model:\n  default: managed/locked\n")
     assert cfg_get(load_config(), "model", "default") == "managed/locked"
+
+
+def test_managed_nested_dict_default_flattens_on_load(homes):
+    """A dict-valued managed ``model.default`` must flatten on load.
+
+    ``load_config()`` merges the managed overlay after its single
+    normalization pass, so a managed ``model.default: {provider: ...,
+    model: ...}`` used to reach runtime readers as a raw dict. The overlay
+    is now normalized before merging (parity with
+    ``managed_scope.apply_managed_overlay``), so the merged config exposes a
+    string ``default`` paired with the nested ``provider``.
+    """
+    from hermes_cli.config import load_config, cfg_get
+
+    home, managed = homes
+    _write(home / "config.yaml", "model:\n  default: user/model\n")
+    _write(managed / "config.yaml", "model:\n  default:\n    provider: nous\n    model: managed/nested\n")
+    cfg = load_config()
+    assert cfg_get(cfg, "model", "default") == "managed/nested"
+    assert cfg_get(cfg, "model", "provider") == "nous"
+
+
+def test_managed_bare_string_model_flattens_to_default_on_load(homes):
+    """A bare ``model: <string>`` in the managed file stays a dict shape.
+
+    Mirrors the existing managed-overlay contract: a bare string model must
+    merge as ``model.default`` so readers that do
+    ``cfg["model"]["default"]`` keep working (never a bare string at
+    ``cfg["model"]``).
+    """
+    from hermes_cli.config import load_config, cfg_get
+
+    home, managed = homes
+    _write(home / "config.yaml", "model:\n  default: user/model\n")
+    _write(managed / "config.yaml", "model: managed/bare\n")
+    cfg = load_config()
+    assert cfg_get(cfg, "model", "default") == "managed/bare"


### PR DESCRIPTION
## Summary
A dict-valued `model.default` (e.g. `{provider:..., model:...}`) in config.yaml was leaking into `agent.model` and crashing the agent at init:

```
AttributeError: 'dict' object has no attribute 'lower'
  agent/agent_runtime_helpers.py: anthropic_prompt_cache_policy
```

### Symptom (production)
On the Telegram gateway this showed up as an infinite reset loop: every turn built an agent with `model=dict`, crashed during init, the gateway treated the failed turn as a session that needed resetting, and `/reset` rebuilt the agent and crashed again. The bot appeared to ask to reset every time, and resetting did nothing, because the fresh agent hit the same crash on the very next message.

## Root cause
`model.default`/`model` resolving to a dict was never normalized to a string at the resolution entry points, so the dict flowed all the way into `.lower()` calls during agent init.

## Fix
Coerce dict -> string at every model-resolution entry point so the value is normalized once and never reaches a `.lower()` as a dict:
- `agent/agent_runtime_helpers.py`: `anthropic_prompt_cache_policy` (the crash site) - falls back to `dict.get("default") or dict.get("model")`
- `agent/agent_init.py`: configured default model resolution
- `cli.py`: CLI config model + `_normalize_model_for_provider`
- `hermes_cli/main.py`: `_has_any_provider_configured`
- `hermes_cli/oneshot.py`: `_run_agent` model resolution
- `hermes_cli/runtime_provider.py`: `_get_model_config` default handling
- `model_tools.py`: `_resolve_active_context_length`

## Verification
- Gateway restarted with the patched code; Telegram reconnected and a live test message produced a normal agent reply (no `AttributeError`, no reset loop) where it had previously crashed every turn.
- `ast.parse` clean on the patched module.

## Test plan
- [ ] Set `model.default` to a dict `{provider: "nous", model: "tencent/hy3:free"}` in config.yaml
- [ ] Confirm CLI + gateway both resolve the correct string model and start an agent without the `AttributeError`
- [ ] Confirm `/model` switch + reset paths still work