### PR TITLE
fix: route deferred update notice through cprint to avoid ANSI garbling

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -615,6 +615,25 @@ def _format_update_notice(behind: int) -> str:
 _deferred_update_notice_started = False
 
 
+def _render_markup_to_ansi(markup: str) -> str:
+    """Render Rich markup to an ANSI escape string.
+
+    Under ``patch_stdout`` (active in the interactive CLI), ``console.print``
+    writes ANSI escapes directly to the StdoutProxy, which strips the ESC
+    bytes and leaves visible ``[1;33m…[0m`` artifacts (#83969).
+
+    Capturing the rendered output and passing it through ``cprint`` (which
+    routes via ``prompt_toolkit``'s ANSI parser) avoids the mangling.
+    """
+    from io import StringIO
+    from rich.console import Console as _Console
+
+    buf = StringIO()
+    cap = _Console(file=buf, force_terminal=True, color_system="truecolor")
+    cap.print(markup)
+    return buf.getvalue().rstrip("\n")
+
+
 def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
     """Print the update warning once the prefetched check completes.
 
@@ -633,7 +652,9 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
             behind = _update_result
             if behind is None or behind == 0:
                 return
-            console.print(_format_update_notice(behind))
+            markup = _format_update_notice(behind)
+            ansi = _render_markup_to_ansi(markup)
+            cprint(ansi)
         except Exception:
             pass  # never break the session over an update notice
 

--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -175,37 +175,41 @@ class TestBannerUpdateCheckNonBlocking:
 
         printed = []
 
-        class _Console:
-            def print(self, msg, *a, **k):
-                printed.append(msg)
+        def _fake_cprint(text):
+            printed.append(text)
 
         done = threading.Event()
         with patch.object(banner, "_update_check_done", done), \
              patch.object(banner, "_update_result", None), \
-             patch.object(banner, "_deferred_update_notice_started", False):
-            banner._defer_update_notice(_Console(), max_wait=5.0)
+             patch.object(banner, "_deferred_update_notice_started", False), \
+             patch.object(banner, "cprint", _fake_cprint):
+            banner._defer_update_notice(None, max_wait=5.0)
             banner._update_result = 3
             done.set()
             deadline = time.time() + 5
             while not printed and time.time() < deadline:
                 time.sleep(0.02)
         assert printed, "deferred update notice never printed"
-        assert "3 commits behind" in printed[0]
+        # cprint receives ANSI-rendered text (ESC escapes + visible text),
+        # so check that the visible payload contains the expected message.
+        import re
+        visible = re.sub(r"\x1b\[[0-9;]*m", "", printed[0])
+        assert "3 commits behind" in visible
 
     def test_deferred_notice_silent_when_up_to_date(self):
         import hermes_cli.banner as banner
 
         printed = []
 
-        class _Console:
-            def print(self, msg, *a, **k):
-                printed.append(msg)
+        def _fake_cprint(text):
+            printed.append(text)
 
         done = threading.Event()
         with patch.object(banner, "_update_check_done", done), \
              patch.object(banner, "_update_result", 0), \
-             patch.object(banner, "_deferred_update_notice_started", False):
-            banner._defer_update_notice(_Console(), max_wait=2.0)
+             patch.object(banner, "_deferred_update_notice_started", False), \
+             patch.object(banner, "cprint", _fake_cprint):
+            banner._defer_update_notice(None, max_wait=2.0)
             done.set()
             time.sleep(0.3)
         assert not printed


### PR DESCRIPTION
## Summary

The deferred update notice (`⚠ N commits behind - run hermes update to update`) renders as garbled ANSI escape codes in the interactive CLI:

```
[1;33m⚠ [0m[1;33m15[0m[1;33m commits behind[0m[2;33m - run [0m[1;2;33mhermes update[0m[2;33m to update[0m
```

The ESC bytes (`\x1b`) are stripped by `patch_stdout`'s `StdoutProxy`, leaving the raw `[1;33m...[0m` text visible.

This is the same class of bug as #2262 (fixed by #2448 for `agent._print_fn` and `display.py`), but the `_defer_update_notice` callsite in `banner.py` was not covered by that fix.

## Root Cause

`banner.py:_defer_update_notice` uses `console.print(_format_update_notice(behind))` which writes ANSI escapes directly to stdout. Under `patch_stdout` (active during the interactive prompt_toolkit session), the `StdoutProxy` mangles the escape sequences.

The existing `cprint()` function in `banner.py` already solves this by routing through `prompt_toolkit.print_formatted_text(ANSI(...))`, but `_defer_update_notice` does not use it.

## Fix

1. Added `_render_markup_to_ansi(markup)` helper that renders Rich markup to an ANSI string using a captured `Console(force_terminal=True, color_system="truecolor")`.
2. Changed `_defer_update_notice` to render the markup to ANSI, then pass through `cprint()` instead of `console.print()`.

## Test Changes

Updated `TestBannerUpdateCheckNonBlocking` to mock `cprint` instead of `console.print`, since the output now flows through `cprint`. The assertion strips ANSI escapes before checking the visible text.

Fixes #83969