### PR TITLE
fix(agent): reject truncated JSON/fence auto-title fragments

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -274,6 +274,24 @@ def derive_title(user_message: str) -> Optional[str]:
     return line or None
 
 
+def _is_truncated_structured_output(raw: str) -> bool:
+    """True when *raw* is truncated JSON/array/fence output, not prose.
+
+    Called only after ``json.loads`` and the loose ``\"title\"`` scan fail, so a
+    complete object embedded in chatter still extracts via the loose path.
+    Structural signatures only — do not reject prose that starts with
+    markdown emphasis or quotes (``*Fix login*``, ``'Quoted'``).
+    """
+    if not raw:
+        return False
+    # Odd fence count ⇒ unclosed markdown code block (lone ``` is the classic).
+    if raw.count("```") % 2:
+        return True
+    # Leading object/array after failed parse ⇒ truncated structured output
+    # (including unquoted-key variants the loose scan never sees).
+    return raw.lstrip().startswith(("{", "["))
+
+
 def _extract_title_text(content: str) -> str:
     """Pull the title out of a model response.
 
@@ -301,6 +319,11 @@ def _extract_title_text(content: str) -> str:
             return json.loads(f'"{match.group(1)}"').strip()
         except ValueError:
             return match.group(1).strip()
+    # max_tokens can cut {"title":"..."} mid-response. json.loads and the
+    # closing-quote regex both fail; do not prose-fallback the fragment.
+    # Check on the raw response (before quote-strip / first-line pick).
+    if _is_truncated_structured_output(raw):
+        return ""
     # Prose fallback. Reuse the canonical scrubber so reasoning-model output
     # (<think>…) can't leak into a title, then keep the first real line.
     try:
@@ -315,20 +338,6 @@ def _extract_title_text(content: str) -> str:
     return raw.strip("\"'").strip()
 
 
-def _is_title_fragment(title: str) -> bool:
-    """True when *title* looks like truncated JSON/markdown, not a real name."""
-    if title.startswith(("{", "}", "*", "```")):
-        return True
-    # Quote-stripped leftover of `"title": "...` (prefix strip leaves `": "...`).
-    if title[:1] in "\"':":
-        return True
-    lowered = title.lower()
-    if lowered == "title" or lowered.startswith(("title\"", "title'")):
-        return True
-    # Only JSON punctuation / quotes / fence markers left.
-    return not re.search(r"[^\s{}\[\]\":,\\'`*]", title)
-
-
 def _clean_title(text: str) -> Optional[str]:
     """Normalize a model-produced title, or None when nothing usable remains."""
     title = " ".join((text or "").split())
@@ -338,11 +347,6 @@ def _clean_title(text: str) -> Optional[str]:
     # Trailing sentence punctuation reads wrong in a sidebar list.
     title = title.rstrip(".!,;:")
     if not title:
-        return None
-    # Truncated JSON / fence output is not a title. max_tokens=64 can cut
-    # {"title": "..."} so json.loads and the closing-quote regex both fail,
-    # and the prose fallback would otherwise persist the fragment.
-    if _is_title_fragment(title):
         return None
     if len(title) > 80:
         title = title[:77].rstrip() + "..."

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -315,6 +315,20 @@ def _extract_title_text(content: str) -> str:
     return raw.strip("\"'").strip()
 
 
+def _is_title_fragment(title: str) -> bool:
+    """True when *title* looks like truncated JSON/markdown, not a real name."""
+    if title.startswith(("{", "}", "*", "```")):
+        return True
+    # Quote-stripped leftover of `"title": "...` (prefix strip leaves `": "...`).
+    if title[:1] in "\"':":
+        return True
+    lowered = title.lower()
+    if lowered == "title" or lowered.startswith(("title\"", "title'")):
+        return True
+    # Only JSON punctuation / quotes / fence markers left.
+    return not re.search(r"[^\s{}\[\]\":,\\'`*]", title)
+
+
 def _clean_title(text: str) -> Optional[str]:
     """Normalize a model-produced title, or None when nothing usable remains."""
     title = " ".join((text or "").split())
@@ -324,6 +338,11 @@ def _clean_title(text: str) -> Optional[str]:
     # Trailing sentence punctuation reads wrong in a sidebar list.
     title = title.rstrip(".!,;:")
     if not title:
+        return None
+    # Truncated JSON / fence output is not a title. max_tokens=64 can cut
+    # {"title": "..."} so json.loads and the closing-quote regex both fail,
+    # and the prose fallback would otherwise persist the fragment.
+    if _is_title_fragment(title):
         return None
     if len(title) > 80:
         title = title[:77].rstrip() + "..."

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -134,7 +134,60 @@ class TestGenerateTitle:
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             assert generate_title("the login button is broken") == "Fix login button"
 
+    def test_accepts_markdown_emphasis_prose_title(self):
+        """Leading * is legit prose emphasis — not a truncated fence."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "*Fix the login flow*"
 
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("the login button is broken") == "*Fix the login flow*"
+
+    def test_accepts_quoted_prose_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "'Quoted phrase'"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            # _clean_title strips matching outer quotes after extract.
+            assert generate_title("quote this") == "Quoted phrase"
+
+    def test_accepts_double_quoted_prose_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '"Debug imports"'
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("debug imports") == "Debug imports"
+
+    def test_json_with_trailing_brace_chatter_still_extracts(self):
+        """Complete title object + trailing brace chatter must not look truncated."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            '{"title": "Fix login"} and chatter {step'
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("the login button is broken") == "Fix login"
+
+    def test_prose_with_braces_survives(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Use dict {key: value} carefully"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert (
+                generate_title("dict help") == "Use dict {key: value} carefully"
+            )
+
+    def test_rejects_unquoted_key_truncated_object(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '{title: "Fix login"'
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("fix the login button") is None
 
     def test_invokes_failure_callback_on_exception(self):
         """failure_callback must fire so the user sees a warning (issue #15775)."""

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -90,6 +90,50 @@ class TestGenerateTitle:
             assert len(title) == 80
             assert title.endswith("...")
 
+    def test_rejects_truncated_json_object_key(self):
+        """max_tokens can cut {"title": "..."} to {"title" — not a session name."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '{"title"'
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("fix the login button") is None
+
+    def test_rejects_bare_markdown_fence(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "```"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("fix the login button") is None
+
+    def test_rejects_truncated_json_title_value(self):
+        """Open-string JSON with no closing quote must not become the title."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            '{"title":"Investigate and fix the login butt'
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("fix the login button") is None
+
+    def test_accepts_valid_json_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '{"title":"Fix login button"}'
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("the login button is broken") == "Fix login button"
+
+    def test_accepts_plain_prose_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Fix login button"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("the login button is broken") == "Fix login button"
+
 
 
     def test_invokes_failure_callback_on_exception(self):


### PR DESCRIPTION
## Problem

Session auto-titles sometimes become raw model leftovers such as `{"title"`, `` ``` ``, or an open-string JSON fragment. Observed on auxiliary title generation when the response is truncated under `max_tokens=64`.

## Root cause

In `agent/title_generator.py`:

1. `generate_title` asks for `{"title":"..."}` with `max_tokens=64`
2. Truncated JSON fails `json.loads` in `_extract_title_text`
3. The closing-quote regex cannot match an unfinished string
4. The prose fallback returns the first line of the fragment
5. `_clean_title` only stripped whitespace/punctuation and accepted the garbage

## Fix

Add `_is_title_fragment` and reject those leftovers in `_clean_title`. `generate_title` returns `None`, so stage-1 derived titles are left alone instead of being overwritten with JSON/fence crumbs.

No `max_tokens` change, no stage-1 / provider changes.

## Why it matters

Sidebar session names are user-visible. Fragment titles look broken and erase a usable derived title for no benefit.

## Test plan

```bash
/Users/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_title_generator.py -q
# 38 passed @ 881f4717
```

Named coverage:

- `test_rejects_truncated_json_object_key`
- `test_rejects_bare_markdown_fence`
- `test_rejects_truncated_json_title_value`
- `test_accepts_valid_json_title`
- `test_accepts_plain_prose_title`

## Risk / blast radius

Low. Only model-produced titles that already look like truncated structured output are rejected. Valid JSON titles and plain prose still pass. Existing think-block and length tests green.

## Closest work

none found for #83903 (open auto-title PRs cover other roots: technical-history filter, profile store, API hook).

Fixes #83903

## Peer-review harden (`afeb511d`)

Accepted @thatssoheil / @asperger514 feedback:
- Structural reject in `_extract_title_text` (leading `{`/`[` or odd fence count) after failed parse + loose scan
- Dropped clean-title punctuation heuristic (false positives on emphasis / quoted titles)
- Do not claim bare one-word `Goal` truncation

**Tests:** `pytest tests/agent/test_title_generator.py -q` → **44 passed** @ `afeb511d`
