### PR TITLE
test(discord): add .command to _FakeGroup stub to unlock slash-command tests

### DIFF
--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -36,6 +36,26 @@ def _ensure_discord_mock():
             def add_command(self, cmd):
                 self._children[cmd.name] = cmd
 
+            def command(self, *, name=None, description=None, **kwargs):
+                """Decorator mirroring discord.app_commands.Group.command.
+
+                Registers a subcommand on this group so the documented
+                ``@group.command(name=..., description=...)`` idiom works
+                against the stub (see issue #83936).
+                """
+
+                def decorator(fn):
+                    cmd = _FakeCommand(
+                        name=name or fn.__name__,
+                        description=description or "No description provided",
+                        callback=fn,
+                        parent=self,
+                    )
+                    self.add_command(cmd)
+                    return cmd
+
+                return decorator
+
         class _FakeCommand:
             def __init__(self, *, name, description, callback, parent=None):
                 self.name = name


### PR DESCRIPTION
## Summary
The `discord` stub `_FakeGroup` in `tests/gateway/test_discord_slash_commands.py` implemented only `__init__` and `add_command`, breaking 7 unrelated slash-command tests that register sub-commands via `@group.command(...)`. This unlocks the idiom for current and future tests.

## Change
- `tests/gateway/test_discord_slash_commands.py`: added `_FakeGroup.command()` — a decorator mirroring `discord.app_commands.Group.command` that creates a `_FakeCommand` (name/description/callback/parent), registers it via `self.add_command(cmd)`, and returns the Command (like the real discord.py), supporting `@group.command(name=..., description=...)` with `**kwargs` and optional name/description falling back to `fn.__name__`.

## Verification
- `pytest tests/gateway/test_discord_slash_commands.py`: **13 passed** (includes the 7 that call `_register_slash_commands()`).
- Issue scenario reproduced and validated via script: `@grp.command(name="sub", ...)` registers the subcommand with correct callback/parent; `tree.add_command(grp)` works; nested groups via `parent=` work.

Closes #83936