### PR TITLE
fix(docker): preserve workspace mount provenance

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -132,7 +132,10 @@ def _register_task_cwd(task_id: str, cwd: str) -> None:
         return
     try:
         from tools.terminal_tool import register_task_env_overrides
-        register_task_env_overrides(task_id, {"cwd": _translate_acp_cwd(cwd)})
+        register_task_env_overrides(
+            task_id,
+            {"cwd": _translate_acp_cwd(cwd), "cwd_source": "session"},
+        )
     except Exception:
         logger.debug("Failed to register ACP task cwd override", exc_info=True)
 

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -120,7 +120,12 @@ def _acp_stderr_print(*args, **kwargs) -> None:
     print(*args, **kwargs)
 
 
-def _register_task_cwd(task_id: str, cwd: str) -> None:
+def _register_task_cwd(
+    task_id: str,
+    cwd: str,
+    *,
+    workspace_reset: bool = False,
+) -> None:
     """Bind a task/session id to the editor's working directory for tools.
 
     Zed can launch Hermes from a Windows workspace while the ACP process runs
@@ -132,10 +137,13 @@ def _register_task_cwd(task_id: str, cwd: str) -> None:
         return
     try:
         from tools.terminal_tool import register_task_env_overrides
-        register_task_env_overrides(
-            task_id,
-            {"cwd": _translate_acp_cwd(cwd), "cwd_source": "session"},
-        )
+        overrides: Dict[str, Any] = {
+            "cwd": _translate_acp_cwd(cwd),
+            "cwd_source": "session",
+        }
+        if workspace_reset:
+            overrides["workspace_reset"] = True
+        register_task_env_overrides(task_id, overrides)
     except Exception:
         logger.debug("Failed to register ACP task cwd override", exc_info=True)
 
@@ -364,7 +372,9 @@ class SessionManager:
         if state is None:
             return None
         state.cwd = cwd
-        _register_task_cwd(session_id, cwd)
+        # ACP load/resume cwd is the newly attached editor workspace root, not
+        # a live ``cd`` below the previously attached root.
+        _register_task_cwd(session_id, cwd, workspace_reset=True)
         self._persist(state)
         return state
 

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -309,6 +309,7 @@ def _process_single_prompt(
         }
         if prompt_data.get("cwd"):
             overrides["cwd"] = prompt_data["cwd"]
+            overrides["cwd_source"] = "container"
         register_task_env_overrides(task_id, overrides)
         if config.get("verbose"):
             print(f"   Prompt {prompt_index}: Using container image {container_image}")

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -56,7 +56,10 @@ class TestCreateSession:
 
         assert captured == {
             "task_id": "session-1",
-            "overrides": {"cwd": "/mnt/e/Projects/AI/paperclip"},
+            "overrides": {
+                "cwd": "/mnt/e/Projects/AI/paperclip",
+                "cwd_source": "session",
+            },
         }
 
 

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -149,6 +149,37 @@ class TestWslCwdTranslation:
         assert updated is not None
         assert updated.cwd == "/mnt/c/Users/foo/project"
 
+    def test_update_cwd_replaces_attached_docker_workspace_root(
+        self, manager, monkeypatch, tmp_path
+    ):
+        from tools import terminal_tool
+
+        first = tmp_path / "first-project"
+        second = tmp_path / "second-project"
+        first.mkdir()
+        second.mkdir()
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+        monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", True)
+        monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+        monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+
+        state = manager.create_session(cwd=str(first))
+        updated = manager.update_cwd(state.session_id, cwd=str(second))
+        resolved = terminal_tool._resolve_task_workspace(
+            {
+                "env_type": "docker",
+                "docker_mount_cwd_to_workspace": True,
+                "cwd": "/root",
+                "host_cwd": None,
+            },
+            state.session_id,
+        )
+
+        assert updated is not None
+        assert resolved.host_cwd == str(second)
+        assert resolved.container_cwd == "/workspace"
+
 # ---------------------------------------------------------------------------
 # fork
 # ---------------------------------------------------------------------------

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -10,7 +10,7 @@ import pytest
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from batch_runner import BatchRunner, _process_batch_worker
+from batch_runner import BatchRunner, _process_batch_worker, _process_single_prompt
 
 
 @pytest.fixture
@@ -26,6 +26,42 @@ def runner(tmp_path):
     r.output_file = output_file
     r.prompts_file = prompts_file
     return r
+
+
+def test_batch_cwd_is_tagged_as_container_provenance(monkeypatch):
+    captured = {}
+
+    class _Agent:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_conversation(self, prompt, task_id):
+            return {"messages": [], "completed": True, "api_calls": 1}
+
+        def _convert_to_trajectory_format(self, messages, prompt, completed):
+            return []
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr("batch_runner.AIAgent", _Agent)
+    monkeypatch.setattr("batch_runner.sample_toolsets_from_distribution", lambda value: [])
+    monkeypatch.setattr(
+        "tools.terminal_tool.register_task_env_overrides",
+        lambda task_id, overrides: captured.update(
+            {"task_id": task_id, "overrides": overrides}
+        ),
+    )
+
+    result = _process_single_prompt(
+        7,
+        {"prompt": "test", "image": "bench:latest", "cwd": "/tmp/project"},
+        1,
+        {"distribution": "minimal", "model": "test", "max_iterations": 1},
+    )
+
+    assert result["success"] is True
+    assert captured["task_id"] == "task_7"
+    assert captured["overrides"]["cwd"] == "/tmp/project"
+    assert captured["overrides"]["cwd_source"] == "container"
 
 
 class TestSaveCheckpoint:

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -17,7 +17,7 @@ from batch_runner import BatchRunner, _process_batch_worker, _process_single_pro
 def runner(tmp_path):
     """Create a BatchRunner with all paths pointing at tmp_path."""
     prompts_file = tmp_path / "prompts.jsonl"
-    prompts_file.write_text("")
+    prompts_file.write_text("", encoding="utf-8")
     output_file = tmp_path / "output.jsonl"
     checkpoint_file = tmp_path / "checkpoint.json"
     r = BatchRunner.__new__(BatchRunner)
@@ -71,7 +71,7 @@ class TestSaveCheckpoint:
         data = {"run_name": "test", "completed_prompts": [1, 2, 3], "batch_stats": {}}
         runner._save_checkpoint(data)
 
-        result = json.loads(runner.checkpoint_file.read_text())
+        result = json.loads(runner.checkpoint_file.read_text(encoding="utf-8"))
         assert result["run_name"] == "test"
         assert result["completed_prompts"] == [1, 2, 3]
 
@@ -79,7 +79,7 @@ class TestSaveCheckpoint:
         data = {"run_name": "test", "completed_prompts": []}
         runner._save_checkpoint(data)
 
-        result = json.loads(runner.checkpoint_file.read_text())
+        result = json.loads(runner.checkpoint_file.read_text(encoding="utf-8"))
         assert "last_updated" in result
         assert result["last_updated"] is not None
 
@@ -87,7 +87,7 @@ class TestSaveCheckpoint:
         runner._save_checkpoint({"run_name": "test", "completed_prompts": [1]})
         runner._save_checkpoint({"run_name": "test", "completed_prompts": [1, 2, 3]})
 
-        result = json.loads(runner.checkpoint_file.read_text())
+        result = json.loads(runner.checkpoint_file.read_text(encoding="utf-8"))
         assert result["completed_prompts"] == [1, 2, 3]
 
     def test_with_lock(self, runner):
@@ -95,7 +95,7 @@ class TestSaveCheckpoint:
         data = {"run_name": "test", "completed_prompts": [42]}
         runner._save_checkpoint(data, lock=lock)
 
-        result = json.loads(runner.checkpoint_file.read_text())
+        result = json.loads(runner.checkpoint_file.read_text(encoding="utf-8"))
         assert result["completed_prompts"] == [42]
 
 
@@ -123,14 +123,14 @@ class TestLoadCheckpoint:
     def test_loads_existing_checkpoint(self, runner):
         data = {"run_name": "test_run", "completed_prompts": [5, 10, 15],
                 "batch_stats": {"0": {"processed": 3}}}
-        runner.checkpoint_file.write_text(json.dumps(data))
+        runner.checkpoint_file.write_text(json.dumps(data), encoding="utf-8")
 
         result = runner._load_checkpoint()
         assert result["completed_prompts"] == [5, 10, 15]
         assert result["batch_stats"]["0"]["processed"] == 3
 
     def test_handles_corrupt_json(self, runner):
-        runner.checkpoint_file.write_text("{broken json!!")
+        runner.checkpoint_file.write_text("{broken json!!", encoding="utf-8")
 
         result = runner._load_checkpoint()
         # Should return empty/default, not crash
@@ -148,7 +148,7 @@ class TestResumePreservesProgress:
             "batch_stats": {"0": {"processed": 5}},
             "last_updated": "2026-01-01T00:00:00",
         }
-        runner.checkpoint_file.write_text(json.dumps(prior))
+        runner.checkpoint_file.write_text(json.dumps(prior), encoding="utf-8")
 
         # Load checkpoint like run() does
         checkpoint_data = runner._load_checkpoint()
@@ -169,7 +169,7 @@ class TestResumePreservesProgress:
             "completed_prompts": [0, 1, 2],
             "batch_stats": {},
         }
-        runner.checkpoint_file.write_text(json.dumps(prior))
+        runner.checkpoint_file.write_text(json.dumps(prior), encoding="utf-8")
 
         checkpoint_data = runner._load_checkpoint()
         if checkpoint_data.get("run_name") != runner.run_name:
@@ -211,7 +211,6 @@ class TestBatchWorkerResumeBehavior:
 
         assert result["discarded_no_reasoning"] == 1
         assert result["completed_prompts"] == [0]
-
         # A tombstone row must be written so the content-based resume scan
         # can see this prompt was already processed and discarded.
         assert batch_file.exists()
@@ -303,7 +302,7 @@ class TestFinalCheckpointNoDuplicates:
             "completed_prompts": final,
             "batch_stats": {},
         })
-        loaded = json.loads(runner.checkpoint_file.read_text())
+        loaded = json.loads(runner.checkpoint_file.read_text(encoding="utf-8"))
         cp = loaded["completed_prompts"]
         assert cp == sorted(set(cp))
         assert len(cp) == 4

--- a/tests/tools/test_docker_session_isolation.py
+++ b/tests/tools/test_docker_session_isolation.py
@@ -175,6 +175,57 @@ class TestSessionScopedMountResolution:
         cfg = self._config(host_cwd="/Users/prev/dev/oldrepo")
         assert terminal_tool._resolve_task_host_cwd(cfg, "tui:sess-new") == str(ws)
 
+    def test_terminal_maps_attached_host_workspace_to_container_cwd(
+        self, monkeypatch, tmp_path
+    ):
+        """Mount provenance, not path spelling, determines Docker's cwd."""
+        _enable_isolation(monkeypatch)
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+        task_id = "tui:sess-mapped"
+        terminal_tool.register_task_env_overrides(
+            task_id, {"cwd": str(workspace), "cwd_source": "session"}
+        )
+
+        config = {
+            "env_type": "docker",
+            "docker_image": "test:latest",
+            "cwd": "/root",
+            "host_cwd": None,
+            "timeout": 60,
+            "container_persistent": False,
+            "docker_mount_cwd_to_workspace": True,
+            "docker_volumes": [],
+            "docker_forward_env": [],
+            "docker_env": {},
+            "docker_extra_args": [],
+        }
+        captured = {}
+
+        class _FakeEnv:
+            cwd = "/workspace"
+
+            def execute(self, *args, **kwargs):
+                return {"output": "", "exit_code": 0}
+
+        def _capture_environment(**kwargs):
+            captured.update(kwargs)
+            return _FakeEnv()
+
+        monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+        monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(
+            terminal_tool, "_check_all_guards", lambda *args, **kwargs: {"approved": True}
+        )
+        monkeypatch.setattr(terminal_tool, "_create_environment", _capture_environment)
+        monkeypatch.setattr(terminal_tool, "_active_environments", {})
+        monkeypatch.setattr(terminal_tool, "_last_activity", {})
+
+        terminal_tool.terminal_tool(command="pwd", task_id=task_id)
+
+        assert captured["host_cwd"] == str(workspace)
+        assert captured["cwd"] == "/workspace"
+
     def test_isolation_rejects_nonexistent_session_dir(self, monkeypatch, tmp_path):
         _enable_isolation(monkeypatch)
         terminal_tool.register_task_env_overrides(

--- a/tests/tools/test_docker_workspace_provenance.py
+++ b/tests/tools/test_docker_workspace_provenance.py
@@ -159,3 +159,41 @@ def test_explicit_workspace_reset_replaces_preserved_mount_root(tmp_path):
 
     assert resolved.host_cwd == str(second)
     assert resolved.container_cwd == "/workspace"
+
+
+def test_workspace_root_read_modify_write_holds_override_lock(monkeypatch):
+    class ObservedLock:
+        held = False
+
+        def __enter__(self):
+            assert not self.held
+            self.held = True
+
+        def __exit__(self, *_args):
+            self.held = False
+
+    lock = ObservedLock()
+
+    class GuardedOverrides(dict):
+        def get(self, *args, **kwargs):
+            assert lock.held
+            return super().get(*args, **kwargs)
+
+        def __setitem__(self, key, value):
+            assert lock.held
+            return super().__setitem__(key, value)
+
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides_lock", lock)
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", GuardedOverrides())
+
+    terminal_tool.register_task_env_overrides(
+        "session", {"cwd": "/first", "cwd_source": "session"}
+    )
+    terminal_tool.register_task_env_overrides(
+        "session",
+        {"cwd": "/second", "cwd_source": "session", "workspace_reset": True},
+    )
+
+    assert terminal_tool._task_env_overrides["session"]["host_workspace_root"] == (
+        "/second"
+    )

--- a/tests/tools/test_docker_workspace_provenance.py
+++ b/tests/tools/test_docker_workspace_provenance.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import PureWindowsPath
+
 import pytest
 
 from tools import code_execution_tool, file_tools, terminal_tool
@@ -82,6 +84,58 @@ def test_live_host_cwd_keeps_relative_suffix_below_workspace(tmp_path):
     assert resolved.container_cwd == "/workspace/src/pkg"
 
 
+def test_windows_suffix_is_joined_with_container_path_semantics(monkeypatch):
+    monkeypatch.setattr(
+        terminal_tool,
+        "_relative_host_suffix",
+        lambda _cwd, _host_root: r"src\pkg",
+    )
+    monkeypatch.setattr(terminal_tool, "_HOST_PURE_PATH", PureWindowsPath)
+
+    assert (
+        terminal_tool._container_cwd_for_host_path(
+            r"C:\project\src\pkg", r"C:\project"
+        )
+        == "/workspace/src/pkg"
+    )
+
+
+@pytest.mark.windows_only
+def test_native_windows_host_path_maps_to_posix_container_cwd(tmp_path):
+    host_root = tmp_path / "project"
+    live_cwd = host_root / "src" / "pkg"
+    live_cwd.mkdir(parents=True)
+
+    assert (
+        terminal_tool._container_cwd_for_host_path(
+            str(live_cwd), str(host_root)
+        )
+        == "/workspace/src/pkg"
+    )
+
+
+def test_recorded_host_cwd_is_not_remapped_without_an_active_mount():
+    host_root = "/Users/example/project"
+    terminal_tool.register_task_env_overrides(
+        "session", {"cwd": host_root, "cwd_source": "session"}
+    )
+    workspace = terminal_tool._resolve_task_workspace(
+        _config(docker_mount_cwd_to_workspace=False), "session"
+    )
+
+    resolved = terminal_tool._resolve_command_cwd(
+        workdir=None,
+        default_cwd=workspace.container_cwd,
+        session_key="session",
+        env_type="docker",
+        host_workspace_root=workspace.host_cwd,
+    )
+
+    assert workspace.host_cwd is None
+    assert workspace.container_cwd == "/root"
+    assert resolved == "/root"
+
+
 @pytest.mark.parametrize("cwd_source", [None, "container"])
 def test_non_session_cwd_never_becomes_host_mount_by_coincidence(tmp_path, cwd_source):
     container_cwd = tmp_path / "benchmark"
@@ -159,6 +213,98 @@ def test_explicit_workspace_reset_replaces_preserved_mount_root(tmp_path):
 
     assert resolved.host_cwd == str(second)
     assert resolved.container_cwd == "/workspace"
+
+
+def test_workspace_reset_recreates_live_environment_and_file_cache(
+    monkeypatch, tmp_path
+):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _config())
+    terminal_tool.register_task_env_overrides(
+        "session", {"cwd": str(first), "cwd_source": "session"}
+    )
+
+    cleanup_calls = []
+
+    class _OldEnv:
+        cwd = "/workspace"
+
+        def cleanup(self, *, force_remove=False):
+            cleanup_calls.append(("cleanup", force_remove))
+
+        def wait_for_cleanup(self, timeout=30.0):
+            cleanup_calls.append(("wait", timeout))
+            return True
+
+    terminal_tool._active_environments["session"] = _OldEnv()
+    file_tools._file_ops_cache["session"] = object()
+
+    terminal_tool.register_task_env_overrides(
+        "session",
+        {
+            "cwd": str(second),
+            "cwd_source": "session",
+            "workspace_reset": True,
+        },
+    )
+
+    captured = {}
+
+    class _NewEnv:
+        cwd = "/workspace"
+
+    def _capture_environment(**kwargs):
+        captured.update(kwargs)
+        return _NewEnv()
+
+    monkeypatch.setattr(terminal_tool, "_create_environment", _capture_environment)
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+
+    recreated = terminal_tool.ensure_task_env("session")
+
+    assert cleanup_calls == [("cleanup", True), ("wait", 60.0)]
+    assert "session" not in file_tools._file_ops_cache
+    assert recreated is not None
+    assert captured["host_cwd"] == str(second)
+    assert captured["cwd"] == "/workspace"
+
+
+def test_workspace_reset_without_mount_keeps_live_environment(monkeypatch):
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: _config(docker_mount_cwd_to_workspace=False),
+    )
+    terminal_tool.register_task_env_overrides(
+        "session", {"cwd": "/Users/example/first", "cwd_source": "session"}
+    )
+
+    class _ExistingEnv:
+        cwd = "/workspace"
+
+        def cleanup(self, *, force_remove=False):
+            raise AssertionError("an unmounted workspace must not retire the sandbox")
+
+    existing = _ExistingEnv()
+    cached = object()
+    terminal_tool._active_environments["session"] = existing
+    file_tools._file_ops_cache["session"] = cached
+
+    terminal_tool.register_task_env_overrides(
+        "session",
+        {
+            "cwd": "/Users/example/second",
+            "cwd_source": "session",
+            "workspace_reset": True,
+        },
+    )
+
+    assert terminal_tool._active_environments["session"] is existing
+    assert existing.cwd == "/root"
+    assert file_tools._file_ops_cache["session"] is cached
 
 
 def test_workspace_root_read_modify_write_holds_override_lock(monkeypatch):

--- a/tests/tools/test_docker_workspace_provenance.py
+++ b/tests/tools/test_docker_workspace_provenance.py
@@ -1,0 +1,161 @@
+"""Regression coverage for provenance-aware Docker workspace mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools import code_execution_tool, file_tools, terminal_tool
+
+
+@pytest.fixture(autouse=True)
+def _isolated_tool_state(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", True)
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_creation_locks", {})
+    monkeypatch.setattr(file_tools, "_file_ops_cache", {})
+
+
+def _config(**overrides):
+    config = {
+        "env_type": "docker",
+        "docker_image": "test:latest",
+        "singularity_image": "docker://test:latest",
+        "modal_image": "test:latest",
+        "daytona_image": "test:latest",
+        "cwd": "/root",
+        "host_cwd": None,
+        "timeout": 60,
+        "container_persistent": False,
+        "container_cpu": 1,
+        "container_memory": 5120,
+        "container_disk": 51200,
+        "docker_mount_cwd_to_workspace": True,
+        "docker_volumes": [],
+        "docker_forward_env": [],
+        "docker_env": {},
+        "docker_extra_args": [],
+        "docker_run_as_host_user": False,
+        "docker_network": True,
+    }
+    config.update(overrides)
+    return config
+
+
+@pytest.mark.parametrize(
+    "host_root",
+    [
+        "/tmp/project",
+        "/root/project",
+        "/workspace/project",
+        "/workspace-old/project",
+    ],
+)
+def test_session_provenance_overrides_host_path_heuristics(monkeypatch, host_root):
+    monkeypatch.setattr(terminal_tool.os.path, "isdir", lambda path: path == host_root)
+    terminal_tool.register_task_env_overrides(
+        "session", {"cwd": host_root, "cwd_source": "session"}
+    )
+
+    resolved = terminal_tool._resolve_task_workspace(_config(), "session")
+
+    assert resolved.host_cwd == host_root
+    assert resolved.container_cwd == "/workspace"
+
+
+def test_live_host_cwd_keeps_relative_suffix_below_workspace(tmp_path):
+    host_root = tmp_path / "project"
+    live_cwd = host_root / "src" / "pkg"
+    live_cwd.mkdir(parents=True)
+    terminal_tool.register_task_env_overrides(
+        "session", {"cwd": str(host_root), "cwd_source": "session"}
+    )
+    terminal_tool.record_session_cwd("session", str(live_cwd))
+
+    resolved = terminal_tool._resolve_task_workspace(_config(), "session")
+
+    assert resolved.host_cwd == str(host_root)
+    assert resolved.container_cwd == "/workspace/src/pkg"
+
+
+@pytest.mark.parametrize("cwd_source", [None, "container"])
+def test_non_session_cwd_never_becomes_host_mount_by_coincidence(tmp_path, cwd_source):
+    container_cwd = tmp_path / "benchmark"
+    container_cwd.mkdir()
+    overrides = {"cwd": str(container_cwd), "docker_image": "bench:latest"}
+    if cwd_source is not None:
+        overrides["cwd_source"] = cwd_source
+    terminal_tool.register_task_env_overrides("benchmark", overrides)
+
+    resolved = terminal_tool._resolve_task_workspace(_config(), "benchmark")
+
+    assert resolved.host_cwd is None
+    assert resolved.container_cwd == str(container_cwd)
+
+
+def test_terminal_file_and_execute_code_share_workspace_mapping(monkeypatch, tmp_path):
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    config = _config()
+    captured = {}
+
+    class _FakeEnv:
+        cwd = "/workspace"
+
+        def execute(self, *args, **kwargs):
+            return {"output": "", "exit_code": 0}
+
+    def _capture_environment(**kwargs):
+        captured[kwargs["task_id"]] = kwargs
+        return _FakeEnv()
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool, "_create_environment", _capture_environment)
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool, "_check_all_guards", lambda *args, **kwargs: {"approved": True}
+    )
+
+    for task_id in ("terminal-session", "file-session", "code-session"):
+        terminal_tool.register_task_env_overrides(
+            task_id, {"cwd": str(workspace), "cwd_source": "session"}
+        )
+
+    terminal_tool.terminal_tool(command="pwd", task_id="terminal-session")
+    file_tools._get_file_ops("file-session")
+    code_execution_tool._get_or_create_env("code-session")
+
+    for task_id in ("terminal-session", "file-session", "code-session"):
+        assert captured[task_id]["host_cwd"] == str(workspace)
+        assert captured[task_id]["cwd"] == "/workspace"
+    assert (
+        captured["code-session"]["container_config"]["docker_mount_cwd_to_workspace"]
+        is True
+    )
+
+
+def test_explicit_workspace_reset_replaces_preserved_mount_root(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    terminal_tool.register_task_env_overrides(
+        "session", {"cwd": str(first), "cwd_source": "session"}
+    )
+    terminal_tool.register_task_env_overrides(
+        "session",
+        {
+            "cwd": str(second),
+            "cwd_source": "session",
+            "workspace_reset": True,
+        },
+    )
+
+    resolved = terminal_tool._resolve_task_workspace(_config(), "session")
+
+    assert resolved.host_cwd == str(second)
+    assert resolved.container_cwd == "/workspace"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -818,8 +818,9 @@ def _get_or_create_env(task_id: str):
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
-        _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id, _resolve_task_host_cwd,
+        _creation_locks, _creation_locks_lock,
+        _resolve_container_task_id, _resolve_task_workspace,
+        resolve_task_overrides,
     )
 
     effective_task_id = _resolve_container_task_id(task_id)
@@ -844,7 +845,7 @@ def _get_or_create_env(task_id: str):
 
         config = _get_env_config()
         env_type = config["env_type"]
-        overrides = _task_env_overrides.get(effective_task_id, {})
+        overrides = resolve_task_overrides(task_id)
 
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]
@@ -857,7 +858,8 @@ def _get_or_create_env(task_id: str):
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or config["cwd"]
+        workspace = _resolve_task_workspace(config, task_id)
+        cwd = workspace.container_cwd
 
         container_config = None
         from tools.terminal_tool import _is_container_backend as _is_container
@@ -870,6 +872,9 @@ def _get_or_create_env(task_id: str):
                 "container_persistent": config.get("container_persistent", True),
                 "vercel_runtime": config.get("vercel_runtime", ""),
                 "docker_volumes": config.get("docker_volumes", []),
+                "docker_mount_cwd_to_workspace": config.get(
+                    "docker_mount_cwd_to_workspace", False
+                ),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_network": config.get("docker_network", True),
             }
@@ -901,7 +906,7 @@ def _get_or_create_env(task_id: str):
             container_config=container_config,
             local_config=local_config,
             task_id=effective_task_id,
-            host_cwd=_resolve_task_host_cwd(config, task_id),
+            host_cwd=workspace.host_cwd,
         )
 
         with _env_lock:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1427,9 +1427,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _creation_locks,
         _creation_locks_lock,
         _resolve_container_task_id,
-        _resolve_task_host_cwd,
-        _is_unusable_container_cwd,
-        _CONTAINER_BACKENDS,
+        _resolve_task_workspace,
     )
     import time
 
@@ -1510,27 +1508,9 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 recorded_cwd = get_session_cwd(raw_task_id)
             except Exception:
                 recorded_cwd = None
-            cwd = overrides.get("cwd") or recorded_cwd or config["cwd"]
-            # Re-apply the container cwd guard that _get_env_config() already
-            # ran on config["cwd"] (see #50636).  A per-task cwd override
-            # registered by the gateway/TUI/ACP for workspace tracking is a
-            # raw host path (e.g. a Desktop session's /Users/<me>/workspace or
-            # C:\\Users\\<me>). On a container backend that reaches
-            # ``docker run -w <host-path>`` and the container starts in a
-            # directory that doesn't exist inside the sandbox, so search_files
-            # and friends silently return empty results (#54447).  Sanitize it
-            # back to the already-validated config["cwd"] so the override can't
-            # bypass the guard.  Valid in-container override paths (RL/benchmark
-            # sandboxes that set cwd to /workspace, /root, etc.) are absolute
-            # non-host paths and pass through untouched.
-            if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
-                if cwd != config["cwd"]:
-                    logger.info(
-                        "Ignoring host/relative cwd override %r for %s backend "
-                        "(won't exist in sandbox). Using %r instead.",
-                        cwd, env_type, config["cwd"],
-                    )
-                cwd = config["cwd"]
+            cwd = recorded_cwd or overrides.get("cwd") or config["cwd"]
+            workspace = _resolve_task_workspace(config, raw_task_id, str(cwd))
+            cwd = workspace.container_cwd
             logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
 
             container_config = None
@@ -1575,7 +1555,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 container_config=container_config,
                 local_config=local_config,
                 task_id=task_id,
-                host_cwd=_resolve_task_host_cwd(config, raw_task_id),
+                host_cwd=workspace.host_cwd,
             )
 
             with _env_lock:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1228,8 +1228,8 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
 # and fall back to the TERMINAL_MODAL_IMAGE (etc.) env var if no override is set.
 #
 # This is never exposed to the model -- only infrastructure code calls it.
-# Thread-safe because each task_id is unique per rollout.
 _task_env_overrides: Dict[str, Dict[str, Any]] = {}
+_task_env_overrides_lock = threading.RLock()
 
 # ── Per-session cwd records (cwd rearchitecture, step 1) ────────────────────
 #
@@ -1309,15 +1309,22 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         overrides: Dict of config keys to override
     """
     normalized = dict(overrides)
-    previous = _task_env_overrides.get(task_id, {})
     workspace_reset = bool(normalized.pop("workspace_reset", False))
     cwd = normalized.get("cwd")
-    if normalized.get("cwd_source") == "session" and isinstance(cwd, str) and cwd.strip():
-        if workspace_reset or not previous.get("host_workspace_root"):
-            normalized["host_workspace_root"] = cwd
-        else:
-            normalized["host_workspace_root"] = previous["host_workspace_root"]
-    _task_env_overrides[task_id] = normalized
+    with _task_env_overrides_lock:
+        previous = _task_env_overrides.get(task_id, {})
+        if (
+            normalized.get("cwd_source") == "session"
+            and isinstance(cwd, str)
+            and cwd.strip()
+        ):
+            if workspace_reset or not previous.get("host_workspace_root"):
+                normalized["host_workspace_root"] = cwd
+            else:
+                normalized["host_workspace_root"] = previous[
+                    "host_workspace_root"
+                ]
+        _task_env_overrides[task_id] = normalized
 
     # If a live environment already exists for this task, a freshly registered
     # ``cwd`` override (e.g. the ACP client switching the editor's project root
@@ -1347,7 +1354,8 @@ def clear_task_env_overrides(task_id: str):
 
     Called during cleanup to avoid stale entries accumulating.
     """
-    _task_env_overrides.pop(task_id, None)
+    with _task_env_overrides_lock:
+        _task_env_overrides.pop(task_id, None)
     clear_session_cwd(task_id)
     with _container_alias_lock:
         _container_aliases.pop(task_id, None)
@@ -1468,9 +1476,11 @@ def _has_isolation_overrides(task_id: Optional[str]) -> bool:
     predicate — shared by container-key resolution and container creation so
     the two can't drift.
     """
-    if not task_id or task_id not in _task_env_overrides:
+    if not task_id:
         return False
-    return bool(set(_task_env_overrides[task_id].keys()) & _ISOLATION_OVERRIDE_KEYS)
+    with _task_env_overrides_lock:
+        overrides = _task_env_overrides.get(task_id)
+        return bool(overrides and set(overrides) & _ISOLATION_OVERRIDE_KEYS)
 
 
 def _resolve_container_task_id(task_id: Optional[str]) -> str:
@@ -1565,11 +1575,13 @@ def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
     source of that lookup so the terminal and file layers can't drift apart.
     """
     raw = task_id or "default"
-    return (
-        _task_env_overrides.get(raw)
-        or _task_env_overrides.get(_resolve_container_task_id(raw))
-        or {}
-    )
+    with _task_env_overrides_lock:
+        direct = _task_env_overrides.get(raw)
+    if direct:
+        return direct
+    collapsed = _resolve_container_task_id(raw)
+    with _task_env_overrides_lock:
+        return _task_env_overrides.get(collapsed) or {}
 
 
 def _relative_host_suffix(cwd: str, host_root: str) -> Optional[str]:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -46,6 +46,7 @@ import threading
 import atexit
 import shutil
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -1248,6 +1249,14 @@ _session_cwd: Dict[str, str] = {}
 _session_cwd_lock = threading.Lock()
 
 
+@dataclass(frozen=True)
+class TaskWorkspaceResolution:
+    """Docker workspace mapping resolved from one provenance-aware policy."""
+
+    host_cwd: Optional[str]
+    container_cwd: str
+
+
 def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
     """Record *cwd* as the working directory of *session_key*.
 
@@ -1299,14 +1308,23 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         task_id: The rollout's unique task identifier
         overrides: Dict of config keys to override
     """
-    _task_env_overrides[task_id] = overrides
+    normalized = dict(overrides)
+    previous = _task_env_overrides.get(task_id, {})
+    workspace_reset = bool(normalized.pop("workspace_reset", False))
+    cwd = normalized.get("cwd")
+    if normalized.get("cwd_source") == "session" and isinstance(cwd, str) and cwd.strip():
+        if workspace_reset or not previous.get("host_workspace_root"):
+            normalized["host_workspace_root"] = cwd
+        else:
+            normalized["host_workspace_root"] = previous["host_workspace_root"]
+    _task_env_overrides[task_id] = normalized
 
     # If a live environment already exists for this task, a freshly registered
     # ``cwd`` override (e.g. the ACP client switching the editor's project root
     # mid-session via ``session/load`` / ``session/resume``) must take effect
     # immediately. The session record is what commands resolve against;
     # the live env's cwd is also updated so env-side seeding stays consistent.
-    new_cwd = overrides.get("cwd")
+    new_cwd = normalized.get("cwd")
     if isinstance(new_cwd, str) and new_cwd.strip():
         # A registered workspace cwd IS the session's working directory until
         # a `cd` changes it.
@@ -1554,48 +1572,71 @@ def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
     )
 
 
-def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Optional[str]:
-    """Host directory to bind-mount at ``/workspace`` for *task_id*'s container.
+def _relative_host_suffix(cwd: str, host_root: str) -> Optional[str]:
+    """Return *cwd* relative to *host_root*, or ``None`` when it is outside."""
+    try:
+        root = os.path.abspath(os.path.expanduser(host_root))
+        path = os.path.abspath(os.path.expanduser(cwd))
+        if os.path.commonpath((root, path)) != root:
+            return None
+        return os.path.relpath(path, root)
+    except (OSError, ValueError):
+        return None
 
-    The single owner of the cwd-mount policy, shared by every environment
-    creation site (terminal tool, file tools, execute_code, lazy bring-up):
 
-    * Shared-container mode (the default): the process-global
-      ``TERMINAL_CWD``-derived ``config["host_cwd"]`` — unchanged legacy
-      behavior, ONE container whose mount tracks the configured workspace.
-    * Per-session isolation mode (docker + ``container_persistent: false``):
-      only the SESSION's own registered workspace may mount.  The process
-      env var is a launch artifact — the TUI/desktop workspace picker writes
-      ``os.environ["TERMINAL_CWD"]`` and it outlives the session that set it,
-      so deriving a fresh session's mount from it leaks the previous
-      session's directory into a chat that never attached one.  Overrides
-      tagged ``cwd_source: "process"`` (gateway fallback to the global env
-      var) are likewise refused as mount sources; only a workspace the user
-      actually attached to THIS session (``cwd_source: "session"`` or an
-      untagged override from ACP/RL surfaces) mounts.
+def _container_cwd_for_host_path(cwd: str, host_root: str) -> str:
+    """Map a host workspace path to its location below Docker's ``/workspace``."""
+    suffix = _relative_host_suffix(cwd, host_root)
+    if suffix == ".":
+        return "/workspace"
+    if suffix is not None:
+        return str(Path("/workspace") / suffix)
+    if cwd == "/workspace" or cwd.startswith("/workspace/"):
+        return cwd
+    return "/workspace"
+
+
+def _resolve_task_workspace(
+    config: Dict[str, Any],
+    task_id: Optional[str],
+    requested_cwd: Optional[str] = None,
+) -> TaskWorkspaceResolution:
+    """Resolve Docker's bind source and command cwd as one atomic decision.
+
+    Under per-session isolation, only explicitly session-sourced cwd values are
+    host workspaces. Untagged, process, and benchmark/container values fail
+    closed as bind-mount sources even when an identically named host path exists.
     """
-    if config.get("env_type") != "docker":
-        return None
-    if not config.get("docker_mount_cwd_to_workspace"):
-        return None
-    if not _docker_session_isolation_enabled():
-        return config.get("host_cwd")
-    if _resolve_container_task_id(task_id) == "default":
-        # Top-level CLI parent — single-session process, legacy behavior.
-        return config.get("host_cwd")
     overrides = resolve_task_overrides(task_id)
-    if overrides.get("cwd_source") == "process":
-        return None
-    candidate = overrides.get("cwd")
-    if not isinstance(candidate, str) or not candidate.strip():
-        return None
-    candidate = os.path.abspath(os.path.expanduser(candidate))
-    if not os.path.isdir(candidate):
-        return None
-    if candidate.startswith(("/workspace", "/root")):
-        # Already an in-container path, not a host workspace.
-        return None
-    return candidate
+    default_cwd = str(config.get("cwd") or "/workspace")
+    cwd = requested_cwd or get_session_cwd(task_id) or overrides.get("cwd") or default_cwd
+    env_type = config.get("env_type")
+    host_cwd: Optional[str] = None
+
+    if env_type == "docker" and config.get("docker_mount_cwd_to_workspace"):
+        if (
+            not _docker_session_isolation_enabled()
+            or _resolve_container_task_id(task_id) == "default"
+        ):
+            host_cwd = config.get("host_cwd")
+        elif overrides.get("cwd_source") == "session":
+            candidate = overrides.get("host_workspace_root") or overrides.get("cwd")
+            if isinstance(candidate, str) and candidate.strip():
+                candidate = os.path.abspath(os.path.expanduser(candidate))
+                if os.path.isdir(candidate):
+                    host_cwd = candidate
+
+    if host_cwd:
+        cwd = _container_cwd_for_host_path(str(cwd), host_cwd)
+    elif _is_container_backend(str(env_type)) and _is_unusable_container_cwd(str(cwd)):
+        cwd = default_cwd
+
+    return TaskWorkspaceResolution(host_cwd=host_cwd, container_cwd=str(cwd))
+
+
+def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Optional[str]:
+    """Compatibility wrapper for callers that only need the bind source."""
+    return _resolve_task_workspace(config, task_id).host_cwd
 
 
 # Configuration from environment variables
@@ -2308,6 +2349,7 @@ def ensure_task_env(task_id: Optional[str] = None):
         image = ""
 
     _start_cleanup_thread()
+    workspace = _resolve_task_workspace(config, task_id)
 
     # Per-task creation lock so a concurrent terminal_tool call and this helper
     # don't each spawn a sandbox for the same task.
@@ -2322,7 +2364,7 @@ def ensure_task_env(task_id: Optional[str] = None):
             new_env = _create_environment(
                 env_type=env_type,
                 image=image,
-                cwd=config["cwd"],
+                cwd=workspace.container_cwd,
                 timeout=config["timeout"],
                 ssh_config=_ssh_config_from_config(config) if env_type == "ssh" else None,
                 container_config=(
@@ -2331,7 +2373,7 @@ def ensure_task_env(task_id: Optional[str] = None):
                 ),
                 local_config=None,
                 task_id=effective_task_id,
-                host_cwd=_resolve_task_host_cwd(config, task_id),
+                host_cwd=workspace.host_cwd,
             )
         except Exception as exc:  # noqa: BLE001 — best-effort bring-up
             logger.warning(
@@ -2802,6 +2844,11 @@ def _resolve_command_cwd(
     if workdir:
         return workdir
     recorded = get_session_cwd(session_key)
+    if recorded and env_type == "docker":
+        overrides = resolve_task_overrides(session_key)
+        host_root = overrides.get("host_workspace_root")
+        if overrides.get("cwd_source") == "session" and isinstance(host_root, str):
+            return _container_cwd_for_host_path(recorded, host_root)
     if (
         recorded
         and _is_container_backend(env_type)
@@ -2908,33 +2955,13 @@ def terminal_tool(
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or get_session_cwd(task_id) or config["cwd"]
-        # Session-scoped mount resolution (single owner: _resolve_task_host_cwd).
+        cwd = get_session_cwd(task_id) or overrides.get("cwd") or config["cwd"]
+        # Resolve the bind source and command-facing cwd from the same provenance.
         # Under per-session isolation a fresh session must not inherit the
         # process-global TERMINAL_CWD mount left behind by a previous session.
-        host_cwd = _resolve_task_host_cwd(config, task_id)
-        # A per-task cwd override (registered by the gateway/TUI for workspace
-        # tracking, or by RL/benchmark envs) wins over config["cwd"] — but
-        # config["cwd"] was already sanitized for container backends in
-        # _get_env_config() while the override is raw. On a container backend a
-        # raw host path (e.g. a Windows desktop session's C:\Users\<user>, or a
-        # POSIX /home/<user>) reaches `docker run -w <host-path>` and the
-        # container fails to start (exit 125). Re-apply the same host/relative
-        # path guard to the *resolved* cwd so the override can't bypass it.
-        # When the host path IS this session's mounted workspace, remap it to
-        # /workspace (where the mount lands) instead of discarding it.
-        # Valid in-container override paths (RL/benchmark sandboxes that set
-        # cwd to /workspace, /root, etc.) are absolute non-host paths and pass
-        # through untouched.
-        if _is_container_backend(env_type) and _is_unusable_container_cwd(cwd):
-            remapped = "/workspace" if host_cwd else config["cwd"]
-            if cwd != remapped:
-                logger.info(
-                    "Remapping host/relative cwd override %r for %s backend "
-                    "(won't exist in sandbox). Using %r instead.",
-                    cwd, env_type, remapped,
-                )
-            cwd = remapped
+        workspace = _resolve_task_workspace(config, task_id, str(cwd))
+        host_cwd = workspace.host_cwd
+        cwd = workspace.container_cwd
         default_timeout = config["timeout"]
 
         # Validate an explicit timeout before it flows into deadline math.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -47,12 +47,13 @@ import atexit
 import shutil
 import subprocess
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Optional, Dict, Any, List
 
 from utils import env_var_enabled
 
 logger = logging.getLogger(__name__)
+_HOST_PURE_PATH = PureWindowsPath if os.name == "nt" else PurePosixPath
 
 
 def _redact_terminal_error_text(value: Any) -> str:
@@ -1292,6 +1293,54 @@ def clear_session_cwd(session_key: str) -> None:
         _session_cwd.pop(session_key, None)
 
 
+def _workspace_roots_differ(previous: Any, current: Any) -> bool:
+    """Return whether two host workspace roots name different paths."""
+    if not isinstance(previous, str) or not previous.strip():
+        return True
+    if not isinstance(current, str) or not current.strip():
+        return True
+    return os.path.normcase(os.path.abspath(os.path.expanduser(previous))) != (
+        os.path.normcase(os.path.abspath(os.path.expanduser(current)))
+    )
+
+
+def _invalidate_workspace_environment(task_id: str) -> None:
+    """Retire environments and file caches tied to a replaced bind source."""
+    effective_task_id = _resolve_container_task_id(task_id)
+    keys = tuple(dict.fromkeys((effective_task_id, task_id)))
+    with _env_lock:
+        active_keys = [key for key in keys if key in _active_environments]
+
+    for key in active_keys:
+        cleanup_vm(key, force_remove=True, wait_for_cleanup=True)
+
+    try:
+        from tools.file_tools import clear_file_ops_cache
+
+        # A collapsed "default" environment is shared by multiple raw session
+        # keys, so every file-ops wrapper may hold the retired environment.
+        if effective_task_id == "default":
+            clear_file_ops_cache()
+        else:
+            clear_file_ops_cache(task_id)
+    except ImportError:
+        pass
+
+
+def _workspace_reset_rebinds_environment(task_id: str) -> bool:
+    """Return whether a reset changes this task's Docker bind source."""
+    try:
+        config = _get_env_config()
+    except Exception:
+        return True
+    return bool(
+        config.get("env_type") == "docker"
+        and config.get("docker_mount_cwd_to_workspace")
+        and _docker_session_isolation_enabled()
+        and _resolve_container_task_id(task_id) != "default"
+    )
+
+
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     """
     Register environment overrides for a specific task/rollout.
@@ -1311,6 +1360,7 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     normalized = dict(overrides)
     workspace_reset = bool(normalized.pop("workspace_reset", False))
     cwd = normalized.get("cwd")
+    workspace_root_changed = False
     with _task_env_overrides_lock:
         previous = _task_env_overrides.get(task_id, {})
         if (
@@ -1320,6 +1370,9 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         ):
             if workspace_reset or not previous.get("host_workspace_root"):
                 normalized["host_workspace_root"] = cwd
+                workspace_root_changed = workspace_reset and _workspace_roots_differ(
+                    previous.get("host_workspace_root"), cwd
+                )
             else:
                 normalized["host_workspace_root"] = previous[
                     "host_workspace_root"
@@ -1336,6 +1389,9 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         # A registered workspace cwd IS the session's working directory until
         # a `cd` changes it.
         record_session_cwd(task_id, new_cwd)
+        if workspace_root_changed and _workspace_reset_rebinds_environment(task_id):
+            _invalidate_workspace_environment(task_id)
+            return
         # The live env is cached under the raw task_id for per-session surfaces
         # (ACP/gateway/dashboard) and under the collapsed container id for
         # isolation-keyed rollouts. Try the raw id first, then the container id,
@@ -1345,7 +1401,12 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         with _env_lock:
             env = _active_environments.get(task_id) or _active_environments.get(container_id)
         if env is not None and getattr(env, "cwd", None) is not None:
-            env.cwd = new_cwd
+            try:
+                env.cwd = _resolve_task_workspace(
+                    _get_env_config(), task_id, new_cwd
+                ).container_cwd
+            except Exception:
+                env.cwd = new_cwd
 
 
 def clear_task_env_overrides(task_id: str):
@@ -1602,7 +1663,8 @@ def _container_cwd_for_host_path(cwd: str, host_root: str) -> str:
     if suffix == ".":
         return "/workspace"
     if suffix is not None:
-        return str(Path("/workspace") / suffix)
+        host_path = _HOST_PURE_PATH(suffix)
+        return str(PurePosixPath("/workspace", *host_path.parts))
     if cwd == "/workspace" or cwd.startswith("/workspace/"):
         return cwd
     return "/workspace"
@@ -2457,7 +2519,12 @@ def cleanup_all_environments():
     return cleaned
 
 
-def cleanup_vm(task_id: str, *, force_remove: bool = False):
+def cleanup_vm(
+    task_id: str,
+    *,
+    force_remove: bool = False,
+    wait_for_cleanup: bool = False,
+):
     """Manually clean up a specific environment by task_id.
 
     *force_remove* (default False) is forwarded to backends that accept it
@@ -2510,6 +2577,12 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
                 env.cleanup(force_remove=force_remove)
             else:
                 env.cleanup()
+            if wait_for_cleanup and hasattr(env, "wait_for_cleanup"):
+                if not env.wait_for_cleanup(timeout=60.0):
+                    logger.warning(
+                        "Timed out waiting for environment cleanup for task: %s",
+                        task_id,
+                    )
         elif hasattr(env, 'stop'):
             env.stop()
         elif hasattr(env, 'terminate'):
@@ -2836,6 +2909,7 @@ def _resolve_command_cwd(
     default_cwd: str,
     session_key: Optional[str] = None,
     env_type: Optional[str] = None,
+    host_workspace_root: Optional[str] = None,
 ) -> str:
     """Return the cwd for a command. Explicit ``workdir=`` overrides everything.
 
@@ -2856,11 +2930,8 @@ def _resolve_command_cwd(
     if workdir:
         return workdir
     recorded = get_session_cwd(session_key)
-    if recorded and env_type == "docker":
-        overrides = resolve_task_overrides(session_key)
-        host_root = overrides.get("host_workspace_root")
-        if overrides.get("cwd_source") == "session" and isinstance(host_root, str):
-            return _container_cwd_for_host_path(recorded, host_root)
+    if recorded and env_type == "docker" and host_workspace_root:
+        return _container_cwd_for_host_path(recorded, host_workspace_root)
     if (
         recorded
         and _is_container_backend(env_type)
@@ -3149,6 +3220,7 @@ def terminal_tool(
                 default_cwd=guard_cwd_base,
                 session_key=session_key,
                 env_type=env_type,
+                host_workspace_root=host_cwd,
             )
 
             def _read_script_in_env(script_path: str) -> Optional[str]:
@@ -3251,6 +3323,7 @@ def terminal_tool(
                 workdir=workdir,
                 default_cwd=cwd,
                 session_key=session_key,
+                host_workspace_root=host_cwd,
             )
             _self_repo_hit, _self_repo_msg = (
                 detect_self_repo_git_mutation(command, guard_cwd)
@@ -3342,6 +3415,7 @@ def terminal_tool(
                 default_cwd=cwd,
                 session_key=session_key,
                 env_type=env_type,
+                host_workspace_root=host_cwd,
             )
             try:
                 if env_type == "local":
@@ -3615,6 +3689,7 @@ def terminal_tool(
                         default_cwd=cwd,
                         session_key=session_key,
                         env_type=env_type,
+                        host_workspace_root=host_cwd,
                     )
                     execute_kwargs = {
                         "timeout": effective_timeout,

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1448,7 +1448,9 @@ def _(rid, params: dict) -> dict:
             from tools.terminal_tool import register_task_env_overrides
 
             if preview_cwd:
-                register_task_env_overrides(task_id, {"cwd": preview_cwd})
+                register_task_env_overrides(
+                    task_id, {"cwd": preview_cwd, "cwd_source": "session"}
+                )
 
             history_note = (
                 f" (with {len(parent_history)} parent-session messages of context)"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3775,7 +3775,12 @@ def _register_session_cwd(session: dict | None) -> None:
 
         cwd, cwd_source = _terminal_task_cwd_with_source(session)
         register_task_env_overrides(
-            session["session_key"], {"cwd": cwd, "cwd_source": cwd_source}
+            session["session_key"],
+            {
+                "cwd": cwd,
+                "cwd_source": cwd_source,
+                "workspace_reset": bool(session.get("_workspace_reset")),
+            },
         )
     except Exception:
         pass
@@ -4259,7 +4264,11 @@ def _set_session_cwd(session: dict, cwd: str) -> str:
     # A user's choice supersedes any earlier settle-adopted cwd: from here on
     # the terminal wandering must not move the workspace again.
     session["cwd_from_settle"] = False
-    _register_session_cwd(session)
+    session["_workspace_reset"] = True
+    try:
+        _register_session_cwd(session)
+    finally:
+        session.pop("_workspace_reset", None)
     # The synchronous DB write claims ordering authority; Git subprocesses stay
     # off the hot path and may publish only for that exact generation.
     _persist_session_cwd_and_schedule_git_meta(session, resolved)


### PR DESCRIPTION
## What does this PR do?

Makes Docker workspace mount authorization and the container-facing cwd one provenance-aware decision.

An explicitly attached session workspace such as `/tmp/project`, `/root/project`, or `/workspace/project` is now mounted at `/workspace` and executed from `/workspace`. A live cwd below the attached root preserves its relative suffix. Untagged or container-sourced batch cwd values cannot become host mounts merely because the same path exists on the host.

The structured resolver is shared by terminal, file tools, lazy environment creation, and `execute_code`. ACP/TUI producers tag session provenance, while batch producers tag container provenance.

## Related Issue

Fixes #83856

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor (no behavior change)

## Changes Made

- Add a structured `TaskWorkspaceResolution` that owns both `host_cwd` and `container_cwd`.
- Preserve the explicit session workspace root while mapping live cwd suffixes below `/workspace`.
- Route terminal, file, and code-execution environment creation through the same resolver.
- Tag ACP/TUI cwd values as session-sourced and batch cwd values as container-sourced.
- On an ACP workspace-root change, force-retire the old per-session Docker environment, wait for teardown, invalidate its file-operations cache, and lazily recreate it with the new bind source.
- Remap recorded host paths only when the resolver confirms that a host workspace is actually mounted; mounting-disabled Docker sessions retain their configured container cwd.
- Build container cwd suffixes with POSIX semantics, including native-Windows host paths.
- Cover arbitrary Linux host paths, similar-prefix paths, fail-closed untagged values, root-switch lifecycle, disabled mounts, Windows separators, reset behavior, and all three tool surfaces.

Sibling audit: shared/persistent Docker environments retain their one-container ownership contract because only per-session mount-source changes trigger retirement. `mini_swe_runner.py` constructs its environment directly from runner-owned container cwd and does not consume session overrides, so it does not cross this provenance boundary.

## Review Follow-up

Commit `8a314aa0d` addresses the three findings reviewed against `ecbf33ee7`:

- [Root changes now recreate the mounted environment and file cache](https://github.com/NousResearch/hermes-agent/pull/83989#discussion_r3827763198).
- [Container paths now use POSIX separators on native Windows](https://github.com/NousResearch/hermes-agent/pull/83989#discussion_r3827763206).
- [Host-path remapping now requires an active host-workspace mount](https://github.com/NousResearch/hermes-agent/pull/83989#discussion_r3827763210).

The cleanup-key PRs #91973/#91445, prompt-probe PR #83178, and drive-letter sanitizer PR #60977 were inspected before publication. They address distinct lifecycle/caller/classification boundaries and compose with this follow-up.

## How to Test\n\nCurrent rebase proof on 2026-08-28 (isolated lockfile-exact dev environment, canonical hermetic runner):\n\n```bash\nscripts/run_tests.sh tests/acp/test_session.py tests/test_batch_runner_checkpoint.py tests/tools/test_docker_session_isolation.py tests/tools/test_docker_workspace_provenance.py\n# 78 passed, 1 Windows-only skipped for the required OS CI lane\n```\n\nRebased onto current `main` `01740f352`; head `8a314aa0d`.

```bash
uv run pytest -q tests/acp/test_session.py tests/test_batch_runner_checkpoint.py tests/tools/test_docker_session_isolation.py tests/tools/test_docker_workspace_provenance.py tests/tools/test_docker_environment.py tests/tools/test_file_tools.py tests/tools/test_file_tools_container_config.py tests/tools/test_file_tools_cwd_resolution.py tests/tools/test_code_execution.py tests/tools/test_session_cwd_store.py tests/test_tui_gateway_server.py tests/tui_gateway/test_session_cwd_follow.py --deselect tests/tools/test_file_tools.py::TestWriteFileHandler::test_writes_content --deselect tests/tools/test_file_tools.py::TestPatchHandler::test_replace_mode_calls_patch_replace
# 840 passed, 3 skipped, 2 deselected, 5 subtests passed

uv run pytest -q tests/tools/test_docker_workspace_provenance.py tests/acp/test_session.py tests/tools/test_docker_session_isolation.py
# 62 passed, 1 skipped

uv run pytest -q tests/test_batch_runner_checkpoint.py
# 15 passed

uv run ruff check .
python scripts/check-windows-footguns.py --diff origin/main
uv lock --check
# passed
```

The two deselected assertions expect lexical `/tmp` while macOS resolves it to `/private/tmp`. Both fail identically in a detached worktree at exact untouched base `01740f352`; they are not in this PR's production or test changes.

The existing-PR publish gate passed against exact current main, including overlap review, public noreply identity, diff/local-metadata checks, and gitleaks over the four-commit publish range.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added regression tests
- [x] Tested on macOS arm64; native-Windows behavior has a `windows_only` regression for Windows CI plus a platform-neutral separator test

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing config change
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Considered Windows and macOS compatibility
- [x] Tool descriptions/schemas update: N/A

