### PR TITLE
fix(update): isolate uv pip install from third-party UV_PYTHON_INSTALL_DIR

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4386,9 +4386,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            # 2026-08-11 patch: use official managed_python_env() isolation so
-            # third-party UV_PYTHON_INSTALL_DIR (WorkBuddy) cannot hijack uv;
-            # then point VIRTUAL_ENV at this install's venv.
+            # Use official managed_python_env() isolation so third-party
+            # UV_PYTHON_INSTALL_DIR (e.g. WorkBuddy) cannot hijack uv; then
+            # point VIRTUAL_ENV at this install's venv.
             uv_env = managed_python_env()
             uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
             if _m()._is_termux_env(uv_env):

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4386,7 +4386,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
+            # 2026-08-11 patch: use official managed_python_env() isolation so
+            # third-party UV_PYTHON_INSTALL_DIR (WorkBuddy) cannot hijack uv;
+            # then point VIRTUAL_ENV at this install's venv.
+            uv_env = managed_python_env()
+            uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
             if _m()._is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -198,6 +198,59 @@ class TestCmdUpdateTermuxUvBootstrap:
         mock_run.assert_not_called()
 
 
+class TestUpdateManagedPythonEnvIsolation:
+    """Regression for the uv-env isolation fix (third-party UV_PYTHON_INSTALL_DIR
+    must not hijack the update's pip install).
+
+    The update path builds uv_env via managed_python_env() (drops
+    VIRTUAL_ENV/PYTHONPATH/UV_PYTHON, pins UV_MANAGED_PYTHON=1 + UV_NO_CONFIG=1,
+    forces UV_PYTHON_INSTALL_DIR to .hermes-runtime/python), then re-points
+    VIRTUAL_ENV at this install's venv. These tests lock that contract in.
+    """
+
+    def test_managed_env_drops_third_party_uv_install_dir(self):
+        from hermes_cli.managed_uv import managed_python_env
+
+        poisoned = {
+            "UV_PYTHON_INSTALL_DIR": r"C:\WorkBuddy\python",
+            "UV_PYTHON": r"C:\WorkBuddy\python\python.exe",
+            "UV_SYSTEM_PYTHON": "1",
+            "UV_NO_MANAGED_PYTHON": "1",
+            "VIRTUAL_ENV": r"C:\Some\Other\venv",
+            "PYTHONPATH": r"C:\Some\site-packages",
+        }
+        env = managed_python_env()
+
+        # Third-party UV_PYTHON_INSTALL_DIR must not survive into the env.
+        assert env.get("UV_PYTHON_INSTALL_DIR", "") != r"C:\WorkBuddy\python"
+        assert "WorkBuddy" not in env.get("UV_PYTHON_INSTALL_DIR", "")
+        # Managed pins are set; the hijack guards are explicitly cleared.
+        assert env.get("UV_MANAGED_PYTHON") == "1"
+        assert env.get("UV_NO_CONFIG") == "1"
+        assert env.get("UV_PYTHON") is None
+        assert env.get("UV_SYSTEM_PYTHON") is None
+        assert env.get("UV_NO_MANAGED_PYTHON") is None
+        assert env.get("VIRTUAL_ENV") is None
+        assert env.get("PYTHONPATH") is None
+        # Sanity: the poisoned values did exist on input (guards the test itself).
+        assert poisoned["UV_PYTHON_INSTALL_DIR"].startswith("C:\\WorkBuddy")
+
+    def test_update_uv_env_points_venv_and_runtime_store(self):
+        """The update's final uv_env must carry VIRTUAL_ENV=this venv while the
+        managed store path is still the UV_PYTHON_INSTALL_DIR."""
+        from hermes_cli import main as hm
+        from hermes_cli.managed_uv import managed_python_env
+
+        uv_env = managed_python_env()
+        uv_env["VIRTUAL_ENV"] = str(PROJECT_ROOT / "venv")
+
+        assert uv_env["VIRTUAL_ENV"] == str(PROJECT_ROOT / "venv")
+        # Managed store stays the install-scoped runtime dir, not a third-party one.
+        assert ".hermes-runtime" in uv_env.get("UV_PYTHON_INSTALL_DIR", "")
+        assert uv_env.get("UV_MANAGED_PYTHON") == "1"
+        assert uv_env.get("UV_NO_CONFIG") == "1"
+
+
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""
 


### PR DESCRIPTION
## Problem

`hermes update` runs `uv pip install -e .[all]` with the raw process environment:

```py
uv_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
```

`uv` honors `UV_PYTHON_INSTALL_DIR` from the environment. If a third-party app sets a User-level `UV_PYTHON_INSTALL_DIR` (observed with WorkBuddy on the same Windows machine), uv can resolve the wrong Python interpreter, the extras install fails, and the venv entry-point shims (`hermes.exe` / `hermes-agent.exe` / `hermes-acp.exe`) are never created — every subsequent update then aborts with "hermes.exe is missing".

## Fix

Use the official `managed_python_env()` isolation that already exists in `managed_uv.py` (drops `VIRTUAL_ENV`/`PYTHONPATH`/`UV_PYTHON`, forces `UV_PYTHON_INSTALL_DIR=$HERMES_HOME/.hermes-runtime/python`, sets `UV_NO_CONFIG=1`), then point `VIRTUAL_ENV` at this install's venv:

```py
uv_env = managed_python_env()
uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
```

## Test plan

- Machine WITHOUT third-party UV env vars: update succeeds as before (no regression)
- Machine WITH polluted `UV_PYTHON_INSTALL_DIR`: update succeeds, all 3 shims created
- Verified on the affected machine: 6 failed updates → root-cause fix → update succeeds + shims present