### PR TITLE
fix(desktop): pass session owner to archive and delete endpoints

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -20,6 +20,8 @@ import {
   listSessions,
   listSidebarSessions,
   resetSidebarBatchCapability,
+  setSessionArchived,
+  deleteSession,
   setApiRequestProfile,
   speakText,
   transcribeAudio
@@ -385,6 +387,36 @@ describe('Hermes REST helpers', () => {
     await expect(getAllSessionMessages('session-1', null, { maxJsonChars: 1 })).rejects.toThrow(
       'Desktop safe-load limit'
     )
+  })
+
+  it('routes a default-profile archive to the owning root store even when the serving backend differs', async () => {
+    await setSessionArchived('session-1', true, 'default')
+
+    expect(api).toHaveBeenCalledWith({
+      body: { archived: true, profile: 'default' },
+      method: 'PATCH',
+      path: '/api/sessions/session-1',
+      profile: 'default'
+    })
+  })
+
+  it('routes a named-profile delete to the owning store instead of the serving backend', async () => {
+    await deleteSession('session-1', 'tangy-researcher')
+
+    expect(api).toHaveBeenCalledWith({
+      method: 'DELETE',
+      path: '/api/sessions/session-1?profile=tangy-researcher',
+      profile: 'tangy-researcher'
+    })
+  })
+
+  it('keeps unowned session requests unscoped for legacy callers', async () => {
+    await deleteSession('session-1')
+
+    expect(api).toHaveBeenCalledWith({
+      method: 'DELETE',
+      path: '/api/sessions/session-1'
+    })
   })
 
   it('bounds blocking TTS synthesis timeouts by text length', () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -627,16 +627,18 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
   }
 }
 
-// Mutations take the owning `profile` so Electron routes them to that profile's
-// backend (remote pool or local primary) via request.profile — matching the
-// read path. A remote session's row lives only on its remote host, so a mutation
-// that hit the local primary would no-op or 404. Omit for the current/default.
+// Mutations carry the owning `profile` twice: `request.profile` lets Electron
+// select the right backend process, while the PATCH body tells that process
+// which state.db owns the row. The latter matters on legacy launches: with no
+// desktop preference, the primary backend honors ~/.hermes/active_profile and
+// may serve a different profile than Electron's apparent primary. Omit only
+// when the caller genuinely does not know the owner.
 export function setSessionArchived(id: string, archived: boolean, profile?: string | null): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { archived }
+    body: { archived, ...(profile ? { profile } : {}) }
   })
 }
 
@@ -753,9 +755,11 @@ export async function getAllSessionMessages(
 }
 
 export function deleteSession(id: string, profile?: string | null): Promise<{ ok: boolean }> {
+  const suffix = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+
   return window.hermesDesktop.api<{ ok: boolean }>({
     ...(profile ? { profile } : {}),
-    path: `/api/sessions/${encodeURIComponent(id)}`,
+    path: `/api/sessions/${encodeURIComponent(id)}${suffix}`,
     method: 'DELETE'
   })
 }

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3353,6 +3353,36 @@ class TestDeleteSessionEndpoint:
             db.close()
 
 
+    def test_patch_archive_uses_the_explicit_owner_profile(self):
+        """An archive mutation targets the owner DB, not the serving backend DB."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        profile_home = get_hermes_home() / "profiles" / "worker-beta"
+        profile_home.mkdir(parents=True)
+        profile_db = SessionDB(db_path=profile_home / "state.db")
+        try:
+            profile_db.create_session(session_id="profile-archived", source="cli")
+        finally:
+            profile_db.close()
+
+        # Without profile, the serving (default) DB does not contain this row.
+        missing = self.auth_client.patch("/api/sessions/profile-archived", json={"archived": True})
+        assert missing.status_code == 404
+
+        updated = self.auth_client.patch(
+            "/api/sessions/profile-archived", json={"archived": True, "profile": "worker-beta"}
+        )
+        assert updated.status_code == 200
+        assert updated.json()["archived"] is True
+
+        profile_db = SessionDB(db_path=profile_home / "state.db")
+        try:
+            row = profile_db.get_session("profile-archived")
+            assert row is not None and bool(row["archived"])
+        finally:
+            profile_db.close()
+
     def test_delete_absent_session_is_idempotent(self):
         # PREMISE / regression: deleting a row that no longer exists must NOT
         # 404 — the desktop would resurrect the ghost row and show


### PR DESCRIPTION
## Summary

Fixes the Desktop `Archive failed — Session not found` failure when a sidebar row belongs to a profile different from the backend process that serves the request.

- carry the known owner profile in archive PATCH bodies;
- carry it in single-session delete query parameters;
- preserve the legacy unscoped API shape when the caller has no owner;
- add client and server regression coverage for owner-DB selection.

This is a rebased, minimal implementation of the owner-profile propagation proposed in #44138. That PR is currently conflicting with `main`; this branch is rebased on current `main` and contains no unrelated contributor/tool changes.

## Why

On legacy Desktop launches, Electron can treat `default` as primary while the backend process follows the sticky active profile. A default-profile session mutation can therefore reach a named-profile backend. Without an explicit owner, the server looks in the serving backend's DB and returns 404. Sending the owner lets the existing server-side profile resolver open the correct `state.db`.

## Validation

- [x] `vitest run src/hermes.test.ts` — 25 passed
- [x] `tsc --noEmit -p apps/desktop/tsconfig.json`
- [x] Isolated real FastAPI contract check: unscoped cross-profile PATCH returns 404; PATCH with `profile` returns 200 and persists `archived = 1` in the owner DB.
- [x] Rebased cleanly onto `main` at `936dd7346f`.

Closes #44117
