### PR TITLE
fix: show prompt caching status for all providers, not just Anthropic

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9512,12 +9512,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 _cprint(f"    Max output: {mi.max_output:,} tokens")
             _cprint(f"    Capabilities: {mi.format_capabilities()}")
 
-        cache_enabled = (
-            (base_url_host_matches(result.base_url or "", "openrouter.ai") and "claude" in result.new_model.lower())
-            or result.api_mode == "anthropic_messages"
-        )
-        if cache_enabled:
-            _cprint("    Prompt caching: enabled")
+        # Show prompt caching status. Anthropic requires client-side
+        # cache_control breakpoints; all other cloud providers use automatic
+        # server-side prefix caching with no client markers needed.
+        if result.api_mode == "anthropic_messages" or (
+            base_url_host_matches(result.base_url or "", "openrouter.ai")
+            and "claude" in result.new_model.lower()
+        ):
+            _cprint("    Prompt caching: enabled (client-side breakpoints)")
+        elif not base_url_host_matches(result.base_url or "", "localhost") and not base_url_host_matches(result.base_url or "", "127.0.0.1"):
+            _cprint("    Prompt caching: automatic (server-side)")
+
         if result.warning_message:
             _cprint(f"    ⚠ {result.warning_message}")
         if persist_global:
@@ -9860,13 +9865,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 _cprint(f"    Max output: {mi.max_output:,} tokens")
             _cprint(f"    Capabilities: {mi.format_capabilities()}")
 
-        # Cache notice
-        cache_enabled = (
-            (base_url_host_matches(result.base_url or "", "openrouter.ai") and "claude" in result.new_model.lower())
-            or result.api_mode == "anthropic_messages"
-        )
-        if cache_enabled:
-            _cprint("    Prompt caching: enabled")
+        # Cache notice — show status for all providers.
+        # Anthropic requires client-side cache_control breakpoints;
+        # all other cloud providers use automatic server-side prefix
+        # caching with no client markers needed.
+        if result.api_mode == "anthropic_messages" or (
+            base_url_host_matches(result.base_url or "", "openrouter.ai")
+            and "claude" in result.new_model.lower()
+        ):
+            _cprint("    Prompt caching: enabled (client-side breakpoints)")
+        elif not base_url_host_matches(result.base_url or "", "localhost") and not base_url_host_matches(result.base_url or "", "127.0.0.1"):
+            _cprint("    Prompt caching: automatic (server-side)")
 
         # Warning from validation
         if result.warning_message:


### PR DESCRIPTION
## What

The 'Prompt caching: enabled' startup banner was gated to only appear for Anthropic (direct API or OpenRouter with Claude models). All other providers — DeepSeek, Kimi, GLM, OpenAI, Gemini, etc. — were silent despite all doing automatic server-side prefix caching.

This removes the Anthropic-only gate. Now:

- **Anthropic**: `Prompt caching: enabled (client-side breakpoints)`
- **All other cloud providers**: `Prompt caching: automatic (server-side)`
- **Local endpoints** (localhost/127.0.0.1): silent

## Why

The cache tracking infrastructure already works correctly — `normalize_usage()` in `usage_pricing.py` reads `cached_tokens` from `prompt_tokens_details` (OpenAI), `prompt_cache_hit_tokens` (DeepSeek native), and `cache_read_input_tokens` (Anthropic/OpenRouter proxy). The session counters in `run_agent.py` and the finalization data in `turn_finalizer.py` all include cache stats regardless of provider.

The only gap was the user-visible banner: users on non-Anthropic providers had no indication that caching was active, leading to confusion (see #4319, #4583).

## Related

- Closes #4319
- Supersedes #4583 (same goal, but that PR added a config flag and a no-op function — this is the simpler approach mentioned in Teknium's review)
- Prior discussion: https://github.com/NousResearch/hermes-agent/pull/4583#issuecomment-2780860229

## Tested

- Syntax: clean (`python -c 'import ast; ast.parse(open("cli.py").read())'`)
- Logic: the `base_url_host_matches` helper is already imported and used throughout cli.py; the localhost/127.0.0.1 check correctly filters local endpoints