### PR TITLE
fix(a2a): preserve complete streamed replies

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -780,11 +780,21 @@ class A2AAdapter(BasePlatformAdapter):
         """Fulfil the oldest pending reply Future for this context (``chat_id`` = A2A context id).
         Only sends carrying ``metadata['notify']`` (the base adapter's final-reply marker) satisfy
         the caller; progress/status/preview sends must not."""
+        message_id = str(int(time.time() * 1000))
         if not (metadata or {}).get("notify"):
-            logger.debug("A2A: ignoring non-final send for context %s", chat_id)
-        elif not self._resolve_oldest_for_context(chat_id, protocol.STATE_COMPLETED, content or ""):
-            logger.debug("A2A: send() for context %s had no pending waiter", chat_id)  # late chunk / out-of-band
-        return SendResult(success=True, message_id=str(int(time.time() * 1000)))
+            # A2A's request/reply Future has no editable preview surface.  A
+            # successful result here tells GatewayStreamConsumer that this
+            # prefix is visible and editable; it then computes the terminal
+            # fallback as only the missing suffix.  Since we actually drop the
+            # preview, that loses the start of the reply.  Report the delivery
+            # truthfully so the consumer retains the full accumulated buffer
+            # for the notify-marked terminal send.
+            logger.debug("A2A: deferring non-final send for context %s", chat_id)
+            return SendResult(success=False, error="A2A defers non-final previews")
+        if not self._resolve_oldest_for_context(chat_id, protocol.STATE_COMPLETED, content or ""):
+            # No waiter (e.g. a late chunk or out-of-band send) — drop it.
+            logger.debug("A2A: send() for context %s had no pending waiter", chat_id)
+        return SendResult(success=True, message_id=message_id)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         return None

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -788,7 +788,9 @@ class A2AAdapter(BasePlatformAdapter):
             # fallback as only the missing suffix.  Since we actually drop the
             # preview, that loses the start of the reply.  Report the delivery
             # truthfully so the consumer retains the full accumulated buffer
-            # for the notify-marked terminal send.
+            # for the notify-marked terminal send. Runtime A2A request/reply
+            # completion uses notify-marked sends; this non-notify path is the
+            # gateway stream-preview path and must not resolve the A2A waiter.
             logger.debug("A2A: deferring non-final send for context %s", chat_id)
             return SendResult(success=False, error="A2A defers non-final previews")
         if not self._resolve_oldest_for_context(chat_id, protocol.STATE_COMPLETED, content or ""):

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -1241,8 +1241,15 @@ class A2AAdapter(BasePlatformAdapter):
         """
         message_id = str(int(time.time() * 1000))
         if not (metadata or {}).get("notify"):
-            logger.debug("A2A: ignoring non-final send for context %s", chat_id)
-            return SendResult(success=True, message_id=message_id)
+            # A2A's request/reply Future has no editable preview surface.  A
+            # successful result here tells GatewayStreamConsumer that this
+            # prefix is visible and editable; it then computes the terminal
+            # fallback as only the missing suffix.  Since we actually drop the
+            # preview, that loses the start of the reply.  Report the delivery
+            # truthfully so the consumer retains the full accumulated buffer
+            # for the notify-marked terminal send.
+            logger.debug("A2A: deferring non-final send for context %s", chat_id)
+            return SendResult(success=False, error="A2A defers non-final previews")
         if not self._resolve_oldest_for_context(chat_id, protocol.STATE_COMPLETED, content or ""):
             # No waiter (e.g. a late chunk or out-of-band send) — drop it.
             logger.debug("A2A: send() for context %s had no pending waiter", chat_id)

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -612,7 +612,21 @@ class TestReplyCapture:
             runner = asyncio.create_task(consumer.run())
             consumer.on_delta("event_id: evt_178645280")
             await asyncio.sleep(0.01)
+
+            # A2A deliberately reports the invisible preview as an
+            # unsuccessful delivery. GatewayStreamConsumer must treat
+            # that as an internal streaming downgrade, not as a terminal
+            # A2A error: the request/reply waiter stays pending and later
+            # deltas continue accumulating for the notify-marked final.
+            assert consumer._edit_supported is False
+            assert consumer.already_sent is False
+            assert consumer.final_response_sent is False
+            assert fut.done() is False
+
             consumer.on_delta("9212_97bccc7032364276")
+            await asyncio.sleep(0.01)
+            assert fut.done() is False
+
             consumer.finish()
             await runner
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -580,7 +580,7 @@ class TestReplyCapture:
                 "⏩ Steered into current run (iteration 1/200).",
                 metadata={"expect_edits": True},
             )
-            assert interim.success is True
+            assert interim.success is False
             assert fut.done() is False
 
             final = await adapter.send(
@@ -595,6 +595,35 @@ class TestReplyCapture:
             asyncio.run(run())
         finally:
             adapter._pop_pending("task-final")
+
+    def test_gateway_stream_consumer_delivers_complete_accumulated_reply(self):
+        """Dropped previews must not make the terminal A2A reply suffix-only."""
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = _bare_adapter()
+        fut = adapter._add_pending("task-stream", "ctx-stream")
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "ctx-stream",
+            StreamConsumerConfig(edit_interval=0.0, buffer_threshold=1),
+        )
+
+        async def run():
+            runner = asyncio.create_task(consumer.run())
+            consumer.on_delta("event_id: evt_178645280")
+            await asyncio.sleep(0.01)
+            consumer.on_delta("9212_97bccc7032364276")
+            consumer.finish()
+            await runner
+
+        try:
+            asyncio.run(run())
+            assert fut.result(timeout=0) == (
+                protocol.STATE_COMPLETED,
+                "event_id: evt_1786452809212_97bccc7032364276",
+            )
+        finally:
+            adapter._pop_pending("task-stream")
 
     def test_concurrent_same_context_tasks_resolve_fifo(self):
         """Two in-flight tasks sharing a context must not cross-talk: replies

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -617,7 +617,7 @@ class TestReplyCapture:
                 "⏩ Steered into current run (iteration 1/200).",
                 metadata={"expect_edits": True},
             )
-            assert interim.success is True
+            assert interim.success is False
             assert fut.done() is False
 
             final = await adapter.send(
@@ -632,6 +632,35 @@ class TestReplyCapture:
             asyncio.run(run())
         finally:
             adapter._pop_pending("task-final")
+
+    def test_gateway_stream_consumer_delivers_complete_accumulated_reply(self):
+        """Dropped previews must not make the terminal A2A reply suffix-only."""
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = _bare_adapter()
+        fut = adapter._add_pending("task-stream", "ctx-stream")
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "ctx-stream",
+            StreamConsumerConfig(edit_interval=0.0, buffer_threshold=1),
+        )
+
+        async def run():
+            runner = asyncio.create_task(consumer.run())
+            consumer.on_delta("event_id: evt_178645280")
+            await asyncio.sleep(0.01)
+            consumer.on_delta("9212_97bccc7032364276")
+            consumer.finish()
+            await runner
+
+        try:
+            asyncio.run(run())
+            assert fut.result(timeout=0) == (
+                protocol.STATE_COMPLETED,
+                "event_id: evt_1786452809212_97bccc7032364276",
+            )
+        finally:
+            adapter._pop_pending("task-stream")
 
     def test_concurrent_same_context_tasks_resolve_fifo(self):
         """Two in-flight tasks sharing a context must not cross-talk: replies


### PR DESCRIPTION
## Summary

- report dropped non-final A2A previews as undelivered
- keep GatewayStreamConsumer from treating invisible prefixes as editable content
- preserve the complete accumulated reply in the terminal A2A response

## Regression

Before this change, a streamed response such as `event_id: evt_178645280` + `9212_97bccc7032364276` could return only the second chunk to the A2A caller. The new integration test drives the real gateway stream consumer through the A2A adapter and asserts the complete value.

## Verification

`uv run --extra dev pytest -q tests/plugins/test_a2a_plugin.py tests/plugins/test_a2a_phase23.py`

152 passed, 17 deselected.