### PR TITLE
fix(model-alias): honor key_env in direct model aliases

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -517,6 +517,7 @@ class DirectAlias(NamedTuple):
     model: str
     provider: str
     base_url: str
+    key_env: str = ""
 
 
 # Built-in direct aliases (can be extended via config.yaml model_aliases:)
@@ -560,9 +561,11 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                 model = entry.get("model", "")
                 provider = entry.get("provider", "custom")
                 base_url = entry.get("base_url", "")
+                key_env = entry.get("key_env", "")
                 if model:
                     merged[name.strip().lower()] = DirectAlias(
                         model=model, provider=provider, base_url=base_url,
+                        key_env=key_env,
                     )
 
         # --- model.aliases (string-based format, from config set) ---
@@ -2018,7 +2021,15 @@ def switch_model(
                     validation_headers = {}
                     suppress_ollama_headers = True
                     api_key = "no-key-required"
-            if not api_key:
+            # A direct alias may reference its own key env var (e.g.
+            # ``key_env: ZHIPU_VELOS_KEY``). Resolve it through the
+            # per-profile secret scope — never a raw os.environ read — and
+            # only fall back to the "no-key-required" placeholder when the
+            # alias declares neither an inline api_key nor a key_env.
+            _alias_key = _scoped_key_env(_da.key_env) if _da.key_env else ""
+            if not api_key and _alias_key:
+                api_key = _alias_key
+            elif not api_key and not _da.key_env:
                 api_key = "no-key-required"
 
     # --- Resolve api_mode from the final (provider, base_url) before validation ---

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2026,11 +2026,25 @@ def switch_model(
             # per-profile secret scope — never a raw os.environ read — and
             # only fall back to the "no-key-required" placeholder when the
             # alias declares neither an inline api_key nor a key_env.
+            #
+            # Note: key resolution runs inside the `_da.base_url` guard. An
+            # alias that declares key_env but no base_url has no endpoint to
+            # associate the resolved key with, so it deliberately skips this
+            # and keeps the provider default — the alias is then a config
+            # error the user should fix, not something we silently key.
             _alias_key = _scoped_key_env(_da.key_env) if _da.key_env else ""
             if not api_key and _alias_key:
                 api_key = _alias_key
             elif not api_key and not _da.key_env:
                 api_key = "no-key-required"
+            elif _da.key_env and not _alias_key:
+                logger.warning(
+                    "Direct alias '%s' declares key_env=%s but it resolved "
+                    "empty in the current secret scope; no key was applied "
+                    "(alias demands one, so the no-key placeholder is not used)",
+                    resolved_alias,
+                    _da.key_env,
+                )
 
     # --- Resolve api_mode from the final (provider, base_url) before validation ---
     # Two cases this closes, both surfaced when the switched model's reasoning

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -365,6 +365,7 @@ class DirectAlias(NamedTuple):
     model: str
     provider: str
     base_url: str
+    key_env: str = ""
 
 
 # Built-in direct aliases (can be extended via config.yaml model_aliases:)
@@ -408,9 +409,11 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                 model = entry.get("model", "")
                 provider = entry.get("provider", "custom")
                 base_url = entry.get("base_url", "")
+                key_env = entry.get("key_env", "")
                 if model:
                     merged[name.strip().lower()] = DirectAlias(
                         model=model, provider=provider, base_url=base_url,
+                        key_env=key_env,
                     )
 
         # --- model.aliases (string-based format, from config set) ---
@@ -1776,7 +1779,15 @@ def switch_model(
         if _da is not None and _da.base_url:
             base_url = _da.base_url
             api_mode = ""  # clear so determine_api_mode re-detects from URL
-            if not api_key:
+            # A direct alias may reference its own key env var (e.g.
+            # ``key_env: ZHIPU_VELOS_KEY``). Resolve it through the
+            # per-profile secret scope — never a raw os.environ read — and
+            # only fall back to the "no-key-required" placeholder when the
+            # alias declares neither an inline api_key nor a key_env.
+            _alias_key = _scoped_key_env(_da.key_env) if _da.key_env else ""
+            if not api_key and _alias_key:
+                api_key = _alias_key
+            elif not api_key and not _da.key_env:
                 api_key = "no-key-required"
 
     # --- Resolve api_mode from the final (provider, base_url) before validation ---

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -77,6 +77,108 @@ class TestDirectAliases:
         assert aliases["mymodel"].provider == "custom"
         assert aliases["mymodel"].base_url == "https://example.com/v1"
 
+    def test_direct_alias_key_env_loaded_from_config(self, monkeypatch):
+        """A model_alias entry with key_env carries it into the DirectAlias.
+
+        Regression for #83847: _load_direct_aliases used to read only model,
+        provider and base_url, silently dropping a user-specified key_env.
+        """
+        mock_config = {
+            "model_aliases": {
+                "glm-flash": {
+                    "model": "glm-4.7-flash",
+                    "provider": "custom",
+                    "base_url": "https://open.bigmodel.cn/api/paas/v4",
+                    "key_env": "ZHIPU_VELOS_KEY",
+                }
+            }
+        }
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: mock_config,
+        )
+
+        from hermes_cli.model_switch import _load_direct_aliases
+        aliases = _load_direct_aliases()
+
+        assert "glm-flash" in aliases
+        assert aliases["glm-flash"].model == "glm-4.7-flash"
+        assert aliases["glm-flash"].provider == "custom"
+        assert aliases["glm-flash"].base_url == "https://open.bigmodel.cn/api/paas/v4"
+        assert aliases["glm-flash"].key_env == "ZHIPU_VELOS_KEY"
+
+    def test_direct_alias_key_env_resolved_from_secret_scope(self, monkeypatch):
+        """A model_alias with key_env resolves its API key via the per-profile
+        secret scope at switch time, not a raw os.environ read (#83847).
+
+        Before the fix the override block fell back to the literal
+        "no-key-required" placeholder (or OPENAI_API_KEY), causing a 401.
+        """
+        from unittest.mock import patch
+
+        import hermes_cli.model_switch as ms
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+        from hermes_cli.model_switch import DirectAlias, switch_model
+
+        alias = DirectAlias(
+            model="glm-4.7-flash",
+            provider="custom",
+            base_url="https://open.bigmodel.cn/api/paas/v4",
+            key_env="ZHIPU_VELOS_KEY",
+        )
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {"glm-flash": alias})
+        monkeypatch.setattr(ms, "_ensure_direct_aliases", lambda: None)
+
+        accepted = {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": None,
+        }
+        token = set_secret_scope({"ZHIPU_VELOS_KEY": "scoped-secret-key"})
+        try:
+            with patch(
+                "hermes_cli.model_switch.resolve_alias",
+                return_value=("custom", "glm-4.7-flash", "glm-flash"),
+            ), patch(
+                "hermes_cli.model_switch.list_provider_models",
+                return_value=[],
+            ), patch(
+                "hermes_cli.model_switch.normalize_model_for_provider",
+                side_effect=lambda model, provider: model,
+            ), patch(
+                "hermes_cli.models.validate_requested_model",
+                return_value=accepted,
+            ), patch(
+                "hermes_cli.models.detect_provider_for_model",
+                return_value=None,
+            ), patch(
+                "hermes_cli.model_switch.get_model_info",
+                return_value=None,
+            ), patch(
+                "hermes_cli.model_switch.get_model_capabilities",
+                return_value=None,
+            ), patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "",
+                    "base_url": "",
+                    "api_mode": "",
+                },
+            ):
+                result = switch_model(
+                    raw_input="glm-flash",
+                    current_provider="openrouter",
+                    current_model="old-model",
+                    current_base_url="",
+                )
+        finally:
+            reset_secret_scope(token)
+
+        assert result.success
+        assert result.api_key == "scoped-secret-key"
+        assert result.base_url == "https://open.bigmodel.cn/api/paas/v4"
+
     def test_direct_alias_resolved_before_catalog(self, monkeypatch):
         """Direct aliases take priority over models.dev catalog lookup."""
         from hermes_cli.model_switch import DirectAlias, resolve_alias

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -179,6 +179,88 @@ class TestDirectAliases:
         assert result.api_key == "scoped-secret-key"
         assert result.base_url == "https://open.bigmodel.cn/api/paas/v4"
 
+    def test_direct_alias_empty_key_env_warns_and_does_not_fake_key(
+        self, monkeypatch
+    ):
+        """A key_env that resolves empty must NOT fall back to no-key-required.
+
+        #83908 / review point 3: an alias that declares key_env demands that
+        key — if the env var is empty/unset we must not fake a key with the
+        no-key-required placeholder (that would silently send an invalid key).
+        Instead we leave api_key empty and warn, so the missing-env case is
+        self-diagnosing rather than a bare empty-key error.
+        """
+        from unittest.mock import patch
+
+        import hermes_cli.model_switch as ms
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+        from hermes_cli.model_switch import DirectAlias, switch_model
+
+        alias = DirectAlias(
+            model="glm-4.7-flash",
+            provider="custom",
+            base_url="https://open.bigmodel.cn/api/paas/v4",
+            key_env="ZHIPU_VELOS_KEY",
+        )
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {"glm-flash": alias})
+        monkeypatch.setattr(ms, "_ensure_direct_aliases", lambda: None)
+
+        accepted = {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": None,
+        }
+        # Secret scope has NO ZHIPU_VELOS_KEY -> resolves empty.
+        token = set_secret_scope({})
+        warned = []
+        try:
+            with patch(
+                "hermes_cli.model_switch.resolve_alias",
+                return_value=("custom", "glm-4.7-flash", "glm-flash"),
+            ), patch(
+                "hermes_cli.model_switch.list_provider_models",
+                return_value=[],
+            ), patch(
+                "hermes_cli.model_switch.normalize_model_for_provider",
+                side_effect=lambda model, provider: model,
+            ), patch(
+                "hermes_cli.models.validate_requested_model",
+                return_value=accepted,
+            ), patch(
+                "hermes_cli.models.detect_provider_for_model",
+                return_value=None,
+            ), patch(
+                "hermes_cli.model_switch.get_model_info",
+                return_value=None,
+            ), patch(
+                "hermes_cli.model_switch.get_model_capabilities",
+                return_value=None,
+            ), patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "",
+                    "base_url": "",
+                    "api_mode": "",
+                },
+            ), patch(
+                "hermes_cli.model_switch.logger.warning",
+                side_effect=lambda *a, **k: warned.append(a),
+            ):
+                result = switch_model(
+                    raw_input="glm-flash",
+                    current_provider="openrouter",
+                    current_model="old-model",
+                    current_base_url="",
+                )
+        finally:
+            reset_secret_scope(token)
+
+        # No fake key, and a warning naming the env var was emitted.
+        assert result.api_key == ""
+        assert warned, "expected a warning naming the empty key_env"
+        assert any("ZHIPU_VELOS_KEY" in str(w) for w in warned)
+
     def test_direct_alias_resolved_before_catalog(self, monkeypatch):
         """Direct aliases take priority over models.dev catalog lookup."""
         from hermes_cli.model_switch import DirectAlias, resolve_alias


### PR DESCRIPTION
## Summary

`_load_direct_aliases()` silently discarded the `key_env` field from user `model_aliases:` entries. A custom provider configured with a per-alias key env var therefore fell back to `OPENAI_API_KEY` (or the literal `"no-key-required"` placeholder) and produced a runtime 401 on the exact same endpoint/key that works via plain HTTP.

Example that was broken:

```yaml
model_aliases:
  glm-flash:
    model: glm-4.7-flash
    provider: custom
    base_url: https://open.bigmodel.cn/api/paas/v4
    key_env: ZHIPU_VELOS_KEY   # <-- was silently discarded
```

## Changes

- **`DirectAlias`** now carries an optional `key_env` field (defaults to `""`, so existing 3-arg construction sites are unaffected).
- **`_load_direct_aliases()`** reads `key_env` from config and stores it on the alias.
- **`switch_model()` direct-alias override** resolves the alias's `key_env` through `_scoped_key_env` (the per-profile secret scope — never a raw `os.environ` read, matching the multiplex-isolation requirement) before falling back to the `"no-key-required"` placeholder.

The placeholder fallback now only fires when the alias declares neither an inline `api_key` nor a `key_env` — so a real configured key is always honored.

## Tests

Two new tests in `tests/hermes_cli/test_ollama_cloud_auth.py::TestDirectAliases`:
- `test_direct_alias_key_env_loaded_from_config` — a `model_alias` entry with `key_env` carries it onto the `DirectAlias`.
- `test_direct_alias_key_env_resolved_from_secret_scope` — the alias override block resolves the key via the secret scope.

Verified the tests genuinely catch the bug: reverting the override to the old `"no-key-required"` path fails the resolution test (`AssertionError: 'no-key-required' == 'scoped-secret-key'`).

Closes #83847
