### PR TITLE
fix(cron): inject archived response into chained jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2687,6 +2687,12 @@ def _build_job_prompt(
                 if not output_files:
                     continue  # silent skip — no output yet
                 latest_output = output_files[0].read_text(encoding="utf-8").strip()
+                # Cron artifacts archive both the assembled prompt and the response.
+                # Chained jobs need the response: truncating the archive from the
+                # front can discard the actual handoff while reinjecting prompt bloat.
+                response_marker = "\n## Response\n"
+                if response_marker in latest_output:
+                    latest_output = latest_output.rsplit(response_marker, 1)[1].strip()
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -175,6 +175,28 @@ class TestBuildJobPromptContextFrom:
         assert "truncated" in prompt
         assert "x" * 10000 not in prompt
 
+    def test_archived_cron_output_injects_response_before_truncation(self, cron_env):
+        """A long archived prompt must not truncate away its actual response."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Collect", schedule="every 1h")
+        out_dir = OUTPUT_DIR / job_a["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        archived = (
+            "# Cron Job: Collector\n\n## Prompt\n\n"
+            + "archived prompt noise " * 1000
+            + "\n\n## Response\n\n<IDEA_BRIEF>fresh evidence</IDEA_BRIEF>\n"
+        )
+        (out_dir / "2026-04-22_10-00-00.md").write_text(archived, encoding="utf-8")
+
+        job_b = create_job(
+            prompt="Write the insight", schedule="every 2h", context_from=job_a["id"]
+        )
+        prompt = _build_job_prompt(job_b)
+
+        assert "<IDEA_BRIEF>fresh evidence</IDEA_BRIEF>" in prompt
+        assert "archived prompt noise" not in prompt
 
     def test_invalid_job_id_skipped(self, cron_env):
         """context_from with path traversal job_id should be skipped."""


### PR DESCRIPTION
## Summary
- extract the archived `## Response` section before truncating `context_from` output
- keep legacy artifact fallback behavior
- add a regression test where a long archived prompt would otherwise hide the actual handoff

## Root cause
Cron artifacts contain both the assembled prompt and final response. Chained jobs read and truncated the entire artifact from the front, allowing archived prompt text to consume the 8K context budget and discard the response needed by the downstream job.

## Test plan
- `python -m pytest tests/cron/test_cron_context_from.py -q -o addopts=`
