### PR TITLE
fix(gateway): label configured vs active runtime model on fallback

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -19,6 +19,7 @@ import asyncio
 import dataclasses
 import hashlib
 import inspect
+import json
 import logging
 import os
 import re
@@ -537,6 +538,44 @@ class GatewaySlashCommandsMixin:
             output = output[:3800] + "\n" + t("gateway.kanban.truncated_suffix")
         return output or t("gateway.kanban.no_output")
 
+    def _resolve_active_runtime_route(self, session_key: str) -> tuple[str, str, bool]:
+        """Resolve the live/cached agent's active runtime model route.
+
+        Provider fallback can switch ``agent.model``/``agent.provider`` after
+        the session row was created (#83910). Returns ``(model, provider,
+        fallback_active)`` so /status and /model can label the route that
+        actually answered calls instead of presenting the configured primary
+        as "current". Empty strings when no agent route is known (idle
+        session that never ran).
+        """
+        from gateway.run import _AGENT_PENDING_SENTINEL
+
+        agent = None
+        if hasattr(self, "_running_agents"):
+            agent = self._running_agents.get(session_key)
+        if agent is None or agent is _AGENT_PENDING_SENTINEL:
+            agent = None
+            cache_lock = getattr(self, "_agent_cache_lock", None)
+            cache = getattr(self, "_agent_cache", None)
+            if cache_lock is not None and cache is not None:
+                try:
+                    with cache_lock:
+                        cached = cache.get(session_key)
+                    if cached:
+                        agent = cached[0]
+                except Exception:
+                    agent = None
+        if agent is None or agent is _AGENT_PENDING_SENTINEL:
+            return "", "", False
+        model = getattr(agent, "model", None)
+        provider = getattr(agent, "provider", None)
+        fallback_active = bool(getattr(agent, "_fallback_activated", False))
+        return (
+            model.strip() if isinstance(model, str) else "",
+            provider.strip() if isinstance(provider, str) else "",
+            fallback_active,
+        )
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         from gateway.run import _AGENT_PENDING_SENTINEL, _load_gateway_config, _resolve_gateway_model
@@ -617,10 +656,14 @@ class GatewaySlashCommandsMixin:
         base_url = ""
         context_used = 0
         context_total = 0
+        fallback_active = False
         if status_agent is not None and status_agent is not _AGENT_PENDING_SENTINEL:
             model_name = _clean_str(getattr(status_agent, "model", ""))
             provider_name = _clean_str(getattr(status_agent, "provider", ""))
             base_url = _clean_str(getattr(status_agent, "base_url", ""))
+            fallback_active = bool(
+                getattr(status_agent, "_fallback_activated", False)
+            )
             ctx = getattr(status_agent, "context_compressor", None)
             if ctx is not None:
                 context_used = _int_value(getattr(ctx, "last_prompt_tokens", 0))
@@ -631,8 +674,21 @@ class GatewaySlashCommandsMixin:
         base_url = base_url or _clean_str(session_row.get("billing_base_url"))
         context_used = context_used or _int_value(getattr(session_entry, "last_prompt_tokens", 0))
 
+        # Between turns the live agent may be gone; trust the persisted
+        # gateway_runtime metadata (written by _sync_session_model_from_agent
+        # after each turn) for the fallback flag (#83910).
+        if not fallback_active:
+            try:
+                _mc = session_row.get("model_config")
+                if isinstance(_mc, str) and _mc:
+                    _parsed = json.loads(_mc)
+                    _gateway_runtime = (_parsed or {}).get("gateway_runtime") or {}
+                    fallback_active = bool(_gateway_runtime.get("fallback_active"))
+            except Exception:
+                pass
+
         user_config: dict[str, Any] = {}
-        if not model_name or not provider_name or not context_total:
+        if not model_name or not provider_name or not context_total or fallback_active:
             try:
                 user_config = _load_gateway_config()
             except Exception:
@@ -652,7 +708,18 @@ class GatewaySlashCommandsMixin:
         model_line = ""
         if model_name:
             if provider_name:
-                model_line = t("gateway.status.model_provider", model=model_name, provider=provider_name)
+                if fallback_active:
+                    model_line = t(
+                        "gateway.status.model_fallback",
+                        model=model_name,
+                        provider=provider_name,
+                    )
+                else:
+                    model_line = t(
+                        "gateway.status.model_provider",
+                        model=model_name,
+                        provider=provider_name,
+                    )
             else:
                 model_line = t("gateway.status.model", model=model_name)
 
@@ -681,6 +748,27 @@ class GatewaySlashCommandsMixin:
         ])
         if model_line:
             lines.append(model_line)
+            if fallback_active:
+                # The runtime route is on fallback — surface the configured
+                # primary so the user sees both layers of state (#83910).
+                _cfg_model = ""
+                _cfg_provider = ""
+                _status_model_cfg = (
+                    user_config.get("model", {})
+                    if isinstance(user_config, dict)
+                    else {}
+                )
+                if isinstance(_status_model_cfg, dict):
+                    _cfg_model = _clean_str(_status_model_cfg.get("default"))
+                    _cfg_provider = _clean_str(_status_model_cfg.get("provider"))
+                if _cfg_model and _cfg_model != model_name:
+                    lines.append(
+                        t(
+                            "gateway.status.model_configured_primary",
+                            model=_cfg_model,
+                            provider=_cfg_provider or "unknown",
+                        )
+                    )
         if context_line:
             lines.append(context_line)
         lines.extend([
@@ -1729,6 +1817,11 @@ class GatewaySlashCommandsMixin:
         current_provider = "openrouter"
         current_base_url = ""
         current_api_key = ""
+        # Raw config values, kept separate from the session override below so
+        # the no-args listing can distinguish the configured primary from a
+        # session /model override and from the active runtime route (#83910).
+        configured_model = ""
+        configured_provider = ""
         user_provs = None
         custom_provs = None
         excluded_provs = []
@@ -1741,6 +1834,8 @@ class GatewaySlashCommandsMixin:
                     current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
+                    configured_model = current_model
+                    configured_provider = current_provider
                 user_provs = cfg.get("providers")
                 try:
                     from hermes_cli.config import get_compatible_custom_providers
@@ -2087,7 +2182,41 @@ class GatewaySlashCommandsMixin:
 
             # Fallback: text list (for platforms without picker or if picker failed)
             provider_label = get_label(current_provider)
-            lines = [t("gateway.model.current_label", model=current_model or "unknown", provider=provider_label), ""]
+
+            # Distinguish the configured primary from the live runtime route.
+            # When provider fallback is active the running agent answers from
+            # a different model/provider, so the configured value must not be
+            # labeled "Current" (#83910).
+            runtime_model, runtime_provider, fallback_active = (
+                self._resolve_active_runtime_route(session_key)
+            )
+            lines: list[str] = []
+            if fallback_active and runtime_model:
+                lines.append(
+                    t(
+                        "gateway.model.configured_primary_label",
+                        model=configured_model or "unknown",
+                        provider=get_label(configured_provider) if configured_provider else "",
+                    )
+                )
+                if override and override.get("model"):
+                    lines.append(
+                        t(
+                            "gateway.model.session_override_label",
+                            model=override.get("model"),
+                            provider=get_label(override.get("provider") or ""),
+                        )
+                    )
+                lines.append(
+                    t(
+                        "gateway.model.active_route_label",
+                        model=runtime_model,
+                        provider=get_label(runtime_provider) if runtime_provider else runtime_provider,
+                    )
+                )
+                lines.append("")
+            else:
+                lines = [t("gateway.model.current_label", model=current_model or "unknown", provider=provider_label), ""]
 
             try:
                 # Offload blocking provider-listing off the event loop so the

--- a/tests/gateway/test_model_command_fallback_labels.py
+++ b/tests/gateway/test_model_command_fallback_labels.py
@@ -1,0 +1,248 @@
+"""Regression tests for #83910: gateway /status and /model must distinguish the
+configured primary from the active runtime route when provider fallback is live.
+
+Previously /model labeled the configured primary as "Current:" even while the
+running agent answered from a fallback provider, making a successfully
+activated fallback look like inconsistent state. /status reported the live
+route without explaining the fallback either.
+
+Fix contract:
+
+* /model (no args, text list) — when fallback is active it shows distinct
+  labels: "Configured primary", "Session override" (if any), and
+  "Active route (fallback)". Without fallback the output is unchanged.
+* /status — when fallback is active the model line says "(fallback active)"
+  and the configured primary is shown on its own line. Without fallback the
+  output is unchanged. The fallback flag is read from the live/cached agent
+  and, when idle, from the persisted ``gateway_runtime`` session metadata.
+"""
+
+import json
+import threading
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.slash_commands as slash_commands
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_state import AsyncSessionDB
+
+SK = "agent:main:telegram:private:12345"
+
+
+def _make_agent(model="deepseek-v4-pro", provider="deepseek", fallback=False):
+    """A bare agent carrying just the route fields the handlers read."""
+    agent = MagicMock()
+    agent.model = model
+    agent.provider = provider
+    agent.base_url = None
+    agent._fallback_activated = fallback
+    return agent
+
+
+def _make_runner(agent=None, cached_agent=None, overrides=None):
+    """Bare GatewayRunner with the fields _handle_model_command needs."""
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = dict(overrides or {})
+    runner._session_key_for_source = MagicMock(return_value=SK)
+    runner._normalize_source_for_session_key = MagicMock(side_effect=lambda s: s)
+    if agent is not None:
+        runner._running_agents[SK] = agent
+    if cached_agent is not None:
+        runner._agent_cache[SK] = (cached_agent, "sig")
+    return runner
+
+
+class _FakeSessionEntry:
+    session_key = SK
+    session_id = "sess-83910"
+    created_at = datetime(2026, 8, 11, 12, 0, 0)
+    updated_at = datetime(2026, 8, 11, 12, 30, 0)
+    last_prompt_tokens = 0
+    total_tokens = 0
+
+
+def _make_status_runner(agent=None, session_row=None):
+    """Bare GatewayRunner with the fields _handle_status_command needs."""
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    store = AsyncMock()
+    store.get_or_create_session.return_value = _FakeSessionEntry()
+    # async_session_store is a read-only property backed by session_store;
+    # plant the mock so the property returns it unchanged.
+    runner.session_store = MagicMock()
+    store._store = runner.session_store
+    runner._async_session_store = store
+    if session_row is not None:
+        db = AsyncSessionDB(MagicMock())
+        db._db.get_session_title.return_value = None
+        db._db.get_session.return_value = session_row
+        runner._session_db = db
+    else:
+        runner._session_db = None
+    runner._queue_depth = lambda *a, **k: 0
+    if agent is not None:
+        runner._running_agents[SK] = agent
+    return runner
+
+
+def _make_event(text="/model"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+    )
+
+
+@pytest.fixture
+def _isolated_config(tmp_path, monkeypatch):
+    """Point the handler at an isolated home with a known configured primary."""
+    import gateway.run as gateway_run
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n  default: gpt-5.6-luna\n  provider: openai-codex\nproviders: {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    return hermes_home
+
+
+def _patch_provider_listing(monkeypatch):
+    """No-op the authenticated-provider listing so tests never touch the network."""
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **kwargs: [],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# /model
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_model_no_args_fallback_active_shows_distinct_labels(
+    _isolated_config, monkeypatch
+):
+    """Fallback live => /model labels configured primary and fallback route separately."""
+    _patch_provider_listing(monkeypatch)
+    runner = _make_runner(agent=_make_agent(fallback=True))
+
+    result = await runner._handle_model_command(_make_event("/model"))
+
+    assert "Configured primary: `gpt-5.6-luna`" in result
+    assert "Active route (fallback): `deepseek-v4-pro`" in result
+    assert "Current:" not in result, (
+        "the configured primary must not be labeled 'Current' while fallback is live"
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_no_args_fallback_active_with_session_override(
+    _isolated_config, monkeypatch
+):
+    """Fallback live + session /model override => all three layers are shown."""
+    _patch_provider_listing(monkeypatch)
+    overrides = {SK: {"model": "claude-sonnet-4.6", "provider": "anthropic"}}
+    runner = _make_runner(agent=_make_agent(fallback=True), overrides=overrides)
+
+    result = await runner._handle_model_command(_make_event("/model"))
+
+    assert "Configured primary: `gpt-5.6-luna`" in result
+    assert "Session override: `claude-sonnet-4.6`" in result
+    assert "Active route (fallback): `deepseek-v4-pro`" in result
+    assert "Current:" not in result
+
+
+@pytest.mark.asyncio
+async def test_model_no_args_cached_agent_fallback_active(_isolated_config, monkeypatch):
+    """Between turns the route comes from the agent cache, not just _running_agents."""
+    _patch_provider_listing(monkeypatch)
+    runner = _make_runner(cached_agent=_make_agent(fallback=True))
+
+    result = await runner._handle_model_command(_make_event("/model"))
+
+    assert "Configured primary: `gpt-5.6-luna`" in result
+    assert "Active route (fallback): `deepseek-v4-pro`" in result
+
+
+@pytest.mark.asyncio
+async def test_model_no_args_without_fallback_is_unchanged(_isolated_config, monkeypatch):
+    """No fallback => /model keeps the existing 'Current:' label."""
+    _patch_provider_listing(monkeypatch)
+    runner = _make_runner(
+        agent=_make_agent(model="gpt-5.6-luna", provider="openai-codex", fallback=False)
+    )
+
+    result = await runner._handle_model_command(_make_event("/model"))
+
+    assert "Current: `gpt-5.6-luna`" in result
+    assert "Active route" not in result
+    assert "Configured primary" not in result
+
+
+# --------------------------------------------------------------------------- #
+# /status
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_status_fallback_active_labels_route_and_primary(_isolated_config):
+    """Fallback live => /status marks the route and shows the configured primary."""
+    runner = _make_status_runner(agent=_make_agent(fallback=True))
+
+    result = await runner._handle_status_command(_make_event("/status"))
+
+    assert "**Model (fallback active):** `deepseek-v4-pro` (deepseek)" in result
+    assert "**Configured primary:** `gpt-5.6-luna` (openai-codex)" in result
+
+
+@pytest.mark.asyncio
+async def test_status_idle_uses_persisted_fallback_flag(_isolated_config):
+    """Idle session => /status trusts persisted gateway_runtime fallback flag."""
+    row = {
+        "model": "deepseek-v4-pro",
+        "billing_provider": "deepseek",
+        "billing_base_url": None,
+        "model_config": json.dumps(
+            {"gateway_runtime": {"provider": "deepseek", "fallback_active": True}}
+        ),
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+    }
+    runner = _make_status_runner(session_row=row)
+
+    result = await runner._handle_status_command(_make_event("/status"))
+
+    assert "**Model (fallback active):** `deepseek-v4-pro` (deepseek)" in result
+    assert "**Configured primary:** `gpt-5.6-luna` (openai-codex)" in result
+
+
+@pytest.mark.asyncio
+async def test_status_without_fallback_is_unchanged(_isolated_config):
+    """No fallback => /status keeps the existing model line and no fallback text."""
+    runner = _make_status_runner(
+        agent=_make_agent(model="gpt-5.6-luna", provider="openai-codex", fallback=False)
+    )
+
+    result = await runner._handle_status_command(_make_event("/status"))
+
+    assert "**Model:** `gpt-5.6-luna` (openai-codex)" in result
+    assert "fallback" not in result.lower()
+    assert "Configured primary" not in result


### PR DESCRIPTION
## Summary
Gateway `/status` and `/model` could report different models after fallback activation, while `/model` labeled the configured value as **Current model**. Both values are internally defensible, but the UI did not explain that they represent different layers of state. Aligns messaging surfaces with the runtime-identity direction from #54509.

## Change
- `gateway/slash_commands.py`:
  - New shared helper `_resolve_active_runtime_route(session_key)` → `(model, provider, fallback_active)` via live agent → cache → empty (same resolver for `/status` and `/model`).
  - `/model` (no-args): captures raw configured values before the override overlay; with fallback active shows `Configured primary:`, `Session override:` (if any) and `Active route (fallback):` — never calls the configured value "Current" in that state. Without fallback: behavior unchanged.
  - `/status`: detects `agent._fallback_activated` (live agent/cache) and the persisted `gateway_runtime.fallback_active` in the session DB (idle case); with fallback active shows `**Model (fallback active):**` + `**Configured primary:**`. Without fallback: unchanged.
- `tests/gateway/test_model_command_fallback_labels.py` (new, 7 tests): fallback active → distinct labels + active fallback shown; no fallback → unchanged; override present; idle-session fallback via session DB.

## Verification
- `tests/gateway/test_model_command_fallback_labels.py`: **7 passed**.

Closes #83910