### PR TITLE
fix: tolerate empty-string tool_call arguments

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -140,6 +140,11 @@ class _BatchAbandoned(BaseException):
 
 def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
     """Parse model-emitted arguments without repairing or coercing them."""
+    # Model quirk: some OpenAI-compatible gateways emit "" (empty string) for
+    # tools with no required params. Normalise to an empty object, matching the
+    # history sanitizer in message_sanitization._repair_tool_call_arguments.
+    if isinstance(raw_arguments, str) and not raw_arguments.strip():
+        return {}, None
     try:
         arguments = json.loads(raw_arguments)
     except (json.JSONDecodeError, TypeError):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1867,6 +1867,25 @@ class TestConcurrentToolExecution:
         assert [m["tool_call_id"] for m in messages] == ["c1", "c2"]
         assert "tool was not executed" in messages[0]["content"].lower()
 
+    def test_concurrent_empty_string_args_execute_with_empty_object(self, agent):
+        """Models sometimes emit arguments="" for tools with no required
+        params; the executor should treat it as an empty object and run."""
+        tc1 = _mock_tool_call(name="web_search", arguments="", call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1])
+        messages = []
+        seen_args = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            seen_args.append((kwargs["tool_call_id"], args))
+            return "ok"
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert seen_args == [("c1", {})]
+        assert messages[0]["tool_call_id"] == "c1"
+        assert "not executed" not in messages[0]["content"].lower()
+
     def test_concurrent_preserves_order_despite_timing(self, agent):
         """Even if tools finish in different order, messages should be in original order."""
         import time as _time

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -268,6 +268,20 @@ class TestBridgeDispatch:
         assert err is not None
 
 
+    def test_resolve_underlying_call_accepts_empty_arguments(self):
+        """Empty-string arguments (a model quirk for zero-required-param tools)
+        are normalised to an empty object before classification."""
+        from tools.tool_search import resolve_underlying_call
+        for raw in ("", "   "):
+            name, args, err = resolve_underlying_call({
+                "name": "unknown_xxx",
+                "arguments": raw,
+            })
+            # Classification still fails (unknown_xxx isn't deferrable), but
+            # the empty string must not produce a JSON parse error.
+            assert err is not None
+            assert "not valid JSON" not in (err or "")
+
     def test_resolve_underlying_call_rejects_recursion(self):
         """tool_call cannot invoke tool_call itself."""
         from tools.tool_search import resolve_underlying_call, TOOL_CALL_NAME

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1035,10 +1035,13 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     if raw_args is None:
         raw_args = {}
     if isinstance(raw_args, str):
-        try:
-            raw_args = json.loads(raw_args)
-        except json.JSONDecodeError as e:
-            return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
+        if not raw_args.strip():
+            raw_args = {}
+        else:
+            try:
+                raw_args = json.loads(raw_args)
+            except json.JSONDecodeError as e:
+                return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name):


### PR DESCRIPTION
## What does this PR do?

Models behind OpenAI-compatible gateways sometimes emit `arguments: ""` (an empty string) for tools that have no required parameters. Hermes rejects such calls at the execution boundary with `tool_call 'arguments' is not valid JSON: Expecting value: line 1 column 1 (char 0)`, and the agent retries the same malformed call repeatedly instead of executing the tool.

This PR normalizes empty/whitespace-only `arguments` to `{}` at the two execution parse sites, matching the behavior the history sanitizer (`message_sanitization._repair_tool_call_arguments`) already applies. `None` handling is intentionally left unchanged to preserve the existing executor contract.

## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/83937

Note: issue #73175 covers deeper schema validation of deferred `tool_call` arguments (type/enum/nested-required); this change is the earlier, narrower empty-string normalization at the parse boundary and is complementary, not a duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_executor.py` — `_parse_tool_arguments()`: empty/whitespace-only string arguments are treated as `{}` (previously rejected as invalid JSON).
- `tools/tool_search.py` — `resolve_underlying_call()`: same normalization for the deferred `tool_call` bridge path.
- Added tests:
  - `tests/tools/test_tool_search.py::TestToolSearchBridge::test_resolve_underlying_call_accepts_empty_arguments`
  - `tests/run_agent/test_run_agent.py::test_concurrent_empty_string_args_execute_with_empty_object`

## How to Test

1. Use a model (e.g. behind an OpenAI-compatible gateway) that emits `""` for zero-required-param tools.
2. Ask the agent to call such a tool.
3. Before: repeated `tool_call 'arguments' is not valid JSON` errors, tool never executes.
4. After: the tool executes with `{}`.

Automated checks run:

```bash
venv/bin/python -m pytest tests/tools/test_tool_search.py -q          # full file, passes
venv/bin/python -m pytest tests/tools/test_tool_search.py tests/run_agent/test_run_agent.py -q -k "resolve_underlying_call or none_args_rejected or empty_string_args"  # targeted, 6 passed
```

The full `pytest tests/ -q` suite was not run in this environment; the change is confined to argument parsing and covered by the tests above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix:`, `fix(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass *(targeted suites run; full suite not run — see How to Test)*
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Hermes Agent v0.20.0, git install)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
