### PR TITLE
fix(voice): speak only the final response with speak_final_only

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14234,7 +14234,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         stream_tts_to_speaker,
                     )
                     _import_sounddevice()
-                    use_streaming_tts = check_tts_requirements()
+                    # speak_final_only: skip the streaming TTS feed entirely.
+                    # Streaming speaks every assistant message as it is
+                    # generated (including preliminary answers before tool
+                    # calls). When only the final answer should be spoken,
+                    # fall through to the non-streaming path below, which
+                    # speaks the turn's final response once, in full.
+                    from tools.tts_tool import should_stream_tts
+                    if should_stream_tts():
+                        use_streaming_tts = check_tts_requirements()
                 except Exception:
                     pass
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1630,6 +1630,11 @@ DEFAULT_CONFIG = {
         "thinking_sound": True,       # Calm ambient bubble sound while the agent works in voice chat (volume follows beep_volume)
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
+        "speak_final_only": False,    # Voice mode: speak ONLY the final response,
+                                      # not intermediate assistant messages
+                                      # (e.g. a preliminary answer before tool
+                                      # calls). Disables streaming TTS so the
+                                      # final message is spoken once, in full.
         "barge_in": True,             # Interrupt the agent / stop TTS when the user starts talking
         "barge_in_grace_seconds": 0.5,  # Trip suppression right after TTS playback starts (onset transient); the mic itself is live for the whole turn
         "barge_in_threshold_multiplier": 3.0,  # Speech trigger = quiet-room floor x this (floor is calibrated BEFORE playback, never against speaker bleed)

--- a/tests/tools/test_voice_speak_final_only.py
+++ b/tests/tools/test_voice_speak_final_only.py
@@ -1,0 +1,48 @@
+"""Tests for voice.speak_final_only (speak only the final response).
+
+Contract:
+  - `should_stream_tts()` returns True by default (streaming enabled).
+  - With `voice.speak_final_only: True` it returns False, so the CLI skips
+    the streaming TTS feed and only the turn's final response is spoken.
+  - A malformed ``voice:`` config block and config-load errors fall back to
+    streaming enabled (the pre-existing default behaviour).
+"""
+
+from unittest.mock import patch
+
+from tools.tts_tool import should_stream_tts
+
+
+class TestShouldStreamTts:
+    def test_default_streaming_enabled(self):
+        assert should_stream_tts({}) is True
+
+    def test_speak_final_only_disables_streaming(self):
+        assert should_stream_tts({"speak_final_only": True}) is False
+
+    def test_false_explicitly_keeps_streaming(self):
+        assert should_stream_tts({"speak_final_only": False}) is True
+
+    def test_other_voice_keys_keep_streaming(self):
+        assert should_stream_tts({"silence_duration": 1.5,
+                                  "barge_in": True}) is True
+
+    def test_loads_from_active_config_when_omitted(self):
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": {"speak_final_only": True}}):
+            assert should_stream_tts() is False
+
+    def test_defaults_when_voice_block_missing(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert should_stream_tts() is True
+
+    def test_config_error_falls_back_to_streaming(self):
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError):
+            assert should_stream_tts() is True
+
+    def test_malformed_voice_block_falls_back_to_streaming(self):
+        # A hand-edited ``voice: true`` leaves load_config()['voice'] as a
+        # non-dict; coerce to {} instead of crashing.
+        with patch("hermes_cli.config.load_config",
+                   return_value={"voice": True}):
+            assert should_stream_tts() is True

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3702,6 +3702,29 @@ def text_to_speech_tool(
 # ===========================================================================
 # Requirements check
 # ===========================================================================
+def should_stream_tts(voice_cfg=None) -> bool:
+    """Whether sentence-by-sentence streaming TTS should be used this turn.
+
+    Streaming speaks every assistant message as the agent generates it —
+    including preliminary answers emitted before tool calls. When the user
+    sets ``voice.speak_final_only``, only the turn's final response should
+    be spoken, so streaming must be skipped (the CLI's non-streaming path
+    speaks the final response once, in full).
+
+    ``voice_cfg`` is injectable for tests; when omitted it is read from the
+    active config (``voice:`` block). Config errors fall back to streaming
+    enabled — the existing default behaviour.
+    """
+    if voice_cfg is None:
+        try:
+            from hermes_cli.config import load_config
+            _raw = load_config().get("voice")
+            voice_cfg = _raw if isinstance(_raw, dict) else {}
+        except Exception:
+            voice_cfg = {}
+    return not voice_cfg.get("speak_final_only", False)
+
+
 def check_tts_requirements() -> bool:
     """Return whether the explicitly resolved TTS provider can run.
 


### PR DESCRIPTION
## What does this PR do?

Fixes a voice-mode annoyance that makes tool-using turns confusing to listen to. Streaming TTS speaks **every assistant message** as the agent generates it — including **preliminary answers emitted before tool calls**. A multi-step turn therefore sounds like two spoken replies: an interim summary, then the real answer after the tools finish.

This PR adds `voice.speak_final_only` (default `false`, preserving current behavior). When set, the CLI skips the streaming-TTS feed entirely, so only the turn's **final response** is spoken once, in full, via the existing non-streaming path. Intermediate assistant messages are still rendered on screen — they just never reach the speaker.

## Related Issue

Fixes #83942

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/tts_tool.py`: new `should_stream_tts(voice_cfg=None)` helper — returns `False` when `voice.speak_final_only` is set; `voice_cfg` is injectable for tests, falls back to the active config, and config errors fall back to streaming enabled (existing default).
- `cli.py`: gate the streaming-TTS setup (`use_streaming_tts = check_tts_requirements()`) on `should_stream_tts()`.
- `hermes_cli/config_defaults.py`: document the new `voice.speak_final_only` key.
- `tests/tools/test_voice_speak_final_only.py`: 8 tests — default, flag on/off, other voice keys, config-loaded value, missing block, load error, malformed `voice:` block.

## How to Test

1. `pytest tests/tools/test_voice_speak_final_only.py -q` → 8 passed
2. `pytest tests/tools/test_voice_stop_phrase.py tests/tools/test_voice_mode.py tests/tools/test_tts_streaming.py -q` → 109 passed, 2 skipped (no regressions)
3. Manual: `/voice on` → ask a question that triggers tool calls → with `speak_final_only: true`, only the final answer is spoken (the interim summary is silent); with the default, both are spoken as before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the targeted voice/tts suites (CI's full-suite gate is temporarily disabled per the Aug 2 note; the affected modules' tests pass)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Arch, CLI voice mode with Mistral Voxtral STT/TTS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings in `config_defaults.py` and `tts_tool.py`) — N/A for README/docs since the CLI voice config block isn't documented in `cli-config.yaml.example`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (the CLI `voice:` block is not in the example; `config_defaults.py` is the source of truth, consistent with `record_key`/`silence_duration` etc.)
- [x] I've considered cross-platform impact (Windows, macOS) — the change is a pure config gate on an existing path; no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Voice mode turn with tool calls (before): interim answer spoken, then final answer spoken.
Voice mode turn with `speak_final_only: true` (after): only the final answer is spoken.
