### PR TITLE
fix(agent): accept empty tool argument strings

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -140,6 +140,8 @@ class _BatchAbandoned(BaseException):
 
 def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
     """Parse model-emitted arguments without repairing or coercing them."""
+    if isinstance(raw_arguments, str) and not raw_arguments.strip():
+        return {}, None
     try:
         arguments = json.loads(raw_arguments)
     except (json.JSONDecodeError, TypeError):

--- a/tests/run_agent/test_malformed_tool_arguments.py
+++ b/tests/run_agent/test_malformed_tool_arguments.py
@@ -53,7 +53,6 @@ def _tool_call(call_id: str, arguments: str):
         pytest.param("not-json", id="malformed-json"),
         pytest.param('"scalar"', id="scalar"),
         pytest.param("[]", id="list"),
-        pytest.param("", id="empty"),
         pytest.param('{"query": "cut off', id="truncated"),
     ],
 )
@@ -95,3 +94,34 @@ def test_malformed_arguments_are_rejected_without_blocking_valid_sibling(
     assert '"error": "Invalid tool arguments"' in messages[0]["content"]
     assert "JSON object" in messages[0]["content"]
     assert json.loads(messages[1]["content"]) == {"ok": "valid"}
+
+
+@pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
+def test_empty_arguments_execute_as_empty_object(dispatch_mode: str):
+    agent = _make_agent()
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=[_tool_call("call-empty", "  ")],
+    )
+    messages = []
+    executed = []
+
+    def fake_dispatch(name, args, task_id, *positional, **kwargs):
+        call_id = kwargs.get("tool_call_id") or (positional[0] if positional else None)
+        executed.append((name, args, call_id))
+        return json.dumps({"ok": True})
+
+    with (
+        patch("run_agent.handle_function_call", side_effect=fake_dispatch),
+        patch.object(agent, "_invoke_tool", side_effect=fake_dispatch),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        execute = getattr(agent, f"_execute_tool_calls_{dispatch_mode}")
+        execute(assistant_message, messages, "task-1")
+
+    assert executed == [("web_search", {}, "call-empty")]
+    assert [message["tool_call_id"] for message in messages] == ["call-empty"]
+    assert json.loads(messages[0]["content"]) == {"ok": True}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1867,6 +1867,24 @@ class TestConcurrentToolExecution:
         assert [m["tool_call_id"] for m in messages] == ["c1", "c2"]
         assert "tool was not executed" in messages[0]["content"].lower()
 
+    def test_concurrent_empty_string_args_execute_as_empty_object(self, agent):
+        """Models sometimes emit "" for no-argument tools; execute it as {}."""
+        tc = _mock_tool_call(name="noop_tool", arguments="   ", call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        seen_args = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            seen_args.append((name, args))
+            return json.dumps({"ok": True})
+
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert seen_args == [("noop_tool", {})]
+        assert [m["tool_call_id"] for m in messages] == ["c1"]
+        assert "invalid tool arguments" not in messages[0]["content"].lower()
+
     def test_concurrent_preserves_order_despite_timing(self, agent):
         """Even if tools finish in different order, messages should be in original order."""
         import time as _time

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -267,6 +267,18 @@ class TestBridgeDispatch:
         # Will fail classification because unknown_xxx isn't deferrable.
         assert err is not None
 
+    def test_resolve_underlying_call_treats_empty_string_args_as_empty_object(self, monkeypatch):
+        from tools import tool_search
+
+        monkeypatch.setattr(tool_search, "is_deferrable_tool_name", lambda name: True)
+        name, args, err = tool_search.resolve_underlying_call({
+            "name": "mcp__demo__ping",
+            "arguments": "  ",
+        })
+
+        assert err is None
+        assert name == "mcp__demo__ping"
+        assert args == {}
 
     def test_resolve_underlying_call_rejects_recursion(self):
         """tool_call cannot invoke tool_call itself."""

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1035,10 +1035,13 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     if raw_args is None:
         raw_args = {}
     if isinstance(raw_args, str):
-        try:
-            raw_args = json.loads(raw_args)
-        except json.JSONDecodeError as e:
-            return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
+        if not raw_args.strip():
+            raw_args = {}
+        else:
+            try:
+                raw_args = json.loads(raw_args)
+            except json.JSONDecodeError as e:
+                return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name):


### PR DESCRIPTION
## Summary
- Treat empty or whitespace-only model-emitted tool argument strings as `{}` at the execution parser boundary
- Apply the same normalization when unwrapping deferred `tool_call` bridge invocations
- Add/update regressions for sequential and concurrent execution plus tool-search bridge parsing

Fixes #83937.

## Tests
- `HERMES_PYTHON=/Users/yuanangyang/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/run_agent/test_malformed_tool_arguments.py tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_concurrent_empty_string_args_execute_as_empty_object tests/tools/test_tool_search.py::TestBridgeDispatch::test_resolve_underlying_call_treats_empty_string_args_as_empty_object -q`
- `/Users/yuanangyang/hermes-agent/.venv/bin/ruff check agent/tool_executor.py tools/tool_search.py tests/run_agent/test_run_agent.py tests/run_agent/test_malformed_tool_arguments.py tests/tools/test_tool_search.py`