### PR TITLE
feat(state): add incremental session history revisions

### DIFF
--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -164,7 +164,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 25
+SCHEMA_VERSION = 26
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -289,6 +289,21 @@ CREATE TABLE IF NOT EXISTS messages (
     display_metadata TEXT
 );
 
+-- Stable, narrow contract for incremental history consumers. Revisions are
+-- opaque: consumers compare them for equality and must not infer ordering.
+-- Keeping only the latest token per live session bounds storage by the number
+-- of sessions instead of the number of history mutations.
+CREATE TABLE IF NOT EXISTS session_history_contract (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    version INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_history_revisions (
+    session_id TEXT PRIMARY KEY
+        REFERENCES sessions(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    revision TEXT NOT NULL CHECK (length(revision) = 32)
+);
+
 CREATE TABLE IF NOT EXISTS session_model_usage (
     session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
     model TEXT NOT NULL,
@@ -371,6 +386,99 @@ CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usag
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
     ON async_delegations(delivery_state, completed_at);
+"""
+
+
+# Complete setup as one write transaction. The contract row is published last,
+# so an external reader that validates it can never observe missing triggers or
+# a partially backfilled revision inventory during upgrade.
+SESSION_HISTORY_SQL = """
+BEGIN IMMEDIATE;
+
+CREATE TRIGGER IF NOT EXISTS session_history_session_insert
+AFTER INSERT ON sessions
+BEGIN
+    INSERT INTO session_history_revisions (session_id, revision)
+    VALUES (new.id, lower(hex(randomblob(16))))
+    ON CONFLICT(session_id) DO UPDATE SET revision = excluded.revision;
+END;
+
+-- message_count and tool_call_count are derived bookkeeping. Every canonical
+-- mutation that changes them is already covered by a messages trigger below;
+-- excluding their follow-up UPDATE avoids a redundant token write and keeps
+-- the existing FTS corruption-recovery transaction path independent.
+CREATE TRIGGER IF NOT EXISTS session_history_session_update
+AFTER UPDATE OF
+    id, source, user_id, session_key, chat_id, chat_type, thread_id,
+    display_name, origin_json, expiry_finalized, model, model_config,
+    system_prompt, system_prompt_hash, parent_session_id, started_at, ended_at,
+    end_reason, input_tokens, output_tokens, cache_read_tokens,
+    cache_write_tokens, reasoning_tokens, cwd, git_branch, git_repo_root,
+    billing_provider, billing_base_url, billing_mode, estimated_cost_usd,
+    actual_cost_usd, cost_status, cost_source, pricing_version, title,
+    title_source, last_activity_at, last_activity_description,
+    last_activity_provenance, api_call_count, handoff_state, handoff_platform,
+    handoff_error, compression_failure_cooldown_until,
+    compression_failure_error, compression_fallback_streak,
+    compression_ineffective_count, profile_name, rewind_count, archived,
+    pinned, last_read_at
+ON sessions
+BEGIN
+    INSERT INTO session_history_revisions (session_id, revision)
+    VALUES (new.id, lower(hex(randomblob(16))))
+    ON CONFLICT(session_id) DO UPDATE SET revision = excluded.revision;
+END;
+
+CREATE TRIGGER IF NOT EXISTS session_history_message_insert
+AFTER INSERT ON messages
+BEGIN
+    INSERT INTO session_history_revisions (session_id, revision)
+    VALUES (new.session_id, lower(hex(randomblob(16))))
+    ON CONFLICT(session_id) DO UPDATE SET revision = excluded.revision;
+END;
+
+CREATE TRIGGER IF NOT EXISTS session_history_message_update
+AFTER UPDATE ON messages
+BEGIN
+    INSERT INTO session_history_revisions (session_id, revision)
+    VALUES (new.session_id, lower(hex(randomblob(16))))
+    ON CONFLICT(session_id) DO UPDATE SET revision = excluded.revision;
+END;
+
+-- A message can be reassigned between sessions by a direct SQLite writer.
+-- The general UPDATE trigger records the new owner; this companion trigger
+-- also invalidates the old owner.
+CREATE TRIGGER IF NOT EXISTS session_history_message_move
+AFTER UPDATE OF session_id ON messages
+WHEN old.session_id != new.session_id
+BEGIN
+    INSERT INTO session_history_revisions (session_id, revision)
+    VALUES (old.session_id, lower(hex(randomblob(16))))
+    ON CONFLICT(session_id) DO UPDATE SET revision = excluded.revision;
+END;
+
+CREATE TRIGGER IF NOT EXISTS session_history_message_delete
+AFTER DELETE ON messages
+BEGIN
+    INSERT INTO session_history_revisions (session_id, revision)
+    VALUES (old.session_id, lower(hex(randomblob(16))))
+    ON CONFLICT(session_id) DO UPDATE SET revision = excluded.revision;
+END;
+
+INSERT OR IGNORE INTO session_history_revisions (session_id, revision)
+SELECT id, lower(hex(randomblob(16)))
+FROM sessions
+WHERE NOT EXISTS (
+    SELECT 1 FROM session_history_contract
+    WHERE singleton = 1 AND version >= 1
+);
+
+INSERT INTO session_history_contract (singleton, version)
+VALUES (1, 1)
+ON CONFLICT(singleton) DO UPDATE SET
+    version = max(session_history_contract.version, excluded.version);
+
+COMMIT;
 """
 
 

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -25,6 +25,7 @@ from hermes_state_common import (
     LEGACY_FTS_TRIGRAM_SQL,
     SCHEMA_SQL,
     SCHEMA_VERSION,
+    SESSION_HISTORY_SQL,
     _FTS_CJK_TRIGGERS,
     _FTS_TRIGGERS,
     _ephemeral_child_sql,
@@ -790,6 +791,11 @@ class SessionSchemaMixin:
         # migration was skipped (e.g. due to version renumbering), the
         # column gets created here.
         self._reconcile_columns(cursor)
+
+        # Publish the narrow external history contract atomically. Existing
+        # sessions are backfilled in the same BEGIN IMMEDIATE transaction as
+        # trigger installation, and the contract version row appears last.
+        cursor.executescript(SESSION_HISTORY_SQL)
 
         # Rebuild gateway_routing if it still carries the pre-scope PRIMARY
         # KEY (session_key alone). ADD COLUMN cannot fix a PK, so this is

--- a/tests/hermes_state/test_session_history_revisions.py
+++ b/tests/hermes_state/test_session_history_revisions.py
@@ -1,0 +1,170 @@
+"""Behavior contract for incremental session-history revisions."""
+
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _inventory(db: SessionDB) -> dict[str, str]:
+    rows = db._conn.execute(
+        "SELECT session_id, revision FROM session_history_revisions"
+    ).fetchall()
+    return {row["session_id"]: row["revision"] for row in rows}
+
+
+def _assert_revision(token: str) -> None:
+    assert len(token) == 32
+    int(token, 16)
+
+
+@pytest.fixture()
+def db(tmp_path):
+    session_db = SessionDB(tmp_path / "state.db")
+    yield session_db
+    session_db.close()
+
+
+def test_contract_tracks_session_and_message_changes(db):
+    version = db._conn.execute(
+        "SELECT version FROM session_history_contract WHERE singleton = 1"
+    ).fetchone()[0]
+    assert version >= 1
+    assert _inventory(db) == {}
+
+    db.create_session("s1", source="cli")
+    created = _inventory(db)["s1"]
+    _assert_revision(created)
+
+    db.update_session_cwd("s1", "/tmp/revision-test")
+    session_updated = _inventory(db)["s1"]
+    assert session_updated != created
+
+    message_id = db.append_message("s1", role="user", content="before", timestamp=123.0)
+    message_inserted = _inventory(db)["s1"]
+    assert message_inserted != session_updated
+
+    # The row identity and timestamp stay fixed: payload-only rewrites still
+    # have to invalidate an incremental consumer's cached session.
+    db._execute_write(
+        lambda conn: conn.execute(
+            "UPDATE messages SET content = ? WHERE id = ?",
+            ("after", message_id),
+        )
+    )
+    message_rewritten = _inventory(db)["s1"]
+    assert message_rewritten != message_inserted
+
+    # Reads never advance the token.
+    assert db.get_messages("s1")[0]["content"] == "after"
+    assert _inventory(db)["s1"] == message_rewritten
+
+
+def test_reparenting_message_invalidates_both_sessions(db):
+    db.create_session("old", source="cli")
+    db.create_session("new", source="cli")
+    message_id = db.append_message("old", role="user", content="move me")
+    before = _inventory(db)
+
+    db._execute_write(
+        lambda conn: conn.execute(
+            "UPDATE messages SET session_id = ? WHERE id = ?",
+            ("new", message_id),
+        )
+    )
+
+    after = _inventory(db)
+    assert after["old"] != before["old"]
+    assert after["new"] != before["new"]
+
+
+def test_message_change_is_scoped_to_its_owning_session(db):
+    db.create_session("changed", source="cli")
+    db.create_session("unchanged", source="cli")
+    changed_id = db.append_message("changed", role="user", content="remove me")
+    db.append_message("unchanged", role="user", content="keep me")
+    before = _inventory(db)
+
+    db._execute_write(
+        lambda conn: conn.execute("DELETE FROM messages WHERE id = ?", (changed_id,))
+    )
+
+    after = _inventory(db)
+    assert after["changed"] != before["changed"]
+    assert after["unchanged"] == before["unchanged"]
+
+
+def test_deletion_is_visible_as_a_missing_inventory_entry(db):
+    db.create_session("delete-me", source="cli")
+    db.append_message("delete-me", role="user", content="temporary")
+    assert "delete-me" in _inventory(db)
+
+    assert db.delete_session("delete-me") is True
+    assert "delete-me" not in _inventory(db)
+
+
+def test_revisions_follow_transaction_rollback(db):
+    db.create_session("s1", source="cli")
+    db.append_message("s1", role="user", content="stable")
+    before = _inventory(db)["s1"]
+
+    def _fail(conn):
+        conn.execute(
+            "UPDATE messages SET content = 'rolled back' WHERE session_id = 's1'"
+        )
+        raise RuntimeError("abort transaction")
+
+    with pytest.raises(RuntimeError, match="abort transaction"):
+        db._execute_write(_fail)
+
+    assert db.get_messages("s1")[0]["content"] == "stable"
+    assert _inventory(db)["s1"] == before
+
+
+def test_reopening_database_is_a_revision_noop(tmp_path):
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    first.create_session("stable", source="cli")
+    first.append_message("stable", role="user", content="unchanged")
+    revision = _inventory(first)["stable"]
+    first.close()
+
+    reopened = SessionDB(path)
+    try:
+        assert _inventory(reopened)["stable"] == revision
+    finally:
+        reopened.close()
+
+
+def test_writable_open_backfills_missing_revision_state(tmp_path):
+    path = tmp_path / "state.db"
+    original = SessionDB(path)
+    original.create_session("legacy", source="cli")
+    original.append_message("legacy", role="user", content="preserved")
+    original.close()
+
+    # Model a database created before the contract existed. Dropping the
+    # contract and its triggers leaves canonical history untouched.
+    conn = sqlite3.connect(path)
+    for name in (
+        "session_history_session_insert",
+        "session_history_session_update",
+        "session_history_message_insert",
+        "session_history_message_update",
+        "session_history_message_move",
+        "session_history_message_delete",
+    ):
+        conn.execute(f"DROP TRIGGER {name}")
+    conn.execute("DROP TABLE session_history_revisions")
+    conn.execute("DROP TABLE session_history_contract")
+    conn.commit()
+    conn.close()
+
+    reopened = SessionDB(path)
+    try:
+        revision = _inventory(reopened)["legacy"]
+        _assert_revision(revision)
+        assert reopened.get_messages("legacy")[0]["content"] == "preserved"
+    finally:
+        reopened.close()

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -136,12 +136,46 @@ The FTS5 table is kept in sync via three triggers that fire on INSERT, UPDATE,
 and DELETE of the `messages` table. The current triggers are gated on the
 `fts_rebuild_high_water` / `fts_rebuild_progress` markers in `state_meta` (so a
 background FTS rebuild can proceed without double-indexing) and cover all three
-indexed columns — see `SCHEMA_SQL` in `hermes_state.py` for the exact SQL.
+indexed columns — see `SCHEMA_SQL` in `hermes_state_common.py` for the exact SQL.
+
+
+### Incremental History Revisions
+
+Tools that synchronize, export, back up, or index session history can discover
+changes without rereading every message body. Two deliberately narrow tables
+form the stable contract:
+
+```sql
+SELECT version FROM session_history_contract WHERE singleton = 1;
+SELECT session_id, revision FROM session_history_revisions;
+```
+
+Validate the contract version before reading the inventory. Contract setup and
+legacy-session backfill publish atomically, so a missing version row means the
+database is not ready for incremental consumption.
+
+`revision` is an opaque token. Cache the `(session_id, revision)` inventory and
+reload a session only when its token changes. A newly present ID is a new
+session; an ID missing from the next complete inventory was deleted. The token
+inventory changes in the same transaction as session creation, deletion, and
+metadata changes and every canonical message insert, update, or delete,
+including message movement between sessions. Derived message counters do not
+cause a second token change because the corresponding message mutation already
+invalidates the session. Tokens appear and change for live sessions; deleting a
+session removes its row. A token is intentionally not a timestamp or ordered
+counter, and consumers must only compare it for equality.
+
+When the inventory and changed payloads must represent one instant, read both
+inside one SQLite read transaction. A later writer then lands after that
+snapshot and changes the next inventory rather than producing a mixed view.
+
+The contract is metadata-only: session and message payloads remain in their
+canonical tables, and no append-only change journal accumulates over time.
 
 
 ## Schema Version and Migrations
 
-Current schema version: **23**
+Current schema version: **26**
 
 The `schema_version` table stores a single integer. Simple column additions are handled declaratively by `_reconcile_columns()` (which diffs live columns against `SCHEMA_SQL` and ADDs any missing ones). The version-gated chain is reserved for data migrations and index/FTS changes that can't be expressed declaratively:
 
@@ -163,6 +197,8 @@ The `schema_version` table stores a single integer. Simple column additions are 
 | 20 | Per-model usage attribution — seed `session_model_usage` rows from historical per-session aggregate totals |
 | 22 | Task-dimension usage attribution — rebuild `session_model_usage` so the `task` column participates in the PRIMARY KEY |
 | 23 | FTS storage redesign — external-content FTS tables replacing the v11 inline-mode copies (opt-in transition for existing DBs) |
+| 25 | Deduplicate per-session system prompt snapshots into a shared content-addressed table |
+| 26 | Add opaque per-session history revisions for efficient incremental consumers |
 
 Versions not listed above were declarative column additions handled by `_reconcile_columns()` (version bump only, no data migration).
 


### PR DESCRIPTION
## What does this PR do?

Adds a small, versioned revision inventory for consumers that synchronize, export, back up, or index Hermes session history.

Each live session has one opaque 128-bit revision token. SQLite triggers replace only the owning session's token whenever its metadata or messages change. Consumers can therefore enumerate lightweight `(session_id, revision)` metadata and reread message bodies only for sessions whose token changed. Missing IDs represent deleted sessions.

The contract is intentionally bounded and metadata-only: there is no daemon, configuration option, transcript copy, timestamp heuristic, or append-only journal. Installation and legacy-session backfill occur atomically under `BEGIN IMMEDIATE`, and the contract version is published last.

This also provides a reusable foundation for external-history work such as #60424 without coupling the state store to one export format.

## Related Issue

Fixes #84001

Related: #60424, #60679

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `session_history_contract` and bounded `session_history_revisions` tables in `hermes_state_common.py`.
- Added transactionally maintained triggers for session metadata and message insert, update, delete, and reparenting.
- Avoided duplicate revision writes for derived message counters, preserving the existing FTS corruption-recovery path.
- Added atomic contract installation and legacy-session backfill in `hermes_state_schema.py`.
- Added behavior tests covering payload-only rewrites with stable IDs/timestamps, owner scoping, reparenting, deletion, rollback, reopen no-op behavior, and legacy backfill.
- Documented contract validation, snapshot consistency, opaque-token semantics, and schema version 26.

## Why opaque per-session tokens?

- Random tokens remain safe across database backup/restore and do not depend on clock behavior.
- A complete revision inventory detects creation, change, and deletion without retaining an unbounded event log.
- Only metadata is scanned on a no-op refresh; unchanged message bodies are not read.
- Triggers keep the token update in the same SQLite transaction as the canonical mutation.

## How to Test

1. Run the focused contract and owning state suites:

   ```bash
   scripts/run_tests.sh \
     tests/hermes_state/test_session_history_revisions.py \
     tests/test_hermes_state.py -q
   ```

2. Run static checks:

   ```bash
   ruff check hermes_state_common.py hermes_state_schema.py \
     tests/hermes_state/test_session_history_revisions.py
   ruff format --check tests/hermes_state/test_session_history_revisions.py
   git diff --check
   ```

3. Optionally open a temporary database, cache the revision inventory, perform a payload-only message update, and verify that only the owning session's token changes.

## Validation Results

- Focused revision tests: 7 passed.
- Existing owning `tests/test_hermes_state.py`: 220 passed.
- Static checks: passed.
- A 7,000-session inventory took 2.30 ms median / 2.97 ms p95 locally and added approximately 408 KiB of database storage (59.7 bytes per session).
- A deliberately large 3,000-message single-transaction insert measured 116.5 ms without revision triggers and 128.3 ms with them: +11.8 ms absolute / 10.1% (about 3.9 microseconds per message). Typical turn flushes contain 3–8 messages.

Benchmarks were run on Linux x86_64 with Python 3.12.3 and SQLite 3.45.1 in DELETE-journal fallback mode.

The repository-wide test command was also run. It is not green in this local environment because optional ACP/provider/platform dependencies are absent and unrelated environment-sensitive tests fail. The changed contract tests and the owning 220-test state suite pass. State-adjacent failures were isolated: the WAL-sidecar fixture, two stale-FTS recovery cases, and a SQLite-version-specific integrity-message assertion reproduce on untouched `main`. An additional FTS recovery interaction found during this run was fixed and its existing upstream regression test now passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64, Python 3.12.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — uses portable SQLite core functions only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model-tool behavior

## Screenshots / Logs

N/A — storage metadata contract with automated behavior coverage.
