### PR TITLE
fix(doctor): don't suggest enabling auto_prune when already enabled

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -325,7 +325,12 @@ STATE_DB_SIZE_WARN_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB logical size
 from hermes_cli.sizefmt import format_bytes as _human_bytes
 
 
-def _render_state_db_stats(stats: dict, holders=None) -> list:
+def _render_state_db_stats(
+    stats: dict,
+    holders=None,
+    auto_prune_enabled: bool = False,
+    retention_days: int | None = None,
+) -> list:
     """Turn a collect_state_db_stats() dict into doctor output lines.
 
     Returns a list of ``(kind, text, detail)`` tuples where kind is one of
@@ -377,10 +382,17 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
     # trigram layout (fts_storage_version marker absent) — the offline
     # optimize-storage pass that migrates/compacts the FTS indexes.
     if logical is not None and logical > STATE_DB_SIZE_WARN_BYTES:
-        detail = (
-            "consider enabling sessions.auto_prune in config.yaml "
-            "to bound growth"
-        )
+        if auto_prune_enabled:
+            detail = (
+                "sessions.auto_prune is enabled"
+                + (f" (retention_days={retention_days})" if retention_days is not None else "")
+                + "; reduce retention_days for further compaction"
+            )
+        else:
+            detail = (
+                "consider enabling sessions.auto_prune in config.yaml "
+                "to bound growth"
+            )
         legacy_trigram = (
             fts is not None
             and fts.get("messages_fts_trigram")
@@ -1795,15 +1807,37 @@ def run_doctor(args):
 
             _db_stats = collect_state_db_stats(state_db_path)
             _db_holders = count_db_holders(state_db_path)
+            # #83933: make the large-DB advisory config-aware — when
+            # sessions.auto_prune is already enabled, do not suggest enabling it.
+            _auto_prune = False
+            _retention_days = None
+            try:
+                from hermes_cli.config import load_config
+                _cfg = load_config()
+                _sess = (_cfg.get("sessions") or {}) if isinstance(_cfg, dict) else {}
+                _auto_prune = bool(_sess.get("auto_prune", False))
+                _rd = _sess.get("retention_days")
+                _retention_days = int(_rd) if isinstance(_rd, (int, float)) else None
+            except Exception:
+                pass
             for _kind, _text, _detail in _render_state_db_stats(
-                _db_stats, holders=_db_holders
+                _db_stats,
+                holders=_db_holders,
+                auto_prune_enabled=_auto_prune,
+                retention_days=_retention_days,
             ):
                 if _kind == "warn":
                     check_warn(_text, _detail)
                     if "auto_prune" in _detail:
                         issues.append(
-                            "state.db is large — enable sessions.auto_prune "
-                            "in config.yaml"
+                            (
+                                "state.db is large — sessions.auto_prune is "
+                                "enabled; reduce retention_days for further "
+                                "compaction"
+                                if _auto_prune
+                                else "state.db is large — enable "
+                                "sessions.auto_prune in config.yaml"
+                            )
                             + (
                                 " and run 'hermes sessions optimize-storage' "
                                 "offline (gateway stopped)"

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -229,3 +229,36 @@ def test_render_handles_all_none_stats():
     empty["fts_tables"] = None
     lines = _render_state_db_stats(empty, holders=None)
     assert isinstance(lines, list)  # must not raise
+
+
+def test_render_large_db_with_auto_prune_enabled_suggests_retention_not_enable():
+    """#83933: when sessions.auto_prune is already enabled, the advisory must
+    not suggest enabling it — it points at retention_days instead."""
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big, page_count=big // 4096, page_size=4096),
+        holders=None,
+        auto_prune_enabled=True,
+        retention_days=90,
+    )
+    warns = [" ".join(str(p) for p in line) for line in lines if line[0] == "warn"]
+    blob = " ".join(warns)
+    assert "auto_prune is enabled" in blob
+    assert "retention_days=90" in blob
+    assert "consider enabling" not in blob
+
+
+def test_render_large_db_with_auto_prune_disabled_still_suggests_enabling():
+    """#83933: default path unchanged — advisory still suggests enabling."""
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big, page_count=big // 4096, page_size=4096),
+        holders=None,
+        auto_prune_enabled=False,
+    )
+    blob = " ".join(" ".join(str(p) for p in line) for line in lines)
+    assert "consider enabling sessions.auto_prune" in blob


### PR DESCRIPTION
## Summary
`hermes doctor` suggested "consider enabling sessions.auto_prune in config.yaml to bound growth" even when `sessions.auto_prune` was already `true`. The advisory is misleading — it points at a fix the user has already applied, offering no new actionable information.

## Change
- `hermes_cli/doctor.py`:
  - `_render_state_db_stats()` now takes `auto_prune_enabled`/`retention_days`; when auto_prune is on, the large-DB advisory says "sessions.auto_prune is enabled (retention_days=90); reduce retention_days for further compaction" instead of "consider enabling…". Default path unchanged.
  - The doctor caller reads `sessions.auto_prune`/`sessions.retention_days` from config (via `load_config`) and passes them; the issue summary is also config-aware.
- `tests/test_state_db_stats.py`: new cases — auto_prune enabled → advisory mentions retention_days and NOT "consider enabling"; disabled → original advisory preserved.

## Verification
- `tests/test_state_db_stats.py`: **14 passed** (12 existing + 2 new).

Closes #83933