### PR TITLE
fix(codex_responses): non-empty reasoning follow-up only when no legal function_call

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -407,6 +407,34 @@ def _normalize_responses_message_status(value: Any, *, default: str = "completed
     return default
 
 
+def _msg_emits_function_call(msg: Dict[str, Any]) -> bool:
+    """Return True when an assistant message's ``tool_calls`` will serialize
+    into at least one Responses ``function_call`` item.
+
+    The predicate mirrors the legality check in the tool_call loop of
+    ``_chat_messages_to_responses_input`` exactly: a tool_call is skipped
+    unless it is a dict whose ``function.name`` is a non-blank string.
+    Callers use this to decide whether a replayed reasoning item still needs
+    an explicit following-item placeholder — deciding on the raw presence of
+    ``msg["tool_calls"]`` instead is wrong when every tool_call is malformed
+    (e.g. empty ``function.name``), because then no ``function_call`` is
+    emitted and the reasoning item would be left without a successor.
+    """
+    tool_calls = msg.get("tool_calls")
+    if not isinstance(tool_calls, list):
+        return False
+    for tc in tool_calls:
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function")
+        if not isinstance(fn, dict):
+            continue
+        fn_name = fn.get("name")
+        if isinstance(fn_name, str) and fn_name.strip():
+            return True
+    return False
+
+
 def _chat_messages_to_responses_input(
     messages: List[Dict[str, Any]],
     *,
@@ -598,13 +626,27 @@ def _chat_messages_to_responses_input(
                     items.append({"role": "assistant", "content": content_parts})
                 elif content_text.strip():
                     items.append({"role": "assistant", "content": content_text})
-                elif has_codex_reasoning:
+                elif has_codex_reasoning and not _msg_emits_function_call(msg):
                     # The Responses API requires a following item after each
                     # reasoning item (otherwise: missing_following_item error).
-                    # When the assistant produced only reasoning with no visible
-                    # content, emit an empty assistant message as the required
-                    # following item.
-                    items.append({"role": "assistant", "content": ""})
+                    # A legal function_call serialized below already satisfies
+                    # that requirement, so only emit a placeholder when no
+                    # function_call will follow. The placeholder must carry
+                    # non-empty content: OpenAI and xAI tolerate an empty
+                    # assistant content string here, but strict providers
+                    # (e.g. Volcano Engine Agent Plan) reject it with
+                    # HTTP 400 MissingParameter: input.content (#75202) —
+                    # and because history is replayed every turn, that single
+                    # bad item bricks the whole session. Emit the canonical
+                    # explicit message shape with a single-space output_text:
+                    # the minimal non-empty payload every Responses surface
+                    # accepts.
+                    items.append({
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": " "}],
+                    })
 
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -487,3 +487,142 @@ def _xai_reasoning_only_response(reasoning_text):
             )
         ],
     )
+
+# ---------------------------------------------------------------------------
+# Reasoning following-item placeholder (#75202) — a replayed reasoning item
+# must be followed by another item (else the API returns
+# missing_following_item).  Hermes used to always inject
+# {"role": "assistant", "content": ""} after a reasoning-only assistant turn.
+# OpenAI and xAI tolerate the empty string, but strict providers (Volcano
+# Engine Agent Plan) reject it with HTTP 400 MissingParameter:
+# input.content — and since history is replayed every turn, the bad item
+# bricks the session permanently.  The fix: skip the placeholder when a
+# legal function_call actually follows (it is itself a valid successor),
+# and otherwise emit an explicit message with non-empty output_text.
+# ---------------------------------------------------------------------------
+
+_REASONING_REPLAY_ITEM = {"type": "reasoning", "encrypted_content": "enc-blob-1"}
+
+
+def _assistant_texts(items):
+    """Collect the text payloads of every assistant message item, both the
+    shorthand {"role": "assistant", "content": str} and the explicit
+    {"type": "message", "content": [{"type": "output_text", ...}]} forms."""
+    texts = []
+    for item in items:
+        if item.get("type") == "function_call":
+            continue
+        if item.get("role") != "assistant":
+            continue
+        content = item.get("content")
+        if isinstance(content, str):
+            texts.append(content)
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "output_text":
+                    texts.append(part.get("text", ""))
+    return texts
+
+
+def test_reasoning_with_legal_tool_call_emits_no_placeholder():
+    """reasoning + legal tool_call: the function_call itself is the
+    following item — no assistant placeholder at all."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [_REASONING_REPLAY_ITEM],
+            "tool_calls": [
+                {
+                    "call_id": "call_1",
+                    "function": {"name": "web_search", "arguments": "{}"},
+                }
+            ],
+        },
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    assert items[0]["type"] == "reasoning"
+    assert any(i.get("type") == "function_call" for i in items)
+    # No assistant message of any form — the function_call follows the
+    # reasoning item directly.
+    assert _assistant_texts(items) == []
+
+
+def test_reasoning_with_malformed_tool_call_emits_nonempty_followup():
+    """reasoning + tool_call with blank function.name: no function_call is
+    serialized, so a following-item placeholder is still required — and it
+    must not be an empty content string."""
+    for bad_name in ("", "   "):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "codex_reasoning_items": [_REASONING_REPLAY_ITEM],
+                "tool_calls": [
+                    {
+                        "call_id": "call_1",
+                        "function": {"name": bad_name, "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+
+        items = _chat_messages_to_responses_input(messages)
+
+        assert items[0]["type"] == "reasoning"
+        assert not any(i.get("type") == "function_call" for i in items)
+        texts = _assistant_texts(items)
+        assert len(texts) == 1
+        assert texts[0] != ""  # strict providers reject empty content
+
+
+def test_pure_reasoning_emits_nonempty_followup():
+    """reasoning with no visible text and no tool_calls: explicit non-empty
+    following item, never content: ""."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [_REASONING_REPLAY_ITEM],
+        },
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    assert items[0]["type"] == "reasoning"
+    texts = _assistant_texts(items)
+    assert len(texts) == 1
+    assert texts[0] != ""
+
+
+def test_no_empty_assistant_content_anywhere():
+    """Blanket guard: whatever the history mix, the serialized request must
+    never contain an assistant message whose content is an empty string —
+    that is the exact payload strict providers 400 on (#75202)."""
+    histories = [
+        # reasoning-only
+        [{"role": "assistant", "content": "", "codex_reasoning_items": [_REASONING_REPLAY_ITEM]}],
+        # reasoning + legal tool call
+        [{
+            "role": "assistant", "content": "",
+            "codex_reasoning_items": [_REASONING_REPLAY_ITEM],
+            "tool_calls": [{"call_id": "c1", "function": {"name": "t", "arguments": "{}"}}],
+        }],
+        # reasoning + malformed tool call
+        [{
+            "role": "assistant", "content": "",
+            "codex_reasoning_items": [_REASONING_REPLAY_ITEM],
+            "tool_calls": [{"call_id": "c1", "function": {"name": "", "arguments": "{}"}}],
+        }],
+        # reasoning + visible text (no placeholder needed at all)
+        [{
+            "role": "assistant", "content": "done",
+            "codex_reasoning_items": [_REASONING_REPLAY_ITEM],
+        }],
+    ]
+    for messages in histories:
+        items = _chat_messages_to_responses_input(messages)
+        for text in _assistant_texts(items):
+            assert text != "", f"empty assistant content leaked for {messages!r}"


### PR DESCRIPTION
## Summary

Fixes #75202. Supersedes the narrower approach in #75250.

When Hermes replays a reasoning-only assistant turn through the codex_responses history converter, it used to always inject `{"role": "assistant", "content": ""}` as the reasoning item's required following item. OpenAI and xAI tolerate the empty string, but strict providers (Volcano Engine Agent Plan, `ark.cn-beijing.volces.com/api/plan/v3/responses`) reject it:

```
HTTP 400 MissingParameter: The request failed because it is missing input.content parameter.
```

Because the converted history is replayed on every subsequent turn, that single illegal item bricks the session permanently — retries, model switches, and fresh user input all keep failing with the same 400 until the user abandons the session.

## Root cause

`_chat_messages_to_responses_input()` emitted the empty assistant placeholder unconditionally after a replayed reasoning item, without considering that a serialized `function_call` is itself a valid following item.

## Fix

1. **Skip the placeholder when a legal `function_call` actually follows.** The new `_msg_emits_function_call()` predicate mirrors the legality check in the serialization loop exactly (a tool_call survives only if its `function.name` is a non-blank string). This is deliberately based on *what will actually be emitted*, not on the raw presence of `msg["tool_calls"]` — a turn whose tool_calls are all malformed (e.g. empty `function.name`, observed when a model degenerates mid-turn) produces no `function_call`, and still needs a follow-up item.

2. **When a placeholder IS needed, emit the canonical explicit message shape** — `{"type": "message", "role": "assistant", "status": "completed", "content": [{"type": "output_text", "text": " "}]}` — instead of an empty content string. A single space is the minimal non-empty payload every Responses surface accepts, and the explicit form passes `_preflight_codex_input_items`'s message validation (content must be a list with at least one text part).

Resulting sequences:

| Turn contents | Serialized output |
|---|---|
| reasoning + legal tool_call | `reasoning → function_call` (no placeholder) |
| reasoning + malformed tool_call (blank name) | `reasoning → message(" ")` |
| reasoning only | `reasoning → message(" ")` |

## Tests

Four regression tests added to `tests/agent/test_codex_responses_adapter.py`:

- `test_reasoning_with_legal_tool_call_emits_no_placeholder` — no assistant placeholder is emitted at all
- `test_reasoning_with_malformed_tool_call_emits_nonempty_followup` — blank `function.name` still yields a non-empty follow-up
- `test_pure_reasoning_emits_nonempty_followup` — reasoning-only turns get the explicit non-empty message
- `test_no_empty_assistant_content_anywhere` — blanket guard: no history mix may serialize an assistant message with empty content (the exact payload strict providers 400 on)

`pytest tests/agent/test_codex_responses_adapter.py` → 20 passed (16 existing + 4 new). The full `tests/agent/` suite was also run locally.
