### PR TITLE
fix(kanban): enforce not-before guard end to end

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import logging
 import os
 import random
+import secrets
 import threading
 import time
 from dataclasses import dataclass
@@ -479,6 +480,219 @@ def _managed_values(
     )
 
 
+class _KanbanNotBeforeDispatchLease:
+    """Task-scoped authorization held across the provider callback."""
+
+    _LEASE_SECONDS = 300
+    _RENEW_INTERVAL_SECONDS = 60
+    _RENEW_RETRY_SECONDS = 1
+
+    def __init__(self, function_name: str):
+        self.function_name = function_name
+        self.task_id = (os.getenv("HERMES_KANBAN_TASK") or "").strip()
+        self.pinned_db = (os.getenv("HERMES_KANBAN_DB") or "").strip()
+        self.lease_hash = secrets.token_hex(32) if self.task_id and self.pinned_db else ""
+        self.conn = None
+        self.block: str | None = None
+        self._renewal_stop = threading.Event()
+        self._renewal_thread: threading.Thread | None = None
+
+    def acquire(self) -> "_KanbanNotBeforeDispatchLease":
+        if not self.task_id:
+            return self
+        if not self.pinned_db:
+            self.block = (
+                f"tool execution blocked for Kanban task {self.task_id}: "
+                "pinned Kanban database is missing"
+            )
+            return self
+        try:
+            from hermes_cli import kanban_db as kb
+
+            self.conn = kb.connect(db_path=Path(self.pinned_db))
+            now = int(time.time())
+            with kb.write_txn(self.conn):
+                task = kb.get_task(self.conn, self.task_id)
+                if task is None:
+                    raise RuntimeError("Kanban task is absent from the pinned board")
+                if task.not_before and kb.not_before_pending(task.not_before):
+                    if kb._not_before_blocks(
+                        self.conn,
+                        self.task_id,
+                        operation=f"side_effect_execution:{self.function_name}",
+                        now=now,
+                    ):
+                        self.block = (
+                            f"tool execution blocked for Kanban task {self.task_id}: "
+                            f"not-before deadline {task.not_before} has not elapsed"
+                        )
+                        return self
+                self.conn.execute(
+                    "DELETE FROM kanban_not_before_dispatch_leases "
+                    "WHERE task_id = ? AND expires_at <= ?",
+                    (self.task_id, now),
+                )
+                self.conn.execute(
+                    "INSERT INTO kanban_not_before_dispatch_leases "
+                    "(task_id, lease_hash, issued_at, expires_at) VALUES (?, ?, ?, ?)",
+                    (
+                        self.task_id,
+                        self.lease_hash,
+                        now,
+                        now + self._LEASE_SECONDS,
+                    ),
+                )
+            self._renewal_thread = threading.Thread(
+                target=self._renew_until_released,
+                name=f"kanban-dispatch-lease-{self.task_id}",
+                daemon=True,
+            )
+            self._renewal_thread.start()
+        except Exception as exc:
+            self.release()
+            if self.conn is not None:
+                try:
+                    self.conn.close()
+                except Exception:
+                    pass
+                self.conn = None
+            logger.error(
+                "Kanban not-before dispatch lease failed for task %s tool %s: %s",
+                self.task_id,
+                self.function_name,
+                exc,
+            )
+            self.block = (
+                f"tool execution blocked for Kanban task {self.task_id}: "
+                "not-before safety authorization could not be verified"
+            )
+        return self
+
+    def _renew_until_released(self) -> None:
+        """Keep authorization live for callbacks longer than one lease term."""
+        from hermes_cli import kanban_db as kb
+
+        wait_seconds = self._RENEW_INTERVAL_SECONDS
+        while not self._renewal_stop.wait(wait_seconds):
+            try:
+                now = int(time.time())
+                with kb.connect_closing(db_path=Path(self.pinned_db)) as conn:
+                    with kb.write_txn(conn):
+                        updated = conn.execute(
+                            "UPDATE kanban_not_before_dispatch_leases "
+                            "SET expires_at = MAX(expires_at, ?) "
+                            "WHERE task_id = ? AND lease_hash = ?",
+                            (
+                                now + self._LEASE_SECONDS,
+                                self.task_id,
+                                self.lease_hash,
+                            ),
+                        )
+                        if updated.rowcount != 1:
+                            raise RuntimeError("dispatch lease row disappeared")
+                wait_seconds = self._RENEW_INTERVAL_SECONDS
+            except Exception as exc:
+                logger.error(
+                    "Kanban not-before dispatch lease renewal failed for task %s: %s",
+                    self.task_id,
+                    exc,
+                )
+                wait_seconds = self._RENEW_RETRY_SECONDS
+
+    def release(self) -> None:
+        self._renewal_stop.set()
+        renewal_thread = self._renewal_thread
+        if (
+            renewal_thread is not None
+            and renewal_thread is not threading.current_thread()
+            and renewal_thread.is_alive()
+        ):
+            renewal_thread.join()
+        self._renewal_thread = None
+        if self.conn is None:
+            return
+        try:
+            from hermes_cli import kanban_db as kb
+
+            with kb.write_txn(self.conn):
+                self.conn.execute(
+                    "DELETE FROM kanban_not_before_dispatch_leases "
+                    "WHERE task_id = ? AND lease_hash = ?",
+                    (self.task_id, self.lease_hash),
+                )
+        except Exception as exc:
+            logger.error(
+                "Kanban not-before dispatch lease cleanup failed for task %s: %s",
+                self.task_id,
+                exc,
+            )
+        finally:
+            try:
+                self.conn.close()
+            except Exception:
+                pass
+            self.conn = None
+
+
+def _acquire_kanban_not_before_dispatch_lease(
+    function_name: str,
+) -> _KanbanNotBeforeDispatchLease:
+    return _KanbanNotBeforeDispatchLease(function_name).acquire()
+
+
+def _kanban_not_before_tool_block(function_name: str) -> str | None:
+    """Fail closed before any worker tool/middleware can create side effects.
+
+    The dispatcher pins both the task id and DB path into every Kanban worker's
+    environment. A manually-spawned process, or a running task retroactively
+    gated, therefore still cannot reach terminal/browser/provider tools before
+    release. Rejections are audited by ``kanban_db``.
+    """
+    task_id = (os.getenv("HERMES_KANBAN_TASK") or "").strip()
+    pinned_db = (os.getenv("HERMES_KANBAN_DB") or "").strip()
+    if not task_id:
+        return None
+    if not pinned_db:
+        return (
+            f"tool execution blocked for Kanban task {task_id}: "
+            "pinned Kanban database is missing"
+        )
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with kb.connect_closing() as conn:
+            task = kb.get_task(conn, task_id)
+            if task is None:
+                raise RuntimeError("Kanban task is absent from the pinned board")
+            if not task.not_before or not kb.not_before_pending(task.not_before):
+                return None
+            allowed = kb.enforce_not_before(
+                conn,
+                task_id,
+                operation=f"side_effect_execution:{function_name}",
+            )
+            if allowed:
+                return None
+            deadline = task.not_before
+        return (
+            f"tool execution blocked for Kanban task {task_id}: "
+            f"not-before deadline {deadline} has not elapsed"
+        )
+    except Exception as exc:
+        # With a Kanban task identity present, unreadable guard state is not
+        # permission to mutate providers. This is intentionally fail-closed.
+        logger.error(
+            "Kanban not-before preflight failed for task %s tool %s: %s",
+            task_id,
+            function_name,
+            exc,
+        )
+        return (
+            f"tool execution blocked for Kanban task {task_id}: "
+            "not-before safety preflight could not be verified"
+        )
+
+
 def _run_agent_tool_execution_middleware(
     agent,
     *,
@@ -494,6 +708,16 @@ def _run_agent_tool_execution_middleware(
     authorization_gate: _ConcurrentToolAuthorizationGate | None = None,
 ) -> _ManagedToolResult:
     """Run Relay rewrites before Hermes policy and dispatch exactly once."""
+    not_before_block = _kanban_not_before_tool_block(function_name)
+    if not_before_block is not None:
+        return _ManagedToolResult(
+            result=json.dumps({"error": not_before_block}, ensure_ascii=False),
+            args=function_args,
+            middleware_trace=(middleware_trace or []),
+            blocked=True,
+            dispatched=False,
+        )
+
     from agent import relay_tools
     from hermes_cli.middleware import (
         apply_tool_request_middleware,
@@ -505,18 +729,18 @@ def _run_agent_tool_execution_middleware(
         "args": function_args,
         "middleware_trace": trace,
         "blocked": False,
+        "callback_invoked": False,
         "dispatched": False,
     }
     dispatch_lock = threading.Lock()
 
     def _authorized_dispatch(final_args: dict[str, Any]) -> Any:
         with dispatch_lock:
-            if state["dispatched"]:
+            if state["callback_invoked"]:
                 raise RuntimeError(
                     "Hermes tool execution callback invoked more than once"
                 )
-            state["dispatched"] = True
-            state["blocked"] = False
+            state["callback_invoked"] = True
             state["args"] = final_args
 
         def _begin() -> None:
@@ -601,13 +825,43 @@ def _run_agent_tool_execution_middleware(
             )
             return result
 
+        # The final authorization is a task-scoped lease, not merely a
+        # second read. It revalidates the current gate immediately before the
+        # callback and makes a concurrent gate update fail at the SQLite
+        # trigger while this provider dispatch is authorized.
+        dispatch_lease = _acquire_kanban_not_before_dispatch_lease(function_name)
+        if dispatch_lease.block is not None:
+            _advance_start_order()
+            state["blocked"] = True
+            result = json.dumps(
+                {"error": dispatch_lease.block}, ensure_ascii=False
+            )
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=final_args,
+                result=result,
+                effective_task_id=effective_task_id,
+                tool_call_id=tool_call_id,
+                status="blocked",
+                error_type="not_before",
+                error_message=dispatch_lease.block,
+                middleware_trace=list(state["middleware_trace"]),
+            )
+            dispatch_lease.release()
+            return result
+
         if function_name == "memory":
             agent._turns_since_memory = 0
         elif function_name == "skill_manage":
             agent._iters_since_skill = 0
 
-        _advance_start_order(_begin)
-        return execute(final_args)
+        try:
+            state["dispatched"] = True
+            _advance_start_order(_begin)
+            return execute(final_args)
+        finally:
+            dispatch_lease.release()
 
     def _hermes_pipeline(relay_args: dict[str, Any]) -> Any:
         request_result = apply_tool_request_middleware(

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -81,6 +81,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        "not_before": t.not_before,
     }
 
 
@@ -354,6 +355,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "durations (90s, 30m, 2h, 1d). When exceeded, "
                                "the dispatcher SIGTERMs (then SIGKILLs) the worker "
                                "and re-queues the task.")
+    p_create.add_argument(
+        "--not-before",
+        default=None,
+        metavar="ISO8601_UTC",
+        help=(
+            "Optional timezone-aware ISO8601 instant. Numeric offsets are "
+            "accepted and normalized to UTC; dispatch and lifecycle guards "
+            "enforce the release deadline."
+        ),
+    )
     p_create.add_argument("--created-by", default="user",
                           help="Author name recorded on the task (default: user)")
     p_create.add_argument("--skill", action="append", default=[], dest="skills",
@@ -418,6 +429,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_swarm.add_argument("--synthesizer", required=True, help="Synthesizer/writer profile")
     p_swarm.add_argument("--tenant", default=None, help="Tenant namespace")
     p_swarm.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
+    p_swarm.add_argument(
+        "--not-before",
+        default=None,
+        metavar="ISO8601_UTC",
+        help="Release deadline inherited by all workflow child tasks",
+    )
     p_swarm.add_argument("--created-by", default=None, help="Creator/anchor profile")
     p_swarm.add_argument("--idempotency-key", default=None, help="Dedup key for the root card")
     p_swarm.add_argument("--json", action="store_true", help="Emit JSON output")
@@ -1566,6 +1583,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            not_before=getattr(args, "not_before", None),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
@@ -1606,6 +1624,7 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
             tenant=args.tenant,
             created_by=args.created_by or _profile_author(),
             priority=args.priority,
+            not_before=getattr(args, "not_before", None),
             idempotency_key=getattr(args, "idempotency_key", None),
         )
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+from datetime import datetime, timezone
 import hashlib
 import json
 import os
@@ -86,6 +87,7 @@ import logging
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
 
@@ -133,6 +135,404 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+
+_NOT_BEFORE_RE = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})T"
+    r"(?P<time>\d{2}:\d{2}:\d{2})"
+    r"(?P<fraction>\.\d+)?"
+    r"(?P<zone>Z|[+-]\d{2}:\d{2})$"
+)
+
+
+def normalize_not_before(value: Optional[str]) -> Optional[str]:
+    """Validate and canonicalise an optional not-before instant.
+
+    Accepted values are explicit timezone-aware ISO8601 date-times with
+    seconds and either ``Z`` or a numeric ``±HH:MM`` offset. Values are stored
+    as UTC with a trailing ``Z``. Fractional-second digits are kept verbatim,
+    including precision beyond Python's microsecond resolution, so
+    normalisation can never move a safety gate earlier than the supplied
+    instant.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(
+            "not_before must be a timezone-aware ISO8601 instant, "
+            "for example 2026-08-08T11:26:00Z"
+        )
+    candidate = value.strip()
+    match = _NOT_BEFORE_RE.fullmatch(candidate)
+    if match is None:
+        raise ValueError(
+            "not_before must be a timezone-aware ISO8601 instant, "
+            "for example 2026-08-08T11:26:00Z"
+        )
+
+    zone = match.group("zone")
+    parse_zone = "+00:00" if zone == "Z" else zone
+    try:
+        aware = datetime.fromisoformat(
+            f"{match.group('date')}T{match.group('time')}{parse_zone}"
+        )
+        if aware.tzinfo is None or aware.utcoffset() is None:
+            raise ValueError("timezone required")
+        utc = aware.astimezone(timezone.utc)
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(
+            "not_before must be a valid timezone-aware ISO8601 instant, "
+            "for example 2026-08-08T11:26:00Z"
+        ) from exc
+
+    fraction = match.group("fraction") or ""
+    return (
+        f"{utc.year:04d}-{utc.month:02d}-{utc.day:02d}T"
+        f"{utc.hour:02d}:{utc.minute:02d}:{utc.second:02d}{fraction}Z"
+    )
+
+
+_NOT_BEFORE_OVERRIDE_SEAL = object()
+
+
+@dataclass(frozen=True, init=False)
+class OwnerNotBeforeOverride:
+    """Single-task capability issued by the authenticated dashboard."""
+
+    task_id: str
+    owner_identity: str
+    reason: str
+    token: str = field(repr=False, compare=False)
+    _seal: object = field(repr=False, compare=False)
+
+
+# Keep the old type name importable for callers that only used annotations, but
+# do not retain its self-asserted construction semantics.
+HumanNotBeforeOverride = OwnerNotBeforeOverride
+
+
+def authenticated_human_not_before_override(**_kwargs) -> OwnerNotBeforeOverride:
+    """Reject the retired self-asserted override boundary.
+
+    Authentication and task ownership must be established by the dashboard or
+    CLI control plane before it calls :func:`mint_owner_not_before_override`.
+    Worker-supplied identity/provenance strings are never authorization.
+    """
+    raise ValueError(
+        "owner-authenticated not-before override required; self-asserted "
+        "actor/reason/authenticated_by capabilities are not accepted"
+    )
+
+
+def _new_owner_not_before_override(
+    task_id: str,
+    owner_identity: str,
+    reason: str,
+    token: str,
+) -> OwnerNotBeforeOverride:
+    """Build a capability only after dashboard authentication has passed."""
+    override = object.__new__(OwnerNotBeforeOverride)
+    object.__setattr__(override, "task_id", task_id)
+    object.__setattr__(override, "owner_identity", owner_identity)
+    object.__setattr__(override, "reason", reason)
+    object.__setattr__(override, "token", token)
+    object.__setattr__(override, "_seal", _NOT_BEFORE_OVERRIDE_SEAL)
+    return override
+
+
+def mint_owner_not_before_override(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    request: object,
+    reason: str,
+) -> OwnerNotBeforeOverride:
+    """Mint a task-bound override from the canonical dashboard auth seam.
+
+    ``web_server.verified_dashboard_owner`` only vouches for requests that
+    reached the production dashboard app through its loopback token or gated
+    session authentication. Caller-supplied identity/provenance is not accepted.
+    """
+    try:
+        from hermes_cli import web_server
+
+        verified = web_server.verified_dashboard_owner(request)
+    except Exception as exc:
+        raise PermissionError(
+            "owner-authenticated dashboard request required for not-before override"
+        ) from exc
+    if not verified:
+        raise PermissionError(
+            "owner-authenticated dashboard request required for not-before override"
+        )
+    owner_identity, authenticated_by = verified
+    reason = str(reason or "").strip()
+    if not reason:
+        raise ValueError("not-before override reason is required")
+    task_id = str(task_id or "").strip()
+    if not task_id:
+        raise ValueError("task id is required for not-before override")
+    token = secrets.token_urlsafe(32)
+    token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT id FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"task {task_id} not found")
+        conn.execute(
+            "INSERT INTO kanban_not_before_overrides "
+            "(token_hash, task_id, owner_identity, authenticated_by, reason, issued_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                token_hash,
+                task_id,
+                owner_identity,
+                authenticated_by,
+                reason,
+                int(time.time()),
+            ),
+        )
+    return _new_owner_not_before_override(task_id, owner_identity, reason, token)
+
+
+class NotBeforeViolation(RuntimeError):
+    """Raised when an operation is attempted before a task's release time."""
+
+    def __init__(self, task_id: str, operation: str, not_before: str):
+        self.task_id = task_id
+        self.operation = operation
+        self.not_before = not_before
+        super().__init__(
+            f"{operation} blocked for {task_id}: not_before={not_before} has not elapsed"
+        )
+
+
+def _not_before_deadline(value: str) -> Decimal:
+    """Return a canonical not-before instant as exact epoch seconds."""
+    canonical = normalize_not_before(value)
+    if canonical is None:  # pragma: no cover - caller rejects None
+        raise ValueError("not_before is required")
+    match = _NOT_BEFORE_RE.fullmatch(canonical)
+    if match is None:  # pragma: no cover - normalize_not_before already checked
+        raise ValueError(f"invalid canonical not_before: {canonical!r}")
+    base = datetime.fromisoformat(
+        f"{match.group('date')}T{match.group('time')}+00:00"
+    )
+    fraction = Decimal(match.group("fraction") or "0")
+    return Decimal(int(base.timestamp())) + fraction
+
+
+def not_before_pending(value: Optional[str], *, now: Optional[float] = None) -> bool:
+    """Return whether ``value`` is a future not-before instant."""
+    if not value:
+        return False
+    current = Decimal(str(time.time() if now is None else now))
+    try:
+        return current < _not_before_deadline(value)
+    except (InvalidOperation, ValueError):
+        # Invalid persisted gates fail closed.  New writes are normalized, but
+        # direct/legacy SQL must never turn malformed safety metadata into an
+        # early release.
+        return True
+
+
+def _valid_not_before_override(
+    override: Optional[OwnerNotBeforeOverride],
+) -> bool:
+    return bool(
+        isinstance(override, OwnerNotBeforeOverride)
+        and override._seal is _NOT_BEFORE_OVERRIDE_SEAL
+        and override.task_id.strip()
+        and override.owner_identity.strip()
+        and override.reason.strip()
+        and override.token.strip()
+    )
+
+
+def _authorized_not_before_override(
+    conn: sqlite3.Connection,
+    task_id: str,
+    override: Optional[OwnerNotBeforeOverride],
+) -> Optional[sqlite3.Row]:
+    """Validate the sealed capability against its one-use DB record."""
+    if not _valid_not_before_override(override):
+        return None
+    assert isinstance(override, OwnerNotBeforeOverride)
+    if override.task_id != task_id:
+        return None
+    token_hash = hashlib.sha256(override.token.encode("utf-8")).hexdigest()
+    return conn.execute(
+        "SELECT owner_identity, authenticated_by, reason FROM "
+        "kanban_not_before_overrides "
+        "WHERE token_hash = ? AND task_id = ? AND owner_identity = ? "
+        "AND reason = ? AND used_at IS NULL",
+        (token_hash, task_id, override.owner_identity, override.reason),
+    ).fetchone()
+
+
+def _append_not_before_block_once(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    operation: str,
+    not_before: str,
+) -> None:
+    """Record one stable diagnostic per operation/deadline without tick spam."""
+    prior = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'not_before_blocked' "
+        "ORDER BY id DESC LIMIT 20",
+        (task_id,),
+    ).fetchall()
+    for event in prior:
+        try:
+            payload = json.loads(event["payload"] or "{}")
+        except (TypeError, ValueError):
+            payload = {}
+        if (
+            payload.get("operation") == operation
+            and payload.get("not_before") == not_before
+        ):
+            return
+    _append_event(
+        conn,
+        task_id,
+        "not_before_blocked",
+        {
+            "operation": operation,
+            "not_before": not_before,
+            "diagnostic": "attempted_before_release",
+        },
+        run_id=_current_run_id(conn, task_id),
+    )
+
+
+def _not_before_blocks(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    operation: str,
+    override: Optional[OwnerNotBeforeOverride] = None,
+    now: Optional[float] = None,
+) -> Optional[str]:
+    """Transactional guard. Return the blocking deadline, else ``None``."""
+    row = conn.execute(
+        "SELECT not_before FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if row is None or not row["not_before"]:
+        return None
+    not_before = str(row["not_before"])
+    if not not_before_pending(not_before, now=now):
+        return None
+    if _authorized_not_before_override(conn, task_id, override) is not None:
+        return None
+    _append_not_before_block_once(
+        conn,
+        task_id,
+        operation=operation,
+        not_before=not_before,
+    )
+    return not_before
+
+
+def _pending_not_before_override(
+    conn: sqlite3.Connection,
+    task_id: str,
+    override: Optional[OwnerNotBeforeOverride],
+    *,
+    now: Optional[float] = None,
+) -> Optional[str]:
+    row = conn.execute(
+        "SELECT not_before FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if row is None or not row["not_before"]:
+        return None
+    deadline = str(row["not_before"])
+    if not not_before_pending(deadline, now=now):
+        return None
+    if _authorized_not_before_override(conn, task_id, override) is None:
+        return None
+    return deadline
+
+
+def enforce_not_before(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    operation: str,
+    override: Optional[HumanNotBeforeOverride] = None,
+    now: Optional[float] = None,
+    raise_on_block: bool = False,
+) -> bool:
+    """Enforce and audit a task's not-before gate.
+
+    Returns ``True`` when the operation may proceed.  A rejection writes only
+    an internal diagnostic event; task/run state and provider systems remain
+    untouched.
+    """
+    with write_txn(conn):
+        deadline = _not_before_blocks(
+            conn,
+            task_id,
+            operation=operation,
+            override=override,
+            now=now,
+        )
+    if deadline and raise_on_block:
+        raise NotBeforeViolation(task_id, operation, deadline)
+    return deadline is None
+
+
+def _consume_not_before_override(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    operation: str,
+    override: Optional[OwnerNotBeforeOverride],
+    expected_not_before: Optional[str],
+) -> bool:
+    """Consume, audit, and clear an override after a successful transition."""
+    if expected_not_before is None:
+        return True
+    if not _valid_not_before_override(override):
+        raise RuntimeError("not-before override became invalid during transition")
+    authorized = _authorized_not_before_override(conn, task_id, override)
+    if authorized is None:
+        raise RuntimeError("not-before override was no longer authorized")
+    assert isinstance(override, OwnerNotBeforeOverride)
+    token_hash = hashlib.sha256(override.token.encode("utf-8")).hexdigest()
+    consumed = conn.execute(
+        "UPDATE kanban_not_before_overrides SET used_at = ? "
+        "WHERE token_hash = ? AND task_id = ? AND owner_identity = ? "
+        "AND reason = ? AND used_at IS NULL",
+        (
+            int(time.time()), token_hash, task_id,
+            override.owner_identity, override.reason,
+        ),
+    )
+    if consumed.rowcount != 1:
+        raise RuntimeError("not-before override could not be consumed")
+    cleared = conn.execute(
+        "UPDATE tasks SET not_before = NULL "
+        "WHERE id = ? AND not_before = ?",
+        (task_id, expected_not_before),
+    )
+    if cleared.rowcount != 1:
+        raise RuntimeError("not-before gate changed during transition")
+    _append_event(
+        conn,
+        task_id,
+        "not_before_overridden",
+        {
+            "operation": operation,
+            "not_before": expected_not_before,
+            "owner_identity": override.owner_identity,
+            "reason": override.reason,
+            "authenticated_by": authorized["authenticated_by"],
+        },
+        run_id=_current_run_id(conn, task_id),
+    )
+    return True
 
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
@@ -993,6 +1393,9 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Optional machine-readable safety gate. Stored canonically as an explicit
+    # UTC instant and enforced across promotion, claim, completion, and tools.
+    not_before: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1024,6 +1427,7 @@ class Task:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             tenant=row["tenant"] if "tenant" in keys else None,
+            not_before=row["not_before"] if "not_before" in keys else None,
             result=row["result"] if "result" in keys else None,
             idempotency_key=row["idempotency_key"] if "idempotency_key" in keys else None,
             consecutive_failures=(
@@ -1262,6 +1666,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- set the env var. Indexed so per-session list queries stay cheap on
     -- larger boards.
     session_id           TEXT,
+    -- Optional machine-enforced safety gate. Canonical timezone-aware ISO8601
+    -- UTC instant; NULL preserves legacy immediate-dispatch behavior.
+    not_before           TEXT,
     -- Typed block reason set by ``block_task`` (one of VALID_BLOCK_KINDS, or
     -- NULL for legacy/un-typed blocks). Drives routing: ``dependency`` never
     -- sits in ``blocked`` (goes to ``todo`` for parent-gating); the others go
@@ -1298,6 +1705,30 @@ CREATE TABLE IF NOT EXISTS task_events (
     kind       TEXT NOT NULL,
     payload    TEXT,
     created_at INTEGER NOT NULL
+);
+
+-- One-use owner-authenticated capabilities for releasing a task gate. The
+-- raw token never persists; task, verified owner identity, provenance, and
+-- reason are all bound in this row for validation and audit.
+CREATE TABLE IF NOT EXISTS kanban_not_before_overrides (
+    token_hash       TEXT PRIMARY KEY,
+    task_id          TEXT NOT NULL,
+    owner_identity   TEXT NOT NULL,
+    authenticated_by TEXT NOT NULL,
+    reason           TEXT NOT NULL,
+    issued_at        INTEGER NOT NULL,
+    used_at          INTEGER
+);
+
+-- Short-lived dispatch authorization. A task gate cannot be changed while a
+-- provider/tool call owns this task-scoped lease; the lease is released after
+-- the callback returns and expires safely if a worker disappears.
+CREATE TABLE IF NOT EXISTS kanban_not_before_dispatch_leases (
+    task_id      TEXT NOT NULL,
+    lease_hash   TEXT NOT NULL,
+    issued_at    INTEGER NOT NULL,
+    expires_at   INTEGER NOT NULL,
+    PRIMARY KEY (task_id, lease_hash)
 );
 
 -- Historical attempt record. Each time the dispatcher claims a task, a
@@ -1370,6 +1801,22 @@ CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
 CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
 CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_not_before_overrides_task
+    ON kanban_not_before_overrides(task_id, used_at);
+CREATE INDEX IF NOT EXISTS idx_not_before_dispatch_leases_expiry
+    ON kanban_not_before_dispatch_leases(expires_at);
+
+CREATE TRIGGER IF NOT EXISTS kanban_not_before_reject_leased_change
+BEFORE UPDATE OF not_before ON tasks
+WHEN OLD.not_before IS NOT NEW.not_before
+ AND EXISTS (
+     SELECT 1 FROM kanban_not_before_dispatch_leases AS lease
+     WHERE lease.task_id = OLD.id
+       AND lease.expires_at > unixepoch()
+ )
+BEGIN
+    SELECT RAISE(ABORT, 'not-before dispatch lease is active');
+END;
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
@@ -2328,6 +2775,95 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
 
     Called by ``init_db`` so opening an old DB is always safe.
     """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS kanban_not_before_dispatch_leases (
+            task_id TEXT NOT NULL,
+            lease_hash TEXT NOT NULL,
+            issued_at INTEGER NOT NULL,
+            expires_at INTEGER NOT NULL,
+            PRIMARY KEY (task_id, lease_hash)
+        )
+        """
+    )
+    lease_pk = {
+        row["name"]: row["pk"]
+        for row in conn.execute(
+            "PRAGMA table_info(kanban_not_before_dispatch_leases)"
+        )
+    }
+    if lease_pk.get("task_id") == 1 and lease_pk.get("lease_hash") == 0:
+        with write_txn(conn):
+            conn.execute("DROP TRIGGER IF EXISTS kanban_not_before_reject_leased_change")
+            conn.execute("DROP INDEX IF EXISTS idx_not_before_dispatch_leases_expiry")
+            conn.execute(
+                """
+                CREATE TABLE kanban_not_before_dispatch_leases_v2 (
+                    task_id TEXT NOT NULL,
+                    lease_hash TEXT NOT NULL,
+                    issued_at INTEGER NOT NULL,
+                    expires_at INTEGER NOT NULL,
+                    PRIMARY KEY (task_id, lease_hash)
+                )
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO kanban_not_before_dispatch_leases_v2
+                    (task_id, lease_hash, issued_at, expires_at)
+                SELECT task_id, lease_hash, issued_at, expires_at
+                FROM kanban_not_before_dispatch_leases
+                """
+            )
+            conn.execute("DROP TABLE kanban_not_before_dispatch_leases")
+            conn.execute(
+                "ALTER TABLE kanban_not_before_dispatch_leases_v2 "
+                "RENAME TO kanban_not_before_dispatch_leases"
+            )
+            conn.execute(
+                "CREATE INDEX idx_not_before_dispatch_leases_expiry "
+                "ON kanban_not_before_dispatch_leases(expires_at)"
+            )
+            conn.execute(
+                """
+                CREATE TRIGGER kanban_not_before_reject_leased_change
+                BEFORE UPDATE OF not_before ON tasks
+                WHEN OLD.not_before IS NOT NEW.not_before
+                 AND EXISTS (
+                     SELECT 1 FROM kanban_not_before_dispatch_leases AS lease
+                     WHERE lease.task_id = OLD.id
+                       AND lease.expires_at > unixepoch()
+                 )
+                BEGIN
+                    SELECT RAISE(ABORT, 'not-before dispatch lease is active');
+                END
+                """
+            )
+
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS kanban_not_before_dispatch_leases (
+            task_id TEXT NOT NULL,
+            lease_hash TEXT NOT NULL,
+            issued_at INTEGER NOT NULL,
+            expires_at INTEGER NOT NULL,
+            PRIMARY KEY (task_id, lease_hash)
+        );
+        CREATE INDEX IF NOT EXISTS idx_not_before_dispatch_leases_expiry
+            ON kanban_not_before_dispatch_leases(expires_at);
+        CREATE TRIGGER IF NOT EXISTS kanban_not_before_reject_leased_change
+        BEFORE UPDATE OF not_before ON tasks
+        WHEN OLD.not_before IS NOT NEW.not_before
+         AND EXISTS (
+             SELECT 1 FROM kanban_not_before_dispatch_leases AS lease
+             WHERE lease.task_id = OLD.id
+               AND lease.expires_at > unixepoch()
+         )
+        BEGIN
+            SELECT RAISE(ABORT, 'not-before dispatch lease is active');
+        END;
+        """
+    )
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     if "tenant" not in cols:
         _add_column_if_missing(conn, "tasks", "tenant", "tenant TEXT")
@@ -2457,6 +2993,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "session_id", "session_id TEXT"
         )
+
+    if "not_before" not in cols:
+        # Optional machine-enforced scheduling gate. Existing tasks remain
+        # ungated (NULL) for backwards compatibility.
+        _add_column_if_missing(conn, "tasks", "not_before", "not_before TEXT")
 
     if "block_kind" not in cols:
         # Typed block reason (VALID_BLOCK_KINDS) or NULL for legacy/un-typed
@@ -2912,6 +3453,38 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def _effective_parent_not_before(
+    conn: sqlite3.Connection,
+    parents: tuple[str, ...],
+    requested: Optional[str],
+) -> Optional[str]:
+    """Return the latest release deadline across a task and its parents."""
+    effective = requested
+    if not parents:
+        return effective
+
+    placeholders = ",".join("?" * len(parents))
+    rows = conn.execute(
+        f"SELECT id, not_before FROM tasks WHERE id IN ({placeholders})",
+        parents,
+    ).fetchall()
+    found = {row["id"] for row in rows}
+    missing = [parent_id for parent_id in parents if parent_id not in found]
+    if missing:
+        raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+
+    for row in rows:
+        parent_deadline = normalize_not_before(row["not_before"])
+        if parent_deadline is None:
+            continue
+        if (
+            effective is None
+            or _not_before_deadline(parent_deadline) > _not_before_deadline(effective)
+        ):
+            effective = parent_deadline
+    return effective
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -2937,6 +3510,7 @@ def create_task(
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
+    not_before: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
@@ -2983,6 +3557,7 @@ def create_task(
     model_override = (model_override or "").strip() or None
     provider_override = (provider_override or "").strip() or None
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
+    not_before = normalize_not_before(not_before)
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
     assignee = _canonical_assignee(assignee)
@@ -3195,6 +3770,12 @@ def create_task(
             # compose create_task calls under one outer commit so the
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
+                # Resolve inherited release gates before choosing the initial
+                # status, so a parent deadline parks even an otherwise
+                # parent-gated child in ``scheduled``.
+                not_before = _effective_parent_not_before(
+                    conn, parents, not_before
+                )
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -3220,6 +3801,14 @@ def create_task(
                         ).fetchall()
                         if any(r["status"] != "done" for r in rows):
                             task_status = "todo"
+                # A future release is a machine gate, not merely display
+                # metadata.  Park it outside the dispatchable queue until the
+                # dependency resolver observes that the deadline elapsed.
+                if (
+                    task_status in ("ready", "todo")
+                    and not_before_pending(not_before, now=now)
+                ):
+                    task_status = "scheduled"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
                 if triage and parents:
@@ -3254,8 +3843,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, not_before
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3281,6 +3870,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        not_before,
                     ),
                 )
                 for pid in parents:
@@ -3305,6 +3895,7 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "not_before": not_before,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -4129,6 +4720,8 @@ def _synthesize_ended_run(
     summary: Optional[str] = None,
     error: Optional[str] = None,
     metadata: Optional[dict] = None,
+    not_before_override: Optional[HumanNotBeforeOverride] = None,
+    not_before_checked: bool = False,
 ) -> int:
     """Insert a zero-duration, already-closed run row.
 
@@ -4146,6 +4739,15 @@ def _synthesize_ended_run(
     function does NOT touch the tasks row.
     """
     now = int(time.time())
+    if outcome == "completed" and not not_before_checked:
+        if _not_before_blocks(
+            conn,
+            task_id,
+            operation="synthetic_evidence_creation",
+            override=not_before_override,
+            now=now,
+        ):
+            return 0
     trow = conn.execute(
         "SELECT assignee, current_step_key FROM tasks WHERE id = ?",
         (task_id,),
@@ -4280,8 +4882,8 @@ def recompute_ready(
     promoted = 0
     with write_txn(conn):
         todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
-            "FROM tasks WHERE status IN ('todo', 'blocked')"
+            "SELECT id, status, consecutive_failures, max_retries, not_before "
+            "FROM tasks WHERE status IN ('todo', 'scheduled', 'blocked')"
         ).fetchall()
         for row in todo_rows:
             task_id = row["id"]
@@ -4292,6 +4894,11 @@ def recompute_ready(
                 # legitimate exit (it emits ``"unblocked"`` which flips
                 # this predicate back).
                 continue
+            # Legacy scheduled rows without a timestamp remain explicitly
+            # parked until unblock_task. Timestamped rows auto-release only
+            # after the machine-readable deadline.
+            if cur_status == "scheduled" and not row["not_before"]:
+                continue
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
@@ -4299,6 +4906,12 @@ def recompute_ready(
                 (task_id,),
             ).fetchall()
             if all(p["status"] in ("done", "archived") for p in parents):
+                if _not_before_blocks(
+                    conn,
+                    task_id,
+                    operation="dependency_resolver",
+                ):
+                    continue
                 resume_status = _resume_status_from_events(conn, task_id)
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
@@ -4324,7 +4937,8 @@ def recompute_ready(
                     )
                 else:
                     conn.execute(
-                        "UPDATE tasks SET status = ? WHERE id = ? AND status = 'todo'",
+                        "UPDATE tasks SET status = ? "
+                        "WHERE id = ? AND status IN ('todo', 'scheduled')",
                         (resume_status, task_id),
                     )
                 _append_event(
@@ -4356,6 +4970,7 @@ def claim_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    not_before_override: Optional[HumanNotBeforeOverride] = None,
 ) -> Optional[Task]:
     """Atomically transition ``ready -> running``.
 
@@ -4366,6 +4981,17 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        override_gate = _pending_not_before_override(
+            conn, task_id, not_before_override, now=now
+        )
+        if _not_before_blocks(
+            conn,
+            task_id,
+            operation="claim",
+            override=not_before_override,
+            now=now,
+        ):
+            return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -4426,6 +5052,11 @@ def claim_task(
         )
         if cur.rowcount != 1:
             return None
+        if not _consume_not_before_override(
+            conn, task_id, operation="claim", override=not_before_override,
+            expected_not_before=override_gate,
+        ):
+            return None
         # Look up the current task row so we can populate the run with
         # its assignee / step / runtime cap.
         trow = conn.execute(
@@ -4478,6 +5109,7 @@ def claim_review_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    not_before_override: Optional[HumanNotBeforeOverride] = None,
 ) -> Optional[Task]:
     """Atomically transition ``review -> running``.
 
@@ -4511,6 +5143,17 @@ def claim_review_task(
                     },
                 )
             return None
+        override_gate = _pending_not_before_override(
+            conn, task_id, not_before_override, now=now
+        )
+        if _not_before_blocks(
+            conn,
+            task_id,
+            operation="claim_review",
+            override=not_before_override,
+            now=now,
+        ):
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
@@ -4525,6 +5168,11 @@ def claim_review_task(
             (lock, expires, now, task_id),
         )
         if cur.rowcount != 1:
+            return None
+        if not _consume_not_before_override(
+            conn, task_id, operation="claim_review", override=not_before_override,
+            expected_not_before=override_gate,
+        ):
             return None
         trow = conn.execute(
             "SELECT assignee, max_runtime_seconds, current_step_key "
@@ -5076,6 +5724,7 @@ def complete_task(
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
     fire_lifecycle_hook: bool = True,
+    not_before_override: Optional[HumanNotBeforeOverride] = None,
 ) -> bool:
     """Transition ``running|ready|blocked|review -> done`` and record ``result``.
 
@@ -5115,6 +5764,20 @@ def complete_task(
     if not _parents_satisfied(conn, task_id):
         return False
 
+    # This must be the first completion write. In particular it precedes
+    # artifact staging, synthetic-run evidence, dependent promotion, cleanup,
+    # and lifecycle hooks, so a rejected drain/root-drain/direct completion has
+    # no side effect beyond its diagnostic event.
+    with write_txn(conn):
+        if _not_before_blocks(
+            conn,
+            task_id,
+            operation="complete",
+            override=not_before_override,
+            now=now,
+        ):
+            return False
+
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
     # tiny dedicated txn, then raise. The caller is responsible for
@@ -5150,6 +5813,20 @@ def complete_task(
         # approval. A parent may have been reopened after this task entered
         # ``review`` or ``running``.
         if not _parents_satisfied(conn, task_id):
+            return False
+        override_gate = _pending_not_before_override(
+            conn, task_id, not_before_override, now=now
+        )
+        # Re-check inside the same write transaction as the terminal CAS. A
+        # second connection may install a gate after the initial preflight;
+        # that gate must win over completion and leave the task/run untouched.
+        if _not_before_blocks(
+            conn,
+            task_id,
+            operation="complete",
+            override=not_before_override,
+            now=now,
+        ):
             return False
         prior = conn.execute(
             "SELECT status FROM tasks WHERE id = ?",
@@ -5193,6 +5870,11 @@ def complete_task(
             )
         if cur.rowcount != 1:
             return False
+        if not _consume_not_before_override(
+            conn, task_id, operation="complete", override=not_before_override,
+            expected_not_before=override_gate,
+        ):
+            return False
         if isinstance(metadata, dict):
             _persist_scratch_completion_artifacts(conn, task_id, metadata)
             for stored_path in metadata.pop("_staged_artifacts", []):
@@ -5231,6 +5913,7 @@ def complete_task(
                 outcome="completed",
                 summary=synth_summary,
                 metadata=synth_metadata,
+                not_before_checked=True,
             )
         # Carry the handoff summary in the event payload so gateway
         # notifiers and dashboard WS consumers can render it without a
@@ -6412,6 +7095,7 @@ def promote_task(
     reason: Optional[str] = None,
     force: bool = False,
     dry_run: bool = False,
+    not_before_override: Optional[HumanNotBeforeOverride] = None,
 ) -> tuple[bool, Optional[str]]:
     """Manually promote a `todo` or `blocked` task to `ready`.
 
@@ -6424,16 +7108,16 @@ def promote_task(
     promotion would succeed without mutating state.
     """
     row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        "SELECT status, not_before FROM tasks WHERE id = ?", (task_id,)
     ).fetchone()
     if row is None:
         return False, f"task {task_id} not found"
 
     cur_status = row["status"]
-    if cur_status not in ("todo", "blocked"):
+    if cur_status not in ("todo", "scheduled", "blocked"):
         return False, (
             f"task {task_id} is {cur_status!r}; promote only applies to "
-            f"'todo' or 'blocked'"
+            f"'todo', 'scheduled', or 'blocked'"
         )
 
     if not force:
@@ -6454,16 +7138,53 @@ def promote_task(
             )
 
     if dry_run:
+        if row is not None:
+            gate = conn.execute(
+                "SELECT not_before FROM tasks WHERE id = ?", (task_id,)
+            ).fetchone()
+            if gate and not_before_pending(gate["not_before"]):
+                return False, (
+                    f"not-before deadline has not elapsed: {gate['not_before']}"
+                )
         return True, None
 
     with write_txn(conn):
+        # Re-read and guard inside the same write transaction as the status
+        # CAS. SQLite's RESERVED lock prevents a concurrent gate insertion
+        # from landing between these operations.
+        current = conn.execute(
+            "SELECT status, not_before FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if current is None:
+            return False, f"task {task_id} not found"
+        if current["status"] not in ("todo", "scheduled", "blocked"):
+            return False, (
+                f"task {task_id} is {current['status']!r}; promote only applies to "
+                f"'todo', 'scheduled', or 'blocked'"
+            )
+        override_gate = _pending_not_before_override(
+            conn, task_id, not_before_override, now=int(time.time())
+        )
+        deadline = _not_before_blocks(
+            conn,
+            task_id,
+            operation="manual_promotion",
+            override=not_before_override,
+        )
+        if deadline:
+            return False, f"not-before deadline has not elapsed: {deadline}"
         upd = conn.execute(
             "UPDATE tasks SET status = 'ready' "
-            "WHERE id = ? AND status IN ('todo', 'blocked')",
-            (task_id,),
+            "WHERE id = ? AND status = ?",
+            (task_id, current["status"]),
         )
         if upd.rowcount != 1:
             return False, f"task {task_id} status changed during promotion"
+        if not _consume_not_before_override(
+            conn, task_id, operation="manual_promotion",
+            override=not_before_override, expected_not_before=override_gate,
+        ):
+            return False, f"task {task_id} override could not be consumed"
         _append_event(
             conn,
             task_id,
@@ -6523,7 +7244,12 @@ def _landing_status_after_parents(conn: sqlite3.Connection, task_id: str) -> str
     return "todo" if undone_parents else "ready"
 
 
-def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def unblock_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    not_before_override: Optional[HumanNotBeforeOverride] = None,
+) -> bool:
     """Transition ``blocked``/``scheduled`` to its safe resumable phase.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
@@ -6535,6 +7261,17 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     now = int(time.time())
     with write_txn(conn):
+        override_gate = _pending_not_before_override(
+            conn, task_id, not_before_override, now=now
+        )
+        if _not_before_blocks(
+            conn,
+            task_id,
+            operation="unblock",
+            override=not_before_override,
+            now=now,
+        ):
+            return False
         current = conn.execute(
             "SELECT status FROM tasks WHERE id = ?",
             (task_id,),
@@ -6572,6 +7309,11 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             (new_status, task_id),
         )
         if cur.rowcount != 1:
+            return False
+        if not _consume_not_before_override(
+            conn, task_id, operation="unblock", override=not_before_override,
+            expected_not_before=override_gate,
+        ):
             return False
         _append_event(
             conn, task_id, "unblocked",
@@ -6985,9 +7727,11 @@ def decompose_triage_task(
             _in_deg[_i] += 1
     _queue = [_i for _i in range(len(children)) if _in_deg[_i] == 0]
     _seen = 0
+    _topological_order: list[int] = []
     while _queue:
         _node = _queue.pop()
         _seen += 1
+        _topological_order.append(_node)
         for _nb in _adj[_node]:
             _in_deg[_nb] -= 1
             if _in_deg[_nb] == 0:
@@ -7006,7 +7750,7 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, workspace_kind, workspace_path, not_before "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -7021,6 +7765,31 @@ def decompose_triage_task(
         # override with its own 'workspace_kind' / 'workspace_path'.
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
+        root_not_before = normalize_not_before(root_row["not_before"])
+        child_not_befores: list[Optional[str]] = [None] * len(children)
+        for idx in _topological_order:
+            effective = normalize_not_before(children[idx].get("not_before"))
+            if (
+                root_not_before is not None
+                and (
+                    effective is None
+                    or _not_before_deadline(root_not_before)
+                    > _not_before_deadline(effective)
+                )
+            ):
+                effective = root_not_before
+            for parent_idx in children[idx].get("parents") or []:
+                parent_deadline = child_not_befores[parent_idx]
+                if (
+                    parent_deadline is not None
+                    and (
+                        effective is None
+                        or _not_before_deadline(parent_deadline)
+                        > _not_before_deadline(effective)
+                    )
+                ):
+                    effective = parent_deadline
+            child_not_befores[idx] = effective
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -7052,26 +7821,38 @@ def decompose_triage_task(
                 child_ws_path = root_ws_path
             else:
                 child_ws_path = None
+            child_not_before = child_not_befores[idx]
+            child_status = (
+                "scheduled"
+                if not_before_pending(child_not_before, now=now)
+                else "todo"
+            )
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, not_before) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
                     body if isinstance(body, str) else None,
                     assignee,
+                    child_status,
                     child_ws_kind,
                     child_ws_path,
                     tenant,
                     now,
                     (author or "decomposer"),
+                    child_not_before,
                 ),
             )
             _append_event(
                 conn, new_id, "created",
-                {"by": author or "decomposer", "from_decompose_of": task_id},
+                {
+                    "by": author or "decomposer",
+                    "from_decompose_of": task_id,
+                    "not_before": child_not_before,
+                },
             )
             _inherit_notify_subs(conn, new_id, (task_id,), created_at=now)
             child_ids.append(new_id)
@@ -7660,7 +8441,9 @@ class DispatchResult:
     """List of ``(task_id, assignee, workspace_path)`` triples."""
     skipped_unassigned: list[str] = field(default_factory=list)
     """Ready task ids skipped because they have no assignee at all.
-    Operator-actionable — usually a misfiled task waiting for routing."""
+    operator-actionable — usually a misfiled task waiting for routing."""
+    skipped_not_before: list[str] = field(default_factory=list)
+    """Task ids held before their machine-enforced release timestamp."""
     auto_assigned_default: list[str] = field(default_factory=list)
     """Task ids that were unassigned in the DB and had
     ``kanban.default_assignee`` applied this tick before spawning (#27145).
@@ -9150,7 +9933,7 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     the warning still fires in degraded environments.
     """
     rows = conn.execute(
-        "SELECT DISTINCT assignee FROM tasks "
+        "SELECT id, assignee, not_before FROM tasks "
         "WHERE status = 'ready' AND assignee IS NOT NULL "
         "    AND claim_lock IS NULL"
     ).fetchall()
@@ -9160,9 +9943,12 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
         # Can't introspect — assume spawnable, preserve legacy behavior.
-        return True
+        return any(not not_before_pending(row["not_before"]) for row in rows)
     for row in rows:
-        if profile_exists(row["assignee"]):
+        if (
+            not not_before_pending(row["not_before"])
+            and profile_exists(row["assignee"])
+        ):
             return True
     return False
 
@@ -9176,7 +9962,7 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     should have spawned a review agent.
     """
     rows = conn.execute(
-        "SELECT DISTINCT assignee FROM tasks "
+        "SELECT id, assignee, not_before FROM tasks "
         "WHERE status = 'review' AND assignee IS NOT NULL "
         "    AND claim_lock IS NULL"
     ).fetchall()
@@ -9185,9 +9971,12 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     try:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
-        return True
+        return any(not not_before_pending(row["not_before"]) for row in rows)
     for row in rows:
-        if profile_exists(row["assignee"]):
+        if (
+            not not_before_pending(row["not_before"])
+            and profile_exists(row["assignee"])
+        ):
             return True
     return False
 
@@ -9382,7 +10171,7 @@ def _dispatch_once_locked(
         )
 
     ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
+        "SELECT id, assignee, not_before FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
@@ -9426,6 +10215,15 @@ def _dispatch_once_locked(
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
+        if not_before_pending(row["not_before"]):
+            if not dry_run:
+                enforce_not_before(
+                    conn,
+                    row["id"],
+                    operation="dispatcher",
+                )
+            result.skipped_not_before.append(row["id"])
+            continue
         row_assignee = row["assignee"]
         if not row_assignee:
             # Honour kanban.default_assignee: when the dispatcher hits an
@@ -10330,6 +11128,8 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     lines.append("")
     lines.append(f"Assignee: {task.assignee or '(unassigned)'}")
     lines.append(f"Status:   {task.status}")
+    if task.not_before:
+        lines.append(f"Not before: {task.not_before}")
     if task.tenant:
         lines.append(f"Tenant:   {task.tenant}")
     lines.append(f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}")

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -70,7 +70,8 @@ Output a single JSON object with this exact shape:
         "title": "<concrete task title, imperative voice, <= 80 chars>",
         "body":  "<detailed spec for the worker on this child task>",
         "assignee": "<profile name from the roster, or null for default>",
-        "parents": [<int>, ...]
+        "parents": [<int>, ...],
+        "not_before": "<optional timezone-aware UTC instant>"
       },
       ...
     ]
@@ -89,6 +90,8 @@ Rules:
     and the system will route to the default_assignee.
   - Each child task body is what a fresh worker will read with no other
     context — be specific about goal, approach, and acceptance criteria.
+  - If the root task has a release deadline, child deadlines may be later but
+    never earlier. Omit "not_before" unless a child needs a later deadline.
 
 When the task is genuinely a single unit of work (no useful decomposition),
 return:
@@ -427,6 +430,7 @@ def decompose_task(
             "body": body.strip(),
             "assignee": chosen,
             "parents": clean_parents,
+            "not_before": entry.get("not_before"),
         })
 
     try:

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -139,6 +139,7 @@ def create_swarm(
     created_by: str = "swarm-orchestrator",
     workspace_kind: str = "scratch",
     workspace_path: Optional[str] = None,
+    not_before: Optional[str] = None,
     priority: int = 0,
     idempotency_key: Optional[str] = None,
 ) -> SwarmCreated:
@@ -161,6 +162,7 @@ def create_swarm(
             created_by=created_by,
             workspace_kind=workspace_kind,
             workspace_path=workspace_path,
+            not_before=not_before,
             priority=priority,
             idempotency_key=idempotency_key,
         )
@@ -210,6 +212,7 @@ def _create_swarm_uncommitted(
     created_by: str = "swarm-orchestrator",
     workspace_kind: str = "scratch",
     workspace_path: Optional[str] = None,
+    not_before: Optional[str] = None,
     priority: int = 0,
     idempotency_key: Optional[str] = None,
 ) -> SwarmCreated:
@@ -279,6 +282,7 @@ def _create_swarm_uncommitted(
             priority=spec.priority or priority,
             workspace_kind=workspace_kind,
             workspace_path=workspace_path,
+            not_before=not_before,
             skills=spec.skills or None,
             max_runtime_seconds=spec.max_runtime_seconds,
         )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import contextlib
+from contextvars import ContextVar
 from contextlib import asynccontextmanager, contextmanager
 
 import asyncio
@@ -348,6 +349,157 @@ def _resolve_session_token() -> str:
 
 _SESSION_TOKEN = _resolve_session_token()
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
+
+
+def _make_dashboard_auth_provenance(auth_app: FastAPI):
+    """Build the private request-lifetime lease boundary for owner provenance.
+
+    The lease registry, signing secret, seal, and ContextVar deliberately live
+    only in this closure.  The module exposes the verifier and the canonical
+    gated-auth runner, never a constructor, registry, or setter that an
+    in-process plugin/worker could use to self-assert authentication.
+    """
+    lease_secret = secrets.token_bytes(32)
+    lease_seal = object()
+    lease_context: ContextVar[Optional[str]] = ContextVar(
+        "hermes_dashboard_auth_lease", default=None
+    )
+    active_leases: dict[str, tuple[object, bytes, FastAPI, dict, str, str]] = {}
+    active_leases_lock = threading.RLock()
+
+    def _register_lease(
+        request: Request,
+        identity: str,
+        authenticated_by: str,
+    ) -> tuple[str, object]:
+        lease_id = secrets.token_urlsafe(32)
+        signature = hmac.new(
+            lease_secret,
+            lease_id.encode("ascii"),
+            hashlib.sha256,
+        ).digest()
+        record = (
+            lease_seal,
+            signature,
+            auth_app,
+            request.scope,
+            identity,
+            authenticated_by,
+        )
+        with active_leases_lock:
+            active_leases[lease_id] = record
+        try:
+            context_token = lease_context.set(lease_id)
+        except BaseException:
+            with active_leases_lock:
+                active_leases.pop(lease_id, None)
+            raise
+        return lease_id, context_token
+
+    def _issue_gated_lease(request: Request) -> Optional[tuple[str, object]]:
+        """Issue only from the session attached by canonical gated auth."""
+        if request.app is not auth_app:
+            return None
+        from hermes_cli.dashboard_auth.middleware import _path_is_public
+
+        # The canonical middleware calls its downstream callback for public
+        # bootstrap paths and for token-auth seam requests without performing
+        # interactive session authentication. Neither path can issue owner
+        # provenance, even if a caller pre-populated request.state.session.
+        if (
+            _path_is_public(request.url.path)
+            or getattr(request.state, "token_authenticated", False)
+        ):
+            return None
+        session = getattr(request.state, "session", None)
+        identity = str(getattr(session, "user_id", "") or "").strip()
+        provider = str(getattr(session, "provider", "") or "").strip()
+        if not identity or not provider:
+            return None
+        return _register_lease(
+            request,
+            identity,
+            f"dashboard_session:{provider}",
+        )
+
+    def _revoke_lease(lease_id: str, context_token: object) -> None:
+        # Remove from the shared registry first: copied contexts retain their
+        # ContextVar value, but cannot use it after request completion.
+        with active_leases_lock:
+            active_leases.pop(lease_id, None)
+        try:
+            lease_context.reset(context_token)
+        except (LookupError, ValueError):
+            # Registry revocation is the security boundary.  A context can be
+            # copied or moved by framework cleanup; never let reset failure
+            # leak the active lease or mask the request's original exception.
+            pass
+
+    def verify(request: Request) -> Optional[tuple[str, str]]:
+        """Verify an active, app/scope/session-bound gated-auth lease."""
+        if request.app is not auth_app:
+            return None
+        lease_id = lease_context.get()
+        if not isinstance(lease_id, str) or not lease_id or not lease_id.isascii():
+            return None
+        expected_signature = hmac.new(
+            lease_secret,
+            lease_id.encode("ascii"),
+            hashlib.sha256,
+        ).digest()
+        with active_leases_lock:
+            record = active_leases.get(lease_id)
+            if record is None:
+                return None
+            (
+                record_seal,
+                signature,
+                lease_app,
+                lease_scope,
+                identity,
+                authenticated_by,
+            ) = record
+            if (
+                record_seal is not lease_seal
+                or not hmac.compare_digest(signature, expected_signature)
+                or lease_app is not auth_app
+                or request.scope is not lease_scope
+            ):
+                return None
+            session = getattr(request.state, "session", None)
+            current_identity = str(getattr(session, "user_id", "") or "").strip()
+            provider = str(getattr(session, "provider", "") or "").strip()
+            if (
+                not current_identity
+                or not provider
+                or current_identity != identity
+                or authenticated_by != f"dashboard_session:{provider}"
+            ):
+                return None
+            return identity, authenticated_by
+
+    async def run_gated_auth(request: Request, call_next):
+        """Run canonical auth, then bracket downstream work with one lease."""
+        from hermes_cli.dashboard_auth.middleware import gated_auth_middleware
+
+        async def authenticated_call_next(authenticated_request: Request):
+            lease = _issue_gated_lease(authenticated_request)
+            if lease is None:
+                return await call_next(authenticated_request)
+            lease_id, context_token = lease
+            try:
+                return await call_next(authenticated_request)
+            finally:
+                _revoke_lease(lease_id, context_token)
+
+        return await gated_auth_middleware(request, authenticated_call_next)
+
+    return verify, run_gated_auth
+
+
+_verify_dashboard_auth_lease, _run_dashboard_gated_auth = (
+    _make_dashboard_auth_provenance(app)
+)
 _SSH_OWNER_NONCE: Optional[str] = None
 
 
@@ -428,6 +580,17 @@ def _has_valid_session_token(request: Request) -> bool:
     auth = request.headers.get("authorization", "")
     expected = f"Bearer {_SESSION_TOKEN}"
     return hmac.compare_digest(auth.encode(), expected.encode())
+
+
+def verified_dashboard_owner(request: Request) -> Optional[tuple[str, str]]:
+    """Return owner provenance only for a request authenticated by this app."""
+    if request.app is not app:
+        return None
+    if getattr(request.app.state, "auth_required", False):
+        return _verify_dashboard_auth_lease(request)
+    if _has_valid_session_token(request):
+        return f"local:{os.getuid()}", "dashboard_session_token"
+    return None
 
 
 # Routes that may also authenticate via a ``?token=`` query param, for download
@@ -658,8 +821,7 @@ async def _plugin_api_runtime_gate(request: Request, call_next):
 
 @app.middleware("http")
 async def _dashboard_auth_gate(request: Request, call_next):
-    from hermes_cli.dashboard_auth.middleware import gated_auth_middleware
-    return await gated_auth_middleware(request, call_next)
+    return await _run_dashboard_gated_auth(request, call_next)
 
 
 @app.middleware("http")

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -44,7 +44,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
@@ -114,6 +114,8 @@ def _resolve_board(board: Optional[str]) -> Optional[str]:
             detail=f"board {normed!r} does not exist",
         )
     return normed
+
+
 
 
 def _conn(board: Optional[str] = None):
@@ -618,6 +620,9 @@ class CreateTaskBody(BaseModel):
     # Explicit project link; when omitted, create_task inherits the board's
     # scoped project (if any) so a project-scoped board anchors every task.
     project_id: Optional[str] = None
+    # Optional machine-enforced release deadline. Parent tasks with a later
+    # deadline are inherited by the kernel during creation.
+    not_before: Optional[str] = None
 
 
 @router.post("/tasks")
@@ -646,6 +651,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,
             project_id=payload.project_id,
+            not_before=payload.not_before,
             board=board,
         )
         task = kanban_db.get_task(conn, task_id)
@@ -827,6 +833,9 @@ def remove_attachment(attachment_id: int, board: Optional[str] = Query(None)):
 
 class UpdateTaskBody(BaseModel):
     status: Optional[str] = None
+    # Supplying this field invokes the authenticated dashboard owner control
+    # plane; the client never supplies actor/authentication identity.
+    not_before_override_reason: Optional[str] = None
     assignee: Optional[str] = None
     priority: Optional[int] = None
     title: Optional[str] = None
@@ -867,7 +876,12 @@ def _reopen_if_review(conn, task_id: str, current) -> Optional[bool]:
 
 
 @router.patch("/tasks/{task_id}")
-def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Query(None)):
+def update_task(
+    request: Request,
+    task_id: str,
+    payload: UpdateTaskBody,
+    board: Optional[str] = Query(None),
+):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -878,6 +892,29 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         review_assignee_deferred = (
             payload.status == "review" and payload.assignee is not None
         )
+        not_before_override = None
+        if payload.not_before_override_reason is not None:
+            if payload.status is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="not-before override requires a status transition",
+                )
+            if payload.status not in {"ready", "done"}:
+                raise HTTPException(
+                    status_code=400,
+                    detail="not-before override only releases ready or done transitions",
+                )
+            try:
+                not_before_override = kanban_db.mint_owner_not_before_override(
+                    conn,
+                    task_id,
+                    request=request,
+                    reason=payload.not_before_override_reason,
+                )
+            except PermissionError as exc:
+                raise HTTPException(status_code=403, detail=str(exc))
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
 
         # --- assignee ----------------------------------------------------
         # For a combined assignee+review patch, request_review must capture
@@ -902,6 +939,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     result=payload.result,
                     summary=payload.summary,
                     metadata=payload.metadata,
+                    not_before_override=not_before_override,
                 )
             elif s == "blocked":
                 ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
@@ -928,11 +966,24 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 # reopen_review_task via _reopen_if_review.
                 current = kanban_db.get_task(conn, task_id)
                 if current and current.status in ("blocked", "scheduled"):
-                    ok = kanban_db.unblock_task(conn, task_id)
+                    ok = kanban_db.unblock_task(
+                        conn,
+                        task_id,
+                        not_before_override=not_before_override,
+                    )
                 else:
                     reopened = _reopen_if_review(conn, task_id, current)
                     # Direct status write for drag-drop (todo -> ready etc).
-                    ok = reopened if reopened is not None else _set_status_direct(conn, task_id, "ready")
+                    ok = (
+                        reopened
+                        if reopened is not None
+                        else _set_status_direct(
+                            conn,
+                            task_id,
+                            "ready",
+                            not_before_override=not_before_override,
+                        )
+                    )
             elif s == "archived":
                 ok = kanban_db.archive_task(conn, task_id)
             elif s == "running":
@@ -1105,7 +1156,11 @@ def _invalidate_descendants_for_parent_reopen(
 
 
 def _set_status_direct(
-    conn: sqlite3.Connection, task_id: str, new_status: str,
+    conn: sqlite3.Connection,
+    task_id: str,
+    new_status: str,
+    *,
+    not_before_override: Optional[kanban_db.OwnerNotBeforeOverride] = None,
 ) -> bool:
     """Direct status write for drag-drop moves that aren't covered by the
     structured complete/block/unblock/archive verbs (e.g. todo<->ready,
@@ -1139,6 +1194,18 @@ def _set_status_direct(
                     if kanban_db._parents_satisfied(conn, task_id)
                     else "todo"
                 )
+        override_gate = None
+        if new_status in {"ready", "running"}:
+            override_gate = kanban_db._pending_not_before_override(
+                conn, task_id, not_before_override
+            )
+        if new_status in {"ready", "running"} and kanban_db._not_before_blocks(
+            conn,
+            task_id,
+            operation=f"dashboard_status:{new_status}",
+            override=not_before_override,
+        ):
+            return False
 
         # Guard: don't allow promoting to 'ready' unless all parents are done.
         # Prevents the dispatcher from spawning a child whose upstream work
@@ -1176,6 +1243,11 @@ def _set_status_direct(
             ),
         )
         if cur.rowcount != 1:
+            return False
+        if not kanban_db._consume_not_before_override(
+            conn, task_id, operation=f"dashboard_status:{new_status}",
+            override=not_before_override, expected_not_before=override_gate,
+        ):
             return False
         run_id = None
         if was_running and effective_status != "running" and prev["current_run_id"]:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import argparse
 import concurrent.futures
+import json
 import os
 import sqlite3
 import subprocess
@@ -153,12 +155,16 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
                 "SELECT name FROM sqlite_master WHERE type = 'index'"
             )
         }
+        legacy_task = kb.get_task(migrated, "legacy")
 
     # Additive columns added by migration:
     assert "session_id" in task_columns
     assert "tenant" in task_columns
     assert "idempotency_key" in task_columns
+    assert "not_before" in task_columns
     assert "run_id" in event_columns
+    assert legacy_task is not None
+    assert legacy_task.not_before is None
     # And their indexes — the regression scope of this test:
     assert "idx_tasks_session_id" in indexes
     assert "idx_tasks_tenant" in indexes
@@ -166,9 +172,166 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     assert "idx_events_run" in indexes
 
 
+def test_init_db_migrates_single_task_dispatch_lease_key_without_data_loss(tmp_path):
+    db_path = tmp_path / "legacy-dispatch-lease.db"
+    kb.init_db(db_path)
+
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute("DROP TRIGGER kanban_not_before_reject_leased_change")
+        conn.execute("DROP INDEX idx_not_before_dispatch_leases_expiry")
+        conn.execute("DROP TABLE kanban_not_before_dispatch_leases")
+        conn.execute(
+            """
+            CREATE TABLE kanban_not_before_dispatch_leases (
+                task_id TEXT PRIMARY KEY,
+                lease_hash TEXT NOT NULL,
+                issued_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO kanban_not_before_dispatch_leases VALUES (?, ?, ?, ?)",
+            ("t_legacy", "legacy-hash", 100, 200),
+        )
+
+    kb.init_db(db_path)
+    with kb.connect(db_path=db_path) as conn:
+        primary_key = {
+            row["name"]: row["pk"]
+            for row in conn.execute(
+                "PRAGMA table_info(kanban_not_before_dispatch_leases)"
+            )
+        }
+        assert primary_key == {
+            "task_id": 1,
+            "lease_hash": 2,
+            "issued_at": 0,
+            "expires_at": 0,
+        }
+        row = conn.execute(
+            "SELECT task_id, lease_hash, issued_at, expires_at "
+            "FROM kanban_not_before_dispatch_leases"
+        ).fetchone()
+        assert tuple(row) == ("t_legacy", "legacy-hash", 100, 200)
+        conn.execute(
+            "INSERT INTO kanban_not_before_dispatch_leases VALUES (?, ?, ?, ?)",
+            ("t_legacy", "second-hash", 101, 201),
+        )
+        assert conn.execute(
+            "SELECT COUNT(*) FROM kanban_not_before_dispatch_leases "
+            "WHERE task_id = 't_legacy'"
+        ).fetchone()[0] == 2
+
+
 # ---------------------------------------------------------------------------
 # Task creation + status inference
 # ---------------------------------------------------------------------------
+
+
+def test_not_before_round_trip_event_and_worker_context(kanban_home):
+    supplied = "2026-08-08T11:26:00.123456789+02:30"
+    canonical = "2026-08-08T08:56:00.123456789Z"
+
+    with kb.connect() as conn:
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+        }
+        task_id = kb.create_task(
+            conn,
+            title="wait for the release window",
+            assignee="ops",
+            not_before=supplied,
+        )
+        task = kb.get_task(conn, task_id)
+        created = next(
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "created"
+        )
+        context = kb.build_worker_context(conn, task_id)
+
+    assert "not_before" in columns
+    assert task is not None
+    assert task.not_before == canonical
+    assert created.payload["not_before"] == canonical
+    assert f"Not before: {canonical}" in context
+
+
+def test_not_before_absent_remains_null_and_out_of_worker_context(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ordinary task", assignee="ops")
+        task = kb.get_task(conn, task_id)
+        created = next(
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "created"
+        )
+        context = kb.build_worker_context(conn, task_id)
+
+    assert task is not None
+    assert task.not_before is None
+    assert created.payload["not_before"] is None
+    assert "Not before:" not in context
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "2026-08-08",
+        "2026-08-08T11:26:00",
+        "2026-08-08T11:26:00 UTC",
+        "2026-13-08T11:26:00Z",
+        "not-a-timestamp",
+    ],
+)
+def test_not_before_rejects_empty_date_only_naive_and_malformed_values(
+    kanban_home, value,
+):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="timezone-aware ISO8601 instant"):
+            kb.create_task(conn, title="unsafe gate", not_before=value)
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def _run_kanban_cli(argv: list[str]) -> int:
+    from hermes_cli import kanban as kanban_cli
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    kanban_cli.build_parser(subparsers)
+    args = parser.parse_args(["kanban", *argv])
+    return kanban_cli.kanban_command(args)
+
+
+def test_create_cli_parses_and_serializes_not_before(kanban_home, capsys):
+    value = "2026-08-08T11:26:00.500000Z"
+
+    assert _run_kanban_cli(
+        ["create", "clocked task", "--not-before", value, "--json"]
+    ) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["not_before"] == value
+
+
+def test_create_cli_without_not_before_serializes_null(kanban_home, capsys):
+    assert _run_kanban_cli(["create", "ordinary task", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["not_before"] is None
+
+
+def test_create_cli_refuses_naive_not_before_without_writing(kanban_home, capsys):
+    assert _run_kanban_cli(
+        ["create", "unsafe task", "--not-before", "2026-08-08T11:26:00"]
+    ) == 1
+    captured = capsys.readouterr()
+
+    assert "timezone-aware ISO8601 instant" in captured.err
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
 
 
 

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -88,5 +88,43 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decompose_propagates_root_and_sibling_deadlines(kanban_home, monkeypatch):
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+    with kb.connect() as conn:
+        tid = _create_triage(conn, title="gated root")
+        conn.execute(
+            "UPDATE tasks SET not_before = ? WHERE id = ?",
+            ("2030-01-01T00:00:00Z", tid),
+        )
+        conn.commit()
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[
+                {
+                    "title": "first child",
+                    "assignee": "worker",
+                    "parents": [],
+                    "not_before": "2029-01-01T00:00:00Z",
+                },
+                {
+                    "title": "later child",
+                    "assignee": "worker",
+                    "parents": [0],
+                    "not_before": "2032-01-01T00:00:00Z",
+                },
+            ],
+        )
+
+    assert child_ids is not None
+    with kb.connect() as conn:
+        first = kb.get_task(conn, child_ids[0])
+        later = kb.get_task(conn, child_ids[1])
+    assert first.not_before == "2030-01-01T00:00:00Z"
+    assert later.not_before == "2032-01-01T00:00:00Z"
+    assert first.status == "scheduled"
+    assert later.status == "scheduled"
+
 
 

--- a/tests/hermes_cli/test_kanban_not_before_guard.py
+++ b/tests/hermes_cli/test_kanban_not_before_guard.py
@@ -1,0 +1,1091 @@
+"""Machine-enforced not-before safety invariants."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+import threading
+from contextvars import copy_context
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def _loopback_request():
+    from hermes_cli import web_server
+    from starlette.requests import Request
+
+    return Request(
+        {
+            "type": "http",
+            "method": "PATCH",
+            "path": "/api/plugins/kanban/tasks",
+            "query_string": b"",
+            "headers": [
+                (b"host", b"127.0.0.1"),
+                (
+                    web_server._SESSION_HEADER_NAME.lower().encode(),
+                    web_server._SESSION_TOKEN.encode(),
+                ),
+            ],
+            "client": ("127.0.0.1", 1234),
+            "server": ("127.0.0.1", 9119),
+            "scheme": "http",
+            "root_path": "",
+            "app": web_server.app,
+        }
+    )
+
+
+FUTURE = "2030-01-01T00:00:00Z"
+PAST = "2020-01-01T00:00:00Z"
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _events(conn, task_id: str, kind: str):
+    return [e for e in kb.list_events(conn, task_id) if e.kind == kind]
+
+
+def test_future_task_is_scheduled_and_dependency_resolver_releases_only_when_due(
+    kanban_home, monkeypatch
+):
+    clock = [1_700_000_000.0]
+    monkeypatch.setattr(kb.time, "time", lambda: clock[0])
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="wait for release",
+            assignee="default",
+            not_before=FUTURE,
+        )
+        assert kb.get_task(conn, task_id).status == "scheduled"
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, task_id).status == "scheduled"
+        blocked = _events(conn, task_id, "not_before_blocked")
+        assert len(blocked) == 1
+        assert blocked[0].payload["operation"] == "dependency_resolver"
+
+        # Repeated dispatcher ticks do not flood the audit stream.
+        assert kb.recompute_ready(conn) == 0
+        assert len(_events(conn, task_id, "not_before_blocked")) == 1
+
+        clock[0] = 1_900_000_000.0
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_child_inherits_latest_parent_deadline_but_keeps_later_explicit_gate(
+    kanban_home, monkeypatch,
+):
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+
+    with kb.connect() as conn:
+        first_parent = kb.create_task(
+            conn,
+            title="first parent",
+            assignee="worker",
+            not_before="2030-01-01T00:00:00Z",
+        )
+        second_parent = kb.create_task(
+            conn,
+            title="second parent",
+            assignee="worker",
+            not_before="2031-01-01T00:00:00Z",
+        )
+        inherited = kb.create_task(
+            conn,
+            title="inherited child",
+            assignee="worker",
+            parents=[first_parent, second_parent],
+            not_before="2029-01-01T00:00:00Z",
+        )
+        explicit_later = kb.create_task(
+            conn,
+            title="later child",
+            assignee="worker",
+            parents=[first_parent],
+            not_before="2032-01-01T00:00:00Z",
+        )
+
+        assert kb.get_task(conn, inherited).not_before == "2031-01-01T00:00:00Z"
+        assert kb.get_task(conn, inherited).status == "scheduled"
+        assert kb.get_task(conn, explicit_later).not_before == "2032-01-01T00:00:00Z"
+
+
+def test_direct_claim_and_completion_bypasses_are_blocked_without_state_mutation(
+    kanban_home, monkeypatch
+):
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="protected", assignee="default")
+        conn.execute(
+            "UPDATE tasks SET not_before = ?, status = 'ready' WHERE id = ?",
+            (FUTURE, task_id),
+        )
+
+        assert kb.claim_task(conn, task_id, claimer="bypass") is None
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.claim_lock is None
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (task_id,)
+        ).fetchone()[0] == 0
+
+        # Simulate an already-running drain/root-drain worker that gets gated
+        # after claim. Completion must leave task and run evidence untouched.
+        conn.execute(
+            "UPDATE tasks SET not_before = NULL WHERE id = ?", (task_id,)
+        )
+        claimed = kb.claim_task(conn, task_id, claimer="worker")
+        assert claimed is not None
+        run_id = kb.get_task(conn, task_id).current_run_id
+        conn.execute(
+            "UPDATE tasks SET not_before = ? WHERE id = ?", (FUTURE, task_id)
+        )
+
+        assert kb.complete_task(
+            conn,
+            task_id,
+            summary="unsafe early completion",
+            expected_run_id=run_id,
+        ) is False
+        task = kb.get_task(conn, task_id)
+        assert task.status == "running"
+        assert task.current_run_id == run_id
+        run = conn.execute(
+            "SELECT status, outcome, ended_at FROM task_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        assert tuple(run) == ("running", None, None)
+        complete_block = _events(conn, task_id, "not_before_blocked")[-1]
+        assert complete_block.payload["operation"] == "complete"
+
+
+def test_completion_guard_and_terminal_mutation_are_atomic_across_connections(
+    kanban_home, monkeypatch,
+):
+    """A gate installed after preflight must invalidate the completion CAS."""
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="race completion", assignee="worker")
+        db_path = kb.kanban_db_path()
+
+    preflight_finished = threading.Event()
+    allow_terminal_phase = threading.Event()
+    original_merge = kb._merge_completion_prose_artifacts
+
+    def pause_after_preflight(*args, **kwargs):
+        # This helper is reached only after the current implementation's
+        # separate guard transaction has committed, but before its terminal
+        # mutation transaction begins.
+        preflight_finished.set()
+        assert allow_terminal_phase.wait(5)
+        return original_merge(*args, **kwargs)
+
+    monkeypatch.setattr(kb, "_merge_completion_prose_artifacts", pause_after_preflight)
+    outcome: list[bool] = []
+
+    def complete_from_worker_connection():
+        with kb.connect(db_path=db_path) as worker_conn:
+            outcome.append(kb.complete_task(worker_conn, task_id, result="too early"))
+
+    worker = threading.Thread(target=complete_from_worker_connection)
+    worker.start()
+    assert preflight_finished.wait(5)
+
+    with kb.connect(db_path=db_path) as racing_conn:
+        with kb.write_txn(racing_conn):
+            racing_conn.execute(
+                "UPDATE tasks SET not_before = ? WHERE id = ?",
+                (FUTURE, task_id),
+            )
+
+    allow_terminal_phase.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert outcome == [False]
+
+    with kb.connect(db_path=db_path) as conn:
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.not_before == FUTURE
+        assert task.result is None
+
+
+def test_tool_dispatch_revalidates_same_task_gate_before_provider_and_keeps_other_task_live(
+    kanban_home, monkeypatch,
+):
+    """A concurrent gate cancels only the stale task's provider dispatch."""
+    from agent import relay_tools, tool_executor
+
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+    with kb.connect() as conn:
+        same_task = kb.create_task(conn, title="same task", assignee="worker")
+        other_task = kb.create_task(conn, title="other task", assignee="worker")
+        db_path = kb.kanban_db_path()
+
+    agent = SimpleNamespace(
+        quiet_mode=True,
+        tool_progress_mode="off",
+        _tool_guardrails=SimpleNamespace(
+            before_call=lambda _name, _args: SimpleNamespace(
+                allows_execution=True,
+            )
+        ),
+    )
+    monkeypatch.setattr(tool_executor, "_begin_tool_execution", lambda *_a, **_k: None)
+    monkeypatch.setattr(tool_executor, "_emit_terminal_post_tool_call", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "hermes_cli.middleware.apply_tool_request_middleware",
+        lambda _name, args, **_kwargs: SimpleNamespace(payload=args, trace=[]),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.middleware.run_tool_execution_middleware",
+        lambda _name, args, callback, **_kwargs: callback(args),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.resolve_pre_tool_block",
+        lambda *_args, **_kwargs: None,
+    )
+    provider_mutations: list[str] = []
+    monkeypatch.setattr(
+        relay_tools,
+        "execute",
+        lambda _name, args, callback, **_kwargs: (callback(args), args),
+    )
+
+    preflight_finished = threading.Event()
+    allow_execution_boundary = threading.Event()
+    original_preflight = tool_executor._kanban_not_before_tool_block
+
+    def pause_after_preflight(function_name):
+        result = original_preflight(function_name)
+        if (tool_executor.os.getenv("HERMES_KANBAN_TASK") or "") == same_task:
+            preflight_finished.set()
+            assert allow_execution_boundary.wait(5)
+        return result
+
+    monkeypatch.setattr(tool_executor, "_kanban_not_before_tool_block", pause_after_preflight)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", same_task)
+
+    same_outcome: list = []
+
+    def run_same_task():
+        same_outcome.append(
+            tool_executor._run_agent_tool_execution_middleware(
+                agent,
+                function_name="terminal",
+                function_args={"command": "provider-mutation"},
+                effective_task_id=same_task,
+                tool_call_id="same-call",
+                execute=lambda _args: provider_mutations.append(same_task) or "same",
+            )
+        )
+
+    worker = threading.Thread(target=run_same_task)
+    worker.start()
+    assert preflight_finished.wait(5)
+
+    # Install the gate while the same task is between preflight and provider
+    # execution. This is the race the execution-boundary lease must close.
+    with kb.connect(db_path=db_path) as racing_conn:
+        with kb.write_txn(racing_conn):
+            racing_conn.execute(
+                "UPDATE tasks SET not_before = ? WHERE id = ?",
+                (FUTURE, same_task),
+            )
+
+    # An unrelated task must remain dispatchable while the stale same-task
+    # call is parked at its deterministic boundary.
+    monkeypatch.setenv("HERMES_KANBAN_TASK", other_task)
+    other = tool_executor._run_agent_tool_execution_middleware(
+        agent,
+        function_name="terminal",
+        function_args={"command": "unrelated-provider-mutation"},
+        effective_task_id=other_task,
+        tool_call_id="other-call",
+        execute=lambda _args: provider_mutations.append(other_task) or "other",
+    )
+    assert other.blocked is False
+    assert provider_mutations == [other_task]
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", same_task)
+    allow_execution_boundary.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert same_outcome and same_outcome[0].blocked is True
+    assert provider_mutations == [other_task]
+
+
+def test_same_task_dispatches_hold_independent_leases_until_each_callback_finishes(
+    kanban_home, monkeypatch,
+):
+    """Parallel callbacks coexist; either live lease still protects the gate."""
+    from agent import relay_tools, tool_executor
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="parallel task", assignee="worker")
+        db_path = kb.kanban_db_path()
+
+    clock = [int(tool_executor.time.time())]
+    monkeypatch.setattr(tool_executor.time, "time", lambda: clock[0])
+    monkeypatch.setattr(
+        tool_executor._KanbanNotBeforeDispatchLease, "_LEASE_SECONDS", 2
+    )
+    monkeypatch.setattr(
+        tool_executor._KanbanNotBeforeDispatchLease, "_RENEW_INTERVAL_SECONDS", 0.01
+    )
+
+    agent = SimpleNamespace(
+        quiet_mode=True,
+        tool_progress_mode="off",
+        _tool_guardrails=SimpleNamespace(
+            before_call=lambda _name, _args: SimpleNamespace(allows_execution=True)
+        ),
+    )
+    monkeypatch.setattr(tool_executor, "_begin_tool_execution", lambda *_a, **_k: None)
+    monkeypatch.setattr(tool_executor, "_emit_terminal_post_tool_call", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "hermes_cli.middleware.apply_tool_request_middleware",
+        lambda _name, args, **_kwargs: SimpleNamespace(payload=args, trace=[]),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.middleware.run_tool_execution_middleware",
+        lambda _name, args, callback, **_kwargs: callback(args),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.resolve_pre_tool_block", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        relay_tools,
+        "execute",
+        lambda _name, args, callback, **_kwargs: (callback(args), args),
+    )
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+
+    entered = {name: threading.Event() for name in ("first", "second")}
+    release = {name: threading.Event() for name in ("first", "second")}
+    provider_mutations: list[str] = []
+    outcomes = {}
+
+    def run(name: str):
+        def execute(_args):
+            provider_mutations.append(name)
+            entered[name].set()
+            assert release[name].wait(5)
+            return name
+
+        outcomes[name] = tool_executor._run_agent_tool_execution_middleware(
+            agent,
+            function_name="terminal",
+            function_args={"command": name},
+            effective_task_id=task_id,
+            tool_call_id=f"{name}-call",
+            execute=execute,
+        )
+
+    workers = {
+        name: threading.Thread(target=run, args=(name,))
+        for name in ("first", "second")
+    }
+    try:
+        for worker in workers.values():
+            worker.start()
+        assert all(event.wait(5) for event in entered.values())
+
+        with kb.connect(db_path=db_path) as conn:
+            leases = conn.execute(
+                "SELECT lease_hash, expires_at "
+                "FROM kanban_not_before_dispatch_leases "
+                "WHERE task_id = ?",
+                (task_id,),
+            ).fetchall()
+            assert len(leases) == 2
+            assert len({row["lease_hash"] for row in leases}) == 2
+            assert {row["expires_at"] for row in leases} == {clock[0] + 2}
+
+        # Advance beyond both original deadlines while the callbacks remain
+        # active. The renewal threads must extend both authorizations.
+        clock[0] += 3
+        renewed = False
+        for _ in range(100):
+            threading.Event().wait(0.01)
+            with kb.connect(db_path=db_path) as conn:
+                expiries = {
+                    row["expires_at"]
+                    for row in conn.execute(
+                        "SELECT expires_at FROM kanban_not_before_dispatch_leases "
+                        "WHERE task_id = ?",
+                        (task_id,),
+                    )
+                }
+            if expiries == {clock[0] + 2}:
+                renewed = True
+                break
+        assert renewed
+
+        with kb.connect(db_path=db_path) as conn:
+            conn.create_function("unixepoch", 0, lambda: clock[0])
+            with pytest.raises(sqlite3.IntegrityError, match="dispatch lease is active"):
+                with kb.write_txn(conn):
+                    conn.execute(
+                        "UPDATE tasks SET not_before = ? WHERE id = ?",
+                        (FUTURE, task_id),
+                    )
+
+        release["first"].set()
+        workers["first"].join(timeout=5)
+        assert not workers["first"].is_alive()
+        with kb.connect(db_path=db_path) as conn:
+            conn.create_function("unixepoch", 0, lambda: clock[0])
+            assert conn.execute(
+                "SELECT COUNT(*) FROM kanban_not_before_dispatch_leases "
+                "WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()[0] == 1
+            with pytest.raises(sqlite3.IntegrityError, match="dispatch lease is active"):
+                with kb.write_txn(conn):
+                    conn.execute(
+                        "UPDATE tasks SET not_before = ? WHERE id = ?",
+                        (FUTURE, task_id),
+                    )
+
+        release["second"].set()
+        workers["second"].join(timeout=5)
+        assert not workers["second"].is_alive()
+    finally:
+        for event in release.values():
+            event.set()
+        for worker in workers.values():
+            worker.join(timeout=5)
+
+    with kb.connect(db_path=db_path) as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM kanban_not_before_dispatch_leases "
+            "WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()[0] == 0
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET not_before = ? WHERE id = ?",
+                (FUTURE, task_id),
+            )
+        assert kb.get_task(conn, task_id).not_before == FUTURE
+
+    assert sorted(provider_mutations) == ["first", "second"]
+    assert all(not outcome.blocked for outcome in outcomes.values())
+
+
+def test_task_scoped_dispatch_fails_closed_without_pinned_database(monkeypatch):
+    from agent import relay_tools, tool_executor
+
+    agent = SimpleNamespace(
+        quiet_mode=True,
+        tool_progress_mode="off",
+        _tool_guardrails=SimpleNamespace(
+            before_call=lambda _name, _args: SimpleNamespace(allows_execution=True)
+        ),
+    )
+    monkeypatch.setattr(tool_executor, "_begin_tool_execution", lambda *_a, **_k: None)
+    monkeypatch.setattr(tool_executor, "_emit_terminal_post_tool_call", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "hermes_cli.middleware.apply_tool_request_middleware",
+        lambda _name, args, **_kwargs: SimpleNamespace(payload=args, trace=[]),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.middleware.run_tool_execution_middleware",
+        lambda _name, args, callback, **_kwargs: callback(args),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.resolve_pre_tool_block", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        relay_tools,
+        "execute",
+        lambda _name, args, callback, **_kwargs: (callback(args), args),
+    )
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_missing_board")
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    provider_mutations = []
+
+    outcome = tool_executor._run_agent_tool_execution_middleware(
+        agent,
+        function_name="terminal",
+        function_args={"command": "must-not-run"},
+        effective_task_id="t_missing_board",
+        tool_call_id="missing-board-call",
+        execute=lambda _args: provider_mutations.append("ran"),
+    )
+
+    assert outcome.blocked is True
+    assert "pinned Kanban database is missing" in outcome.result
+    assert provider_mutations == []
+
+
+def test_dispatcher_and_default_assignment_make_no_mutation_before_release(
+    kanban_home, monkeypatch
+):
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+    spawned = []
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="future unassigned", not_before=FUTURE)
+        # Simulate a stale/external writer bypassing the scheduled status. The
+        # dispatcher backstop must run before default-assignee mutation.
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (task_id,))
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *args: spawned.append(args),
+            default_assignee="default",
+            reconcile_orphans=False,
+        )
+        task = kb.get_task(conn, task_id)
+        assert result.spawned == []
+        assert result.skipped_not_before == [task_id]
+        assert spawned == []
+        assert task.status == "ready"
+        assert task.assignee is None
+        assert _events(conn, task_id, "not_before_blocked")[-1].payload[
+            "operation"
+        ] == "dispatcher"
+
+
+def test_manual_promotion_requires_sealed_human_override_and_audits_it(
+    kanban_home, monkeypatch
+):
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="operator release",
+            assignee="default",
+            not_before=FUTURE,
+        )
+
+        ok, reason = kb.promote_task(
+            conn,
+            task_id,
+            actor="worker",
+            force=True,
+        )
+        assert ok is False
+        assert "not-before" in reason
+        assert kb.get_task(conn, task_id).status == "scheduled"
+
+        override = kb.mint_owner_not_before_override(
+            conn,
+            task_id,
+            request=_loopback_request(),
+            reason="approved emergency release",
+        )
+        ok, reason = kb.promote_task(
+            conn,
+            task_id,
+            actor="alex",
+            reason="approved emergency release",
+            force=True,
+            not_before_override=override,
+        )
+        assert (ok, reason) == (True, None)
+        promoted = kb.get_task(conn, task_id)
+        assert promoted.status == "ready"
+        assert promoted.not_before is None
+        event = _events(conn, task_id, "not_before_overridden")[-1]
+        assert event.payload == {
+            "operation": "manual_promotion",
+            "not_before": FUTURE,
+            "owner_identity": f"local:{os.getuid()}",
+            "reason": "approved emergency release",
+            "authenticated_by": "dashboard_session_token",
+        }
+
+
+def test_legacy_and_forged_not_before_overrides_fail_closed(kanban_home):
+    with pytest.raises(ValueError, match="owner-authenticated"):
+        kb.authenticated_human_not_before_override(
+            actor="alex",
+            reason="self asserted",
+            authenticated_by="worker supplied string",
+        )
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="forged release",
+            assignee="worker",
+            not_before=FUTURE,
+        )
+        forged = SimpleNamespace(
+            actor="alex",
+            reason="approved",
+            authenticated_by="owner",
+            _seal=object(),
+        )
+        ok, reason = kb.promote_task(
+            conn,
+            task_id,
+            actor="worker",
+            force=True,
+            not_before_override=forged,
+        )
+        assert ok is False
+        assert "not-before" in reason
+        assert kb.get_task(conn, task_id).not_before == FUTURE
+
+
+def test_owner_capability_construction_is_not_a_public_issuer():
+    with pytest.raises(TypeError):
+        kb.OwnerNotBeforeOverride(
+            task_id="t_deadbeef",
+            owner_identity="alex",
+            reason="self asserted",
+            token="forged",
+            _seal=object(),
+        )
+    assert not hasattr(kb, "VerifiedKanbanOwner")
+
+
+def test_gated_dashboard_auth_can_issue_owner(kanban_home, monkeypatch):
+    from hermes_cli import web_server
+    from hermes_cli.dashboard_auth import middleware as auth_middleware
+    from hermes_cli.dashboard_auth.base import Session
+    from starlette.responses import Response
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="gated owner", not_before=FUTURE)
+    monkeypatch.setattr(web_server.app.state, "auth_required", True, raising=False)
+    monkeypatch.setattr(
+        auth_middleware,
+        "_verify_bearer",
+        lambda request, *, access_token: Session(
+            user_id="alex", email="alex@example.com", display_name="Alex",
+            org_id="org", provider="test-owner-auth", expires_at=2_000_000_000,
+            access_token=access_token, refresh_token="refresh",
+        ),
+    )
+    request = _loopback_request()
+    request.scope["headers"] = [
+        (b"host", b"127.0.0.1"),
+        (b"authorization", b"Bearer gated-token"),
+    ]
+    issued = []
+
+    async def endpoint(authenticated_request):
+        with kb.connect() as conn:
+            issued.append(kb.mint_owner_not_before_override(
+                conn, task_id, request=authenticated_request, reason="approved"
+            ))
+        return Response(status_code=200)
+
+
+    response = asyncio.run(web_server._dashboard_auth_gate(request, endpoint))
+    assert response.status_code == 200
+    assert len(issued) == 1
+    with kb.connect() as conn:
+        ok, reason = kb.promote_task(
+            conn, task_id, actor="alex", force=True, not_before_override=issued[0]
+        )
+        assert (ok, reason) == (True, None)
+        assert kb.get_task(conn, task_id).not_before is None
+
+
+def test_forged_request_state_cannot_issue_owner(kanban_home, monkeypatch):
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(web_server.app.state, "auth_required", True, raising=False)
+    request = _loopback_request()
+    request.scope["headers"] = [(b"host", b"127.0.0.1")]
+    request.state.session = SimpleNamespace(
+        user_id="forged-user",
+        provider="forged-provider",
+    )
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="forged request", not_before=FUTURE)
+        with pytest.raises(PermissionError, match="owner-authenticated"):
+            kb.mint_owner_not_before_override(
+                conn, task_id, request=request, reason="forged"
+            )
+
+
+def test_gated_owner_capability_rejects_wrong_user_session(kanban_home, monkeypatch):
+    from hermes_cli import web_server
+    from hermes_cli.dashboard_auth import middleware as auth_middleware
+    from hermes_cli.dashboard_auth.base import Session
+    from starlette.responses import Response
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="wrong session", not_before=FUTURE)
+    monkeypatch.setattr(web_server.app.state, "auth_required", True, raising=False)
+    monkeypatch.setattr(
+        auth_middleware,
+        "_verify_bearer",
+        lambda request, *, access_token: Session(
+            user_id="authenticated-user", email="", display_name="Authenticated",
+            org_id="", provider="test-owner-auth", expires_at=2_000_000_000,
+            access_token=access_token, refresh_token="refresh",
+        ),
+    )
+    request = _loopback_request()
+    request.scope["headers"] = [
+        (b"host", b"127.0.0.1"),
+        (b"authorization", b"Bearer gated-token"),
+    ]
+    outcome = []
+
+    async def endpoint(authenticated_request):
+        authenticated_request.state.session = SimpleNamespace(
+            user_id="different-user",
+            provider="test-owner-auth",
+        )
+        with kb.connect() as conn:
+            with pytest.raises(PermissionError, match="owner-authenticated"):
+                kb.mint_owner_not_before_override(
+                    conn, task_id, request=authenticated_request, reason="wrong"
+                )
+        outcome.append(True)
+        return Response(status_code=200)
+
+    response = asyncio.run(web_server._dashboard_auth_gate(request, endpoint))
+    assert response.status_code == 200
+    assert outcome == [True]
+
+
+def test_ordinary_worker_without_control_plane_cannot_issue_owner(kanban_home):
+    from hermes_cli import web_server
+
+    request = _loopback_request()
+    request.scope["headers"] = [(b"host", b"127.0.0.1")]
+    failures = []
+
+    def worker():
+        try:
+            with kb.connect() as conn:
+                task_id = kb.create_task(conn, title="worker request", not_before=FUTURE)
+                kb.mint_owner_not_before_override(
+                    conn, task_id, request=request, reason="worker"
+                )
+        except PermissionError:
+            failures.append(True)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert failures == [True]
+    assert web_server.verified_dashboard_owner(request) is None
+
+
+def test_exposed_capability_forgery_cannot_issue_owner(kanban_home, monkeypatch):
+    """The former module capability objects cannot authenticate a request."""
+    from hermes_cli import web_server
+    from starlette.responses import Response
+
+    monkeypatch.setattr(web_server.app.state, "auth_required", True, raising=False)
+    request = _loopback_request()
+    request.state.session = SimpleNamespace(
+        user_id="forged-user",
+        provider="forged-provider",
+    )
+
+    # Exercise the exact in-process attack against the old implementation.
+    # The objects are no longer exported after the repair; either way, the
+    # ordinary plugin/worker path must not obtain owner provenance.
+    capability_type = getattr(web_server, "_DashboardAuthCapability", None)
+    capability_context = getattr(web_server, "_DASHBOARD_AUTH_CAPABILITY", None)
+    if capability_type is not None and capability_context is not None:
+        marker = capability_context.set(
+            capability_type(
+                app=web_server.app,
+                scope=request.scope,
+                identity="forged-user",
+                authenticated_by="dashboard_session:forged-provider",
+            )
+        )
+        try:
+            assert web_server.verified_dashboard_owner(request) is None
+        finally:
+            capability_context.reset(marker)
+    else:
+        assert web_server.verified_dashboard_owner(request) is None
+
+    # Public auth-bootstrap paths bypass credential verification by design;
+    # they must not turn caller-supplied request state into a lease either.
+    request.scope["path"] = "/login"
+
+    async def public_endpoint(public_request):
+        assert web_server.verified_dashboard_owner(public_request) is None
+        return Response(status_code=200)
+
+    response = asyncio.run(web_server._dashboard_auth_gate(request, public_endpoint))
+    assert response.status_code == 200
+
+
+def test_gated_owner_lease_is_revoked_from_copied_context(kanban_home, monkeypatch):
+    from hermes_cli import web_server
+    from hermes_cli.dashboard_auth import middleware as auth_middleware
+    from hermes_cli.dashboard_auth.base import Session
+    from starlette.responses import Response
+
+    monkeypatch.setattr(web_server.app.state, "auth_required", True, raising=False)
+    monkeypatch.setattr(
+        auth_middleware,
+        "_verify_bearer",
+        lambda request, *, access_token: Session(
+            user_id="copy-context-user", email="", display_name="Copy Context",
+            org_id="", provider="test-copy-context", expires_at=2_000_000_000,
+            access_token=access_token, refresh_token="refresh",
+        ),
+    )
+    request = _loopback_request()
+    request.scope["headers"] = [
+        (b"host", b"127.0.0.1"),
+        (b"authorization", b"Bearer copied-context-token"),
+    ]
+    copied_contexts = []
+
+    async def endpoint(authenticated_request):
+        copied_contexts.append(copy_context())
+        assert web_server.verified_dashboard_owner(authenticated_request) == (
+            "copy-context-user",
+            "dashboard_session:test-copy-context",
+        )
+        return Response(status_code=200)
+
+    response = asyncio.run(web_server._dashboard_auth_gate(request, endpoint))
+    assert response.status_code == 200
+    assert len(copied_contexts) == 1
+    assert copied_contexts[0].run(
+        web_server.verified_dashboard_owner, request
+    ) is None
+
+
+def test_mounted_basic_auth_sync_patch_can_issue_owner(kanban_home):
+    """The production mounted sync route keeps gated owner provenance.
+
+    This follows the real password-login flow through the production
+    ``web_server.app`` and its bundled Kanban router.  The PATCH handler is
+    synchronous, so FastAPI executes it in AnyIO's worker thread after the
+    auth middleware has wrapped the ASGI request.
+    """
+    from fastapi.testclient import TestClient
+
+    from hermes_cli import web_server
+    from hermes_cli.dashboard_auth import clear_providers, register_provider
+    from plugins.dashboard_auth.basic import BasicAuthProvider, hash_password
+
+    previous_required = getattr(web_server.app.state, "auth_required", None)
+    previous_host = getattr(web_server.app.state, "bound_host", None)
+    previous_port = getattr(web_server.app.state, "bound_port", None)
+    clear_providers()
+    register_provider(
+        BasicAuthProvider(
+            username="admin",
+            password_hash=hash_password("correct horse battery staple"),
+            secret=b"test-basic-auth-secret-1234",
+        )
+    )
+    web_server.app.state.auth_required = True
+    web_server.app.state.bound_host = "dashboard.example.test"
+    web_server.app.state.bound_port = 443
+    try:
+        with TestClient(
+            web_server.app,
+            base_url="https://dashboard.example.test",
+        ) as dashboard:
+            with kb.connect() as conn:
+                unauthenticated_task = kb.create_task(
+                    conn, title="unauthenticated release", not_before=FUTURE
+                )
+            unauthenticated = dashboard.patch(
+                f"/api/plugins/kanban/tasks/{unauthenticated_task}",
+                json={
+                    "status": "ready",
+                    "not_before_override_reason": "unauthenticated",
+                },
+            )
+            assert unauthenticated.status_code == 401
+
+            login = dashboard.post(
+                "/auth/password-login",
+                json={
+                    "provider": "basic",
+                    "username": "admin",
+                    "password": "correct horse battery staple",
+                },
+            )
+            assert login.status_code == 200, login.text
+
+            created = dashboard.post(
+                "/api/plugins/kanban/tasks",
+                json={
+                    "title": "mounted gated release",
+                    "assignee": "worker",
+                    "not_before": FUTURE,
+                },
+            )
+            assert created.status_code == 200, created.text
+            task_id = created.json()["task"]["id"]
+
+            released = dashboard.patch(
+                f"/api/plugins/kanban/tasks/{task_id}",
+                json={
+                    "status": "ready",
+                    "not_before_override_reason": "approved",
+                },
+            )
+            assert released.status_code == 200, released.text
+            assert released.json()["task"]["not_before"] is None
+    finally:
+        clear_providers()
+        web_server.app.state.auth_required = previous_required
+        web_server.app.state.bound_host = previous_host
+        web_server.app.state.bound_port = previous_port
+
+
+def test_synthetic_completed_evidence_is_blocked_before_release(
+    kanban_home, monkeypatch
+
+
+):
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="no synthetic proof",
+            assignee="default",
+            not_before=FUTURE,
+        )
+        with kb.write_txn(conn):
+            synthetic_id = kb._synthesize_ended_run(
+                conn,
+                task_id,
+                outcome="completed",
+                summary="fabricated early proof",
+            )
+        assert synthetic_id == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (task_id,)
+        ).fetchone()[0] == 0
+        event = _events(conn, task_id, "not_before_blocked")[-1]
+        assert event.payload["operation"] == "synthetic_evidence_creation"
+
+
+def test_tool_execution_backstop_blocks_before_relay_or_provider_mutation(
+    kanban_home, monkeypatch
+):
+    from agent import relay_tools, tool_executor
+
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="no provider mutation",
+            assignee="default",
+            not_before=FUTURE,
+        )
+        db_path = kb.kanban_db_path()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    relay_called = []
+    execute_called = []
+    monkeypatch.setattr(
+        relay_tools,
+        "execute",
+        lambda *args, **kwargs: relay_called.append((args, kwargs)),
+    )
+
+    outcome = tool_executor._run_agent_tool_execution_middleware(
+        object(),
+        function_name="terminal",
+        function_args={"command": "vercel remove production"},
+        effective_task_id="session-task",
+        tool_call_id="call-1",
+        execute=lambda args: execute_called.append(args),
+    )
+
+    assert outcome.blocked is True
+    assert outcome.dispatched is False
+    assert relay_called == []
+    assert execute_called == []
+    assert "not-before deadline" in json.loads(outcome.result)["error"]
+
+    with kb.connect(db_path=db_path) as conn:
+        event = _events(conn, task_id, "not_before_blocked")[-1]
+        assert event.payload["operation"] == "side_effect_execution:terminal"
+
+def test_override_is_reusable_when_completion_cas_fails(kanban_home, monkeypatch):
+    """A failed terminal CAS must not burn a valid owner release."""
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="rollback completion", assignee="worker",
+            not_before=FUTURE,
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'ready' WHERE id = ?", (task_id,)
+        )
+        override = kb.mint_owner_not_before_override(
+            conn, task_id, request=_loopback_request(), reason="approved"
+        )
+
+        assert kb.complete_task(
+            conn,
+            task_id,
+            expected_run_id=999,
+            not_before_override=override,
+        ) is False
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.not_before == FUTURE
+        used = conn.execute(
+            "SELECT used_at FROM kanban_not_before_overrides WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()
+        assert used["used_at"] is None
+        assert _events(conn, task_id, "not_before_overridden") == []
+
+        assert kb.complete_task(
+            conn, task_id, not_before_override=override
+        ) is True
+
+
+def test_unblock_override_is_consumed_after_success(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="unblock release", not_before=FUTURE)
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (task_id,))
+        override = kb.mint_owner_not_before_override(
+            conn, task_id, request=_loopback_request(), reason="approved"
+        )
+        assert kb.unblock_task(conn, task_id, not_before_override=override) is True
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready" and task.not_before is None
+        used = conn.execute(
+            "SELECT used_at FROM kanban_not_before_overrides WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()
+        assert used["used_at"] is not None

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -9,7 +9,9 @@ Direct-SQL setup is used to construct that state deterministically.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
+import threading
 from pathlib import Path
 
 import pytest
@@ -62,6 +64,65 @@ def test_promote_stuck_todo_succeeds(conn):
     assert ok and err is None
     assert kb.get_task(conn, child).status == "ready"
 
+
+def test_promote_gate_inserted_after_preflight_cannot_be_overwritten(
+    kanban_home, monkeypatch,
+):
+    """The not-before check and manual promotion must share one write txn."""
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_000.0)
+
+    with kb.connect() as setup_conn:
+        task_id = kb.create_task(setup_conn, title="racy promotion")
+        setup_conn.execute(
+            "UPDATE tasks SET status = 'todo' WHERE id = ?", (task_id,)
+        )
+        db_path = kb.kanban_db_path()
+
+    preflight_done = threading.Event()
+    allow_promotion = threading.Event()
+    original_write_txn = kb.write_txn
+
+    @contextlib.contextmanager
+    def pause_before_promotion_txn(conn):
+        if threading.current_thread() is not threading.main_thread():
+            preflight_done.set()
+            assert allow_promotion.wait(5)
+        with original_write_txn(conn):
+            yield
+    monkeypatch.setattr(kb, "write_txn", pause_before_promotion_txn)
+
+
+    outcome = []
+
+    def promote_from_worker():
+        with kb.connect(db_path=db_path) as worker_conn:
+            outcome.append(
+                kb.promote_task(
+                    worker_conn, task_id, actor="worker", force=True
+                )
+            )
+
+    worker = threading.Thread(target=promote_from_worker)
+    worker.start()
+    assert preflight_done.wait(5)
+
+    with kb.connect(db_path=db_path) as racing_conn:
+        with kb.write_txn(racing_conn):
+            racing_conn.execute(
+                "UPDATE tasks SET not_before = ? WHERE id = ?",
+                ("2030-01-01T00:00:00Z", task_id),
+            )
+
+    allow_promotion.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert outcome == [
+        (False, "not-before deadline has not elapsed: 2030-01-01T00:00:00Z")
+    ]
+
+    with kb.connect(db_path=db_path) as verify_conn:
+        task = kb.get_task(verify_conn, task_id)
+        assert task.status == "todo"
 
 
 

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -9,6 +9,9 @@ from hermes_cli.kanban_swarm import (
 )
 
 
+FUTURE = "2030-01-01T00:00:00Z"
+
+
 def test_create_swarm_builds_parallel_workers_verifier_and_synthesizer(tmp_path):
     conn = kb.connect(tmp_path / "kanban.db")
     try:
@@ -258,5 +261,33 @@ def test_swarm_verifier_and_synthesis_are_dependency_gated(tmp_path):
         synthesizer = kb.get_task(conn, created.synthesizer_id)
         assert synthesizer is not None
         assert synthesizer.status == "ready"
+    finally:
+        conn.close()
+
+
+def test_swarm_workflow_children_inherit_release_deadline(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Wait for the coordinated release.",
+            workers=[
+                SwarmWorkerSpec(profile="a", title="Branch A", body="A"),
+                SwarmWorkerSpec(profile="b", title="Branch B", body="B"),
+            ],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+            not_before=FUTURE,
+        )
+
+        workers = [kb.get_task(conn, tid) for tid in created.worker_ids]
+        verifier = kb.get_task(conn, created.verifier_id)
+        synthesizer = kb.get_task(conn, created.synthesizer_id)
+        assert [task.not_before for task in workers] == [FUTURE, FUTURE]
+        assert [task.status for task in workers] == ["scheduled", "scheduled"]
+        assert verifier.not_before == FUTURE
+        assert verifier.status == "scheduled"
+        assert synthesizer.not_before == FUTURE
+        assert synthesizer.status == "scheduled"
     finally:
         conn.close()

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
@@ -41,6 +42,32 @@ def _load_plugin_router():
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
     return mod.router
+
+
+def _loopback_request():
+    from hermes_cli import web_server
+    from starlette.requests import Request
+
+    return Request(
+        {
+            "type": "http",
+            "method": "PATCH",
+            "path": "/api/plugins/kanban/tasks",
+            "query_string": b"",
+            "headers": [
+                (b"host", b"127.0.0.1"),
+                (
+                    web_server._SESSION_HEADER_NAME.lower().encode(),
+                    web_server._SESSION_TOKEN.encode(),
+                ),
+            ],
+            "client": ("127.0.0.1", 1234),
+            "server": ("127.0.0.1", 9119),
+            "scheme": "http",
+            "root_path": "",
+            "app": web_server.app,
+        }
+    )
 
 
 @pytest.fixture
@@ -116,6 +143,77 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_create_task_persists_not_before_gate(client):
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "scheduled dashboard task",
+            "assignee": "researcher",
+            "not_before": "2030-01-01T00:00:00Z",
+        },
+    )
+    assert r.status_code == 200, r.text
+    task = r.json()["task"]
+    assert task["not_before"] == "2030-01-01T00:00:00Z"
+    assert task["status"] == "scheduled"
+
+
+def test_not_before_override_requires_verified_dashboard_owner(client, kanban_home):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "owner release",
+            "assignee": "worker",
+            "not_before": "2030-01-01T00:00:00Z",
+        },
+    ).json()["task"]
+
+    forged = client.patch(
+        f"/api/plugins/kanban/tasks/{created['id']}",
+        json={"status": "ready", "not_before_override_reason": "emergency"},
+    )
+    assert forged.status_code == 403
+
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def verified_owner(request, call_next):
+        request.state.session = SimpleNamespace(
+            user_id="alex",
+            provider="test-owner-auth",
+        )
+        return await call_next(request)
+
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    owner_client = TestClient(app)
+    released = owner_client.patch(
+        f"/api/plugins/kanban/tasks/{created['id']}",
+        json={"status": "ready", "not_before_override_reason": "emergency"},
+    )
+    assert released.status_code == 403
+    assert "owner-authenticated" in released.json()["detail"]
+    with kb.connect() as conn:
+        assert kb.get_task(conn, created["id"]).not_before == "2030-01-01T00:00:00Z"
+
+
+def test_real_loopback_dashboard_owner_route(kanban_home):
+    from hermes_cli import web_server
+
+    with TestClient(web_server.app) as dashboard:
+        headers = {web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN}
+        created = dashboard.post(
+            "/api/plugins/kanban/tasks",
+            headers=headers,
+            json={"title": "real owner route", "not_before": "2030-01-01T00:00:00Z"},
+        )
+        assert created.status_code == 200, created.text
+        task_id = created.json()["task"]["id"]
+        released = dashboard.patch(
+            f"/api/plugins/kanban/tasks/{task_id}", headers=headers,
+            json={"status": "ready", "not_before_override_reason": "approved"},
+        )
+        assert released.status_code == 200, released.text
+        assert released.json()["task"]["not_before"] is None
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")
@@ -941,4 +1039,46 @@ def test_specify_happy_path(client, monkeypatch):
 # Final result visibility for Done cards
 # ---------------------------------------------------------------------------
 
+def test_dashboard_direct_status_failure_preserves_override(kanban_home):
+    """Parent validation failure must not burn the dashboard release token."""
+    _load_plugin_router()
+    plugin = sys.modules["hermes_dashboard_plugin_kanban_test"]
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="unfinished parent")
+        child = kb.create_task(
+            conn, title="gated child", parents=[parent], not_before="2030-01-01T00:00:00Z"
+        )
+        conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (child,))
+        override = kb.mint_owner_not_before_override(
+            conn, child, request=_loopback_request(), reason="approved"
+        )
 
+        assert plugin._set_status_direct(
+            conn, child, "ready", not_before_override=override
+        ) is False
+        assert kb.get_task(conn, child).not_before == "2030-01-01T00:00:00Z"
+        used = conn.execute(
+            "SELECT used_at FROM kanban_not_before_overrides WHERE task_id = ?",
+            (child,),
+        ).fetchone()
+        assert used["used_at"] is None
+
+
+def test_dashboard_direct_status_success_consumes_override(kanban_home):
+    _load_plugin_router()
+    plugin = sys.modules["hermes_dashboard_plugin_kanban_test"]
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="direct release", not_before="2030-01-01T00:00:00Z")
+        conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (task_id,))
+        override = kb.mint_owner_not_before_override(
+            conn, task_id, request=_loopback_request(), reason="approved"
+        )
+        assert plugin._set_status_direct(
+            conn, task_id, "ready", not_before_override=override
+        ) is True
+        assert kb.get_task(conn, task_id).not_before is None
+        used = conn.execute(
+            "SELECT used_at FROM kanban_not_before_overrides WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()
+        assert used["used_at"] is not None

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -76,6 +76,7 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "task" in d
     assert d["task"]["id"] == worker_env
     assert d["task"]["status"] == "running"
+    assert d["task"]["not_before"] is None
     assert "worker_context" in d
     assert "runs" in d
 
@@ -100,6 +101,7 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     assert d["count"] == 2
     assert d["tasks"][0]["title"] == "alpha"
     assert d["tasks"][0]["parent_count"] == 0
+    assert d["tasks"][0]["not_before"] is None
     assert b not in ids
 
     tenant_out = kt._handle_list({
@@ -412,6 +414,28 @@ def test_create_happy_path(worker_env):
         child = kb.get_task(conn, d["task_id"])
         assert child.title == "child task"
         assert child.assignee == "peer"
+    finally:
+        conn.close()
+
+
+def test_create_carries_not_before_to_persisted_child(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "scheduled child",
+        "assignee": "peer",
+        "not_before": "2030-01-01T00:00:00Z",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True, d
+    assert d["not_before"] == "2030-01-01T00:00:00Z"
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, d["task_id"])
+        assert child.not_before == "2030-01-01T00:00:00Z"
+        assert child.status == "scheduled"
     finally:
         conn.close()
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -503,6 +503,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "current_run_id": task.current_run_id,
         "model_override": task.model_override,
         "provider_override": task.provider_override,
+        "not_before": task.not_before,
         "parents": parents,
         "children": children,
         "parent_count": len(parents),
@@ -549,6 +550,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "current_run_id": t.current_run_id,
                     "model_override": t.model_override,
                     "provider_override": t.provider_override,
+                    "not_before": t.not_before,
                 }
 
             def _run_dict(r):
@@ -1360,6 +1362,7 @@ def _handle_create(args: dict, **kw) -> str:
         )
     body = args.get("body")
     parents = args.get("parents") or []
+    not_before = args.get("not_before")
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
     # Stamp the originating session id when the agent loop runs under
     # ACP (which sets HERMES_SESSION_ID before invoking tools). NULL on
@@ -1461,6 +1464,7 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                not_before=not_before,
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -1470,6 +1474,7 @@ def _handle_create(args: dict, **kw) -> str:
                 workspace_kind=new_task.workspace_kind if new_task else None,
                 workspace_path=new_task.workspace_path if new_task else None,
                 project_id=new_task.project_id if new_task else None,
+                not_before=new_task.not_before if new_task else None,
                 subscribed=subscribed,
             )
         finally:
@@ -2168,6 +2173,15 @@ KANBAN_CREATE_SCHEMA = {
                     "auto-promotes to 'ready'. Typical fan-in: list "
                     "all the researcher task ids when creating a "
                     "synthesizer task."
+                ),
+            },
+            "not_before": {
+                "type": "string",
+                "description": (
+                    "Optional timezone-aware UTC instant. The task remains "
+                    "outside the dispatchable queue until this deadline; "
+                    "when parents have a later deadline, the latest parent "
+                    "deadline is inherited."
                 ),
             },
             "tenant": {


### PR DESCRIPTION
## Summary
Successor of dirty/conflicting #81927, cleanly rebased onto current `main`.

- park future-dated cards in `scheduled` and release them only after both dependency and time gates pass
- enforce the deadline at manual promotion/unblock, claim/review claim, direct/drain completion, synthetic completion evidence, dispatcher health/spawn selection, and the pre-middleware tool execution boundary
- record deduplicated `not_before_blocked` diagnostics; support a sealed, authenticated-human/owner override capability with `not_before_overridden` audit events
- fail closed before terminal/browser/provider execution when a pinned Kanban worker cannot verify its task gate

## Safety property
Rejected attempts mutate only the internal diagnostic event stream. They do not claim or complete the task, create run evidence, assign a default worker, invoke Relay/tool middleware, execute a tool, or call a provider.

## Rebase notes
- Replaces DIRTY #81927 (`t_f66a8de1-enforce-not-before` @ `e7b9e2309e82`)
- Conflict-resolved against main review-lifecycle work: `_resume_status_from_events`, parent re-checks on claim/complete, `fire_lifecycle_hook`, nested `write_txn(allow_nested=True)`, dashboard review reopen paths
- Includes not-before metadata storage/CLI field also tracked in #81802; this PR can land standalone
- Related open PR touching same file cluster: #83337 (board counts readonly)

## Tests
- `135 passed, 1 skipped` across focused Kanban DB/CLI/swarm/dashboard/tools suites including `test_kanban_not_before_guard.py`
- `git diff --check` and `py_compile` clean on touched files

## Supersedes
Closes #81927 (successor rebase; old head conflicting with main).