### PR TITLE
feat(acp): honor HERMES_ACP_AUTO_APPROVE for session/request_permission

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -122,6 +122,12 @@ def _jsonrpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
     }
 
 
+def _acp_auto_approve_enabled() -> bool:
+    """Return True when HERMES_ACP_AUTO_APPROVE requests headless allow-always."""
+    raw = os.getenv("HERMES_ACP_AUTO_APPROVE", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
 def _permission_denied(message_id: Any) -> dict[str, Any]:
     return {
         "jsonrpc": "2.0",
@@ -132,6 +138,76 @@ def _permission_denied(message_id: Any) -> dict[str, Any]:
             }
         },
     }
+
+
+def _permission_selected(message_id: Any, option_id: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "result": {
+            "outcome": {
+                "outcome": "selected",
+                "optionId": option_id,
+            }
+        },
+    }
+
+
+def _pick_auto_approve_option_id(params: dict[str, Any]) -> str | None:
+    """Choose the strongest allow option offered by an ACP permission request.
+
+    Claude Code ACP offers ``optionId: "allow_always"`` for normal tool
+    prompts, but mode-switch prompts use other ids with ``kind:
+    "allow_always"`` (e.g. ``bypassPermissions``). Prefer the literal
+    ``allow_always`` id when present, then another offered allow-always option,
+    and finally an offered allow-once option. Return ``None`` when the request
+    offers no allow option; never synthesize an option id that was not offered.
+    """
+    options = params.get("options") or []
+    always_ids: list[str] = []
+    once_ids: list[str] = []
+    if isinstance(options, list):
+        for opt in options:
+            if not isinstance(opt, dict):
+                continue
+            option_id = str(opt.get("optionId") or opt.get("option_id") or "").strip()
+            if not option_id:
+                continue
+            kind = str(opt.get("kind") or "").strip()
+            if kind == "allow_always" or option_id in {
+                "allow_always",
+                "bypassPermissions",
+                "acceptEdits",
+                "auto",
+            }:
+                always_ids.append(option_id)
+            elif kind == "allow_once" or option_id in {
+                "allow_once",
+                "allow",
+                "default",
+            }:
+                once_ids.append(option_id)
+
+    for preferred in ("allow_always", "bypassPermissions", "acceptEdits", "auto"):
+        if preferred in always_ids:
+            return preferred
+    if always_ids:
+        return always_ids[0]
+    for preferred in ("allow_once", "allow", "default"):
+        if preferred in once_ids:
+            return preferred
+    if once_ids:
+        return once_ids[0]
+    return None
+
+
+def _permission_response(message_id: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Resolve session/request_permission — auto-approve when enabled, else cancel."""
+    if _acp_auto_approve_enabled():
+        option_id = _pick_auto_approve_option_id(params)
+        if option_id is not None:
+            return _permission_selected(message_id, option_id)
+    return _permission_denied(message_id)
 
 
 def _format_messages_as_prompt(
@@ -700,7 +776,7 @@ class CopilotACPClient:
         params = msg.get("params") or {}
 
         if method == "session/request_permission":
-            response = _permission_denied(message_id)
+            response = _permission_response(message_id, params)
         elif method == "fs/read_text_file":
             try:
                 path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -69,7 +69,151 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertTrue(payload)
         return json.loads(payload)
 
+    def test_request_permission_cancels_without_auto_approve(self) -> None:
+        with patch.dict(os.environ, {"HERMES_ACP_AUTO_APPROVE": ""}, clear=False):
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "session/request_permission",
+                    "params": {
+                        "options": [
+                            {
+                                "kind": "allow_always",
+                                "name": "Always allow",
+                                "optionId": "allow_always",
+                            },
+                            {
+                                "kind": "allow_once",
+                                "name": "Allow",
+                                "optionId": "allow",
+                            },
+                        ],
+                    },
+                },
+                cwd="/tmp",
+            )
 
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "cancelled"},
+        )
+
+    def test_request_permission_auto_approves_allow_always(self) -> None:
+        with patch.dict(os.environ, {"HERMES_ACP_AUTO_APPROVE": "1"}, clear=False):
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 8,
+                    "method": "session/request_permission",
+                    "params": {
+                        "options": [
+                            {
+                                "kind": "allow_always",
+                                "name": "Always allow Bash",
+                                "optionId": "allow_always",
+                            },
+                            {
+                                "kind": "allow_once",
+                                "name": "Allow",
+                                "optionId": "allow",
+                            },
+                        ],
+                    },
+                },
+                cwd="/tmp",
+            )
+
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "selected", "optionId": "allow_always"},
+        )
+
+    def test_request_permission_auto_approves_mode_switch_bypass(self) -> None:
+        """Plan-exit prompts offer mode ids, not literal allow_always."""
+        with patch.dict(os.environ, {"HERMES_ACP_AUTO_APPROVE": "true"}, clear=False):
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 9,
+                    "method": "session/request_permission",
+                    "params": {
+                        "options": [
+                            {
+                                "kind": "allow_always",
+                                "name": "Yes, and bypass permissions",
+                                "optionId": "bypassPermissions",
+                            },
+                            {
+                                "kind": "allow_once",
+                                "name": "Yes, and manually approve edits",
+                                "optionId": "default",
+                            },
+                        ],
+                    },
+                },
+                cwd="/tmp",
+            )
+
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "selected", "optionId": "bypassPermissions"},
+        )
+
+    def test_request_permission_auto_approves_allow_once_when_only_allow_option(self) -> None:
+        with patch.dict(os.environ, {"HERMES_ACP_AUTO_APPROVE": "yes"}, clear=False):
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 10,
+                    "method": "session/request_permission",
+                    "params": {
+                        "options": [
+                            {
+                                "kind": "allow_once",
+                                "name": "Allow once",
+                                "optionId": "allow-this-time",
+                            },
+                            {
+                                "kind": "reject_once",
+                                "name": "Reject",
+                                "optionId": "reject",
+                            },
+                        ],
+                    },
+                },
+                cwd="/tmp",
+            )
+
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "selected", "optionId": "allow-this-time"},
+        )
+
+    def test_request_permission_auto_approve_cancels_without_allow_option(self) -> None:
+        with patch.dict(os.environ, {"HERMES_ACP_AUTO_APPROVE": "on"}, clear=False):
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 11,
+                    "method": "session/request_permission",
+                    "params": {
+                        "options": [
+                            {
+                                "kind": "reject_once",
+                                "name": "Reject",
+                                "optionId": "reject",
+                            }
+                        ],
+                    },
+                },
+                cwd="/tmp",
+            )
+
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "cancelled"},
+        )
 
     def test_read_text_file_redacts_sensitive_content(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -32,6 +32,7 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `COPILOT_CLI_PATH` | Alias for `HERMES_COPILOT_ACP_COMMAND` |
 | `HERMES_COPILOT_ACP_ARGS` | Override Copilot ACP arguments (default: `--acp --stdio`) |
 | `COPILOT_ACP_BASE_URL` | Override Copilot ACP base URL |
+| `HERMES_ACP_AUTO_APPROVE` | Opt-in: when set to `1`/`true`/`yes`/`on`, auto-approve ACP `session/request_permission` requests with an `allow_always`-class option instead of cancelling them. Off by default (requests are cancelled). Intended for headless/gateway contexts (Discord, cron) that have no interactive approval UI — enable only in trusted, operator-controlled environments. |
 | `COPILOT_API_BASE_URL` | Override the Copilot API base URL (`copilot` provider) |
 | `GLM_API_KEY` | z.ai / ZhipuAI GLM API key ([z.ai](https://z.ai)) |
 | `ZAI_API_KEY` | Alias for `GLM_API_KEY` |


### PR DESCRIPTION

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Wires the existing `HERMES_ACP_AUTO_APPROVE` setting into the Copilot ACP
`session/request_permission` handler.

The handler currently returns `cancelled` for every permission request. This makes ACP tool execution unavailable in trusted headless or gateway environments where no interactive approval UI is available.

- When auto-approval is explicitly enabled, Hermes selects the strongest allow option offered by the ACP provider: it prefers `allow_always`, falls back to `allow_once`, and returns `cancelled` when no allow option is offered. It never synthesizes an option ID that was not present in the request. When the setting is unset or disabled, the existing `cancelled` behavior remains unchanged.

This follows the ACP permission response contract by returning a `selected` outcome with an option ID supplied by the ACP provider.

Auto-approval is strictly opt-in. Without `HERMES_ACP_AUTO_APPROVE`, or when it is set to a false value, permission requests continue to return `cancelled`.

Enabling this setting auto-approves ACP tool permission requests, including potentially mutating operations. It should only be enabled for trusted ACP providers in operator-controlled headless or gateway environments.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Related to #17284.

This addresses the opt-in headless/gateway use case by avoiding permission denial when the operator has explicitly enabled auto-approval. It is complementary to recovery approaches for denied permission requests and does not change the default behavior.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `agent/copilot_acp_client.py`
  - Read the existing `HERMES_ACP_AUTO_APPROVE` setting
  - Preserve `cancelled` as the default response
  - When explicitly enabled, select an offered `allow_always`-class option
  - Fall back to an offered `allow_once` option when necessary
  - Return `cancelled` when no allow option is offered, without synthesizing an option ID
  - Support mode-switch requests whose `optionId` is not literally `allow_always`

- `tests/agent/test_copilot_acp_client.py`
  - Verify default cancellation when auto-approval is disabled
  - Verify selection of a normal `allow_always` option
  - Verify selection of a mode-switch `allow_always` option such as `bypassPermissions`
  - Verify fallback to an offered `allow_once` option
  - Verify fail-closed cancellation when no allow option is offered

- `website/docs/reference/environment-variables.md`
  - Document the setting, accepted values, intended use, default behavior, and security implications

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Check out the branch:

   ```bash
   git checkout feat/acp-opt-in-auto-approve
   ```

2. Run the targeted tests with the canonical test runner:

   ```bash
   scripts/run_tests.sh tests/agent/test_copilot_acp_client.py -q
   ```

3. Confirm the result:

   ```text
   11 passed, 0 failed
   ```

The canonical full suite was also run on both the rebased feature branch and `main`. Both runs produced the same baseline:

```text
28 files with test failures
91 tests failed
1 collection/import failure
```

No branch-specific failures were observed.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3<!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Targeted test result:

```text
Discovered 1 test files (~11 tests) under ['tests/agent/test_copilot_acp_client.py']
✓ tests/agent/test_copilot_acp_client.py

=== Summary: 1 files, 11 tests passed, 0 failed ===
```