### PR TITLE
fix(env): strip PYTHONPATH from subprocess env to prevent cross-Python pydantic_core mismatch

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -346,7 +346,7 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # to a different Python version overwrites it and breaks the gateway). The
 # Hermes venv stays reachable via PATH (its bin dir is first), so stripping
 # these markers is safe and only prevents the cross-project clobber (#23473).
-_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
+_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX", "PYTHONPATH")
 
 
 def _is_hermes_internal_secret(key: str) -> bool:


### PR DESCRIPTION
## Problem

Hermes sets `PYTHONPATH` to its Python 3.11 venv site-packages (e.g., `C:\Users\Justin\AppData\Local\hermes\hermes-agent;...\venv\Lib\site-packages`). When the browser-use CLI (which runs Python 3.12 from a uv-managed virtualenv) inherits this `PYTHONPATH`, Python 3.12 finds the 3.11-compiled `pydantic_core._pydantic_core` binary in Hermes's site-packages instead of its own 3.12-compiled one, and crashes:

```
ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'
```

## Root cause

`_ACTIVE_VENV_MARKER_VARS` strips `VIRTUAL_ENV` and `CONDA_PREFIX` from spawned subprocess envs to prevent exactly this kind of cross-project clobbering (#23473), but `PYTHONPATH` is not in the tuple. `hermes_subprocess_env()` copies `os.environ` as its base, so Hermes's own `PYTHONPATH` leaks through to every non-terminal child.

## Fix

Add `PYTHONPATH` to `_ACTIVE_VENV_MARKER_VARS`. This is consistent with the existing purpose of the tuple: strip markers that would cause a child process to load the wrong project's packages. Each child finds its own site-packages via its own `sys.path` / `VIRTUAL_ENV`.

## Testing

- `pytest tests/agent/test_subprocess_env_guard.py` — 2/2 passed
- `pytest tests/agent/test_auxiliary_client_proxy_env.py` — 2/2 passed
- `pytest tests/computer_use/test_cua_spawn_env_sanitization.py` — 6/6 passed
- `pytest tests/cli/test_cwd_env_respect.py` — 9/9 passed
- **19/19 passed** total across env and subprocess test suites
- Verified browser-use CLI works correctly after the fix (Python 3.12 finds its own pydantic_core)