### PR TITLE
fix(kanban): stop reusing closed connection in non-JSON show output

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1685,6 +1685,10 @@ def _cmd_show(args: argparse.Namespace) -> int:
         # ``result=``. Surfacing the latest summary here keeps ``show`` from
         # looking like a no-op when the worker actually did real work.
         latest_summary = kb.latest_summary(conn, args.task_id)
+        # Computed inside the connection scope — used by the diagnostics
+        # section below, which runs after `conn` has already closed on the
+        # non-JSON path (issue: sqlite3.ProgrammingError on closed conn).
+        task_graph = kb.task_graph_context(conn, task.id)
 
     if getattr(args, "json", False):
         payload = {
@@ -1762,9 +1766,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     # of show output so CLI users see them before scrolling through
     # comments / runs.
     from hermes_cli import kanban_diagnostics as kd
-    diags = kd.compute_task_diagnostics(
-        task, events, runs, graph=kb.task_graph_context(conn, task.id)
-    )
+    diags = kd.compute_task_diagnostics(task, events, runs, graph=task_graph)
     if diags:
         sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}
         print(f"\n  Diagnostics ({len(diags)}):")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -154,6 +154,32 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
+def test_kanban_show_non_json_does_not_crash_on_closed_connection(kanban_home):
+    """Regression guard: ``_cmd_show``'s non-JSON path used to reuse ``conn``
+    after the ``with kb.connect_closing()`` block that opened it had already
+    exited, raising ``sqlite3.ProgrammingError: Cannot operate on a closed
+    database`` from the diagnostics section (``kb.task_graph_context``).
+
+    The ``--json`` path never hit this because it returns from inside the
+    ``with`` block. ``run_slash`` catches the exception and reports it via
+    stderr rather than raising, so a naive substring check on early output
+    (e.g. "ready" appears in the status line printed *before* the crash)
+    does not catch this — assert the error text is absent instead.
+    """
+    import re
+
+    out = kc.run_slash("create 'diag repro task'")
+    m = re.search(r"(t_[a-f0-9]+)", out)
+    assert m, out
+    tid = m.group(1)
+
+    shown = kc.run_slash(f"show {tid}")
+    assert "ProgrammingError" not in shown, shown
+    assert "closed database" not in shown, shown
+    assert "Diagnostics" not in shown  # no active diagnostics on a fresh task
+    assert f"Task {tid}" in shown
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #83929 — every non-JSON `hermes kanban show <id>` raises `sqlite3.ProgrammingError: Cannot operate on a closed database`.
- Root cause: `_cmd_show` opens `conn` in `with kb.connect_closing() as conn:` and the block closes right after reading `latest_summary`. The `--json` branch returns from inside that block, so it never hits the bug. The plain-text branch continues past the block and later calls `kb.task_graph_context(conn, task.id)` for the diagnostics section — reusing the already-closed connection.
- Fix: compute `task_graph_context()` inside the connection scope (alongside the other reads) and pass the precomputed graph down to the diagnostics call, instead of reopening/reusing `conn` after it closes.

## Why the existing test suite didn't catch this
There's an existing `show` assertion (`test_kanban_reclaim_...`, around line 153 of `test_kanban_cli.py`) that only checks a substring (`"ready" in out2.lower()`). `run_slash()` catches the exception internally and reports it via stderr rather than raising — and the crash happens *after* the status line is already printed to the captured stdout buffer, so `"ready"` is present regardless of the later crash. The weak assertion passed even while the command was actively failing.

## Test plan
- [x] Added `test_kanban_show_non_json_does_not_crash_on_closed_connection`, which asserts the error text is absent from the *full* captured output.
- [x] Verified the new test fails against the pre-fix code (`git stash` of the `kanban.py` hunk) and passes after it.
- [x] `python -m pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_core_functionality.py -q` → 32 passed, 1 skipped.
- [x] `ruff check` on changed files → clean.
- [x] `ty check` on `kanban.py` → no new diagnostics introduced near the changed lines (pre-existing unrelated warnings elsewhere in the file, untouched).