### PR TITLE
feat(plugins): expose bounded Codex app-server lifecycle hook

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
@@ -297,6 +298,135 @@ def _record_codex_app_server_compaction(
 _CODEX_TOOL_ITEM_TYPES = frozenset(
     {"commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall", "webSearch"}
 )
+
+_CODEX_PLUGIN_OBSERVER_METHODS = frozenset(
+    {
+        "thread/started",
+        "turn/started",
+        "item/started",
+        "item/completed",
+        "turn/completed",
+    }
+)
+_CODEX_PLUGIN_OBSERVER_SCHEMA = "hermes.codex_app_server_event.v1"
+
+
+def _observer_string(value: Any, *, limit: int = 1024) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return value[:limit]
+
+
+def _sanitize_codex_app_server_event(note: Any) -> dict[str, Any] | None:
+    """Return the bounded public plugin shape for one app-server event.
+
+    This is intentionally not a raw JSON-RPC passthrough. Prompt/model text,
+    reasoning deltas, commands, tool arguments, tool output, and arbitrary
+    provider fields never cross the plugin boundary.
+    """
+    if not isinstance(note, dict):
+        return None
+    method = note.get("method")
+    if method not in _CODEX_PLUGIN_OBSERVER_METHODS:
+        return None
+    params = note.get("params")
+    if not isinstance(params, dict):
+        params = {}
+
+    safe_params: dict[str, Any] = {}
+    thread_id = _observer_string(params.get("threadId"), limit=256)
+    if thread_id is not None:
+        safe_params["threadId"] = thread_id
+    thread = params.get("thread")
+    if isinstance(thread, dict):
+        nested_thread_id = _observer_string(thread.get("id"), limit=256)
+        if nested_thread_id is not None:
+            safe_params["thread"] = {"id": nested_thread_id}
+
+    turn_id = _observer_string(params.get("turnId"), limit=256)
+    if turn_id is not None:
+        safe_params["turnId"] = turn_id
+    turn = params.get("turn")
+    if isinstance(turn, dict):
+        safe_turn: dict[str, str] = {}
+        nested_turn_id = _observer_string(turn.get("id"), limit=256)
+        turn_status = _observer_string(turn.get("status"), limit=80)
+        if nested_turn_id is not None:
+            safe_turn["id"] = nested_turn_id
+        if turn_status is not None:
+            safe_turn["status"] = turn_status
+        if safe_turn:
+            safe_params["turn"] = safe_turn
+
+    item = params.get("item")
+    if isinstance(item, dict):
+        safe_item: dict[str, Any] = {}
+        for field, limit in (
+            ("id", 256),
+            ("type", 80),
+            ("status", 80),
+            ("path", 1024),
+        ):
+            value = _observer_string(item.get(field), limit=limit)
+            if value is not None:
+                safe_item[field] = value
+        for field in ("exitCode", "durationMs"):
+            value = item.get(field)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                safe_item[field] = value
+        changes = item.get("changes")
+        if isinstance(changes, list):
+            safe_changes: list[dict[str, Any]] = []
+            for change in changes[:100]:
+                if not isinstance(change, dict):
+                    continue
+                path = _observer_string(change.get("path"), limit=1024)
+                if path is None:
+                    continue
+                safe_change: dict[str, Any] = {"path": path}
+                kind = change.get("kind")
+                if isinstance(kind, dict):
+                    kind_type = _observer_string(kind.get("type"), limit=80)
+                    if kind_type is not None:
+                        safe_change["kind"] = {"type": kind_type}
+                safe_changes.append(safe_change)
+            if safe_changes:
+                safe_item["changes"] = safe_changes
+        if safe_item:
+            safe_params["item"] = safe_item
+
+    return {
+        "schemaVersion": _CODEX_PLUGIN_OBSERVER_SCHEMA,
+        "method": method,
+        "params": safe_params,
+    }
+
+
+def _notify_codex_app_server_observers(agent: Any, note: Any) -> None:
+    event = _sanitize_codex_app_server_event(note)
+    if event is None:
+        return
+    try:
+        from hermes_cli.plugins import has_hook, invoke_hook
+
+        if not has_hook("codex_app_server_event"):
+            return
+        invoke_hook(
+            "codex_app_server_event",
+            event=event,
+            session_id=str(getattr(agent, "session_id", "") or ""),
+            task_id=str(getattr(agent, "_current_task_id", "") or ""),
+            runtime="codex_app_server",
+            process_id=os.getpid(),
+        )
+    except Exception:
+        # Observer code can never make the owner runtime fail. PluginManager
+        # already isolates individual callbacks; this outer guard also covers
+        # discovery/registry failures.
+        logger.warning(
+            "codex app-server plugin observer dispatch failed",
+            exc_info=True,
+        )
 
 # Internal MCP server that wraps Hermes' native tools for codex. When
 # codex calls back through it, the inner dispatch runs in a SEPARATE
@@ -589,6 +719,7 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     def on_event(note: dict) -> None:
         if not isinstance(note, dict):
             return
+        _notify_codex_app_server_observers(agent, note)
         method = note.get("method") or ""
         params = note.get("params") or {}
         if not isinstance(params, dict):

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -134,6 +134,10 @@ _install_plugin_debug_handler()
 # ---------------------------------------------------------------------------
 
 VALID_HOOKS: Set[str] = {
+    # Read-only, bounded Codex App Server lifecycle observations. The runtime
+    # strips prompts, model text, reasoning, commands, arguments, and tool
+    # output before invoking this hook. Return values are ignored.
+    "codex_app_server_event",
     "pre_tool_call",
     "post_tool_call",
     "transform_terminal_output",

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from agent.codex_runtime import (
+    _sanitize_codex_app_server_event,
     _codex_item_completion_payload,
     _codex_item_to_args,
     _codex_item_to_preview,
@@ -48,6 +49,196 @@ def _item_started(item: dict) -> dict:
 
 def _item_completed(item: dict) -> dict:
     return {"method": "item/completed", "params": {"item": item}}
+
+
+class TestCodexAppServerPluginObserver:
+    def test_sanitizer_keeps_lifecycle_identity_and_drops_sensitive_content(self):
+        event = _sanitize_codex_app_server_event({
+            "method": "item/completed",
+            "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "commandExecution",
+                    "status": "completed",
+                    "command": "curl -H 'Authorization: secret' example.test",
+                    "aggregatedOutput": "secret output",
+                    "arguments": {"token": "secret"},
+                    "text": "private model text",
+                    "exitCode": 0,
+                    "durationMs": 12,
+                    "changes": [
+                        {"path": "src/app.py", "kind": {"type": "update"}},
+                    ],
+                },
+            },
+        })
+
+        assert event == {
+            "schemaVersion": "hermes.codex_app_server_event.v1",
+            "method": "item/completed",
+            "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "commandExecution",
+                    "status": "completed",
+                    "exitCode": 0,
+                    "durationMs": 12,
+                    "changes": [
+                        {"path": "src/app.py", "kind": {"type": "update"}},
+                    ],
+                },
+            },
+        }
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "item/agentMessage/delta",
+            "item/reasoning/delta",
+            "thread/tokenUsage/updated",
+            "unknown/event",
+        ],
+    )
+    def test_sanitizer_rejects_high_volume_or_unsupported_events(self, method):
+        assert _sanitize_codex_app_server_event({
+            "method": method,
+            "params": {"delta": "secret"},
+        }) is None
+
+    def test_bridge_notifies_registered_plugin_with_runtime_correlation(
+        self, monkeypatch
+    ):
+        observed = []
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda name, **kwargs: observed.append((name, kwargs)) or [],
+        )
+        agent = _make_stub_agent()
+        agent.session_id = "hermes-session-1"
+        agent._current_task_id = "task-1"
+        bridge = make_codex_app_server_event_bridge(agent)
+
+        bridge({
+            "method": "turn/started",
+            "params": {
+                "threadId": "thread-1",
+                "turn": {"id": "turn-1", "status": "inProgress"},
+            },
+        })
+
+        assert observed == [
+            (
+                "codex_app_server_event",
+                {
+                    "event": {
+                        "schemaVersion": "hermes.codex_app_server_event.v1",
+                        "method": "turn/started",
+                        "params": {
+                            "threadId": "thread-1",
+                            "turn": {"id": "turn-1", "status": "inProgress"},
+                        },
+                    },
+                    "session_id": "hermes-session-1",
+                    "task_id": "task-1",
+                    "runtime": "codex_app_server",
+                    "process_id": __import__("os").getpid(),
+                },
+            )
+        ]
+
+    def test_bridge_observer_receives_the_bounded_lifecycle_in_wire_order(
+        self, monkeypatch
+    ):
+        observed = []
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda _name, **kwargs: observed.append(kwargs["event"]["method"])
+            or [],
+        )
+        bridge = make_codex_app_server_event_bridge(_make_stub_agent())
+
+        for note in (
+            {
+                "method": "thread/started",
+                "params": {"thread": {"id": "thread-1"}},
+            },
+            {
+                "method": "turn/started",
+                "params": {
+                    "threadId": "thread-1",
+                    "turn": {"id": "turn-1"},
+                },
+            },
+            _item_started({"id": "item-1", "type": "commandExecution"}),
+            _item_completed(
+                {
+                    "id": "item-1",
+                    "type": "commandExecution",
+                    "status": "completed",
+                }
+            ),
+            {
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-1",
+                    "turn": {"id": "turn-1", "status": "completed"},
+                },
+            },
+        ):
+            bridge(note)
+
+        assert observed == [
+            "thread/started",
+            "turn/started",
+            "item/started",
+            "item/completed",
+            "turn/completed",
+        ]
+
+    def test_bridge_does_not_invoke_hook_when_no_observer_is_registered(
+        self, monkeypatch
+    ):
+        invoked = MagicMock()
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: False)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoked)
+        bridge = make_codex_app_server_event_bridge(_make_stub_agent())
+
+        bridge({
+            "method": "thread/started",
+            "params": {"thread": {"id": "thread-1"}},
+        })
+
+        invoked.assert_not_called()
+
+    def test_observer_failure_does_not_interrupt_existing_bridge_callbacks(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+
+        def fail_observer(name, **kwargs):
+            raise RuntimeError("observer unavailable")
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fail_observer)
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+
+        bridge(_item_started({
+            "type": "commandExecution",
+            "id": "exec-1",
+            "command": "printf secret",
+        }))
+
+        agent.tool_progress_callback.assert_called_once()
+        assert agent.tool_progress_callback.call_args.args[:2] == (
+            "tool.started",
+            "exec_command",
+        )
 
 
 # ---------- name / args / preview / result mapping ----------

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -35,6 +35,10 @@ from hermes_cli.middleware import (
 # ── Helpers ────────────────────────────────────────────────────────────────
 
 
+def test_codex_app_server_event_is_a_supported_observer_hook():
+    assert "codex_app_server_event" in VALID_HOOKS
+
+
 def test_portable_skill_namespace_is_ascii_safe():
     from agent.skill_utils import is_valid_namespace
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -672,6 +672,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
+| [`codex_app_server_event`](/user-guide/features/hooks#codex_app_server_event) | A bounded Codex App Server lifecycle notification is received | `event: dict, session_id: str \| None, task_id: str \| None, runtime: str, process_id: int` | ignored |
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -408,6 +408,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `on_session_end` | Observer | Canonically at each turn finalization; CLI/TUI exits have additional reduced legacy shapes. Return ignored. | Canonical: `session_id`, `task_id`, `turn_id`, `completed`, `failed`, `interrupted`, `turn_exit_reason`, `model`, `platform`; exit paths may add `reason`/`api_request_id` and omit fields. | IDs, model/platform, and outcome; canonical payload has no message body. |
 | `on_session_finalize` | Observer | CLI/TUI/gateway teardown through `finalize_session`; gateway shutdown or expiry may finalize without a reset. Return ignored. | Surface-dependent `session_id`, `platform`, optionally `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
 | `on_session_reset` | Observer | CLI/TUI session boundary and gateway after the replacement session exists; return ignored. | CLI: `session_id`, `platform`, `reason`; TUI: `session_id`, `platform`; gateway: those plus `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
+| `codex_app_server_event` | Observer | Immediately after a supported Codex App Server lifecycle notification is received and before Hermes projects it to its existing UI callbacks. Return ignored. | `event`, `session_id`, `task_id`, `runtime`, `process_id` | Bounded lifecycle metadata only. Prompt, model output, reasoning, command text, arguments, output, deltas, and token usage are excluded. |
 | `on_skill_lifecycle` | Observer | After an authoritative skill-usage state change; return ignored. | `action`, `skill_name`, `provenance`, `task_id`, `session_id`, `use_count`, `reused`, `reuse_after_patch` | Exposes the local skill name and provenance. |
 | `subagent_start` | Observer | Child constructed and about to run; return ignored. | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal may contain user/project content. |
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
@@ -419,6 +420,30 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `kanban_task_blocked` | Observer | After a blocked transition; the dependency-wait path fires before its transaction exits. Return ignored. | `task_id`, `profile_name`, `board`, `assignee`, `run_id`, `reason` | Reason may contain project/user content. |
 
 ---
+
+### `codex_app_server_event`
+
+Fires for the bounded lifecycle subset `thread/started`, `turn/started`, `item/started`, `item/completed`, and `turn/completed` when Hermes runs a turn through the Codex App Server runtime. High-volume deltas and token-usage notifications do not fire this hook.
+
+The nested `event` uses schema `hermes.codex_app_server_event.v1`. It contains only thread, turn, and item identity/status metadata, item path/change kind, exit code, and duration where the Codex event provides them. It deliberately excludes prompt text, assistant text, reasoning, command strings, arguments, command output, deltas, model configuration, and token usage. `session_id`, `task_id`, and `process_id` let an external observer correlate the notification to the owning Hermes process without changing Hermes task state.
+
+```python
+def observe_codex_runtime(
+    event: dict,
+    session_id: str | None,
+    task_id: str | None,
+    runtime: str,
+    process_id: int,
+    **kwargs,
+):
+    if event["method"] == "turn/completed":
+        record_lifecycle_receipt(event, session_id, task_id, process_id)
+
+def register(ctx):
+    ctx.register_hook("codex_app_server_event", observe_codex_runtime)
+```
+
+Observer exceptions are isolated from the Codex turn and existing Hermes progress callbacks. Plugins should return quickly and move network or durable processing to their own bounded background path.
 
 ### `pre_tool_call`
 


### PR DESCRIPTION
## What does this PR do?

Exposes a generic codex_app_server_event plugin hook from the existing Codex App Server runtime. Standalone observer integrations can consume bounded lifecycle notifications without patching Hermes internals.

The bridge emits only thread/started, turn/started, item/started, item/completed, and turn/completed. Payloads are allowlisted and omit prompts, model output, reasoning, commands, arguments, deltas, and token usage. Plugin failures are isolated from the existing runtime callback path. No third-party integration is included in this PR.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Security fix
- [x] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Register codex_app_server_event as an observer-only plugin hook.
- Sanitize and publish five low-volume lifecycle events with Hermes session and runtime correlation.
- Document the hook contract and privacy boundary.
- Add bridge, plugin registry, ordering, privacy, and failure-isolation tests.

## How to Test

1. Run: uv run pytest -q tests/agent/test_codex_app_server_event_bridge.py tests/agent/test_codex_app_server_persist.py tests/agent/test_codex_runtime_live_events.py tests/agent/transports/test_codex_app_server_runtime.py tests/agent/transports/test_codex_app_server_session.py tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_codex_app_server_lifecycle.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_lifecycle.py
2. Confirm: 170 passed.
3. Run: uv run ruff check agent/codex_runtime.py hermes_cli/plugins.py tests/agent/test_codex_app_server_event_bridge.py tests/hermes_cli/test_plugins.py
4. Confirm: All checks passed.

The complete pytest suite was also attempted in the current dev environment. Collection stopped on 11 existing optional ACP import errors after 29,924 of 29,976 tests were discovered, so this PR does not claim a full-suite pass.

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Commit follows Conventional Commits
- [x] Searched current open PRs for duplicates
- [x] PR contains only related files
- [ ] Full pytest tests/ -q passes in this local environment
- [x] Added tests for the new behavior
- [x] Tested on macOS 26.5.2 arm64 with Python 3.13.7

### Documentation and Housekeeping

- [x] Updated relevant documentation
- [x] cli-config.yaml.example: N/A, no config key added
- [x] CONTRIBUTING.md or AGENTS.md: N/A, no contributor workflow changed
- [x] Considered cross-platform impact; the hook path is pure Python and adds no OS-specific behavior
- [x] Tool descriptions and schemas: N/A, no tool behavior changed

## Screenshots / Logs

N/A. This is a runtime plugin contract with automated test coverage.