### PR TITLE
fix(telegram): preserve partial quote attribution across chats

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2337,6 +2337,7 @@ class MessageEvent:
     reply_to_author_id: Optional[str] = None
     reply_to_author_name: Optional[str] = None
     reply_to_is_own_message: bool = False  # True when the user replied to this bot/assistant's message
+    reply_to_is_partial_quote: bool = False
 
     # Structured interactive-prompt reply (relay Phase 3). Present when this
     # event is the user answering a native interactive prompt rendered by the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14720,6 +14720,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 reply_to_author_id=event.reply_to_author_id,
                 reply_to_author_name=event.reply_to_author_name,
                 reply_to_is_own_message=event.reply_to_is_own_message,
+                reply_to_is_partial_quote=event.reply_to_is_partial_quote,
                 auto_skill=event.auto_skill,
                 channel_prompt=event.channel_prompt,
                 channel_context=event.channel_context,
@@ -16673,7 +16674,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
             reply_snippet = event.reply_to_text[:500]
-            if getattr(event, "reply_to_is_own_message", False):
+            is_partial_quote = getattr(event, "reply_to_is_partial_quote", False)
+            if is_partial_quote and getattr(event, "reply_to_is_own_message", False):
+                message_text = (
+                    f'[Quoting selected text from your previous message: "{reply_snippet}"]\n\n'
+                    f"{message_text}"
+                )
+            elif is_partial_quote and getattr(event, "reply_to_author_name", None):
+                message_text = (
+                    f'[Quoting selected text from message by {event.reply_to_author_name}: '
+                    f'"{reply_snippet}"]\n\n{message_text}'
+                )
+            elif is_partial_quote:
+                message_text = (
+                    f'[Quoting selected text: "{reply_snippet}"]\n\n{message_text}'
+                )
+            elif getattr(event, "reply_to_is_own_message", False):
                 message_text = (
                     f'[Replying to your previous message: "{reply_snippet}"]\n\n'
                     f"{message_text}"

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9872,12 +9872,30 @@ class TelegramAdapter(BasePlatformAdapter):
         # / caption when no native quote is present.
         reply_to_id = None
         reply_to_text = None
+        reply_to_author_id = None
+        reply_to_author_name = None
+        reply_to_is_own_message = False
+        reply_to_is_partial_quote = False
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
+            reply_author = getattr(message.reply_to_message, "from_user", None)
+            if reply_author is not None:
+                author_id = getattr(reply_author, "id", None)
+                if author_id is not None:
+                    reply_to_author_id = str(author_id)
+                reply_to_author_name = (
+                    getattr(reply_author, "full_name", None)
+                    or getattr(reply_author, "username", None)
+                    or None
+                )
+                reply_to_is_own_message = self._is_own_message(
+                    message.reply_to_message
+                )
             quote = getattr(message, "quote", None)
             quote_text = getattr(quote, "text", None) if quote is not None else None
             if quote_text:
                 reply_to_text = quote_text
+                reply_to_is_partial_quote = True
             else:
                 reply_to_text = (
                     message.reply_to_message.text
@@ -9916,6 +9934,10 @@ class TelegramAdapter(BasePlatformAdapter):
             platform_update_id=update_id,
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            reply_to_author_id=reply_to_author_id,
+            reply_to_author_name=reply_to_author_name,
+            reply_to_is_own_message=reply_to_is_own_message,
+            reply_to_is_partial_quote=reply_to_is_partial_quote,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,

--- a/tests/gateway/test_queue_command.py
+++ b/tests/gateway/test_queue_command.py
@@ -124,6 +124,7 @@ async def test_queue_preserves_reply_context():
         reply_to_text="the original message",
         reply_to_author_id="a1",
         reply_to_author_name="alice",
+        reply_to_is_partial_quote=True,
     )
     result = await runner._handle_message(event)
 
@@ -133,6 +134,7 @@ async def test_queue_preserves_reply_context():
     assert queued.reply_to_text == "the original message"
     assert queued.reply_to_author_id == "a1"
     assert queued.reply_to_author_name == "alice"
+    assert queued.reply_to_is_partial_quote is True
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -99,3 +99,52 @@ async def test_reply_prefix_still_injected_when_text_in_history():
     assert result.endswith("What's the best time to go?")
 
 
+@pytest.mark.asyncio
+async def test_partial_quote_from_assistant_is_labeled_as_selected_text():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="Only address this point.",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="Item B: rotate keys",
+        reply_to_is_own_message=True,
+        reply_to_is_partial_quote=True,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith(
+        '[Quoting selected text from your previous message: "Item B: rotate keys"]'
+    )
+
+
+@pytest.mark.asyncio
+async def test_partial_quote_from_participant_includes_quoted_author():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="Continue from here.",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="deployment is blocked",
+        reply_to_author_name="Alice",
+        reply_to_is_partial_quote=True,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith(
+        '[Quoting selected text from message by Alice: "deployment is blocked"]'
+    )
+

--- a/tests/gateway/test_telegram_reply_quote.py
+++ b/tests/gateway/test_telegram_reply_quote.py
@@ -12,6 +12,8 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from gateway.config import PlatformConfig
 
 
@@ -36,8 +38,14 @@ _ensure_telegram_mock()
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 
 
+BOT_ID = 777
+USER_ID = 42
+
+
 def _make_adapter():
-    return TelegramAdapter(PlatformConfig(enabled=True, token="***", extra={}))
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***", extra={}))
+    adapter._bot = SimpleNamespace(id=BOT_ID)
+    return adapter
 
 
 def _make_message(
@@ -46,9 +54,19 @@ def _make_message(
     reply_to_caption=None,
     reply_to_id=42,
     quote_text=None,
+    chat_type="private",
+    reply_author_id=BOT_ID,
+    reply_author_name="Hermes",
+    reply_author_is_bot=True,
 ):
-    chat = SimpleNamespace(id=111, type="private", title=None, full_name="Alice")
-    user = SimpleNamespace(id=42, full_name="Alice")
+    is_group = chat_type in {"group", "supergroup"}
+    chat = SimpleNamespace(
+        id=-100111 if is_group else 111,
+        type=chat_type,
+        title="Test group" if is_group else None,
+        full_name=None if is_group else "Alice",
+    )
+    user = SimpleNamespace(id=USER_ID, full_name="Alice", is_bot=False)
 
     reply_to_message = None
     if reply_to_text is not None or reply_to_caption is not None:
@@ -56,6 +74,11 @@ def _make_message(
             message_id=reply_to_id,
             text=reply_to_text,
             caption=reply_to_caption,
+            from_user=SimpleNamespace(
+                id=reply_author_id,
+                full_name=reply_author_name,
+                is_bot=reply_author_is_bot,
+            ),
         )
 
     quote = None
@@ -93,4 +116,41 @@ def test_native_partial_quote_used_as_reply_to_text():
     assert event.reply_to_text == "Item B: rotate keys"
     assert event.reply_to_message_id == "42"
 
+
+@pytest.mark.parametrize("chat_type", ["private", "supergroup"])
+@pytest.mark.parametrize(
+    ("reply_author_id", "reply_author_name", "reply_author_is_bot", "expected_own"),
+    [
+        (BOT_ID, "Hermes", True, True),
+        (USER_ID, "Alice", False, False),
+    ],
+)
+def test_partial_quote_preserves_selection_and_author_across_chat_types(
+    chat_type,
+    reply_author_id,
+    reply_author_name,
+    reply_author_is_bot,
+    expected_own,
+):
+    """Telegram quote semantics must not depend on chat type or quoted author."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="please address this part",
+        reply_to_text="alpha beta gamma",
+        quote_text="beta",
+        chat_type=chat_type,
+        reply_author_id=reply_author_id,
+        reply_author_name=reply_author_name,
+        reply_author_is_bot=reply_author_is_bot,
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "beta"
+    assert event.reply_to_author_id == str(reply_author_id)
+    assert event.reply_to_author_name == reply_author_name
+    assert event.reply_to_is_own_message is expected_own
+    assert event.reply_to_is_partial_quote is True
 


### PR DESCRIPTION
## What does this PR do?

Preserve Telegram's native partial-quote semantics all the way from the inbound `Message` to the model-visible reply pointer.

Telegram exposes a selected excerpt as [`Message.quote`](https://core.telegram.org/bots/api#message), whose value is a [`TextQuote`](https://core.telegram.org/bots/api#textquote). The field is not limited by chat type or by the author of the quoted message. Hermes already preferred `quote.text`, but then flattened the reply into an unattributed generic string. That made a selected excerpt ambiguous in multi-user group history and when users quoted their own earlier messages.

This change keeps the selected excerpt, quoted author, bot ownership, and partial-quote marker together so the agent sees an explicit pointer such as:

```text
[Quoting selected text from your previous message: "..."]
```

or:

```text
[Quoting selected text from message by Alice: "..."]
```

Normal full-message replies retain their existing prompt format.

## Related Issue

Follow-up to #22619.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - preserve the quoted message author's ID and display name
  - detect when the quoted message was sent by the current bot
  - mark native `TextQuote` excerpts as partial quotes in both private and group chats
- `gateway/platforms/base.py`
  - add a `reply_to_is_partial_quote` event field
- `gateway/run.py`
  - render partial quotes as selected excerpts with explicit author attribution
  - preserve the marker through `/queue`
- Regression tests cover private chat and supergroup quotes of both bot-authored and user-authored messages.

## How to Test

```bash
pytest tests/gateway/test_telegram_reply_quote.py \
  tests/gateway/test_reply_to_injection.py \
  tests/gateway/test_queue_command.py -q
```

Expected result: `11 passed`.

Additional checks:

```bash
ruff check gateway/platforms/base.py gateway/run.py \
  plugins/platforms/telegram/adapter.py \
  tests/gateway/test_queue_command.py \
  tests/gateway/test_reply_to_injection.py \
  tests/gateway/test_telegram_reply_quote.py

python scripts/check-windows-footguns.py \
  gateway/platforms/base.py gateway/run.py \
  plugins/platforms/telegram/adapter.py \
  tests/gateway/test_queue_command.py \
  tests/gateway/test_reply_to_injection.py \
  tests/gateway/test_telegram_reply_quote.py
```

## Manual Reproduction

1. In a Telegram private chat, select and quote part of a bot message, then send a follow-up.
2. Repeat in a group or supergroup.
3. Select and quote part of one of your own earlier messages in both chat types.
4. Confirm the model-visible input identifies the selected excerpt and its author instead of treating it as an unattributed full-message reply.

## Checklist

- [x] Read the contributing guide
- [x] Searched open and closed PRs for duplicates
- [x] Kept the change focused on Telegram quote context
- [x] Added regression coverage for all four chat/author combinations
- [x] Ran focused tests and Ruff checks
- [x] No dependencies or configuration keys added
- [x] Cross-platform footgun scan passed
