### PR TITLE
fix(providers): route MiniMax /v1 endpoints to chat_completions

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -620,6 +620,14 @@ def host_mandated_api_mode(base_url: str = "") -> Optional[str]:
       - api.anthropic.com / ``…/anthropic`` suffixes speak native Messages.
       - Kimi's ``/coding`` endpoint speaks native Messages.
       - AWS Bedrock runtime hosts speak Converse.
+      - MiniMax (international + China) exposes an OpenAI-compatible
+        ``/v1`` endpoint alongside its Anthropic-Messages ``/anthropic``
+        endpoint. The MiniMax overlay defaults to ``anthropic_messages``,
+        so a user pointing ``MINIMAX_CN_BASE_URL`` (or
+        ``model.base_url``) at the OpenAI-compatible ``/v1`` route would
+        silently 4xx until they hand-rolled a custom provider. Treat the
+        ``/v1`` suffix on the two known MiniMax hosts as mandating
+        ``chat_completions`` so the URL on the wire wins over the overlay.
 
     These are *mandatory* — a session carrying a stale api_mode (e.g. a
     /model switch that kept the previous provider's ``chat_completions``)
@@ -644,6 +652,21 @@ def host_mandated_api_mode(base_url: str = "") -> Optional[str]:
     # catalog filtering and listing authority.
     if is_official_openai_host(base_url):
         return "codex_responses"
+    # MiniMax OpenAI-compatible endpoint. The ``/v1`` path on the two
+    # known MiniMax hosts is documented as the OpenAI-compat surface —
+    # see the ``MiniMaxProfile`` reasoning-controls hook in
+    # plugins/model-providers/minimax/__init__.py, which is only wired up
+    # for that route. Mandating ``chat_completions`` here lets a user set
+    # ``MINIMAX_CN_BASE_URL=https://api.minimaxi.com/v1`` (or the global
+    # equivalent) without a custom-provider workaround; the
+    # ``/anthropic`` path on these hosts is caught by the
+    # ``endswith("/anthropic")`` branch above and stays on
+    # ``anthropic_messages``.
+    if (
+        hostname in {"api.minimax.io", "api.minimaxi.com"}
+        and (url_lower.endswith("/v1") or "/v1/" in url_lower)
+    ):
+        return "chat_completions"
     if hostname.startswith("bedrock-runtime.") and base_url_host_matches(base_url, "amazonaws.com"):
         return "bedrock_converse"
     return None

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -123,6 +123,18 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     - Kimi Code's ``api.kimi.com/coding`` endpoint also speaks the
       Anthropic Messages protocol (the /coding route accepts Claude
       Code's native request shape).
+    - MiniMax (international + China) exposes an OpenAI-compatible
+      ``/v1`` endpoint alongside its Anthropic-Messages ``/anthropic``
+      endpoint. The MiniMax overlay defaults to ``anthropic_messages``,
+      so without this carve-out a user pointing ``MINIMAX_CN_BASE_URL``
+      (or ``model.base_url``) at the OpenAI-compatible ``/v1`` route
+      would land on the wrong wire because the URL detection has no
+      opinion and the overlay wins. The ``/v1`` path on the two known
+      MiniMax hosts is documented as the OpenAI-compat surface — see
+      the ``MiniMaxProfile`` reasoning-controls hook in
+      ``plugins/model-providers/minimax/__init__.py``, which is only
+      wired up for that route. Mirrors the matching rule in
+      ``providers.host_mandated_api_mode``.
     """
     normalized = (base_url or "").strip().lower().rstrip("/")
     hostname = base_url_hostname(base_url)
@@ -147,6 +159,16 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
         return "anthropic_messages"
     if hostname == "api.kimi.com" and "/coding" in normalized:
         return "anthropic_messages"
+    # MiniMax OpenAI-compatible endpoint (sibling of the matching rule in
+    # providers.host_mandated_api_mode — kept in lockstep so URL detection
+    # and the overlay-precedence path agree on the wire for this host).
+    # Hostname match is exact (no bare substring) so lookalike subdomains
+    # (api.minimaxi.com.attacker.test/v1) are NOT treated as MiniMax.
+    if (
+        hostname in {"api.minimax.io", "api.minimaxi.com"}
+        and (normalized.endswith("/v1") or "/v1/" in normalized)
+    ):
+        return "chat_completions"
     return None
 
 

--- a/tests/hermes_cli/test_runtime_transport_precedence.py
+++ b/tests/hermes_cli/test_runtime_transport_precedence.py
@@ -76,6 +76,79 @@ class TestFallbackApiMode:
         )
 
 
+class TestMiniMaxOpenAiCompatRoute:
+    """Regression: MiniMax overlays default to anthropic_messages but the
+    /v1 endpoint is OpenAI-compatible. A user setting
+    ``MINIMAX_CN_BASE_URL=https://api.minimaxi.com/v1`` (or pointing
+    ``model.base_url`` at the same path) used to land on
+    ``anthropic_messages`` because the overlay won outright and the URL
+    was not recognised as a wire-format mandate. That forced the user to
+    hand-roll a custom provider. Hosts recognised here:
+
+      - api.minimaxi.com   (China, /v1 OpenAI-compat)
+      - api.minimax.io    (global, /v1 OpenAI-compat)
+
+    The /anthropic path on the same hosts is NOT affected — it's caught
+    by the ``endswith("/anthropic")`` branch and stays on
+    ``anthropic_messages`` as before.
+    """
+
+    @pytest.mark.parametrize(
+        "provider,base_url",
+        [
+            ("minimax-cn", "https://api.minimaxi.com/v1"),
+            ("minimax-cn", "https://api.minimaxi.com/v1/"),
+            ("minimax", "https://api.minimax.io/v1"),
+            ("minimax", "https://api.minimax.io/v1/"),
+            ("minimax-oauth", "https://api.minimax.io/v1"),
+        ],
+    )
+    def test_minimax_v1_openai_compat_routes_to_chat_completions(
+        self, provider, base_url
+    ):
+        # Both URL detection and the full determine_api_mode path must
+        # agree, because runtime_provider._fallback_api_mode consults
+        # URL detection first, but model_switch / persisted config paths
+        # consult determine_api_mode directly.
+        from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+        assert _detect_api_mode_for_url(base_url) == "chat_completions"
+        assert _fallback_api_mode(provider, base_url) == "chat_completions"
+        assert (
+            __import__("hermes_cli.providers", fromlist=["determine_api_mode"])
+            .determine_api_mode(provider, base_url)
+            == "chat_completions"
+        )
+
+    @pytest.mark.parametrize(
+        "provider,base_url",
+        [
+            ("minimax-cn", "https://api.minimaxi.com/anthropic"),
+            ("minimax", "https://api.minimax.io/anthropic"),
+            ("minimax-oauth", "https://api.minimax.io/anthropic"),
+        ],
+    )
+    def test_minimax_anthropic_path_still_anthropic_messages(
+        self, provider, base_url
+    ):
+        # The OpenAI-compat carve-out must NOT regress the working
+        # /anthropic routes — those are the default and stay
+        # anthropic_messages.
+        from hermes_cli.providers import determine_api_mode
+
+        assert determine_api_mode(provider, base_url) == "anthropic_messages"
+
+    def test_minimax_v1_spoofed_subdomain_is_not_anthropic(self):
+        # The hostname match is exact — a lookalike subdomain
+        # (api.minimaxi.com.attacker.test/v1) must NOT inherit the
+        # MiniMax carve-out. Same spoof-rejection contract as
+        # is_official_openai_host (#32243).
+        from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+        spoofed = "https://api.minimaxi.com.attacker.test/v1"
+        assert _detect_api_mode_for_url(spoofed) is None
+
+
 class TestExplicitRuntimeIntegration:
     """The explicit-runtime path resolves regional OpenAI to codex_responses."""
 


### PR DESCRIPTION
## Summary

In Hermes v0.20.0, the `minimax`, `minimax-cn`, and `minimax-oauth` provider
overlays declare `transport: anthropic_messages`. Their default `base_url` is
the Anthropic-Messages-compatible `/anthropic` endpoint — that part is correct.

**The bug:** MiniMax also exposes an OpenAI-compatible endpoint on the same
hosts under the `/v1` path (`https://api.minimaxi.com/v1` for China,
`https://api.minimax.io/v1` for global). A user setting `MINIMAX_CN_BASE_URL`
(or `model.base_url`) at this `/v1` URL to use the OpenAI-compat route gets
silently routed to `anthropic_messages`, and every tool-calling turn 4xx's,
because:

1. `hermes_cli.providers.determine_api_mode` consults the overlay after the
   host-mandated check; the host-mandated check returns `None` for `/v1` (it
   only recognises `/anthropic` and a few mandated hosts).
2. `hermes_cli.runtime_provider._detect_api_mode_for_url` also returns `None`
   for `/v1` — same gap.

The overlay's `anthropic_messages` wins outright, the runtime posts to the
wrong wire path on the OpenAI-compat server, and tool-calling 4xx's.

Fixes #83923 (filed earlier on `main` reproduction).

## Reproduction

Hermes v0.20.0:

```python
>>> from hermes_cli.providers import determine_api_mode
>>> determine_api_mode("minimax-cn", "https://api.minimaxi.com/v1")
'anthropic_messages'   # wrong; should be 'chat_completions'
```

The same call against the `/anthropic` path is correct:

```python
>>> determine_api_mode("minimax-cn", "https://api.minimaxi.com/anthropic")
'anthropic_messages'   # correct
```

Three affected overlays: `minimax`, `minimax-cn`, `minimax-oauth` — all on the
two known hosts (`api.minimaxi.com`, `api.minimax.io`) when the path is `/v1`.

## Fix

Add a narrow `/v1` carve-out to BOTH URL-mode resolvers, scoped to the two
known MiniMax hosts (exact-hostname match, no bare substring — same
spoof-rejection contract as `is_official_openai_host` from #32243):

- `hermes_cli/providers.py::host_mandated_api_mode` — return `chat_completions`
  when hostname ∈ `{api.minimaxi.com, api.minimax.io}` and URL ends with `/v1`
  (or contains `/v1/`).
- `hermes_cli/runtime_provider.py::_detect_api_mode_for_url` — same predicate,
  kept in lockstep with the first so URL detection and the overlay-precedence
  path agree on the wire.

The `/anthropic` path on these hosts is caught by the existing
`endswith("/anthropic")` branch and stays on `anthropic_messages` — no
regression.

## Files changed

| File | Change |
|---|---|
| `hermes_cli/providers.py` | `+23` lines — `/v1` carve-out in `host_mandated_api_mode` + docstring |
| `hermes_cli/runtime_provider.py` | `+22` lines — same carve-out in `_detect_api_mode_for_url` + docstring |
| `tests/hermes_cli/test_runtime_transport_precedence.py` | `+73` lines — `TestMiniMaxOpenAiCompatRoute` (5 parametrized cases + 2 sibling paths + 1 spoof-rejection) |

Total: **3 files, +118, -0**.

## Sibling call sites covered (per AGENTS.md rubric)

> Fix the whole bug class — sibling call paths included — not just the one site
> the reporter hit.

The two URL-mode resolvers are the only authoritative readers of `base_url`
for `api_mode` resolution. `providers.py`, `plugins/`, and runtime paths all
flow through them. Patching only one would leave the other path broken —
verified by reproducing the bug at both layers before writing the patch.

## Tests

5 new parametrized regression tests in
`tests/hermes_cli/test_runtime_transport_precedence.py::TestMiniMaxOpenAiCompatRoute`:

- `test_minimax_v1_openai_compat_routes_to_chat_completions` (parametrized ×5)
  — all three overlays on `/v1` (and `/v1/` trailing slash)
- `test_minimax_anthropic_path_still_anthropic_messages` (parametrized ×3)
  — `/anthropic` preservation cases
- `test_minimax_v1_spoofed_subdomain_is_not_anthropic` —
  `api.minimaxi.com.attacker.test/v1` must NOT inherit the carve-out

Focused subset (every test that touches the changed paths):

```
tests/hermes_cli/test_runtime_transport_precedence.py
tests/hermes_cli/test_determine_api_mode_hostname.py
tests/hermes_cli/test_detect_api_mode_for_url.py
tests/hermes_cli/test_runtime_provider_resolution.py
tests/agent/test_minimax_provider.py
tests/plugins/model_providers/test_minimax_profile.py
→ 114 passed in 14.34s
```

The full `tests/hermes_cli/` was timing out at the 5-min cap (large directory
with several long-running integration tests). The focused subset covers every
test that exercises the changed code paths.

## Workaround for v0.20.0 users

Add a custom provider entry under `providers.*` in `config.yaml` with an
explicit `transport: chat_completions`:

```yaml
providers:
  minimax-cn-oai:
    api: https://api.minimaxi.com/v1
    key_env: MINIMAX_CN_API_KEY
    transport: chat_completions
    default_model: MiniMax-M3
```

Confirmed working on v0.20.0 with MiniMax-M3 against the China endpoint.
