### PR TITLE
fix(tui_gateway): keep a strong reference to the coalesced token flush task

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -228,3 +228,112 @@ def test_ws_transport_preserves_cross_batch_order():
     asyncio.run(scenario())
 
 
+def test_ws_transport_anchors_coalesced_token_flush():
+    """The coalesce timer empties _pending_tokens before it creates the send
+    task, so that task holds the only surviving reference to the batch. A bare
+    asyncio.create_task() is only weakly referenced by the loop, so the
+    transport must keep a strong reference of its own — otherwise a pending
+    flush can be collected mid-flight and those streamed tokens never reach the
+    client, with nothing left to retry or re-queue them."""
+
+    async def scenario():
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        sent = []
+
+        class FakeWS:
+            async def send_text(self, line):
+                entered.set()
+                await release.wait()
+                sent.append(line)
+
+        transport = ws_mod.WSTransport(
+            FakeWS(), asyncio.get_running_loop(), peer="anchor-test"
+        )
+        with transport._token_lock:
+            transport._pending_tokens.extend(["T1", "T2"])
+            transport._token_flush_armed = True
+
+        transport._flush_tokens()
+
+        # The batch is no longer reachable through the buffer.
+        assert transport._pending_tokens == []
+
+        await entered.wait()
+        in_flight = [t for t in transport._background_tasks if not t.done()]
+        assert len(in_flight) == 1
+
+        release.set()
+        await asyncio.wait_for(asyncio.gather(*in_flight), timeout=5)
+        assert sent == ["T1", "T2"]
+        # The done callback releases the reference, so the set cannot grow
+        # across a streamed turn's hundreds of flushes.
+        assert not transport._background_tasks
+
+    asyncio.run(scenario())
+
+
+def test_ws_transport_close_cancels_in_flight_batch_send():
+    """close() latches _closed, but _safe_send_many only re-checks that between
+    frames: a send already suspended inside ws.send_text() on a wedged socket
+    never observes it. Now that the transport anchors that task, teardown has to
+    cancel it, or the task and the transport keep each other alive after
+    handle_ws has returned."""
+
+    async def scenario():
+        entered = asyncio.Event()
+        wedged = asyncio.Event()  # never set: the socket never completes a send
+
+        class FakeWS:
+            async def send_text(self, line):
+                entered.set()
+                await wedged.wait()
+
+        transport = ws_mod.WSTransport(
+            FakeWS(), asyncio.get_running_loop(), peer="close-cancel-test"
+        )
+        with transport._token_lock:
+            transport._pending_tokens.append("T1")
+            transport._token_flush_armed = True
+
+        transport._flush_tokens()
+
+        await entered.wait()
+        in_flight = [t for t in transport._background_tasks if not t.done()]
+        assert len(in_flight) == 1
+        task = in_flight[0]
+
+        transport.close()
+
+        _done, pending = await asyncio.wait({task}, timeout=5)
+        assert not pending, "close() left an in-flight batch send pending"
+        assert task.cancelled()
+
+    asyncio.run(scenario())
+
+
+def test_ws_transport_close_drops_the_coalesce_buffer():
+    """close() cancels the coalesce TimerHandle, which is the only caller that
+    would ever have drained _pending_tokens. Anything still buffered there is
+    undeliverable from that moment on, so close() must release it instead of
+    pinning the frames on a dead transport."""
+
+    async def scenario():
+        class FakeWS:
+            async def send_text(self, line):
+                raise AssertionError("a closed transport must not send")
+
+        transport = ws_mod.WSTransport(
+            FakeWS(), asyncio.get_running_loop(), peer="close-buffer-test"
+        )
+        with transport._token_lock:
+            transport._pending_tokens.extend(["T1", "T2"])
+            transport._token_flush_armed = True
+
+        transport.close()
+
+        assert transport._pending_tokens == []
+
+    asyncio.run(scenario())
+
+

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -305,6 +305,11 @@ def test_ws_transport_close_cancels_in_flight_batch_send():
 
         transport.close()
 
+        # Tracking is dropped synchronously rather than one done callback at a
+        # time, so close() leaves no transport -> set -> task -> transport cycle
+        # behind for the loop to unpick later.
+        assert not transport._background_tasks
+
         _done, pending = await asyncio.wait({task}, timeout=5)
         assert not pending, "close() left an in-flight batch send pending"
         assert task.cancelled()

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -106,6 +106,14 @@ class WSTransport:
         # writes need an async boundary because several batches can be queued on
         # the owning loop while it recovers from a stall.
         self._send_lock = asyncio.Lock()
+        # Strong references to the in-flight batch sends started by the coalesce
+        # timer. A bare asyncio.create_task() keeps only a weak reference, so
+        # the loop may garbage-collect a still-pending task mid-flight — and
+        # _flush_tokens has already swapped the batch out of _pending_tokens by
+        # the time it creates that task, so a collected task takes the only
+        # surviving copy of those frames with it. Mutated only on the loop
+        # thread (the timer callback and the done callback below).
+        self._background_tasks: set[asyncio.Task] = set()
 
     @staticmethod
     def _is_streaming_frame(obj: dict) -> bool:
@@ -199,6 +207,11 @@ class WSTransport:
 
         The send is scheduled under the lock so its wire order is fixed relative
         to a concurrent non-streaming flush in :meth:`write`.
+
+        The batch leaves ``_pending_tokens`` before the task exists, so the task
+        holds the only reference to those frames: it is anchored in
+        ``_background_tasks`` until it completes, or the loop can collect it and
+        the tokens are lost with it.
         """
         with self._token_lock:
             self._token_flush_handle = None
@@ -208,7 +221,9 @@ class WSTransport:
                 return
             batch = self._pending_tokens
             self._pending_tokens = []
-            self._loop.create_task(self._safe_send_many(batch))
+            task = self._loop.create_task(self._safe_send_many(batch))
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
     async def write_async(self, obj: dict) -> bool:
         """Send from the owning event loop. Awaits until the frame is on the wire."""

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -268,6 +268,22 @@ class WSTransport:
         if handle is not None:
             handle.cancel()
             self._token_flush_handle = None
+        # Cancelling that timer removed the only thing that would ever have
+        # drained the coalesce buffer, so drop what is still queued in it rather
+        # than pinning frames on a transport that can no longer send them.
+        with self._token_lock:
+            self._pending_tokens = []
+        # Release the anchored batch sends. Latching _closed above is not enough
+        # on its own: _safe_send_many only re-checks it between frames, so a
+        # send already suspended inside ws.send_text() on a wedged socket never
+        # observes it — and now that the transport holds a strong reference to
+        # that task, the two keep each other alive after handle_ws has returned.
+        # close() is synchronous and runs on the loop thread, so it cannot await
+        # the drain the way GatewayPlatform.cancel_background_tasks does;
+        # cancelling without awaiting is the bounded half of the same contract,
+        # and each task's done callback removes it from the set as it unwinds.
+        for task in [t for t in self._background_tasks if not t.done()]:
+            task.cancel()
 
 
 def _ws_peer_label(ws: Any) -> str:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -280,10 +280,19 @@ class WSTransport:
         # that task, the two keep each other alive after handle_ws has returned.
         # close() is synchronous and runs on the loop thread, so it cannot await
         # the drain the way GatewayPlatform.cancel_background_tasks does;
-        # cancelling without awaiting is the bounded half of the same contract,
-        # and each task's done callback removes it from the set as it unwinds.
+        # cancelling without awaiting is the bounded half of the same contract.
         for task in [t for t in self._background_tasks if not t.done()]:
             task.cancel()
+        # Then drop the tracking outright, as cancel_background_tasks does after
+        # its own drain. Waiting for each done callback to discard its task
+        # would leave transport -> _background_tasks -> task -> bound
+        # _safe_send_many -> transport intact until the loop next runs, so the
+        # pair would only be reclaimable by the cycle collector rather than by
+        # refcount — and on a wedged send_text() that wait is unbounded.
+        # Clearing is terminal here: _flush_tokens returns early once _closed is
+        # latched, so nothing repopulates the set, and set.discard on an
+        # already-removed task is a no-op.
+        self._background_tasks.clear()
 
 
 def _ws_peer_label(ws: Any) -> str:


### PR DESCRIPTION
## This is a sibling follow-up to #69684 (commit `8e013099177`)

- **What #69684 covered:** it introduced the whole token-coalescing subsystem in `tui_gateway/ws.py` — `_pending_tokens`, `_token_lock`, `_safe_send_many`, `_flush_tokens` — and made a coalesced batch *indivisible and correctly ordered*, with the two tests that still live in `tests/test_tui_gateway_ws.py`.
- **What #69684 did NOT touch:** the *survival* of that batch. `_flush_tokens()` swaps the buffer out and hands the resulting list to a bare `asyncio.create_task()` whose return value is dropped. Ordering was completed; the reference was not.
- **What this adds:** a strong reference to the in-flight flush, and the teardown bound that new reference implies.

## What does this PR do?

`_flush_tokens()` is the streaming hot path. Every `message.delta` / `reasoning.delta` / `thinking.delta` frame bound for a TUI, desktop or web WebSocket client is buffered into `_pending_tokens` and flushed from this ~30 fps timer callback (`_TOKEN_COALESCE_S = 0.033`). On `main` it ends:

```python
batch = self._pending_tokens
self._pending_tokens = []
self._loop.create_task(self._safe_send_many(batch))
```

`asyncio.create_task()` keeps only a **weak** reference, so the loop may garbage-collect a still-pending task mid-flight. The repo already states this invariant against itself, at `gateway/run.py:10494-10497`:

> We still hold a strong reference in `self._restart_task`: a bare `asyncio.create_task()` keeps only a weak reference, so the event loop may garbage-collect a still-pending task mid-flight.

**Why this instance is worse than the ordinary fire-and-forget case.** The batch left `_pending_tokens` *before* the task existed, so the task holds the only surviving reference to those frames. A collected task takes them with it — nothing retries, nothing re-queues, and no error is logged anywhere. The user-visible symptom is the assistant's reply stopping part-way through in the TUI/desktop window while the turn is still running server-side.

**Reachability** (all on `main`): `server.py:5767`/`:5772`/`:9976` `_emit("message.delta", …)` → `server.py:1573` `_emit` → `write_json` → `server.py:1558-1561` routes the session's frame to `t.write(obj)` → `ws.py:118` `WSTransport.write()` → `_is_streaming_frame` true (`ws.py:53-57`) → buffered, `_arm_token_flush` arms `call_later` → `_flush_tokens()` → the unanchored task. Every streamed token frame on every WS client goes through it; no unusual configuration is required.

**And the invariant the remedy creates.** Anchoring the task gives the transport a strong reference it did not have before, so `close()` — the sole teardown path, `handle_ws`'s `finally`, on the loop thread — now owes that reference a bound. `close()` currently latches `_closed` and cancels the coalesce `TimerHandle`, and neither releases what the transport still holds:

- Cancelling that timer removes the only caller that would ever have drained `_pending_tokens`, so whatever is buffered at that instant stays retained on a transport that can no longer send it.
- `_safe_send_many` only re-checks `_closed` *between* frames. A send already suspended inside `ws.send_text()` on a wedged socket — the exact condition `_WS_WRITE_TIMEOUT_S` exists for — never observes the latch. With the anchor in place that task and the transport keep each other alive after `handle_ws` has returned, one pair per wedged connection.

`close()` is synchronous, so it cannot `await` the drain the way `GatewayPlatform.cancel_background_tasks()` does. **That bound is deliberate and disclosed:** it cancels without awaiting, which is the non-blocking half of the same contract. Nothing is lost by it — `_closed` already guarantees no further frame reaches the wire, and `handle_ws` closes the socket immediately afterwards. `CancelledError` derives from `BaseException`, so `_safe_send_many`'s `except Exception` neither swallows it nor spuriously latches `_closed`.

The anchor uses the repo's established idiom rather than a bespoke one: a `self._background_tasks: set[asyncio.Task]` plus `task.add_done_callback(self._background_tasks.discard)`, as in `gateway/platforms/base.py:3058`/`:5773`/`:5781` and `gateway/platforms/api_server.py:3952`/`:3956`. The set is touched only on the loop thread (the timer callback and the done callback), so it needs no extra locking.

## Related Issue

No filed issue. This is a sibling completion of merged PR #69684 (`8e013099177 fix(tui_gateway): preserve websocket batch order`), which introduced the coalescing subsystem this defect lives in.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Three atomic commits:

1. **`fix(tui_gateway): anchor the coalesced token flush task`** — `tui_gateway/ws.py`. Adds `self._background_tasks: set[asyncio.Task]` to `WSTransport.__init__`; `_flush_tokens()` now keeps the task it creates and releases it from the task's own done callback.
2. **`fix(tui_gateway): release the coalesce buffer and in-flight sends on close`** — `tui_gateway/ws.py`. `close()` clears `_pending_tokens` under `_token_lock` (matching what `_flush_tokens` already does on its own `_closed` branch) and cancels every task still in the anchor set.
3. **`test(tui_gateway): cover coalesced flush anchoring and transport teardown`** — `tests/test_tui_gateway_ws.py`, three cases, +109 lines.

### Deliberately not changed

- **`write()`'s `if on_loop:` branch (`ws.py:156`) keeps its bare `create_task`.** It looks like the same defect and is not shipped as one, because on current `main` that branch is unreachable in production: `ws.py:392` dispatches **every** request via `await asyncio.to_thread(server.dispatch, req, transport)` (the file says so itself at `:385-388` — *"a separate thread, so transport.write is the safe path there"*), inline responses are written by `handle_ws` with `write_async` (`ws.py:314`, `:370`, `:401`, `:419`) and never `write()`, and the other production caller `server.py:1616 _broadcast_global_event` is documented as running on background threads. So every real `write()` call takes the `safe_schedule_threadsafe` branch, which is already safe — the concurrent `Future` from `run_coroutine_threadsafe` keeps the loop-side task referenced. That branch is a latent hazard on a defensive path, not a live bug, and this PR does not claim otherwise.
- **`_token_flush_armed` is not reset in `close()`.** Leaving it `True` actively suppresses re-arming from a racing writer thread on a closed transport, which is the safer state.

## How to Test

```bash
pytest tests/test_tui_gateway_ws.py -v
```

Verified in **both** directions, and the two production commits were verified independently of each other:

| tree under test | `…anchors_coalesced_token_flush` | `…close_cancels_in_flight_batch_send` | `…close_drops_the_coalesce_buffer` |
|---|---|---|---|
| `main` (neither fix) | FAIL | FAIL | FAIL |
| commit 1 only (anchor, no teardown) | PASS | FAIL | FAIL |
| this branch | PASS | PASS | PASS |

Failure texts, read rather than merely observed:

- On `main`, all three: `AttributeError: 'WSTransport' object has no attribute '_background_tasks'` — the transport keeps no reference to the in-flight send at all.
- On commit 1 only: `AssertionError: close() left an in-flight batch send pending` / `assert not {<Task pending name='Task-6' coro=<WSTransport._safe_send_many() running at tui_gateway/ws.py:252> …>}`, and `AssertionError: assert ['T1', 'T2'] == []`.

The tests are deterministic — `asyncio.Event` gates, no `sleep` as synchronization and **no forced garbage collection** (whether a pending task is collected is timing-dependent, so a `gc.collect()` repro would be a flake and could pass on broken code). They assert the behavioural invariant instead: after `_flush_tokens()` returns the batch is gone from `_pending_tokens` and exactly one in-flight send is still reachable from the transport, it delivers both frames in order when released, and the done callback empties the set again so it cannot grow across a turn's hundreds of flushes.

They extend the harness #69684 itself added (`test_ws_transport_serializes_concurrent_sends`, `test_ws_transport_preserves_cross_batch_order`) rather than introducing a new one.

Also run green: `tests/tui_gateway/test_inline_rpc_gil_starvation.py` and `tests/tui_gateway/test_cold_start_gil_stall.py`, the other suites that exercise `WSTransport`'s write path — 23 passed together with the file above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the focused and adjacent suites listed under "How to Test" (23 passed), not the full suite locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4.0), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the `_flush_tokens` docstring and the `__init__`/`close` comments now state the reference invariant
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure `asyncio` task bookkeeping, no platform-specific code or syscalls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Overlap was measured rather than assumed, and both nets are reported separately.

**By changed path** (`gh pr list --json files`, newest 300 open PRs, spanning #83486–#83970 — this is a recency net covering roughly the last day, not a coverage net): one hit, **#83524** (@jaxmatrix, *"stop a resuming viewer stealing a running session's stream"*). Its production file is `tui_gateway/server.py`, **not** `ws.py`; it touches `tests/test_tui_gateway_ws.py` only, appending at `@@ -228,3 +228,47 @@`. Different production surface, different defect — but the test-file overlap is real and is disclosed here.

**By symbol, corpus-wide** (`gh search prs --state open`, which reaches all open PRs but indexes title/body text only): `_flush_tokens`, `_pending_tokens`, `_arm_token_flush` and `_token_flush_armed` each return **zero** open PRs.

**Every open PR that touches `tui_gateway/ws.py`, hunk-anchored against the regions edited here** (`_flush_tokens` and `close()`):

| PR | author | `ws.py` hunks | overlap |
|---|---|---|---|
| #42983 | @Ghostkyi | written against a **pre-coalescing** `ws.py` — its base has singular `_safe_send(line)` and no `_pending_tokens`/`_token_lock`/`_safe_send_many`/`_flush_tokens` | none; it moves the worker-thread `fut.result()` wait onto a module-level `_WRITE_EXECUTOR` and leaves the on-loop `create_task` bare |
| #39393 | @rodboev | `@@ -28,6`, `@@ -40,6`, `@@ -75,6 +94,22 @@ def __init__` — header/`__init__` only | none in production. **It also touches `tests/test_tui_gateway_ws.py`** — disclosed |
| #52519 | @Sahil-SS9 | `@@ -119,7`, `@@ -221,7` | neither region |
| #55969 | @Sahil-SS9 | `@@ -240,7 +240,14 @@ async def _safe_send_many` | inside the coroutine body, not its scheduling |

#49605 (@Morad37) creates `tests/tui_gateway/test_ws.py`, a path that does not exist on `main`, and does not touch this file. #81395, #42249 and #50586 match `WSTransport` in title/body text only and none of the three touches `tui_gateway/ws.py`.
