### PR TITLE
fix(ci): repair red main — busy-mode test + missing checkout in skills-index workflows

### DIFF
--- a/.github/workflows/skills-index-freshness.yml
+++ b/.github/workflows/skills-index-freshness.yml
@@ -23,6 +23,14 @@ jobs:
     timeout-minutes: 10
     environment: trusted-automation
     steps:
+      # `Get GitHub App token` below is a LOCAL composite action
+      # (./.github/actions/get-app-token), so the repository must be on disk
+      # before it can be resolved. Without this checkout the job dies with
+      # "Can't find 'action.yml' ... under .github/actions/get-app-token"
+      # every time the probe is non-ok — i.e. exactly when the watchdog is
+      # supposed to file its issue.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Probe live index
         id: probe
         run: |

--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -63,12 +63,19 @@ jobs:
     timeout-minutes: 15
     environment: trusted-automation
     steps:
+      # Required: `Get GitHub App token` is a LOCAL composite action
+      # (./.github/actions/get-app-token) and cannot resolve without the repo
+      # checked out. `build-index` above already does this; this job did not,
+      # so the scheduled deploy re-trigger never fired.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Get GitHub App token
         id: app-token
         uses: ./.github/actions/get-app-token
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Trigger Deploy Site workflow
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/tests/gateway/test_multiplex_busy_input_mode.py
+++ b/tests/gateway/test_multiplex_busy_input_mode.py
@@ -1,7 +1,8 @@
 """Profile-specific busy-input behavior for multiplexed gateways."""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -336,7 +337,20 @@ def test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries():
     ]
     source = _event(profile=None).source
 
-    assert runner._effective_busy_input_mode(source) == "steer"
+    # `_profile_name_for_source` rejects a route whose target profile is not in
+    # the served set (`profiles_to_serve`). Without this patch the test reads
+    # the runner's real on-disk profiles, so "research" is unserved on any
+    # machine that does not happen to have it — and the route is rejected
+    # before the busy-mode snapshot is consulted. Sibling coverage in
+    # tests/gateway/test_profile_resolution.py patches the same seam.
+    with patch(
+        "hermes_cli.profiles.profiles_to_serve",
+        return_value=[
+            ("default", Path("/profiles/default")),
+            ("research", Path("/profiles/research")),
+        ],
+    ):
+        assert runner._effective_busy_input_mode(source) == "steer"
 
     runner.config.multiplex_profiles = False
     source.profile = "research"


### PR DESCRIPTION
Main is red. Three distinct failures; two are fixed here, the third needs no code.

## 1. `test_multiplex_busy_input_mode.py` — blocks every merge

`test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries` fails on
main, taking down `Python tests / Run tests slice 5/12` and therefore
`All required checks pass`. **Every PR is currently blocked behind this.**

### Cause

A semantic merge conflict between two PRs (both by @tmchow) that merged
57 minutes apart:

| PR | merge commit | merged (UTC) | role |
|---|---|---|---|
| [#83550](https://github.com/NousResearch/hermes-agent/pull/83550) — fix(gateway): respect routed profile busy modes | [`a31be480`](https://github.com/NousResearch/hermes-agent/commit/a31be48030f60383bf4c1d96ba46bd4b48430218) | 2026-08-11 04:51:47 | **added the test** |
| [#83400](https://github.com/NousResearch/hermes-agent/pull/83400) — feat(gateway): allow selective multiplex profile serving | [`9829746d`](https://github.com/NousResearch/hermes-agent/commit/9829746dfe3d5077f4f076e257505ec7f8feaa65) → [`c8f235a1`](https://github.com/NousResearch/hermes-agent/commit/c8f235a106680b900b54c0ec15c515dfa0b91490) | 2026-08-11 05:48:24 | **added the gate** |

#83400 taught `_profile_name_for_source` to reject a route whose target profile
is not in the served set (`profiles_to_serve`). #83550 added a test that routes
to profile `research` without ever declaring it served. Each is correct alone;
together the gate rejects the route the test depends on.

**Why CI didn't catch it: #83400 was never re-tested after #83550 landed.**

- #83400's last CI run was on head [`0eb96d7a`](https://github.com/NousResearch/hermes-agent/commit/0eb96d7a2edccb6b16dfd41316730b22817108c2) at **2026-08-10 19:23:59Z** —
  `Run tests slice 5/12` ✅, `All required checks pass` ✅.
- #83550's test landed on main **9h 28m later**, at 2026-08-11 04:51:47Z.
- #83400 then merged at 05:48:24Z **on that stale green**, with no re-run.

The test literally did not exist on the commit CI approved:

```console
$ git merge-base --is-ancestor a31be480 0eb96d7a   # test in tested head?
NO — tested head predates the test

$ git show 0eb96d7a:tests/gateway/test_multiplex_busy_input_mode.py \
    | grep -c test_profile_route_and_nonmultiplexed
0
```

So this is not a flake and not a bad review — it's a stale-base merge. The
first execution of gate + test together happened on main, in the merge result
that no CI run ever covered.

The mechanism, concretely: the test never patches `profiles_to_serve`, so it
reads the runner's **real on-disk profiles**. `research` isn't among them, the
route is rejected before the busy-mode snapshot is ever consulted, and the
assertion receives the gateway default instead:

```
WARNING gateway.run: Rejecting profile route 'research-chat':
                     target profile 'research' is not served
AssertionError: assert 'interrupt' == 'steer'
```

**Fix:** patch `profiles_to_serve` around the assertion — the same seam every
sibling test in `tests/gateway/test_profile_resolution.py` already patches
(`test_route_inside_allowlist_resolves`, `test_route_outside_allowlist_rejects`).

This also removes an ambient-state dependency. The test previously passed or
failed depending on which profiles happened to exist on the machine running it;
it now passes under an empty `HERMES_HOME`.

Test-only — no production behavior changes. The serving gate from #83400 is
correct and is left fully intact.

## 2. Skills-index workflows: local action used without `actions/checkout`

`check-freshness` has failed **all 12 of its last 12** scheduled runs:

```
##[error]Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'.../.github/actions/get-app-token'. Did you forget to run
actions/checkout before running your local action?
```

`./.github/actions/get-app-token` is a local composite action and can't resolve
without the repo on disk. `skills-index-freshness.yml` had no checkout step at
all.

The real-world impact is worse than one red check: that step is gated on
`status != 'ok'`, so **the watchdog only broke at the exact moment it was
supposed to work.** The live skills index is right now **521.4h stale** against
a 26h limit, and the alarm designed to tell us never fired.

Auditing every workflow for this bug class turned up one more instance —
`skills-index.yml`'s `trigger-deploy` job, which re-triggers the docs deploy so
a refreshed index actually reaches the live site. Its sibling `build-index` job
checks out; this one didn't. That is plausibly **why the index went stale in the
first place**: the rebuild ran, but the deploy was never kicked.

Both are fixed. The audit now reports zero remaining jobs that invoke a local
action without a prior checkout. Pinned to the same `actions/checkout` SHA used
by the other 35 call sites in the repo.

## 3. `Publish inline E2E evidence` — no fix needed

Failed once at 13:33Z on a transient TLS error reaching `api.github.com`
(`certificate is not valid for any names`) while installing a `gh` extension.
The last 25 runs of that workflow are 25/25 success. Infra blip, not a defect —
flagging it so it isn't mistaken for a real regression.

## Verification

- Reproduced the test failure deterministically on main HEAD before fixing.
- `tests/gateway/test_multiplex_busy_input_mode.py` — 15/15 pass after the fix.
- Re-ran under an empty `HERMES_HOME` to confirm the ambient-state dependency is gone.
- `tests/gateway/test_multiplex_busy_input_mode.py` + `test_profile_resolution.py` + `tests/hermes_cli/test_profiles.py` — 76 passed, 2 skipped.
- Both workflow files parse as valid YAML with correct step structure; workflow diffs are pure additions (no steps altered or lost).
- `ruff` clean.

Note: `tests/gateway/test_api_server.py::TestHealthDetailedEndpoint::test_health_detailed_returns_ok`
fails in my local environment (`assert 'degraded' == 'ok'`), but it fails
identically on unmodified main and its CI slice is green — pre-existing and
environment-specific, unrelated to this change.
