### PR TITLE
fix: route Feishu card button clicks as regular agent messages

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3079,7 +3079,7 @@ class FeishuAdapter(BasePlatformAdapter):
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
 
-        synthetic_text = f"/card {action_tag}"
+        synthetic_text = f"🖱️ 卡片按钮点击: {action_tag}"
         if action_value:
             try:
                 synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
@@ -3098,12 +3098,13 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=None,
             user_id_alt=sender_profile["user_id_alt"],
         )
+        real_message_id = str(getattr(context, "open_message_id", "") or "")
         synthetic_event = MessageEvent(
             text=synthetic_text,
-            message_type=MessageType.COMMAND,
+            message_type=MessageType.TEXT,
             source=source,
             raw_message=data,
-            message_id=token or str(uuid.uuid4()),
+            message_id=real_message_id or token or str(uuid.uuid4()),
             channel_prompt=self._resolve_channel_prompt(chat_id),
             timestamp=datetime.now(),
         )


### PR DESCRIPTION
## Summary

Fixes the Feishu interactive-card button click path so clicks reach the agent session and replies can be delivered.

## Problem

When a user clicks a button on an interactive card (e.g. a custom card sent by the bot), the Feishu adapter synthesizes a `COMMAND` event with text `/card <tag> <value-json>` and uses the card-action token (`c-...`) as the message id. Two things go wrong:

1. **`/card` is not a registered slash command** — the gateway rejects it with `Unrecognized slash command /card` and the agent never sees the click. The "synthetic COMMAND events" routing documented in the adapter header was never actually wired up.
2. **Invalid reply target** — the card-action token is not a valid Feishu `open_message_id`, so the reply send fails with `99992354` (`The request you send is not a valid {open_message_id}`), even the plain-text fallback.

Observed in gateway log:

```
[Feishu] Routing card action 'button' from ou_xxx in oc_xxx as synthetic command
WARNING gateway.run: Unrecognized slash command /card from feishu — replying with unknown-command notice
WARNING gateway.platforms.base: [Feishu] Send failed: [99992354] ... Invalid ids: [c-...]
```

## Fix

In `_handle_card_action_event` (`plugins/platforms/feishu/adapter.py`):

- Synthesize button clicks as a plain **TEXT** message (`🖱️ 卡片按钮点击: <tag> <value-json>`) instead of a `COMMAND`/`/card` slash command, so the click flows into the agent session like any other user message and the agent can respond to it.
- Use the real `open_message_id` from the card-action callback `context` as the synthetic event's `message_id`, so replies are addressed to a valid message id and the send succeeds.

The `hermes_action` / `hermes_update_prompt_action` approval paths are untouched.

## Test Plan

Verified on a live gateway (Feishu, websocket mode):

- Before: clicking a card button produced `Unrecognized slash command /card` + `Send failed: 99992354`, no reply.
- After: clicking a card button delivers the click to the agent session; the agent receives the click text with the button tag and value JSON, and its reply is delivered successfully.
