### PR TITLE
fix(cron): keep profile secret scope active through delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4618,9 +4618,13 @@ def run_one_job(
             # still triggers teardown before propagating.
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
-            raise
-        finally:
+            # The scope is reset here (and again after delivery below) because
+            # this re-raise short-circuits the outer finally. Keeping it reset
+            # on every path matters: delivery reads platform tokens through the
+            # secret scope, so an abandoned scope would leak the wrong profile's
+            # credential into os.environ fallback reads.
             reset_secret_scope(_scope_token)
+            raise
 
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step
@@ -4714,6 +4718,13 @@ def run_one_job(
             # their subprocesses/clients (#10200).
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
+            # The profile secret scope installed above must stay active through
+            # delivery so `_deliver_result` resolves the job-owning profile's
+            # platform tokens (via gateway _getenv -> secret scope) instead of
+            # falling through to the process-global os.environ, which in a
+            # multiplex gateway holds whichever profile's token was loaded
+            # last (#83859). Reset it here — after delivery — on every path.
+            reset_secret_scope(_scope_token)
 
         # Treat empty final_response as a soft failure so last_status
         # is not "ok" — the agent ran but produced nothing useful.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1037,6 +1037,52 @@ class TestOneShotDispatchClaim:
         assert order == ["claim", "run"]  # claim strictly before side effect
 
 
+class TestRunOneJobSecretScopeThroughDelivery:
+    """Issue #83859: the job-owning profile's secret scope must stay active
+    through cron delivery so platform tokens resolve to the owning profile,
+    not whatever the multiplex gateway last loaded into os.environ.
+
+    Regression test: _deliver_result runs after the scope was previously
+    reset (in run_one_job's inner finally), so a Telegram cron delivery read
+    the wrong bot token. The scope must be live when _deliver_result runs
+    and reset only afterwards.
+    """
+
+    def _job(self):
+        return {
+            "id": "scope-job",
+            "name": "scope",
+            "prompt": "hello",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+    def test_scope_active_during_delivery_and_reset_after(self):
+        from agent.secret_scope import current_secret_scope
+
+        observed = {}
+
+        def _fake_deliver_result(job, content, adapters=None, loop=None):
+            observed["scope_during_delivery"] = current_secret_scope() is not None
+            return None
+
+        with patch("cron.scheduler._hermes_home", tmp_path := __import__("tempfile").mkdtemp()), \
+             patch("cron.scheduler.claim_dispatch", return_value=True), \
+             patch("cron.scheduler.create_execution", return_value={"id": "exec-1"}), \
+             patch("cron.scheduler.run_job", return_value=(True, "# out", "ok", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result", side_effect=_fake_deliver_result), \
+             patch("cron.scheduler.mark_job_run"), \
+             patch("cron.scheduler.finish_execution"):
+            from cron.scheduler import run_one_job
+            result = run_one_job(self._job())
+            observed["scope_after_return"] = current_secret_scope() is not None
+
+        assert result is True
+        assert observed["scope_during_delivery"] is True
+        assert observed["scope_after_return"] is False
+
+
 class TestBuildJobPromptSilentHint:
     """Verify _build_job_prompt always injects [SILENT] guidance."""
 


### PR DESCRIPTION
## Summary

In a multiplex gateway serving multiple profiles (each with its own Telegram bot token in `platforms.telegram.bot_token`), cron job output delivered to Telegram was sent from the **wrong bot**. The message reached the correct chat, but the sending bot was whichever token the gateway event loop last had in context — not the job-owning profile's bot.

## Root cause

`run_one_job()` installs the job-owning profile's **secret scope** before running the job, but reset it in an inner `finally` that executed **before** `_deliver_result`. Delivery reads platform tokens via `gateway/config._getenv` → the active secret scope; with the scope already torn down, the read fell through to the process-global `os.environ` — which in a multiplex gateway holds whichever profile's token was loaded last.

## Changes

- **`cron/scheduler.py`** — the profile secret scope is now kept installed through the delivery phase and reset only afterwards, on every path:
  - the re-raise (exception) branch resets it before propagating;
  - the normal path resets it in the delivery `finally`, after `_deliver_result` runs.

This makes `_deliver_result` resolve the job-owning profile's Telegram token instead of a random profile's.

## Tests

New regression test `TestRunOneJobSecretScopeThroughDelivery` in `tests/cron/test_scheduler.py` asserts the secret scope is **active during** `_deliver_result` and **reset after** `run_one_job` returns. Verified it catches the bug: with the post-delivery reset removed, the test fails (`assert observed["scope_after_return"] is False`).

Full `tests/cron/test_scheduler.py` suite: **69 passed**.

Closes #83859
