### PR TITLE
fix(agent): accept empty tool_call arguments for no-required-param tools

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -138,8 +138,26 @@ class _BatchAbandoned(BaseException):
     """
 
 
-def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
+def _parse_tool_arguments(
+    raw_arguments: Any, tool_name: Optional[str] = None
+) -> tuple[dict, Optional[str]]:
     """Parse model-emitted arguments without repairing or coercing them."""
+    # Issue #83937: models behind OpenAI-compatible gateways emit "" instead
+    # of "{}" for tools whose schema has no required params. Normalize
+    # empty/whitespace-only arguments to {} for such tools so the call
+    # executes instead of looping on a JSON parse error; tools with required
+    # params (and tools we cannot identify) keep the strict rejection below.
+    if (
+        isinstance(raw_arguments, str)
+        and not raw_arguments.strip()
+        and tool_name is not None
+    ):
+        try:
+            from tools.registry import registry as _registry
+            if not _registry.schema_has_required(tool_name):
+                return {}, None
+        except Exception:  # pragma: no cover — never block dispatch on registry bugs
+            pass
     try:
         arguments = json.loads(raw_arguments)
     except (json.JSONDecodeError, TypeError):
@@ -812,7 +830,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         function_name = tool_call.function.name
 
         function_args, malformed_args_result = _parse_tool_arguments(
-            tool_call.function.arguments
+            tool_call.function.arguments,
+            tool_call.function.name,
         )
 
         if malformed_args_result is not None:
@@ -1653,7 +1672,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         function_name = tool_call.function.name
 
         function_args, malformed_args_result = _parse_tool_arguments(
-            tool_call.function.arguments
+            tool_call.function.arguments,
+            tool_call.function.name,
         )
         if malformed_args_result is not None:
             _emit_terminal_post_tool_call(

--- a/tests/run_agent/test_malformed_tool_arguments.py
+++ b/tests/run_agent/test_malformed_tool_arguments.py
@@ -46,6 +46,14 @@ def _tool_call(call_id: str, arguments: str):
     )
 
 
+def _named_tool_call(call_id: str, name: str, arguments: str):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
 @pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
 @pytest.mark.parametrize(
     "bad_arguments",
@@ -95,3 +103,99 @@ def test_malformed_arguments_are_rejected_without_blocking_valid_sibling(
     assert '"error": "Invalid tool arguments"' in messages[0]["content"]
     assert "JSON object" in messages[0]["content"]
     assert json.loads(messages[1]["content"]) == {"ok": "valid"}
+
+
+# ---------------------------------------------------------------------------
+# Issue #83937: empty-string arguments for tools with no required params must
+# be accepted as {} at the execution boundary, not rejected as invalid JSON.
+# ---------------------------------------------------------------------------
+
+
+def _register_test_tool(name: str, required=()):
+    from tools.registry import registry
+
+    def _handler(args, task_id=None, **kw):
+        return json.dumps({"ok": True, "args": args})
+
+    params = {
+        "type": "object",
+        "properties": {"query": {"type": "string", "description": "q"}},
+    }
+    if required:
+        params["required"] = list(required)
+    registry.register(
+        name=name,
+        toolset="test-empty-83937",
+        handler=_handler,
+        schema={"type": "function",
+                "function": {"name": name, "description": f"desc {name}",
+                             "parameters": params}},
+    )
+
+
+@pytest.mark.parametrize("empty", ["", "   "])
+def test_parse_empty_arguments_accepted_for_tool_without_required(empty):
+    """Empty/whitespace-only arguments parse to {} for tools whose schema
+    declares no required parameters (issue #83937)."""
+    from agent.tool_executor import _parse_tool_arguments
+
+    _register_test_tool("parse_empty_ok_83937")
+    args, err = _parse_tool_arguments(empty, "parse_empty_ok_83937")
+    assert err is None
+    assert args == {}
+
+
+def test_parse_empty_arguments_still_rejected_for_tool_with_required():
+    """Tools with required params keep the strict rejection (issue #83937)."""
+    from agent.tool_executor import _parse_tool_arguments
+
+    _register_test_tool("parse_empty_req_83937", required=("query",))
+    args, err = _parse_tool_arguments("", "parse_empty_req_83937")
+    assert err is not None
+    assert "Invalid tool arguments" in err
+
+
+def test_parse_empty_object_arguments_unchanged():
+    """Literal '{}' parses to {} as before — normalization is a no-op."""
+    from agent.tool_executor import _parse_tool_arguments
+
+    _register_test_tool("parse_empty_obj_83937")
+    args, err = _parse_tool_arguments("{}", "parse_empty_obj_83937")
+    assert err is None
+    assert args == {}
+
+
+@pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
+def test_empty_arguments_execute_for_tool_without_required(dispatch_mode):
+    """End-to-end: an empty-string tool_call for a no-required-param tool
+    executes with {} instead of looping on a JSON parse error."""
+    agent = _make_agent()
+    _register_test_tool("empty_exec_ok_83937")
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=[
+            _named_tool_call("call-empty", "empty_exec_ok_83937", ""),
+            _named_tool_call("call-obj", "empty_exec_ok_83937", "{}"),
+        ],
+    )
+    messages = []
+    executed = []
+
+    def fake_dispatch(name, args, task_id, *positional, **kwargs):
+        executed.append((name, dict(args)))
+        return json.dumps({"ok": True})
+
+    with (
+        patch("run_agent.handle_function_call", side_effect=fake_dispatch),
+        patch.object(agent, "_invoke_tool", side_effect=fake_dispatch),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        execute = getattr(agent, f"_execute_tool_calls_{dispatch_mode}")
+        execute(assistant_message, messages, "task-1")
+
+    assert executed == [("empty_exec_ok_83937", {}), ("empty_exec_ok_83937", {})]
+    assert all(message["role"] == "tool" for message in messages)
+    assert len(messages) == 2

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -616,3 +616,83 @@ class TestDeferredCallSchemaProbe:
         ))
         assert result.get("ok") is True
         assert result.get("doc") == "abc"
+
+
+class TestRegression_EmptyStringArguments83937:
+    """Issue #83937: models behind OpenAI-compatible gateways emit
+    ``arguments: ""`` (empty string) for tools whose parameter schema has
+    no required fields. The execution boundary must treat that as ``{}``
+    instead of rejecting with "tool_call 'arguments' is not valid JSON"
+    — which made the agent retry the same malformed call forever.
+    Tools with required params must keep the strict JSON rejection.
+    """
+
+    @staticmethod
+    def _register(name, toolset, required=()):
+        from tools.registry import registry
+
+        def _handler(args, task_id=None, **kw):
+            return json.dumps({"ok": True, "args": args})
+
+        params = {
+            "type": "object",
+            "properties": {
+                "document_id": {"type": "string", "description": "Doc id"},
+            },
+        }
+        if required:
+            params["required"] = list(required)
+        registry.register(
+            name=name,
+            handler=_handler,
+            schema={"type": "function",
+                    "function": {"name": name, "description": f"desc {name}",
+                                 "parameters": params}},
+            toolset=toolset,
+        )
+
+    def test_empty_arguments_accepted_for_tool_without_required(self):
+        from tools.tool_search import resolve_underlying_call
+
+        self._register("mcp_empty_ok_83937", "mcp-empty-83937")
+        name, args, err = resolve_underlying_call({
+            "name": "mcp_empty_ok_83937",
+            "arguments": "",
+        })
+        assert err is None
+        assert name == "mcp_empty_ok_83937"
+        assert args == {}
+
+    def test_whitespace_arguments_accepted_for_tool_without_required(self):
+        from tools.tool_search import resolve_underlying_call
+
+        self._register("mcp_empty_ws_83937", "mcp-empty-83937")
+        name, args, err = resolve_underlying_call({
+            "name": "mcp_empty_ws_83937",
+            "arguments": "   ",
+        })
+        assert err is None
+        assert args == {}
+
+    def test_empty_arguments_still_rejected_for_tool_with_required(self):
+        from tools.tool_search import resolve_underlying_call
+
+        self._register("mcp_empty_req_83937", "mcp-empty-83937", required=("document_id",))
+        name, args, err = resolve_underlying_call({
+            "name": "mcp_empty_req_83937",
+            "arguments": "",
+        })
+        assert err is not None
+        assert "not valid JSON" in err
+
+    def test_empty_object_arguments_unchanged(self):
+        from tools.tool_search import resolve_underlying_call
+
+        self._register("mcp_empty_obj_83937", "mcp-empty-83937")
+        name, args, err = resolve_underlying_call({
+            "name": "mcp_empty_obj_83937",
+            "arguments": "{}",
+        })
+        assert err is None
+        assert args == {}
+

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -860,6 +860,29 @@ class ToolRegistry:
         entry = self.get_entry(name)
         return entry.schema if entry else None
 
+    def schema_has_required(self, name: str) -> bool:
+        """Return True when the named tool's schema declares required params.
+
+        Unknown tools (no registered schema) return False, matching the
+        fail-open philosophy of ``validate_deferred_call_args``: a missing
+        schema must never block dispatch on a validator edge case.
+        """
+        try:
+            schema = self.get_schema(name)
+            if not isinstance(schema, dict):
+                return False
+            fn = schema.get("function") if schema.get("type") == "function" else schema
+            if not isinstance(fn, dict):
+                return False
+            params = fn.get("parameters")
+            if not isinstance(params, dict):
+                return False
+            required = params.get("required")
+            return isinstance(required, list) and bool(required)
+        except Exception:  # pragma: no cover — never block dispatch on registry bugs
+            return False
+
+
     def get_toolset_for_tool(self, name: str) -> Optional[str]:
         """Return the toolset a tool belongs to, or None."""
         entry = self.get_entry(name)

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1035,10 +1035,20 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     if raw_args is None:
         raw_args = {}
     if isinstance(raw_args, str):
-        try:
-            raw_args = json.loads(raw_args)
-        except json.JSONDecodeError as e:
-            return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
+        # Issue #83937: models behind OpenAI-compatible gateways emit ""
+        # instead of "{}" for tools whose schema has no required params.
+        # Normalize empty/whitespace-only arguments to {} for such tools so
+        # the call executes instead of looping on a JSON parse error; tools
+        # with required params keep the strict JSON validation below.
+        if not raw_args.strip():
+            from tools.registry import registry as _registry
+            if not _registry.schema_has_required(name):
+                raw_args = {}
+        if isinstance(raw_args, str):
+            try:
+                raw_args = json.loads(raw_args)
+            except json.JSONDecodeError as e:
+                return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name):


### PR DESCRIPTION
## Summary
When a model emits a tool call with `arguments: ""` (empty string) for a tool whose parameter schema has no required fields, Hermes rejected the call with `tool_call 'arguments' is not valid JSON: Expecting value: line 1 column 1 (char 0)` — the agent then retried the same malformed call repeatedly. Empty arguments are semantically equivalent to `{}` when the tool declares no required parameters.

## Change
- `tools/registry.py`: new `ToolRegistry.schema_has_required(name)` — True only when the schema declares a non-empty `required`; fail-open (False) for unknown tools, consistent with `validate_deferred_call_args`.
- `tools/tool_search.py::resolve_underlying_call()`: empty/whitespace `arguments` + no-required tool → normalized to `{}` before `json.loads`; with required → JSON error kept.
- `agent/tool_executor.py::_parse_tool_arguments()`: new `tool_name` param; `""`/whitespace + no-required tool → `({}, None)`; with required → "Invalid tool arguments" rejection kept. Both call sites pass `tool_call.function.name`.
- `tests/tools/test_tool_search.py` + `tests/run_agent/test_malformed_tool_arguments.py`: regression cases — `""` accepted, whitespace accepted, `""` + required rejected, `"{}"` unchanged.

## Verification
- `tests/tools/test_tool_search.py -k 83937`: **4 passed**; `test_malformed_tool_arguments.py`: full suite green.
- Smoke: real `web_search` (schema `required: ["query"]`) still rejects `""` at both parse points — behavior preserved.

Closes #83937