### PR TITLE
fix(gateway): persist configured cwd on new sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6054,11 +6054,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _bg_max_age_seconds = (
             _bg_max_age_hours * 3600 if _bg_max_age_hours and _bg_max_age_hours > 0 else None
         )
+        # TERMINAL_CWD was normalized by the gateway bootstrap from terminal.cwd.
+        # In multiplex mode it belongs to the launch profile, so persisting it on a
+        # routed secondary session would be a false project assignment. Stay unbound
+        # until the routed profile has a source-specific cwd resolver.
+        initial_session_cwd = None
+        if not getattr(self.config, "multiplex_profiles", False):
+            initial_session_cwd = os.environ.get("TERMINAL_CWD")
         self.session_store = SessionStore(
             self.config.sessions_dir, self.config,
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(
                 key, max_active_age=_bg_max_age_seconds,
             ),
+            initial_cwd=initial_session_cwd,
         )
         # One enforced loop-side boundary for the synchronous SessionStore.
         # Sync helpers keep using ``session_store`` directly; async gateway

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1243,10 +1243,17 @@ class SessionStore:
     Falls back to legacy JSONL files if SQLite is unavailable.
     """
     
-    def __init__(self, sessions_dir: Path, config: GatewayConfig,
-                 has_active_processes_fn=None):
+    def __init__(
+        self,
+        sessions_dir: Path,
+        config: GatewayConfig,
+        has_active_processes_fn=None,
+        initial_cwd: Optional[str] = None,
+    ):
         self.sessions_dir = sessions_dir
         self.config = config
+        normalized_initial_cwd = str(initial_cwd or "").strip()
+        self._initial_cwd = normalized_initial_cwd or None
         self._entries: Dict[str, SessionEntry] = {}
         self._loaded = False
         self._lock = threading.Lock()
@@ -2750,6 +2757,7 @@ class SessionStore:
                     "chat_type": source.chat_type,
                     "thread_id": source.thread_id,
                     "profile_name": source.profile,
+                    "cwd": self._initial_cwd,
                     # Identity lands atomically in the INSERT (#82616): a
                     # crash after this write can no longer strand the row
                     # unroutable, and lineage survives resets (#12857).

--- a/tests/gateway/test_session_default_cwd.py
+++ b/tests/gateway/test_session_default_cwd.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+import hermes_state
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from tui_gateway import project_tree
+
+
+def _source(platform: Platform = Platform.TELEGRAM) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        chat_id=f"chat-{platform.value}",
+        chat_type="dm",
+        user_id="user-1",
+        scope_id="workspace-1" if platform == Platform.SLACK else None,
+    )
+
+
+def _runner(
+    tmp_path,
+    monkeypatch,
+    *,
+    terminal_cwd: str | None,
+    multiplex_profiles: bool = False,
+) -> GatewayRunner:
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    if terminal_cwd is None:
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    else:
+        monkeypatch.setenv("TERMINAL_CWD", terminal_cwd)
+    return GatewayRunner(
+        GatewayConfig(
+            sessions_dir=tmp_path / "sessions",
+            multiplex_profiles=multiplex_profiles,
+        )
+    )
+
+
+def _project_session(row):
+    return {
+        "id": row["id"],
+        "cwd": row.get("cwd"),
+        "git_branch": row.get("git_branch") or "",
+        "git_repo_root": row.get("git_repo_root") or "",
+        "started_at": row.get("started_at") or 0,
+        "last_active": row.get("last_active") or 0,
+        "title": row.get("title"),
+        "preview": None,
+        "source": row.get("source") or "telegram",
+    }
+
+
+@pytest.mark.parametrize(
+    "platform",
+    [Platform.TELEGRAM, Platform.SLACK, Platform.DISCORD],
+)
+def test_runner_persists_configured_cwd_and_project_tree_uses_it(
+    tmp_path, monkeypatch, platform
+):
+    workspace = tmp_path / "Assistant"
+    workspace.mkdir()
+    runner = _runner(
+        tmp_path,
+        monkeypatch,
+        terminal_cwd=f"  {workspace}  ",
+    )
+    try:
+        entry = runner.session_store.get_or_create_session(_source(platform))
+        row = runner.session_store._db.get_session(entry.session_id)
+        assert row["cwd"] == str(workspace)
+
+        project = {
+            "id": "personal-assistant",
+            "name": "Personal Assistant",
+            "primary_path": str(workspace),
+            "archived": False,
+            "folders": [{"path": str(workspace), "is_primary": True}],
+        }
+        tree = project_tree.build_tree(
+            [project],
+            [_project_session(row)],
+            [],
+            resolve=lambda _cwd: None,
+            hydrate=True,
+        )
+        personal = next(
+            node for node in tree["projects"] if node["id"] == "personal-assistant"
+        )
+        grouped_ids = {
+            session["id"]
+            for repo in personal["repos"]
+            for group in repo["groups"]
+            for session in group["sessions"]
+        }
+        assert grouped_ids == {entry.session_id}
+        assert not any(
+            node["id"] == project_tree.NO_PROJECT_ID and node["sessionCount"]
+            for node in tree["projects"]
+        )
+    finally:
+        runner.session_store._db.close()

--- a/tests/gateway/test_session_default_cwd.py
+++ b/tests/gateway/test_session_default_cwd.py
@@ -102,3 +102,71 @@ def test_runner_persists_configured_cwd_and_project_tree_uses_it(
         )
     finally:
         runner.session_store._db.close()
+
+
+def test_reset_and_force_new_sessions_persist_configured_cwd(tmp_path, monkeypatch):
+    workspace = tmp_path / "Assistant"
+    workspace.mkdir()
+    runner = _runner(tmp_path, monkeypatch, terminal_cwd=str(workspace))
+    source = _source()
+    try:
+        first = runner.session_store.get_or_create_session(source)
+        reset = runner.session_store.reset_session(first.session_key)
+        forced = runner.session_store.get_or_create_session(source, force_new=True)
+
+        assert reset is not None
+        assert runner.session_store._db.get_session(reset.session_id)["cwd"] == str(
+            workspace
+        )
+        assert runner.session_store._db.get_session(forced.session_id)["cwd"] == str(
+            workspace
+        )
+    finally:
+        runner.session_store._db.close()
+
+
+def test_missing_configured_cwd_stays_unbound(tmp_path, monkeypatch):
+    runner = _runner(tmp_path, monkeypatch, terminal_cwd=None)
+    try:
+        entry = runner.session_store.get_or_create_session(_source())
+        assert runner.session_store._db.get_session(entry.session_id)["cwd"] is None
+    finally:
+        runner.session_store._db.close()
+
+
+def test_existing_unbound_session_is_not_backfilled(tmp_path, monkeypatch):
+    source = _source()
+    first_runner = _runner(tmp_path, monkeypatch, terminal_cwd=None)
+    first = first_runner.session_store.get_or_create_session(source)
+    assert first_runner.session_store._db.get_session(first.session_id)["cwd"] is None
+    first_runner.session_store._db.close()
+
+    workspace = tmp_path / "Assistant"
+    workspace.mkdir()
+    restarted = _runner(tmp_path, monkeypatch, terminal_cwd=str(workspace))
+    try:
+        recovered = restarted.session_store.get_or_create_session(source)
+        assert recovered.session_id == first.session_id
+        assert restarted.session_store._db.get_session(first.session_id)["cwd"] is None
+    finally:
+        restarted.session_store._db.close()
+
+
+def test_multiplex_runner_does_not_persist_launch_profile_cwd(
+    tmp_path, monkeypatch
+):
+    primary_workspace = tmp_path / "primary"
+    primary_workspace.mkdir()
+    runner = _runner(
+        tmp_path,
+        monkeypatch,
+        terminal_cwd=str(primary_workspace),
+        multiplex_profiles=True,
+    )
+    source = _source()
+    source.profile = "secondary"
+    try:
+        entry = runner.session_store.get_or_create_session(source)
+        assert runner.session_store._db.get_session(entry.session_id)["cwd"] is None
+    finally:
+        runner.session_store._db.close()


### PR DESCRIPTION
## What does this PR do?

Persist the gateway's already-resolved `terminal.cwd` on newly created messaging-session rows. Telegram, Slack, and Discord sessions then appear under the matching Desktop project instead of the synthetic Home project, while their tools continue to execute in the same configured directory.

The shared `SessionStore` receives one normalized initial cwd. `GatewayRunner` supplies `TERMINAL_CWD` for single-profile gateways and deliberately leaves multiplex-routed sessions unbound until a source-specific resolver exists. Existing rows are never rewritten.

## Related Issue

No issue found. PR #70600 is adjacent multiplex runtime-CWD work, but it does not persist the project binding in the session database and is not a dependency for this fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: inject the resolved gateway cwd only for non-multiplexed gateways
- `gateway/session.py`: normalize and persist that cwd on new durable session rows
- `tests/gateway/test_session_default_cwd.py`: cover Telegram, Slack, Discord, reset/force-new behavior, project-tree placement, missing cwd, historical-null preservation, and multiplex isolation

## How to Test

1. Set `terminal.cwd` to a directory that is registered as a Desktop project.
2. Start a new Telegram, Slack, or Discord conversation and verify its session row has that cwd and Desktop groups it under the configured project.
3. Run:

   ```bash
   scripts/run_tests.sh \
     tests/gateway/test_session_default_cwd.py \
     tests/gateway/test_session.py \
     tests/gateway/test_routing_save_fast_path.py \
     tests/gateway/test_session_reset_notify.py \
     tests/gateway/test_multiplex_phase0.py \
     tests/tui_gateway/test_project_tree.py -q
   ```

   Result: 134 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Python 3.11

The canonical full runner completed with 29,587 passing tests, six unrelated failed tests, and one unrelated setup-error file. The same seven files fail identically on an untouched `origin/main` worktree (383 passing tests, six failures, and the same setup errors): installed-live import contamination, credential-pool routing, Vercel doctor diagnostics, local shell-init pickup, GNU `sort` behavior, SQLite trace counting, and container audio detection. All changed-area tests are green.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing config or command changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

Additional checks:

- Ruff: passed
- Windows-footgun scan: passed for all three changed files
- `git diff --check`: passed
- mutation proof: removing the runner-to-store cwd binding fails all three platform regressions; allowing process-global cwd in multiplex mode fails the isolation regression

## Screenshots / Logs

The project-tree regression exercises the real `build_tree(...)` path and verifies the new session is owned by the configured Personal Assistant project with no non-empty synthetic Home group.
