### PR TITLE
fix(auxiliary): strip response_format from Anthropic extra_body passthrough

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1972,18 +1972,28 @@ class _AnthropicCompletionsAdapter:
         # form is the documented Anthropic SDK passthrough for non-standard
         # request body keys; merge on top of whatever build_anthropic_kwargs
         # already produced (e.g. fast-mode ``speed``) so call-time settings
-        # survive. Two exclusions:
+        # survive. Exclusions:
         #   - ``reasoning``: the OpenAI-shaped config dict is TRANSLATED into
         #     the native ``thinking`` field above (build_anthropic_kwargs);
         #     forwarding the raw field alongside would double-specify
         #     reasoning and 400 on strict gateways.
+        #   - ``response_format``: OpenAI/Chat-Completions-only field (used by
+        #     e.g. title_generator's JSON-schema-constrained calls). Anthropic's
+        #     native Messages API has no such top-level field and 400s with
+        #     "response_format: Extra inputs are not permitted" if forwarded.
+        #     Callers relying on response_format already have prose-fallback
+        #     parsing for providers that don't honor it (see
+        #     title_generator._extract_title_text), so dropping it here just
+        #     means Anthropic answers in prose instead of erroring.
         #   - ``_``-prefixed keys: private Hermes plumbing (_reasoning_config
         #     et al.), never wire fields.
+        _ANTHROPIC_UNSUPPORTED_EXTRA_BODY_KEYS = {"reasoning", "response_format"}
         caller_extra_body = kwargs.get("extra_body")
         if caller_extra_body and isinstance(caller_extra_body, dict):
             passthrough = {
                 k: v for k, v in caller_extra_body.items()
-                if k != "reasoning" and not str(k).startswith("_")
+                if k not in _ANTHROPIC_UNSUPPORTED_EXTRA_BODY_KEYS
+                and not str(k).startswith("_")
             }
             if passthrough:
                 existing = anthropic_kwargs.get("extra_body") or {}

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2386,7 +2386,21 @@ class TestAuxiliaryTaskExtraBody:
             "thinking": {"type": "disabled"}, "metadata": {"user_id": "u1"},
         }
 
-
+    def test_anthropic_aux_strips_response_format(self):
+        """response_format is OpenAI/Chat-Completions-only; Anthropic's native
+        Messages API 400s with "response_format: Extra inputs are not
+        permitted" if it leaks through. title_generator.generate_title() sends
+        exactly this field to force JSON-schema output, so any main-provider
+        Anthropic user hit this on every title generation. Vendor fields in
+        the same extra_body dict must still pass through untouched."""
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={
+                "response_format": {"type": "json_schema", "json_schema": {"name": "x"}},
+                "metadata": {"user_id": "u1"},
+            },
+        )
+        assert "response_format" not in api_kwargs.get("extra_body", {})
+        assert api_kwargs["extra_body"] == {"metadata": {"user_id": "u1"}}
 
 
 


### PR DESCRIPTION
## Summary

The auxiliary Anthropic client (`_AnthropicCompletionsAdapter.create` in `agent/auxiliary_client.py`) forwards caller-supplied `extra_body` almost unfiltered into the native Messages API request, excluding only `reasoning` and `_`-prefixed private keys.

`title_generator.generate_title()` sends `extra_body={"response_format": ...}` to force JSON-schema-constrained output — a Chat Completions-only field. Anthropic's native Messages API has no such top-level field, so any user whose main provider is native Anthropic (`provider: anthropic` in config.yaml) gets:

```
⚠ Auxiliary title generation failed: HTTP 400: response_format: Extra inputs are not permitted
```

on every auxiliary title-generation call, since resolve order step 1 for auxiliary tasks is "user's main provider + main model".

The failure is non-fatal — `title_generator` already has a prose fallback for providers that don't honor `response_format` (`_extract_title_text`), and a fast derived-title write happens synchronously regardless — but it surfaces a scary warning on effectively every fresh session and silently downgrades every Anthropic-main-provider user from LLM-polished titles to the dumber instant/derived title.

## Fix

Add `response_format` to the extra_body exclusion set alongside `reasoning`, so Anthropic just answers in prose (parsed by the existing fallback) instead of 400ing.

## Test Plan

- Added `test_anthropic_aux_strips_response_format` to `tests/agent/test_auxiliary_client.py`, asserting `response_format` is stripped from the Anthropic passthrough while sibling vendor fields (e.g. `metadata`) in the same `extra_body` dict still pass through untouched.
- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_title_generator.py` — 214/214 passed
- Broader sweep `scripts/run_tests.sh tests/agent/ -k "auxiliary or title or anthropic"` — 628/628 passed, 0 failed
- `ruff check` on both changed files — clean
- Manually reproduced against a live `provider: anthropic` config: `generate_title()` returned a clean HTTP 400 before the fix and a proper LLM-generated title after