### PR TITLE
feat(kanban): board-level default notification channel

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4759,6 +4759,15 @@ _DYNAMIC_TOP_LEVEL_KEYS = frozenset({
 # accepted because ``PlatformConfig`` carries an open ``extra`` mapping.
 _PLATFORM_CONTAINER_KEYS = frozenset({"platforms"})
 
+# Dotted paths (below the top level) that are open dicts: the schema declares
+# the container, the user supplies the child keys. Validation walks down to
+# the container and then accepts anything beneath it, so
+# ``kanban.default_notify.<board-slug>.platform`` doesn't trip the
+# unknown-key notice for a board name we cannot possibly enumerate.
+_OPEN_DICT_NESTED_PATHS = frozenset({
+    "kanban.default_notify",
+})
+
 
 def _known_top_level_keys() -> set[str]:
     """Return the union of known top-level config keys for validation.
@@ -4859,6 +4868,11 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     node: Any = DEFAULT_CONFIG.get(top)
     consumed = [top]
     for seg in segments[1:]:
+        # Nested open dicts (``kanban.default_notify.<board>.<field>``):
+        # once we've consumed the container path, the user defines every
+        # segment below it.
+        if ".".join(consumed) in _OPEN_DICT_NESTED_PATHS:
+            return True, None
         # ``gateway.platforms.<name>.<field>`` (and any other nested
         # ``platforms`` container) — the segment after ``platforms`` is a
         # user-supplied platform name, so accept everything below it.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2340,6 +2340,29 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
+        # Board-level default notification channel. Task creation paths that
+        # have NO live chat context — `hermes kanban create` run from a
+        # detached terminal/cron script, or `kanban_create` invoked by an
+        # orchestrator agent with no user-facing message behind it — have no
+        # chat_id to auto-subscribe, so those tasks used to get zero
+        # notification coverage and nobody heard about them when they later
+        # hit `blocked` / `review_requested`.
+        #
+        # Keyed by board slug, because boards are the isolation unit here:
+        #
+        #   kanban:
+        #     default_notify:
+        #       myboard:
+        #         platform: slack
+        #         chat_id: C0BP91D49CH
+        #         chat_type: channel   # optional
+        #         thread_id: ""        # optional
+        #         user_id: ""          # optional
+        #
+        # A board with no entry keeps today's behaviour exactly: no
+        # auto-subscribe, no error, one dict lookup of overhead. This never
+        # overrides a live chat context — it is a fallback only.
+        "default_notify": {},
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1567,11 +1567,28 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
         )
+        # Detached CLI creation has no live chat context to auto-subscribe
+        # (that path lives in tools/kanban_tools.py::_maybe_auto_subscribe),
+        # so a task created from a terminal or a cron script used to get zero
+        # notification coverage and nobody heard about it when it later
+        # blocked. Fall back to the board's configured default channel, if
+        # any. No entry for this board => no-op, exactly as before.
+        default_notified = kb.apply_default_notify_sub(
+            conn,
+            task_id,
+            notifier_profile=args.created_by or _profile_author(),
+        )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:
         print(f"Created {task_id}  ({task.status}, assignee={task.assignee or '-'})")
+        if default_notified:
+            target = kb.resolve_default_notify() or {}
+            print(
+                f"Notifications: {target.get('platform')}:{target.get('chat_id')} "
+                "(board default)"
+            )
 
         # Warn when the task would sit in `ready` because no dispatcher is
         # present. Only warn on ready+assigned tasks — triage/todo are

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9753,6 +9753,111 @@ def worker_log_rotation_config(kanban_cfg: Optional[dict] = None) -> tuple[int, 
     return max_bytes, backup_count
 
 
+def resolve_default_notify(
+    board: Optional[str] = None,
+    kanban_cfg: Optional[Mapping[str, Any]] = None,
+) -> Optional[dict[str, Any]]:
+    """Return the configured board-level default notification target, or None.
+
+    Reads ``kanban.default_notify.<board-slug>`` from config.yaml. ``board``
+    defaults to the currently active board (:func:`get_current_board`), which
+    is the board a bare ``hermes kanban create`` / ``kanban_create`` writes to.
+
+    The return value is a kwargs dict for :func:`add_notify_sub` — always with
+    non-empty ``platform`` and ``chat_id``; ``chat_type`` / ``thread_id`` /
+    ``user_id`` are included only when configured. Returns None when the board
+    has no entry, the entry isn't a mapping, or platform/chat_id are missing —
+    i.e. an unconfigured board costs one dict lookup and behaves exactly as it
+    did before this feature existed.
+
+    Honours the same ``kanban.auto_subscribe_on_create`` kill switch as the
+    live-session auto-subscribe path: "auto-subscribe on create: off" means
+    off for every create-time subscription source, not just the chat one.
+
+    Never raises: a malformed config must not fail the task creation it is
+    merely decorating.
+    """
+    try:
+        if kanban_cfg is None:
+            from hermes_cli.config import load_config
+
+            kanban_cfg = (load_config() or {}).get("kanban") or {}
+        if not (kanban_cfg or {}).get("auto_subscribe_on_create", True):
+            return None
+        defaults = (kanban_cfg or {}).get("default_notify") or {}
+        if not isinstance(defaults, Mapping) or not defaults:
+            return None
+        slug = _normalize_board_slug(board) or get_current_board()
+        entry = defaults.get(slug)
+        if not isinstance(entry, Mapping):
+            return None
+        platform = str(entry.get("platform") or "").strip()
+        chat_id = str(entry.get("chat_id") or "").strip()
+        if not platform or not chat_id:
+            return None
+        resolved: dict[str, Any] = {"platform": platform, "chat_id": chat_id}
+        for field in ("chat_type", "thread_id", "user_id"):
+            value = str(entry.get(field) or "").strip()
+            if value:
+                resolved[field] = value
+        return resolved
+    except Exception:
+        _log.debug("resolve_default_notify failed for board=%r", board, exc_info=True)
+        return None
+
+
+def apply_default_notify_sub(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    board: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+    kanban_cfg: Optional[Mapping[str, Any]] = None,
+) -> bool:
+    """Subscribe the board's default notification channel to ``task_id``.
+
+    Returns True when a default is configured and :func:`add_notify_sub` was
+    called, False when the board has no default (or the write failed). This is
+    the no-live-chat-context fallback shared by ``hermes kanban create`` and
+    ``kanban_create``; it is never used to override a real chat context.
+
+    ``add_notify_sub`` is ``INSERT OR IGNORE`` on
+    (task, platform, chat, thread), so calling this after an explicit
+    subscription to the same target is a no-op rather than a duplicate row.
+
+    Best-effort: notification bookkeeping must never fail a task creation.
+    """
+    target = resolve_default_notify(board, kanban_cfg=kanban_cfg)
+    if not target:
+        return False
+    thread_id = target.get("thread_id")
+    chat_type = target.get("chat_type")
+    delivery_metadata: dict[str, Any] = {}
+    if thread_id:
+        delivery_metadata["thread_id"] = thread_id
+    if chat_type:
+        delivery_metadata["chat_type"] = chat_type
+    try:
+        add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform=target["platform"],
+            chat_id=target["chat_id"],
+            chat_type=chat_type,
+            thread_id=thread_id,
+            user_id=target.get("user_id"),
+            notifier_profile=notifier_profile,
+            delivery_metadata=delivery_metadata or None,
+        )
+        return True
+    except Exception:
+        _log.warning(
+            "apply_default_notify_sub failed for task=%s board=%r",
+            task_id, board, exc_info=True,
+        )
+        return False
+
+
 def _rotated_log_path(log_path: Path, generation: int) -> Path:
     return log_path.with_suffix(log_path.suffix + f".{generation}")
 

--- a/tests/hermes_cli/test_kanban_default_notify.py
+++ b/tests/hermes_cli/test_kanban_default_notify.py
@@ -1,0 +1,308 @@
+"""Board-level default notification channel (``kanban.default_notify``).
+
+Task creation paths that carry a live chat context auto-subscribe that
+context (``tools/kanban_tools.py::_maybe_auto_subscribe``). Paths that do
+NOT — a detached ``hermes kanban create`` from a terminal or cron script,
+or ``kanban_create`` called by an orchestrator with no user-facing message
+behind it — used to produce tasks with zero notification coverage, so a
+later ``blocked`` / ``review_requested`` transition reached nobody.
+
+These tests pin the behaviour of the fallback:
+
+  - configured board  -> exactly one sub, with the configured target
+  - unconfigured board -> zero subs, no error (pre-feature behaviour)
+  - live chat context  -> still wins; the fallback never overrides it
+  - both apply         -> still one row (add_notify_sub is idempotent)
+  - board isolation    -> board A's default never lands on board B's task
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-profile")
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _write_config(home: Path, body: str) -> None:
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def _subs(task_id: str, board: str | None = None) -> list[dict]:
+    conn = kb.connect(board=board)
+    try:
+        return list(kb.list_notify_subs(conn, task_id))
+    finally:
+        conn.close()
+
+
+def _created_id(output: str) -> str:
+    for line in output.splitlines():
+        if line.startswith("Created "):
+            return line.split()[1]
+    raise AssertionError(f"no task id in CLI output: {output!r}")
+
+
+# ---------------------------------------------------------------------------
+# CLI create
+# ---------------------------------------------------------------------------
+
+def test_cli_create_subscribes_board_default(kanban_home):
+    """A board with a configured default gets exactly one subscription row
+    on the new task, carrying the configured platform/chat_id/chat_type."""
+    _write_config(
+        kanban_home,
+        "kanban:\n"
+        "  default_notify:\n"
+        "    default:\n"
+        "      platform: slack\n"
+        "      chat_id: C0BP91D49CH\n"
+        "      chat_type: channel\n",
+    )
+    out = kc.run_slash("create 'detached create' --assignee worker")
+    subs = _subs(_created_id(out))
+
+    assert len(subs) == 1, subs
+    assert subs[0]["platform"] == "slack"
+    assert subs[0]["chat_id"] == "C0BP91D49CH"
+    assert subs[0]["chat_type"] == "channel"
+
+
+def test_cli_create_without_default_notify_subscribes_nothing(kanban_home):
+    """Regression guard for the pre-feature behaviour: no config entry means
+    no subscription and no failure — creation still succeeds."""
+    out = kc.run_slash("create 'no default' --assignee worker")
+    task_id = _created_id(out)
+
+    assert _subs(task_id) == []
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, task_id) is not None
+    finally:
+        conn.close()
+
+
+def test_cli_create_tolerates_malformed_default_notify(kanban_home):
+    """A default_notify entry missing chat_id (or shaped wrong) must not
+    fail the create — it degrades to the no-default behaviour."""
+    _write_config(
+        kanban_home,
+        "kanban:\n"
+        "  default_notify:\n"
+        "    default:\n"
+        "      platform: slack\n",
+    )
+    out = kc.run_slash("create 'half configured' --assignee worker")
+    assert _subs(_created_id(out)) == []
+
+
+def test_cli_create_default_notify_is_idempotent(kanban_home):
+    """Explicitly subscribing the same target afterwards must not produce a
+    second row — add_notify_sub is INSERT OR IGNORE on
+    (task, platform, chat, thread)."""
+    _write_config(
+        kanban_home,
+        "kanban:\n"
+        "  default_notify:\n"
+        "    default:\n"
+        "      platform: slack\n"
+        "      chat_id: C0BP91D49CH\n"
+        "      chat_type: channel\n",
+    )
+    task_id = _created_id(
+        kc.run_slash("create 'dedupe' --assignee worker")
+    )
+    kc.run_slash(
+        f"notify-subscribe {task_id} --platform slack "
+        "--chat-id C0BP91D49CH --chat-type channel"
+    )
+
+    assert len(_subs(task_id)) == 1, _subs(task_id)
+
+
+def test_cli_create_respects_auto_subscribe_kill_switch(kanban_home):
+    """``auto_subscribe_on_create: false`` disables every create-time
+    subscription source, board defaults included."""
+    _write_config(
+        kanban_home,
+        "kanban:\n"
+        "  auto_subscribe_on_create: false\n"
+        "  default_notify:\n"
+        "    default:\n"
+        "      platform: slack\n"
+        "      chat_id: C0BP91D49CH\n",
+    )
+    out = kc.run_slash("create 'gated off' --assignee worker")
+    assert _subs(_created_id(out)) == []
+
+
+# ---------------------------------------------------------------------------
+# Board isolation
+# ---------------------------------------------------------------------------
+
+def test_default_notify_does_not_leak_across_boards(kanban_home):
+    """A default configured for one board must never be applied to a task
+    created on a different board."""
+    kb.create_board("alt")
+    _write_config(
+        kanban_home,
+        "kanban:\n"
+        "  default_notify:\n"
+        "    alt:\n"
+        "      platform: slack\n"
+        "      chat_id: C-ALT\n",
+    )
+
+    # Default board: no entry for "default" -> nothing.
+    assert kb.resolve_default_notify("default") is None
+    # Alt board: its own entry resolves.
+    assert kb.resolve_default_notify("alt") == {
+        "platform": "slack",
+        "chat_id": "C-ALT",
+    }
+
+    conn = kb.connect(board="alt")
+    try:
+        tid = kb.create_task(conn, title="alt task", assignee="worker")
+        assert kb.apply_default_notify_sub(conn, tid, board="alt") is True
+    finally:
+        conn.close()
+    alt_subs = _subs(tid, board="alt")
+    assert len(alt_subs) == 1
+    assert alt_subs[0]["chat_id"] == "C-ALT"
+
+    conn = kb.connect()
+    try:
+        default_tid = kb.create_task(conn, title="default task", assignee="worker")
+        assert kb.apply_default_notify_sub(conn, default_tid) is False
+    finally:
+        conn.close()
+    assert _subs(default_tid) == []
+
+
+# ---------------------------------------------------------------------------
+# Tool path (tools/kanban_tools.py)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def worker_env(kanban_home, monkeypatch):
+    """A kanban worker context, so the gated kanban_* handlers will run."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="worker-root", assignee="test-profile")
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    return tid
+
+
+def test_tool_create_live_chat_context_still_wins(worker_env, kanban_home, monkeypatch):
+    """Regression guard: when the tool call HAS a live chat context, that
+    context is subscribed — the board default must not displace it."""
+    _write_config(
+        kanban_home,
+        "kanban:\n"
+        "  default_notify:\n"
+        "    default:\n"
+        "      platform: slack\n"
+        "      chat_id: C-BOARD-DEFAULT\n",
+    )
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-live")
+
+    from tools import kanban_tools as kt
+    payload = json.loads(
+        kt._handle_create({"title": "live ctx", "assignee": "peer"})
+    )
+    assert payload["ok"] is True
+    assert payload["subscribed"] is True
+
+    subs = _subs(payload["task_id"])
+    assert len(subs) == 1, subs
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "chat-live"
+
+
+def test_tool_create_without_chat_context_falls_back_to_board_default(
+    worker_env, kanban_home
+):
+    """No live chat context (orchestrator / cron) + a configured board
+    default -> the default channel is subscribed instead of nothing."""
+    _write_config(
+        kanban_home,
+        "kanban:\n"
+        "  default_notify:\n"
+        "    default:\n"
+        "      platform: slack\n"
+        "      chat_id: C-BOARD-DEFAULT\n"
+        "      chat_type: channel\n",
+    )
+
+    from tools import kanban_tools as kt
+    payload = json.loads(
+        kt._handle_create({"title": "no ctx", "assignee": "peer"})
+    )
+    assert payload["ok"] is True
+    assert payload["subscribed"] is True
+
+    subs = _subs(payload["task_id"])
+    assert len(subs) == 1, subs
+    assert subs[0]["platform"] == "slack"
+    assert subs[0]["chat_id"] == "C-BOARD-DEFAULT"
+    assert subs[0]["chat_type"] == "channel"
+
+
+def test_tool_create_without_chat_context_or_default_is_still_a_noop(
+    worker_env, kanban_home
+):
+    """Regression guard: the unconfigured case keeps reporting
+    subscribed=False and writing no rows."""
+    from tools import kanban_tools as kt
+    payload = json.loads(
+        kt._handle_create({"title": "nothing at all", "assignee": "peer"})
+    )
+    assert payload["ok"] is True
+    assert payload["subscribed"] is False
+    assert _subs(payload["task_id"]) == []
+
+
+# ---------------------------------------------------------------------------
+# `hermes config set` must not flag the new key as unrecognized
+# ---------------------------------------------------------------------------
+
+def test_default_notify_paths_validate_as_known_config_keys():
+    """Board slugs are user-supplied, so everything below the
+    ``kanban.default_notify`` container has to validate as known — otherwise
+    `hermes config set` warns on a key the runtime does read."""
+    from hermes_cli.config import _validate_config_key
+
+    assert _validate_config_key("kanban.default_notify")[0] is True
+    assert _validate_config_key(
+        "kanban.default_notify.assemblywatch.platform"
+    )[0] is True
+    assert _validate_config_key(
+        "kanban.default_notify.some-other-board.chat_id"
+    )[0] is True
+    # The container is scoped: a typo'd sibling of default_notify is still
+    # reported as unknown.
+    assert _validate_config_key("kanban.default_notifyy.x")[0] is False

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1463,7 +1463,7 @@ def _handle_create(args: dict, **kw) -> str:
                 session_id=session_id,
             )
             new_task = kb.get_task(conn, new_tid)
-            subscribed = _maybe_auto_subscribe(conn, new_tid)
+            subscribed = _maybe_auto_subscribe(conn, new_tid, board=board)
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
@@ -1481,7 +1481,9 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(f"kanban_create: {e}")
 
 
-def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
+def _maybe_auto_subscribe(
+    conn: Any, task_id: str, board: Optional[str] = None
+) -> bool:
     """Auto-subscribe the calling session to task completion / block events.
 
     Returns True if a subscription row was written, False otherwise (no
@@ -1511,8 +1513,11 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
       for these rows and posts the completion message into the running
       session.
 
-    - **CLI / cron / test / unattached**: no persistent delivery channel,
-      no-op.
+    - **CLI / cron / orchestrator / test / unattached**: no persistent
+      delivery channel of its own. Falls back to the board's configured
+      default channel (``kanban.default_notify.<board>``) when one exists,
+      so tasks created without a user-facing message behind them are still
+      covered. Boards with no entry stay a no-op, as before.
 
     Failure mode: any exception inside the function is logged at WARNING
     with the offending exception + diagnostic env vars and swallowed.
@@ -1553,7 +1558,23 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
                 or os.environ.get("HERMES_SESSION_KEY", "")
             )
             if not session_key:
-                return False  # CLI / cron / test — no persistent channel
+                # CLI / cron / orchestrator — no persistent channel of our
+                # own. Fall back to the board's configured default channel
+                # (kanban.default_notify.<board>) so tasks created without a
+                # user-facing message behind them still get notified when
+                # they block or request review. Unconfigured boards return
+                # False here, preserving the historical no-op.
+                from hermes_cli import kanban_db as _kb_default
+                return _kb_default.apply_default_notify_sub(
+                    conn,
+                    task_id,
+                    board=board,
+                    notifier_profile=(
+                        get_session_env("HERMES_SESSION_PROFILE", "")
+                        or os.environ.get("HERMES_PROFILE")
+                        or None
+                    ),
+                )
             platform = "tui"
             chat_id = session_key
         thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or None

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -611,7 +611,8 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
-| `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
+| `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. Also disables `default_notify`. |
+| `default_notify` | `{}` | Per-board fallback notification channel, used when a task is created with **no** live chat context — a detached `hermes kanban create`, a cron script, or an orchestrator agent calling `kanban_create` without a user-facing message behind it. Keyed by board slug; boards with no entry keep the previous no-subscription behaviour. See [Board default notification channel](#board-default-notification-channel). |
 
 And the two auxiliary LLM slots:
 
@@ -1009,6 +1010,49 @@ hermes kanban notify-unsubscribe t_abcd \
 ```
 
 A subscription removes itself automatically once the task reaches `done` or `archived`; no cleanup needed.
+
+### Board default notification channel
+
+Auto-subscribe only works when the creating session *has* a chat to
+subscribe. Tasks created without one — `hermes kanban create` from an SSH
+session, a cron script, an orchestrator agent working outside any chat
+platform — got zero notification coverage, so nobody heard about them when
+they later hit `blocked` or `review_requested` and you had to poll the board
+by hand to find stuck work.
+
+Configure a per-board fallback channel and those tasks get covered too:
+
+```yaml
+# ~/.hermes/config.yaml
+kanban:
+  default_notify:
+    default:                    # board slug
+      platform: slack
+      chat_id: C0BP91D49CH
+      chat_type: channel        # optional: dm / group / channel
+    assemblywatch:              # a second board, its own channel
+      platform: telegram
+      chat_id: "12345678"
+```
+
+Or from the CLI:
+
+```bash
+hermes config set kanban.default_notify.default.platform slack
+hermes config set kanban.default_notify.default.chat_id C0BP91D49CH
+hermes config set kanban.default_notify.default.chat_type channel
+```
+
+Semantics:
+
+- **Fallback only.** A live chat context always wins — creating a task from
+  Slack still notifies *that* Slack conversation, not the board default.
+- **Per board.** Boards are the isolation unit; a board with no entry behaves
+  exactly as before (no subscription, no error).
+- **Idempotent.** The default never produces a duplicate row if the same
+  target is also subscribed explicitly.
+- **Respects the kill switch.** `auto_subscribe_on_create: false` turns off
+  every create-time subscription source, this one included.
 
 ### Multi-profile setups: delivery is profile-owned
 


### PR DESCRIPTION
## The gap

When a kanban task transitions to `blocked` or `review_requested`, the gateway notifier delivers a message to whoever is subscribed in `kanban_notify_subs`. Subscriptions come from two places today:

- `hermes kanban notify-subscribe <task_id> ...`, run manually, per task.
- `tools/kanban_tools.py::_maybe_auto_subscribe`, which auto-subscribes the **calling session** when `kanban_create` runs inside a session that has a persistent delivery channel (gateway chat or TUI).

Neither covers task creation with no live chat context:

- `hermes kanban create ...` run detached — a human over SSH, a cron script.
- `kanban_create` called by an orchestrator/cron-spawned agent with no user-facing message behind it.

Those tasks get **zero** notification coverage. They dispatch, they block, and nobody hears about it — you find out by remembering to poll the board. That defeats the point of the async approval workflow (approve things from Slack while away from a terminal). This came out of real production use: several tasks created via detached CLI in one session, none of them notified when they later blocked, discovered only by manually checking.

## What this adds

An opt-in, **per-board** fallback channel under the existing `kanban:` config section:

```yaml
kanban:
  default_notify:
    default:                 # board slug
      platform: slack
      chat_id: C0BP91D49CH
      chat_type: channel     # optional
    assemblywatch:           # another board, its own channel
      platform: telegram
      chat_id: "12345678"
```

Keyed by board slug because boards are the hard isolation unit here — each board wants its own channel, or none. A board with no entry behaves **exactly** as it does today: no subscribe, no error, one dict lookup of overhead.

Or via the CLI:

```bash
hermes config set kanban.default_notify.default.platform slack
hermes config set kanban.default_notify.default.chat_id C0BP91D49CH
```

### Semantics

- **Fallback only.** A live chat context always wins. Creating a task from Slack still notifies *that* conversation — the existing live-context branch is untouched.
- **Per board.** Board A's default never lands on a task created on board B.
- **Idempotent.** `add_notify_sub` is already `INSERT OR IGNORE` on `(task, platform, chat, thread)`, so the default can't duplicate an explicit subscription.
- **Respects the kill switch.** `kanban.auto_subscribe_on_create: false` already means "no create-time subscriptions"; that now covers this source too, rather than introducing a second knob that quietly overrides the first.
- **Never raises.** Notification bookkeeping must not fail the task creation it decorates — malformed config degrades to the no-default behaviour.

## Changes

| File | What |
|---|---|
| `hermes_cli/kanban_db.py` | New `resolve_default_notify()` (config → subscribe kwargs, or `None`) and `apply_default_notify_sub()` (best-effort subscribe). Shared by both hook points. |
| `hermes_cli/kanban.py` | `_cmd_create` applies the fallback after a successful create and prints the target in human output. `--json` output shape is unchanged. |
| `tools/kanban_tools.py` | `_maybe_auto_subscribe` takes the resolved `board` and applies the fallback **only** on the branch that previously returned `False` for "CLI / cron / no persistent channel". The gateway and TUI branches are byte-for-byte unchanged. |
| `hermes_cli/config_defaults.py` | Declares `kanban.default_notify: {}` alongside the other `kanban.*` keys, with the shape documented inline. |
| `hermes_cli/config.py` | New `_OPEN_DICT_NESTED_PATHS`, so `kanban.default_notify.<board>.<field>` validates as a known key. Board slugs are user-supplied and can't be enumerated in the schema; without this, `hermes config set` would warn "not a recognized config key" on a key the runtime does read. The container is narrowly scoped — a typo'd sibling like `kanban.default_notifyy` is still reported unknown. |
| `website/docs/user-guide/features/kanban.md` | Config-table row + a "Board default notification channel" section under Gateway notifications. |

## Testing

New `tests/hermes_cli/test_kanban_default_notify.py`, 10 tests, all behavioural (no assertions on config-dict membership or key counts):

- CLI create on a configured board → exactly one `kanban_notify_subs` row with the configured platform/chat_id/chat_type.
- CLI create on an unconfigured board → zero rows, task still created (regression guard for current behaviour).
- Malformed entry (missing `chat_id`) → degrades to zero rows, create still succeeds.
- Explicit `notify-subscribe` of the same target after create → still one row.
- `auto_subscribe_on_create: false` → zero rows even with a default configured.
- Board isolation: a default configured for `alt` resolves for `alt` and not for `default`, and vice versa.
- Tool path **with** live chat context → still subscribes that context, not the board default (regression guard).
- Tool path **without** live chat context + configured default → falls back to the default.
- Tool path without either → still `subscribed: false`, zero rows.
- `kanban.default_notify.<board>.<field>` validates as a known config key; `kanban.default_notifyy.x` does not.

Related existing suites re-run green: `tests/tools/test_kanban_tools.py`, `tests/hermes_cli/test_kanban_notify.py`, `test_kanban_cli.py`, `test_kanban_core_functionality.py`, `test_kanban_boards.py`, `test_config.py`, `tests/gateway/test_kanban_notifier.py` — 161 passed, 0 failed.

`ruff check .` passes. `ty check` reports no new diagnostics in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CwKMWCbpWz3C8FxVf4fum
