### PR TITLE
fix(gateway): offload all blocking atomic_json_write calls from async paths

### DIFF
--- a/contributors/emails/landaun@gmail.com
+++ b/contributors/emails/landaun@gmail.com
@@ -1,0 +1,1 @@
+landaun

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -206,7 +206,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     }
 
     try:
-        atomic_json_write(DIRECTORY_PATH, directory)
+        await asyncio.to_thread(atomic_json_write, DIRECTORY_PATH, directory)
     except Exception as e:
         logger.warning("Channel directory: failed to write: %s", e)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10082,10 +10082,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return suspended
 
-    def _clear_restart_failure_count(self, session_key: str) -> None:
+    async def _clear_restart_failure_count(self, session_key: str) -> None:
         """Clear the restart-failure counter for a session that completed OK.
 
         Called after a successful agent turn to signal the loop is broken.
+        Offloaded to a thread because the caller (_handle_message_with_agent)
+        runs on the event loop and atomic_json_write calls os.fsync.
         """
         import json
 
@@ -10097,7 +10099,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if session_key in counts:
                 del counts[session_key]
                 if counts:
-                    atomic_json_write(path, counts, indent=None)
+                    await asyncio.to_thread(atomic_json_write, path, counts, indent=None)
                 else:
                     path.unlink(missing_ok=True)
         except Exception:
@@ -18339,7 +18341,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # succeeded and subsequent messages should no longer receive
             # the restart-interruption system note.
             if session_key and _should_clear_resume_pending_after_turn(agent_result):
-                self._clear_restart_failure_count(session_key)
+                await self._clear_restart_failure_count(session_key)
                 try:
                     await self.async_session_store.clear_resume_pending(session_key)
                 except Exception as _e:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1578,7 +1578,8 @@ class GatewaySlashCommandsMixin:
                     )
                 except Exception:
                     self._restart_command_source = event.source
-            atomic_json_write(
+            await asyncio.to_thread(
+                atomic_json_write,
                 _hermes_home / ".restart_notify.json",
                 notify_data,
                 indent=None,
@@ -1598,7 +1599,8 @@ class GatewaySlashCommandsMixin:
             }
             if event.platform_update_id is not None:
                 dedup_data["update_id"] = event.platform_update_id
-            atomic_json_write(
+            await asyncio.to_thread(
+                atomic_json_write,
                 _hermes_home / ".restart_last_processed.json",
                 dedup_data,
                 indent=None,

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -110,6 +110,27 @@ class TestBuildChannelDirectoryOffload:
         assert builder_threads
         assert all(tid != loop_thread for tid in builder_threads)
 
+    def test_directory_write_runs_off_event_loop_thread(self, tmp_path):
+        """The persist step calls os.fsync, which blocks the loop until the write
+        reaches stable storage. #60794 moved the builders off the loop; the write
+        stayed on it."""
+        from gateway.config import Platform
+
+        cache_file = tmp_path / "channel_directory.json"
+        loop_thread = threading.get_ident()
+        write_threads = []
+
+        def fake_write(path, data, *args, **kwargs):
+            write_threads.append(threading.get_ident())
+
+        with patch("gateway.channel_directory.atomic_json_write", side_effect=fake_write), \
+             patch("gateway.channel_directory._build_discord", return_value=[]), \
+             patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            asyncio.run(build_channel_directory({Platform.DISCORD: object()}))
+
+        assert write_threads
+        assert all(tid != loop_thread for tid in write_threads)
+
 
 class TestResolveChannelName:
     def _setup(self, tmp_path, platforms):


### PR DESCRIPTION
## Summary
Completes the bug class from #83906 — offloads all remaining blocking `atomic_json_write` calls that run inside async gateway paths, using the same `await asyncio.to_thread(...)` pattern already established in `build_channel_directory()`.

Root cause: `atomic_json_write` calls `os.fsync()`, which blocks until the write reaches stable storage. When called directly inside an async function on the gateway event loop, discord.py's heartbeat task waits behind the flush.

## Changes
- `gateway/channel_directory.py`: offload the persist step with `asyncio.to_thread` (@landaun's original commit, cherry-picked from #83906)
- `tests/gateway/test_channel_directory.py`: test asserting the write runs off-loop (@landaun's original commit, cherry-picked from #83906)
- `gateway/slash_commands.py`: offload two `atomic_json_write` calls in `_handle_restart_command()` — `.restart_notify.json` and `.restart_last_processed.json` were blocking on fsync inside an async function
- `gateway/run.py`: `_clear_restart_failure_count()` made async + `atomic_json_write` offloaded via `asyncio.to_thread`; caller in `_handle_message_with_agent` updated to `await`

## Sites intentionally left synchronous
Two `atomic_json_write` calls inside `_stop_impl_body` (shutdown path: `_increment_restart_failure_counts` and planned restart notification marker) are left synchronous — the event loop is draining/stopping during shutdown and offloading adds complexity for no benefit.

## Validation
| | Before | After |
|---|---|---|
| channel_directory tests | 21 passed | 21 passed |
| restart tests (5 files) | 60 passed | 60 passed |
| E2E (real imports) | — | all 3 sites confirmed off-loop |
| ruff | clean | clean |
| py_compile | OK | OK |

Closes #83906
Completes #60794
