### PR TITLE
fix(desktop): keep HUD window solid on Linux so clicks and drag work

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10310,9 +10310,22 @@ ipcMain.handle('hermes:hud:vibrancy', (_event, on) => {
 // rectangle is a faded-out band over whatever the user is actually working in.
 // `forward` keeps mousemove flowing so the renderer can re-arm when the cursor
 // reaches the bar.
+//
+// Linux caveat (Aug 2026): `forward: true` is macOS/Windows only — on Linux the
+// window becomes permanently click-through when ignored (the cursor poll feed
+// in hud-cursor.ts uses webContents zoomFactor, which mismatches KDE fractional
+// DPI scaling, so the hit-test never lands on the bar and the HUD stays
+// unclickable: no clicks, no long-press composer drag). Keep the HUD window
+// solid on Linux so pointer events always arrive. Trade-off: clicks on the
+// transparent band no longer fall through to the app behind — acceptable, the
+// bar is thin.
 ipcMain.on('hermes:hud:ignore-mouse', (_event, ignore) => {
   if (hudWindow && !hudWindow.isDestroyed()) {
-    hudWindow.setIgnoreMouseEvents(Boolean(ignore), { forward: true })
+    if (process.platform === 'linux') {
+      hudWindow.setIgnoreMouseEvents(false)
+    } else {
+      hudWindow.setIgnoreMouseEvents(Boolean(ignore), { forward: true })
+    }
   }
 })
 


### PR DESCRIPTION
## Problem

On Linux, `setIgnoreMouseEvents(ignore, { forward: true })` does **not** forward mousemove events — the `forward` option is macOS/Windows only. When the Hermes Desktop HUD enters click-through, the renderer never re-arms because the cursor poll feed (`hud-cursor.ts`) computes points using `webContents.getZoomFactor()`, which mismatches KDE fractional DPI scaling (e.g. 4K @ 150%).

Result: the hit-test never lands on the composer bar, so the HUD stays **permanently click-through** — no clicks work, and the long-press composer drag (the only way to move the HUD) never receives pointer events.

## Fix

On Linux, keep the HUD window always solid:

```js
if (process.platform === 'linux') {
  hudWindow.setIgnoreMouseEvents(false)
} else {
  hudWindow.setIgnoreMouseEvents(Boolean(ignore), { forward: true })
}
```

Trade-off: clicks on the transparent band no longer pass through to the app behind — acceptable since the band is thin.

## Verification

Tested on KDE Plasma 6 / X11 @ 4K with fractional scaling (150%):
- HUD clicks work
- Long-press composer drag moves the window
- `Ctrl+Shift+G` snap still works

This affects all Linux users with fractional DPI scaling (common on 4K displays).