### PR TITLE
fix(cron): fence cross-process scheduler handoff

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -9,24 +9,49 @@ from __future__ import annotations
 
 import os
 import sqlite3
+import sys
 import threading
 import uuid
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
 EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
+_IMPORT_EXECUTIONS_FILE = EXECUTIONS_FILE
 MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
 
 
+def _current_executions_file() -> Path:
+    """Resolve the ledger for the active cron profile context.
+
+    ``EXECUTIONS_FILE`` remains a compatibility surface for tests and
+    embedders that deliberately re-point it. Otherwise resolve lazily through
+    the same ContextVar-backed store as jobs.json so a multiplex gateway does
+    not keep writing the profile that happened to import this module first.
+
+    The import is intentionally local. ``cron.jobs`` only imports this module
+    from inside listing functions, so runtime resolution avoids an import-time
+    cycle while keeping both stores on one profile-selection source of truth.
+    """
+    configured = Path(EXECUTIONS_FILE)
+    if configured != _IMPORT_EXECUTIONS_FILE:
+        return configured
+
+    from cron.jobs import _current_cron_store
+
+    return _current_cron_store().cron_dir / "executions.db"
+
+
 def _connect() -> sqlite3.Connection:
-    EXECUTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    return sqlite3.connect(EXECUTIONS_FILE, timeout=5)
+    executions_file = _current_executions_file()
+    executions_file.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(executions_file, timeout=5)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
@@ -44,6 +69,7 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
              process_id TEXT NOT NULL,
              pid INTEGER NOT NULL,
              process_started_at INTEGER,
+             process_started_at_stable INTEGER,
              status TEXT NOT NULL CHECK(status IN
                ('claimed','running','completed','failed','unknown')),
              claimed_at TEXT NOT NULL,
@@ -60,6 +86,13 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_executions_status_claimed "
         "ON executions(status, claimed_at DESC, id DESC)"
     )
+    columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(executions)")
+    }
+    if "process_started_at_stable" not in columns:
+        conn.execute(
+            "ALTER TABLE executions ADD COLUMN process_started_at_stable INTEGER"
+        )
 
 
 @contextmanager
@@ -101,23 +134,56 @@ def _emit_execution_state(
 
 def _process_start_time(pid: int) -> Optional[int]:
     try:
+        from gateway.status import get_stable_process_start_time
+        return get_stable_process_start_time(pid)
+    except Exception:
+        return None
+
+
+def _legacy_process_start_time(pid: int) -> Optional[int]:
+    """Read the legacy persisted gateway/ledger fingerprint format."""
+    try:
         from gateway.status import get_process_start_time
         return get_process_start_time(pid)
     except Exception:
         return None
 
 
-def _owner_is_live(pid: int, started_at: Optional[int]) -> bool:
+def _owner_is_live(
+    pid: int,
+    started_at: Optional[int],
+    *,
+    stable_started_at: Optional[int] = None,
+) -> bool:
     try:
         from gateway.status import _pid_exists
         if not _pid_exists(pid):
             return False
     except Exception:
         return True  # fail safe: inability to prove death must not rewrite state
+    if stable_started_at is not None:
+        current_stable = _process_start_time(pid)
+        if current_stable is None:
+            return True  # inability to prove identity mismatch is not death
+        return current_stable == stable_started_at
+
     if started_at is None:
-        return pid == os.getpid()
-    current = _process_start_time(pid)
-    return current is not None and current == started_at
+        # PID existence is all we can prove. Treat the owner as live rather
+        # than rewriting/redispatching work whose exact identity is unknown.
+        return True
+    current = _legacy_process_start_time(pid)
+    if current is None:
+        return True  # fail safe: unavailable identity is not proof of death
+    if current == started_at:
+        return True
+    # Transitional macOS compatibility: psutil 7.2's legacy public timestamp
+    # can differ between interpreters after a wall-clock correction. Existing
+    # rows have no source/version field, so a small bounded difference is
+    # ambiguous rather than proof that the PID was reused. New rows carry the
+    # stable raw fingerprint above and retain exact reuse protection.
+    if sys.platform == "darwin" and abs(current - started_at) <= 500:
+        return True
+    return False
 
 
 def _prune_unlocked(conn: sqlite3.Connection) -> None:
@@ -141,10 +207,10 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
         conn.execute(
             """INSERT INTO executions
                (id, job_id, source, process_id, pid, process_started_at,
-                status, claimed_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'claimed', ?)""",
+                process_started_at_stable, status, claimed_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'claimed', ?)""",
             (execution_id, str(job_id), str(source), _PROCESS_ID, pid,
-             _process_start_time(pid), now),
+             _legacy_process_start_time(pid), _process_start_time(pid), now),
         )
         row = conn.execute(
             "SELECT * FROM executions WHERE id=?", (execution_id,)
@@ -203,13 +269,18 @@ def recover_interrupted_executions() -> int:
     recovered: List[Dict[str, Any]] = []
     with _transaction() as conn:
         rows = conn.execute(
-            """SELECT id, process_id, pid, process_started_at FROM executions
+            """SELECT id, process_id, pid, process_started_at,
+                      process_started_at_stable FROM executions
                WHERE status IN ('claimed','running')"""
         ).fetchall()
         for row in rows:
             if row["process_id"] == _PROCESS_ID:
                 continue
-            if _owner_is_live(int(row["pid"]), row["process_started_at"]):
+            if _owner_is_live(
+                int(row["pid"]),
+                row["process_started_at"],
+                stable_started_at=row["process_started_at_stable"],
+            ):
                 continue
             cur = conn.execute(
                 """UPDATE executions SET status='unknown', finished_at=?, error=?

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -11,7 +11,9 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 import json
 import logging
+import math
 import shutil
+import stat
 import tempfile
 import threading
 import time
@@ -20,9 +22,10 @@ import re
 import uuid
 
 # Cross-process advisory file locking for jobs.json critical sections.
-# fcntl is Unix-only; on Windows fall back to msvcrt. Either may be absent,
-# in which case _jobs_lock() degrades to in-process locking only (the old
-# behaviour) rather than failing.
+# fcntl is Unix-only; on Windows fall back to msvcrt. If the platform provides
+# neither primitive, retain the historical in-process lock. When a primitive
+# exists, acquisition failures are fail-closed: durable attempt CAS operations
+# must never run in an unlocked "degraded" critical section.
 try:
     import fcntl
 except ImportError:  # pragma: no cover - non-Unix
@@ -97,6 +100,16 @@ TICKER_SUCCESS_FILE = CRON_DIR / "ticker_last_success"
 # threshold in `hermes cron status` (hermes_cli/cron.py), so the two never
 # drift apart.
 TICKER_INTERVAL_SECONDS = 60
+# A gateway ticker refreshes its profile-local ownership lease once per loop.
+# Desktop waits through roughly three missed iterations before treating a
+# crashed/stalled gateway as gone, matching the existing ticker-health window.
+GATEWAY_TICKER_LEASE_STALE_SECONDS = TICKER_INTERVAL_SECONDS * 3 + 20
+_GATEWAY_TICKER_LEASE_FUTURE_SKEW_SECONDS = 5.0
+_GATEWAY_TICKER_LEASE_PREFIX = ".gateway_ticker_lease."
+_GATEWAY_TICKER_OWNER_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
+_GATEWAY_TICKER_PROCESS_OWNER_RE = re.compile(
+    r"p(?P<pid>[1-9][0-9]*)-s(?P<started>[0-9]+)-[a-f0-9]{32}\Z"
+)
 
 # In-process lock protecting load_jobs→modify→save_jobs cycles.
 # Required when tick() runs jobs in parallel threads — without this,
@@ -113,6 +126,7 @@ _jobs_lock_state = threading.local()
 # worst-case stall well under one status-alarm threshold.
 _JOBS_LOCK_TIMEOUT_SECONDS = 30.0
 OUTPUT_DIR = CRON_DIR / "output"
+_MONITOR_SNAPSHOT_FILENAME = "monitor_last_output.txt"
 ONESHOT_GRACE_SECONDS = 120
 
 
@@ -195,6 +209,7 @@ def get_cron_output_dir() -> Path:
 # floor for the derived value so a very short configured timeout can't make the
 # claim expire mid-run.
 ONESHOT_RUN_CLAIM_TTL_SECONDS = 1800
+_RUN_CLAIM_FUTURE_SKEW_SECONDS = 5.0
 
 # The derived TTL is the cron inactivity timeout times this headroom multiplier.
 # A healthy run clears its claim via mark_job_run() long before the TTL; the
@@ -234,6 +249,18 @@ def _oneshot_run_claim_ttl_seconds() -> float:
         timeout * _ONESHOT_RUN_CLAIM_TTL_HEADROOM,
         float(ONESHOT_RUN_CLAIM_TTL_SECONDS),
     )
+
+
+def _claim_is_fresh(claim: Any, *, now: datetime, ttl_seconds: float) -> bool:
+    """Validate a persisted claim timestamp with tightly bounded clock skew."""
+    if not isinstance(claim, dict):
+        return False
+    try:
+        claimed_at = _ensure_aware(datetime.fromisoformat(claim["at"]))
+        age = (now - claimed_at).total_seconds()
+        return -_RUN_CLAIM_FUTURE_SKEW_SECONDS <= age < ttl_seconds
+    except (KeyError, ValueError, TypeError):
+        return False
 
 
 def _job_running_in_this_process(job_id: str) -> bool:
@@ -321,10 +348,10 @@ def _jobs_lock():
                     # get_due_jobs() — silently and forever: the heartbeat
                     # file stops updating and all jobs stop firing with no
                     # error logged.  Poll LOCK_NB against a deadline instead;
-                    # on timeout, log loudly and fall through to the same
-                    # in-process-only degraded mode used when locking is
-                    # unavailable.  A briefly-torn cross-process write is
-                    # strictly better than a permanently dead scheduler.
+                    # on timeout, log loudly and fail closed. The ticker catches
+                    # the bounded exception and retries; entering an unlocked
+                    # section would let two immutable attempt-token CAS writers
+                    # both win and execute duplicate external side effects.
                     _deadline = time.monotonic() + _JOBS_LOCK_TIMEOUT_SECONDS
                     while True:
                         try:
@@ -335,8 +362,8 @@ def _jobs_lock():
                                 logger.error(
                                     "Timed out after %.0fs waiting for the cron "
                                     "jobs lock (%s) — another process is holding "
-                                    "it. Proceeding with in-process locking only "
-                                    "so the scheduler stays alive (#60703).",
+                                    "it. Refusing to enter an unlocked CAS "
+                                    "critical section (#60703).",
                                     _JOBS_LOCK_TIMEOUT_SECONDS,
                                     _jobs_lock_file(),
                                 )
@@ -345,15 +372,56 @@ def _jobs_lock():
                                 except OSError:
                                     pass
                                 lock_fd = None
-                                break
+                                raise RuntimeError(
+                                    "Timed out waiting for the cron jobs lock"
+                                )
                             time.sleep(0.1)
                 elif msvcrt is not None:
-                    getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+                    _deadline = time.monotonic() + _JOBS_LOCK_TIMEOUT_SECONDS
+                    while True:
+                        try:
+                            getattr(msvcrt, "locking")(
+                                lock_fd.fileno(), getattr(msvcrt, "LK_NBLCK"), 1
+                            )
+                            break
+                        except (OSError, IOError):
+                            if time.monotonic() >= _deadline:
+                                logger.error(
+                                    "Timed out after %.0fs waiting for the cron "
+                                    "jobs lock (%s). Refusing to enter an "
+                                    "unlocked CAS critical section (#60703).",
+                                    _JOBS_LOCK_TIMEOUT_SECONDS,
+                                    _jobs_lock_file(),
+                                )
+                                try:
+                                    lock_fd.close()
+                                except OSError:
+                                    pass
+                                lock_fd = None
+                                raise RuntimeError(
+                                    "Timed out waiting for the cron jobs lock"
+                                )
+                            time.sleep(0.1)
             except (OSError, IOError) as e:
-                # Never let a locking failure take down cron writes — fall back to
-                # in-process-only protection (still held via _jobs_file_lock).
-                logger.warning("jobs.json cross-process lock unavailable (%s); "
-                               "proceeding with in-process lock only", e)
+                if lock_fd is not None:
+                    try:
+                        lock_fd.close()
+                    except OSError:
+                        pass
+                    lock_fd = None
+                if fcntl is not None or msvcrt is not None:
+                    logger.error(
+                        "jobs.json cross-process lock unavailable (%s); "
+                        "refusing unsafe unlocked mutation",
+                        e,
+                    )
+                    raise RuntimeError(
+                        "Cron jobs lock unavailable; mutation was not attempted"
+                    ) from e
+                logger.warning(
+                    "No cross-process lock primitive is available; using "
+                    "the in-process cron jobs lock only"
+                )
             try:
                 yield
             finally:
@@ -895,6 +963,117 @@ def _atomic_write_epoch(path: Path) -> None:
     atomic_write_text(path, str(time.time()), tmp_prefix=".hb_")
 
 
+def _gateway_ticker_lease_path(owner_id: str) -> Path:
+    """Return the profile-local lease path for one gateway instance.
+
+    Each gateway gets a unique file instead of sharing a single marker.  That
+    makes cleanup owner-local by construction: an exiting predecessor cannot
+    unlink a successor's lease between a compare and delete.
+    """
+    owner = str(owner_id or "")
+    if _GATEWAY_TICKER_OWNER_RE.fullmatch(owner) is None:
+        raise ValueError(f"Invalid gateway ticker owner id: {owner_id!r}")
+    return _current_cron_store().cron_dir / f"{_GATEWAY_TICKER_LEASE_PREFIX}{owner}"
+
+
+def record_gateway_ticker_lease(owner_id: str) -> None:
+    """Publish/refresh this gateway ticker's profile-local readiness lease.
+
+    Unlike the observability heartbeat below, this is a coordination signal:
+    callers intentionally see write failures so a gateway never dispatches
+    concurrently with Desktop merely because it could not advertise ownership.
+    """
+    # Reclaim crash remnants opportunistically even on headless installs where
+    # no Desktop process ever probes readiness. Cleanup is restricted to a
+    # structured owner whose exact PID/start fingerprint proves it is gone.
+    gateway_ticker_lease_is_fresh()
+    path = _gateway_ticker_lease_path(owner_id)
+    _atomic_write_epoch(path)
+    _secure_file(path)
+
+
+def clear_gateway_ticker_lease(owner_id: str) -> None:
+    """Remove only ``owner_id``'s lease after a clean gateway shutdown."""
+    path = _gateway_ticker_lease_path(owner_id)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _gateway_ticker_owner_is_definitely_dead(owner_id: str) -> bool:
+    """Return True only when a structured lease owner's exact process is gone."""
+    match = _GATEWAY_TICKER_PROCESS_OWNER_RE.fullmatch(owner_id)
+    if match is None:
+        return False
+    pid = int(match.group("pid"))
+    started_text = match.group("started")
+    try:
+        from gateway.status import _pid_exists, get_stable_process_start_time
+
+        if not _pid_exists(pid):
+            return True
+        current_start = get_stable_process_start_time(pid)
+        if current_start is None:
+            return False
+        return current_start != int(started_text)
+    except Exception:
+        return False
+
+
+def gateway_ticker_lease_is_fresh(*, max_age_seconds: Optional[float] = None) -> bool:
+    """Whether a ready gateway ticker currently owns this profile's cron.
+
+    Gateway writes one unpredictable, owner-specific regular file only after
+    its cron provider thread starts, and refreshes it on every ticker cycle.
+    Multiplex gateways write the same owner ID into every served profile's
+    cron directory.  Stale crash remnants and malformed/non-regular files are
+    ignored, so they cannot permanently disable the Desktop fallback.
+    """
+    max_age = (
+        float(GATEWAY_TICKER_LEASE_STALE_SECONDS)
+        if max_age_seconds is None
+        else max(0.0, float(max_age_seconds))
+    )
+    now = time.time()
+    cron_dir = _current_cron_store().cron_dir
+    fresh = False
+    try:
+        candidates = cron_dir.glob(f"{_GATEWAY_TICKER_LEASE_PREFIX}*")
+        for path in candidates:
+            try:
+                # Do not follow a planted symlink while probing readiness.
+                if not stat.S_ISREG(path.lstat().st_mode):
+                    continue
+                updated_at = float(path.read_text(encoding="utf-8").strip())
+                if not math.isfinite(updated_at):
+                    continue
+                # Bound backwards clock correction to a few seconds. Accepting
+                # one full TTL of future skew nearly doubles failover time;
+                # rejecting every sub-second correction can cause a false
+                # Desktop takeover while Gateway is still healthy.
+                age = now - updated_at
+                timestamp_is_fresh = (
+                    -_GATEWAY_TICKER_LEASE_FUTURE_SKEW_SECONDS
+                    <= age
+                    <= max_age
+                )
+                if timestamp_is_fresh:
+                    fresh = True
+                    continue
+                owner_id = path.name.removeprefix(_GATEWAY_TICKER_LEASE_PREFIX)
+                if _gateway_ticker_owner_is_definitely_dead(owner_id):
+                    # Owner paths contain a random per-process UUID, so no
+                    # successor can refresh this exact file. Conditional
+                    # process-identity proof makes this unlink race-safe.
+                    path.unlink()
+            except (OSError, ValueError):
+                continue
+    except OSError:
+        return False
+    return fresh
+
+
 def _atomic_write_counter(path: Path, value: int) -> None:
     """Atomically persist a non-negative integer counter."""
     ensure_dirs()
@@ -929,16 +1108,13 @@ def record_ticker_heartbeat(success: bool = False) -> None:
 
     Best-effort: a write failure must never disrupt the tick loop.
     """
-    store = _current_cron_store()
     try:
+        store = _current_cron_store()
         _atomic_write_epoch(store.cron_dir / "ticker_heartbeat")
+        if success:
+            _atomic_write_epoch(store.cron_dir / "ticker_last_success")
     except Exception:
         pass
-    if success:
-        try:
-            _atomic_write_epoch(store.cron_dir / "ticker_last_success")
-        except Exception:
-            pass
 
 
 def _epoch_file_age(path: Path) -> Optional[float]:
@@ -999,9 +1175,9 @@ def record_ticker_error(message: str) -> None:
 
     Best-effort: a write failure must never disrupt the tick loop.
     """
-    store = _current_cron_store()
-    path = store.cron_dir / "ticker_last_error"
     try:
+        store = _current_cron_store()
+        path = store.cron_dir / "ticker_last_error"
         ensure_dirs()
         fd, tmp_path = tempfile.mkstemp(
             dir=str(path.parent), suffix=".tmp", prefix=".terr_"
@@ -1033,10 +1209,10 @@ def get_catch_up_occurrence_count() -> int:
 
 def clear_ticker_error() -> None:
     """Remove the last-tick-error marker after a successful tick. Best-effort."""
-    store = _current_cron_store()
     try:
+        store = _current_cron_store()
         (store.cron_dir / "ticker_last_error").unlink()
-    except OSError:
+    except Exception:
         pass
 
 
@@ -1981,6 +2157,62 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
     return None
 
 
+def persist_monitor_state(
+    job_id: str,
+    new_hash: str,
+    output: str,
+    *,
+    expected_run_claim_owner: Optional[str] = None,
+) -> bool:
+    """Persist one monitor observation without crossing attempt ownership.
+
+    Claimed scheduler runs pass their immutable ``run_claim`` token.  The
+    snapshot and hash are then written while holding the same cross-process
+    lock used to replace that token, so a stale attempt can neither overwrite
+    a successor's snapshot nor publish state after ownership changes.
+
+    Unclaimed/manual monitor calls retain the historical unconditional update
+    behavior by leaving ``expected_run_claim_owner`` unset.
+    """
+    with _jobs_lock():
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job["id"] != job_id:
+                continue
+            if expected_run_claim_owner is not None:
+                current_claim = job.get("run_claim")
+                current_owner = (
+                    str(current_claim.get("by") or "")
+                    if isinstance(current_claim, dict)
+                    else ""
+                )
+                if current_owner != expected_run_claim_owner:
+                    logger.warning(
+                        "Job '%s': ignoring monitor state from stale run-claim "
+                        "owner %r (current owner %r)",
+                        job_id,
+                        expected_run_claim_owner,
+                        current_owner or None,
+                    )
+                    return False
+
+            snapshot_path = _job_output_dir(job_id) / _MONITOR_SNAPSHOT_FILENAME
+            atomic_write_text(
+                snapshot_path,
+                output,
+                encoding="utf-8",
+                tmp_prefix=".monitor_",
+            )
+            job["monitor_state"] = {
+                "last_output_hash": new_hash,
+                "last_changed_at": _hermes_now().isoformat(),
+            }
+            jobs[i] = job
+            save_jobs(jobs)
+            return True
+    return False
+
+
 def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """Pause a job without deleting it. Accepts a job ID or name."""
     job = resolve_job_ref(job_id)
@@ -2073,7 +2305,12 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
-def _set_preflight_alerted(job_id: str, value: bool) -> bool:
+def _set_preflight_alerted(
+    job_id: str,
+    value: bool,
+    *,
+    expected_run_claim_owner: Optional[str] = None,
+) -> Optional[bool]:
     """Set/clear the preflight alert-dedup marker; return the PRIOR value.
 
     The marker records that the operator was already alerted about this
@@ -2086,6 +2323,22 @@ def _set_preflight_alerted(job_id: str, value: bool) -> bool:
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
+                if expected_run_claim_owner is not None:
+                    current_claim = job.get("run_claim")
+                    current_owner = (
+                        str(current_claim.get("by") or "")
+                        if isinstance(current_claim, dict)
+                        else ""
+                    )
+                    if current_owner != expected_run_claim_owner:
+                        logger.warning(
+                            "Job '%s': ignoring preflight marker write from "
+                            "stale run-claim owner %r (current owner %r)",
+                            job_id,
+                            expected_run_claim_owner,
+                            current_owner or None,
+                        )
+                        return None
                 prior = bool(job.get("preflight_alerted"))
                 if value:
                     job["preflight_alerted"] = True
@@ -2095,22 +2348,40 @@ def _set_preflight_alerted(job_id: str, value: bool) -> bool:
                     jobs[i] = job
                     save_jobs(jobs)
                 return prior
-    return False
+    return None if expected_run_claim_owner is not None else False
 
 
-def mark_preflight_alerted(job_id: str) -> bool:
+def mark_preflight_alerted(
+    job_id: str, *, expected_run_claim_owner: Optional[str] = None
+) -> Optional[bool]:
     """Mark the job as preflight-alerted; return True if it already was."""
-    return _set_preflight_alerted(job_id, True)
+    return _set_preflight_alerted(
+        job_id,
+        True,
+        expected_run_claim_owner=expected_run_claim_owner,
+    )
 
 
-def clear_preflight_alerted(job_id: str) -> None:
+def clear_preflight_alerted(
+    job_id: str, *, expected_run_claim_owner: Optional[str] = None
+) -> Optional[bool]:
     """Clear the preflight alert-dedup marker (config validates again)."""
-    _set_preflight_alerted(job_id, False)
+    return _set_preflight_alerted(
+        job_id,
+        False,
+        expected_run_claim_owner=expected_run_claim_owner,
+    )
 
 
-def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None,
-                 status: Optional[str] = None):
+def mark_job_run(
+    job_id: str,
+    success: bool,
+    error: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+    status: Optional[str] = None,
+    *,
+    expected_run_claim_owner: Optional[str] = None,
+) -> bool:
     """
     Mark a job as having been run.
     
@@ -2125,11 +2396,32 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
     the pre-dispatch configuration validation refused to run the agent
     (T1-26), so `cronjob list` distinguishes "your config is broken" from
     "the run itself failed".
+
+    When ``expected_run_claim_owner`` is supplied, the terminal write is a
+    compare-and-set against that immutable attempt token.  A stale runner that
+    resumes after another process reclaimed the job must not clear or overwrite
+    its successor's claim, status, repeat counter, or schedule.
     """
     with _jobs_lock():
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
+                if expected_run_claim_owner is not None:
+                    current_claim = job.get("run_claim")
+                    current_owner = (
+                        str(current_claim.get("by") or "")
+                        if isinstance(current_claim, dict)
+                        else ""
+                    )
+                    if current_owner != expected_run_claim_owner:
+                        logger.warning(
+                            "Job '%s': ignoring terminal write from stale "
+                            "run-claim owner %r (current owner %r)",
+                            job_id,
+                            expected_run_claim_owner,
+                            current_owner or None,
+                        )
+                        return False
                 now = _hermes_now().isoformat()
                 job["last_run_at"] = now
                 job["last_status"] = status or ("ok" if success else "error")
@@ -2186,7 +2478,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         job["state"] = "completed"
                         job["next_run_at"] = None
                         save_jobs(jobs)
-                        return
+                        return True
                 
                 # Compute next run
                 job["next_run_at"] = compute_next_run(job["schedule"], now)
@@ -2221,9 +2513,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     job["state"] = "scheduled"
 
                 save_jobs(jobs)
-                return
+                return True
 
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+        return False
 
 
 def _write_wedged_oneshot_diagnostic(job: Dict[str, Any]) -> None:
@@ -2270,7 +2563,9 @@ def _write_wedged_oneshot_diagnostic(job: Dict[str, Any]) -> None:
         )
 
 
-def claim_dispatch(job_id: str) -> bool:
+def claim_dispatch(
+    job_id: str, *, expected_run_claim_owner: Optional[str] = None
+) -> bool:
     """Atomically claim a finite one-shot job dispatch BEFORE execution.
 
     Increments ``repeat.completed`` under the cross-process jobs lock and
@@ -2292,6 +2587,22 @@ def claim_dispatch(job_id: str) -> bool:
         for i, job in enumerate(jobs):
             if job["id"] != job_id:
                 continue
+            if expected_run_claim_owner is not None:
+                current_claim = job.get("run_claim")
+                current_owner = (
+                    str(current_claim.get("by") or "")
+                    if isinstance(current_claim, dict)
+                    else ""
+                )
+                if current_owner != expected_run_claim_owner:
+                    logger.warning(
+                        "Job '%s': rejecting dispatch claim from stale "
+                        "run-claim owner %r (current owner %r)",
+                        job_id,
+                        expected_run_claim_owner,
+                        current_owner or None,
+                    )
+                    return False
             if job.get("schedule", {}).get("kind") != "once":
                 return True  # recurring jobs use advance_next_run(), not dispatch claims
             repeat = job.get("repeat")
@@ -2349,11 +2660,11 @@ def claim_dispatch(job_id: str) -> bool:
             "(handed-in job dict; nothing to persist a claim against)",
             job_id,
         )
-        return True
+        return expected_run_claim_owner is None
 
 
 def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
-    """Refresh a one-shot's ``run_claim`` timestamp while its run is alive.
+    """Refresh a job's ``run_claim`` timestamp while its run is alive.
 
     Called periodically from the scheduler's run monitor (#62002) so a
     legitimately long run keeps its claim fresh: an expired claim then really
@@ -2373,8 +2684,6 @@ def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
         for job in jobs:
             if job.get("id") != job_id:
                 continue
-            if job.get("schedule", {}).get("kind") != "once":
-                return False
             claim = job.get("run_claim")
             if not isinstance(claim, dict) or claim.get("by") != expected_owner:
                 return False
@@ -2392,14 +2701,18 @@ def advance_next_runs(job_ids) -> int:
     O(N loads + N saves) for N due jobs (~110 ms at N=50, measured), the
     batch form O(1 + 1) (~2 ms). ``job_ids`` may contain ids of one-shot
     or unknown jobs; they are skipped exactly as the per-job form skips
-    them. Returns the number of jobs whose ``next_run_at`` was advanced.
+    them. A mapping of ``job_id -> expected run_claim owner`` enables the
+    scheduler's exact-attempt CAS; the legacy iterable-of-ids form remains
+    unconditional for existing callers. Returns the number of jobs whose
+    ``next_run_at`` was advanced.
 
     Crash semantics: the batch persists once at the end, so a crash
     mid-batch re-fires the whole set on restart (at-least-once burst)
     rather than advancing a prefix — acceptable given the sub-10ms window,
     and identical to the per-job form once the batch completes.
     """
-    ids = set(job_ids)
+    expected_owners = dict(job_ids) if isinstance(job_ids, dict) else {}
+    ids = set(expected_owners or job_ids)
     if not ids:
         return 0
     with _jobs_lock():
@@ -2409,6 +2722,23 @@ def advance_next_runs(job_ids) -> int:
         for job in jobs:
             if job["id"] not in ids:
                 continue
+            expected_owner = expected_owners.get(job["id"])
+            if expected_owner:
+                claim = job.get("run_claim")
+                current_owner = (
+                    str(claim.get("by") or "")
+                    if isinstance(claim, dict)
+                    else ""
+                )
+                if current_owner != expected_owner:
+                    logger.warning(
+                        "Job '%s': refusing next-run advance from stale "
+                        "run-claim owner %r (current owner %r)",
+                        job["id"],
+                        expected_owner,
+                        current_owner or None,
+                    )
+                    continue
             kind = job.get("schedule", {}).get("kind")
             if kind not in {"cron", "interval"}:
                 continue
@@ -2419,6 +2749,33 @@ def advance_next_runs(job_ids) -> int:
         if advanced:
             save_jobs(jobs)
         return advanced
+
+
+def release_run_claim(job_id: str, *, expected_owner: str) -> bool:
+    """Clear only this attempt's claim when dispatch never begins.
+
+    This is the rollback half of the due-scan CAS. It is intentionally owner
+    fenced so a failed/stopping scheduler cannot clear a successor's claim.
+    ``fire_claim`` is cleared only when it belongs to the same attempt token.
+    """
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job.get("id") != job_id:
+                continue
+            claim = job.get("run_claim")
+            if not isinstance(claim, dict) or claim.get("by") != expected_owner:
+                return False
+            job["run_claim"] = None
+            fire_claim = job.get("fire_claim")
+            if (
+                isinstance(fire_claim, dict)
+                and fire_claim.get("by") == expected_owner
+            ):
+                job["fire_claim"] = None
+            save_jobs(jobs)
+            return True
+    return False
 
 
 def advance_next_run(job_id: str) -> bool:
@@ -2455,22 +2812,29 @@ def _machine_id() -> str:
     return f"{host}:{os.getpid()}"
 
 
-def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
-    """Atomically claim a job for a single external 'fire' (multi-machine
-    at-most-once). Returns True iff THIS caller won the claim.
+def _new_run_claim_owner() -> str:
+    """Return an immutable, unique token for one concrete run attempt."""
+    return f"{_machine_id()}:{uuid.uuid4().hex}"
+
+
+def claim_job_for_fire_attempt(
+    job_id: str, *, claim_ttl_seconds: int = 300
+) -> Optional[str]:
+    """Atomically claim an external/manual fire and return its attempt token.
 
     Used by the external-provider fire path (``CronScheduler.fire_due``) when an
     external scheduler (Chronos) signals a job is due across N gateway replicas:
     exactly one wins. Single-machine deployments always win.
 
     Under the file lock: reject if the job is missing/disabled/paused. If a
-    fresh claim (younger than ``claim_ttl_seconds``) already exists, lose.
-    Otherwise stamp a ``fire_claim`` and, for recurring jobs, advance
+    fresh fire or run claim already exists, lose. Otherwise stamp both claims
+    with one immutable per-attempt token and, for recurring jobs, advance
     ``next_run_at`` (mirrors ``advance_next_run``'s at-most-once bump so a stale
     re-delivery for the old time can't re-fire). One-shots keep ``next_run_at``
     but the fresh ``fire_claim`` blocks a duplicate retry for the same fire.
-    ``mark_job_run`` clears the claim on completion so a re-armed recurring job
-    is claimable again next fire.
+    ``mark_job_run`` clears the claims only when that same attempt token
+    completes, so a manual/external fire can neither impersonate nor clear a
+    scheduled run owned by another process.
 
     The stale-claim TTL means a machine that crashed after claiming but before
     completing doesn't wedge the job forever — after the TTL another fire can
@@ -2484,32 +2848,44 @@ def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
             # enabled + pause markers must both clear — a half-paused record
             # (enabled=true, state=paused/paused_at set) must not claim.
             if not is_job_runnable(job):
-                return False
+                return None
             now = _hermes_now()
             existing = job.get("fire_claim")
-            if existing:
-                try:
-                    claimed_at = _ensure_aware(datetime.fromisoformat(existing["at"]))
-                    # Bounded on BOTH sides (#60703): a claim stamped in the
-                    # future (clock/TZ skew across a restart, or a corrupted
-                    # timestamp) would otherwise have a negative age and stay
-                    # "fresh" forever — the job becomes permanently unfireable
-                    # and every manual `cron run` reports "already being
-                    # fired". Treat future-dated claims as stale/overwritable.
-                    _age = (now - claimed_at).total_seconds()
-                    if 0 <= _age < claim_ttl_seconds:
-                        return False  # someone holds a fresh claim
-                except Exception:
-                    pass  # malformed claim → overwrite
-            job["fire_claim"] = {"at": now.isoformat(), "by": _machine_id()}
+            if _claim_is_fresh(
+                existing,
+                now=now,
+                ttl_seconds=float(claim_ttl_seconds),
+            ):
+                return None  # someone holds a fresh claim
+
+            existing_run = job.get("run_claim")
+            if existing_run:
+                # The explicit zero-TTL mode remains a recovery/testing escape
+                # hatch. Normal callers use at least the long-run TTL so a
+                # manual fire cannot overlap queued scheduler work.
+                run_ttl = (
+                    0.0
+                    if claim_ttl_seconds <= 0
+                    else max(
+                        float(claim_ttl_seconds),
+                        _oneshot_run_claim_ttl_seconds(),
+                    )
+                )
+                if _claim_is_fresh(existing_run, now=now, ttl_seconds=run_ttl):
+                    return None
+
+            attempt_owner = _new_run_claim_owner()
+            attempt_claim = {"at": now.isoformat(), "by": attempt_owner}
+            job["fire_claim"] = dict(attempt_claim)
+            job["run_claim"] = dict(attempt_claim)
             kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())
                 if nxt:
                     job["next_run_at"] = nxt
             save_jobs(jobs)
-            return True
-        return False
+            return attempt_owner
+        return None
 
 
 # Completed one-shot job records are retained in jobs.json (final status +
@@ -2598,7 +2974,14 @@ def _sweep_completed_oneshots(
     return removed
 
 
-def get_due_jobs() -> List[Dict[str, Any]]:
+def claim_job_for_fire(job_id: str, *, claim_ttl_seconds: int = 300) -> bool:
+    """Backward-compatible bool wrapper around the attempt-token CAS."""
+    return claim_job_for_fire_attempt(
+        job_id, claim_ttl_seconds=claim_ttl_seconds
+    ) is not None
+
+
+def get_due_jobs(*, claim_recurring: bool = False) -> List[Dict[str, Any]]:
     """Get all jobs that are due to run now.
 
     For recurring jobs (cron/interval), if the scheduled time is stale (more
@@ -2611,12 +2994,18 @@ def get_due_jobs() -> List[Dict[str, Any]]:
 
     Note: firing once on catch-up flows through ``mark_job_run``, so a job with
     a ``repeat.times`` limit consumes one of its runs on that catch-up fire.
+
+    ``claim_recurring=True`` is used only by the builtin scheduler's dispatch
+    path. It atomically stamps recurring run claims under this same jobs lock;
+    read-only callers retain the historical behavior of merely listing due
+    recurring jobs. One-shot claims remain unconditional for their existing
+    at-most-once contract.
     """
     with _jobs_lock():
-        return _get_due_jobs_locked()
+        return _get_due_jobs_locked(claim_recurring=claim_recurring)
 
 
-def _get_due_jobs_locked() -> List[Dict[str, Any]]:
+def _get_due_jobs_locked(*, claim_recurring: bool = False) -> List[Dict[str, Any]]:
     """Inner implementation of get_due_jobs(); must be called with _jobs_lock held."""
     now = _hermes_now()
     raw_jobs = load_jobs()
@@ -2767,26 +3156,19 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 continue
 
             # Cross-process running-claim guard (#59229): if another scheduler
-            # process already claimed this one-shot and its run is still in flight
+            # process already claimed this job and its run is still in flight
             # (claim younger than the TTL), skip it — do NOT re-dispatch. The
             # claim is stamped just before we return the job as due (below) and
             # cleared by mark_job_run() on completion. A claim older than the TTL
-            # is treated as stale (the claiming tick died mid-run) and allowed
-            # through so the job is recovered rather than wedged forever.
+            # is treated as stale (the worker died or its final write failed) and
+            # allowed through so recurring jobs cannot wedge forever.
             existing_claim = job.get("run_claim")
-            if existing_claim and job.get("schedule", {}).get("kind") == "once":
-                try:
-                    claimed_at = _ensure_aware(
-                        datetime.fromisoformat(existing_claim["at"])
-                    )
-                    # 0 <= age: a future-dated claim (clock/TZ skew across a
-                    # restart) must be treated as stale, not eternally fresh,
-                    # or the one-shot is skipped forever (#60703).
-                    _age = (now - claimed_at).total_seconds()
-                    if 0 <= _age < _run_claim_ttl:
-                        continue  # a fresh claim is held by an in-flight run
-                except (KeyError, ValueError, TypeError):
-                    pass  # malformed claim → fall through and (re)claim
+            if _claim_is_fresh(
+                existing_claim,
+                now=now,
+                ttl_seconds=_run_claim_ttl,
+            ):
+                continue  # a fresh claim is held by an in-flight run
 
             next_run = job.get("next_run_at")
             if not next_run:
@@ -2958,24 +3340,17 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                             _write_wedged_oneshot_diagnostic(job)
                             continue
 
-                # Durably claim a one-shot for the DURATION of its run before
-                # returning it as due, so a second scheduler process (gateway +
-                # desktop both run in-process 60s tickers on one HERMES_HOME)
-                # cannot re-dispatch it while the first run is still in flight
-                # (#59229). A plain one-shot's due-state is not resolved until
-                # mark_job_run() completes it minutes later, so advancing
-                # next_run_at by a fixed window is not enough — a job that outlives
-                # one tick (e.g. a 2.5-min research prompt) would simply re-fire on
-                # the next tick after the window. Instead we stamp a run_claim under
-                # the same lock get_due_jobs already holds; the other process reads
-                # a fresh claim on its next tick and skips (handled at the top of
-                # this loop). mark_job_run() clears the claim on completion. The TTL
-                # is only a safety valve: a claiming tick that DIES mid-run leaves a
-                # stale claim that expires after the resolved run-claim TTL
-                # (_oneshot_run_claim_ttl_seconds, derived from HERMES_CRON_TIMEOUT),
-                # so the job is re-dispatched rather than wedged forever.
-                if kind == "once":
-                    claim = {"at": now.isoformat(), "by": _machine_id()}
+                # Durably claim the job for the DURATION of its run before
+                # returning it as due, so Gateway and Desktop cannot dispatch
+                # the same long one-shot OR recurring job across a process
+                # handoff. The worker refreshes this claim and mark_job_run()
+                # clears it. If the worker dies or its final store write fails,
+                # the TTL eventually makes the claim reclaimable rather than
+                # wedging recurrence forever.
+                if kind == "once" or (
+                    claim_recurring and kind in {"cron", "interval"}
+                ):
+                    claim = {"at": now.isoformat(), "by": _new_run_claim_owner()}
                     job["run_claim"] = claim
                     for rj in raw_jobs:
                         if rj["id"] == job["id"]:
@@ -3045,15 +3420,56 @@ def _prune_job_output(job_output_dir: Path, keep: int) -> int:
     return deleted
 
 
-def save_job_output(job_id: str, output: str):
-    """Save job output to file."""
+def save_job_output(
+    job_id: str,
+    output: str,
+    *,
+    expected_run_claim_owner: Optional[str] = None,
+) -> Optional[Path]:
+    """Save output, optionally as one exact-owner atomic publication.
+
+    For a claimed attempt, ownership validation and the filesystem replace run
+    under the same cross-process jobs lock.  A successor therefore cannot
+    replace the token between a check and publication.
+    """
+    if expected_run_claim_owner is not None:
+        with _jobs_lock():
+            jobs = load_jobs()
+            matched = next(
+                (job for job in jobs if job.get("id") == job_id),
+                None,
+            )
+            current_claim = matched.get("run_claim") if matched else None
+            current_owner = (
+                str(current_claim.get("by") or "")
+                if isinstance(current_claim, dict)
+                else ""
+            )
+            if current_owner != expected_run_claim_owner:
+                logger.warning(
+                    "Job '%s': suppressing output from stale run-claim owner "
+                    "%r (current owner %r)",
+                    job_id,
+                    expected_run_claim_owner,
+                    current_owner or None,
+                )
+                return None
+            return _save_job_output_unlocked(job_id, output)
+    return _save_job_output_unlocked(job_id, output)
+
+
+def _save_job_output_unlocked(job_id: str, output: str) -> Path:
+    """Filesystem half of :func:`save_job_output`; caller may hold jobs lock."""
     ensure_dirs()
     job_output_dir = _job_output_dir(job_id)
     job_output_dir.mkdir(parents=True, exist_ok=True)
     _secure_dir(job_output_dir)
 
-    timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
-    output_file = job_output_dir / f"{timestamp}.md"
+    timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S-%f")
+    # A successor can publish in the same clock tick after this attempt drops
+    # the jobs lock. Keep the returned path attempt-unique so manual/background
+    # completion excerpts can never be overwritten by that successor.
+    output_file = job_output_dir / f"{timestamp}-{uuid.uuid4().hex[:8]}.md"
 
     fd, tmp_path = tempfile.mkstemp(dir=str(job_output_dir), suffix='.tmp', prefix='.output_')
     try:

--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import difflib
 import hashlib
 import logging
+import threading
 from dataclasses import dataclass
 from typing import Optional
 
@@ -99,15 +100,6 @@ def _read_last_output(job_id: str) -> str:
     return ""
 
 
-def _write_last_output(job_id: str, output: str) -> None:
-    try:
-        path = _snapshot_path(job_id)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(output, encoding="utf-8")
-    except Exception as exc:
-        logger.warning("Monitor: failed to persist last output for %r: %s", job_id, exc)
-
-
 def _fetch_monitor_url(url: str) -> tuple[bool, str]:
     """Bounded GET of a monitor URL. Returns (ok, body-or-error)."""
     import urllib.request
@@ -125,18 +117,32 @@ def _fetch_monitor_url(url: str) -> tuple[bool, str]:
         return False, f"monitor_url fetch failed: {exc}"
 
 
-def _run_monitor_source(job: dict) -> tuple[bool, str]:
+def _run_monitor_source(
+    job: dict,
+    *,
+    claim_ownership_lost: Optional[threading.Event] = None,
+) -> tuple[bool, str]:
     """Run the job's monitor source (script or URL). Returns (ok, output)."""
     monitor_script = (job.get("monitor_script") or "").strip()
     if monitor_script:
         # Same containment + interpreter rules as the existing `script` field.
-        from cron.scheduler import _run_job_script
+        from cron.scheduler import _run_job_script_with_claim_heartbeat
 
         workdir = (job.get("workdir") or "").strip() or None
-        return _run_job_script(monitor_script, workdir=workdir)
+        return _run_job_script_with_claim_heartbeat(
+            job,
+            monitor_script,
+            workdir=workdir,
+            claim_ownership_lost=claim_ownership_lost,
+        )
     monitor_url = (job.get("monitor_url") or "").strip()
     if monitor_url:
-        return _fetch_monitor_url(monitor_url)
+        if claim_ownership_lost is not None and claim_ownership_lost.is_set():
+            return False, "Run claim ownership was lost before monitor fetch."
+        result = _fetch_monitor_url(monitor_url)
+        if claim_ownership_lost is not None and claim_ownership_lost.is_set():
+            return False, "Run claim ownership was lost during monitor fetch."
+        return result
     return False, "monitor job has neither monitor_script nor monitor_url"
 
 
@@ -144,7 +150,11 @@ def job_has_monitor(job: dict) -> bool:
     return bool((job.get("monitor_script") or "").strip() or (job.get("monitor_url") or "").strip())
 
 
-def check_monitor(job: dict) -> MonitorOutcome:
+def check_monitor(
+    job: dict,
+    *,
+    claim_ownership_lost: Optional[threading.Event] = None,
+) -> MonitorOutcome:
     """Run the monitor source and decide whether the agent should run.
 
     On change (or first run) the new hash + snapshot are persisted BEFORE
@@ -153,9 +163,21 @@ def check_monitor(job: dict) -> MonitorOutcome:
     On failure nothing is persisted.
     """
     job_id = str(job.get("id") or "")
-    ok, output = _run_monitor_source(job)
+    claim = job.get("run_claim")
+    expected_owner = (
+        str(claim.get("by") or "") if isinstance(claim, dict) else ""
+    ) or None
+    ok, output = _run_monitor_source(
+        job,
+        claim_ownership_lost=claim_ownership_lost,
+    )
     if not ok:
         return MonitorOutcome(ok=False, error=output)
+    if claim_ownership_lost is not None and claim_ownership_lost.is_set():
+        return MonitorOutcome(
+            ok=False,
+            error="Run claim ownership was lost after monitor source execution.",
+        )
 
     new_hash = hash_monitor_output(output)
     raw_state = job.get("monitor_state")
@@ -188,25 +210,40 @@ def check_monitor(job: dict) -> MonitorOutcome:
             f"### Current output\n\n```\n{shown_output}\n```"
         )
 
-    _persist_monitor_state(job_id, new_hash, output)
+    persisted = _persist_monitor_state(
+        job_id,
+        new_hash,
+        output,
+        expected_run_claim_owner=expected_owner,
+    )
+    if expected_owner is not None and not persisted:
+        if claim_ownership_lost is not None:
+            claim_ownership_lost.set()
+        return MonitorOutcome(
+            ok=False,
+            error="Run claim ownership was lost before monitor state persistence.",
+        )
     return MonitorOutcome(
         ok=True, changed=True, first_run=first_run, context_block=context_block
     )
 
 
-def _persist_monitor_state(job_id: str, new_hash: str, output: str) -> None:
-    from cron.jobs import _hermes_now, update_job
+def _persist_monitor_state(
+    job_id: str,
+    new_hash: str,
+    output: str,
+    *,
+    expected_run_claim_owner: Optional[str] = None,
+) -> bool:
+    from cron.jobs import persist_monitor_state
 
-    _write_last_output(job_id, output)
     try:
-        update_job(
+        return persist_monitor_state(
             job_id,
-            {
-                "monitor_state": {
-                    "last_output_hash": new_hash,
-                    "last_changed_at": _hermes_now().isoformat(),
-                }
-            },
+            new_hash,
+            output,
+            expected_run_claim_owner=expected_run_claim_owner,
         )
     except Exception as exc:
         logger.warning("Monitor: failed to persist state for %r: %s", job_id, exc)
+        return False

--- a/cron/notepad.py
+++ b/cron/notepad.py
@@ -26,21 +26,37 @@ from __future__ import annotations
 import sqlite3
 import threading
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
 NOTEPAD_FILE = get_hermes_home().resolve() / "cron" / "notepad.db"
+_IMPORT_NOTEPAD_FILE = NOTEPAD_FILE
 MAX_VALUE_BYTES = 16 * 1024
 MAX_KEY_CHARS = 128
 MAX_JOB_TOTAL_BYTES = 64 * 1024
 _lock = threading.RLock()
 
 
+def _current_notepad_file() -> Path:
+    """Resolve the notepad for the active cron profile context."""
+    configured = Path(NOTEPAD_FILE)
+    if configured != _IMPORT_NOTEPAD_FILE:
+        return configured
+
+    # Delayed to avoid coupling cron.jobs' import-time initialization back to
+    # this module. jobs only imports notepad from inside runtime functions.
+    from cron.jobs import _current_cron_store
+
+    return _current_cron_store().cron_dir / "notepad.db"
+
+
 def _connect() -> sqlite3.Connection:
-    NOTEPAD_FILE.parent.mkdir(parents=True, exist_ok=True)
-    return sqlite3.connect(NOTEPAD_FILE, timeout=5)
+    notepad_file = _current_notepad_file()
+    notepad_file.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(notepad_file, timeout=5)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
@@ -155,7 +171,7 @@ def clear_notepad(job_id: str) -> int:
     Called from ``cron.jobs.remove_job`` so deleted jobs don't orphan their
     rows. No-ops without creating the DB when no notepad file exists yet.
     """
-    if not NOTEPAD_FILE.exists():
+    if not _current_notepad_file().exists():
         return 0
     with _transaction() as conn:
         cur = conn.execute(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -34,14 +35,14 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_process_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import (
     _expand_env_vars,
@@ -290,8 +291,21 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_runs, claim_dispatch, heartbeat_run_claim
-from cron.executions import create_execution, finish_execution, mark_execution_running
+from cron.jobs import (
+    _oneshot_run_claim_ttl_seconds,
+    advance_next_runs,
+    claim_dispatch,
+    get_due_jobs,
+    heartbeat_run_claim,
+    mark_job_run,
+    release_run_claim,
+    save_job_output,
+)
+from cron.executions import (
+    create_execution,
+    finish_execution,
+    mark_execution_running,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -334,6 +348,7 @@ def _is_cron_silence_response(text: str) -> bool:
 _parallel_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _parallel_pool_max_workers: Optional[int] = None
 _running_job_ids: set = set()
+_running_run_claim_owners: dict[str, str] = {}
 _running_lock = threading.Lock()
 
 # Job IDs the gateway shutdown path force-killed the tool subprocess of
@@ -344,6 +359,7 @@ _running_lock = threading.Lock()
 # plausible-looking final response from truncated output — can never
 # overwrite the interrupted status with a false "ok" (#60432).
 _interrupted_job_ids: set = set()
+_interrupted_run_claim_owners: dict[str, Optional[str]] = {}
 
 
 def get_running_job_ids() -> "frozenset[str]":
@@ -362,10 +378,39 @@ def get_running_job_ids() -> "frozenset[str]":
     blind to them (#60432).
     """
     with _running_lock:
-        return frozenset(_running_job_ids)
+        return frozenset(
+            str(running_key).rsplit("\0", 1)[-1]
+            for running_key in _running_job_ids
+        )
 
 
-def try_register_running_job(job_id: str) -> bool:
+def _running_job_key(job_id: str, *, profile_scoped: bool) -> str:
+    """Return the legacy bare ID or the active profile's in-flight key."""
+    if not profile_scoped:
+        return job_id
+    return f"{_get_hermes_home().resolve()}\0{job_id}"
+
+
+def is_running_job(job_id: str, *, profile_scoped: bool = False) -> bool:
+    """Whether ``job_id`` is registered in the requested profile scope.
+
+    A legacy bare registration has no recoverable profile identity, so it
+    conservatively blocks a scoped lookup. Scoped registrations from another
+    profile do not: identical job IDs are valid in independent cron stores.
+    """
+    running_key = _running_job_key(job_id, profile_scoped=profile_scoped)
+    with _running_lock:
+        return running_key in _running_job_ids or (
+            profile_scoped and job_id in _running_job_ids
+        )
+
+
+def try_register_running_job(
+    job_id: str,
+    *,
+    profile_scoped: bool = False,
+    attempt_owner: Optional[str] = None,
+) -> bool:
     """Atomically add ``job_id`` to the in-flight running set.
 
     Returns False (without registering) when the job is already mid-run —
@@ -380,18 +425,46 @@ def try_register_running_job(job_id: str) -> bool:
     gateway shutdown drain, #60432) and ``mark_running_jobs_interrupted``.
     Callers MUST pair a successful registration with
     ``release_running_job`` in a ``finally`` block.
+
+    ``profile_scoped=False`` preserves the historical bare-ID API for older
+    callers and tests. Manual/background attempts pass ``profile_scoped=True``
+    plus their immutable claim owner so shutdown can target the correct cron
+    store and make an exact-owner terminal write.
     """
+    running_key = _running_job_key(job_id, profile_scoped=profile_scoped)
     with _running_lock:
-        if job_id in _running_job_ids:
+        if running_key in _running_job_ids or (
+            profile_scoped and job_id in _running_job_ids
+        ):
             return False
-        _running_job_ids.add(job_id)
+        _running_job_ids.add(running_key)
+        if attempt_owner:
+            _running_run_claim_owners[running_key] = attempt_owner
         return True
 
 
-def release_running_job(job_id: str) -> None:
-    """Remove ``job_id`` from the in-flight running set (idempotent)."""
+def release_running_job(
+    job_id: str,
+    *,
+    profile_scoped: bool = False,
+    attempt_owner: Optional[str] = None,
+) -> bool:
+    """Remove an in-flight registration, optionally fencing by owner.
+
+    Legacy bare-ID calls remain idempotent. Scoped manual/background callers
+    provide ``attempt_owner`` so a stale attempt cannot discard its successor's
+    in-process registration.
+    """
+    running_key = _running_job_key(job_id, profile_scoped=profile_scoped)
     with _running_lock:
-        _running_job_ids.discard(job_id)
+        if attempt_owner is not None and (
+            _running_run_claim_owners.get(running_key) != attempt_owner
+        ):
+            return False
+        existed = running_key in _running_job_ids
+        _running_job_ids.discard(running_key)
+        _running_run_claim_owners.pop(running_key, None)
+        return existed
 
 
 def mark_running_jobs_interrupted(reason: str) -> list:
@@ -419,19 +492,80 @@ def mark_running_jobs_interrupted(reason: str) -> list:
     Returns the list of job IDs marked, for the caller to log.
     """
     with _running_lock:
-        job_ids = list(_running_job_ids)
-        _interrupted_job_ids.update(job_ids)
+        attempts = []
+        for running_key in _running_job_ids:
+            key_text = str(running_key)
+            if "\0" in key_text:
+                profile_home, job_id = key_text.rsplit("\0", 1)
+            else:
+                profile_home, job_id = None, key_text
+            attempts.append(
+                (
+                    key_text,
+                    profile_home,
+                    job_id,
+                    _running_run_claim_owners.get(key_text),
+                )
+            )
+        _interrupted_job_ids.update(
+            interrupt_key
+            for interrupt_key, _home, _job_id, _owner in attempts
+        )
+        _interrupted_run_claim_owners.update(
+            {
+                interrupt_key: owner
+                for interrupt_key, _home, _job_id, owner in attempts
+            }
+        )
     marked = []
-    for job_id in job_ids:
+    for _interrupt_key, profile_home, job_id, claim_owner in attempts:
         try:
-            mark_job_run(job_id, False, reason)
-            marked.append(job_id)
+            mark_kwargs = (
+                {"expected_run_claim_owner": claim_owner}
+                if claim_owner
+                else {}
+            )
+            if profile_home is None:
+                marked_result = mark_job_run(
+                    job_id, False, reason, **mark_kwargs
+                )
+            else:
+                from cron.jobs import use_cron_store
+                from hermes_constants import (
+                    reset_hermes_home_override,
+                    set_hermes_home_override,
+                )
+
+                home_token = set_hermes_home_override(profile_home)
+                try:
+                    with use_cron_store(Path(profile_home)):
+                        marked_result = mark_job_run(
+                            job_id, False, reason, **mark_kwargs
+                        )
+                finally:
+                    reset_hermes_home_override(home_token)
+            # Legacy/mocked mark_job_run returned None on success. Only an
+            # explicit False means the attempt token lost its CAS.
+            if marked_result is not False:
+                marked.append(job_id)
+            else:
+                with _running_lock:
+                    if (
+                        _interrupted_run_claim_owners.get(_interrupt_key)
+                        == claim_owner
+                    ):
+                        _interrupted_job_ids.discard(_interrupt_key)
+                        _interrupted_run_claim_owners.pop(
+                            _interrupt_key, None
+                        )
         except Exception as e:
             logger.warning("Failed to mark job %s interrupted: %s", job_id, e)
     return marked
 
 
-def _is_interrupted(job_id: str) -> bool:
+def _is_interrupted(
+    job_id: str, *, expected_run_claim_owner: Optional[str] = None
+) -> bool:
     """Non-destructive peek at whether the shutdown path has marked
     ``job_id`` interrupted (see ``mark_running_jobs_interrupted``).
 
@@ -443,10 +577,23 @@ def _is_interrupted(job_id: str) -> bool:
     flag: the later, authoritative check (right before ``last_status`` is
     written) still needs to see it."""
     with _running_lock:
-        return job_id in _interrupted_job_ids
+        scoped_key = f"{_get_hermes_home().resolve()}\0{job_id}"
+        for key in (scoped_key, job_id):
+            if key not in _interrupted_job_ids:
+                continue
+            flagged_owner = _interrupted_run_claim_owners.get(key)
+            if (
+                expected_run_claim_owner is None
+                or flagged_owner is None
+                or flagged_owner == expected_run_claim_owner
+            ):
+                return True
+        return False
 
 
-def _consume_interrupted_flag(job_id: str) -> bool:
+def _consume_interrupted_flag(
+    job_id: str, *, expected_run_claim_owner: Optional[str] = None
+) -> bool:
     """Return True and clear the flag if the shutdown path already marked
     ``job_id`` interrupted (see ``mark_running_jobs_interrupted``).
 
@@ -455,8 +602,19 @@ def _consume_interrupted_flag(job_id: str) -> bool:
     the flag from leaking across a later, unrelated run of the same job ID
     (recurring jobs reuse their ID every fire)."""
     with _running_lock:
-        if job_id in _interrupted_job_ids:
-            _interrupted_job_ids.discard(job_id)
+        scoped_key = f"{_get_hermes_home().resolve()}\0{job_id}"
+        for key in (scoped_key, job_id):
+            if key not in _interrupted_job_ids:
+                continue
+            flagged_owner = _interrupted_run_claim_owners.get(key)
+            if (
+                expected_run_claim_owner is not None
+                and flagged_owner is not None
+                and flagged_owner != expected_run_claim_owner
+            ):
+                continue
+            _interrupted_job_ids.discard(key)
+            _interrupted_run_claim_owners.pop(key, None)
             return True
         return False
 
@@ -1178,16 +1336,35 @@ def _resolve_home_env_var(platform_name: str) -> str:
     return _plugin_cron_env_var(name)
 
 
+def _profile_scoped_env(name: str) -> str:
+    """Read profile-local dotenv data when a secret scope is active.
+
+    Multiplex workers share ``os.environ``; it can only represent the process
+    profile.  ``build_profile_secret_scope`` snapshots each selected profile's
+    dotenv values, so delivery routing must use that scope before falling back
+    to the legacy single-profile process environment.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, get_secret
+
+        if current_secret_scope() is not None:
+            return str(get_secret(name) or "")
+    except Exception:
+        logger.debug("Failed to read profile-scoped value %s", name, exc_info=True)
+        return ""
+    return os.getenv(name, "")
+
+
 def _get_home_target_chat_id(platform_name: str) -> str:
     """Return the configured home target chat/room ID for a delivery platform."""
     env_var = _resolve_home_env_var(platform_name)
     if not env_var:
         return ""
-    value = os.getenv(env_var, "")
+    value = _profile_scoped_env(env_var)
     if not value:
         legacy = _LEGACY_HOME_TARGET_ENV_VARS.get(env_var)
         if legacy:
-            value = os.getenv(legacy, "")
+            value = _profile_scoped_env(legacy)
     return value
 
 
@@ -1206,14 +1383,14 @@ def _get_home_target_thread_id(platform_name: str) -> Optional[str]:
     if not env_var:
         return None
     if platform_name.lower() == "telegram":
-        cron_thread = os.getenv("TELEGRAM_CRON_THREAD_ID", "").strip()
+        cron_thread = _profile_scoped_env("TELEGRAM_CRON_THREAD_ID").strip()
         if cron_thread:
             return cron_thread
-    value = os.getenv(f"{env_var}_THREAD_ID", "").strip()
+    value = _profile_scoped_env(f"{env_var}_THREAD_ID").strip()
     if not value:
         legacy = _LEGACY_HOME_TARGET_ENV_VARS.get(env_var)
         if legacy:
-            value = os.getenv(f"{legacy}_THREAD_ID", "").strip()
+            value = _profile_scoped_env(f"{legacy}_THREAD_ID").strip()
     return value or None
 
 
@@ -1477,6 +1654,7 @@ def _send_media_via_adapter(
     loop,
     job: dict,
     platform=None,
+    ownership_guard: Optional[Callable[[], bool]] = None,
 ) -> None:
     """Send extracted MEDIA files as native platform attachments via a live adapter.
 
@@ -1491,6 +1669,8 @@ def _send_media_via_adapter(
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
     for media_path, _is_voice in media_files:
+        if ownership_guard is not None and not ownership_guard():
+            return
         try:
             ext = Path(media_path).suffix.lower()
             route_platform = platform if platform is not None else getattr(adapter, "platform", None)
@@ -1602,7 +1782,15 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    *,
+    claim_ownership_lost: Optional[threading.Event] = None,
+    expected_run_claim_owner: Optional[str] = None,
+) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -1613,6 +1801,32 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     Returns None on success, or an error string on failure.
     """
+    ownership_error = "Run claim ownership was lost during delivery."
+
+    def _delivery_owned(phase: str) -> bool:
+        if claim_ownership_lost is not None and claim_ownership_lost.is_set():
+            return False
+        if expected_run_claim_owner is None:
+            return True
+        try:
+            owned = heartbeat_run_claim(
+                job["id"], expected_owner=expected_run_claim_owner
+            )
+        except Exception:
+            owned = False
+            logger.warning(
+                "Job '%s': could not verify run claim before delivery phase %s",
+                job.get("id"),
+                phase,
+                exc_info=True,
+            )
+        if not owned and claim_ownership_lost is not None:
+            claim_ownership_lost.set()
+        return owned
+
+    if not _delivery_owned("target resolution"):
+        return ownership_error
+
     targets = _resolve_delivery_targets(job)
     if not targets:
         deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
@@ -1690,6 +1904,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     delivery_errors = []
 
     for target in targets:
+        if not _delivery_owned("target"):
+            return ownership_error
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
@@ -1862,6 +2078,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             and loop is not None
             and not thread_id  # never override an explicit origin thread/topic
         ):
+            if not _delivery_owned("continuation thread creation"):
+                return ownership_error
             new_thread_id = _open_continuable_cron_thread(
                 job, runtime_adapter, chat_id, loop,
             )
@@ -1900,7 +2118,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             )
             route_via_dm_topic = is_ambiguous_telegram_topic and _is_channel_dm_topic(
                 runtime_adapter, chat_id, loop, job["id"],
-            )
+            ) if _delivery_owned("Telegram topic probe") else False
+            if not _delivery_owned("post-topic-probe"):
+                return ownership_error
             if route_via_dm_topic:
                 # Genuine Bot API channel Direct-Messages topic (#22773 mode 2):
                 # routed via direct_messages_topic_id, no bare thread_id.
@@ -1939,6 +2159,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 adapter_ok = True
                 timed_out = False
                 if text_to_send:
+                    if not _delivery_owned("live text send"):
+                        return ownership_error
                     from agent.async_utils import safe_schedule_threadsafe
 
                     router = DeliveryRouter(config, adapters)
@@ -2084,7 +2306,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # payload is already assumed delivered (#38922).  Record the
                 # skipped attachments so the drop is visible rather than silently
                 # lost.
+                if not _delivery_owned("post-live-send"):
+                    return ownership_error
                 if adapter_ok and not timed_out and media_files:
+                    if not _delivery_owned("live media send"):
+                        return ownership_error
                     routed_media_metadata = dict(media_metadata or {})
                     if transport is not None and transport.is_relay:
                         routed_media_metadata["_relay_logical_platform"] = platform.value
@@ -2102,6 +2328,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         loop,
                         job,
                         platform=platform,
+                        ownership_guard=lambda: _delivery_owned(
+                            "live media item"
+                        ),
                     )
                 elif timed_out and media_files:
                     msg = (
@@ -2117,6 +2346,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     # Seed the thread session only now that delivery into it
                     # succeeded (deferred from thread-open above).
                     if opened_thread_id and not thread_seeded:
+                        if not _delivery_owned("thread session seed"):
+                            return ownership_error
                         _seed_cron_thread_session(
                             job, runtime_adapter, platform_name, chat_id,
                             opened_thread_id, mirror_text,
@@ -2128,12 +2359,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     # session — the flat row is otherwise absent for a
                     # chat_postMessage delivery, so the brief would be lost).
                     if in_channel_surface and mirror_this_target and not thread_seeded:
+                        if not _delivery_owned("channel session seed"):
+                            return ownership_error
                         inchannel_seeded = _seed_cron_channel_session(
                             job, runtime_adapter, platform_name, chat_id,
                             mirror_text, is_dm=is_dm_target,
                             user_id=origin_user_id,
                             chat_name=origin.get("chat_name"),
                         )
+                    if not _delivery_owned("live delivery mirror"):
+                        return ownership_error
                     _maybe_mirror_cron_delivery(
                         job, platform_name, chat_id, mirror_text,
                         thread_id=thread_id, user_id=origin_user_id,
@@ -2152,6 +2387,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
 
         if not delivered:
+            if not _delivery_owned("standalone fallback"):
+                return ownership_error
             if transport is not None and transport.is_relay:
                 # Relay owns the logical destination and its connector owns the
                 # platform credential. A native retry could duplicate delivery
@@ -2175,7 +2412,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            if not _delivery_owned("standalone send"):
+                return ownership_error
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+                ownership_guard=lambda: _delivery_owned("standalone item"),
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -2204,7 +2451,24 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        if not _delivery_owned("standalone thread submit"):
+                            return ownership_error
+                        delivery_context = contextvars.copy_context()
+                        future = pool.submit(
+                            delivery_context.run,
+                            asyncio.run,
+                            _send_to_platform(
+                                platform,
+                                pconfig,
+                                chat_id,
+                                cleaned_delivery_content,
+                                thread_id=thread_id,
+                                media_files=media_files,
+                                ownership_guard=lambda: _delivery_owned(
+                                    "standalone thread item"
+                                ),
+                            ),
+                        )
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)
@@ -2229,6 +2493,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
 
+            if not _delivery_owned("post-standalone send"):
+                return ownership_error
             if result and result.get("error"):
                 # Include target context (platform/chat) so a bare error string
                 # like "Discord send failed: TimeoutError: " is attributable.
@@ -2240,6 +2506,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
 
+            if not _delivery_owned("standalone delivery mirror"):
+                return ownership_error
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
             _maybe_mirror_cron_delivery(
                 job, platform_name, chat_id, mirror_text,
@@ -2256,6 +2524,99 @@ _DEFAULT_SCRIPT_TIMEOUT = 3600  # seconds (1 hour)
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
 _RUN_CLAIM_HEARTBEAT_SECONDS = 60.0
+_RUN_CLAIM_SELF_FENCE_FRACTION = 0.75
+
+
+def _run_claim_self_fence_seconds() -> float:
+    """Stop an unverifiable worker before a peer may reclaim its token."""
+    return max(
+        0.001,
+        _oneshot_run_claim_ttl_seconds() * _RUN_CLAIM_SELF_FENCE_FRACTION,
+    )
+
+
+def _run_claim_owner(job: dict) -> str:
+    claim = job.get("run_claim")
+    return str(claim.get("by") or "") if isinstance(claim, dict) else ""
+
+
+def _start_run_claim_heartbeat(
+    job: dict,
+    *,
+    thread_name: str,
+    ownership_lost: Optional[threading.Event] = None,
+) -> tuple[threading.Event, threading.Event, threading.Thread] | None:
+    """Start a profile-scoped heartbeat for one immutable attempt token.
+
+    The builtin scheduler starts this before executor submission, so the claim
+    remains live while a job waits in a persistent pool as well as while its
+    worker runs. Direct/external paths also retain their inner script/agent
+    heartbeats because they do not pass through that pool.
+    """
+    owner = _run_claim_owner(job)
+    if not owner:
+        return None
+
+    job_id = str(job.get("id") or "")
+    ownership_lost = ownership_lost or threading.Event()
+    if ownership_lost.is_set():
+        raise RuntimeError("run was cancelled before claim heartbeat startup")
+    if not heartbeat_run_claim(job_id, expected_owner=owner):
+        raise RuntimeError("run claim is no longer owned by this attempt")
+
+    stop = threading.Event()
+    heartbeat_context = contextvars.copy_context()
+
+    def _heartbeat_loop() -> None:
+        last_success = time.monotonic()
+        while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
+            try:
+                if not heartbeat_run_claim(job_id, expected_owner=owner):
+                    ownership_lost.set()
+                    return
+                last_success = time.monotonic()
+            except Exception:
+                logger.debug(
+                    "Job '%s': transient run_claim heartbeat failure; retrying",
+                    job_id,
+                    exc_info=True,
+                )
+                # Store availability errors do not prove that a successor owns
+                # the attempt. Keep retrying: while the store is unavailable a
+                # peer cannot safely claim either, and a definite later CAS
+                # mismatch will set ownership_lost.
+                if (
+                    time.monotonic() - last_success
+                    >= _run_claim_self_fence_seconds()
+                ):
+                    logger.error(
+                        "Job '%s': run claim could not be renewed before "
+                        "the self-fence deadline; cancelling stale attempt",
+                        job_id,
+                    )
+                    ownership_lost.set()
+                    return
+                continue
+
+    heartbeat_thread = threading.Thread(
+        target=heartbeat_context.run,
+        args=(_heartbeat_loop,),
+        name=thread_name,
+        daemon=True,
+    )
+    heartbeat_thread.start()
+    return stop, ownership_lost, heartbeat_thread
+
+
+def _stop_run_claim_heartbeat(
+    heartbeat: tuple[threading.Event, threading.Event, threading.Thread] | None,
+) -> None:
+    if heartbeat is None:
+        return
+    stop, _ownership_lost, thread = heartbeat
+    stop.set()
+    if thread is not threading.current_thread():
+        thread.join(timeout=1.0)
 
 
 def _get_script_timeout() -> int:
@@ -2349,9 +2710,80 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
     return str(interpreter), env_overlay
 
 
+class _CronScriptClaimLost(RuntimeError):
+    """Raised after terminating a script whose immutable attempt was replaced."""
+
+
+def _terminate_cron_script_process(proc: subprocess.Popen) -> None:
+    """Best-effort terminate the script's isolated process tree."""
+    if sys.platform == "win32":
+        try:
+            from gateway.status import terminate_pid
+
+            terminate_pid(proc.pid, force=True)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+        try:
+            proc.wait(timeout=2.0)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+        return
+
+    # Cancellable scripts are spawned in a fresh POSIX session, whose process
+    # group ID is the leader PID. Signal the group so a shell script cannot
+    # leave grandchildren running after its scheduler attempt loses ownership.
+    pgid = proc.pid
+    killpg = getattr(os, "killpg", None)
+    if killpg is None:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        return
+    sigterm = getattr(signal, "SIGTERM", 15)
+    sigkill = getattr(signal, "SIGKILL", sigterm)
+    try:
+        killpg(pgid, sigterm)
+    except (ProcessLookupError, PermissionError, OSError):
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline:
+        try:
+            killpg(pgid, 0)
+        except ProcessLookupError:
+            break
+        except (PermissionError, OSError):
+            break
+        try:
+            proc.poll()
+        except Exception:
+            pass
+        time.sleep(0.02)
+    else:
+        try:
+            killpg(pgid, sigkill)
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.kill()
+            except Exception:
+                pass
+    try:
+        proc.wait(timeout=1.0)
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
+    cancel_event: Optional[threading.Event] = None,
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -2384,6 +2816,9 @@ def _run_job_script(
             mutated, avoiding the global-side-effect bug where a cron
             job's ``os.chdir()`` leaks into concurrent gateway sessions
             (#69396).
+        cancel_event: When set, terminate the isolated script process group
+            before returning. Claimed cron attempts use this to fence stale
+            scripts after a successor replaces their immutable run token.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -2468,15 +2903,64 @@ def _run_job_script(
         # NEVER mutate the Python process cwd — that would leak into
         # concurrent gateway sessions (#69396).
         _script_cwd = workdir or str(path.parent)
-        result = subprocess.run(
-            argv,
-            capture_output=True,
-            text=True,
-            timeout=script_timeout,
-            cwd=_script_cwd,
-            env=env,
-            **popen_kwargs,
-        )
+        if cancel_event is None:
+            # Preserve the historical direct helper behavior and its platform
+            # decoding contract. Claimed runs always take the cancellable path
+            # below via _run_job_script_with_claim_heartbeat.
+            result = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=script_timeout,
+                cwd=_script_cwd,
+                env=env,
+                **popen_kwargs,
+            )
+        else:
+            if cancel_event.is_set():
+                raise _CronScriptClaimLost(
+                    "Run claim ownership was lost before script execution."
+                )
+            cancellable_kwargs = dict(popen_kwargs)
+            if sys.platform == "win32":
+                cancellable_kwargs["creationflags"] = (
+                    int(cancellable_kwargs.get("creationflags", 0))
+                    | int(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0))
+                )
+            else:
+                cancellable_kwargs["start_new_session"] = True
+            proc = subprocess.Popen(
+                argv,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                cwd=_script_cwd,
+                env=env,
+                **cancellable_kwargs,
+            )
+            deadline = time.monotonic() + script_timeout
+            while True:
+                if cancel_event.is_set():
+                    _terminate_cron_script_process(proc)
+                    raise _CronScriptClaimLost(
+                        "Run claim ownership was lost during script execution."
+                    )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    _terminate_cron_script_process(proc)
+                    raise subprocess.TimeoutExpired(argv, script_timeout)
+                try:
+                    stdout, stderr = proc.communicate(timeout=min(0.1, remaining))
+                    result = subprocess.CompletedProcess(
+                        argv,
+                        proc.returncode,
+                        stdout=stdout,
+                        stderr=stderr,
+                    )
+                    break
+                except subprocess.TimeoutExpired:
+                    continue
         stdout = (result.stdout or "").strip()
         stderr = (result.stderr or "").strip()
 
@@ -2502,49 +2986,72 @@ def _run_job_script(
 
     except subprocess.TimeoutExpired:
         return False, f"Script timed out after {script_timeout}s: {path}"
+    except _CronScriptClaimLost as exc:
+        return False, str(exc)
     except Exception as exc:
         return False, f"Script execution failed: {exc}"
 
 
 def _run_job_script_with_claim_heartbeat(
-    job: dict, script_path: str, workdir: Optional[str] = None,
+    job: dict,
+    script_path: str,
+    workdir: Optional[str] = None,
+    claim_ownership_lost: Optional[threading.Event] = None,
 ) -> tuple[bool, str]:
-    """Run a cron script while keeping its owned one-shot claim fresh.
+    """Run a cron script while keeping its durable run claim fresh.
 
     Script execution is synchronous and may legitimately outlive the stale
     claim TTL.  Without a concurrent heartbeat, another scheduler process can
-    mistake the live run for a dead owner and dispatch the same one-shot again.
-    Recurring jobs and unclaimed/manual runs have no durable one-shot claim and
-    therefore use the ordinary script path without starting a thread.
+    mistake the live run for a dead owner and dispatch the same job again.
+    Unclaimed/manual runs use the ordinary script path without a heartbeat.
 
     The claim owner is captured from the dispatched job and never re-read from
     storage.  ``heartbeat_run_claim`` compares that stable owner before every
     refresh, so a stale runner cannot extend a replacement owner's claim.
     """
-    schedule = job.get("schedule")
     claim = job.get("run_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
-    if not (
-        isinstance(schedule, dict)
-        and schedule.get("kind") == "once"
-        and owner
-    ):
+    if not owner:
         return _run_job_script(script_path, workdir=workdir)
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
+    has_outer_heartbeat = claim_ownership_lost is not None
+    ownership_lost = claim_ownership_lost or threading.Event()
     heartbeat_context = contextvars.copy_context()
 
+    try:
+        if not heartbeat_run_claim(job_id, expected_owner=owner):
+            ownership_lost.set()
+            return False, "Run claim ownership was lost before script execution."
+    except Exception:
+        return False, "Run claim ownership could not be verified before script execution."
+
     def _heartbeat_loop() -> None:
+        last_success = time.monotonic()
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
             try:
-                heartbeat_run_claim(job_id, expected_owner=owner)
+                if not heartbeat_run_claim(job_id, expected_owner=owner):
+                    ownership_lost.set()
+                    return
+                last_success = time.monotonic()
             except Exception:
                 logger.debug(
-                    "Job '%s': script run_claim heartbeat failed",
+                    "Job '%s': transient script run_claim heartbeat failure; retrying",
                     job_id,
                     exc_info=True,
                 )
+                if (
+                    time.monotonic() - last_success
+                    >= _run_claim_self_fence_seconds()
+                ):
+                    logger.error(
+                        "Job '%s': script claim could not be renewed before "
+                        "the self-fence deadline; terminating script",
+                        job_id,
+                    )
+                    ownership_lost.set()
+                    return
 
     heartbeat_thread = threading.Thread(
         target=heartbeat_context.run,
@@ -2560,10 +3067,30 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path, workdir=workdir)
+        if not has_outer_heartbeat:
+            return False, (
+                "Run claim heartbeat could not start; refusing to execute "
+                "an unfenced script."
+            )
+        # run_one_job's lifecycle heartbeat still owns this shared loss Event.
+        # Keep the process cancellable by that outer fence.
+        return _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=ownership_lost,
+        )
 
     try:
-        return _run_job_script(script_path, workdir=workdir)
+        if ownership_lost.is_set():
+            return False, "Run claim ownership was lost before script execution."
+        result = _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=ownership_lost,
+        )
+        if ownership_lost.is_set():
+            return False, "Run claim ownership was lost during script execution."
+        return result
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -3166,8 +3693,11 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
 
 
 def run_job(
-    job: dict, *, defer_agent_teardown: Optional[list] = None,
+    job: dict,
+    *,
+    defer_agent_teardown: Optional[list] = None,
     extra_prompt: Optional[str] = None,
+    claim_ownership_lost: Optional[threading.Event] = None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -3191,6 +3721,11 @@ def run_job(
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    claim_ownership_lost = claim_ownership_lost or threading.Event()
+
+    if claim_ownership_lost.is_set():
+        error = "Run claim ownership was lost before job execution."
+        return False, "", "", error
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -3221,7 +3756,14 @@ def run_job(
         try:
             from hermes_cli.env_loader import load_hermes_dotenv
 
-            load_hermes_dotenv(hermes_home=_get_hermes_home())
+            if _get_hermes_home().resolve() == get_process_hermes_home().resolve():
+                load_hermes_dotenv(hermes_home=_get_hermes_home())
+            else:
+                logger.debug(
+                    "Job '%s': secondary profile no_agent run uses scoped "
+                    "delivery config; skipping process env reload",
+                    job_id,
+                )
         except Exception:
             logger.debug(
                 "Job '%s': no_agent .env reload failed", job_id, exc_info=True
@@ -3247,7 +3789,10 @@ def run_job(
 
         try:
             ok, output = _run_job_script_with_claim_heartbeat(
-                job, script_path, workdir=_job_workdir,
+                job,
+                script_path,
+                workdir=_job_workdir,
+                claim_ownership_lost=claim_ownership_lost,
             )
         except Exception as exc:
             logger.exception(
@@ -3321,7 +3866,10 @@ def run_job(
 
     _monitor_context: Optional[str] = None
     if job_has_monitor(job):
-        _mon = check_monitor(job)
+        _mon = check_monitor(
+            job,
+            claim_ownership_lost=claim_ownership_lost,
+        )
         _mon_now = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
         if not _mon.ok:
             # Source failure is an ERROR, never a change: alert the user so
@@ -3423,7 +3971,13 @@ def run_job(
         if _session_db_timeout > 0:
             _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
             try:
-                _session_db = _session_db_pool.submit(SessionDB).result(timeout=_session_db_timeout)
+                # Pass the path explicitly: ContextVars do not automatically
+                # cross ThreadPoolExecutor boundaries, and SessionDB() would
+                # otherwise fall back to the process/default profile state.db.
+                _session_db = _session_db_pool.submit(
+                    SessionDB,
+                    db_path=_get_hermes_home() / "state.db",
+                ).result(timeout=_session_db_timeout)
             finally:
                 # Don't wait for a wedged connect() to unwind — abandon the
                 # worker thread (same pattern as the agent inactivity timeout
@@ -3431,7 +3985,7 @@ def run_job(
                 _session_db_pool.shutdown(wait=False)
         else:
             # 0 = unlimited (legacy behavior, opt-in for debugging)
-            _session_db = SessionDB()
+            _session_db = SessionDB(db_path=_get_hermes_home() / "state.db")
     except concurrent.futures.TimeoutError:
         logger.error(
             "Job '%s': SessionDB init did not return within %.0fs — proceeding "
@@ -3449,8 +4003,14 @@ def run_job(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
+        prerun_script = _run_job_script_with_claim_heartbeat(
+            job,
+            script_path,
+            claim_ownership_lost=claim_ownership_lost,
+        )
         _ran_ok, _script_output = prerun_script
+        if claim_ownership_lost.is_set():
+            return False, "", "", "Run claim ownership was lost during pre-run script."
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
                 "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
@@ -3672,8 +4232,18 @@ def run_job(
             load_hermes_dotenv,
             reset_secret_source_cache,
         )
-        reset_secret_source_cache()
-        load_hermes_dotenv(hermes_home=_get_hermes_home())
+        if _get_hermes_home().resolve() == get_process_hermes_home().resolve():
+            reset_secret_source_cache()
+            load_hermes_dotenv(hermes_home=_get_hermes_home())
+        else:
+            # A multiplex/profile override is context-local but os.environ is
+            # process-global. Loading a secondary .env here would overwrite the
+            # primary profile for concurrent chat/cron workers. Credentials and
+            # delivery routing resolve from the active ProfileSecretScope.
+            logger.debug(
+                "Job '%s': using profile secret scope; skipping process env reload",
+                job_id,
+            )
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
@@ -3839,7 +4409,21 @@ def run_job(
                     # marker so a FUTURE config break re-alerts.
                     try:
                         from cron.jobs import clear_preflight_alerted
-                        clear_preflight_alerted(job_id)
+                        cleared = clear_preflight_alerted(
+                            job_id,
+                            expected_run_claim_owner=(
+                                _run_claim_owner(job) or None
+                            ),
+                        )
+                        if _run_claim_owner(job) and cleared is None:
+                            claim_ownership_lost.set()
+                            return (
+                                False,
+                                "",
+                                "",
+                                "Run claim ownership was lost while clearing "
+                                "preflight state.",
+                            )
                     except Exception:
                         pass
         except Exception:
@@ -3859,7 +4443,19 @@ def run_job(
             already_alerted = False
             try:
                 from cron.jobs import mark_preflight_alerted
-                already_alerted = mark_preflight_alerted(job_id)
+                already_alerted = mark_preflight_alerted(
+                    job_id,
+                    expected_run_claim_owner=(_run_claim_owner(job) or None),
+                )
+                if _run_claim_owner(job) and already_alerted is None:
+                    claim_ownership_lost.set()
+                    return (
+                        False,
+                        "",
+                        "",
+                        "Run claim ownership was lost while recording "
+                        "preflight state.",
+                    )
             except Exception:
                 logger.debug(
                     "Job '%s': could not persist preflight alert marker",
@@ -4124,36 +4720,85 @@ def run_job(
         _cron_timeout = _cron_inactivity_seconds()
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _POLL_INTERVAL = 5.0
-        # Keep the one-shot run_claim fresh while the run is alive (#62002):
+        # Keep the durable run_claim fresh while the run is alive (#62002):
         # the claim TTL is a dead-owner detector, but without a heartbeat a
         # run that legitimately outlives it (stream stall, laptop asleep
         # mid-run) is indistinguishable from a dead tick — another process
         # re-dispatches it and get_due_jobs stale-removes the job record out
         # from under the live run. Refreshing the claim from this monitor
         # keeps "expired claim" meaning "owner died".
-        _job_schedule = job.get("schedule")
-        _is_oneshot = (
-            isinstance(_job_schedule, dict) and _job_schedule.get("kind") == "once"
-        )
         _run_claim = job.get("run_claim")
-        _run_claim_owner = (
+        _active_run_claim_owner = (
             str(_run_claim.get("by") or "") if isinstance(_run_claim, dict) else ""
         )
         _last_claim_heartbeat = time.monotonic()
+        _last_claim_success = _last_claim_heartbeat
 
         def _heartbeat_run_claim_if_due():
-            nonlocal _last_claim_heartbeat
-            if not _is_oneshot or not _run_claim_owner:
+            nonlocal _last_claim_heartbeat, _last_claim_success
+            if not _active_run_claim_owner:
                 return
             _mono = time.monotonic()
             if _mono - _last_claim_heartbeat < _RUN_CLAIM_HEARTBEAT_SECONDS:
                 return
             _last_claim_heartbeat = _mono
             try:
-                heartbeat_run_claim(job_id, expected_owner=_run_claim_owner)
+                if not heartbeat_run_claim(
+                    job_id, expected_owner=_active_run_claim_owner
+                ):
+                    claim_ownership_lost.set()
+                else:
+                    _last_claim_success = time.monotonic()
             except Exception:
                 logger.debug(
-                    "Job '%s': run_claim heartbeat failed", job_name, exc_info=True
+                    "Job '%s': transient run_claim heartbeat failure; retrying",
+                    job_name,
+                    exc_info=True,
+                )
+                if (
+                    time.monotonic() - _last_claim_success
+                    >= _run_claim_self_fence_seconds()
+                ):
+                    claim_ownership_lost.set()
+
+        def _interrupt_if_claim_lost() -> bool:
+            if not claim_ownership_lost.is_set():
+                return False
+            if hasattr(agent, "interrupt"):
+                try:
+                    agent.interrupt("Cron run claim ownership was lost")
+                except Exception:
+                    logger.debug(
+                        "Job '%s': failed to interrupt stale attempt",
+                        job_name,
+                        exc_info=True,
+                    )
+            return True
+
+        # Construction can load plugins/MCP transports and SessionDB setup can
+        # take seconds. Revalidate at the last boundary before the paid agent
+        # call/tool loop is submitted; a successor that replaced the token
+        # during setup must prevent this stale attempt from starting.
+        if _active_run_claim_owner:
+            try:
+                still_owned = (
+                    not claim_ownership_lost.is_set()
+                    and heartbeat_run_claim(
+                        job_id, expected_owner=_active_run_claim_owner
+                    )
+                )
+            except Exception:
+                still_owned = False
+                logger.warning(
+                    "Job '%s': could not verify run claim before agent submit",
+                    job_id,
+                    exc_info=True,
+                )
+            if not still_owned:
+                claim_ownership_lost.set()
+                raise RuntimeError(
+                    "Run claim ownership was lost before agent execution; "
+                    "the API/tool loop was not started."
                 )
 
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
@@ -4166,17 +4811,24 @@ def run_job(
         _audit_t_start = time.monotonic()
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
+        _claim_lost_during_run = False
         try:
             if _cron_inactivity_limit is None:
-                # Unlimited — no inactivity watchdog, but a one-shot still
-                # needs its run_claim heartbeat, so poll instead of blocking.
-                if _is_oneshot:
+                # Unlimited — no inactivity watchdog, but a claimed run still
+                # needs its heartbeat, so poll instead of blocking.
+                if _active_run_claim_owner:
                     result = None
                     while True:
+                        if _interrupt_if_claim_lost():
+                            _claim_lost_during_run = True
+                            break
                         done, _ = concurrent.futures.wait(
                             {_cron_future}, timeout=_POLL_INTERVAL,
                         )
                         if done:
+                            if _interrupt_if_claim_lost():
+                                _claim_lost_during_run = True
+                                break
                             result = _cron_future.result()
                             break
                         _heartbeat_run_claim_if_due()
@@ -4185,13 +4837,22 @@ def run_job(
             else:
                 result = None
                 while True:
+                    if _interrupt_if_claim_lost():
+                        _claim_lost_during_run = True
+                        break
                     done, _ = concurrent.futures.wait(
                         {_cron_future}, timeout=_POLL_INTERVAL,
                     )
                     if done:
+                        if _interrupt_if_claim_lost():
+                            _claim_lost_during_run = True
+                            break
                         result = _cron_future.result()
                         break
                     _heartbeat_run_claim_if_due()
+                    if _interrupt_if_claim_lost():
+                        _claim_lost_during_run = True
+                        break
                     # Agent still running — check inactivity.
                     _idle_secs = 0.0
                     if hasattr(agent, "get_activity_summary"):
@@ -4208,6 +4869,12 @@ def run_job(
             raise
         finally:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
+
+        if _claim_lost_during_run:
+            raise RuntimeError(
+                "Run claim ownership was lost during agent execution; "
+                "stale attempt was interrupted."
+            )
 
         if _inactivity_timeout:
             # Build diagnostic summary from the agent's activity tracker.
@@ -4537,8 +5204,87 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
 
 
 def run_one_job(
-    job: dict, *, adapters=None, loop=None, verbose: bool = False,
+    job: dict,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
     extra_prompt: Optional[str] = None,
+    _attempt_outcome: Optional[dict] = None,
+    cancel_event: Optional[threading.Event] = None,
+) -> bool:
+    """Fence one claimed attempt before executing any job side effect.
+
+    ``cancel_event`` lets an owning dispatch surface cancel the same script /
+    agent rail used for durable run-claim loss.  The immutable claim token
+    remains the authority for terminal writes; the event only stops work.
+    """
+    heartbeat = None
+    expected_owner = _run_claim_owner(job)
+    if expected_owner:
+        try:
+            heartbeat = _start_run_claim_heartbeat(
+                job,
+                thread_name="cron-attempt-claim-heartbeat",
+                ownership_lost=cancel_event,
+            )
+        except Exception as exc:
+            _consume_interrupted_flag(
+                job["id"], expected_run_claim_owner=expected_owner
+            )
+            try:
+                release_run_claim(
+                    job["id"], expected_owner=expected_owner
+                )
+            except Exception:
+                logger.debug(
+                    "Job '%s': could not release lost pre-run claim",
+                    job.get("id"),
+                    exc_info=True,
+                )
+            execution_id = job.get("execution_id")
+            if not execution_id:
+                execution_id = create_execution(
+                    job["id"], source="direct"
+                )["id"]
+            finish_execution(
+                execution_id,
+                success=False,
+                error=f"Run claim ownership lost before execution: {exc}",
+            )
+            logger.warning(
+                "Job '%s' not executed because attempt %r no longer owns "
+                "its run claim",
+                job.get("name", job.get("id")),
+                expected_owner,
+            )
+            return False
+    try:
+        claim_ownership_lost = (
+            heartbeat[1] if heartbeat is not None else cancel_event
+        )
+        return _run_one_job_body(
+            job,
+            adapters=adapters,
+            loop=loop,
+            verbose=verbose,
+            extra_prompt=extra_prompt,
+            claim_ownership_lost=claim_ownership_lost,
+            attempt_outcome=_attempt_outcome,
+        )
+    finally:
+        _stop_run_claim_heartbeat(heartbeat)
+
+
+def _run_one_job_body(
+    job: dict,
+    *,
+    adapters=None,
+    loop=None,
+    verbose: bool = False,
+    extra_prompt: Optional[str] = None,
+    claim_ownership_lost: Optional[threading.Event] = None,
+    attempt_outcome: Optional[dict] = None,
 ) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
@@ -4554,9 +5300,30 @@ def run_one_job(
     Returns True if the job was processed (even if the job itself failed —
     failure is recorded via ``mark_job_run``), False only if processing raised.
     """
+    expected_run_claim_owner = _run_claim_owner(job) or None
+    if attempt_outcome is not None:
+        attempt_outcome.clear()
+        attempt_outcome.update(
+            success=False,
+            error=None,
+            output_file=None,
+            terminal_recorded=False,
+        )
     execution_id = job.get("execution_id")
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]
+    if claim_ownership_lost is not None and claim_ownership_lost.is_set():
+        _consume_interrupted_flag(
+            job["id"], expected_run_claim_owner=expected_run_claim_owner
+        )
+        finish_execution(
+            execution_id,
+            success=False,
+            error="Run claim ownership was lost before execution.",
+        )
+        return False
+    _scope_token = None
+    _reset_secret_scope = None
     try:
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
@@ -4565,7 +5332,12 @@ def run_one_job(
         # use advance_next_run) and infinite/no-repeat jobs. This lives here in
         # the shared body so BOTH the built-in ticker and the external provider
         # (Chronos fire_due) get at-most-times semantics.
-        if not claim_dispatch(job["id"]):
+        dispatch_kwargs = (
+            {"expected_run_claim_owner": expected_run_claim_owner}
+            if expected_run_claim_owner
+            else {}
+        )
+        if not claim_dispatch(job["id"], **dispatch_kwargs):
             logger.info(
                 "Job '%s': one-shot dispatch limit reached — skipping",
                 job.get("name", job["id"]),
@@ -4575,7 +5347,17 @@ def run_one_job(
                 success=False,
                 error="Dispatch claim rejected; execution was not started.",
             )
-            return True  # not an error — already handled/removed
+            if expected_run_claim_owner:
+                _consume_interrupted_flag(
+                    job["id"],
+                    expected_run_claim_owner=expected_run_claim_owner,
+                )
+                if attempt_outcome is not None:
+                    attempt_outcome["error"] = (
+                        "Run claim ownership was lost before dispatch."
+                    )
+                return False
+            return True  # legacy/unclaimed dispatch limit was already handled
 
         # The attempt is claimed durably before executor/provider dispatch and
         # becomes running only immediately before the actual run.
@@ -4597,6 +5379,7 @@ def run_one_job(
         _scope_token = set_secret_scope(
             build_profile_secret_scope(_get_hermes_home())
         )
+        _reset_secret_scope = reset_secret_scope
         # Defer the cron agent's async-resource teardown until AFTER delivery.
         # run_job normally closes the agent (and reaps stale async clients) in
         # its finally block; doing that before _deliver_result runs means the
@@ -4607,8 +5390,10 @@ def run_one_job(
         _deferred_agents: list = []
         try:
             success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents,
+                job,
+                defer_agent_teardown=_deferred_agents,
                 extra_prompt=extra_prompt,
+                claim_ownership_lost=claim_ownership_lost,
             )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
@@ -4619,8 +5404,6 @@ def run_one_job(
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
             raise
-        finally:
-            reset_secret_scope(_scope_token)
 
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step
@@ -4631,7 +5414,32 @@ def run_one_job(
         delivery_error = None
         blocked_config = False
         try:
-            output_file = save_job_output(job["id"], output)
+            save_kwargs = (
+                {"expected_run_claim_owner": expected_run_claim_owner}
+                if expected_run_claim_owner
+                else {}
+            )
+            output_file = save_job_output(job["id"], output, **save_kwargs)
+            if expected_run_claim_owner and output_file is None:
+                _consume_interrupted_flag(
+                    job["id"],
+                    expected_run_claim_owner=expected_run_claim_owner,
+                )
+                if attempt_outcome is not None:
+                    attempt_outcome["error"] = (
+                        "Run claim ownership was lost before output publication."
+                    )
+                finish_execution(
+                    execution_id,
+                    success=False,
+                    error=(
+                        "Run claim ownership was lost before output publication; "
+                        "stale output was suppressed."
+                    ),
+                )
+                return False
+            if attempt_outcome is not None and output_file is not None:
+                attempt_outcome["output_file"] = str(output_file)
             if verbose:
                 logger.info("Output saved to: %s", output_file)
 
@@ -4642,11 +5450,42 @@ def run_one_job(
             # "this run was interrupted" summary instead of that response.
             # Peek-only: the flag stays set for the authoritative check
             # right before mark_job_run below.
-            if success and _is_interrupted(job["id"]):
+            if success and _is_interrupted(
+                job["id"],
+                expected_run_claim_owner=expected_run_claim_owner,
+            ):
                 success = False
                 error = (
                     "Interrupted by gateway shutdown before the run finished "
                     "(tool subprocess was killed mid-flight)."
+                )
+
+            attempt_ownership_lost = bool(
+                claim_ownership_lost is not None
+                and claim_ownership_lost.is_set()
+            )
+            if expected_run_claim_owner and not attempt_ownership_lost:
+                try:
+                    attempt_ownership_lost = not heartbeat_run_claim(
+                        job["id"],
+                        expected_owner=expected_run_claim_owner,
+                    )
+                except Exception:
+                    # Delivery is an external side effect. If ownership cannot
+                    # be verified at that boundary, fail closed; the later
+                    # terminal CAS still protects durable job state.
+                    attempt_ownership_lost = True
+                    logger.warning(
+                        "Job '%s': could not verify run claim before delivery; "
+                        "suppressing output",
+                        job["id"],
+                        exc_info=True,
+                    )
+            if attempt_ownership_lost:
+                success = False
+                error = (
+                    "Run claim ownership was lost before delivery; stale "
+                    "attempt output was suppressed."
                 )
 
             # Deliver the final response to the origin/target chat.
@@ -4664,7 +5503,9 @@ def run_one_job(
             blocked_config = blocked_config_silent or (
                 bool(error) and BLOCKED_CONFIG_MARKER in str(error)
             )
-            if blocked_config and not success:
+            if attempt_ownership_lost:
+                deliver_content = ""
+            elif blocked_config and not success:
                 # Blocked-config alert: bypass the generic failure summarizer
                 # (whose auth/timeout heuristics would mislabel this as a
                 # provider runtime failure) — say plainly that config
@@ -4704,7 +5545,24 @@ def run_one_job(
                     and not _resolve_delivery_targets(job)
                 )
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    delivery_error = _deliver_result(
+                        job,
+                        deliver_content,
+                        adapters=adapters,
+                        loop=loop,
+                        claim_ownership_lost=claim_ownership_lost,
+                        expected_run_claim_owner=expected_run_claim_owner,
+                    )
+                    if (
+                        expected_run_claim_owner
+                        and claim_ownership_lost is not None
+                        and claim_ownership_lost.is_set()
+                    ):
+                        success = False
+                        error = (
+                            "Run claim ownership was lost during delivery; "
+                            "later side effects were suppressed."
+                        )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
@@ -4722,14 +5580,55 @@ def run_one_job(
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
-        if not _consume_interrupted_flag(job["id"]):
-            if blocked_config:
-                mark_job_run(
-                    job["id"], success, error, delivery_error=delivery_error,
-                    status="blocked_config",
+        interrupted = _consume_interrupted_flag(
+            job["id"], expected_run_claim_owner=expected_run_claim_owner
+        )
+        terminal_recorded = False
+        if not interrupted:
+            mark_kwargs = (
+                {"expected_run_claim_owner": expected_run_claim_owner}
+                if expected_run_claim_owner
+                else {}
+            )
+            mark_result = mark_job_run(
+                job["id"],
+                success,
+                error,
+                delivery_error=delivery_error,
+                status="blocked_config" if blocked_config else None,
+                **mark_kwargs,
+            )
+            terminal_recorded = not (
+                expected_run_claim_owner and mark_result is False
+            )
+        else:
+            # The shutdown path already wrote this exact attempt's terminal
+            # failure before clearing its run claim.
+            terminal_recorded = True
+            success = False
+            error = (
+                "Interrupted by gateway shutdown before this attempt "
+                "completed."
+            )
+            should_deliver = False
+            delivery_error = None
+        if expected_run_claim_owner and not terminal_recorded:
+            ownership_error = (
+                "Run claim ownership was lost before terminal state commit."
+            )
+            if attempt_outcome is not None:
+                attempt_outcome.update(
+                    success=False,
+                    error=ownership_error,
+                    terminal_recorded=False,
                 )
-            else:
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+            finish_execution(
+                execution_id,
+                success=False,
+                error=ownership_error,
+                delivery_outcome="suppressed",
+            )
+            return False
         normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
         if delivery_error:
             delivery_outcome = "failed"
@@ -4745,6 +5644,12 @@ def run_one_job(
             error=error,
             delivery_outcome=delivery_outcome,
         )
+        if attempt_outcome is not None:
+            attempt_outcome.update(
+                success=bool(success),
+                error=error,
+                terminal_recorded=terminal_recorded,
+            )
         return True
 
     except BaseException as e:  # noqa: BLE001 — deliberate: see below
@@ -4760,8 +5665,23 @@ def run_one_job(
         _err_text = str(e) or type(e).__name__
         logger.error("Error processing job %s: %s", job['id'], _err_text)
         try:
-            if not _consume_interrupted_flag(job["id"]):
-                mark_job_run(job["id"], False, _err_text)
+            interrupted = _consume_interrupted_flag(
+                job["id"], expected_run_claim_owner=expected_run_claim_owner
+            )
+            if not interrupted:
+                mark_kwargs = (
+                    {"expected_run_claim_owner": expected_run_claim_owner}
+                    if expected_run_claim_owner
+                    else {}
+                )
+                mark_result = mark_job_run(
+                    job["id"], False, _err_text, **mark_kwargs
+                )
+                if expected_run_claim_owner and mark_result is False:
+                    _err_text = (
+                        "Run claim ownership was lost before terminal failure "
+                        "could be recorded."
+                    )
         except Exception as record_err:
             # Never let bookkeeping mask the original interruption.
             logger.error(
@@ -4777,7 +5697,12 @@ def run_one_job(
             )
         if not isinstance(e, Exception):
             raise
+        if attempt_outcome is not None:
+            attempt_outcome.update(success=False, error=_err_text)
         return False
+    finally:
+        if _scope_token is not None and _reset_secret_scope is not None:
+            _reset_secret_scope(_scope_token)
 
 
 def _notify_provider_jobs_changed() -> None:
@@ -4884,6 +5809,7 @@ def tick(
             lock_fd.close()
         return 0
 
+    pending_run_claims: dict[str, str] = {}
     try:
         # Global emergency stop (`hermes pause`): skip dispatch entirely while
         # the ESTOP sentinel exists. Never touches in-flight runs — due jobs
@@ -4900,7 +5826,11 @@ def tick(
             logger.debug("Cron dispatch paused while gateway drains existing work")
             return 0
 
-        due_jobs = get_due_jobs()
+        due_jobs = get_due_jobs(claim_recurring=True)
+        for claimed_job in due_jobs:
+            claimed_owner = _run_claim_owner(claimed_job)
+            if claimed_owner:
+                pending_run_claims[claimed_owner] = claimed_job["id"]
 
         if not due_jobs:
             # Idle tick: skip config load + pool partitioning entirely
@@ -4927,7 +5857,12 @@ def tick(
         # bumping next_run_at forward so the grace window never expires.
         # mark_job_run() overwrites next_run_at on completion.
         # Batched: one load + one save for the whole due set, not one per job.
-        advance_next_runs([job["id"] for job in due_jobs])
+        advance_next_runs(
+            {
+                job["id"]: (_run_claim_owner(job) or None)
+                for job in due_jobs
+            }
+        )
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
@@ -4983,6 +5918,25 @@ def tick(
             membership is released in the worker's finally block.
             """
             job_id = job["id"]
+            running_key = f"{_get_hermes_home().resolve()}\0{job_id}"
+            claim_owner = _run_claim_owner(job)
+
+            def _release_unsubmitted_claim() -> None:
+                if not claim_owner:
+                    return
+                try:
+                    release_run_claim(job_id, expected_owner=claim_owner)
+                except Exception:
+                    logger.warning(
+                        "Job '%s': could not release unsubmitted run claim",
+                        job.get("name", job_id),
+                        exc_info=True,
+                    )
+                else:
+                    # Keep the pending entry on transient failure so tick's
+                    # outer finally gets one more exact-owner release attempt.
+                    pending_run_claims.pop(claim_owner, None)
+
             # A tick can race gateway teardown: once the interpreter is
             # finalizing, ``pool.submit`` raises "cannot schedule new futures
             # after interpreter shutdown" and crashes the tick. Skip cleanly —
@@ -4993,31 +5947,134 @@ def tick(
                     "Job '%s' not dispatched — interpreter is shutting down",
                     job.get("name", job_id),
                 )
+                _release_unsubmitted_claim()
                 return None
-            if not try_register_running_job(job_id):
-                logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+            with _running_lock:
+                already_running = (
+                    running_key in _running_job_ids
+                    or job_id in _running_job_ids  # legacy/test injection
+                )
+                if not already_running:
+                    _running_job_ids.add(running_key)
+                    if claim_owner:
+                        _running_run_claim_owners[running_key] = claim_owner
+            if already_running:
+                logger.info(
+                    "Job '%s' already running — skipping",
+                    job.get("name", job_id),
+                )
+                _release_unsubmitted_claim()
                 return None
             # Record the attempt before executor dispatch. Recovery classifies
             # abandoned records as unknown; it never automatically retries them.
-            execution = create_execution(job_id, source="builtin")
+            try:
+                execution = create_execution(job_id, source="builtin")
+            except Exception:
+                with _running_lock:
+                    _running_job_ids.discard(running_key)
+                    _running_run_claim_owners.pop(running_key, None)
+                _release_unsubmitted_claim()
+                raise
             dispatched_job = dict(job, execution_id=execution["id"])
             _ctx = contextvars.copy_context()
+            try:
+                queue_heartbeat = _start_run_claim_heartbeat(
+                    dispatched_job,
+                    thread_name="cron-queued-claim-heartbeat",
+                )
+            except Exception as heartbeat_err:
+                with _running_lock:
+                    _running_job_ids.discard(running_key)
+                    _running_run_claim_owners.pop(running_key, None)
+                finish_execution(
+                    execution["id"],
+                    success=False,
+                    error=f"Run-claim heartbeat startup failed: {heartbeat_err}",
+                )
+                logger.error(
+                    "Job '%s' not dispatched because its durable claim "
+                    "heartbeat could not start: %s",
+                    job.get("name", job_id),
+                    heartbeat_err,
+                )
+                _release_unsubmitted_claim()
+                return None
 
-            def _run_and_release(j=dispatched_job, ctx=_ctx):
+            def _run_and_release(
+                j=dispatched_job,
+                ctx=_ctx,
+                heartbeat=queue_heartbeat,
+                key=running_key,
+            ):
                 try:
-                    return ctx.run(_process_job, j)
+                    def _run_if_owned() -> bool:
+                        if heartbeat is not None:
+                            _stop, ownership_lost, _thread = heartbeat
+                            owner = _run_claim_owner(j)
+                            claim_error = None
+                            try:
+                                owned = (
+                                    not ownership_lost.is_set()
+                                    and heartbeat_run_claim(
+                                        j["id"], expected_owner=owner
+                                    )
+                                )
+                            except Exception as exc:
+                                owned = False
+                                claim_error = exc
+                            if not owned:
+                                _consume_interrupted_flag(
+                                    j["id"],
+                                    expected_run_claim_owner=owner or None,
+                                )
+                                try:
+                                    release_run_claim(
+                                        j["id"], expected_owner=owner
+                                    )
+                                except Exception:
+                                    logger.warning(
+                                        "Job '%s': failed to release unverifiable "
+                                        "queued claim",
+                                        j["id"],
+                                        exc_info=True,
+                                    )
+                                detail = (
+                                    f" ({claim_error})" if claim_error else ""
+                                )
+                                finish_execution(
+                                    j["execution_id"],
+                                    success=False,
+                                    error=(
+                                        "Run claim ownership lost while queued; "
+                                        f"execution was not started{detail}."
+                                    ),
+                                )
+                                return False
+                        return _process_job(j)
+
+                    return ctx.run(_run_if_owned)
                 finally:
-                    release_running_job(j["id"])
+                    _stop_run_claim_heartbeat(heartbeat)
+                    with _running_lock:
+                        _running_job_ids.discard(key)
+                        _running_run_claim_owners.pop(key, None)
 
             try:
-                return pool.submit(_run_and_release)
+                future = pool.submit(_run_and_release)
+                if claim_owner:
+                    pending_run_claims.pop(claim_owner, None)
+                return future
             except Exception as submit_err:
-                release_running_job(job_id)
+                _stop_run_claim_heartbeat(queue_heartbeat)
+                with _running_lock:
+                    _running_job_ids.discard(running_key)
+                    _running_run_claim_owners.pop(running_key, None)
                 finish_execution(
                     execution["id"],
                     success=False,
                     error=f"Executor dispatch failed: {submit_err}",
                 )
+                _release_unsubmitted_claim()
                 # Interpreter began finalizing between the guard above and the
                 # submit — release the in-flight claim we just took and skip.
                 if isinstance(submit_err, RuntimeError) and _interpreter_shutting_down(submit_err):
@@ -5113,6 +6170,19 @@ def tick(
 
         return sum(_results)
     finally:
+        for pending_owner, pending_job_id in list(pending_run_claims.items()):
+            try:
+                release_run_claim(
+                    pending_job_id,
+                    expected_owner=pending_owner,
+                )
+            except Exception:
+                logger.warning(
+                    "Job '%s': could not release claim after tick aborted "
+                    "before executor submission",
+                    pending_job_id,
+                    exc_info=True,
+                )
         if fcntl:
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -110,17 +110,45 @@ class CronScheduler(ABC):
         Returns True if THIS caller claimed and ran the job, False if the claim
         was lost (another machine/retry won it) or the job no longer exists.
         """
-        from cron.jobs import claim_job_for_fire, get_job
+        from cron.jobs import (
+            claim_job_for_fire_attempt,
+            get_job,
+            release_run_claim,
+        )
         from cron.executions import create_execution
         from cron.scheduler import run_one_job
 
-        if not claim_job_for_fire(job_id):
+        attempt_owner = claim_job_for_fire_attempt(job_id)
+        if attempt_owner is None:
             return False  # another machine already claimed this fire
-        job = get_job(job_id)
-        if job is None:
-            return False  # job removed (e.g. repeat-N exhausted) between arm and fire
-        job["execution_id"] = create_execution(job_id, source=self.name)["id"]
-        return run_one_job(job, adapters=adapters, loop=loop)
+        handed_off = False
+        try:
+            job = get_job(job_id)
+            if job is None:
+                return False  # removed between atomic claim and refetch
+            run_claim = job.get("run_claim")
+            if (
+                not isinstance(run_claim, dict)
+                or run_claim.get("by") != attempt_owner
+            ):
+                return False  # a successor replaced this exact attempt
+            job["execution_id"] = create_execution(job_id, source=self.name)["id"]
+            # From here run_one_job owns terminal bookkeeping/release. Set the
+            # flag before calling it so even BaseException cannot make this
+            # pre-handoff cleanup impersonate a completed worker.
+            handed_off = True
+            return run_one_job(job, adapters=adapters, loop=loop)
+        except Exception:
+            return False
+        finally:
+            if not handed_off:
+                try:
+                    release_run_claim(job_id, expected_owner=attempt_owner)
+                except Exception:
+                    # Exact-owner release is best effort. A later TTL retry is
+                    # safer than allowing cleanup failure to escape the fire
+                    # endpoint and trigger an unbounded upstream retry storm.
+                    pass
 
     def reconcile(self) -> None:
         """Converge the external registry toward jobs.json (the desired state):
@@ -192,11 +220,15 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        gateway_owner_id=None,
+        recover_when_dispatchable=False,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
         from cron.jobs import (
+            clear_gateway_ticker_lease,
             clear_ticker_error,
+            record_gateway_ticker_lease,
             record_ticker_error,
             record_ticker_heartbeat,
         )
@@ -219,56 +251,137 @@ class InProcessCronScheduler(CronScheduler):
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                gateway_owner_id=gateway_owner_id,
             )
             return
 
         # ── Single-profile (legacy) path ──────────────────────────────────
-        recovered = self.recover_interrupted()
-        if recovered:
-            logger.warning(
-                "Marked %d interrupted cron execution(s) unknown after restart",
-                recovered,
-            )
-        # Heartbeat once before the first sleep so `hermes cron status` sees a
-        # live ticker immediately after startup, not only after the first tick.
-        record_ticker_heartbeat()
-        while not stop_event.is_set():
-            ok = False
+        recovery_pending = True
+
+        def _recover_once():
+            nonlocal recovery_pending
+            recovered = self.recover_interrupted()
+            recovery_pending = False
+            if recovered:
+                logger.warning(
+                    "Marked %d interrupted cron execution(s) unknown after restart",
+                    recovered,
+                )
+
+        def _publish_gateway_lease() -> bool:
+            if gateway_owner_id is None:
+                return True
             try:
-                if can_dispatch is not None and not can_dispatch():
-                    logger.debug("Cron dispatch paused while gateway drains existing work")
-                else:
-                    cron_tick(
-                        verbose=False,
-                        adapters=adapters,
-                        loop=loop,
-                        sync=False,
-                        can_dispatch=can_dispatch,
+                record_gateway_ticker_lease(gateway_owner_id)
+                return True
+            except Exception as exc:
+                logger.error(
+                    "Could not publish gateway cron ownership lease: %s; "
+                    "skipping dispatch and retrying next cycle",
+                    exc,
+                    exc_info=True,
+                )
+                # An earlier successful refresh may still exist. Remove only
+                # this unique owner's path so Desktop can take over promptly.
+                try:
+                    clear_gateway_ticker_lease(gateway_owner_id)
+                except Exception:
+                    logger.warning(
+                        "Could not clear failed gateway cron ownership lease",
+                        exc_info=True,
                     )
-                ok = True
-            except BaseException as e:
-                # Catch BaseException (not just Exception) so a SystemExit from
-                # a misbehaving provider SDK / agent retry path does not kill
-                # the ticker thread silently (#32612). KeyboardInterrupt is
-                # intentionally caught here too — gateway shutdown is driven by
-                # stop_event (set by the main thread's signal handler), not by
-                # an exception in this daemon thread, so swallowing it and
-                # re-checking stop_event keeps shutdown clean.
-                logger.error("Cron tick error: %s", e, exc_info=True)
-                # Persist the failure reason next to the heartbeat markers so
-                # `hermes cron status`/`list` (separate processes) can show
-                # WHY ticks fail, not just that the success marker is stale —
-                # e.g. a root-rewritten jobs.json locking out the ticker's
-                # uid went unnoticed for ~14h with the reason buried in the
-                # gateway log (#68483).
-                record_ticker_error(f"{type(e).__name__}: {e}")
-            # Record liveness every iteration; bump the success marker only on a
-            # clean tick, so status can tell "alive but failing every tick" from
-            # "actually firing jobs" (#32612, #32895).
-            record_ticker_heartbeat(success=ok)
-            if ok:
-                clear_ticker_error()
-            stop_event.wait(interval)
+                try:
+                    record_ticker_error(f"GatewayTickerLeaseError: {exc}")
+                except Exception:
+                    logger.warning(
+                        "Could not record gateway cron ownership failure",
+                        exc_info=True,
+                    )
+                return False
+
+        try:
+            if not recover_when_dispatchable:
+                _recover_once()
+
+            # Heartbeat once before the first sleep so `hermes cron status`
+            # sees a live ticker immediately after startup, not only after the
+            # first tick.
+            record_ticker_heartbeat()
+            while not stop_event.is_set():
+                # This is the readiness boundary: publish only after provider
+                # initialization/recovery completed. A transient fsync/write
+                # failure skips this cycle and retries instead of killing the
+                # ticker thread or dispatching without an ownership signal.
+                if not _publish_gateway_lease():
+                    try:
+                        record_ticker_heartbeat(success=False)
+                    except Exception:
+                        logger.warning(
+                            "Could not record failed gateway cron heartbeat",
+                            exc_info=True,
+                        )
+                    stop_event.wait(interval)
+                    continue
+
+                ok = False
+                try:
+                    dispatch_allowed = can_dispatch is None or can_dispatch()
+                    # Desktop uses deferred recovery during a Gateway handoff.
+                    # Probe again immediately before reconciliation to close
+                    # the gap between its outer standby check and provider
+                    # startup as tightly as possible.
+                    if (
+                        dispatch_allowed
+                        and recovery_pending
+                        and recover_when_dispatchable
+                        and can_dispatch is not None
+                    ):
+                        dispatch_allowed = can_dispatch()
+
+                    if not dispatch_allowed:
+                        logger.debug(
+                            "Cron dispatch paused while another owner is active"
+                        )
+                    else:
+                        if recovery_pending:
+                            _recover_once()
+                        # Ownership can change while recovery runs. Recheck
+                        # before the due-job scan so the new owner wins without
+                        # waiting for another full interval.
+                        if can_dispatch is not None and not can_dispatch():
+                            logger.debug(
+                                "Cron dispatch paused after ownership changed"
+                            )
+                        else:
+                            cron_tick(
+                                verbose=False,
+                                adapters=adapters,
+                                loop=loop,
+                                sync=False,
+                                can_dispatch=can_dispatch,
+                            )
+                    ok = True
+                except BaseException as e:
+                    # Catch BaseException (not just Exception) so a SystemExit
+                    # from a misbehaving provider SDK / agent retry path does
+                    # not kill the ticker thread silently (#32612).
+                    logger.error("Cron tick error: %s", e, exc_info=True)
+                    record_ticker_error(f"{type(e).__name__}: {e}")
+                # Record liveness every iteration; bump success only on a clean
+                # tick so status distinguishes alive-but-failing from firing.
+                record_ticker_heartbeat(success=ok)
+                if ok:
+                    clear_ticker_error()
+                stop_event.wait(interval)
+        finally:
+            if gateway_owner_id is not None:
+                try:
+                    clear_gateway_ticker_lease(gateway_owner_id)
+                except Exception:
+                    logger.warning(
+                        "Could not clear gateway cron ownership lease",
+                        exc_info=True,
+                    )
 
     def _start_multiplex(
         self,
@@ -279,6 +392,7 @@ class InProcessCronScheduler(CronScheduler):
         loop=None,
         interval=60,
         can_dispatch=None,
+        gateway_owner_id=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -291,7 +405,9 @@ class InProcessCronScheduler(CronScheduler):
         import logging
         from cron.scheduler import tick as cron_tick
         from cron.jobs import (
+            clear_gateway_ticker_lease,
             clear_ticker_error,
+            record_gateway_ticker_lease,
             record_ticker_error,
             record_ticker_heartbeat,
             use_cron_store,
@@ -305,63 +421,150 @@ class InProcessCronScheduler(CronScheduler):
             [p[0] if isinstance(p, tuple) else p for p in profile_homes],
         )
 
-        # Recovery + initial heartbeat for every profile.
-        for entry in profile_homes:
-            home = entry[1] if isinstance(entry, tuple) else entry
-            home_token = set_hermes_home_override(str(home))
-            try:
-                with use_cron_store(home):
-                    recovered = self.recover_interrupted()
-                    if recovered:
-                        logger.warning(
-                            "Marked %d interrupted cron execution(s) for profile at %s",
-                            recovered,
-                            home,
-                        )
-                    record_ticker_heartbeat()
-            finally:
-                reset_hermes_home_override(home_token)
+        homes = [entry[1] if isinstance(entry, tuple) else entry for entry in profile_homes]
 
-        while not stop_event.is_set():
-            ok = False
-            try:
-                if can_dispatch is not None and not can_dispatch():
-                    logger.debug("Cron dispatch paused while gateway drains existing work")
-                else:
-                    for entry in profile_homes:
-                        home = entry[1] if isinstance(entry, tuple) else entry
-                        home_token = set_hermes_home_override(str(home))
+        def _clear_profile_leases() -> None:
+            if gateway_owner_id is None:
+                return
+            for home in homes:
+                home_token = None
+                try:
+                    home_token = set_hermes_home_override(str(home))
+                    with use_cron_store(home):
+                        clear_gateway_ticker_lease(gateway_owner_id)
+                except Exception:
+                    logger.warning(
+                        "Could not clear gateway cron ownership lease for %s",
+                        home,
+                        exc_info=True,
+                    )
+                finally:
+                    if home_token is not None:
                         try:
-                            with use_cron_store(home):
-                                cron_tick(
-                                    verbose=False,
-                                    adapters=adapters,
-                                    loop=loop,
-                                    sync=False,
-                                    can_dispatch=can_dispatch,
-                                )
-                        finally:
                             reset_hermes_home_override(home_token)
-                ok = True
-            except BaseException as e:
-                logger.error("Cron tick error: %s", e, exc_info=True)
-                _tick_error = f"{type(e).__name__}: {e}"
-            else:
-                _tick_error = None
-            # Record per-profile heartbeat after each tick cycle.
-            for entry in profile_homes:
-                home = entry[1] if isinstance(entry, tuple) else entry
+                        except Exception:
+                            logger.warning(
+                                "Could not reset profile scope after lease cleanup for %s",
+                                home,
+                                exc_info=True,
+                            )
+
+        def _record_profile_lease_failure(home, lease_error: str | None) -> None:
+            """Best-effort diagnostics that can never terminate multiplex."""
+            home_token = None
+            try:
+                home_token = set_hermes_home_override(str(home))
+                with use_cron_store(home):
+                    record_ticker_heartbeat(success=False)
+                    if lease_error:
+                        record_ticker_error(lease_error)
+            except Exception:
+                logger.warning(
+                    "Could not record gateway lease failure for profile %s",
+                    home,
+                    exc_info=True,
+                )
+            finally:
+                if home_token is not None:
+                    try:
+                        reset_hermes_home_override(home_token)
+                    except Exception:
+                        logger.warning(
+                            "Could not reset profile scope after lease diagnostics for %s",
+                            home,
+                            exc_info=True,
+                        )
+
+        def _publish_profile_leases() -> tuple[bool, str | None]:
+            if gateway_owner_id is None:
+                return True, None
+            try:
+                for home in homes:
+                    home_token = set_hermes_home_override(str(home))
+                    try:
+                        with use_cron_store(home):
+                            record_gateway_ticker_lease(gateway_owner_id)
+                    finally:
+                        reset_hermes_home_override(home_token)
+                return True, None
+            except Exception as exc:
+                logger.error(
+                    "Could not publish multiplex gateway cron ownership leases: %s; "
+                    "skipping dispatch and retrying next cycle",
+                    exc,
+                    exc_info=True,
+                )
+                # Do not leave a partial profile set advertised as ready.
+                _clear_profile_leases()
+                return False, f"GatewayTickerLeaseError: {exc}"
+
+        try:
+            # Complete recovery/initialization for every served profile before
+            # advertising any of them as Gateway-owned. If a later profile's
+            # recovery stalls, already-initialized profiles keep their working
+            # Desktop fallback instead of observing a false ready signal.
+            for home in homes:
                 home_token = set_hermes_home_override(str(home))
                 try:
                     with use_cron_store(home):
-                        record_ticker_heartbeat(success=ok)
-                        # Surface the failure reason (or clear it) per profile
-                        # so `hermes cron status` can show WHY ticks fail
-                        # (#68483).
-                        if ok:
-                            clear_ticker_error()
-                        elif _tick_error:
-                            record_ticker_error(_tick_error)
+                        recovered = self.recover_interrupted()
+                        if recovered:
+                            logger.warning(
+                                "Marked %d interrupted cron execution(s) for profile at %s",
+                                recovered,
+                                home,
+                            )
+                        record_ticker_heartbeat()
                 finally:
                     reset_hermes_home_override(home_token)
-            stop_event.wait(interval)
+
+            while not stop_event.is_set():
+                leases_ready, lease_error = _publish_profile_leases()
+                if not leases_ready:
+                    for home in homes:
+                        _record_profile_lease_failure(home, lease_error)
+                    stop_event.wait(interval)
+                    continue
+
+                ok = False
+                try:
+                    if can_dispatch is not None and not can_dispatch():
+                        logger.debug(
+                            "Cron dispatch paused while gateway drains existing work"
+                        )
+                    else:
+                        for home in homes:
+                            home_token = set_hermes_home_override(str(home))
+                            try:
+                                with use_cron_store(home):
+                                    cron_tick(
+                                        verbose=False,
+                                        adapters=adapters,
+                                        loop=loop,
+                                        sync=False,
+                                        can_dispatch=can_dispatch,
+                                    )
+                            finally:
+                                reset_hermes_home_override(home_token)
+                    ok = True
+                except BaseException as e:
+                    logger.error("Cron tick error: %s", e, exc_info=True)
+                    _tick_error = f"{type(e).__name__}: {e}"
+                else:
+                    _tick_error = None
+                # Record per-profile heartbeat after each tick cycle. The next
+                # cycle refreshes all leases before any profile dispatches.
+                for home in homes:
+                    home_token = set_hermes_home_override(str(home))
+                    try:
+                        with use_cron_store(home):
+                            record_ticker_heartbeat(success=ok)
+                            if ok:
+                                clear_ticker_error()
+                            elif _tick_error:
+                                record_ticker_error(_tick_error)
+                    finally:
+                        reset_hermes_home_override(home_token)
+                stop_event.wait(interval)
+        finally:
+            _clear_profile_leases()

--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -47,6 +47,8 @@ logger = logging.getLogger(__name__)
 # shared default root. See cron/jobs.py for the full rationale.
 CRON_DIR = get_hermes_home().resolve() / "cron"
 SUGGESTIONS_FILE = CRON_DIR / "suggestions.json"
+_IMPORT_CRON_DIR = CRON_DIR
+_IMPORT_SUGGESTIONS_FILE = SUGGESTIONS_FILE
 
 # In-process lock protecting load->modify->save cycles (the background review
 # fork and the main agent can both write).
@@ -69,15 +71,33 @@ def _secure_file(path: Path) -> None:
         pass
 
 
-def _ensure_dir() -> None:
-    CRON_DIR.mkdir(parents=True, exist_ok=True)
+def _current_suggestions_file() -> Path:
+    """Resolve suggestions storage for the active cron profile context."""
+    configured_file = Path(SUGGESTIONS_FILE)
+    if configured_file != _IMPORT_SUGGESTIONS_FILE:
+        return configured_file
+
+    configured_dir = Path(CRON_DIR)
+    if configured_dir != _IMPORT_CRON_DIR:
+        return configured_dir / "suggestions.json"
+
+    # Runtime-only import avoids an import-time cycle while sharing jobs.json's
+    # ContextVar-backed profile selection in multiplex gateways.
+    from cron.jobs import _current_cron_store
+
+    return _current_cron_store().cron_dir / "suggestions.json"
+
+
+def _ensure_dir(suggestions_file: Path) -> None:
+    suggestions_file.parent.mkdir(parents=True, exist_ok=True)
 
 
 def _load_raw() -> Dict[str, Any]:
-    if not SUGGESTIONS_FILE.exists():
+    suggestions_file = _current_suggestions_file()
+    if not suggestions_file.exists():
         return {"suggestions": []}
     try:
-        with open(SUGGESTIONS_FILE, "r", encoding="utf-8") as f:
+        with open(suggestions_file, "r", encoding="utf-8") as f:
             data = json.load(f)
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("suggestions.json unreadable (%s); starting empty", e)
@@ -91,8 +111,11 @@ def _load_raw() -> Dict[str, Any]:
 
 
 def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
-    _ensure_dir()
-    fd, tmp_path = tempfile.mkstemp(dir=str(SUGGESTIONS_FILE.parent), suffix=".tmp", prefix=".sugg_")
+    suggestions_file = _current_suggestions_file()
+    _ensure_dir(suggestions_file)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(suggestions_file.parent), suffix=".tmp", prefix=".sugg_"
+    )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(
@@ -102,8 +125,8 @@ def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
             )
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, SUGGESTIONS_FILE)
-        _secure_file(SUGGESTIONS_FILE)
+        atomic_replace(tmp_path, suggestions_file)
+        _secure_file(suggestions_file)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2325,12 +2325,28 @@ async def send_weixin_direct(
     chat_id: str,
     message: str,
     media_files: Optional[List[Tuple[str, bool]]] = None,
+    ownership_guard=None,
 ) -> Dict[str, Any]:
     """
     One-shot send helper for ``send_message`` and cron delivery.
 
     This bypasses the long-poll adapter lifecycle and uses the raw API directly.
     """
+    def _owned() -> bool:
+        if ownership_guard is None:
+            return True
+        try:
+            return bool(ownership_guard())
+        except Exception:
+            logger.exception("Weixin standalone delivery ownership guard failed")
+            return False
+
+    ownership_error = {
+        "error": "Delivery ownership lost during standalone send"
+    }
+    if not _owned():
+        return ownership_error
+
     account_id = str(extra.get("account_id") or _wx_secret("WEIXIN_ACCOUNT_ID", "")).strip()
     base_url = str(extra.get("base_url") or _wx_secret("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
     cdn_base_url = str(extra.get("cdn_base_url") or _wx_secret("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)).strip().rstrip("/")
@@ -2352,11 +2368,15 @@ async def send_weixin_direct(
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:
+            if not _owned():
+                return ownership_error
             last_result = await live_adapter.send(chat_id, cleaned)
             if not last_result.success:
                 return {"error": f"Weixin send failed: {last_result.error}"}
 
         for media_path, _is_voice in media_files or []:
+            if not _owned():
+                return ownership_error
             ext = Path(media_path).suffix.lower()
             if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
                 last_result = await live_adapter.send_image_file(chat_id, media_path)
@@ -2397,11 +2417,15 @@ async def send_weixin_direct(
         last_result: Optional[SendResult] = None
         cleaned = adapter.format_message(message)
         if cleaned:
+            if not _owned():
+                return ownership_error
             last_result = await adapter.send(chat_id, cleaned)
             if not last_result.success:
                 return {"error": f"Weixin send failed: {last_result.error}"}
 
         for media_path, _is_voice in media_files or []:
+            if not _owned():
+                return ownership_error
             ext = Path(media_path).suffix.lower()
             if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
                 last_result = await adapter.send_image_file(chat_id, media_path)

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4460,6 +4460,7 @@ class MessageSender:
         chat_id: str,
         message: str,
         media_files: Optional[List[Tuple[str, bool]]] = None,
+        ownership_guard=None,
     ) -> Dict[str, Any]:
         """Send text + media via Yuanbao (used by the ``send_message`` tool).
 
@@ -4471,14 +4472,31 @@ class MessageSender:
         adapter = self._adapter
         last_result: Optional["SendResult"] = None
 
+        def _owned() -> bool:
+            if ownership_guard is None:
+                return True
+            try:
+                return bool(ownership_guard())
+            except Exception:
+                logger.exception("Yuanbao standalone delivery ownership guard failed")
+                return False
+
+        ownership_error = {
+            "error": "Delivery ownership lost during standalone send"
+        }
+
         # 1. Send text
         if message.strip():
+            if not _owned():
+                return ownership_error
             last_result = await adapter.send(chat_id, message)
             if not last_result.success:
                 return {"error": f"Yuanbao send failed: {last_result.error}"}
 
         # 2. Iterate media_files, dispatch by file extension
         for media_path, _is_voice in media_files or []:
+            if not _owned():
+                return ownership_error
             ext = Path(media_path).suffix.lower()
             if ext in self.IMAGE_EXTS:
                 last_result = await adapter.send_image_file(chat_id, media_path)
@@ -4818,9 +4836,15 @@ class OutboundManager:
     async def send_direct(
         self, chat_id: str, message: str,
         media_files: Optional[List[Tuple[str, bool]]] = None,
+        ownership_guard=None,
     ) -> Dict[str, Any]:
         """Send text + media (used by send_message tool)."""
-        return await self.sender.send_direct(chat_id, message, media_files)
+        return await self.sender.send_direct(
+            chat_id,
+            message,
+            media_files,
+            ownership_guard=ownership_guard,
+        )
 
     async def start_typing(self, chat_id: str) -> None:
         """Start reply heartbeat (RUNNING)."""
@@ -5293,6 +5317,12 @@ async def send_yuanbao_direct(
     chat_id: str,
     message: str,
     media_files: Optional[List[Tuple[str, bool]]] = None,
+    ownership_guard=None,
 ) -> Dict[str, Any]:
     """Delegate to ``OutboundManager.send_direct``."""
-    return await adapter._outbound.send_direct(chat_id, message, media_files)
+    return await adapter._outbound.send_direct(
+        chat_id,
+        message,
+        media_files,
+        ownership_guard=ownership_guard,
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -40,6 +40,7 @@ import sys
 import signal
 import threading
 import time
+import uuid
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -27458,6 +27459,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         acquire_gateway_runtime_lock,
         get_running_pid,
         get_process_start_time,
+        get_stable_process_start_time,
         release_gateway_runtime_lock,
         remove_pid_file,
         terminate_pid,
@@ -27980,6 +27982,26 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         cron_start_kwargs["can_dispatch"] = lambda: not (
             runner._draining or runner._external_drain_active
         )
+        # Published by the provider thread only after Gateway startup reaches
+        # the cron-running boundary. Desktop uses the profile-local lease to
+        # yield dispatch without confusing another profile's Gateway (and a
+        # multiplex Gateway publishes this owner into every served profile).
+        gateway_pid = os.getpid()
+        gateway_started_at = get_stable_process_start_time(gateway_pid)
+        if gateway_started_at is None:
+            # A lease without a stable PID-reuse guard cannot be reclaimed
+            # safely after a crash. Fail closed: leave the lease absent so a
+            # profile-local Desktop ticker can retain ownership, and keep this
+            # Gateway ticker from dispatching concurrently.
+            logger.error(
+                "Gateway cron ticker disabled: stable process fingerprint "
+                "is unavailable"
+            )
+            cron_start_kwargs["can_dispatch"] = lambda: False
+        else:
+            cron_start_kwargs["gateway_owner_id"] = (
+                f"p{gateway_pid}-s{gateway_started_at}-{uuid.uuid4().hex}"
+            )
     cron_thread = threading.Thread(
         target=cron_provider.start,
         args=(cron_stop,),

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -311,8 +311,9 @@ def _get_process_start_time(pid: int) -> Optional[int]:
         pass
 
     # No /proc (macOS / Windows): psutil is a hard dependency and exposes a
-    # cross-platform creation time.  Quantize to centiseconds so repeated reads
-    # of the same process compare equal without float-precision fragility.
+    # cross-platform creation time.  Keep this persisted gateway-record format
+    # unchanged for rolling compatibility; see get_stable_process_start_time()
+    # for new coordination records that need a cross-interpreter fingerprint.
     try:
         import psutil  # type: ignore
         return int(round(psutil.Process(pid).create_time() * 100))
@@ -323,6 +324,34 @@ def _get_process_start_time(pid: int) -> Optional[int]:
 def get_process_start_time(pid: int) -> Optional[int]:
     """Public wrapper for retrieving a process start time when available."""
     return _get_process_start_time(pid)
+
+
+def get_stable_process_start_time(pid: int) -> Optional[int]:
+    """Return a host-stable fingerprint for new coordination records.
+
+    macOS psutil 7.2 adjusts public ``create_time()`` using an interpreter-local
+    boot-time baseline, so NTP corrections can make the same live PID differ by
+    seconds between Gateway and Desktop. Prefer the raw platform monotonic value
+    for new leases/ledgers, while leaving legacy gateway PID records on their
+    existing unversioned format during rolling upgrades.
+    """
+    stat_path = Path(f"/proc/{pid}/stat")
+    try:
+        return int(stat_path.read_text(encoding="utf-8").split()[21])
+    except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        pass
+
+    try:
+        import psutil  # type: ignore
+
+        process = psutil.Process(pid)
+        try:
+            created_at = process._proc.create_time(monotonic=True)
+        except (AttributeError, TypeError):
+            created_at = process.create_time()
+        return int(round(created_at * 100))
+    except Exception:
+        return None
 
 
 def _read_process_cmdline(pid: int) -> Optional[str]:
@@ -686,24 +715,19 @@ def _running_pid_cache_signature(
 
 
 def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
-    """Delete a stale gateway PID file (and its sibling lock metadata).
+    """Delete stale PID metadata without unlinking the runtime lock inode.
 
     Called from ``get_running_pid()`` after the runtime lock has already been
-    confirmed inactive, so the on-disk metadata is known to belong to a dead
-    process.  Unlike ``remove_pid_file()`` (which defensively refuses to delete
-    a PID file whose ``pid`` field differs from ``os.getpid()`` to protect
-    ``--replace`` handoffs), this path force-unlinks both files so the next
-    startup sees a clean slate.
+    observed inactive. That observation cannot make a later pathname unlink
+    safe: another starter can acquire the same inode immediately after the
+    probe. Keep ``gateway.lock`` permanently as a reusable coordination inode;
+    the eventual lock winner rewrites its contents through the held handle.
     """
     if not cleanup_stale:
         return
     _clear_running_pid_cache()
     try:
         pid_path.unlink(missing_ok=True)
-    except Exception:
-        pass
-    try:
-        _get_gateway_lock_path(pid_path).unlink(missing_ok=True)
     except Exception:
         pass
 
@@ -880,19 +904,11 @@ def acquire_gateway_runtime_lock() -> bool:
     try:
         handle = open(path, "a+", encoding="utf-8")
     except PermissionError:
-        # Stale root-owned lock file from a previous launchd Background
-        # session that ran as root (same failure mode handled in
-        # is_gateway_runtime_lock_active).  The parent directory owner can
-        # unlink files even when they don't own them, so remove the stale
-        # lock and retry once with a fresh file.
-        try:
-            path.unlink()
-        except OSError:
-            return False
-        try:
-            handle = open(path, "a+", encoding="utf-8")
-        except OSError:
-            return False
+        # We cannot prove whether a root-owned inode is actively flocked.
+        # Unlinking it would let two processes hold locks on different inodes.
+        # Fail closed and require the operator/service manager to repair owner
+        # permissions after stopping the prior Gateway.
+        return False
     if not _try_acquire_file_lock(handle):
         handle.close()
         return False
@@ -930,15 +946,9 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     try:
         handle = open(resolved_lock_path, "a+", encoding="utf-8")
     except PermissionError:
-        # Stale root-owned lock file from a previous launchd Background
-        # session that ran as root.  The parent directory owner can unlink
-        # files even when they don't own them, so remove the stale lock
-        # and report inactive — the new process will create a fresh one.
-        try:
-            resolved_lock_path.unlink()
-        except OSError:
-            pass
-        return False
+        # Inability to open is not proof that no process holds this inode.
+        # Treat it as active; unlinking an unknown flock pathname is unsafe.
+        return True
     try:
         if _try_acquire_file_lock(handle):
             _release_file_lock(handle)
@@ -2200,12 +2210,33 @@ def get_running_pid(
         recorded_start = record.get("start_time")
         current_start = _get_process_start_time(pid)
         if recorded_start is not None and current_start is not None and current_start != recorded_start:
+            # Legacy macOS psutil timestamps can drift between interpreters.
+            # The actively-held flock proves some process owns this runtime;
+            # when the recorded PID is alive and its *live, readable* command
+            # line still identifies a Gateway for this profile, treat it as the
+            # predecessor. This lets --replace terminate it safely while never
+            # unlinking the active lock pathname. An unreadable command line
+            # remains ambiguous and fails closed.
+            live_cmdline = _read_process_cmdline(pid)
+            if (
+                sys.platform == "darwin"
+                and abs(current_start - recorded_start) <= 500
+                and live_cmdline
+                and looks_like_gateway_runtime_command_line(live_cmdline)
+                and _command_line_belongs_to_profile(
+                    live_cmdline, resolved_pid_path.parent
+                )
+            ):
+                return pid
             continue
 
         if _record_matches_live_gateway_pid(record, pid):
             return pid
 
-    _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+    # The runtime lock is actively flocked. Even when its metadata is malformed
+    # or uses an older start-time format, never unlink the pathname: flock stays
+    # attached to the old inode, and a replacement could otherwise create and
+    # lock a new inode while the original Gateway is still alive.
     if pid_path is None:
         runtime_pid = get_runtime_status_running_pid()
         if runtime_pid is not None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -156,16 +156,44 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     scheduler provider here (no live adapters; delivery falls back to the
     per-platform send path).
 
-    Cross-process safe: the built-in provider's ``cron.scheduler.tick`` takes
-    the ``cron/.tick.lock`` file lock, so this never double-fires alongside a
-    real gateway on the same HERMES_HOME — whichever process grabs the lock
-    first wins the tick.
+    When a real gateway owns the same HERMES_HOME, the desktop fallback yields
+    dispatch to it. The built-in provider's ``cron/.tick.lock`` only protects
+    the short due-job scan; agent jobs continue asynchronously after that lock
+    is released, so the lock alone cannot prevent cross-process overlap.
     """
-    from cron.scheduler_provider import resolve_cron_scheduler
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        resolve_cron_scheduler,
+    )
 
     provider = resolve_cron_scheduler()
+    start_kwargs: Dict[str, Any] = {"interval": interval}
+    if isinstance(provider, InProcessCronScheduler):
+
+        def _gateway_is_absent() -> bool:
+            try:
+                from cron.jobs import gateway_ticker_lease_is_fresh
+
+                return not gateway_ticker_lease_is_fresh()
+            except Exception:
+                # Fail open during partial upgrades: without the new lease API,
+                # Desktop remains a working fallback instead of silently
+                # dropping every local schedule.
+                return True
+
+        if not _gateway_is_absent():
+            _log.info("Desktop cron scheduler standing by while gateway owns dispatch")
+        while not _gateway_is_absent():
+            if stop_event.wait(max(float(interval), 0.01)):
+                return
+        start_kwargs["can_dispatch"] = _gateway_is_absent
+        # A Gateway may publish its lease between the standby probe above and
+        # provider startup. Defer execution-ledger recovery until the same gate
+        # authorizes dispatch, so Desktop cannot mark that Gateway's live work
+        # interrupted during the handoff.
+        start_kwargs["recover_when_dispatchable"] = True
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
-    provider.start(stop_event, interval=interval)
+    provider.start(stop_event, **start_kwargs)
 
 
 def _warm_gateway_module() -> None:

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -58,3 +58,46 @@ def test_mark_job_run_clears_claim(temp_home):
     assert get_job(jid).get("fire_claim") is None
     # …and the re-armed recurring job is claimable again.
     assert claim_job_for_fire(jid) is True
+
+
+def test_manual_fire_cannot_impersonate_fresh_scheduled_run(temp_home):
+    """A run-now request loses while a scheduled attempt owns run_claim."""
+    from datetime import datetime, timezone
+    from cron.jobs import create_job, claim_job_for_fire, get_job, save_jobs
+
+    job = create_job(prompt="x", schedule="every 1h")
+    jobs = [get_job(job["id"])]
+    jobs[0]["run_claim"] = {
+        "at": datetime.now(timezone.utc).isoformat(),
+        "by": "scheduled-attempt",
+    }
+    save_jobs(jobs)
+
+    assert claim_job_for_fire(job["id"]) is False
+    assert get_job(job["id"])["run_claim"]["by"] == "scheduled-attempt"
+
+
+def test_attempt_claim_returns_exact_persisted_fence_token(temp_home):
+    from cron.jobs import claim_job_for_fire_attempt, create_job, get_job
+
+    job = create_job(prompt="x", schedule="every 1h")
+    token = claim_job_for_fire_attempt(job["id"])
+
+    assert token
+    assert get_job(job["id"])["run_claim"]["by"] == token
+
+
+def test_small_future_clock_skew_does_not_replace_live_claim(temp_home):
+    from datetime import datetime, timedelta, timezone
+    from cron.jobs import create_job, claim_job_for_fire, get_job, save_jobs
+
+    job = create_job(prompt="x", schedule="every 1h")
+    record = get_job(job["id"])
+    record["run_claim"] = {
+        "at": (datetime.now(timezone.utc) + timedelta(seconds=1)).isoformat(),
+        "by": "future-live-owner",
+    }
+    save_jobs([record])
+
+    assert claim_job_for_fire(job["id"]) is False
+    assert get_job(job["id"])["run_claim"]["by"] == "future-live-owner"

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -135,6 +135,46 @@ def test_run_job_no_agent_reloads_dotenv_before_script(hermes_env, monkeypatch):
     assert str(loaded_homes[0]) == str(hermes_env)
 
 
+def test_secondary_no_agent_does_not_mutate_process_dotenv(
+    hermes_env, tmp_path, monkeypatch
+):
+    import cron.scheduler as scheduler
+    import hermes_cli.env_loader as env_loader
+
+    secondary = tmp_path / "secondary"
+    secondary.mkdir()
+    loaded = []
+    monkeypatch.setattr(scheduler, "_hermes_home", secondary)
+    monkeypatch.setattr(
+        scheduler, "get_process_hermes_home", lambda: hermes_env
+    )
+    monkeypatch.setattr(
+        env_loader,
+        "load_hermes_dotenv",
+        lambda **kwargs: loaded.append(kwargs),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_run_job_script_with_claim_heartbeat",
+        lambda *_a, **_kw: (True, "ok"),
+    )
+
+    success, _doc, response, error = scheduler.run_job(
+        {
+            "id": "secondary-no-agent",
+            "name": "secondary",
+            "no_agent": True,
+            "script": "probe.sh",
+            "deliver": "local",
+        }
+    )
+
+    assert success is True
+    assert response == "ok"
+    assert error is None
+    assert loaded == []
+
+
 # ---------------------------------------------------------------------------
 # _run_job_script: shell-script support
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import sqlite3
@@ -15,6 +16,50 @@ def _point_ledger(monkeypatch, tmp_path):
 
     monkeypatch.setattr(executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db")
     return executions
+
+
+def test_ledger_follows_active_cron_store_after_default_import(monkeypatch, tmp_path):
+    """A multiplex secondary profile must not write the default ledger."""
+    default_home = tmp_path / "default"
+    ops_home = tmp_path / "home-ops"
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    import cron.executions as executions
+    from cron.jobs import use_cron_store
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    # Reproduce the gateway lifetime: the module is first imported for the
+    # default profile, then a multiplex iteration switches to a secondary
+    # profile without re-importing it.
+    executions = importlib.reload(executions)
+    assert executions.EXECUTIONS_FILE == default_home / "cron" / "executions.db"
+
+    token = set_hermes_home_override(ops_home)
+    try:
+        with use_cron_store(ops_home):
+            claimed = executions.create_execution("ops-job", source="builtin")
+            assert executions.list_executions(job_id="ops-job") == [claimed]
+
+            # Recovery has an orthogonal process-liveness dependency. Turn
+            # this row into a foreign abandoned attempt so the test exercises
+            # the real recovery transaction against the selected profile DB.
+            with sqlite3.connect(ops_home / "cron" / "executions.db") as conn:
+                conn.execute(
+                    "UPDATE executions SET process_id='foreign-owner' WHERE id=?",
+                    (claimed["id"],),
+                )
+            monkeypatch.setattr(executions, "_owner_is_live", lambda *_a, **_kw: False)
+
+            assert executions.recover_interrupted_executions() == 1
+            assert executions.latest_execution("ops-job")["status"] == "unknown"
+    finally:
+        reset_hermes_home_override(token)
+
+    assert (ops_home / "cron" / "executions.db").is_file()
+    assert not (default_home / "cron" / "executions.db").exists()
 
 
 def test_execution_transitions_are_durable(monkeypatch, tmp_path):
@@ -114,6 +159,48 @@ def test_recovery_does_not_mark_live_process_execution_unknown(monkeypatch, tmp_
     assert executions.latest_execution("still-live")["status"] == "running"
 
 
+def test_owner_liveness_fails_safe_when_start_time_is_unavailable(monkeypatch):
+    """An existing PID is not declared dead merely because identity is unknown."""
+    import cron.executions as executions
+    import gateway.status as gateway_status
+
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: True)
+    monkeypatch.setattr(executions, "_legacy_process_start_time", lambda _pid: None)
+
+    assert executions._owner_is_live(12345, 67890) is True
+
+
+def test_foreign_live_legacy_owner_tolerates_macos_psutil_drift(monkeypatch):
+    """Rolling readers do not mark a live pre-stable-fingerprint row unknown."""
+    import cron.executions as executions
+    import gateway.status as gateway_status
+
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: True)
+    monkeypatch.setattr(executions.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        executions, "_legacy_process_start_time", lambda _pid: 178624314936
+    )
+
+    assert executions._owner_is_live(777, 178624315136) is True
+    assert executions._owner_is_live(777, 178624315437) is False
+
+
+def test_stable_owner_fingerprint_remains_exact(monkeypatch):
+    """New versioned rows keep strict PID-reuse protection."""
+    import cron.executions as executions
+    import gateway.status as gateway_status
+
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: True)
+    monkeypatch.setattr(executions, "_process_start_time", lambda _pid: 12345)
+
+    assert executions._owner_is_live(
+        777, 99999, stable_started_at=12345
+    ) is True
+    assert executions._owner_is_live(
+        777, 99999, stable_started_at=12346
+    ) is False
+
+
 def test_restart_marks_interrupted_execution_unknown_without_requeue(tmp_path):
     """Real temp-HERMES_HOME subprocess restart: in-flight is audit-only unknown."""
     home = tmp_path / "home"
@@ -181,7 +268,11 @@ def test_generic_submit_failure_finishes_attempt_and_releases_guard(monkeypatch)
         scheduler, "finish_execution",
         lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
     )
-    monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [{"id": "submit-fail"}])
+    monkeypatch.setattr(
+        scheduler,
+        "get_due_jobs",
+        lambda **_kwargs: [{"id": "submit-fail"}],
+    )
     monkeypatch.setattr(scheduler, "advance_next_runs", lambda _ids: 0)
     monkeypatch.setattr(scheduler, "_get_parallel_pool", lambda _workers: BrokenPool())
 
@@ -215,7 +306,12 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
     monkeypatch.setattr(
         scheduler,
         "run_job",
-        lambda job, *, defer_agent_teardown=None, **_kw: (True, "output", "response", None),
+        lambda job, *, defer_agent_teardown=None, **_kwargs: (
+            True,
+            "output",
+            "response",
+            None,
+        ),
     )
     monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
     monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -22,6 +22,8 @@ from cron.jobs import (
     claim_dispatch,
     claim_job_for_fire,
     heartbeat_run_claim,
+    mark_preflight_alerted,
+    clear_preflight_alerted,
     get_due_jobs,
     save_job_output,
     _hermes_now,
@@ -740,6 +742,92 @@ class TestGetDueJobs:
             assert get_due_jobs() == [], f"double-dispatched at +{gap}s"
 
 
+    def test_recurring_job_not_redispatched_while_running(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """A durable run claim extends the running guard across processes."""
+        from cron.jobs import _hermes_now
+
+        t0 = _hermes_now()
+        due_at = (t0 - timedelta(seconds=5)).isoformat()
+        save_jobs([{
+            "id": "long-recurring", "name": "R", "prompt": "long report",
+            "schedule": {"kind": "interval", "minutes": 1},
+            "next_run_at": due_at, "enabled": True, "state": "scheduled",
+        }])
+
+        first = get_due_jobs(claim_recurring=True)
+        assert [job["id"] for job in first] == ["long-recurring"]
+        assert get_job("long-recurring").get("run_claim") is not None
+
+        for gap in (61, 130):
+            monkeypatch.setattr(
+                "cron.jobs._hermes_now",
+                lambda t0=t0, gap=gap: t0 + timedelta(seconds=gap),
+            )
+            assert get_due_jobs() == [], f"recurring job redispatched at +{gap}s"
+
+
+    def test_recurring_run_claim_expires_after_worker_stops(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """A failed final ledger/store write cannot wedge recurrence forever."""
+        monkeypatch.delenv("HERMES_CRON_TIMEOUT", raising=False)
+        from cron.jobs import _hermes_now, _oneshot_run_claim_ttl_seconds
+
+        now = _hermes_now()
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        ttl = _oneshot_run_claim_ttl_seconds()
+        due_at = (now - timedelta(seconds=5)).isoformat()
+        stale_claim_at = (now - timedelta(seconds=ttl + 1)).isoformat()
+        save_jobs([{
+            "id": "stale-recurring", "name": "R", "prompt": "retry safely",
+            "schedule": {"kind": "interval", "minutes": 1},
+            "next_run_at": due_at, "enabled": True, "state": "scheduled",
+            "run_claim": {"at": stale_claim_at, "by": "dead-worker"},
+        }])
+
+        due = get_due_jobs(claim_recurring=True)
+        assert [job["id"] for job in due] == ["stale-recurring"]
+        replacement = get_job("stale-recurring")["run_claim"]
+        assert replacement["at"] == now.isoformat()
+        assert replacement["by"] != "dead-worker"
+
+
+    def test_recurring_run_claim_heartbeat_extends_ownership_past_ttl(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_CRON_TIMEOUT", raising=False)
+        from cron.jobs import _hermes_now, _oneshot_run_claim_ttl_seconds
+
+        ttl = _oneshot_run_claim_ttl_seconds()
+        t0 = _hermes_now()
+        due_at = (t0 - timedelta(seconds=5)).isoformat()
+        save_jobs([{
+            "id": "heartbeat-recurring", "name": "R", "prompt": "x",
+            "schedule": {"kind": "interval", "minutes": 1},
+            "next_run_at": due_at, "enabled": True, "state": "scheduled",
+        }])
+        assert [job["id"] for job in get_due_jobs(claim_recurring=True)] == [
+            "heartbeat-recurring"
+        ]
+        owner = get_job("heartbeat-recurring")["run_claim"]["by"]
+
+        monkeypatch.setattr(
+            "cron.jobs._hermes_now",
+            lambda: t0 + timedelta(seconds=ttl - 60),
+        )
+        assert heartbeat_run_claim(
+            "heartbeat-recurring", expected_owner=owner
+        ) is True
+
+        monkeypatch.setattr(
+            "cron.jobs._hermes_now",
+            lambda: t0 + timedelta(seconds=ttl + 10),
+        )
+        assert get_due_jobs() == []
+
+
     def test_run_claim_heartbeat_keeps_long_run_claimed_past_ttl(
         self, tmp_cron_dir, monkeypatch
     ):
@@ -803,6 +891,40 @@ class TestGetDueJobs:
             "at": original_at,
             "by": "new-owner",
         }
+
+
+    def test_mark_job_run_rejects_stale_attempt_owner(self, tmp_cron_dir):
+        """A resumed old attempt cannot clear or overwrite its successor."""
+        next_run = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        replacement_claim = {
+            "at": datetime.now(timezone.utc).isoformat(),
+            "by": "replacement-owner",
+        }
+        save_jobs([{
+            "id": "reclaimed-completion", "name": "R", "prompt": "x",
+            "schedule": {"kind": "interval", "minutes": 60},
+            "next_run_at": next_run, "enabled": True, "state": "scheduled",
+            "last_status": None,
+            "run_claim": replacement_claim,
+        }])
+
+        assert mark_job_run(
+            "reclaimed-completion",
+            success=False,
+            error="late old failure",
+            expected_run_claim_owner="old-owner",
+        ) is False
+        persisted = get_job("reclaimed-completion")
+        assert persisted["run_claim"] == replacement_claim
+        assert persisted["last_status"] is None
+        assert persisted["next_run_at"] == next_run
+
+        assert mark_job_run(
+            "reclaimed-completion",
+            success=True,
+            expected_run_claim_owner="replacement-owner",
+        ) is True
+        assert get_job("reclaimed-completion")["run_claim"] is None
 
 
 class TestEnabledToolsets:
@@ -988,6 +1110,19 @@ class TestSaveJobOutput:
         assert output_file.exists()
         assert output_file.read_text() == "# Results\nEverything ok."
         assert "test123" in str(output_file)
+
+    def test_same_timestamp_outputs_remain_attempt_unique(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        fixed = datetime(2026, 8, 11, 1, 2, 3, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: fixed)
+
+        first = save_job_output("same-tick", "first")
+        second = save_job_output("same-tick", "second")
+
+        assert first != second
+        assert first.read_text() == "first"
+        assert second.read_text() == "second"
 
 
 class TestCronOutputRetention:
@@ -1215,10 +1350,6 @@ class TestJobsJsonUtf8Bom:
 
         loaded = load_jobs()
         assert [j["id"] for j in loaded] == ["plainjob01"]
-
-
-
-
 class TestAdvanceNextRuns:
     """Tests for advance_next_runs() — the batched due-set advance.
 
@@ -1280,6 +1411,28 @@ class TestAdvanceNextRuns:
             saves.__setitem__(0, saves[0] + 1), real_save(*a, **k))[1])
         assert advance_next_runs(one_ids + ["missing-id"]) == 0
         assert saves[0] == 0
+
+    def test_exact_owner_mapping_preserves_successor_schedule(self, tmp_cron_dir):
+        from cron.jobs import advance_next_runs
+
+        rec_ids, _ = self._make_due(
+            tmp_cron_dir, n_recurring=1, n_oneshot=0
+        )
+        job_id = rec_ids[0]
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] == job_id:
+                job["run_claim"] = {
+                    "at": _hermes_now().isoformat(),
+                    "by": "successor-owner",
+                }
+                successor_next = job["next_run_at"]
+        save_jobs(jobs)
+
+        assert advance_next_runs({job_id: "stale-owner"}) == 0
+        stored = get_job(job_id)
+        assert stored["run_claim"]["by"] == "successor-owner"
+        assert stored["next_run_at"] == successor_next
 
     def test_wrapper_semantics_unchanged(self, tmp_cron_dir):
         """advance_next_run keeps its per-job contract over the batch."""
@@ -1354,3 +1507,75 @@ class TestCompletedOneshotRetentionSweep:
         assert updated["enabled"] is True
         assert updated["state"] == "scheduled"
         assert updated["next_run_at"] is not None
+
+
+class TestAttemptLifecycleFences:
+    """Every attempt-owned durable mutation is one exact-owner CAS."""
+
+    @staticmethod
+    def _claimed_oneshot(owner: str = "attempt-a"):
+        return {
+            "id": "lifecycle-job",
+            "name": "lifecycle",
+            "prompt": "run",
+            "enabled": True,
+            "state": "scheduled",
+            "schedule": {"kind": "once", "run_at": _hermes_now().isoformat()},
+            "repeat": {"times": 1, "completed": 0},
+            "run_claim": {"at": _hermes_now().isoformat(), "by": owner},
+        }
+
+    def test_dispatch_claim_rejects_replaced_owner_without_consuming_successor(
+        self, tmp_cron_dir
+    ):
+        successor = self._claimed_oneshot("attempt-b")
+        save_jobs([successor])
+
+        assert claim_dispatch(
+            successor["id"], expected_run_claim_owner="attempt-a"
+        ) is False
+
+        stored = get_job(successor["id"])
+        assert stored is not None
+        assert stored["run_claim"]["by"] == "attempt-b"
+        assert stored["repeat"]["completed"] == 0
+        assert stored["enabled"] is True
+
+    def test_dispatch_claim_missing_job_fails_closed_for_claimed_attempt(
+        self, tmp_cron_dir
+    ):
+        save_jobs([])
+        assert claim_dispatch(
+            "missing", expected_run_claim_owner="attempt-a"
+        ) is False
+
+    def test_output_save_rejects_replaced_owner_without_writing_file(
+        self, tmp_cron_dir
+    ):
+        successor = self._claimed_oneshot("attempt-b")
+        save_jobs([successor])
+
+        assert save_job_output(
+            successor["id"],
+            "stale output",
+            expected_run_claim_owner="attempt-a",
+        ) is None
+
+        output_dir = tmp_cron_dir / "cron" / "output" / successor["id"]
+        assert not output_dir.exists() or list(output_dir.glob("*.md")) == []
+
+    def test_preflight_marker_rejects_replaced_owner(self, tmp_cron_dir):
+        successor = self._claimed_oneshot("attempt-b")
+        successor["preflight_alerted"] = True
+        save_jobs([successor])
+
+        assert mark_preflight_alerted(
+            successor["id"], expected_run_claim_owner="attempt-a"
+        ) is None
+        assert clear_preflight_alerted(
+            successor["id"], expected_run_claim_owner="attempt-a"
+        ) is None
+
+        stored = get_job(successor["id"])
+        assert stored["run_claim"]["by"] == "attempt-b"
+        assert stored["preflight_alerted"] is True

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -23,7 +23,10 @@ enabler: #80774.
 from __future__ import annotations
 
 import json
+import shlex
 import sys
+import threading
+import time
 
 import pytest
 
@@ -386,6 +389,123 @@ def test_monitor_script_failure_is_error_not_change(hermes_env, monkeypatch):
     assert observed["agent_runs"] == 1  # agent NOT invoked on source failure
     # Stored hash untouched — a later recovery to 'state A' still suppresses.
     assert get_job(job["id"])["monitor_state"]["last_output_hash"] == stored_hash
+
+
+def test_claim_loss_terminates_monitor_script_process_group(
+    hermes_env, monkeypatch
+):
+    """A replaced attempt cannot leave monitor-script children doing work."""
+    from cron.jobs import get_job, update_job
+    import cron.scheduler as scheduler
+
+    started = hermes_env / "monitor-started"
+    side_effect = hermes_env / "stale-side-effect"
+    job = _make_monitor_job(
+        hermes_env,
+        "printf started > " + shlex.quote(str(started)) + "\n"
+        "(\n"
+        "  sleep 0.5\n"
+        "  printf stale > " + shlex.quote(str(side_effect)) + "\n"
+        ") &\n"
+        "wait\n",
+    )
+    update_job(
+        job["id"],
+        {
+            "run_claim": {
+                "at": "2026-08-11T00:00:00+00:00",
+                "by": "original-attempt",
+            }
+        },
+    )
+    job = get_job(job["id"])
+    ownership_lost = threading.Event()
+    heartbeat_calls = 0
+
+    def lose_after_monitor_starts(*_args, **_kwargs):
+        nonlocal heartbeat_calls
+        heartbeat_calls += 1
+        if heartbeat_calls == 1:
+            return True
+        deadline = time.monotonic() + 2
+        while not started.exists() and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert started.exists(), "monitor script never started"
+        return False
+
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "heartbeat_run_claim", lose_after_monitor_starts)
+
+    success, _doc, _final, error = scheduler.run_job(
+        job,
+        claim_ownership_lost=ownership_lost,
+    )
+
+    assert success is False
+    assert "ownership was lost" in str(error).lower()
+    assert ownership_lost.is_set()
+    time.sleep(0.7)
+    assert not side_effect.exists()
+    assert observed["agent_runs"] == 0
+
+
+def test_successor_monitor_state_survives_stale_attempt_persistence(
+    hermes_env, monkeypatch
+):
+    """A source that returns after claim replacement cannot overwrite state."""
+    from cron.jobs import get_job, update_job
+    import cron.monitor as monitor
+
+    job = _make_monitor_job(hermes_env, "echo stale\n")
+    update_job(
+        job["id"],
+        {
+            "run_claim": {
+                "at": "2026-08-11T00:00:00+00:00",
+                "by": "original-attempt",
+            },
+            "monitor_state": {
+                "last_output_hash": "original-hash",
+                "last_changed_at": "2026-08-11T00:00:00+00:00",
+            },
+        },
+    )
+    job = get_job(job["id"])
+    snapshot_path = monitor._snapshot_path(job["id"])
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_path.write_text("original snapshot", encoding="utf-8")
+    successor_state = {
+        "last_output_hash": "successor-hash",
+        "last_changed_at": "2026-08-11T00:01:00+00:00",
+    }
+    successor_claim = {
+        "at": "2026-08-11T00:01:00+00:00",
+        "by": "successor-attempt",
+    }
+
+    def fetch_after_successor_takes_over(_job, **_kwargs):
+        update_job(
+            job["id"],
+            {
+                "run_claim": successor_claim,
+                "monitor_state": successor_state,
+            },
+        )
+        snapshot_path.write_text("successor snapshot", encoding="utf-8")
+        return True, "stale output"
+
+    monkeypatch.setattr(monitor, "_run_monitor_source", fetch_after_successor_takes_over)
+
+    outcome = monitor.check_monitor(job)
+
+    persisted = get_job(job["id"])
+    assert outcome.ok is False
+    assert "ownership was lost" in str(outcome.error).lower()
+    assert persisted["run_claim"] == successor_claim
+    assert persisted["monitor_state"] == successor_state
+    assert snapshot_path.read_text(encoding="utf-8") == "successor snapshot"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_notepad.py
+++ b/tests/cron/test_notepad.py
@@ -8,6 +8,7 @@ use the notepad, and the `hermes cron notepad` CLI handler.
 from __future__ import annotations
 
 import argparse
+import importlib
 import sys
 from pathlib import Path
 
@@ -42,6 +43,52 @@ def cron_env(tmp_path, monkeypatch, notepad):
     monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
     monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
     return hermes_home
+
+
+def test_notepad_follows_active_cron_store_after_default_import(monkeypatch, tmp_path):
+    """A multiplex profile must not read or mutate the default notepad."""
+    default_home = tmp_path / "default"
+    ops_home = tmp_path / "home-ops"
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    import cron.notepad as notepad_mod
+    from cron.jobs import use_cron_store
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    # Reproduce a multiplex gateway: imports happen under the default profile,
+    # while later scheduler iterations run under a secondary profile context.
+    notepad_mod = importlib.reload(notepad_mod)
+    assert notepad_mod.NOTEPAD_FILE == default_home / "cron" / "notepad.db"
+
+    job_id = "same-job-id"
+    notepad_mod.set_note(job_id, "sentinel", "default-profile")
+
+    token = set_hermes_home_override(ops_home)
+    try:
+        with use_cron_store(ops_home):
+            notepad_mod.set_note(job_id, "sentinel", "ops-profile")
+            notepad_mod.set_note(job_id, "remove-me", "delete this")
+            notepad_mod.set_note(job_id, "clear-me", "clear this")
+
+            rendered = notepad_mod.render_notepad_section(job_id)
+            assert "ops-profile" in rendered
+            assert "default-profile" not in rendered
+
+            assert notepad_mod.delete_note(job_id, "remove-me") is True
+            assert notepad_mod.get_note(job_id, "remove-me") is None
+            assert notepad_mod.clear_notepad(job_id) == 2
+            assert notepad_mod.render_notepad_section(job_id) == ""
+    finally:
+        reset_hermes_home_override(token)
+
+    # The same job ID has an independent row in the default profile, and no
+    # secondary-profile operation above was allowed to mutate it.
+    assert notepad_mod.get_note(job_id, "sentinel") == "default-profile"
+    assert (default_home / "cron" / "notepad.db").is_file()
+    assert (ops_home / "cron" / "notepad.db").is_file()
 
 
 class TestNotepadCrud:

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -70,7 +70,7 @@ class TestRunningJobGuard:
         sched._running_job_ids.add("guard-job")
 
         dispatched = []
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
         monkeypatch.setattr(sched, "advance_next_runs", lambda *_a, **_kw: 0)
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: dispatched.append(j["id"]) or (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)
@@ -84,6 +84,291 @@ class TestRunningJobGuard:
         sched._running_job_ids.discard("guard-job")
         sched._shutdown_parallel_pool()
 
+    def test_queued_job_heartbeats_claim_before_worker_starts(
+        self, monkeypatch
+    ):
+        """A pool backlog cannot let a durable attempt claim expire."""
+        import cron.scheduler as sched
+
+        sched._running_job_ids.clear()
+        heartbeat_seen = threading.Event()
+        submitted = {}
+        advanced_attempts = {}
+        job = {
+            "id": "queued-claim",
+            "name": "queued-claim",
+            "prompt": "test",
+            "schedule": {"kind": "interval", "minutes": 1},
+            "enabled": True,
+            "next_run_at": "2020-01-01T00:00:00+00:00",
+            "deliver": "local",
+            "run_claim": {
+                "at": "2020-01-01T00:00:00+00:00",
+                "by": "attempt-token",
+            },
+        }
+
+        class QueuedPool:
+            def submit(self, fn):
+                submitted["worker"] = fn
+                return concurrent.futures.Future()
+
+        monkeypatch.setattr(sched, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
+        monkeypatch.setattr(
+            sched,
+            "advance_next_runs",
+            lambda attempts: advanced_attempts.update(attempts) or 0,
+        )
+        monkeypatch.setattr(sched, "_get_parallel_pool", lambda _limit: QueuedPool())
+        monkeypatch.setattr(
+            sched,
+            "create_execution",
+            lambda *_a, **_kw: {"id": "execution-1"},
+        )
+        monkeypatch.setattr(sched, "run_one_job", lambda *_a, **_kw: True)
+        monkeypatch.setattr(
+            sched,
+            "heartbeat_run_claim",
+            lambda *_a, **_kw: heartbeat_seen.set() or True,
+        )
+
+        assert sched.tick(verbose=False, sync=False) == 1
+        assert heartbeat_seen.wait(timeout=1), (
+            "claim heartbeat did not start while work remained queued"
+        )
+        assert advanced_attempts == {"queued-claim": "attempt-token"}
+        submitted["worker"]()
+        assert "queued-claim" not in sched.get_running_job_ids()
+
+    def test_queued_worker_does_not_run_after_attempt_token_is_lost(
+        self, monkeypatch
+    ):
+        """The worker rechecks its exact fence immediately before side effects."""
+        import cron.scheduler as sched
+
+        sched._running_job_ids.clear()
+        submitted = {}
+        owned = [True]
+        ran = []
+        finished = []
+        job = {
+            "id": "replaced-while-queued",
+            "name": "queued",
+            "prompt": "test",
+            "schedule": {"kind": "interval", "minutes": 1},
+            "enabled": True,
+            "next_run_at": "2020-01-01T00:00:00+00:00",
+            "run_claim": {
+                "at": "2020-01-01T00:00:00+00:00",
+                "by": "original-attempt",
+            },
+        }
+
+        class QueuedPool:
+            def submit(self, fn):
+                submitted["worker"] = fn
+                return concurrent.futures.Future()
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
+        monkeypatch.setattr(sched, "advance_next_runs", lambda *_a, **_kw: 0)
+        monkeypatch.setattr(sched, "_get_parallel_pool", lambda _limit: QueuedPool())
+        monkeypatch.setattr(
+            sched, "create_execution", lambda *_a, **_kw: {"id": "execution-2"}
+        )
+        monkeypatch.setattr(
+            sched,
+            "heartbeat_run_claim",
+            lambda *_a, **_kw: owned[0],
+        )
+        monkeypatch.setattr(
+            sched, "release_run_claim", lambda *_a, **_kw: True
+        )
+        monkeypatch.setattr(
+            sched, "run_one_job", lambda *_a, **_kw: ran.append(True) or True
+        )
+        monkeypatch.setattr(
+            sched,
+            "finish_execution",
+            lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+        )
+
+        assert sched.tick(verbose=False, sync=False) == 1
+        owned[0] = False
+        assert submitted["worker"]() is False
+        assert ran == []
+        assert finished[-1][0] == "execution-2"
+        assert "not started" in finished[-1][1]["error"]
+
+    def test_queued_heartbeat_error_and_release_error_still_finish_ledger(
+        self, monkeypatch
+    ):
+        import cron.scheduler as sched
+
+        sched._running_job_ids.clear()
+        submitted = {}
+        finished = []
+        heartbeat_calls = [0]
+        job = {
+            "id": "queued-store-error",
+            "name": "queued",
+            "schedule": {"kind": "interval", "minutes": 1},
+            "run_claim": {"at": "2020-01-01T00:00:00+00:00", "by": "owner"},
+        }
+
+        class QueuedPool:
+            def submit(self, fn):
+                submitted["worker"] = fn
+                return concurrent.futures.Future()
+
+        def heartbeat(*_a, **_kw):
+            heartbeat_calls[0] += 1
+            if heartbeat_calls[0] == 1:
+                return True  # heartbeat startup
+            raise OSError("jobs store unavailable")
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kw: [job])
+        monkeypatch.setattr(sched, "advance_next_runs", lambda *_a, **_kw: 0)
+        monkeypatch.setattr(sched, "_get_parallel_pool", lambda _limit: QueuedPool())
+        monkeypatch.setattr(
+            sched, "create_execution", lambda *_a, **_kw: {"id": "exec-error"}
+        )
+        monkeypatch.setattr(sched, "heartbeat_run_claim", heartbeat)
+        monkeypatch.setattr(
+            sched,
+            "release_run_claim",
+            lambda *_a, **_kw: (_ for _ in ()).throw(OSError("release failed")),
+        )
+        monkeypatch.setattr(
+            sched,
+            "finish_execution",
+            lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+        )
+        monkeypatch.setattr(
+            sched,
+            "run_one_job",
+            lambda *_a, **_kw: (_ for _ in ()).throw(
+                AssertionError("unverifiable queued attempt must not run")
+            ),
+        )
+
+        assert sched.tick(verbose=False, sync=False) == 1
+        assert submitted["worker"]() is False
+        assert finished[-1][0] == "exec-error"
+        assert finished[-1][1]["success"] is False
+        assert "unavailable" in finished[-1][1]["error"]
+
+    def test_same_job_id_in_two_profiles_dispatches_independently(
+        self, tmp_path, monkeypatch
+    ):
+        """Multiplex profile-local job IDs must not collide in the running guard."""
+        import cron.scheduler as sched
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        sched._running_job_ids.clear()
+        workers = []
+        job = {
+            "id": "shared-id",
+            "name": "profile-local",
+            "prompt": "test",
+            "schedule": {"kind": "interval", "minutes": 1},
+            "next_run_at": "2020-01-01T00:00:00+00:00",
+        }
+
+        class QueuedPool:
+            def submit(self, fn):
+                workers.append(fn)
+                return concurrent.futures.Future()
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
+        monkeypatch.setattr(sched, "advance_next_runs", lambda *_a, **_kw: 0)
+        monkeypatch.setattr(sched, "_get_parallel_pool", lambda _limit: QueuedPool())
+        execution_count = iter(range(2))
+        monkeypatch.setattr(
+            sched,
+            "create_execution",
+            lambda *_a, **_kw: {"id": f"execution-{next(execution_count)}"},
+        )
+        monkeypatch.setattr(sched, "run_one_job", lambda *_a, **_kw: True)
+
+        for profile in (tmp_path / "a", tmp_path / "b"):
+            token = set_hermes_home_override(str(profile))
+            try:
+                assert sched.tick(verbose=False, sync=False) == 1
+            finally:
+                reset_hermes_home_override(token)
+
+        assert len(workers) == 2
+        for worker in workers:
+            assert worker() is True
+        assert sched.get_running_job_ids() == frozenset()
+
+    def test_tick_abort_releases_every_unsubmitted_attempt_claim(
+        self, monkeypatch
+    ):
+        import cron.scheduler as sched
+
+        job = {
+            "id": "abort-before-submit",
+            "run_claim": {
+                "at": "2026-01-01T00:00:00+00:00",
+                "by": "abort-token",
+            },
+        }
+        released = []
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
+        monkeypatch.setattr(
+            sched,
+            "advance_next_runs",
+            lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("advance failed")),
+        )
+        monkeypatch.setattr(
+            sched,
+            "release_run_claim",
+            lambda job_id, *, expected_owner: released.append(
+                (job_id, expected_owner)
+            ) or True,
+        )
+
+        with pytest.raises(RuntimeError, match="advance failed"):
+            sched.tick(verbose=False)
+
+        assert released == [("abort-before-submit", "abort-token")]
+
+    def test_unsubmitted_claim_release_retries_after_transient_error(
+        self, monkeypatch
+    ):
+        """A failed early release remains pending for tick's final cleanup."""
+        import cron.scheduler as sched
+
+        job = {
+            "id": "shutdown-before-submit",
+            "run_claim": {
+                "at": "2026-01-01T00:00:00+00:00",
+                "by": "shutdown-token",
+            },
+        }
+        release_calls = []
+
+        def flaky_release(job_id, *, expected_owner):
+            release_calls.append((job_id, expected_owner))
+            if len(release_calls) == 1:
+                raise OSError("temporary jobs-store failure")
+            return True
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
+        monkeypatch.setattr(sched, "advance_next_runs", lambda *_a, **_kw: 0)
+        monkeypatch.setattr(sched, "_interpreter_shutting_down", lambda *_a: True)
+        monkeypatch.setattr(sched, "release_run_claim", flaky_release)
+
+        assert sched.tick(verbose=False) == 0
+        assert release_calls == [
+            ("shutdown-before-submit", "shutdown-token"),
+            ("shutdown-before-submit", "shutdown-token"),
+        ]
 
 class TestSyncMode:
     """tick() blocks by default (sync=True); tick(sync=False) returns immediately."""
@@ -103,7 +388,7 @@ class TestSyncMode:
             for i in range(3)
         ]
 
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: jobs)
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: jobs)
         monkeypatch.setattr(sched, "advance_next_runs", lambda *_a, **_kw: 0)
         monkeypatch.setattr(sched, "run_job", lambda j, **_kw: (True, "out", "resp", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
@@ -146,11 +431,11 @@ class TestSequentialPool:
 
         barrier = threading.Barrier(2, timeout=5)
 
-        def slow_run(j, *, defer_agent_teardown=None, **_kw):
+        def slow_run(j, *, defer_agent_teardown=None, **_kwargs):
             barrier.wait()
             return True, "out", "resp", None
 
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: [job])
         monkeypatch.setattr(sched, "advance_next_runs", lambda *_a, **_kw: 0)
         monkeypatch.setattr(sched, "run_job", slow_run)
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
@@ -203,7 +488,7 @@ class TestTickBatchAdvance:
         ]
 
         advance_calls = []
-        monkeypatch.setattr(sched, "get_due_jobs", lambda: jobs)
+        monkeypatch.setattr(sched, "get_due_jobs", lambda **_kwargs: jobs)
         monkeypatch.setattr(
             sched, "advance_next_runs",
             lambda ids: advance_calls.append(list(ids)) or len(list(ids)))

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -108,6 +108,50 @@ def _run_job_patched(job, tmp_path, *, resolve=None, skill_view=None):
 
 
 class TestMissingProviderKeyBlocks:
+    def test_claimed_preflight_marker_uses_exact_attempt_owner(self, tmp_path):
+        job = _job(
+            run_claim={
+                "at": "2026-01-01T00:00:00+00:00",
+                "by": "attempt-a",
+            }
+        )
+        with patch(
+            "cron.jobs.mark_preflight_alerted", return_value=False
+        ) as mark_alerted:
+            success, _out, _final, error, _agent = _run_job_patched(
+                job, tmp_path, resolve=_AuthErrorFactory()
+            )
+
+        assert success is False
+        assert "blocked_config" in error
+        mark_alerted.assert_called_once_with(
+            job["id"], expected_run_claim_owner="attempt-a"
+        )
+
+    def test_claimed_preflight_clear_uses_exact_attempt_owner(self, tmp_path):
+        job = _job(
+            model="test-model",
+            preflight_alerted=True,
+            run_claim={
+                "at": "2026-01-01T00:00:00+00:00",
+                "by": "attempt-a",
+            },
+        )
+        with patch(
+            "cron.jobs.clear_preflight_alerted", return_value=True
+        ) as clear_alerted, patch(
+            "cron.scheduler.heartbeat_run_claim", return_value=True
+        ):
+            success, _out, _final, error, _agent = _run_job_patched(
+                job, tmp_path
+            )
+
+        assert success is True
+        assert error is None
+        clear_alerted.assert_called_once_with(
+            job["id"], expected_run_claim_owner="attempt-a"
+        )
+
     def test_missing_key_blocked_config_no_agent(self, tmp_path):
         """Missing provider key (AuthError, no fallback chain) → blocked_config,
         agent never constructed, no LLM run burned."""
@@ -129,7 +173,7 @@ class TestMissingProviderKeyBlocks:
         job = _job()
         deliveries = []
 
-        def fake_deliver(job, content, adapters=None, loop=None):
+        def fake_deliver(job, content, adapters=None, loop=None, **_kwargs):
             deliveries.append(content)
             return None
 
@@ -233,7 +277,7 @@ class TestOptOut:
         job = _job()
         deliveries = []
 
-        def fake_deliver(job, content, adapters=None, loop=None):
+        def fake_deliver(job, content, adapters=None, loop=None, **_kwargs):
             deliveries.append(content)
             return None
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -11,6 +11,10 @@ the extraction didn't change `tick`'s behavior); the rest unit-test the
 extracted helper directly.
 """
 import cron.scheduler as s
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import threading
+import time
 
 
 def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final response",
@@ -18,7 +22,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
     """Patch the job pipeline primitives and record the call order."""
     calls = []
 
-    def fake_run_job(job, *, defer_agent_teardown=None, **kw):
+    def fake_run_job(job, *, defer_agent_teardown=None, **_kwargs):
         calls.append(("run_job", job["id"]))
         fr = final if silent_marker_in is None else silent_marker_in
         return (success, output, fr, error)
@@ -27,11 +31,11 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("save", jid))
         return f"/tmp/{jid}.txt"
 
-    def fake_deliver(job, content, adapters=None, loop=None):
+    def fake_deliver(job, content, adapters=None, loop=None, **_kwargs):
         calls.append(("deliver", job["id"]))
         return None
 
-    def fake_mark(jid, ok, err=None, delivery_error=None, **_kw):
+    def fake_mark(jid, ok, err=None, delivery_error=None, **_kwargs):
         calls.append(("mark", jid, ok))
 
     monkeypatch.setattr(s, "run_job", fake_run_job)
@@ -45,7 +49,11 @@ def test_tick_process_job_sequence(monkeypatch):
     """Characterization: a single due job driven through tick() runs the
     sequence run_job → save → deliver → mark, in that order."""
     calls = _patch_pipeline(monkeypatch)
-    monkeypatch.setattr(s, "get_due_jobs", lambda: [{"id": "j1", "name": "t"}])
+    monkeypatch.setattr(
+        s,
+        "get_due_jobs",
+        lambda **_kwargs: [{"id": "j1", "name": "t"}],
+    )
     monkeypatch.setattr(s, "advance_next_runs", lambda ids: 1)
 
     s.tick(verbose=False, sync=True)
@@ -66,6 +74,250 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j2", True)
 
 
+def test_claimed_run_passes_exact_owner_to_dispatch_and_output(monkeypatch):
+    """Dispatch consumption and output publication share the attempt token."""
+    dispatch_owners = []
+    save_owners = []
+    monkeypatch.setattr(
+        s,
+        "_start_run_claim_heartbeat",
+        lambda *_a, **_kw: (threading.Event(), threading.Event(), threading.Thread()),
+    )
+    monkeypatch.setattr(s, "_stop_run_claim_heartbeat", lambda *_a: None)
+    monkeypatch.setattr(
+        s,
+        "claim_dispatch",
+        lambda _jid, *, expected_run_claim_owner=None: (
+            dispatch_owners.append(expected_run_claim_owner) or True
+        ),
+    )
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (True, "output", "[SILENT]", None),
+    )
+    monkeypatch.setattr(
+        s,
+        "save_job_output",
+        lambda _jid, _out, *, expected_run_claim_owner=None: (
+            save_owners.append(expected_run_claim_owner) or Path("/tmp/out.md")
+        ),
+    )
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: True)
+    monkeypatch.setattr(s, "finish_execution", lambda *_a, **_kw: None)
+
+    assert s.run_one_job({
+        "id": "owned-pipeline",
+        "execution_id": "execution-owned",
+        "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt-a"},
+    }) is True
+    assert dispatch_owners == ["attempt-a"]
+    assert save_owners == ["attempt-a"]
+
+
+def test_output_rejection_is_ownership_loss_and_stale_execution_fails(monkeypatch):
+    finished = []
+    monkeypatch.setattr(
+        s,
+        "_start_run_claim_heartbeat",
+        lambda *_a, **_kw: (threading.Event(), threading.Event(), threading.Thread()),
+    )
+    monkeypatch.setattr(s, "_stop_run_claim_heartbeat", lambda *_a: None)
+    monkeypatch.setattr(s, "claim_dispatch", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (True, "stale output", "stale response", None),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: None)
+    monkeypatch.setattr(s, "_deliver_result", lambda *_a, **_kw: (_ for _ in ()).throw(
+        AssertionError("stale attempt must not deliver")
+    ))
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: False)
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+
+    assert s.run_one_job({
+        "id": "stale-save",
+        "execution_id": "execution-stale-save",
+        "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt-a"},
+    }) is False
+    assert finished[-1][1]["success"] is False
+    assert "ownership" in finished[-1][1]["error"].lower()
+
+
+def test_shutdown_output_rejection_consumes_only_current_attempt_flag(monkeypatch):
+    """A shutdown-cleared token must not poison the next run of the same job."""
+    job = {
+        "id": "shutdown-save-loss",
+        "execution_id": "execution-shutdown-save-loss",
+        "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt-a"},
+    }
+    scoped_key = f"{s._get_hermes_home().resolve()}\0{job['id']}"
+    s._interrupted_job_ids.add(scoped_key)
+    s._interrupted_run_claim_owners[scoped_key] = "attempt-a"
+    monkeypatch.setattr(
+        s,
+        "_start_run_claim_heartbeat",
+        lambda *_a, **_kw: (threading.Event(), threading.Event(), threading.Thread()),
+    )
+    monkeypatch.setattr(s, "_stop_run_claim_heartbeat", lambda *_a: None)
+    monkeypatch.setattr(s, "claim_dispatch", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        s, "run_job", lambda *_a, **_kw: (True, "output", "response", None)
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: None)
+    monkeypatch.setattr(s, "finish_execution", lambda *_a, **_kw: None)
+
+    try:
+        assert s.run_one_job(job) is False
+        assert scoped_key not in s._interrupted_job_ids
+        assert scoped_key not in s._interrupted_run_claim_owners
+    finally:
+        s._interrupted_job_ids.discard(scoped_key)
+        s._interrupted_run_claim_owners.pop(scoped_key, None)
+
+
+def test_run_one_job_rejects_lost_attempt_before_side_effect(monkeypatch):
+    ran = []
+    finished = []
+    monkeypatch.setattr(s, "heartbeat_run_claim", lambda *_a, **_kw: False)
+    monkeypatch.setattr(s, "run_job", lambda *_a, **_kw: ran.append(True))
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+
+    assert s.run_one_job({
+        "id": "lost-fence",
+        "execution_id": "execution-lost",
+        "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "old"},
+    }) is False
+    assert ran == []
+    assert finished[-1][0] == "execution-lost"
+    assert "ownership lost" in finished[-1][1]["error"].lower()
+
+
+def test_run_claim_heartbeat_retries_transient_store_error(monkeypatch):
+    """A temporary jobs-store error must not make a live attempt look dead."""
+    calls = []
+
+    def flaky_heartbeat(*_args, **_kwargs):
+        calls.append(True)
+        if len(calls) == 2:
+            raise OSError("temporary fsync failure")
+        return True
+
+    monkeypatch.setattr(s, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(s, "heartbeat_run_claim", flaky_heartbeat)
+
+    heartbeat = s._start_run_claim_heartbeat(
+        {
+            "id": "transient-heartbeat",
+            "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt"},
+        },
+        thread_name="test-run-claim-heartbeat",
+    )
+    assert heartbeat is not None
+    stop, ownership_lost, _thread = heartbeat
+    deadline = time.monotonic() + 2
+    while len(calls) < 3 and time.monotonic() < deadline:
+        time.sleep(0.005)
+    stop.set()
+    s._stop_run_claim_heartbeat(heartbeat)
+
+    assert len(calls) >= 3
+    assert not ownership_lost.is_set()
+
+
+def test_run_claim_heartbeat_self_fences_after_persistent_store_error(monkeypatch):
+    """A worker stops itself before its unverifiable token can expire."""
+    calls = []
+
+    def persistent_failure(*_args, **_kwargs):
+        calls.append(True)
+        if len(calls) == 1:
+            return True
+        raise OSError("persistent isolated store failure")
+
+    monkeypatch.setattr(s, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.005)
+    monkeypatch.setattr(s, "_run_claim_self_fence_seconds", lambda: 0.02)
+    monkeypatch.setattr(s, "heartbeat_run_claim", persistent_failure)
+
+    heartbeat = s._start_run_claim_heartbeat(
+        {
+            "id": "self-fenced-heartbeat",
+            "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt"},
+        },
+        thread_name="test-run-claim-self-fence",
+    )
+    assert heartbeat is not None
+    _stop, ownership_lost, _thread = heartbeat
+    assert ownership_lost.wait(timeout=2)
+    s._stop_run_claim_heartbeat(heartbeat)
+    assert len(calls) >= 2
+
+
+def test_run_one_job_propagates_claim_loss_signal_to_job_pipeline(monkeypatch):
+    """The active job pipeline must receive the heartbeat's loss signal."""
+    ownership_lost = threading.Event()
+    heartbeat = (threading.Event(), ownership_lost, threading.Thread())
+    seen = []
+
+    monkeypatch.setattr(s, "_start_run_claim_heartbeat", lambda *_a, **_kw: heartbeat)
+    monkeypatch.setattr(s, "_stop_run_claim_heartbeat", lambda _heartbeat: None)
+    monkeypatch.setattr(
+        s,
+        "_run_one_job_body",
+        lambda *_a, **kwargs: seen.append(kwargs.get("claim_ownership_lost")) or True,
+    )
+
+    assert s.run_one_job({
+        "id": "claim-loss-signal",
+        "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt"},
+    }) is True
+    assert seen == [ownership_lost]
+
+
+def test_delivery_fails_closed_when_claim_store_cannot_verify(monkeypatch):
+    """Unverifiable ownership must suppress the external delivery side effect."""
+    heartbeats = 0
+    delivered = []
+
+    def heartbeat(*_args, **_kwargs):
+        nonlocal heartbeats
+        heartbeats += 1
+        if heartbeats == 1:
+            return True
+        raise OSError("claim store unavailable")
+
+    monkeypatch.setattr(s, "heartbeat_run_claim", heartbeat)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (True, "output", "do not deliver", None),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: "/tmp/output")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda *_a, **_kw: delivered.append(True),
+    )
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: None)
+    monkeypatch.setattr(s, "finish_execution", lambda *_a, **_kw: None)
+
+    assert s.run_one_job({
+        "id": "unverifiable-delivery",
+        "execution_id": "execution-unverifiable",
+        "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt"},
+    }) is False
+    assert delivered == []
+
+
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):
     """Regression: under profile isolation (multiplex active), run_one_job must
     execute run_job inside a profile secret scope so credential reads
@@ -83,17 +335,24 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
 
     scope_during_run = {}
 
-    def fake_run_job(job, *, defer_agent_teardown=None, **kw):
+    def fake_run_job(job, *, defer_agent_teardown=None, **_kwargs):
         # This is where resolve_runtime_provider() would read a secret. Prove a
         # scope is installed and the profile's secret resolves without raising.
         scope_during_run["scope"] = ss.current_secret_scope()
         scope_during_run["base_url"] = ss.get_secret("OPENROUTER_BASE_URL")
         return (True, "out", "final", None)
 
+    def fake_deliver(*_args, **_kwargs):
+        scope_during_run["scope_during_delivery"] = ss.current_secret_scope()
+        scope_during_run["delivery_base_url"] = ss.get_secret(
+            "OPENROUTER_BASE_URL"
+        )
+        return None
+
     monkeypatch.setattr(s, "run_job", fake_run_job)
     monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
-    monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
-    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: True)
 
     ss.set_multiplex_active(True)
     try:
@@ -105,7 +364,84 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     # Scope was installed during run_job and the profile secret resolved.
     assert scope_during_run["scope"] is not None
     assert scope_during_run["base_url"] == "https://openrouter.ai/api/v1"
+    assert scope_during_run["scope_during_delivery"] is not None
+    assert scope_during_run["delivery_base_url"] == "https://openrouter.ai/api/v1"
     # And it was torn down after run_one_job returned (no leak).
     assert ss.current_secret_scope() is None
 
 
+def test_terminal_mark_cas_false_fails_execution_ledger(monkeypatch):
+    finished = []
+    monkeypatch.setattr(
+        s,
+        "_start_run_claim_heartbeat",
+        lambda *_a, **_kw: (threading.Event(), threading.Event(), threading.Thread()),
+    )
+    monkeypatch.setattr(s, "_stop_run_claim_heartbeat", lambda *_a: None)
+    monkeypatch.setattr(s, "claim_dispatch", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        s, "run_job", lambda *_a, **_kw: (True, "output", "[SILENT]", None)
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: Path("/tmp/out"))
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: False)
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+
+    assert s.run_one_job({
+        "id": "terminal-cas-loss",
+        "execution_id": "execution-terminal-cas-loss",
+        "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt-a"},
+    }) is False
+    assert finished[-1][1]["success"] is False
+    assert "terminal" in finished[-1][1]["error"].lower()
+
+
+def test_shutdown_race_after_delivery_check_fails_ledger_and_attempt(monkeypatch):
+    job = {
+        "id": "late-shutdown",
+        "execution_id": "execution-late-shutdown",
+        "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt-a"},
+    }
+    scoped_key = f"{s._get_hermes_home().resolve()}\0{job['id']}"
+    finished = []
+    outcome = {}
+    monkeypatch.setattr(
+        s,
+        "_start_run_claim_heartbeat",
+        lambda *_a, **_kw: (threading.Event(), threading.Event(), threading.Thread()),
+    )
+    monkeypatch.setattr(s, "_stop_run_claim_heartbeat", lambda *_a: None)
+    monkeypatch.setattr(s, "claim_dispatch", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        s, "run_job", lambda *_a, **_kw: (True, "output", "[SILENT]", None)
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: Path("/tmp/out"))
+    monkeypatch.setattr(s, "heartbeat_run_claim", lambda *_a, **_kw: True)
+    monkeypatch.setattr(s, "_is_interrupted", lambda *_a, **_kw: False)
+
+    def race_shutdown(_content):
+        s._interrupted_job_ids.add(scoped_key)
+        s._interrupted_run_claim_owners[scoped_key] = "attempt-a"
+        return True
+
+    monkeypatch.setattr(s, "_is_cron_silence_response", race_shutdown)
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            AssertionError("shutdown already wrote the terminal state")
+        ),
+    )
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+
+    assert s.run_one_job(job, _attempt_outcome=outcome) is True
+    assert finished[-1][1]["success"] is False
+    assert outcome["success"] is False
+    assert "shutdown" in outcome["error"].lower()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1,10 +1,13 @@
 """Tests for cron/scheduler.py — origin resolution, delivery routing, and error logging."""
 
 import contextlib
+import asyncio
+import concurrent.futures
 import itertools
 import json
 import logging
 import os
+import threading
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
@@ -104,6 +107,44 @@ class TestResolveOrigin:
         """
         job = {"origin": non_dict_origin}
         assert _resolve_origin(job) is None
+
+
+class TestProfileScopedHomeRouting:
+    def test_two_concurrent_profiles_resolve_their_own_home_and_thread(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope as ss
+        import cron.scheduler as scheduler
+
+        homes = [tmp_path / "alpha", tmp_path / "beta"]
+        expected = [("alpha-chat", "11"), ("beta-chat", "22")]
+        for home, (chat_id, thread_id) in zip(homes, expected):
+            home.mkdir()
+            (home / ".env").write_text(
+                f"TELEGRAM_HOME_CHANNEL={chat_id}\n"
+                f"TELEGRAM_HOME_CHANNEL_THREAD_ID={thread_id}\n",
+                encoding="utf-8",
+            )
+
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "process-chat")
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL_THREAD_ID", "999")
+        barrier = threading.Barrier(2)
+
+        def resolve(home):
+            token = ss.set_secret_scope(ss.build_profile_secret_scope(home))
+            try:
+                barrier.wait(timeout=2)
+                return (
+                    scheduler._get_home_target_chat_id("telegram"),
+                    scheduler._get_home_target_thread_id("telegram"),
+                )
+            finally:
+                ss.reset_secret_scope(token)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            actual = list(pool.map(resolve, homes))
+
+        assert actual == expected
 
 
 class TestResolveDeliveryTarget:
@@ -418,6 +459,153 @@ class TestDeliverResultWrapping:
         voice_call = adapter.send_voice.call_args
         assert voice_call[1]["audio_path"] == str(media_path)
 
+    def test_claim_loss_during_first_target_stops_media_mirror_and_fanout(
+        self, monkeypatch
+    ):
+        """An in-flight send is irreversible, but no later side effect may start."""
+        from gateway.config import Platform
+
+        lost = threading.Event()
+        scheduled = []
+        media_calls = []
+        mirror_calls = []
+        pconfig = MagicMock(enabled=True, extra={})
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+        adapter = MagicMock()
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        class _ResultFuture:
+            def result(self, timeout=None):
+                lost.set()
+                return MagicMock(success=True, raw_response=None)
+
+        def fake_schedule(coro, _loop):
+            coro.close()
+            scheduled.append(True)
+            return _ResultFuture()
+
+        targets = [
+            {"platform": "discord", "chat_id": "first"},
+            {"platform": "discord", "chat_id": "second"},
+        ]
+        with patch("cron.scheduler._resolve_delivery_targets", return_value=targets), \
+             patch("cron.scheduler._resolve_origin", return_value={}), \
+             patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("gateway.delivery.resolve_delivery_transport") as resolve_transport, \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule), \
+             patch("gateway.platforms.base.BasePlatformAdapter.extract_media",
+                   return_value=(["/tmp/media"], "text")), \
+             patch("gateway.platforms.base.BasePlatformAdapter.filter_media_delivery_paths",
+                   return_value=["/tmp/media"]), \
+             patch("cron.scheduler._send_media_via_adapter",
+                   side_effect=lambda *_a, **_kw: media_calls.append(True)), \
+             patch("cron.scheduler._maybe_mirror_cron_delivery",
+                   side_effect=lambda *_a, **_kw: mirror_calls.append(True)), \
+             patch("cron.scheduler.heartbeat_run_claim", return_value=True):
+            resolve_transport.return_value = MagicMock(
+                config=pconfig, adapter=adapter, is_relay=False
+            )
+            result = _deliver_result(
+                {"id": "loss-fanout", "deliver": "discord"},
+                "text\nMEDIA:/tmp/media",
+                adapters={Platform.DISCORD: adapter},
+                loop=loop,
+                claim_ownership_lost=lost,
+                expected_run_claim_owner="attempt-a",
+            )
+
+        assert result is not None
+        assert "ownership" in result.lower()
+        assert scheduled == [True]
+        assert media_calls == []
+        assert mirror_calls == []
+
+    def test_standalone_sender_gets_guard_for_internal_fanout(self):
+        """The standalone transport must re-check ownership between API calls."""
+        from gateway.config import Platform
+
+        lost = threading.Event()
+        calls = []
+        pconfig = MagicMock(enabled=True, extra={})
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        async def standalone_send(*_args, ownership_guard=None, **_kwargs):
+            assert ownership_guard is not None
+            assert ownership_guard()
+            calls.append("first")
+            lost.set()
+            if ownership_guard():
+                calls.append("second")
+            return {"error": "Delivery ownership lost during standalone send"}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send), \
+             patch("cron.scheduler.heartbeat_run_claim", return_value=True):
+            result = _deliver_result(
+                {
+                    "id": "standalone-loss",
+                    "deliver": "origin",
+                    "origin": {"platform": "discord", "chat_id": "first"},
+                },
+                "scheduled result",
+                claim_ownership_lost=lost,
+                expected_run_claim_owner="attempt-a",
+            )
+
+        assert calls == ["first"]
+        assert result is not None
+        assert "ownership" in result.lower()
+
+    def test_standalone_thread_fallback_copies_secret_scope(
+        self, tmp_path, monkeypatch
+    ):
+        """The RuntimeError fallback must keep the secondary profile context."""
+        from agent import secret_scope as ss
+        from gateway.config import Platform
+
+        (tmp_path / ".env").write_text(
+            "OPENROUTER_BASE_URL=https://secondary.invalid/v1\n",
+            encoding="utf-8",
+        )
+        pconfig = MagicMock(enabled=True)
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        observed = []
+
+        async def fake_send(*_args, **_kwargs):
+            observed.append(
+                (ss.current_secret_scope(), ss.get_secret("OPENROUTER_BASE_URL"))
+            )
+            return {"success": True}
+
+        async def invoke_inside_running_loop():
+            return _deliver_result(
+                {
+                    "id": "secondary-fallback",
+                    "deliver": "origin",
+                    "origin": {"platform": "telegram", "chat_id": "123"},
+                },
+                "hello",
+            )
+
+        scope_token = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+        try:
+            with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+                 patch("tools.send_message_tool._send_to_platform",
+                       side_effect=fake_send):
+                result = asyncio.run(invoke_inside_running_loop())
+        finally:
+            ss.reset_secret_scope(scope_token)
+
+        assert result is None
+        assert len(observed) == 1
+        assert observed[0][0] is not None
+        assert observed[0][1] == "https://secondary.invalid/v1"
+
 
 class TestDeliverResultErrorReturns:
     """Verify _deliver_result returns error strings on failure, None on success."""
@@ -442,6 +630,78 @@ class TestDeliverResultErrorReturns:
 
 
 class TestRunJobSessionPersistence:
+    def test_run_job_interrupts_agent_after_definite_claim_loss(
+        self, tmp_path, monkeypatch
+    ):
+        """A successor CAS stops a live stale agent before it can deliver."""
+        import cron.scheduler as scheduler
+
+        claim_lost = threading.Event()
+        agent_started = threading.Event()
+        agent_interrupted = threading.Event()
+        interrupt_reasons = []
+        fake_db = MagicMock()
+        agent = MagicMock()
+
+        def run_conversation(_prompt):
+            agent_started.set()
+            agent_interrupted.wait(timeout=2)
+            return {"final_response": "stale output"}
+
+        def interrupt(reason):
+            interrupt_reasons.append(reason)
+            agent_interrupted.set()
+
+        agent.run_conversation.side_effect = run_conversation
+        agent.interrupt.side_effect = interrupt
+        agent.get_activity_summary.return_value = {
+            "seconds_since_activity": 0.0,
+            "last_activity_desc": "test",
+            "current_tool": None,
+            "api_call_count": 1,
+            "max_iterations": 60,
+        }
+
+        real_wait = concurrent.futures.wait
+        monkeypatch.setattr(
+            scheduler.concurrent.futures,
+            "wait",
+            lambda futures, timeout=None: real_wait(futures, timeout=0.01),
+        )
+
+        def lose_claim_after_agent_starts():
+            assert agent_started.wait(timeout=2)
+            claim_lost.set()
+
+        loss_thread = threading.Thread(target=lose_claim_after_agent_starts)
+        loss_thread.start()
+        with (
+            patch("cron.scheduler._hermes_home", tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("hermes_cli.env_loader.load_hermes_dotenv"),
+            patch("hermes_cli.env_loader.reset_secret_source_cache"),
+            patch("hermes_state.SessionDB", return_value=fake_db),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": "test-key",
+                    "base_url": "https://example.invalid/v1",
+                    "provider": "openrouter",
+                    "api_mode": "chat_completions",
+                },
+            ),
+            patch("run_agent.AIAgent", return_value=agent),
+        ):
+            success, _output, _response, error = run_job(
+                {"id": "lost-live-claim", "name": "test", "prompt": "hello"},
+                claim_ownership_lost=claim_lost,
+            )
+        loss_thread.join(timeout=2)
+
+        assert success is False
+        assert "ownership was lost" in (error or "").lower()
+        assert interrupt_reasons == ["Cron run claim ownership was lost"]
+
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):
         job = {
             "id": "test-job",
@@ -1007,6 +1267,7 @@ class TestSilentDelivery:
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
+            status=None,
         )
 
 
@@ -1268,7 +1529,7 @@ class TestParallelTick:
         barrier = threading.Barrier(2, timeout=5)
         call_order = []
 
-        def mock_run_job(job, *, defer_agent_teardown=None, **kw):
+        def mock_run_job(job, *, defer_agent_teardown=None, **_kwargs):
             """Each job hits a barrier — both must be active simultaneously."""
             call_order.append(("start", job["id"]))
             barrier.wait()  # blocks until both threads reach here
@@ -1302,7 +1563,7 @@ class TestParallelTick:
         from gateway.session_context import get_session_env
         seen = {}
 
-        def mock_run_job(job, *, defer_agent_teardown=None, **kw):
+        def mock_run_job(job, *, defer_agent_teardown=None, **_kwargs):
             origin = job.get("origin", {})
             # run_job sets ContextVars — verify each job sees its own
             from gateway.session_context import set_session_vars, clear_session_vars
@@ -1974,5 +2235,3 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-
-

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -84,7 +84,10 @@ def test_desktop_ticker_calls_tick_then_stops():
         calls.append(kwargs)
         return 0
 
-    with patch("cron.scheduler.tick", side_effect=fake_tick):
+    with (
+        patch("cron.jobs.gateway_ticker_lease_is_fresh", return_value=False),
+        patch("cron.scheduler.tick", side_effect=fake_tick),
+    ):
         t = threading.Thread(
             target=_start_desktop_cron_ticker,
             args=(stop,),
@@ -99,6 +102,168 @@ def test_desktop_ticker_calls_tick_then_stops():
     assert not t.is_alive(), "desktop ticker did not exit after stop_event was set"
     assert len(calls) >= 1, "desktop ticker never called tick()"
     assert calls[0].get("sync") is False
+
+
+def test_desktop_ticker_yields_while_gateway_is_running():
+    """The desktop fallback must not dispatch alongside a real gateway.
+
+    The tick file lock only serializes the short due-job scan.  Agent jobs run
+    asynchronously after that lock is released, so two provider loops can
+    otherwise execute the same recurring job at the same time.
+    """
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_cli.web_server import _start_desktop_cron_ticker
+
+    calls = []
+    gateway_checked = threading.Event()
+    gateway_ready = threading.Event()
+    gateway_ready.set()
+    stop = threading.Event()
+
+    def fake_gateway_ready():
+        gateway_checked.set()
+        return gateway_ready.is_set()
+
+    with (
+        patch(
+            "cron.jobs.gateway_ticker_lease_is_fresh",
+            side_effect=fake_gateway_ready,
+        ),
+        patch.object(
+            InProcessCronScheduler,
+            "recover_interrupted",
+            return_value=0,
+        ) as recover_interrupted,
+        patch(
+            "cron.scheduler.tick",
+            side_effect=lambda *args, **kwargs: calls.append(kwargs) or 0,
+        ),
+    ):
+        t = threading.Thread(
+            target=_start_desktop_cron_ticker,
+            args=(stop,),
+            kwargs={"interval": 0.01},
+            daemon=True,
+        )
+        t.start()
+        assert gateway_checked.wait(timeout=5), "desktop ticker never checked gateway"
+        assert calls == [], "desktop fallback dispatched before entering standby"
+        assert not recover_interrupted.called, (
+            "desktop fallback reconciled while gateway owned dispatch"
+        )
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive(), "desktop ticker did not exit after stop_event was set"
+    assert calls == [], "desktop fallback dispatched while gateway was running"
+    assert not recover_interrupted.called, (
+        "desktop fallback reconciled another live scheduler's executions"
+    )
+
+
+def test_desktop_ticker_takes_over_after_gateway_exits():
+    """The standby remains a fallback when the real gateway goes away."""
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_cli.web_server import _start_desktop_cron_ticker
+
+    calls = []
+    gateway_checked = threading.Event()
+    gateway_ready = threading.Event()
+    gateway_ready.set()
+    stop = threading.Event()
+
+    def fake_gateway_ready():
+        gateway_checked.set()
+        return gateway_ready.is_set()
+
+    with (
+        patch(
+            "cron.jobs.gateway_ticker_lease_is_fresh",
+            side_effect=fake_gateway_ready,
+        ),
+        patch.object(
+            InProcessCronScheduler,
+            "recover_interrupted",
+            return_value=0,
+        ) as recover_interrupted,
+        patch(
+            "cron.scheduler.tick",
+            side_effect=lambda *args, **kwargs: calls.append(kwargs) or 0,
+        ),
+    ):
+        t = threading.Thread(
+            target=_start_desktop_cron_ticker,
+            args=(stop,),
+            kwargs={"interval": 0.01},
+            daemon=True,
+        )
+        t.start()
+        assert gateway_checked.wait(timeout=5), "desktop ticker never checked gateway"
+        assert calls == [], "desktop fallback dispatched while gateway was ready"
+        assert not recover_interrupted.called, (
+            "desktop fallback reconciled while gateway was ready"
+        )
+        gateway_ready.clear()
+        assert _wait_until(lambda: len(calls) >= 1), (
+            "desktop ticker did not take over after gateway exit"
+        )
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive(), "desktop ticker did not exit after stop_event was set"
+    recover_interrupted.assert_called_once_with()
+    assert calls[0].get("sync") is False
+
+
+def test_desktop_ticker_rechecks_gateway_before_recovery():
+    """A gateway becoming ready at handoff must fence desktop recovery.
+
+    The desktop performs an initial readiness probe before starting the
+    provider.  The provider must probe again before reconciling executions;
+    otherwise a gateway that becomes ready between those two operations can
+    have its live execution marked interrupted by the desktop.
+    """
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_cli.web_server import _start_desktop_cron_ticker
+
+    probes = 0
+    provider_probe = threading.Event()
+    stop = threading.Event()
+
+    def gateway_becomes_ready():
+        nonlocal probes
+        probes += 1
+        if probes <= 2:
+            return False
+        provider_probe.set()
+        return True
+
+    with (
+        patch(
+            "cron.jobs.gateway_ticker_lease_is_fresh",
+            side_effect=gateway_becomes_ready,
+        ),
+        patch.object(
+            InProcessCronScheduler,
+            "recover_interrupted",
+            return_value=0,
+        ) as recover_interrupted,
+        patch("cron.scheduler.tick") as cron_tick,
+    ):
+        t = threading.Thread(
+            target=_start_desktop_cron_ticker,
+            args=(stop,),
+            kwargs={"interval": 0.01},
+            daemon=True,
+        )
+        t.start()
+        assert provider_probe.wait(timeout=5), "provider never rechecked gateway lease"
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive(), "desktop ticker did not exit after stop_event was set"
+    assert not recover_interrupted.called
+    assert not cron_tick.called
 
 
 # ── Phase 1: CronScheduler ABC + InProcessCronScheduler ──────────────────────
@@ -245,12 +410,105 @@ def test_fire_due_default_claims_then_runs(monkeypatch):
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
-    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda jid: True, raising=False)
-    monkeypatch.setattr(jobs, "get_job", lambda jid: {"id": jid, "name": "t"})
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire_attempt",
+        lambda jid: "attempt",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        jobs,
+        "get_job",
+        lambda jid: {
+            "id": jid,
+            "name": "t",
+            "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt"},
+        },
+    )
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job["id"]) or True)
 
     assert InProcessCronScheduler().fire_due("j1") is True
     assert ran == ["j1"]
+
+
+def test_fire_due_does_not_adopt_replacement_attempt(monkeypatch):
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    monkeypatch.setattr(
+        jobs, "claim_job_for_fire_attempt", lambda _jid: "original"
+    )
+    monkeypatch.setattr(
+        jobs,
+        "get_job",
+        lambda jid: {
+            "id": jid,
+            "run_claim": {"at": "2026-01-01T00:00:01+00:00", "by": "successor"},
+        },
+    )
+    ran = []
+    monkeypatch.setattr(
+        sched, "run_one_job", lambda *_a, **_kw: ran.append(True)
+    )
+
+    assert InProcessCronScheduler().fire_due("j1") is False
+    assert ran == []
+
+
+def test_fire_due_releases_exact_claim_when_refetch_raises(monkeypatch):
+    """An exception before handoff must not strand the acquired attempt."""
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    released = []
+    monkeypatch.setattr(
+        jobs, "claim_job_for_fire_attempt", lambda _jid: "attempt-owner"
+    )
+    monkeypatch.setattr(
+        jobs, "get_job", lambda _jid: (_ for _ in ()).throw(OSError("read failed"))
+    )
+    monkeypatch.setattr(
+        jobs,
+        "release_run_claim",
+        lambda jid, *, expected_owner: released.append((jid, expected_owner)) or True,
+    )
+
+    assert InProcessCronScheduler().fire_due("j1") is False
+    assert released == [("j1", "attempt-owner")]
+
+
+def test_fire_due_releases_exact_claim_when_execution_create_raises(monkeypatch):
+    """Execution-ledger failure before worker handoff must release the token."""
+    import cron.executions as executions
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    released = []
+    monkeypatch.setattr(
+        jobs, "claim_job_for_fire_attempt", lambda _jid: "attempt-owner"
+    )
+    monkeypatch.setattr(
+        jobs,
+        "get_job",
+        lambda jid: {
+            "id": jid,
+            "run_claim": {"at": "2026-01-01T00:00:00+00:00", "by": "attempt-owner"},
+        },
+    )
+    monkeypatch.setattr(
+        jobs,
+        "release_run_claim",
+        lambda jid, *, expected_owner: released.append((jid, expected_owner)) or True,
+    )
+    monkeypatch.setattr(
+        executions,
+        "create_execution",
+        lambda *_a, **_kw: (_ for _ in ()).throw(OSError("ledger unavailable")),
+    )
+
+    assert InProcessCronScheduler().fire_due("j1") is False
+    assert released == [("j1", "attempt-owner")]
 
 
 # ── F2a: ticker liveness — survival, heartbeat, honest status (#32612, #32895) ──
@@ -305,6 +563,402 @@ def test_heartbeat_roundtrip_and_age(tmp_path, monkeypatch):
     jobs.record_ticker_heartbeat(success=True)
     ok = jobs.get_ticker_success_age()
     assert ok is not None and 0.0 <= ok < 5.0
+
+
+def test_gateway_ticker_lease_is_profile_scoped_and_owner_local(tmp_path):
+    """Gateway readiness is per profile and one owner cannot clear another."""
+    import cron.jobs as jobs
+
+    default_home = tmp_path / "default"
+    ops_home = tmp_path / "home-ops"
+
+    with jobs.use_cron_store(default_home):
+        assert not jobs.gateway_ticker_lease_is_fresh()
+        jobs.record_gateway_ticker_lease("123-owner-a")
+        jobs.record_gateway_ticker_lease("456-owner-b")
+        assert jobs.gateway_ticker_lease_is_fresh()
+
+    with jobs.use_cron_store(ops_home):
+        assert not jobs.gateway_ticker_lease_is_fresh(), (
+            "a gateway serving another profile must not fence this profile"
+        )
+
+    with jobs.use_cron_store(default_home):
+        jobs.clear_gateway_ticker_lease("123-owner-a")
+        assert jobs.gateway_ticker_lease_is_fresh(), (
+            "an exiting predecessor removed its successor's readiness lease"
+        )
+        jobs.clear_gateway_ticker_lease("456-owner-b")
+        assert not jobs.gateway_ticker_lease_is_fresh()
+
+
+def test_gateway_ticker_lease_expires_and_rejects_unsafe_owner(tmp_path, monkeypatch):
+    """A crashed gateway's lease expires and owner IDs cannot escape cron/."""
+    import pytest
+    import cron.jobs as jobs
+
+    with jobs.use_cron_store(tmp_path):
+        written_at = time.time()
+        jobs.record_gateway_ticker_lease("123-owner")
+        assert jobs.gateway_ticker_lease_is_fresh()
+
+        monkeypatch.setattr(
+            jobs.time,
+            "time",
+            lambda: written_at + jobs.GATEWAY_TICKER_LEASE_STALE_SECONDS + 1,
+        )
+        assert not jobs.gateway_ticker_lease_is_fresh()
+
+        with pytest.raises(ValueError):
+            jobs.record_gateway_ticker_lease("../outside")
+        with pytest.raises(ValueError):
+            jobs.clear_gateway_ticker_lease("../outside")
+
+
+def test_gateway_ticker_lease_rejects_future_timestamp(tmp_path, monkeypatch):
+    """A clock-skewed marker cannot extend ownership by another full TTL."""
+    import cron.jobs as jobs
+
+    now = time.time()
+    owner = "123-future-owner"
+    with jobs.use_cron_store(tmp_path):
+        jobs.record_gateway_ticker_lease(owner)
+        jobs._gateway_ticker_lease_path(owner).write_text(
+            str(now + jobs._GATEWAY_TICKER_LEASE_FUTURE_SKEW_SECONDS + 1)
+        )
+        monkeypatch.setattr(jobs.time, "time", lambda: now)
+
+        assert not jobs.gateway_ticker_lease_is_fresh()
+
+
+def test_stale_gateway_lease_is_pruned_only_after_exact_owner_death(
+    tmp_path, monkeypatch
+):
+    """Crash remnants stay while identity is live/unknown, then are reclaimed."""
+    import cron.jobs as jobs
+
+    owner = f"p123-s456-{'a' * 32}"
+    with jobs.use_cron_store(tmp_path):
+        jobs.record_gateway_ticker_lease(owner)
+        lease_path = jobs._gateway_ticker_lease_path(owner)
+        written_at = time.time()
+        monkeypatch.setattr(
+            jobs.time,
+            "time",
+            lambda: written_at + jobs.GATEWAY_TICKER_LEASE_STALE_SECONDS + 1,
+        )
+
+        monkeypatch.setattr(
+            jobs,
+            "_gateway_ticker_owner_is_definitely_dead",
+            lambda _owner: False,
+        )
+        assert not jobs.gateway_ticker_lease_is_fresh()
+        assert lease_path.exists(), "probe deleted a lease without proof of death"
+
+        monkeypatch.setattr(
+            jobs,
+            "_gateway_ticker_owner_is_definitely_dead",
+            lambda _owner: True,
+        )
+        assert not jobs.gateway_ticker_lease_is_fresh()
+        assert not lease_path.exists(), "dead owner's stale lease was never reclaimed"
+
+
+def test_gateway_lease_owner_death_uses_pid_and_start_fingerprint(monkeypatch):
+    import cron.jobs as jobs
+    import gateway.status as gateway_status
+
+    owner = f"p123-s456-{'a' * 32}"
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: True)
+    monkeypatch.setattr(
+        gateway_status, "get_stable_process_start_time", lambda _pid: 456
+    )
+    assert not jobs._gateway_ticker_owner_is_definitely_dead(owner)
+
+    monkeypatch.setattr(
+        gateway_status, "get_stable_process_start_time", lambda _pid: 789
+    )
+    assert jobs._gateway_ticker_owner_is_definitely_dead(owner)
+
+    monkeypatch.setattr(gateway_status, "_pid_exists", lambda _pid: False)
+    assert jobs._gateway_ticker_owner_is_definitely_dead(owner)
+
+
+def test_gateway_provider_owns_lease_for_its_lifecycle():
+    """Readiness is published after recovery, then cleaned up on shutdown."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    events = []
+    stop = threading.Event()
+    provider = InProcessCronScheduler()
+
+    def stop_after_tick(**_kwargs):
+        events.append(("tick", None))
+        stop.set()
+        return 0
+
+    with (
+        patch(
+            "cron.jobs.record_gateway_ticker_lease",
+            side_effect=lambda owner: events.append(("lease", owner)),
+        ),
+        patch(
+            "cron.jobs.clear_gateway_ticker_lease",
+            side_effect=lambda owner: events.append(("clear", owner)),
+        ),
+        patch.object(
+            provider,
+            "recover_interrupted",
+            side_effect=lambda: events.append(("recover", None)) or 0,
+        ),
+        patch(
+            "cron.jobs.record_ticker_heartbeat",
+            side_effect=lambda **_kwargs: events.append(("heartbeat", None)),
+        ),
+        patch("cron.scheduler.tick", side_effect=stop_after_tick),
+    ):
+        provider.start(stop, interval=0, gateway_owner_id="123-owner")
+
+    assert events == [
+        ("recover", None),
+        ("heartbeat", None),
+        ("lease", "123-owner"),
+        ("tick", None),
+        ("heartbeat", None),
+        ("clear", "123-owner"),
+    ]
+
+
+def test_gateway_provider_retries_transient_lease_write_before_dispatch():
+    """A lease fsync failure skips that cycle; it does not kill the ticker."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    attempts = []
+    ticks = []
+    stop = threading.Event()
+    provider = InProcessCronScheduler()
+
+    def flaky_publish(owner):
+        attempts.append(owner)
+        if len(attempts) == 1:
+            raise OSError("transient fsync failure")
+
+    def successful_tick(**_kwargs):
+        ticks.append(True)
+        stop.set()
+        return 0
+
+    with (
+        patch("cron.jobs.record_gateway_ticker_lease", side_effect=flaky_publish),
+        patch("cron.jobs.clear_gateway_ticker_lease"),
+        patch("cron.jobs.record_ticker_heartbeat"),
+        patch("cron.jobs.record_ticker_error"),
+        patch("cron.jobs.clear_ticker_error"),
+        patch.object(provider, "recover_interrupted", return_value=0),
+        patch("cron.scheduler.tick", side_effect=successful_tick),
+    ):
+        provider.start(stop, interval=0, gateway_owner_id="123-owner")
+
+    assert attempts == ["123-owner", "123-owner"]
+    assert ticks == [True], "provider dispatched before it could publish readiness"
+
+
+def test_gateway_provider_survives_errors_while_reporting_lease_failure():
+    """Secondary cleanup/diagnostic failures must not kill the ticker loop."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    attempts = []
+    ticks = []
+    stop = threading.Event()
+    provider = InProcessCronScheduler()
+
+    def flaky_publish(_owner):
+        attempts.append(True)
+        if len(attempts) == 1:
+            raise OSError("lease write failed")
+
+    def successful_tick(**_kwargs):
+        ticks.append(True)
+        stop.set()
+        return 0
+
+    with (
+        patch("cron.jobs.record_gateway_ticker_lease", side_effect=flaky_publish),
+        patch("cron.jobs.clear_gateway_ticker_lease", side_effect=OSError("cleanup failed")),
+        patch("cron.jobs.record_ticker_error", side_effect=OSError("diagnostic failed")),
+        patch("cron.jobs.record_ticker_heartbeat"),
+        patch("cron.jobs.clear_ticker_error"),
+        patch.object(provider, "recover_interrupted", return_value=0),
+        patch("cron.scheduler.tick", side_effect=successful_tick),
+    ):
+        provider.start(stop, interval=0, gateway_owner_id="123-owner")
+
+    assert len(attempts) == 2
+    assert ticks == [True]
+
+
+def test_multiplex_gateway_lease_covers_every_served_profile(tmp_path):
+    """A multiplex gateway advertises readiness in every profile it ticks."""
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    profile_homes = [
+        ("default", tmp_path / "default"),
+        ("home-ops", tmp_path / "home-ops"),
+    ]
+    for _name, home in profile_homes:
+        (home / "cron").mkdir(parents=True)
+
+    stop = threading.Event()
+    provider = InProcessCronScheduler()
+
+    def every_profile_is_ready():
+        for _name, home in profile_homes:
+            with jobs.use_cron_store(home):
+                if not jobs.gateway_ticker_lease_is_fresh():
+                    return False
+        return True
+
+    with (
+        patch.object(provider, "recover_interrupted", return_value=0),
+        patch("cron.scheduler.tick", return_value=0),
+    ):
+        ticker = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0.01,
+                "profile_homes": profile_homes,
+                "gateway_owner_id": "123-multiplex",
+            },
+            daemon=True,
+        )
+        ticker.start()
+        assert _wait_until(every_profile_is_ready), (
+            "multiplex gateway did not publish all profile leases"
+        )
+        stop.set()
+        ticker.join(timeout=5)
+
+    assert not ticker.is_alive()
+    for _name, home in profile_homes:
+        with jobs.use_cron_store(home):
+            assert not jobs.gateway_ticker_lease_is_fresh(), (
+                f"gateway lease for {home} survived clean shutdown"
+            )
+
+
+def test_multiplex_gateway_waits_for_all_profile_initialization(tmp_path):
+    """No profile advertises readiness while a later profile is still recovering."""
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    profile_homes = [
+        ("default", tmp_path / "default"),
+        ("home-ops", tmp_path / "home-ops"),
+    ]
+    for _name, home in profile_homes:
+        (home / "cron").mkdir(parents=True)
+
+    second_recovery_started = threading.Event()
+    release_recovery = threading.Event()
+    stop = threading.Event()
+    recoveries = 0
+    provider = InProcessCronScheduler()
+
+    def recover_profile():
+        nonlocal recoveries
+        recoveries += 1
+        if recoveries == 2:
+            second_recovery_started.set()
+            assert release_recovery.wait(timeout=5)
+        return 0
+
+    with (
+        patch.object(provider, "recover_interrupted", side_effect=recover_profile),
+        patch("cron.scheduler.tick", return_value=0),
+    ):
+        ticker = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0.01,
+                "profile_homes": profile_homes,
+                "gateway_owner_id": "123-multiplex",
+            },
+            daemon=True,
+        )
+        ticker.start()
+        assert second_recovery_started.wait(timeout=5)
+        with jobs.use_cron_store(profile_homes[0][1]):
+            assert not jobs.gateway_ticker_lease_is_fresh(), (
+                "first profile advertised ready before all profiles initialized"
+            )
+        release_recovery.set()
+        assert _wait_until(
+            lambda: all(
+                _profile_gateway_lease_is_fresh(jobs, home)
+                for _name, home in profile_homes
+            )
+        )
+        stop.set()
+        ticker.join(timeout=5)
+
+    assert not ticker.is_alive()
+
+
+def _profile_gateway_lease_is_fresh(jobs, home):
+    with jobs.use_cron_store(home):
+        return jobs.gateway_ticker_lease_is_fresh()
+
+
+def test_multiplex_gateway_retries_partial_lease_publish_before_any_tick(tmp_path):
+    """One profile's transient write failure must not dispatch a partial cycle."""
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    profile_homes = [
+        ("default", tmp_path / "default"),
+        ("home-ops", tmp_path / "home-ops"),
+    ]
+    for _name, home in profile_homes:
+        (home / "cron").mkdir(parents=True)
+
+    publishes = []
+    ticks = []
+    stop = threading.Event()
+    provider = InProcessCronScheduler()
+
+    def flaky_publish(_owner):
+        publishes.append(jobs._current_cron_store().cron_dir.parent.name)
+        if len(publishes) == 2:
+            raise OSError("transient profile fsync failure")
+
+    def track_tick(**_kwargs):
+        ticks.append(jobs._current_cron_store().cron_dir.parent.name)
+        if len(ticks) == len(profile_homes):
+            stop.set()
+        return 0
+
+    with (
+        patch.object(provider, "recover_interrupted", return_value=0),
+        patch("cron.jobs.record_gateway_ticker_lease", side_effect=flaky_publish),
+        patch("cron.jobs.clear_gateway_ticker_lease"),
+        patch("cron.jobs.record_ticker_heartbeat"),
+        patch("cron.jobs.record_ticker_error"),
+        patch("cron.jobs.clear_ticker_error"),
+        patch("cron.scheduler.tick", side_effect=track_tick),
+    ):
+        provider.start(
+            stop,
+            interval=0,
+            profile_homes=profile_homes,
+            gateway_owner_id="123-multiplex",
+        )
+
+    assert publishes == ["default", "home-ops", "default", "home-ops"]
+    assert ticks == ["default", "home-ops"]
 
 
 # ── F8: runtime backstop — never resolve a stored pair that exfiltrates a key ──
@@ -412,5 +1066,3 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
     # With 2 profiles and multiple iterations, we should have seen at least 2 calls.
     assert len(tick_count) >= len(profile_homes), \
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
-
-

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta, timezone
 import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,10 +16,11 @@ import pytest
     ],
     ids=("script-only-job", "pre-agent-script"),
 )
+@pytest.mark.parametrize("schedule_kind", ["once", "interval"])
 def test_long_running_script_refreshes_owned_claim_in_profile_store(
-    tmp_path, monkeypatch, no_agent, script_output
+    tmp_path, monkeypatch, no_agent, script_output, schedule_kind
 ):
-    """Both blocking script paths keep their one-shot claim alive.
+    """Both blocking script paths keep one-shot and recurring claims alive.
 
     The real store update runs on the heartbeat thread.  A second store holds
     the same job ID, proving the thread inherited the active profile's
@@ -44,16 +46,18 @@ def test_long_running_script_refreshes_owned_claim_in_profile_store(
     monkeypatch.setattr(jobs, "_hermes_now", lambda: current_time[0])
 
     def _job() -> dict:
+        schedule = (
+            {"kind": "once", "run_at": original_timestamp}
+            if schedule_kind == "once"
+            else {"kind": "interval", "minutes": 1}
+        )
         return {
             "id": "long-script",
             "name": "long script",
             "prompt": "inspect the script output",
             "script": "watchdog.py",
             "no_agent": no_agent,
-            "schedule": {
-                "kind": "once",
-                "run_at": original_timestamp,
-            },
+            "schedule": schedule,
             "next_run_at": original_timestamp,
             "enabled": True,
             "run_claim": {
@@ -147,19 +151,110 @@ def test_script_heartbeat_uses_captured_claim_owner(tmp_path, monkeypatch):
         return updated
 
     def _blocking_script(_script_path: str, **kwargs) -> tuple[bool, str]:
-        assert heartbeat_seen.wait(timeout=2)
-        return True, "done"
+        pytest.fail("a stale script must be fenced before it starts")
 
     monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
     monkeypatch.setattr(scheduler, "heartbeat_run_claim", _observed_heartbeat)
     monkeypatch.setattr(scheduler, "_run_job_script", _blocking_script)
 
     with jobs.use_cron_store(profile_home):
-        assert scheduler._run_job_script_with_claim_heartbeat(job, "watchdog.py") == (
-            True,
-            "done",
+        ok, error = scheduler._run_job_script_with_claim_heartbeat(
+            job, "watchdog.py"
         )
+        assert ok is False
+        assert "ownership was lost" in error.lower()
+        assert heartbeat_seen.is_set()
         assert jobs.get_job("reclaimed-script")["run_claim"] == {
             "at": replacement_timestamp,
             "by": "replacement-owner",
         }
+
+
+def test_script_is_terminated_after_definite_claim_loss(tmp_path, monkeypatch):
+    """A stale script process cannot keep producing side effects after CAS loss."""
+    import cron.scheduler as scheduler
+
+    profile_home = tmp_path / "profile"
+    scripts_dir = profile_home / "scripts"
+    scripts_dir.mkdir(parents=True)
+    started = tmp_path / "started"
+    side_effect = tmp_path / "side-effect"
+    script = scripts_dir / "stale.py"
+    script.write_text(
+        "from pathlib import Path\n"
+        "import time\n"
+        f"Path({str(started)!r}).write_text('started')\n"
+        "time.sleep(1.0)\n"
+        f"Path({str(side_effect)!r}).write_text('should-not-exist')\n",
+        encoding="utf-8",
+    )
+    job = {
+        "id": "lost-script-claim",
+        "run_claim": {
+            "at": "2026-01-01T00:00:00+00:00",
+            "by": "original-attempt",
+        },
+    }
+
+    heartbeat_calls = 0
+
+    def lose_after_script_starts(*_args, **_kwargs):
+        nonlocal heartbeat_calls
+        heartbeat_calls += 1
+        if heartbeat_calls == 1:
+            return True
+        deadline = time.monotonic() + 2
+        while not started.exists() and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert started.exists(), "script never started"
+        return False
+
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: profile_home)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "heartbeat_run_claim", lose_after_script_starts)
+
+    ok, error = scheduler._run_job_script_with_claim_heartbeat(job, "stale.py")
+
+    assert ok is False
+    assert "ownership was lost" in error.lower()
+    time.sleep(1.1)
+    assert not side_effect.exists()
+
+
+def test_script_thread_start_failure_requires_outer_fence(monkeypatch):
+    """A claimed script never falls back to an uncancellable subprocess."""
+    import cron.scheduler as scheduler
+
+    job = {
+        "id": "thread-start-failure",
+        "run_claim": {
+            "at": "2026-01-01T00:00:00+00:00",
+            "by": "attempt",
+        },
+    }
+    calls = []
+    monkeypatch.setattr(scheduler, "heartbeat_run_claim", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        scheduler.threading.Thread,
+        "start",
+        lambda _self: (_ for _ in ()).throw(RuntimeError("thread unavailable")),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_run_job_script",
+        lambda *_a, **kwargs: calls.append(kwargs.get("cancel_event"))
+        or (True, "done"),
+    )
+
+    ok, error = scheduler._run_job_script_with_claim_heartbeat(job, "script.py")
+    assert ok is False
+    assert "unfenced" in error
+    assert calls == []
+
+    outer_loss = threading.Event()
+    assert scheduler._run_job_script_with_claim_heartbeat(
+        job,
+        "script.py",
+        claim_ownership_lost=outer_loss,
+    ) == (True, "done")
+    assert calls == [outer_loss]

--- a/tests/cron/test_sessiondb_init_hang.py
+++ b/tests/cron/test_sessiondb_init_hang.py
@@ -83,7 +83,7 @@ class TestSessionDbInitTimeout:
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("hermes_cli.env_loader.load_hermes_dotenv"), \
              patch("hermes_cli.env_loader.reset_secret_source_cache"), \
-             patch("hermes_state.SessionDB"), \
+             patch("hermes_state.SessionDB") as mock_session_db, \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
                  return_value=_RUNTIME,
@@ -105,6 +105,43 @@ class TestSessionDbInitTimeout:
         assert success is True
         assert final_response == "ok"
         assert mock_agent_cls.call_args.kwargs["session_db"] is None
+        mock_session_db.assert_called_once_with(db_path=tmp_path / "state.db")
+
+    def test_claim_loss_after_setup_prevents_agent_submit(
+        self, tmp_path, monkeypatch
+    ):
+        """A replaced token after agent construction must stop before API/tool work."""
+        job = {
+            "id": "lost-before-submit",
+            "name": "test",
+            "prompt": "hello",
+            "model": "test-model",
+            "run_claim": {
+                "at": "2026-01-01T00:00:00+00:00",
+                "by": "attempt-a",
+            },
+        }
+        fake_db = MagicMock()
+        agent = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value=_RUNTIME,
+             ), \
+             patch("cron.scheduler.heartbeat_run_claim", return_value=False), \
+             patch("run_agent.AIAgent", return_value=agent):
+            success, _output, _response, error = run_job(job)
+
+        assert success is False
+        assert "ownership" in error.lower()
+        agent.run_conversation.assert_not_called()
+        agent.close.assert_called_once()
 
     def test_invalid_timeout_env_falls_back_to_default(self, tmp_path, monkeypatch, caplog):
         """A malformed HERMES_CRON_SESSION_DB_TIMEOUT logs a warning and still

--- a/tests/cron/test_shutdown_interrupt.py
+++ b/tests/cron/test_shutdown_interrupt.py
@@ -23,9 +23,11 @@ def _reset_scheduler_state():
     import cron.scheduler as sched
 
     sched._running_job_ids.clear()
+    sched._running_run_claim_owners.clear()
     sched._interrupted_job_ids.clear()
     yield
     sched._running_job_ids.clear()
+    sched._running_run_claim_owners.clear()
     sched._interrupted_job_ids.clear()
 
 
@@ -111,6 +113,70 @@ class TestMarkRunningJobsInterrupted:
             marked = sched.mark_running_jobs_interrupted("shutdown")
 
         assert marked == ["job-2"]
+
+    def test_profile_scoped_manual_run_marks_its_store_with_exact_owner(
+        self, tmp_path
+    ):
+        import cron.jobs as jobs
+        import cron.scheduler as sched
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        default_home = (tmp_path / "default").resolve()
+        ops_home = (tmp_path / "profiles" / "ops").resolve()
+        job_id = "same-id"
+
+        def save_claimed(home, owner):
+            with jobs.use_cron_store(home):
+                jobs.save_jobs(
+                    [
+                        {
+                            "id": job_id,
+                            "name": "manual run",
+                            "prompt": "work",
+                            "schedule": {"kind": "interval", "minutes": 60},
+                            "enabled": True,
+                            "state": "scheduled",
+                            "run_claim": {
+                                "at": "2026-08-11T00:00:00+00:00",
+                                "by": owner,
+                            },
+                        }
+                    ]
+                )
+
+        save_claimed(default_home, "default-owner")
+        save_claimed(ops_home, "ops-owner")
+
+        ops_token = set_hermes_home_override(ops_home)
+        try:
+            assert sched.try_register_running_job(
+                job_id,
+                profile_scoped=True,
+                attempt_owner="ops-owner",
+            )
+        finally:
+            reset_hermes_home_override(ops_token)
+
+        default_token = set_hermes_home_override(default_home)
+        try:
+            marked = sched.mark_running_jobs_interrupted("gateway shutdown")
+        finally:
+            reset_hermes_home_override(default_token)
+
+        assert marked == [job_id]
+        with jobs.use_cron_store(default_home):
+            default_job = jobs.get_job(job_id)
+        with jobs.use_cron_store(ops_home):
+            ops_job = jobs.get_job(job_id)
+
+        assert default_job["run_claim"]["by"] == "default-owner"
+        assert default_job.get("last_status") is None
+        assert ops_job["run_claim"] is None
+        assert ops_job["last_status"] == "error"
+        assert ops_job["last_error"] == "gateway shutdown"
 
 
 class TestIsInterrupted:

--- a/tests/cron/test_suggestions.py
+++ b/tests/cron/test_suggestions.py
@@ -37,6 +37,72 @@ def _add(store, key="k1", title="Test", source="catalog", schedule="0 9 * * *"):
     )
 
 
+def test_suggestions_follow_active_cron_store_after_default_import(
+    monkeypatch, tmp_path
+):
+    """Secondary-profile decisions must not resolve default suggestions."""
+    default_home = tmp_path / "default"
+    ops_home = tmp_path / "home-ops"
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    import cron.suggestions as suggestions
+    from cron.jobs import use_cron_store
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    suggestions = importlib.reload(suggestions)
+    assert suggestions.SUGGESTIONS_FILE == (
+        default_home / "cron" / "suggestions.json"
+    )
+
+    default_accept = _add(
+        suggestions, key="shared-accept", title="Default accept"
+    )
+    default_dismiss = _add(
+        suggestions, key="shared-dismiss", title="Default dismiss"
+    )
+
+    token = set_hermes_home_override(ops_home)
+    try:
+        with use_cron_store(ops_home):
+            # Identical dedup keys are valid in a different profile.
+            ops_accept = _add(
+                suggestions, key="shared-accept", title="Ops accept"
+            )
+            ops_dismiss = _add(
+                suggestions, key="shared-dismiss", title="Ops dismiss"
+            )
+            assert ops_accept is not None
+            assert ops_dismiss is not None
+
+            with patch(
+                "cron.scheduler.create_job_with_scheduler_registration",
+                return_value={"id": "ops-job"},
+            ):
+                assert suggestions.accept_suggestion(ops_accept["id"]) == {
+                    "id": "ops-job"
+                }
+            assert suggestions.dismiss_suggestion(ops_dismiss["id"]) is True
+
+            ops_records = {
+                row["id"]: row for row in suggestions.load_suggestions()
+            }
+            assert ops_records[ops_accept["id"]]["status"] == "accepted"
+            assert ops_records[ops_dismiss["id"]]["status"] == "dismissed"
+    finally:
+        reset_hermes_home_override(token)
+
+    default_records = {
+        row["id"]: row for row in suggestions.load_suggestions()
+    }
+    assert default_records[default_accept["id"]]["status"] == "pending"
+    assert default_records[default_dismiss["id"]]["status"] == "pending"
+    assert (default_home / "cron" / "suggestions.json").is_file()
+    assert (ops_home / "cron" / "suggestions.json").is_file()
+
+
 class TestStore:
     def test_add_and_list_pending(self, store):
         rec = _add(store)

--- a/tests/cron/test_ticker_stall_60703.py
+++ b/tests/cron/test_ticker_stall_60703.py
@@ -3,9 +3,8 @@
 Three fixes under test:
 
 1. ``_jobs_lock()`` bounds its cross-process flock: when another process holds
-   ``.jobs.lock`` indefinitely, acquisition times out, logs at ERROR, and falls
-   through to in-process-only locking — instead of blocking the calling thread
-   (and, transitively, the cron ticker heartbeat) forever.
+   ``.jobs.lock`` indefinitely, acquisition times out and fails closed instead
+   of either blocking forever or entering an unsafe unlocked CAS section.
 
 2. Claim freshness checks are bounded on both sides (``0 <= age < ttl``): a
    ``fire_claim``/``run_claim`` stamped in the FUTURE (clock/TZ skew across a
@@ -65,7 +64,7 @@ def _hold_jobs_flock(path: Path, release: threading.Event, held: threading.Event
 
 
 class TestBoundedJobsLock:
-    def test_lock_acquisition_times_out_and_degrades(self, monkeypatch, caplog):
+    def test_lock_acquisition_times_out_and_fails_closed(self, monkeypatch, caplog):
         """A foreign holder of .jobs.lock must NOT block _jobs_lock forever."""
         jobs_mod.ensure_dirs()
         lock_path = jobs_mod._jobs_lock_file()
@@ -85,14 +84,15 @@ class TestBoundedJobsLock:
             start = time.monotonic()
             entered = False
             with caplog.at_level("ERROR", logger="cron.jobs"):
-                with _jobs_lock():
-                    entered = True
+                with pytest.raises(RuntimeError, match="jobs lock"):
+                    with _jobs_lock():
+                        entered = True
             elapsed = time.monotonic() - start
 
-            assert entered, "critical section must still run in degraded mode"
+            assert not entered, "CAS critical section must never run unlocked"
             assert elapsed < 10, f"lock wait was not bounded (took {elapsed:.1f}s)"
             assert any("Timed out" in r.message for r in caplog.records), (
-                "degraded-mode fallback must be logged at ERROR"
+                "fail-closed timeout must be logged at ERROR"
             )
         finally:
             release.set()

--- a/tests/gateway/test_multiplex_busy_input_mode.py
+++ b/tests/gateway/test_multiplex_busy_input_mode.py
@@ -320,8 +320,17 @@ async def test_missing_or_invalid_secondary_mode_falls_back_to_gateway_default(
     assert runner._busy_text_mode == "queue"
 
 
-def test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries():
+def test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries(
+    monkeypatch, tmp_path
+):
     runner = _runner(default_mode="interrupt")
+    monkeypatch.setattr(
+        "gateway.run._multiplex_profile_homes",
+        lambda _config: [
+            ("default", tmp_path),
+            ("research", tmp_path / "profiles" / "research"),
+        ],
+    )
     runner._snapshot_profile_busy_modes(
         "research",
         {"display": {"busy_input_mode": "steer"}},

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -134,6 +134,92 @@ class TestGatewayPidState:
         finally:
             status.release_gateway_runtime_lock()
 
+    def test_active_runtime_lock_path_survives_legacy_fingerprint_mismatch(
+        self, tmp_path, monkeypatch
+    ):
+        """A format/drift mismatch must not unlink an actively flocked inode."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record = {
+            "pid": 777,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": 12345,
+        }
+        pid_path = tmp_path / "gateway.pid"
+        lock_path = tmp_path / "gateway.lock"
+        pid_path.write_text(json.dumps(record))
+        lock_path.write_text(json.dumps(record))
+
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda *_a: True)
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: True)
+        monkeypatch.setattr(status.sys, "platform", "darwin")
+        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 12545)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda _pid: "python -m hermes_cli.main gateway run",
+        )
+
+        assert status.get_running_pid() == 777
+        assert pid_path.exists()
+        assert lock_path.exists()
+
+    @pytest.mark.parametrize(
+        ("platform", "current_start"),
+        [("linux", 12545), ("darwin", 12846)],
+    )
+    def test_active_lock_mismatch_compatibility_is_bounded(
+        self, tmp_path, monkeypatch, platform, current_start
+    ):
+        """Definite reuse/large drift is not treated as the recorded owner."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record = {
+            "pid": 777,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": 12345,
+        }
+        pid_path = tmp_path / "gateway.pid"
+        lock_path = tmp_path / "gateway.lock"
+        pid_path.write_text(json.dumps(record))
+        lock_path.write_text(json.dumps(record))
+
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda *_a: True)
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: True)
+        monkeypatch.setattr(status.sys, "platform", platform)
+        monkeypatch.setattr(
+            status, "_get_process_start_time", lambda _pid: current_start
+        )
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda _pid: "python -m hermes_cli.main gateway run",
+        )
+
+        assert status.get_running_pid() is None
+        assert pid_path.exists()
+        assert lock_path.exists()
+
+    def test_inactive_probe_cleanup_never_unlinks_runtime_lock_inode(
+        self, tmp_path, monkeypatch
+    ):
+        """A starter may acquire the inode immediately after an inactive probe."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        lock_path = tmp_path / "gateway.lock"
+        pid_path.write_text("stale")
+        lock_path.write_text("reusable-lock-inode")
+        monkeypatch.setattr(
+            status, "is_gateway_runtime_lock_active", lambda *_a: False
+        )
+        monkeypatch.setattr(
+            status, "get_runtime_status_running_pid", lambda *_a, **_kw: None
+        )
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+        assert lock_path.read_text() == "reusable-lock-inode"
+
     def test_gateway_identity_files_use_process_home_not_context_override(
         self, tmp_path, monkeypatch
     ):
@@ -309,6 +395,27 @@ class TestGetProcessStartTime:
         finally:
             p.kill()
             p.wait()
+
+    def test_psutil_fallback_prefers_raw_monotonic_creation_time(self, monkeypatch):
+        """macOS public create_time drifts with per-process boot-time baselines."""
+        import psutil
+
+        class FakePlatformProcess:
+            def create_time(self, *, monotonic=False):
+                assert monotonic is True
+                return 123.45
+
+        class FakeProcess:
+            _proc = FakePlatformProcess()
+
+            def create_time(self):
+                # Simulate psutil's adjusted public wall-clock value in a
+                # second interpreter after an NTP/boot-time correction.
+                return 125.45
+
+        monkeypatch.setattr(psutil, "Process", lambda _pid: FakeProcess())
+
+        assert status.get_stable_process_start_time(987_654_321) == 12_345
 
 
 class TestTerminatePid:
@@ -983,12 +1090,10 @@ class TestLaunchdPlistRespawnGovernance:
 
 
 class TestPermissionErrorOnLockFile:
-    """Stale root-owned lock files from launchd Background sessions must not
-    crash the gateway on restart (issue #42685)."""
+    """Unknown root-owned flock state fails closed without replacing its inode."""
 
-    def test_permission_error_on_lock_file_returns_false_and_removes(self, tmp_path, monkeypatch):
-        """When the lock file is not writable (root-owned), the function should
-        remove the stale file and report the lock as inactive."""
+    def test_permission_error_on_lock_file_returns_active_and_preserves(self, tmp_path, monkeypatch):
+        """A root-owned inode may still be flocked and must never be unlinked."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         lock_path = tmp_path / "gateway.lock"
         lock_path.write_text("stale", encoding="utf-8")
@@ -1003,12 +1108,11 @@ class TestPermissionErrorOnLockFile:
         monkeypatch.setattr("builtins.open", deny_write)
 
         result = status.is_gateway_runtime_lock_active(lock_path)
-        assert result is False
-        assert not lock_path.exists(), "stale root-owned lock file should be removed"
+        assert result is True
+        assert lock_path.exists()
 
-    def test_permission_error_unlink_failure_still_returns_false(self, tmp_path, monkeypatch):
-        """Even if unlinking the stale lock file fails (e.g. directory not writable),
-        the function should still return False to allow startup."""
+    def test_permission_error_does_not_attempt_unlink(self, tmp_path, monkeypatch):
+        """The liveness probe has no destructive PermissionError path."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         lock_path = tmp_path / "gateway.lock"
         lock_path.write_text("stale", encoding="utf-8")
@@ -1020,22 +1124,20 @@ class TestPermissionErrorOnLockFile:
                 raise PermissionError(13, "Permission denied", str(path))
             return real_open(path, *args, **kwargs)
 
-        real_unlink = Path.unlink
-
-        def deny_unlink(self, *args, **kwargs):
-            if str(self) == str(lock_path):
-                raise OSError(13, "Permission denied", str(self))
-            return real_unlink(self, *args, **kwargs)
-
         monkeypatch.setattr("builtins.open", deny_write)
-        monkeypatch.setattr(Path, "unlink", deny_unlink)
+        unlink_calls = []
+        monkeypatch.setattr(
+            Path,
+            "unlink",
+            lambda self, *args, **kwargs: unlink_calls.append(self),
+        )
 
         result = status.is_gateway_runtime_lock_active(lock_path)
-        assert result is False
+        assert result is True
+        assert unlink_calls == []
 
-    def test_acquire_gateway_runtime_lock_recovers_from_permission_error(self, tmp_path, monkeypatch):
-        """acquire_gateway_runtime_lock must survive a stale root-owned lock
-        file: unlink it and retry with a fresh file instead of crashing."""
+    def test_acquire_gateway_runtime_lock_fails_closed_on_permission_error(self, tmp_path, monkeypatch):
+        """A starter cannot replace an inode whose lock state is unknowable."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         lock_path = status._get_gateway_lock_path()
         lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1044,23 +1146,14 @@ class TestPermissionErrorOnLockFile:
         real_open = open
 
         def deny_write(path, *args, **kwargs):
-            # Simulate a root-owned file: opening fails while the ORIGINAL
-            # stale file is still on disk; after unlink, the fresh file the
-            # retry creates opens fine.
-            if (
-                str(path) == str(lock_path)
-                and lock_path.exists()
-                and lock_path.read_text(encoding="utf-8") == "stale"
-            ):
+            if str(path) == str(lock_path):
                 raise PermissionError(13, "Permission denied", str(path))
             return real_open(path, *args, **kwargs)
 
         monkeypatch.setattr("builtins.open", deny_write)
 
-        try:
-            assert status.acquire_gateway_runtime_lock() is True
-        finally:
-            status.release_gateway_runtime_lock()
+        assert status.acquire_gateway_runtime_lock() is False
+        assert lock_path.exists()
 
 
 class TestNormalizeUpdatedAt:
@@ -1219,4 +1312,3 @@ class TestResolveGatewayLiveness:
         # expected_home is what stops a recycled PID belonging to another
         # profile's live gateway from being reported as this profile's.
         assert seen["expected_home"] == profile_dir
-

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -203,6 +203,50 @@ class TestWeixinSendMessageIntegration:
         assert _parse_target_ref("weixin", "filehelper") == ("filehelper", None, True)
         assert _parse_target_ref("weixin", "group@chatroom") == ("group@chatroom", None, True)
 
+    def test_direct_send_stops_media_after_text_loses_ownership(self, tmp_path):
+        owned = True
+
+        async def run():
+            nonlocal owned
+            adapter = Mock()
+            adapter._send_session = Mock(
+                closed=False,
+                _loop=asyncio.get_running_loop(),
+            )
+            adapter.format_message.return_value = "scheduled result"
+            adapter.send = AsyncMock()
+
+            async def send_text(*_args, **_kwargs):
+                nonlocal owned
+                owned = False
+                return Mock(success=True, message_id="text-1")
+
+            adapter.send.side_effect = send_text
+            adapter.send_image_file = AsyncMock(
+                return_value=Mock(success=True, message_id="image-1")
+            )
+            weixin._LIVE_ADAPTERS["test-token"] = adapter
+            try:
+                with patch.object(ContextTokenStore, "restore"), \
+                     patch.object(ContextTokenStore, "get", return_value="ctx"):
+                    result = await weixin.send_weixin_direct(
+                        extra={"account_id": "test-account"},
+                        token="test-token",
+                        chat_id="wxid_test123",
+                        message="scheduled result",
+                        media_files=[(str(tmp_path / "later.png"), False)],
+                        ownership_guard=lambda: owned,
+                    )
+            finally:
+                weixin._LIVE_ADAPTERS.pop("test-token", None)
+            return result, adapter
+
+        result, adapter = asyncio.run(run())
+
+        assert result["error"] == "Delivery ownership lost during standalone send"
+        adapter.send.assert_awaited_once()
+        adapter.send_image_file.assert_not_awaited()
+
 
 class TestWeixinChunkDelivery:
     def _connected_adapter(self) -> WeixinAdapter:

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -14,6 +14,7 @@ Sync fallbacks preserved:
 """
 import json
 import threading
+import time
 from unittest.mock import patch
 
 from tools.cronjob_tools import (
@@ -38,6 +39,31 @@ def _job(job_id):
             "schedule": {"kind": "cron", "expr": "0 9 * * *"}}
 
 
+_ATTEMPT_OWNER = "manual-attempt-token"
+
+
+def _claimed_job(
+    job_id,
+    *,
+    status="ok",
+    error=None,
+    next_run_at=None,
+    owner=_ATTEMPT_OWNER,
+):
+    job = {
+        **_job(job_id),
+        "last_status": status,
+        "last_error": error,
+        "run_claim": {
+            "at": "2026-08-11T00:00:00+00:00",
+            "by": owner,
+        },
+    }
+    if next_run_at is not None:
+        job["next_run_at"] = next_run_at
+    return job
+
+
 def _bound_session_key(key="agent:main:telegram:dm:123"):
     """Context manager binding the approval session key contextvar."""
     import contextlib
@@ -56,6 +82,298 @@ def _bound_session_key(key="agent:main:telegram:dm:123"):
 
 
 class TestBackgroundDispatch:
+    def test_queued_cancel_terminalizes_exact_attempt_before_worker_starts(self):
+        """A session reset can cancel the claim-to-worker registration gap."""
+        captured = {}
+
+        def capture_dispatch(**kwargs):
+            captured.update(kwargs)
+            return {"status": "dispatched", "delegation_id": "queued-cancel"}
+
+        with _bound_session_key(), patch(
+            "tools.cronjob_tools.claim_job_for_fire_attempt",
+            return_value=_ATTEMPT_OWNER,
+        ), patch(
+            "tools.async_delegation.dispatch_async_delegation",
+            side_effect=capture_dispatch,
+        ), patch("tools.cronjob_tools.mark_job_run", return_value=True) as m_mark, \
+             patch("tools.cronjob_tools.get_job") as m_get, \
+             patch("cron.scheduler.run_one_job") as m_run:
+            dispatched = _try_dispatch_background_run(_job("job-bg-queued-cancel"))
+            captured["interrupt_fn"]()
+            completed = captured["runner"]()
+
+        assert dispatched["dispatched"] is True
+        assert completed["status"] == "interrupted"
+        assert "interrupted" in completed["error"].lower()
+        m_get.assert_not_called()
+        m_run.assert_not_called()
+        m_mark.assert_called_once_with(
+            "job-bg-queued-cancel",
+            False,
+            "Manual cron run interrupted because its owning session ended.",
+            status="interrupted",
+            expected_run_claim_owner=_ATTEMPT_OWNER,
+        )
+
+    def test_interrupt_after_runner_completion_is_noop(self):
+        """A stale interrupt callback cannot rewrite a completed attempt."""
+        captured = {}
+
+        def capture_dispatch(**kwargs):
+            captured.update(kwargs)
+            return {"status": "dispatched", "delegation_id": "done-noop"}
+
+        with _bound_session_key(), patch(
+            "tools.cronjob_tools.claim_job_for_fire_attempt",
+            return_value=_ATTEMPT_OWNER,
+        ), patch(
+            "tools.async_delegation.dispatch_async_delegation",
+            side_effect=capture_dispatch,
+        ), patch(
+            "tools.cronjob_tools.get_job",
+            return_value=_claimed_job("job-bg-done-noop"),
+        ), patch("cron.scheduler.run_one_job", return_value=True), patch(
+            "tools.cronjob_tools.mark_job_run"
+        ) as m_mark:
+            _try_dispatch_background_run(_job("job-bg-done-noop"))
+            completed = captured["runner"]()
+            captured["interrupt_fn"]()
+
+        assert completed["status"] == "completed"
+        m_mark.assert_not_called()
+
+    def test_interrupt_callback_is_pinned_to_dispatch_profile(self, tmp_path):
+        """The session/shutdown thread cannot cancel a same-id peer profile."""
+        import cron.jobs as jobs
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        job_id = "job-bg-profile-cancel"
+        default_home = tmp_path / "default"
+        profile_home = tmp_path / "profiles" / "ops"
+        captured = {}
+
+        def capture_dispatch(**kwargs):
+            captured.update(kwargs)
+            return {"status": "dispatched", "delegation_id": "profile-cancel"}
+
+        default_token = set_hermes_home_override(default_home)
+        try:
+            jobs.save_jobs([
+                _claimed_job(job_id, owner="successor-in-default-profile")
+            ])
+        finally:
+            reset_hermes_home_override(default_token)
+
+        profile_token = set_hermes_home_override(profile_home)
+        try:
+            jobs.save_jobs([_claimed_job(job_id)])
+            with _bound_session_key(), patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value=_ATTEMPT_OWNER,
+            ), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                side_effect=capture_dispatch,
+            ):
+                _try_dispatch_background_run(_job(job_id))
+        finally:
+            reset_hermes_home_override(profile_token)
+
+        # Execute from a context explicitly pointing at the OTHER profile,
+        # matching /new and gateway-shutdown callback threads.
+        default_token = set_hermes_home_override(default_home)
+        try:
+            captured["interrupt_fn"]()
+            default_job = jobs.get_job(job_id)
+        finally:
+            reset_hermes_home_override(default_token)
+
+        profile_token = set_hermes_home_override(profile_home)
+        try:
+            profile_job = jobs.get_job(job_id)
+        finally:
+            reset_hermes_home_override(profile_token)
+
+        assert default_job["run_claim"]["by"] == "successor-in-default-profile"
+        assert default_job["last_status"] == "ok"
+        assert profile_job["run_claim"] is None
+        assert profile_job["last_status"] == "interrupted"
+
+    def test_interrupt_for_session_stops_running_manual_cron(self):
+        """``/new`` interrupts a running manual cron through the shared event."""
+        from tools.async_delegation import interrupt_for_session
+
+        run_started = threading.Event()
+        run_stopped = threading.Event()
+        seen_cancel_event = {}
+
+        def blocking_run(_job, *, _attempt_outcome=None, cancel_event=None, **_kw):
+            seen_cancel_event["event"] = cancel_event
+            run_started.set()
+            assert cancel_event is not None
+            assert cancel_event.wait(timeout=5.0)
+            _attempt_outcome.update(
+                success=False,
+                error="Manual cron run interrupted because its owning session ended.",
+                output_file=None,
+                terminal_recorded=False,
+            )
+            run_stopped.set()
+            return False
+
+        session_key = "agent:main:telegram:dm:cron-cancel-session"
+        with _bound_session_key(session_key), patch(
+            "tools.cronjob_tools.claim_job_for_fire_attempt",
+            return_value=_ATTEMPT_OWNER,
+        ), patch(
+            "tools.cronjob_tools.get_job",
+            return_value=_claimed_job("job-bg-session-cancel"),
+        ), patch(
+            "cron.scheduler.run_one_job", side_effect=blocking_run
+        ), patch("tools.cronjob_tools.mark_job_run", return_value=True) as m_mark:
+            dispatched = _try_dispatch_background_run(
+                _job("job-bg-session-cancel"), session_id="parent-session-1"
+            )
+            assert run_started.wait(timeout=5.0)
+            assert interrupt_for_session(session_key=session_key) == 1
+            assert run_stopped.wait(timeout=5.0)
+
+            from tools.process_registry import process_registry
+
+            found = None
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                try:
+                    event = process_registry.completion_queue.get_nowait()
+                except Exception:
+                    time.sleep(0.01)
+                    continue
+                if event.get("delegation_id") == dispatched["delegation_id"]:
+                    found = event
+                    break
+                process_registry.completion_queue.put(event)
+                time.sleep(0.01)
+
+        assert seen_cancel_event["event"].is_set()
+        assert found is not None
+        assert found["status"] == "interrupted"
+        assert "interrupted" in (found.get("error") or "").lower()
+        m_mark.assert_called_once_with(
+            "job-bg-session-cancel",
+            False,
+            "Manual cron run interrupted because its owning session ended.",
+            status="interrupted",
+            expected_run_claim_owner=_ATTEMPT_OWNER,
+        )
+
+    def test_interrupt_all_stops_running_manual_cron(self):
+        """Gateway shutdown interrupts manual cron, not only subagents."""
+        from tools.async_delegation import interrupt_all
+
+        run_started = threading.Event()
+        run_stopped = threading.Event()
+
+        def blocking_run(_job, *, _attempt_outcome=None, cancel_event=None, **_kw):
+            run_started.set()
+            assert cancel_event is not None
+            assert cancel_event.wait(timeout=5.0)
+            _attempt_outcome.update(
+                success=False,
+                error="Manual cron run interrupted because its owning session ended.",
+                output_file=None,
+                terminal_recorded=False,
+            )
+            run_stopped.set()
+            return False
+
+        with _bound_session_key("agent:main:telegram:dm:cron-shutdown"), patch(
+            "tools.cronjob_tools.claim_job_for_fire_attempt",
+            return_value=_ATTEMPT_OWNER,
+        ), patch(
+            "tools.cronjob_tools.get_job",
+            return_value=_claimed_job("job-bg-shutdown-cancel"),
+        ), patch(
+            "cron.scheduler.run_one_job", side_effect=blocking_run
+        ), patch("tools.cronjob_tools.mark_job_run", return_value=True):
+            _try_dispatch_background_run(_job("job-bg-shutdown-cancel"))
+            assert run_started.wait(timeout=5.0)
+            assert interrupt_all(reason="test shutdown") >= 1
+            assert run_stopped.wait(timeout=5.0)
+
+    def test_running_script_is_killed_without_late_side_effect(self, tmp_path):
+        """The shared cancel event terminates the real script process group."""
+        import cron.jobs as jobs
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from tools.async_delegation import interrupt_for_session
+        from tools.process_registry import process_registry
+
+        job_id = "job-bg-real-script-cancel"
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir(parents=True)
+        started_file = tmp_path / "script-started"
+        forbidden_file = tmp_path / "script-completed"
+        (scripts_dir / "slow.py").write_text(
+            "import pathlib, time\n"
+            f"pathlib.Path({str(started_file)!r}).write_text('started')\n"
+            "time.sleep(10)\n"
+            f"pathlib.Path({str(forbidden_file)!r}).write_text('completed')\n",
+            encoding="utf-8",
+        )
+        claimed = _claimed_job(job_id, status=None)
+        claimed.update(
+            no_agent=True,
+            script="slow.py",
+            deliver="local",
+            schedule={"kind": "interval", "minutes": 60},
+        )
+
+        home_token = set_hermes_home_override(tmp_path)
+        try:
+            jobs.save_jobs([claimed])
+            session_key = "agent:main:telegram:dm:cron-real-script"
+            with _bound_session_key(session_key), patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value=_ATTEMPT_OWNER,
+            ):
+                dispatched = _try_dispatch_background_run(_job(job_id))
+                deadline = time.monotonic() + 5.0
+                while not started_file.exists() and time.monotonic() < deadline:
+                    time.sleep(0.02)
+                assert started_file.exists(), "script process never started"
+                assert interrupt_for_session(session_key=session_key) == 1
+
+                completion = None
+                deadline = time.monotonic() + 5.0
+                while time.monotonic() < deadline:
+                    try:
+                        event = process_registry.completion_queue.get_nowait()
+                    except Exception:
+                        time.sleep(0.02)
+                        continue
+                    if event.get("delegation_id") == dispatched["delegation_id"]:
+                        completion = event
+                        break
+                    process_registry.completion_queue.put(event)
+                    time.sleep(0.02)
+            persisted = jobs.get_job(job_id)
+        finally:
+            reset_hermes_home_override(home_token)
+
+        # Give an accidentally orphaned child enough time to expose itself;
+        # the correct path terminates it before the ten-second sleep completes.
+        time.sleep(0.2)
+        assert completion is not None
+        assert completion["status"] == "interrupted"
+        assert persisted["run_claim"] is None
+        assert persisted["last_status"] == "interrupted"
+        assert not forbidden_file.exists()
+
     def test_dispatches_and_returns_handle_immediately(self):
         """With a routable session, run claims sync then dispatches async."""
         run_started = threading.Event()
@@ -67,23 +385,26 @@ class TestBackgroundDispatch:
             return True
 
         with _bound_session_key():
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value=_ATTEMPT_OWNER,
+            ) as m_claim, \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run_one_job), \
                  patch("tools.cronjob_tools.get_job",
-                       return_value={"last_status": "ok", "last_error": None}):
+                       return_value=_claimed_job("job-bg-01")):
                 res = _try_dispatch_background_run(_job('job-bg-01'))
-
-        try:
-            # Returned BEFORE the job finished — that's the whole point.
-            assert res is not None
-            assert res["claimed"] is True
-            assert res["dispatched"] is True
-            assert res["delegation_id"]
-            m_claim.assert_called_once_with("job-bg-01")
-            # The job actually starts on the daemon executor.
-            assert run_started.wait(timeout=5.0), "job never started in background"
-        finally:
-            run_release.set()
+                try:
+                    # Returned BEFORE the job finished — that's the whole point.
+                    assert res is not None
+                    assert res["claimed"] is True
+                    assert res["dispatched"] is True
+                    assert res["delegation_id"]
+                    m_claim.assert_called_once_with("job-bg-01")
+                    # Keep patches alive until the daemon worker enters the run.
+                    assert run_started.wait(timeout=5.0), \
+                        "job never started in background"
+                finally:
+                    run_release.set()
 
     def test_completion_event_reaches_shared_queue(self):
         """The finished run pushes a type='async_delegation' event carrying
@@ -95,11 +416,16 @@ class TestBackgroundDispatch:
         # The runner executes on a daemon thread — the patches must stay
         # active until the completion event lands, so poll INSIDE the blocks.
         with _bound_session_key("agent:main:telegram:dm:777"):
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value=_ATTEMPT_OWNER,
+            ), \
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
-                       return_value={"last_status": "ok", "last_error": None,
-                                     "next_run_at": "2026-08-07T09:00:00"}):
+                       return_value=_claimed_job(
+                           "job-bg-02",
+                           next_run_at="2026-08-07T09:00:00",
+                       )):
                 res = _try_dispatch_background_run(_job('job-bg-02'))
                 assert res["dispatched"] is True
 
@@ -127,12 +453,28 @@ class TestBackgroundDispatch:
 
         from tools.process_registry import process_registry
 
+        def failed_attempt(_job, *, _attempt_outcome=None, **_kwargs):
+            _attempt_outcome.update(
+                success=False,
+                error="provider exploded",
+                output_file=None,
+                terminal_recorded=True,
+            )
+            return True
+
         with _bound_session_key("agent:main:telegram:dm:778"):
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
-                 patch("cron.scheduler.run_one_job", return_value=True), \
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value=_ATTEMPT_OWNER,
+            ), \
+                 patch("cron.scheduler.run_one_job", side_effect=failed_attempt), \
+                 patch("tools.cronjob_tools._attempt_output_excerpt") as excerpt, \
                  patch("tools.cronjob_tools.get_job",
-                       return_value={"last_status": "error",
-                                     "last_error": "provider exploded"}):
+                       return_value=_claimed_job(
+                           "job-bg-03",
+                           status="error",
+                           error="provider exploded",
+                       )):
                 res = _try_dispatch_background_run(_job('job-bg-03'))
                 assert res["dispatched"] is True
 
@@ -151,12 +493,16 @@ class TestBackgroundDispatch:
         assert found is not None
         assert found["status"] == "error"
         assert "provider exploded" in (found.get("error") or "")
+        excerpt.assert_not_called()
 
     def test_claim_lost_reports_immediately_without_dispatch(self):
         """Paused/already-firing jobs report in the tool response, not as a
         delayed completion event."""
         with _bound_session_key():
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value=None,
+            ), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={**_JOB, "enabled": False}), \
                  patch("tools.async_delegation.dispatch_async_delegation") as m_disp:
@@ -164,6 +510,84 @@ class TestBackgroundDispatch:
         assert res["claimed"] is False
         assert "paused/disabled" in res["error"]
         m_disp.assert_not_called()
+
+    def test_dispatched_runner_rejects_successor_attempt(self):
+        """A queued background runner cannot adopt a replacement token."""
+        captured = {}
+        replacement = _claimed_job(
+            "job-bg-successor",
+            owner="successor-attempt-token",
+        )
+
+        def capture_runner(**kwargs):
+            captured["runner"] = kwargs["runner"]
+            return {"status": "dispatched", "delegation_id": "delegation-1"}
+
+        with _bound_session_key():
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value=_ATTEMPT_OWNER,
+            ), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                side_effect=capture_runner,
+            ), patch(
+                "tools.cronjob_tools.get_job",
+                return_value=replacement,
+            ), patch("cron.scheduler.run_one_job") as m_run, patch(
+                "tools.cronjob_tools.mark_job_run"
+            ) as m_mark:
+                dispatched = _try_dispatch_background_run(
+                    _job("job-bg-successor")
+                )
+                completed = captured["runner"]()
+
+        assert dispatched["dispatched"] is True
+        assert completed["status"] == "error"
+        assert "claim could not be reloaded safely" in completed["error"]
+        m_run.assert_not_called()
+        m_mark.assert_called_once_with(
+            "job-bg-successor",
+            False,
+            "Job attempt claim could not be reloaded safely; not executing",
+            expected_run_claim_owner=_ATTEMPT_OWNER,
+        )
+
+    def test_background_worker_keeps_dispatching_profile_context(self, tmp_path):
+        """The daemon worker must resolve the same profile that claimed it."""
+        from hermes_constants import (
+            get_hermes_home,
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        profile_home = (tmp_path / "profiles" / "ops").resolve()
+        run_started = threading.Event()
+        observed = {}
+
+        def probe_profile(job, **kwargs):
+            observed["home"] = get_hermes_home().resolve()
+            run_started.set()
+            return True
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            with _bound_session_key(), patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value=_ATTEMPT_OWNER,
+            ), patch(
+                "cron.scheduler.run_one_job", side_effect=probe_profile
+            ), patch(
+                "tools.cronjob_tools.get_job",
+                return_value=_claimed_job("job-bg-profile"),
+            ):
+                res = _try_dispatch_background_run(_job("job-bg-profile"))
+                assert res["dispatched"] is True
+                assert run_started.wait(timeout=5.0), \
+                    "background run never started"
+        finally:
+            reset_hermes_home_override(token)
+
+        assert observed["home"] == profile_home
 
 
 class TestSyncFallbacks:
@@ -183,16 +607,55 @@ class TestSyncFallbacks:
     def test_pool_at_capacity_runs_inline(self):
         """A rejected dispatch must not strand the already-taken claim."""
         with _bound_session_key():
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value=_ATTEMPT_OWNER,
+            ), \
                  patch("tools.async_delegation.dispatch_async_delegation",
                        return_value={"status": "rejected", "error": "capacity"}), \
                  patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
                  patch("tools.cronjob_tools.get_job",
-                       return_value={"last_status": "ok", "last_error": None}):
+                       return_value=_claimed_job("job-bg-07")):
                 res = _try_dispatch_background_run(_job('job-bg-07'))
         assert res["dispatched"] is False
         assert res["success"] is True
         m_run.assert_called_once()   # ran inline on this thread
+
+    def test_dispatch_exception_runs_inline_without_stranding_claim(self, tmp_path):
+        """A registry exception has the same safe fallback as rejection."""
+        import cron.jobs as jobs
+
+        job_id = "job-bg-dispatch-raise"
+        claimed = _claimed_job(job_id, status=None)
+        claimed["schedule"] = {"kind": "interval", "minutes": 60}
+
+        def complete_run(job, **kwargs):
+            return jobs.mark_job_run(
+                job_id,
+                True,
+                expected_run_claim_owner=_ATTEMPT_OWNER,
+            )
+
+        with jobs.use_cron_store(tmp_path):
+            jobs.save_jobs([claimed])
+            with _bound_session_key(), patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value=_ATTEMPT_OWNER,
+            ), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                side_effect=RuntimeError("registry unavailable"),
+            ), patch(
+                "cron.scheduler.run_one_job", side_effect=complete_run
+            ) as m_run:
+                res = _try_dispatch_background_run(_job(job_id))
+            persisted = jobs.get_job(job_id)
+
+        assert res["claimed"] is True
+        assert res["dispatched"] is False
+        assert res["success"] is True
+        m_run.assert_called_once()
+        assert persisted["run_claim"] is None
+        assert persisted["last_status"] == "ok"
 
 
 class TestInFlightDedupe:
@@ -208,11 +671,20 @@ class TestInFlightDedupe:
 
         assert sched.try_register_running_job("job-bg-08")   # simulate ticker mid-run
         try:
-            with patch("cron.scheduler.run_one_job") as m_run:
-                res = _run_claimed_job(_job('job-bg-08'))
+            with patch("cron.scheduler.run_one_job") as m_run, patch(
+                "tools.cronjob_tools.release_run_claim"
+            ) as m_release:
+                res = _run_claimed_job(
+                    _job('job-bg-08'),
+                    attempt_owner=_ATTEMPT_OWNER,
+                )
             assert res["success"] is False
             assert "already running" in res["error"]
             m_run.assert_not_called()
+            m_release.assert_called_once_with(
+                "job-bg-08",
+                expected_owner=_ATTEMPT_OWNER,
+            )
         finally:
             sched.release_running_job("job-bg-08")
 
@@ -230,8 +702,11 @@ class TestInFlightDedupe:
 
         with patch("cron.scheduler.run_one_job", side_effect=probe_run), \
              patch("tools.cronjob_tools.get_job",
-                   return_value={"last_status": "ok", "last_error": None}):
-            res = _run_claimed_job(_job('job-bg-09'))
+                   return_value=_claimed_job("job-bg-09")):
+            res = _run_claimed_job(
+                _job('job-bg-09'),
+                attempt_owner=_ATTEMPT_OWNER,
+            )
 
         assert res["success"] is True
         assert seen_during_run["registered"] is True
@@ -245,7 +720,9 @@ class TestInFlightDedupe:
         assert sched.try_register_running_job("job-bg-10")
         try:
             with _bound_session_key():
-                with patch("tools.cronjob_tools.claim_job_for_fire") as m_claim, \
+                with patch(
+                    "tools.cronjob_tools.claim_job_for_fire_attempt"
+                ) as m_claim, \
                      patch("tools.async_delegation.dispatch_async_delegation") as m_disp:
                     res = _try_dispatch_background_run(_job('job-bg-10'))
             assert res["claimed"] is False
@@ -272,17 +749,108 @@ class TestInFlightDedupe:
         # Idempotent release: never raises on a non-member.
         sched.release_running_job("job-shared-1")
 
+    def test_same_job_id_in_two_profiles_registers_independently(self, tmp_path):
+        from cron import scheduler as sched
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        profiles = [tmp_path / "default", tmp_path / "profiles" / "ops"]
+        registrations = []
+        for index, profile_home in enumerate(profiles):
+            token = set_hermes_home_override(profile_home)
+            try:
+                registrations.append(
+                    sched.try_register_running_job(
+                        "shared-job",
+                        profile_scoped=True,
+                        attempt_owner=f"attempt-{index}",
+                    )
+                )
+            finally:
+                reset_hermes_home_override(token)
+
+        try:
+            assert registrations == [True, True]
+            # This helper intentionally exposes process-wide activity, including
+            # daemon workers started by earlier background tests.  Only this
+            # profile-pair's shared membership is stable here.
+            assert "shared-job" in sched.get_running_job_ids()
+        finally:
+            for index, profile_home in enumerate(profiles):
+                token = set_hermes_home_override(profile_home)
+                try:
+                    assert sched.release_running_job(
+                        "shared-job",
+                        profile_scoped=True,
+                        attempt_owner=f"attempt-{index}",
+                    )
+                finally:
+                    reset_hermes_home_override(token)
+
+    def test_background_precheck_is_profile_aware(self, tmp_path):
+        from cron import scheduler as sched
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        profile_a = tmp_path / "profiles" / "a"
+        profile_b = tmp_path / "profiles" / "b"
+        token_a = set_hermes_home_override(profile_a)
+        try:
+            assert sched.try_register_running_job(
+                "same-id",
+                profile_scoped=True,
+                attempt_owner="profile-a-attempt",
+            )
+        finally:
+            reset_hermes_home_override(token_a)
+
+        token_b = set_hermes_home_override(profile_b)
+        try:
+            with _bound_session_key(), patch(
+                "tools.cronjob_tools.claim_job_for_fire_attempt",
+                return_value="profile-b-attempt",
+            ) as m_claim, patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                return_value={
+                    "status": "dispatched",
+                    "delegation_id": "profile-b-delegation",
+                },
+            ):
+                res = _try_dispatch_background_run(_job("same-id"))
+        finally:
+            reset_hermes_home_override(token_b)
+
+        try:
+            assert res["dispatched"] is True
+            m_claim.assert_called_once_with("same-id")
+        finally:
+            token_a = set_hermes_home_override(profile_a)
+            try:
+                sched.release_running_job(
+                    "same-id",
+                    profile_scoped=True,
+                    attempt_owner="profile-a-attempt",
+                )
+            finally:
+                reset_hermes_home_override(token_a)
+
 
 class TestCronjobRunToolIntegration:
     def test_run_action_returns_background_note(self):
         """cronjob(action='run') surfaces the handle + do-not-wait note."""
         with _bound_session_key():
             with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job('job-bg-12')), \
-                 patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+                 patch(
+                     "tools.cronjob_tools.claim_job_for_fire_attempt",
+                     return_value=_ATTEMPT_OWNER,
+                 ), \
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
-                       return_value={"id": "job-bg-12", "name": "bg run",
-                                     "last_status": "ok", "last_error": None}):
+                       return_value=_claimed_job("job-bg-12")):
                 out = json.loads(cronjob(action="run", job_id="job-bg-12"))
 
         assert out["success"] is True
@@ -294,9 +862,12 @@ class TestCronjobRunToolIntegration:
     def test_run_action_sync_path_unchanged_without_session(self):
         """No session context → the legacy synchronous behavior (executed +
         execution_success populated from the completed run)."""
-        ran = {"job": "after-run", "last_status": "ok", "last_error": None}
+        ran = _claimed_job("job-bg-13")
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job('job-bg-13')), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
+             patch(
+                 "tools.cronjob_tools.claim_job_for_fire_attempt",
+                 return_value=_ATTEMPT_OWNER,
+             ) as m_claim, \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=ran):
             out = json.loads(cronjob(action="run", job_id="job-bg-13"))

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -25,12 +25,24 @@ _JOB = {"id": "job-run-1", "name": "manual run", "prompt": "hi",
         "schedule": {"kind": "cron", "expr": "0 9 * * *"}}
 
 
+def _claimed_job(*, status="ok"):
+    return {
+        **_JOB,
+        "last_status": status,
+        "last_error": None,
+        "run_claim": {
+            "at": "2026-01-01T00:00:00+00:00",
+            "by": "attempt",
+        },
+    }
+
+
 class TestCronjobRunExecutesImmediately:
     def test_run_action_claims_and_fires_via_run_one_job(self):
         """action='run' must claim the job then fire it through run_one_job."""
-        ran = {"job": "after-run", "last_status": "ok", "last_error": None}
+        ran = _claimed_job()
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
+             patch("tools.cronjob_tools.claim_job_for_fire_attempt", return_value="attempt") as m_claim, \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=ran):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -44,21 +56,40 @@ class TestCronjobRunExecutesImmediately:
 
     def test_execute_job_now_bails_without_claim(self):
         """_execute_job_now never calls run_one_job when the claim is lost."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+        with patch("tools.cronjob_tools.claim_job_for_fire_attempt", return_value=None), \
              patch("cron.scheduler.run_one_job") as m_run:
             res = _execute_job_now(dict(_JOB))
         assert res["claimed"] is False
         assert res["success"] is False
         m_run.assert_not_called()
 
+    def test_successor_last_status_cannot_impersonate_lost_manual_attempt(self):
+        """The manual result comes from this attempt, never shared job state."""
+        successor = _claimed_job(status="ok")
+        successor["run_claim"]["by"] = "successor-attempt"
+        with patch(
+            "tools.cronjob_tools.claim_job_for_fire_attempt",
+            return_value="attempt",
+        ), patch(
+            "cron.scheduler.run_one_job", return_value=False
+        ), patch(
+            "tools.cronjob_tools.get_job",
+            side_effect=[_claimed_job(status=None), successor],
+        ):
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["claimed"] is True
+        assert res["success"] is False
+        assert "ownership" in (res["error"] or "").lower()
+
     def test_execute_job_now_passes_live_gateway_context_to_delivery(self):
         """Manual runs must deliver on the live gateway adapter's owning loop."""
         adapters = {"matrix": object()}
         gateway_loop = object()
         runner = SimpleNamespace(adapters=adapters, _gateway_loop=gateway_loop)
-        completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+        completed = _claimed_job()
 
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+        with patch("tools.cronjob_tools.claim_job_for_fire_attempt", return_value="attempt"), \
              patch("gateway.run._gateway_runner_ref", return_value=runner), \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=completed):
@@ -66,36 +97,57 @@ class TestCronjobRunExecutesImmediately:
 
         assert res["success"] is True
         m_run.assert_called_once_with(
-            _JOB,
+            completed,
             adapters=adapters,
             loop=gateway_loop,
             extra_prompt=None,
+            _attempt_outcome={},
         )
 
     def test_execute_job_now_remains_standalone_without_gateway(self):
         """CLI-only runs retain the standalone delivery path."""
-        completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
+        completed = _claimed_job()
 
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+        with patch("tools.cronjob_tools.claim_job_for_fire_attempt", return_value="attempt"), \
              patch.dict(sys.modules, {"gateway.run": None}), \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=completed):
             res = _execute_job_now(dict(_JOB))
 
         assert res["success"] is True
-        m_run.assert_called_once_with(_JOB, adapters=None, loop=None, extra_prompt=None)
+        m_run.assert_called_once_with(
+            completed,
+            adapters=None,
+            loop=None,
+            extra_prompt=None,
+            _attempt_outcome={},
+        )
 
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+        with patch("tools.cronjob_tools.claim_job_for_fire_attempt", return_value="attempt"), \
              patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
              patch("tools.cronjob_tools.mark_job_run") as m_mark, \
-             patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
+             patch(
+                 "tools.cronjob_tools.get_job",
+                 return_value={
+                     **_JOB,
+                     "run_claim": {
+                         "at": "2026-01-01T00:00:00+00:00",
+                         "by": "attempt",
+                     },
+                 },
+             ):
             res = _execute_job_now(dict(_JOB))
         assert res["claimed"] is True
         assert res["success"] is False
         assert "boom" in res["error"]
-        m_mark.assert_called_once()
+        m_mark.assert_called_once_with(
+            "job-run-1",
+            False,
+            "boom",
+            expected_run_claim_owner="attempt",
+        )
 
     def test_execute_job_now_heartbeats_while_job_runs(self):
         """A manual run ticks the caller's activity tracker while the job
@@ -116,11 +168,10 @@ class TestCronjobRunExecutesImmediately:
                 assert heartbeat_seen.wait(timeout=5.0), "no heartbeat within 5s"
                 return True
 
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire_attempt", return_value="attempt"), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run) as m_run, \
-                 patch("tools.cronjob_tools.get_job",
-                       return_value={"last_status": "ok", "last_error": None}):
+                 patch("tools.cronjob_tools.get_job", return_value=_claimed_job()):
                 res = _execute_job_now(dict(_JOB))
 
             m_run.assert_called_once()
@@ -134,10 +185,9 @@ class TestCronjobRunExecutesImmediately:
         heartbeat thread is never started and behavior is unchanged."""
         set_activity_callback(None)
         try:
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire_attempt", return_value="attempt"), \
                  patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
-                 patch("tools.cronjob_tools.get_job",
-                       return_value={"last_status": "ok", "last_error": None}), \
+                 patch("tools.cronjob_tools.get_job", return_value=_claimed_job()), \
                  patch("tools.cronjob_tools.threading.Thread") as m_thread:
                 res = _execute_job_now(dict(_JOB))
             assert res["success"] is True
@@ -165,12 +215,11 @@ class TestCronjobRunExecutesImmediately:
                 time.sleep(0.2)
                 return True
 
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire_attempt", return_value="attempt"), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_CEILING", 0.0), \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run), \
-                 patch("tools.cronjob_tools.get_job",
-                       return_value={"last_status": "ok", "last_error": None}):
+                 patch("tools.cronjob_tools.get_job", return_value=_claimed_job()):
                 res = _execute_job_now(dict(_JOB))
             assert res["success"] is True, res
             assert not first_beat.is_set(), touches   # heartbeat never fired
@@ -198,13 +247,60 @@ class TestCronjobRunExecutesImmediately:
                     "heartbeat stopped after one callback exception"
                 return True
 
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
+            with patch("tools.cronjob_tools.claim_job_for_fire_attempt", return_value="attempt"), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run), \
-                 patch("tools.cronjob_tools.get_job",
-                       return_value={"last_status": "ok", "last_error": None}):
+                 patch("tools.cronjob_tools.get_job", return_value=_claimed_job()):
                 res = _execute_job_now(dict(_JOB))
             assert res["success"] is True, res
             assert len(calls) >= 2, calls
         finally:
             set_activity_callback(None)
+
+    def test_execute_job_now_never_adopts_replacement_attempt(self):
+        """CAS winner A cannot refetch successor B and execute as B."""
+        replacement = {
+            **_JOB,
+            "run_claim": {
+                "at": "2026-01-01T00:00:01+00:00",
+                "by": "successor",
+            },
+        }
+        with patch(
+            "tools.cronjob_tools.claim_job_for_fire_attempt",
+            return_value="original",
+        ), patch(
+            "tools.cronjob_tools.get_job", return_value=replacement
+        ), patch("cron.scheduler.run_one_job") as m_run, patch(
+            "tools.cronjob_tools.mark_job_run"
+        ) as m_mark:
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["claimed"] is True
+        assert res["success"] is False
+        m_run.assert_not_called()
+        m_mark.assert_called_once_with(
+            "job-run-1",
+            False,
+            "Job attempt claim could not be reloaded safely; not executing",
+            expected_run_claim_owner="original",
+        )
+
+    def test_execute_job_now_claim_exception_never_touches_snapshot_owner(self):
+        """A caller snapshot cannot grant cleanup authority before CAS succeeds."""
+        snapshot = {
+            **_JOB,
+            "run_claim": {
+                "at": "2026-01-01T00:00:00+00:00",
+                "by": "someone-elses-attempt",
+            },
+        }
+        with patch(
+            "tools.cronjob_tools.claim_job_for_fire_attempt",
+            side_effect=OSError("claim store unavailable"),
+        ), patch("tools.cronjob_tools.mark_job_run") as m_mark:
+            res = _execute_job_now(snapshot)
+
+        assert res["claimed"] is False
+        assert res["success"] is False
+        m_mark.assert_not_called()

--- a/tests/tools/test_send_message_ownership.py
+++ b/tests/tools/test_send_message_ownership.py
@@ -1,0 +1,82 @@
+"""Ownership fences for standalone cron delivery transport."""
+
+import asyncio
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.platform_registry import platform_registry
+from hermes_cli.plugins import discover_plugins
+from tools.send_message_tool import _send_to_platform
+
+
+def test_ownership_loss_after_first_chunk_stops_later_chunk_and_media():
+    """A stale standalone attempt must not continue its internal fanout."""
+    discover_plugins()
+    entry = platform_registry.get("discord")
+    assert entry is not None
+    original = entry.standalone_sender_fn
+    owned = True
+    sent = []
+
+    async def send(_pconfig, _chat_id, message, **kwargs):
+        nonlocal owned
+        sent.append((message, kwargs.get("media_files")))
+        owned = False
+        return {"success": True, "message_id": "1"}
+
+    entry.standalone_sender_fn = send
+    try:
+        result = asyncio.run(
+            _send_to_platform(
+                Platform.DISCORD,
+                SimpleNamespace(enabled=True, token="***", extra={}),
+                "ch",
+                "word " * 1000,
+                media_files=[("/tmp/attachment.png", False)],
+                ownership_guard=lambda: owned,
+            )
+        )
+    finally:
+        entry.standalone_sender_fn = original
+
+    assert result["error"] == "Delivery ownership lost during standalone send"
+    assert len(sent) == 1
+    assert sent[0][1] == []
+
+
+def test_single_chunk_plugin_stops_after_first_media_item():
+    """Guarded media iteration fences plugin-owned attachment fanout."""
+    discover_plugins()
+    entry = platform_registry.get("discord")
+    assert entry is not None
+    original = entry.standalone_sender_fn
+    owned = True
+    sent_media = []
+
+    async def send(_pconfig, _chat_id, _message, **kwargs):
+        nonlocal owned
+        for media_item in kwargs["media_files"]:
+            sent_media.append(media_item)
+            owned = False
+        return {"success": True, "message_id": "1"}
+
+    entry.standalone_sender_fn = send
+    try:
+        result = asyncio.run(
+            _send_to_platform(
+                Platform.DISCORD,
+                SimpleNamespace(enabled=True, token="***", extra={}),
+                "ch",
+                "short body",
+                media_files=[
+                    ("/tmp/first.png", False),
+                    ("/tmp/second.png", False),
+                ],
+                ownership_guard=lambda: owned,
+            )
+        )
+    finally:
+        entry.standalone_sender_fn = original
+
+    assert result["error"] == "Delivery ownership lost during standalone send"
+    assert sent_media == [("/tmp/first.png", False)]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -14,7 +14,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cron.jobs import (
     AmbiguousJobReference,
-    claim_job_for_fire,
+    claim_job_for_fire_attempt,
     effective_job_state,
     get_job,
     is_job_runnable,
@@ -48,6 +48,7 @@ from cron.jobs import (
     parse_schedule,
     pause_job,
     remove_job,
+    release_run_claim,
     resolve_job_ref,
     resume_job,
     update_job,
@@ -602,7 +603,7 @@ def _execute_job_now(
 ) -> Dict[str, Any]:
     """Execute a cron job immediately, outside the scheduler tick.
 
-    Atomically claims the job first via ``claim_job_for_fire`` — the same
+    Atomically claims the job first via ``claim_job_for_fire_attempt`` — the same
     at-most-once CAS the scheduler/external-provider fire path uses — so a
     concurrently-running gateway ticker cannot also fire it (the claim both
     blocks a duplicate fire and advances ``next_run_at`` for recurring jobs).
@@ -616,10 +617,12 @@ def _execute_job_now(
     Returns {"claimed": bool, "success": bool, "error": str|None}.
     """
     job_id = job["id"]
+    attempt_owner: Optional[str] = None
     try:
         # At-most-once claim: bail without running if a tick/other fire owns it.
-        if not claim_job_for_fire(job_id):
-            # claim_job_for_fire returns False for paused/disabled/missing
+        attempt_owner = claim_job_for_fire_attempt(job_id)
+        if attempt_owner is None:
+            # The claim CAS returns None for paused/disabled/missing
             # jobs too — don't mislabel those as "already being fired"
             # (#60703): that message sends the user chasing a phantom
             # in-flight run when the job simply isn't runnable.
@@ -633,17 +636,23 @@ def _execute_job_now(
             return {"claimed": False, "success": False, "error": reason}
     except Exception as e:
         logger.error("Failed to claim cron job %s for immediate run: %s", job_id, e)
-        try:
-            mark_job_run(job_id, False, str(e))
-        except Exception:
-            pass
-        return {"claimed": True, "success": False, "error": str(e)}
+        # A failed CAS grants no cleanup authority.  In particular, never use
+        # a caller-supplied snapshot to clear a live scheduler attempt.
+        return {"claimed": False, "success": False, "error": str(e)}
 
-    return _run_claimed_job(job, extra_prompt=extra_prompt)
+    return _run_claimed_job(
+        job,
+        attempt_owner=attempt_owner,
+        extra_prompt=extra_prompt,
+    )
 
 
 def _run_claimed_job(
-    job: Dict[str, Any], extra_prompt: Optional[str] = None
+    job: Dict[str, Any],
+    *,
+    attempt_owner: str,
+    extra_prompt: Optional[str] = None,
+    cancel_event: Optional[threading.Event] = None,
 ) -> Dict[str, Any]:
     """Fire an already-claimed job through the shared ``run_one_job`` body.
 
@@ -663,6 +672,16 @@ def _run_claimed_job(
             try_register_running_job,
         )
 
+        if cancel_event is not None and cancel_event.is_set():
+            return {
+                "claimed": True,
+                "success": False,
+                "error": (
+                    "Manual cron run interrupted because its owning session "
+                    "ended."
+                ),
+            }
+
         # In-flight dedupe (idea from #53395 by @izumi0uu): the fire claim's
         # TTL (300s) is routinely outlived by real jobs, so it alone cannot
         # stop a manual run from double-firing a job the ticker (or another
@@ -670,7 +689,23 @@ def _run_claimed_job(
         # running set — the same guard _submit_with_guard uses — which also
         # makes this run visible to the gateway shutdown drain
         # (get_running_job_ids, #60432) and mark_running_jobs_interrupted.
-        if not try_register_running_job(job_id):
+        if not try_register_running_job(
+            job_id,
+            profile_scoped=True,
+            attempt_owner=attempt_owner,
+        ):
+            # We did win this concrete durable attempt, but an older in-process
+            # worker is still active.  Release only our exact token so the
+            # newly-created manual claim is not stranded and cannot erase a
+            # replacement owner.
+            try:
+                release_run_claim(job_id, expected_owner=attempt_owner)
+            except Exception:
+                logger.exception(
+                    "Failed to release rejected manual cron attempt %s for %s",
+                    attempt_owner,
+                    job_id,
+                )
             return {
                 "claimed": True,
                 "success": False,
@@ -681,6 +716,23 @@ def _run_claimed_job(
             }
         _registered = True
 
+        # Refetch after the CAS: claim_job_for_fire stamped this concrete
+        # attempt's immutable run token. Passing the caller's pre-claim snapshot
+        # could impersonate a scheduled owner or clear a newer claim.
+        refreshed_claimed_job = get_job(job_id)
+        if not isinstance(refreshed_claimed_job, dict):
+            raise RuntimeError(
+                "Job attempt disappeared after it was claimed; not executing"
+            )
+        claim = refreshed_claimed_job.get("run_claim")
+        if not isinstance(claim, dict) or claim.get("by") != attempt_owner:
+            raise RuntimeError(
+                "Job attempt claim could not be reloaded safely; not executing"
+            )
+        if cancel_event is not None and cancel_event.is_set():
+            raise RuntimeError(
+                "Manual cron run interrupted because its owning session ended."
+            )
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
         #
@@ -708,7 +760,7 @@ def _run_claimed_job(
         _heartbeat_thread = None
 
         if activity_cb is not None:
-            job_name = str(job.get("name") or job_id)
+            job_name = str(refreshed_claimed_job.get("name") or job_id)
 
             def _heartbeat_loop() -> None:
                 started = time.monotonic()
@@ -755,25 +807,42 @@ def _run_claimed_job(
         adapters = getattr(runner, "adapters", None) if runner is not None else None
         gateway_loop = getattr(runner, "_gateway_loop", None) if runner is not None else None
 
+        attempt_outcome: Dict[str, Any] = {}
         try:
             try:
-                processed = run_one_job(
-                    job, adapters=adapters, loop=gateway_loop,
-                    extra_prompt=extra_prompt,
-                )
+                run_kwargs: Dict[str, Any] = {
+                    "adapters": adapters,
+                    "loop": gateway_loop,
+                    "extra_prompt": extra_prompt,
+                    "_attempt_outcome": attempt_outcome,
+                }
+                if cancel_event is not None:
+                    run_kwargs["cancel_event"] = cancel_event
+                processed = run_one_job(refreshed_claimed_job, **run_kwargs)
             finally:
                 _heartbeat_stop.set()
                 if _heartbeat_thread is not None:
                     _heartbeat_thread.join(timeout=_CRON_RUN_HEARTBEAT_INTERVAL + 1)
         finally:
             _registered = False
-            release_running_job(job_id)
-        refreshed = get_job(job_id) or {}
-        ok = refreshed.get("last_status") == "ok"
+            release_running_job(
+                job_id,
+                profile_scoped=True,
+                attempt_owner=attempt_owner,
+            )
+        # Never infer this attempt from shared job state: a successor can claim
+        # and update last_status immediately after our terminal CAS. Production
+        # run_one_job fills the exact-attempt sink; simple test doubles retain
+        # compatibility by falling back to their returned processed boolean.
+        ok = bool(attempt_outcome.get("success")) if attempt_outcome else bool(processed)
+        attempt_error = attempt_outcome.get("error") if attempt_outcome else None
+        if not processed and not attempt_error:
+            attempt_error = "Run claim ownership was lost before this manual attempt completed."
         return {
             "claimed": True,
             "success": bool(processed and ok),
-            "error": refreshed.get("last_error"),
+            "error": attempt_error,
+            "output_file": attempt_outcome.get("output_file"),
         }
 
     except Exception as e:
@@ -786,35 +855,46 @@ def _run_claimed_job(
             try:
                 from cron.scheduler import release_running_job as _release
 
-                _release(job_id)
+                _release(
+                    job_id,
+                    profile_scoped=True,
+                    attempt_owner=attempt_owner,
+                )
             except Exception:
                 pass
         try:
-            mark_job_run(job_id, False, str(e))
+            # Cleanup authority comes only from this call's successful CAS.
+            # Never trust a caller-supplied snapshot, which may contain a live
+            # scheduler attempt belonging to another process.
+            if attempt_owner:
+                mark_job_run(
+                    job_id,
+                    False,
+                    str(e),
+                    expected_run_claim_owner=attempt_owner,
+                )
         except Exception:
             pass
-        return {"claimed": True, "success": False, "error": str(e)}
+        return {
+            "claimed": attempt_owner is not None,
+            "success": False,
+            "error": str(e),
+        }
 
 
-def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[str]:
-    """Best-effort excerpt of the job's most recent saved output file.
-
-    Included in the background-run completion block so the parent agent sees
-    what the job actually produced without having to dig through
-    ``~/.hermes/cron/output/``. Never raises.
-    """
+def _attempt_output_excerpt(
+    output_file: Optional[str], max_chars: int = 2000
+) -> Optional[str]:
+    """Read only the output published by this exact attempt."""
+    if not output_file:
+        return None
     try:
-        from cron.jobs import get_cron_output_dir
-
-        out_dir = get_cron_output_dir() / job_id
-        files = sorted(out_dir.glob("*.md"))
-        if not files:
-            return None
-        text = files[-1].read_text(encoding="utf-8", errors="replace").strip()
+        path = Path(output_file)
+        text = path.read_text(encoding="utf-8", errors="replace").strip()
         if not text:
             return None
         if len(text) > max_chars:
-            text = text[:max_chars] + f"\n… (truncated; full output: {files[-1]})"
+            text = text[:max_chars] + f"\n… (truncated; full output: {path})"
         return text
     except Exception:
         return None
@@ -871,6 +951,7 @@ def _try_dispatch_background_run(
 
     job_id = job["id"]
     job_name = str(job.get("name") or job_id)
+    attempt_owner: Optional[str] = None
 
     # ---- routing capture (on THIS thread; contextvars don't cross the pool) ----
     # Resolved BEFORE the claim: with no routable session there is no durable
@@ -900,9 +981,9 @@ def _try_dispatch_background_run(
         # authoritative (atomic) check is try_register_running_job inside
         # _run_claimed_job on the worker.
         try:
-            from cron.scheduler import get_running_job_ids
+            from cron.scheduler import is_running_job
 
-            if job_id in get_running_job_ids():
+            if is_running_job(job_id, profile_scoped=True):
                 return {
                     "claimed": False,
                     "success": False,
@@ -914,7 +995,8 @@ def _try_dispatch_background_run(
         except Exception:
             pass
 
-        if not claim_job_for_fire(job_id):
+        attempt_owner = claim_job_for_fire_attempt(job_id)
+        if attempt_owner is None:
             refreshed = get_job(job_id)
             if refreshed is None:
                 reason = "Job no longer exists; nothing to run."
@@ -925,11 +1007,12 @@ def _try_dispatch_background_run(
             return {"claimed": False, "success": False, "error": reason}
     except Exception as e:
         logger.error("Failed to claim cron job %s for background run: %s", job_id, e)
-        try:
-            mark_job_run(job_id, False, str(e))
-        except Exception:
-            pass
-        return {"claimed": True, "dispatched": False, "success": False, "error": str(e)}
+        return {
+            "claimed": False,
+            "dispatched": False,
+            "success": False,
+            "error": str(e),
+        }
 
     origin_ui_session_id = ""
     try:
@@ -951,7 +1034,11 @@ def _try_dispatch_background_run(
             "cronjob run: async delegation registry unavailable (%s); "
             "running job '%s' inline.", e, job_name,
         )
-        result = _run_claimed_job(job, extra_prompt=extra_prompt)
+        result = _run_claimed_job(
+            job,
+            attempt_owner=attempt_owner,
+            extra_prompt=extra_prompt,
+        )
         result["dispatched"] = False
         return result
 
@@ -964,15 +1051,87 @@ def _try_dispatch_background_run(
 
     started_at = time.time()
     deliver = job.get("deliver", "local")
+    dispatch_profile_home = get_hermes_home().resolve()
+    cancel_event = threading.Event()
+    cancel_state_lock = threading.Lock()
+    cancel_requested = False
+    runner_finished = False
+    interrupt_error = (
+        "Manual cron run interrupted because its owning session ended."
+    )
+
+    def _interrupt_run() -> None:
+        """Cancel only this immutable manual attempt, from any caller thread."""
+        nonlocal cancel_requested
+        with cancel_state_lock:
+            if runner_finished or cancel_requested:
+                return
+            cancel_requested = True
+            cancel_event.set()
+
+        # interrupt_for_session()/interrupt_all() run outside the dispatching
+        # ContextVars. Pin the exact profile store captured before dispatch so
+        # a profile-B cancellation cannot mutate profile A/default jobs.json.
+        from cron.jobs import use_cron_store
+
+        try:
+            with use_cron_store(dispatch_profile_home):
+                marked = mark_job_run(
+                    job_id,
+                    False,
+                    interrupt_error,
+                    status="interrupted",
+                    expected_run_claim_owner=attempt_owner,
+                )
+                if marked is False:
+                    # The exact attempt already completed or was replaced.
+                    # Never clear the current successor's token.
+                    return
+        except Exception:
+            logger.exception(
+                "Failed to terminalize interrupted manual cron attempt %s "
+                "for %s; releasing its exact claim",
+                attempt_owner,
+                job_id,
+            )
+            try:
+                with use_cron_store(dispatch_profile_home):
+                    release_run_claim(job_id, expected_owner=attempt_owner)
+            except Exception:
+                logger.exception(
+                    "Failed to release interrupted manual cron attempt %s "
+                    "for %s",
+                    attempt_owner,
+                    job_id,
+                )
 
     def _runner() -> Dict[str, Any]:
-        res = _run_claimed_job(job, extra_prompt=extra_prompt)
+        nonlocal runner_finished
+        with cancel_state_lock:
+            cancelled_before_start = cancel_event.is_set()
+        if cancelled_before_start:
+            res = {
+                "claimed": True,
+                "success": False,
+                "error": interrupt_error,
+            }
+        else:
+            res = _run_claimed_job(
+                job,
+                attempt_owner=attempt_owner,
+                extra_prompt=extra_prompt,
+                cancel_event=cancel_event,
+            )
+        with cancel_state_lock:
+            runner_finished = True
         duration = round(time.time() - started_at, 2)
-        refreshed = get_job(job_id) or {}
+        interrupted = cancel_event.is_set() and not res.get("success")
+        refreshed = {} if interrupted else (get_job(job_id) or {})
+        result_error = interrupt_error if interrupted else res.get("error")
         lines = [
             f"Cron job '{job_name}' ({job_id}) finished its manual run.",
-            f"Result: {'ok' if res.get('success') else 'FAILED'}"
-            + (f" — {res.get('error')}" if res.get("error") else ""),
+            f"Result: {'INTERRUPTED' if interrupted else ('ok' if res.get('success') else 'FAILED')}"
+            + (f" — {result_error}" if result_error else ""),
             f"Delivery target: {deliver}"
             + (
                 " (output was delivered there by the job itself)"
@@ -982,34 +1141,61 @@ def _try_dispatch_background_run(
         ]
         if refreshed.get("next_run_at"):
             lines.append(f"Next scheduled run: {refreshed['next_run_at']}")
-        excerpt = _latest_job_output_excerpt(job_id)
+        excerpt = (
+            _attempt_output_excerpt(res.get("output_file"))
+            if res.get("success")
+            else None
+        )
         if excerpt:
             lines.append("--- JOB OUTPUT ---")
             lines.append(excerpt)
         return {
-            "status": "completed" if res.get("success") else "error",
+            "status": (
+                "interrupted"
+                if interrupted
+                else ("completed" if res.get("success") else "error")
+            ),
             "summary": "\n".join(lines),
-            "error": res.get("error"),
+            "error": result_error,
             "api_calls": 0,
             "duration_seconds": duration,
         }
 
-    dispatch = dispatch_async_delegation(
-        goal=f"Manual run of cron job '{job_name}' ({job_id})",
-        context=(
-            "Triggered via cronjob(action='run'). The job executed in its own "
-            "fresh cron session; this block reports its outcome."
-        ),
-        toolsets=None,
-        role="cron_run",
-        model=job.get("model"),
-        session_key=session_key,
-        parent_session_id=str(session_id) if session_id else None,
-        runner=_runner,
-        origin_ui_session_id=origin_ui_session_id,
-        origin_session_id=origin_session_id,
-        max_async_children=max_async,
-    )
+    try:
+        dispatch = dispatch_async_delegation(
+            goal=f"Manual run of cron job '{job_name}' ({job_id})",
+            context=(
+                "Triggered via cronjob(action='run'). The job executed in its own "
+                "fresh cron session; this block reports its outcome."
+            ),
+            toolsets=None,
+            role="cron_run",
+            model=job.get("model"),
+            session_key=session_key,
+            parent_session_id=str(session_id) if session_id else None,
+            runner=_runner,
+            origin_ui_session_id=origin_ui_session_id,
+            origin_session_id=origin_session_id,
+            interrupt_fn=_interrupt_run,
+            max_async_children=max_async,
+        )
+    except Exception as dispatch_error:
+        # The durable attempt was already claimed. Treat registry failures the
+        # same as an explicit rejection and execute inline; otherwise the exact
+        # run claim remains stranded until its TTL expires.
+        logger.warning(
+            "cronjob run: background dispatch failed (%s); running job '%s' "
+            "inline.",
+            dispatch_error,
+            job_name,
+        )
+        result = _run_claimed_job(
+            job,
+            attempt_owner=attempt_owner,
+            extra_prompt=extra_prompt,
+        )
+        result["dispatched"] = False
+        return result
 
     if dispatch.get("status") == "dispatched":
         return {
@@ -1024,7 +1210,11 @@ def _try_dispatch_background_run(
         "cronjob run: background pool unavailable (%s); running job '%s' inline.",
         dispatch.get("error", "rejected"), job_name,
     )
-    result = _run_claimed_job(job, extra_prompt=extra_prompt)
+    result = _run_claimed_job(
+        job,
+        attempt_owner=attempt_owner,
+        extra_prompt=extra_prompt,
+    )
     result["dispatched"] = False
     return result
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -180,8 +180,58 @@ def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
     return None
 
 
-async def _send_telegram_message_with_retry(bot, *, attempts: int = 3, **kwargs):
+def _ownership_guard_active(ownership_guard) -> bool:
+    """Fail closed when a cron attempt's ownership cannot be verified."""
+    if ownership_guard is None:
+        return True
+    try:
+        return bool(ownership_guard())
+    except Exception:
+        logger.exception("Standalone delivery ownership guard failed")
+        return False
+
+
+class _GuardedMediaSequence:
+    """List-like media view that stops iteration as soon as ownership is lost."""
+
+    def __init__(self, media_files, ownership_guard):
+        self._media_files = list(media_files)
+        self._ownership_guard = ownership_guard
+
+    def __bool__(self):
+        return bool(self._media_files) and _ownership_guard_active(
+            self._ownership_guard
+        )
+
+    def __len__(self):
+        if not _ownership_guard_active(self._ownership_guard):
+            return 0
+        return len(self._media_files)
+
+    def __iter__(self):
+        for item in self._media_files:
+            if not _ownership_guard_active(self._ownership_guard):
+                return
+            yield item
+
+    def __getitem__(self, index):
+        if not _ownership_guard_active(self._ownership_guard):
+            if isinstance(index, slice):
+                return []
+            raise IndexError(index)
+        return self._media_files[index]
+
+
+async def _send_telegram_message_with_retry(
+    bot,
+    *,
+    attempts: int = 3,
+    ownership_guard=None,
+    **kwargs,
+):
     for attempt in range(attempts):
+        if not _ownership_guard_active(ownership_guard):
+            raise RuntimeError("Delivery ownership lost during standalone send")
         try:
             return await bot.send_message(**kwargs)
         except Exception as exc:
@@ -694,6 +744,7 @@ async def _send_via_adapter(
     thread_id=None,
     media_files=None,
     force_document=False,
+    ownership_guard=None,
 ):
     """Send a message via a live gateway adapter, with a standalone fallback
     for out-of-process callers (e.g. cron running separately from the gateway).
@@ -707,6 +758,8 @@ async def _send_via_adapter(
       3. A descriptive error explaining both options.
     """
     platform_name = platform.value if hasattr(platform, "value") else str(platform)
+    if not _ownership_guard_active(ownership_guard):
+        return {"error": "Delivery ownership lost during standalone send"}
     runner = None
     try:
         from gateway.run import _gateway_runner_ref
@@ -728,7 +781,11 @@ async def _send_via_adapter(
                     metadata["publish_topic"] = chat_id
                 if not metadata:
                     metadata = None
+                if not _ownership_guard_active(ownership_guard):
+                    return {"error": "Delivery ownership lost during standalone send"}
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
+                if not _ownership_guard_active(ownership_guard):
+                    return {"error": "Delivery ownership lost during standalone send"}
             except asyncio.CancelledError:
                 raise
             except Exception as e:
@@ -746,6 +803,8 @@ async def _send_via_adapter(
 
     if entry is not None and entry.standalone_sender_fn is not None:
         try:
+            if not _ownership_guard_active(ownership_guard):
+                return {"error": "Delivery ownership lost during standalone send"}
             result = await entry.standalone_sender_fn(
                 pconfig,
                 chat_id,
@@ -754,6 +813,8 @@ async def _send_via_adapter(
                 media_files=media_files,
                 force_document=force_document,
             )
+            if not _ownership_guard_active(ownership_guard):
+                return {"error": "Delivery ownership lost during standalone send"}
         except asyncio.CancelledError:
             raise
         except Exception as e:
@@ -780,7 +841,16 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    ownership_guard=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -789,14 +859,42 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     """
     from gateway.config import Platform
 
+    def _owned():
+        if ownership_guard is None:
+            return True
+        try:
+            return bool(ownership_guard())
+        except Exception:
+            logger.exception("Standalone delivery ownership guard failed")
+            return False
+
+    ownership_error = {
+        "error": "Delivery ownership lost during standalone send"
+    }
+    if not _owned():
+        return ownership_error
+
     media_files = media_files or []
+    if ownership_guard is not None and media_files:
+        media_files = _GuardedMediaSequence(media_files, ownership_guard)
 
     # Weixin handles text/media delivery inside its native helper and does not
     # need the optional platform adapter imports below. Keep this branch early
     # so a Weixin send is not blocked by unrelated optional dependencies (for
     # example lark-oapi's heavy Feishu import path).
     if platform == Platform.WEIXIN:
-        return await _send_weixin(pconfig, chat_id, message, media_files=media_files)
+        if not _owned():
+            return ownership_error
+        result = await _send_weixin(
+            pconfig,
+            chat_id,
+            message,
+            media_files=media_files,
+            ownership_guard=ownership_guard,
+        )
+        if not _owned():
+            return ownership_error
+        return result
 
     from gateway.platforms.base import BasePlatformAdapter, utf16_len
 
@@ -852,7 +950,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # after all text chunks.
     if platform == Platform.TELEGRAM:
         disable_link_previews = bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews"))
-        return await _send_telegram(
+        result = await _send_telegram(
             pconfig.token,
             chat_id,
             message,
@@ -860,7 +958,11 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            ownership_guard=ownership_guard,
         )
+        if not _owned():
+            return ownership_error
+        return result
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
     # The plugin's ``_standalone_send`` (registered in
@@ -883,6 +985,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             max_caption_len=(max_len or _DEFAULT_CAPTION_LIMIT),
         )
         if _dc_caption is not None:
+            if not _owned():
+                return ownership_error
             result = await entry.standalone_sender_fn(
                 pconfig,
                 chat_id,
@@ -891,11 +995,15 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 media_files=media_files,
                 caption=_dc_caption,
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             return result
         last_result = None
         for i, chunk in enumerate(chunks):
+            if not _owned():
+                return ownership_error
             is_last = (i == len(chunks) - 1)
             result = await entry.standalone_sender_fn(
                 pconfig,
@@ -904,6 +1012,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files if is_last else [],
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             last_result = result
@@ -917,6 +1027,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if platform == Platform.MATRIX:
         last_result = None
         for i, chunk in enumerate(chunks):
+            if not _owned():
+                return ownership_error
             is_last = (i == len(chunks) - 1)
             result = await _send_matrix_via_adapter(
                 pconfig,
@@ -924,7 +1036,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 chunk,
                 media_files=media_files if is_last else [],
                 thread_id=thread_id,
+                ownership_guard=ownership_guard,
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             last_result = result
@@ -934,13 +1049,18 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if platform == Platform.SIGNAL and media_files:
         last_result = None
         for i, chunk in enumerate(chunks):
+            if not _owned():
+                return ownership_error
             is_last = (i == len(chunks) - 1)
             result = await _send_signal(
                 pconfig.extra,
                 chat_id,
                 chunk,
                 media_files=media_files if is_last else [],
+                ownership_guard=ownership_guard,
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             last_result = result
@@ -950,12 +1070,17 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if platform == Platform.YUANBAO and media_files:
         last_result = None
         for i, chunk in enumerate(chunks):
+            if not _owned():
+                return ownership_error
             is_last = (i == len(chunks) - 1)
             result = await _send_yuanbao(
                 chat_id,
                 chunk,
                 media_files=media_files if is_last else None,
+                ownership_guard=ownership_guard,
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             last_result = result
@@ -972,6 +1097,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             return {"error": "Feishu plugin not registered or missing standalone_sender_fn"}
         last_result = None
         for i, chunk in enumerate(chunks):
+            if not _owned():
+                return ownership_error
             is_last = (i == len(chunks) - 1)
             result = await _feishu_entry.standalone_sender_fn(
                 pconfig,
@@ -980,6 +1107,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 media_files=media_files if is_last else None,
                 thread_id=thread_id,
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             last_result = result
@@ -1001,6 +1130,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             max_caption_len=(max_len or _DEFAULT_CAPTION_LIMIT),
         )
         if _sl_caption is not None:
+            if not _owned():
+                return ownership_error
             result = await _slack_entry.standalone_sender_fn(
                 pconfig,
                 chat_id,
@@ -1009,11 +1140,15 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 media_files=media_files,
                 caption=_sl_caption,
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             return result
         last_result = None
         for i, chunk in enumerate(chunks):
+            if not _owned():
+                return ownership_error
             is_last = (i == len(chunks) - 1)
             result = await _slack_entry.standalone_sender_fn(
                 pconfig,
@@ -1022,6 +1157,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files if is_last else [],
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             last_result = result
@@ -1050,6 +1187,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         if _wa_caption is not None:
             # Single-file captioned send: no separate text chunk, caption on
             # the media itself.
+            if not _owned():
+                return ownership_error
             result = await _wa_entry.standalone_sender_fn(
                 pconfig,
                 chat_id,
@@ -1059,10 +1198,14 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 force_document=force_document,
                 caption=_wa_caption,
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             return result
         for i, chunk in enumerate(chunks):
+            if not _owned():
+                return ownership_error
             is_last = (i == len(chunks) - 1)
             result = await _wa_entry.standalone_sender_fn(
                 pconfig,
@@ -1072,6 +1215,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 force_document=force_document,
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             last_result = result
@@ -1088,6 +1233,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if platform == Platform.SLACK:
         last_result = None
         for i, chunk in enumerate(chunks):
+            if not _owned():
+                return ownership_error
             is_last = i == len(chunks) - 1
             result = await _send_via_adapter(
                 platform,
@@ -1097,7 +1244,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files if is_last else [],
                 force_document=force_document,
+                ownership_guard=ownership_guard,
             )
+            if not _owned():
+                return ownership_error
             if isinstance(result, dict) and result.get("error"):
                 return result
             last_result = result
@@ -1120,10 +1270,17 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     last_result = None
     for chunk in chunks:
+        if not _owned():
+            return ownership_error
         if platform == Platform.WHATSAPP:
             result = await _registry_standalone_send("whatsapp", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.SIGNAL:
-            result = await _send_signal(pconfig.extra, chat_id, chunk)
+            result = await _send_signal(
+                pconfig.extra,
+                chat_id,
+                chunk,
+                ownership_guard=ownership_guard,
+            )
         elif platform == Platform.EMAIL:
             result = await _registry_standalone_send("email", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.SMS:
@@ -1135,11 +1292,25 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.WECOM:
             result = await _registry_standalone_send("wecom", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.BLUEBUBBLES:
-            result = await _send_bluebubbles(pconfig.extra, chat_id, chunk)
+            result = await _send_bluebubbles(
+                pconfig.extra,
+                chat_id,
+                chunk,
+                ownership_guard=ownership_guard,
+            )
         elif platform == Platform.QQBOT:
-            result = await _send_qqbot(pconfig, chat_id, chunk)
+            result = await _send_qqbot(
+                pconfig,
+                chat_id,
+                chunk,
+                ownership_guard=ownership_guard,
+            )
         elif platform == Platform.YUANBAO:
-            result = await _send_yuanbao(chat_id, chunk)
+            result = await _send_yuanbao(
+                chat_id,
+                chunk,
+                ownership_guard=ownership_guard,
+            )
         else:
             # Plugin platform: route through the gateway's live adapter if
             # available, otherwise the plugin's standalone_sender_fn.
@@ -1151,8 +1322,11 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document,
+                ownership_guard=ownership_guard,
             )
 
+        if not _owned():
+            return ownership_error
         if isinstance(result, dict) and result.get("error"):
             return result
         last_result = result
@@ -1173,7 +1347,16 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(
+    token,
+    chat_id,
+    message,
+    media_files=None,
+    thread_id=None,
+    disable_link_previews=False,
+    force_document=False,
+    ownership_guard=None,
+):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1298,11 +1481,15 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 formatted, 4096, len_fn=utf16_len
             )
             for chunk in text_chunks:
+                if not _ownership_guard_active(ownership_guard):
+                    return {"error": "Delivery ownership lost during standalone send"}
                 try:
                     last_msg = await _send_telegram_message_with_retry(
                         bot,
                         chat_id=int_chat_id, text=chunk,
-                        parse_mode=send_parse_mode, **text_kwargs
+                        parse_mode=send_parse_mode,
+                        ownership_guard=ownership_guard,
+                        **text_kwargs,
                     )
                 except Exception as md_error:
                     # Thread not found — retry without message_thread_id so the
@@ -1317,7 +1504,9 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         last_msg = await _send_telegram_message_with_retry(
                             bot,
                             chat_id=int_chat_id, text=chunk,
-                            parse_mode=send_parse_mode, **text_kwargs
+                            parse_mode=send_parse_mode,
+                            ownership_guard=ownership_guard,
+                            **text_kwargs,
                         )
                     elif "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
                         logger.warning(
@@ -1336,12 +1525,16 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         last_msg = await _send_telegram_message_with_retry(
                             bot,
                             chat_id=int_chat_id, text=plain,
-                            parse_mode=None, **text_kwargs
+                            parse_mode=None,
+                            ownership_guard=ownership_guard,
+                            **text_kwargs,
                         )
                     else:
                         raise
 
         for media_path, is_voice in media_files:
+            if not _ownership_guard_active(ownership_guard):
+                return {"error": "Delivery ownership lost during standalone send"}
             if not os.path.exists(media_path):
                 warning = f"Media file not found, skipping: {media_path}"
                 logger.warning(warning)
@@ -1353,7 +1546,9 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                     try:
                         last_msg = await _send_telegram_message_with_retry(
                             bot, chat_id=int_chat_id, text=_tg_caption,
-                            parse_mode=send_parse_mode, **text_kwargs
+                            parse_mode=send_parse_mode,
+                            ownership_guard=ownership_guard,
+                            **text_kwargs,
                         )
                         _tg_caption = None  # delivered — don't re-caption a later file
                     except Exception as _cap_err:
@@ -1383,6 +1578,8 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         except Exception:
                             pass
                     try:
+                        if not _ownership_guard_active(ownership_guard):
+                            return {"error": "Delivery ownership lost during standalone send"}
                         if ext in _IMAGE_EXTS and not force_document:
                             last_msg = await bot.send_photo(
                                 chat_id=int_chat_id, photo=f, **media_kwargs
@@ -1414,6 +1611,8 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             # Re-seek the file since the first attempt consumed it
                             f.seek(0)
                             media_kwargs.pop("message_thread_id", None)
+                            if not _ownership_guard_active(ownership_guard):
+                                return {"error": "Delivery ownership lost during standalone send"}
                             if ext in _IMAGE_EXTS and not force_document:
                                 last_msg = await bot.send_photo(
                                     chat_id=int_chat_id, photo=f, **media_kwargs
@@ -1453,6 +1652,8 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                     media_kwargs["caption"] = _strip_mdv2(media_kwargs["caption"])
                                 except Exception:
                                     pass
+                            if not _ownership_guard_active(ownership_guard):
+                                return {"error": "Delivery ownership lost during standalone send"}
                             if ext in _IMAGE_EXTS and not force_document:
                                 last_msg = await bot.send_photo(
                                     chat_id=int_chat_id, photo=f, **media_kwargs
@@ -1595,7 +1796,13 @@ async def _resolve_slack_user_target(token, chat_id):
         return None, _error(f"Slack DM resolution failed: {e}")
 
 
-async def _send_signal(extra, chat_id, message, media_files=None):
+async def _send_signal(
+    extra,
+    chat_id,
+    message,
+    media_files=None,
+    ownership_guard=None,
+):
     """Send via signal-cli JSON-RPC API.
 
     Supports both text-only and text-with-attachments (images/audio/documents).
@@ -1649,6 +1856,8 @@ async def _send_signal(extra, chat_id, message, media_files=None):
         plain_text, text_styles = markdown_to_signal(message)
 
         async def _post(batch_attachments, batch_message):
+            if not _ownership_guard_active(ownership_guard):
+                raise RuntimeError("Delivery ownership lost during standalone send")
             params = {"account": account, "message": batch_message}
             if batch_message and text_styles:
                 if len(text_styles) == 1:
@@ -1676,6 +1885,8 @@ async def _send_signal(extra, chat_id, message, media_files=None):
 
         async def _send_inline_notice(text: str) -> None:
             """Best-effort one-shot RPC for a user-facing pacing notice."""
+            if not _ownership_guard_active(ownership_guard):
+                return
             notice_params = {"account": account, "message": text}
             if chat_id.startswith("group:"):
                 notice_params["groupId"] = chat_id[6:]
@@ -1702,6 +1913,8 @@ async def _send_signal(extra, chat_id, message, media_files=None):
         )
         failed_batches: list[int] = []
         for idx, att_batch in enumerate(att_batches):
+            if not _ownership_guard_active(ownership_guard):
+                return {"error": "Delivery ownership lost during standalone send"}
             n = len(att_batch)
             if n > 0:
                 estimated = scheduler.estimate_wait(n)
@@ -1714,6 +1927,8 @@ async def _send_signal(extra, chat_id, message, media_files=None):
             batch_message = plain_text if idx == 0 else ""
 
             for attempt in range(1, SIGNAL_RATE_LIMIT_MAX_ATTEMPTS + 1):
+                if not _ownership_guard_active(ownership_guard):
+                    return {"error": "Delivery ownership lost during standalone send"}
                 try:
                     await scheduler.acquire(n)
                     _rpc_t0 = time.monotonic()
@@ -1794,7 +2009,14 @@ async def _send_signal(extra, chat_id, message, media_files=None):
 # (_send_matrix_via_adapter below stays — it's the native-media upload path.)
 
 
-async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, thread_id=None):
+async def _send_matrix_via_adapter(
+    pconfig,
+    chat_id,
+    message,
+    media_files=None,
+    thread_id=None,
+    ownership_guard=None,
+):
     """Send via the Matrix adapter so native Matrix media uploads are preserved.
 
     When a live gateway adapter is available (i.e. the tool runs inside a
@@ -1842,7 +2064,12 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
         # before the ephemeral ``adapter`` is constructed below, so the
         # ephemeral ``finally`` disconnect never touches the live session.
         return await _matrix_send_core(
-            live_adapter, chat_id, message, media_files, metadata
+            live_adapter,
+            chat_id,
+            message,
+            media_files,
+            metadata,
+            ownership_guard=ownership_guard,
         )
 
     # --- Fallback: ephemeral adapter (standalone / cron context) ---
@@ -1853,11 +2080,18 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
 
     adapter = MatrixAdapter(pconfig)
     try:
+        if not _ownership_guard_active(ownership_guard):
+            return {"error": "Delivery ownership lost during standalone send"}
         connected = await adapter.connect()
         if not connected:
             return _error("Matrix connect failed")
         return await _matrix_send_core(
-            adapter, chat_id, message, media_files, metadata
+            adapter,
+            chat_id,
+            message,
+            media_files,
+            metadata,
+            ownership_guard=ownership_guard,
         )
     except Exception as e:
         return _error(f"Matrix send failed: {e}")
@@ -1868,16 +2102,27 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
             pass
 
 
-async def _matrix_send_core(adapter, chat_id, message, media_files, metadata):
+async def _matrix_send_core(
+    adapter,
+    chat_id,
+    message,
+    media_files,
+    metadata,
+    ownership_guard=None,
+):
     """Core send logic shared by live and ephemeral Matrix adapters."""
     last_result = None
 
     if message.strip():
+        if not _ownership_guard_active(ownership_guard):
+            return {"error": "Delivery ownership lost during standalone send"}
         last_result = await adapter.send(chat_id, message, metadata=metadata)
         if not last_result.success:
             return _error(f"Matrix send failed: {last_result.error}")
 
     for media_path, is_voice in media_files:
+        if not _ownership_guard_active(ownership_guard):
+            return {"error": "Delivery ownership lost during standalone send"}
         if not os.path.exists(media_path):
             return _error(f"Media file not found: {media_path}")
 
@@ -1915,7 +2160,13 @@ async def _matrix_send_core(adapter, chat_id, message, media_files, metadata):
 # wired via standalone_sender_fn and reached through _registry_standalone_send. #41112.
 
 
-async def _send_weixin(pconfig, chat_id, message, media_files=None):
+async def _send_weixin(
+    pconfig,
+    chat_id,
+    message,
+    media_files=None,
+    ownership_guard=None,
+):
     """Send via Weixin iLink using the native adapter helper."""
     try:
         from gateway.platforms.weixin import check_weixin_requirements, send_weixin_direct
@@ -1931,12 +2182,18 @@ async def _send_weixin(pconfig, chat_id, message, media_files=None):
             chat_id=chat_id,
             message=message,
             media_files=media_files,
+            ownership_guard=ownership_guard,
         )
     except Exception as e:
         return _error(f"Weixin send failed: {e}")
 
 
-async def _send_bluebubbles(extra, chat_id, message):
+async def _send_bluebubbles(
+    extra,
+    chat_id,
+    message,
+    ownership_guard=None,
+):
     """Send via BlueBubbles iMessage server using the adapter's REST API."""
     try:
         from gateway.platforms.bluebubbles import BlueBubblesAdapter, check_bluebubbles_requirements
@@ -1949,10 +2206,14 @@ async def _send_bluebubbles(extra, chat_id, message):
         from gateway.config import PlatformConfig
         pconfig = PlatformConfig(extra=extra)
         adapter = BlueBubblesAdapter(pconfig)
+        if not _ownership_guard_active(ownership_guard):
+            return {"error": "Delivery ownership lost during standalone send"}
         connected = await adapter.connect()
         if not connected:
             return _error("BlueBubbles: failed to connect to server")
         try:
+            if not _ownership_guard_active(ownership_guard):
+                return {"error": "Delivery ownership lost during standalone send"}
             result = await adapter.send(chat_id, message)
             if not result.success:
                 return _error(f"BlueBubbles send failed: {result.error}")
@@ -1994,7 +2255,7 @@ def _check_send_message():
         return False
 
 
-async def _send_qqbot(pconfig, chat_id, message):
+async def _send_qqbot(pconfig, chat_id, message, ownership_guard=None):
     """Send via QQBot using the REST API directly (no WebSocket needed).
 
     Uses the QQ Bot Open Platform REST endpoints to get an access token
@@ -2021,6 +2282,8 @@ async def _send_qqbot(pconfig, chat_id, message):
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             # Step 1: Get access token
+            if not _ownership_guard_active(ownership_guard):
+                return {"error": "Delivery ownership lost during standalone send"}
             token_resp = await client.post(
                 "https://bots.qq.com/app/getAppAccessToken",
                 json={"appId": str(appid), "clientSecret": str(secret)},
@@ -2042,6 +2305,8 @@ async def _send_qqbot(pconfig, chat_id, message):
             payload = {"content": message[:4000], "msg_type": 0}
 
             # Try channel endpoint first (works for guild channels)
+            if not _ownership_guard_active(ownership_guard):
+                return {"error": "Delivery ownership lost during standalone send"}
             url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
             resp = await client.post(url, json=payload, headers=headers)
             if resp.status_code in {200, 201}:
@@ -2050,6 +2315,8 @@ async def _send_qqbot(pconfig, chat_id, message):
                         "message_id": data.get("id")}
 
             # If channel endpoint failed (likely "频道不存在"), try C2C endpoint
+            if not _ownership_guard_active(ownership_guard):
+                return {"error": "Delivery ownership lost during standalone send"}
             url_c2c = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
             resp_c2c = await client.post(url_c2c, json=payload, headers=headers)
             if resp_c2c.status_code in {200, 201}:
@@ -2058,6 +2325,8 @@ async def _send_qqbot(pconfig, chat_id, message):
                         "message_id": data.get("id")}
 
             # If C2C also failed, try group endpoint
+            if not _ownership_guard_active(ownership_guard):
+                return {"error": "Delivery ownership lost during standalone send"}
             url_group = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
             resp_group = await client.post(url_group, json=payload, headers=headers)
             if resp_group.status_code in {200, 201}:
@@ -2071,7 +2340,12 @@ async def _send_qqbot(pconfig, chat_id, message):
         return _error(f"QQBot send failed: {e}")
 
 
-async def _send_yuanbao(chat_id, message, media_files=None):
+async def _send_yuanbao(
+    chat_id,
+    message,
+    media_files=None,
+    ownership_guard=None,
+):
     """Send via Yuanbao using the running gateway adapter's WebSocket connection.
 
     Yuanbao uses a persistent WebSocket — unlike HTTP-based platforms, we
@@ -2095,7 +2369,13 @@ async def _send_yuanbao(chat_id, message, media_files=None):
         )
 
     try:
-        return await send_yuanbao_direct(adapter, chat_id, message, media_files=media_files)
+        return await send_yuanbao_direct(
+            adapter,
+            chat_id,
+            message,
+            media_files=media_files,
+            ownership_guard=ownership_guard,
+        )
     except Exception as e:
         return _error(f"Yuanbao send failed: {e}")
 


### PR DESCRIPTION
## Summary

- add durable, exact-owner run claims across Desktop, Gateway, scheduled, and manual cron execution paths
- make scheduler handoff readiness, execution liveness, profile-local stores, scripts, agents, output, and delivery fail closed after ownership loss
- prevent stale attempts from overwriting successor state or continuing multi-step external side effects
- update the multiplex busy-mode fixture to explicitly declare the secondary profile it exercises

## Root cause

The incident that started this investigation was a model-provider timeout/hang before any tool execution. Recovery exposed separate scheduler correctness gaps: Desktop and Gateway coordination relied partly on process-local state, persisted process fingerprints were unstable on macOS, and mutable cron state and side effects were not consistently fenced by an immutable attempt owner. Manual runs and scheduled ticks could therefore overlap or leave stale attempts able to write state after ownership changed.

## Validation

- 70 focused cron, delivery, Gateway, and platform test files: 905 passed, 0 failed, 7 platform-specific skipped
- 10 upstream-overlap and multiplex handoff files: 285 passed, 0 failed, 2 platform-specific skipped
- Ruff on every changed Python file
- Python bytecode compilation on every changed Python file
- git diff check
- Windows footgun scan: 944 files, no findings
- independent final review found no remaining Critical or Important issues
