### PR TITLE
fix(deps): allow firecrawl-py range instead of exact pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
 # Web search backends — each only loaded when the user picks it as their
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]
-firecrawl = ["firecrawl-py==4.17.0"]
+firecrawl = ["firecrawl-py>=4.17.0,<5"]
 parallel-web = ["parallel-web==0.4.2"]
 # Image generation backends
 fal = ["fal-client==0.13.1"]

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -239,6 +239,29 @@ class TestIsSatisfiedVersionAware:
         assert ld._is_satisfied(spec) is True
         assert ld.feature_missing("tool.trace_upload") == ()
 
+    def test_firecrawl_newer_install_not_force_downgraded(self, monkeypatch):
+        """#83852: the firecrawl pin is a range, not an exact pin.
+
+        When a newer firecrawl-py is already installed (e.g. 4.32.1 from an
+        unpinned base-image install), an exact ``==4.17.0`` pin makes
+        ``_is_satisfied`` return False and ``ensure`` then tries to install
+        the older version, which fails with ResolutionImpossible against core
+        constraints. A floor-and-ceiling range keeps the security lower-bound
+        while not forcing a downgrade of an already-working newer install."""
+        spec = ld.LAZY_DEPS["search.firecrawl"][0]
+        assert "==" not in ld._specifier_from_spec(spec)  # must be a range, not exact
+        self._fake_version(monkeypatch, {"firecrawl-py": "4.32.1"})
+        assert ld._is_satisfied(spec) is True
+        assert ld.feature_missing("search.firecrawl") == ()
+
+    def test_firecrawl_below_floor_still_flagged(self, monkeypatch):
+        """The range still enforces the security floor: an older version is
+        not silently accepted."""
+        spec = ld.LAZY_DEPS["search.firecrawl"][0]
+        self._fake_version(monkeypatch, {"firecrawl-py": "4.10.0"})
+        assert ld._is_satisfied(spec) is False
+        assert ld.feature_missing("search.firecrawl") == (spec,)
+
     @pytest.mark.parametrize(
         ("feature", "installed_versions", "expected_repairs"),
         [

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -116,7 +116,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Web search backends ───────────────────────────────────────────────
     "search.exa": ("exa-py==2.10.2",),
-    "search.firecrawl": ("firecrawl-py==4.17.0",),
+    "search.firecrawl": ("firecrawl-py>=4.17.0,<5",),
     "search.parallel": ("parallel-web==0.4.2",),
 
     # ─── Monitoring ─────────────────────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -1843,7 +1843,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'web'", specifier = "==0.133.1" },
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = "==1.2.1" },
     { name = "fire", specifier = "==0.7.1" },
-    { name = "firecrawl-py", marker = "extra == 'firecrawl'", specifier = "==4.17.0" },
+    { name = "firecrawl-py", marker = "extra == 'firecrawl'", specifier = ">=4.17.0,<5" },
     { name = "google-api-python-client", marker = "extra == 'google'", specifier = "==2.194.0" },
     { name = "google-auth", marker = "extra == 'google'", specifier = "==2.55.1" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = "==2.55.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1831,7 +1831,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'web'", specifier = "==0.133.1" },
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = "==1.2.1" },
     { name = "fire", specifier = "==0.7.1" },
-    { name = "firecrawl-py", marker = "extra == 'firecrawl'", specifier = "==4.17.0" },
+    { name = "firecrawl-py", marker = "extra == 'firecrawl'", specifier = ">=4.17.0,<5" },
     { name = "google-api-python-client", marker = "extra == 'google'", specifier = "==2.194.0" },
     { name = "google-auth", marker = "extra == 'google'", specifier = "==2.55.1" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = "==2.55.1" },


### PR DESCRIPTION
## Summary

`search.firecrawl` was pinned to the exact version `firecrawl-py==4.17.0` in three places: `tools/lazy_deps.py` LAZY_DEPS, the `pyproject.toml` `firecrawl` extra, and `uv.lock`.

When a **newer** firecrawl-py (e.g. 4.32.1) is already installed — for example from an unpinned base-image install — `_is_satisfied()` reports the exact pin as unsatisfied, so `ensure()` attempts a downgrade. That downgrade fails with `ResolutionImpossible` against core constraints, and `web_search` becomes unavailable.

## Changes

Loosen the pin to a floor-and-ceiling range `>=4.17.0,<5` in all three places:
- `tools/lazy_deps.py` — LAZY_DEPS entry
- `pyproject.toml` — `firecrawl` extra
- `uv.lock` — keeps the lockfile in lockstep

This preserves the security lower-bound (4.17.0) while no longer forcing a downgrade of an already-working newer install. It matches the range-spec convention that `_is_satisfied` already supports (the existing test suite uses `slack-bolt>=1.18.0,<2`).

## Tests

Two new tests in `tests/tools/test_lazy_deps.py::TestIsSatisfiedVersionAware`:
- `test_firecrawl_newer_install_not_force_downgraded` — a newer installed version (4.32.1) is accepted under the range pin.
- `test_firecrawl_below_floor_still_flagged` — the range still rejects versions below the security floor (4.10.0).

Verified the tests genuinely catch the bug: reverting to the exact `==4.17.0` pin makes the first test fail (`assert '==' not in '==4.17.0'`).

Full `tests/tools/test_lazy_deps.py` suite: **60 passed, 1 skipped**.

Closes #83852
