### PR TITLE
fix(sessions): list gateway reset continuations instead of hiding them

### DIFF
--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -98,19 +98,52 @@ _COMPRESSION_CHILD_SQL = (
 )
 
 
-# Rows that surface in pickers: roots + branch children (subagent runs and
-# compression continuations stay hidden).
-_LISTABLE_CHILD_SQL = f"(s.parent_session_id IS NULL OR {_BRANCH_CHILD_SQL.format(a='s')})"
+# A child whose parent ended at an explicit gateway conversation boundary
+# (reset/switch/timeout — the same set find_latest_gateway_session_for_peer
+# treats as non-recoverable) is a fresh user conversation, not a subagent run
+# or a compression continuation. It must surface in pickers and must NOT be a
+# cascade-delete target. Without this, every gateway reset (微信/飞书/TG 的
+# /new、idle/daily 超时重置) hid the new session from all session lists
+# (CLI /sessions, `hermes sessions list`, desktop sidebar, dashboard).
+#
+# The started_at >= p.ended_at guard keeps this from accidentally admitting
+# subagent rows whose parent happened to end with a boundary reason: a real
+# reset continuation is created only after its parent is ended, while a
+# delegate spawns while the parent is still live. The _delegate_from guard
+# additionally protects the ephemeral (schema-migration) path, which has no
+# outer delegate filter.
+_GATEWAY_BOUNDARY_END_REASONS = (
+    "'session_reset', 'session_switch', 'idle', 'daily',"
+    " 'suspended', 'resume_pending_expired'"
+)
+_GATEWAY_BOUNDARY_CHILD_SQL = (
+    "json_extract(COALESCE({a}.model_config, '{{}}'), '$._delegate_from') IS NULL"
+    " AND EXISTS (SELECT 1 FROM sessions p"
+    "            WHERE p.id = {a}.parent_session_id"
+    f"            AND p.end_reason IN ({_GATEWAY_BOUNDARY_END_REASONS})"
+    "            AND {a}.started_at >= p.ended_at)"
+)
+
+
+# Rows that surface in pickers: roots + branch children + gateway-boundary
+# children (subagent runs and compression continuations stay hidden).
+_LISTABLE_CHILD_SQL = (
+    f"(s.parent_session_id IS NULL OR {_BRANCH_CHILD_SQL.format(a='s')}"
+    f" OR {_GATEWAY_BOUNDARY_CHILD_SQL.format(a='s')})"
+)
 
 
 def _ephemeral_child_sql(alias: str = "s") -> str:
-    """Subagent runs (cascade-delete targets), not branches or compression tips."""
+    """Subagent runs (cascade-delete targets), not branches, gateway-boundary
+    children (real user conversations), or compression tips."""
     branch = _BRANCH_CHILD_SQL.format(a=alias)
     compression = _COMPRESSION_CHILD_SQL.format(a=alias)
+    boundary = _GATEWAY_BOUNDARY_CHILD_SQL.format(a=alias)
     return (
         f"({alias}.parent_session_id IS NOT NULL"
         f" AND NOT ({branch})"
-        f" AND NOT ({compression}))"
+        f" AND NOT ({compression})"
+        f" AND NOT ({boundary}))"
     )
 
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1920,6 +1920,47 @@ class TestListSessionsRich:
         assert "delegate" not in ids, "Delegate sub-agent should not appear in default list"
         assert "root" in ids
 
+    def test_gateway_reset_child_visible(self, db):
+        """A session created after a gateway reset (/new, idle/daily timeout,
+        session_switch) is a fresh user conversation — it must surface in
+        default listings even though it carries a parent_session_id.
+
+        Regression: gateway reset_session() writes parent_session_id for
+        lineage, but _LISTABLE_CHILD_SQL only admitted 'branched' parents, so
+        every reset continuation disappeared from all session lists.
+        """
+        db.create_session("reset-root", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason='session_reset' "
+            "WHERE id='reset-root'",
+            (time.time() - 10,),
+        )
+        db.create_session(
+            "reset-child", "weixin", parent_session_id="reset-root"
+        )
+        db.append_message("reset-child", "user", "继续聊")
+
+        sessions = db.list_sessions_rich()
+        ids = [s["id"] for s in sessions]
+        assert "reset-child" in ids, (
+            "Gateway reset continuation should appear in default list"
+        )
+
+    def test_gateway_reset_child_not_ephemeral(self, db):
+        """Reset-boundary children are real conversations — the ephemeral
+        (cascade-delete) classifier must exclude them alongside branches and
+        compression tips."""
+        import hermes_state_common as hsc
+
+        sql = hsc._ephemeral_child_sql("sessions")
+        # Boundary exclusion is wired in: a session_reset/daily/... parent
+        # keeps the child out of the ephemeral (cascade-delete) class.
+        assert "session_reset" in sql
+        assert "NOT (" in sql
+        assert hsc._GATEWAY_BOUNDARY_CHILD_SQL.format(
+            a="sessions"
+        ) in sql
+
 
 
 class TestCompressionChainProjection:


### PR DESCRIPTION
## Summary

A session created after a gateway reset (`/new`, idle/daily timeout, compression exhaustion) keeps `parent_session_id` for provenance, but `_LISTABLE_CHILD_SQL` only admitted `branched` parents. Every reset continuation was therefore classified as a hidden subagent/compression row and disappeared from **all** session listings — `hermes sessions list`, `/sessions`, desktop sidebar, dashboard — even though the transcript stayed intact in `state.db`. Worse, `_ephemeral_child_sql` also failed to exclude them, making reset continuations cascade-delete targets.

**Reproduced in production (2026-08-11):** a WeChat (`weixin`) conversation with 71 messages vanished from every list after a `session_reset`; only the empty 0-message pre-reset shell remained visible. The whole gateway-history pattern is affected: every reset hides the conversation that follows it.

## Fix

- New `_GATEWAY_BOUNDARY_CHILD_SQL`: a child is user-visible when its parent ended with a gateway conversation boundary (`session_reset`, `session_switch`, `idle`, `daily`, `suspended`, `resume_pending_expired` — the same set `find_latest_gateway_session_for_peer` treats as non-recoverable), guarded by:
  - `child.started_at >= parent.ended_at` — a real reset continuation is created only after its parent ended; delegates spawn while the parent is still live
  - `_delegate_from IS NULL` — protects the ephemeral/schema-migration path, which has no outer delegate filter
- `_LISTABLE_CHILD_SQL` admits boundary children; `_ephemeral_child_sql` excludes them (real conversations are never cascade-delete targets)
- Tests: `test_gateway_reset_child_visible` + `test_gateway_reset_child_not_ephemeral`; related suites pass (257 in test_hermes_state.py + test_resume_command.py, 16 compression)

## Relation to #83727

This addresses the same bug class previously attempted in #83727 ("fix(sessions): list reset continuations"), which was closed unmerged. This PR implements the same boundary end_reason set with additional guards (`started_at >= ended_at`, `_delegate_from`) and both list-visibility and ephemeral-classifier coverage. The bug is still live on `main` — reproduced against current upstream on 2026-08-11.

## Checklist

- [x] Root-cause traced to `reset_session()` writing `parent_session_id` (gateway/session.py) + `_LISTABLE_CHILD_SQL` visibility predicate (hermes_state_common.py)
- [x] Regression tests added; existing subagent-hidden and compression-projection tests still pass
- [x] E2E verified: data-layer fix restored the hidden production session; all listing entry points read `list_sessions_rich`
