### PR TITLE
fix(tui): enable copy-on-select for remote shells in macOS

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -31,7 +31,7 @@ import { useGitBranch } from '../hooks/useGitBranch.js'
 import { pruneVirtualHeightCache, useVirtualHistory } from '../hooks/useVirtualHistory.js'
 import { composerPromptWidth } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage, capTranscriptHistory } from '../lib/messages.js'
-import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
+import { DEFAULT_VOICE_RECORD_KEY, isMac, isRemoteShell, type ParsedVoiceRecordKey } from '../lib/platform.js'
 import { createResizeCoalescer } from '../lib/resizeCoalescer.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
@@ -259,11 +259,17 @@ export function useMainApp(gw: GatewayClient) {
   // copy-on-select: once a drag creates a stable TUI selection, write it to
   // the system clipboard while keeping the highlight visible.
   //
+  // Remote shells (SSH_CONNECTION set) need the same treatment: the Cmd/Ctrl
+  // copy shortcut belongs to the local terminal client and never reaches the
+  // remote app, and multiplexers/herdr swallow native selection while the TUI
+  // captures the mouse. Copy-on-select is the only path that lands on the
+  // user's local clipboard there (via OSC 52).
+  //
   // Subscribe directly via the ink selection bus (not useSyncExternalStore)
   // so React doesn't re-render MainApp on every drag-move tick. The version
   // ref de-dupes against re-entrant notifications.
   useEffect(() => {
-    if (!isMac) {
+    if (!isMac && !isRemoteShell()) {
       return
     }
 


### PR DESCRIPTION
## Problem

Copy-on-select (auto-copy to the clipboard when a mouse drag selection completes) is gated to macOS only in `ui-tui/src/app/useMainApp.ts`:

```ts
useEffect(() => {
  if (!isMac) {
    return
  }
  ...
```

It was added as a workaround for macOS Terminal.app, which does not forward Cmd+C to fullscreen TUIs that enable mouse tracking. But remote-shell users have the same problem: Cmd/Ctrl+C is handled by the *local* terminal client and never reaches the remote app, and multiplexers (tmux, herdr, screen) swallow native text selection while the app captures the mouse. Result: in a remote Linux TUI inside a multiplexer, drag selection highlights but never copies — the user must press Ctrl+C (non-macOS) with the selection active, which is not discoverable and not available to macOS-client users whose Cmd+C is intercepted locally.

## Fix

Extend the gate so copy-on-select also runs in remote shells (`SSH_CONNECTION` set):

```ts
if (!isMac && !isRemoteShell()) {
  return
}
```

The copy uses the existing `setClipboard` path, which already handles SSH correctly: native clipboard tools (pbcopy/wl-copy/xclip) are skipped when `SSH_CONNECTION` is set, and the raw OSC 52 sequence is written to stdout so the user's local terminal client (which supports OSC 52 clipboard writes) receives it.

## Verification

- Tested end-to-end: iTerm2 (macOS) → Eternal Terminal → herdr (multiplexer, Ghostty-vt based) → Hermes TUI on Linux. After this change, drag-release copies the selected text to the client's macOS clipboard via OSC 52; double/triple-click word/line selection copies as well.
- OSC 52 passthrough through the multiplexer was confirmed independently: a raw `ESC]52;c;...` sequence written from a pane reaches the client clipboard.
- Ctrl+C-with-active-selection (the existing non-macOS copy shortcut) continues to work, before and after.
- No behavior change on local Linux (gate still skips; Ctrl+C remains the copy shortcut there) or local macOS (unchanged).

## Known limitation: classic macOS Terminal.app

Terminal.app ignores OSC 52 clipboard writes entirely (empirically verified on macOS 26.6.1 — the current release, including the Tahoe-era rewritten Terminal: `ESC]52;c;<base64>` produces no clipboard change — matching upstream issue #15664, "/copy command does not work on macOS Terminal.app (OSC 52 not supported)"), and it does not support XTVERSION. Since OSC 52 is the only clipboard transport available to a TUI running on a remote host, **remote Terminal.app users get no TUI clipboard copy at all — with or without this change**. We evaluated detecting Terminal.app specifically (DA2 first parameter `>1;95;0c` vs iTerm2's `>0;95;0c`, XTVERSION silence, `TERM_PROGRAM=Apple_Terminal` locally, `LC_TERMINAL` which survives ssh → multiplexer chains) and deliberately did not build it: detection cannot add copy capability where the transport is absent, and the local-macOS case is already covered by the `isMac` gate (pbcopy path). If Terminal.app ever implements OSC 52, the remote gate already enables copy-on-select for it.

## Notes

- The macOS-only gate was introduced for Terminal.app; remote shells over multiplexers are the same failure mode, which is why the gate is extended rather than removed.
- A follow-up could expose this as a config option (`display.copy_on_select`), but the remote-shell heuristic matches the existing SSH detection used by `setClipboard` and is a minimal, low-risk change.

## Authoring note

Prepared by Hermes Agent (Nous Research) on behalf of the PR author (model: deepseek-v4-flash, provider: deepseek). The change was tested live by the PR author in their own setup before publication.
