### PR TITLE
fix(backup): exclude regeneratable runtime state

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -74,6 +74,35 @@ _EXCLUDED_DIRS = {
     ".ruff_cache",
 }
 
+# Root-level browser profiles are live, machine-specific runtime state. Their
+# SQLite databases can remain locked indefinitely while Chromium is running,
+# which prevents the ZIP central directory from ever being written. Managed
+# browser and Node runtimes are downloaded again by setup/update, while quick
+# state snapshots duplicate the live state already written to the full backup.
+# Keep these exclusions root-only so identically named directories inside user
+# skills/projects remain portable. ``chrome-debug`` is the canonical Hermes
+# browser-profile name; the cdp variants are retained for older/local
+# LaunchAgent configurations.
+_ROOT_ONLY_EXCLUDED_DIRS = {
+    "browsers",
+    "chrome-debug",
+    "chrome-cdp-profile",
+    "chrome-cdp-visible-profile",
+    "node",
+    "state-snapshots",
+}
+
+
+def _is_runtime_output_path(rel_path: Path) -> bool:
+    """Return True for generated cron output in the default or named profiles."""
+    parts = rel_path.parts
+    return (
+        parts[:2] == ("cron", "output")
+        or len(parts) >= 4
+        and parts[0] == "profiles"
+        and parts[2:4] == ("cron", "output")
+    )
+
 # File-name suffixes to skip
 _EXCLUDED_SUFFIXES = (
     ".pyc",
@@ -298,6 +327,12 @@ def _should_exclude(rel_path: Path) -> bool:
     """Return True if *rel_path* (relative to hermes root) should be skipped."""
     parts = rel_path.parts
 
+    if parts and parts[0] in _ROOT_ONLY_EXCLUDED_DIRS:
+        return True
+
+    if _is_runtime_output_path(rel_path):
+        return True
+
     for part in parts:
         if part not in _EXCLUDED_DIRS:
             continue
@@ -317,6 +352,26 @@ def _should_exclude(rel_path: Path) -> bool:
         return True
 
     return False
+
+
+def _prune_backup_dirnames(dirnames: list[str], rel_dir: Path) -> set[str]:
+    """Prune excluded child directories from one ``os.walk`` iteration."""
+    is_root = rel_dir == Path(".")
+    kept: list[str] = []
+    for dirname in dirnames:
+        if is_root and dirname in _ROOT_ONLY_EXCLUDED_DIRS:
+            continue
+        if _is_runtime_output_path(rel_dir / dirname):
+            continue
+        if dirname in _EXCLUDED_DIRS:
+            if dirname == "hermes-agent" and not is_root:
+                kept.append(dirname)
+            continue
+        kept.append(dirname)
+
+    removed = set(dirnames) - set(kept)
+    dirnames[:] = kept
+    return removed
 
 
 def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> bool:
@@ -626,16 +681,8 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         dp = Path(dirpath)
         rel_dir = dp.relative_to(hermes_root)
 
-        # Prune excluded directories in-place so os.walk doesn't descend
-        # ``hermes-agent`` is only pruned at the root level; nested dirs
-        # with the same name (e.g. in skills/) must be preserved.
-        is_root = rel_dir == Path(".")
-        orig_dirnames = dirnames[:]
-        dirnames[:] = [
-            d for d in dirnames
-            if d not in _EXCLUDED_DIRS or (d == "hermes-agent" and not is_root)
-        ]
-        for removed in set(orig_dirnames) - set(dirnames):
+        # Prune excluded directories in-place so os.walk doesn't descend.
+        for removed in _prune_backup_dirnames(dirnames, rel_dir):
             skipped_dirs.add(str(rel_dir / removed))
 
         for fname in filenames:
@@ -1654,8 +1701,9 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
     try:
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
-            # Prune excluded directories in-place so os.walk doesn't descend
-            dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+            rel_dir = dp.relative_to(hermes_root)
+            # Keep this path in lockstep with run_backup().
+            _prune_backup_dirnames(dirnames, rel_dir)
 
             for fname in filenames:
                 fpath = dp / fname

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -121,6 +121,30 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    @pytest.mark.parametrize(
+        "dirname",
+        [
+            "browsers",
+            "chrome-debug",
+            "chrome-cdp-profile",
+            "chrome-cdp-visible-profile",
+            "node",
+            "state-snapshots",
+        ],
+    )
+    def test_excludes_only_root_regeneratable_runtime_dirs(self, dirname):
+        """Machine-local runtimes and duplicate snapshots stay out of backups."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path(dirname) / "nested" / "file")
+        assert not _should_exclude(Path("skills/example") / dirname / "notes.md")
+
+    def test_excludes_generated_cron_output_but_not_job_definitions(self):
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("cron/output/job/result.md"))
+        assert _should_exclude(Path("profiles/operator/cron/output/job/result.md"))
+        assert not _should_exclude(Path("cron/jobs.json"))
+        assert not _should_exclude(Path("workspace/example/cron/output/fixture.md"))
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state
@@ -201,10 +225,64 @@ class TestBackup:
         assert staged_dirs, "no SQLite snapshot was staged"
         assert all(d == str(out_zip.parent) for d in staged_dirs), staged_dirs
 
+    @pytest.mark.parametrize(
+        "writer_name",
+        ["run_backup", "_write_full_zip_backup"],
+    )
+    def test_full_backup_walkers_prune_live_root_browser_profiles(
+        self, tmp_path, monkeypatch, writer_name
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        runtime_dirs = {
+            "browsers": Path("chrome-for-testing") / "chrome",
+            "chrome-cdp-profile": Path("Default") / "History",
+            "node": Path("bin") / "node",
+            "state-snapshots": Path("snapshot") / "state.db",
+        }
+        for dirname, child in runtime_dirs.items():
+            path = hermes_home / dirname / child
+            path.parent.mkdir(parents=True)
+            path.write_text("runtime")
+        nested = hermes_home / "skills" / "example" / "chrome-cdp-profile"
+        nested.mkdir(parents=True)
+        (nested / "notes.md").write_text("keep")
+        cron_output = hermes_home / "cron" / "output" / "job"
+        cron_output.mkdir(parents=True)
+        (cron_output / "result.md").write_text("generated")
 
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        out_zip = tmp_path / f"{writer_name}.zip"
 
+        import hermes_cli.backup as backup_mod
+        real_walk = backup_mod.os.walk
+        walked = []
 
+        def traced_walk(*args, **kwargs):
+            for item in real_walk(*args, **kwargs):
+                walked.append(Path(item[0]))
+                yield item
 
+        monkeypatch.setattr(backup_mod.os, "walk", traced_walk)
+        if writer_name == "run_backup":
+            backup_mod.run_backup(Namespace(output=str(out_zip)))
+        else:
+            assert backup_mod._write_full_zip_backup(out_zip, hermes_home) == out_zip
+
+        for dirname in runtime_dirs:
+            runtime_dir = hermes_home / dirname
+            assert not any(
+                path == runtime_dir or runtime_dir in path.parents for path in walked
+            )
+        assert not any(path == cron_output or cron_output in path.parents for path in walked)
+        with zipfile.ZipFile(out_zip) as zf:
+            names = zf.namelist()
+        for dirname in runtime_dirs:
+            assert not any(name.startswith(f"{dirname}/") for name in names)
+        assert not any(name.startswith("cron/output/") for name in names)
+        assert "skills/example/chrome-cdp-profile/notes.md" in names
 
     def test_skips_symlinked_files(self, tmp_path, monkeypatch):
         """Backup must not dereference symlinks and leak files outside HERMES_HOME."""


### PR DESCRIPTION
## Summary

- prune live Chrome/CDP profile directories and generated cron output from both ZIP backup paths
- omit root-managed browser and Node runtimes plus duplicate quick state snapshots while preserving identically named nested user directories
- share directory-pruning behaviour between writers and cover both paths with behavioural tests

## Operational evidence

A real Hermes estate backup had grown to 7,686,323,777 bytes and 31,200 ZIP entries. A full backup produced with this patch was independently validated by the DR verifier and measured 5,877,734,553 bytes with 19,245 entries: **23.53% smaller** and **38.32% fewer entries**. All intended root exclusions were absent.

Verifier output:

```text
dr_backup=valid entries=19245 sha256=afb8961029258654f2443f7c443b337bff42c356a7bf3bd825aee10fb12b268a
```

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_backup.py -q` (49 passed)
- `git diff --check`