### PR TITLE
fix(providers): route custom OpenCode Zen auth correctly

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1656,6 +1656,20 @@ def normalize_extra_headers(extra_headers: Any) -> Dict[str, str]:
     return {str(k): str(v) for k, v in extra_headers.items() if v is not None}
 
 
+def _is_opencode_zen_endpoint(base_url: str) -> bool:
+    """Return whether *base_url* is OpenCode Zen, excluding OpenCode Go."""
+    try:
+        from utils import base_url_host_matches
+        normalized = str(base_url or "").lower().rstrip("/")
+        return (
+            base_url_host_matches(normalized, "opencode.ai")
+            and normalized.endswith("/zen/v1")
+            and "/zen/go/" not in normalized
+        )
+    except Exception:
+        return False
+
+
 def get_custom_provider_extra_headers(
     base_url: str,
     custom_providers: Optional[List[Dict[str, Any]]] = None,
@@ -1708,6 +1722,10 @@ def apply_custom_provider_extra_headers_to_client_kwargs(
     SECURITY: values may carry credentials — never log them.
     """
     extra_headers = get_custom_provider_extra_headers(base_url, custom_providers, config)
+    api_key = client_kwargs.get("api_key")
+    if api_key and _is_opencode_zen_endpoint(base_url):
+        if not any(str(key).lower() == "x-api-key" for key in extra_headers):
+            extra_headers = {**extra_headers, "x-api-key": str(api_key)}
     if not extra_headers:
         return
     merged = dict(client_kwargs.get("default_headers") or {})

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -44,6 +44,7 @@ from hermes_cli.config import (
     get_compatible_custom_providers,
     load_config,
     normalize_extra_headers,
+    _is_opencode_zen_endpoint,
 )
 from hermes_cli.providers import custom_provider_aliases, custom_provider_slug
 from hermes_constants import OPENROUTER_BASE_URL
@@ -1094,7 +1095,7 @@ def _resolve_named_custom_runtime(
             (c for c in api_key_candidates if has_usable_secret(c)),
             "",
         ) or "no-key-required"
-        return {
+        result: Dict[str, Any] = {
             "provider": "custom",
             "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
             "base_url": base_url,
@@ -1102,6 +1103,9 @@ def _resolve_named_custom_runtime(
             "source": "direct-alias",
             "requested_provider": requested_provider,
         }
+        if api_key and _is_opencode_zen_endpoint(base_url):
+            result["extra_headers"] = {"x-api-key": api_key}
+        return result
 
     custom_provider = _get_named_custom_provider(requested_provider)
     if not custom_provider:
@@ -1134,7 +1138,13 @@ def _resolve_named_custom_runtime(
         # Cloudflare Access service tokens) still apply with pooled
         # credentials. NEVER log the values.
         if custom_provider.get("extra_headers"):
-            pool_result["extra_headers"] = dict(custom_provider["extra_headers"])
+            pool_result["extra_headers"] = normalize_extra_headers(
+                custom_provider["extra_headers"]
+            )
+        if pool_result.get("api_key") and _is_opencode_zen_endpoint(base_url):
+            headers = pool_result.setdefault("extra_headers", {})
+            if not any(str(key).lower() == "x-api-key" for key in headers):
+                headers["x-api-key"] = pool_result["api_key"]
         return pool_result
 
     _cp_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
@@ -1170,8 +1180,12 @@ def _resolve_named_custom_runtime(
         result["max_output_tokens"] = custom_provider["max_output_tokens"]
     # Per-provider extra HTTP headers (proxies, gateways, custom auth).
     # Values may carry credentials — NEVER log them.
-    if custom_provider.get("extra_headers"):
-        result["extra_headers"] = dict(custom_provider["extra_headers"])
+    extra_headers = normalize_extra_headers(custom_provider.get("extra_headers"))
+    if api_key and _is_opencode_zen_endpoint(base_url):
+        if not any(str(key).lower() == "x-api-key" for key in extra_headers):
+            extra_headers["x-api-key"] = api_key
+    if extra_headers:
+        result["extra_headers"] = extra_headers
     request_overrides = _custom_provider_request_overrides(custom_provider)
     if request_overrides:
         result["request_overrides"] = request_overrides

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -244,3 +244,33 @@ def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):
     assert captured["headers"]["authorization"] == "Bearer proxy-key"
     assert captured["headers"]["sleeve-harness"] == "hermes"
     assert captured["headers"]["sleeve-base-url"] == "http://localhost:8081/v1"
+
+
+def test_apply_extra_headers_injects_opencode_zen_api_key():
+    client_kwargs = {"api_key": "zen-secret", "base_url": "https://opencode.ai/zen/v1"}
+    apply_custom_provider_extra_headers_to_client_kwargs(
+        client_kwargs, client_kwargs["base_url"], custom_providers=[]
+    )
+    assert client_kwargs["default_headers"] == {"x-api-key": "zen-secret"}
+
+
+def test_apply_extra_headers_preserves_case_insensitive_zen_header():
+    base_url = "https://opencode.ai/zen/v1"
+    client_kwargs = {"api_key": "ignored", "base_url": base_url}
+    providers = [{"base_url": base_url, "extra_headers": {"X-Api-Key": "user"}}]
+    apply_custom_provider_extra_headers_to_client_kwargs(
+        client_kwargs, base_url, custom_providers=providers
+    )
+    assert client_kwargs["default_headers"] == {"X-Api-Key": "user"}
+
+
+def test_apply_extra_headers_excludes_go_and_lookalike_hosts():
+    for base_url in (
+        "https://opencode.ai/zen/go/v1",
+        "https://evil.com/opencode.ai/zen/v1",
+    ):
+        client_kwargs = {"api_key": "secret", "base_url": base_url}
+        apply_custom_provider_extra_headers_to_client_kwargs(
+            client_kwargs, base_url, custom_providers=[]
+        )
+        assert "default_headers" not in client_kwargs

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1553,3 +1553,13 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     assert resolved["source"] == "pool:lmstudio-pool"
     assert resolved["provider"] == "custom"
     assert resolved["requested_provider"] == "custom:lmstudio"
+
+
+def test_direct_alias_zen_runtime_includes_x_api_key(monkeypatch):
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+    resolved = rp._resolve_named_custom_runtime(
+        requested_provider="custom",
+        explicit_api_key="zen-key",
+        explicit_base_url="https://opencode.ai/zen/v1",
+    )
+    assert resolved["extra_headers"] == {"x-api-key": "zen-key"}


### PR DESCRIPTION
## What does this PR do?

Fixes authentication for named custom-provider and fallback routes pointed at OpenCode Zen.

OpenCode Zen's OpenAI-compatible endpoint requires `x-api-key`. Hermes's generic custom-provider path only supplied the OpenAI-compatible Bearer authorization, so a valid Zen credential resolved successfully but fallback requests failed with HTTP 401.

## Changes

- Add shared, host-safe OpenCode Zen endpoint detection.
- Inject `x-api-key` at the actual OpenAI client `default_headers` merge point.
- Cover named custom direct-key, credential-pool, and bare `custom` direct-alias runtime paths.
- Preserve user-supplied `X-Api-Key` casing without creating a duplicate header.
- Normalize custom `extra_headers` consistently.
- Explicitly exclude OpenCode Go and lookalike hosts.

## Regression coverage

Added tests for Zen injection, case-insensitive header preservation, OpenCode Go exclusion, lookalike-host exclusion, and direct-alias runtime resolution.

The new tests were verified to fail against the unpatched source (`2 failed, 70 passed`) and pass with the fix (`72 passed`).

## Verification

```text
pytest tests/hermes_cli/test_custom_provider_extra_headers.py tests/hermes_cli/test_runtime_provider_resolution.py -q
72 passed
```

A live OpenCode Zen smoke request using the resolved headers returned HTTP 200 for `deepseek-v4-flash-free`.

The broader `tests/hermes_cli` run currently has unrelated baseline failures in web UI, webhook, and profile-scoping tests; the affected provider suites pass.

## Scope

This PR does not change fallback-list configuration, provider credentials, or OpenCode Go transport behavior.
