### PR TITLE
fix(cron): surface delivery failures instead of hiding under last_status ok

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2113,7 +2113,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                  status: Optional[str] = None):
     """
     Mark a job as having been run.
-    
+
     Updates last_run_at, last_status, increments completed count,
     computes next_run_at, and auto-deletes if repeat limit reached.
 
@@ -2125,6 +2125,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
     the pre-dispatch configuration validation refused to run the agent
     (T1-26), so `cronjob list` distinguishes "your config is broken" from
     "the run itself failed".
+
+A delivery failure is NOT a clean "ok" run: the output never reached
+the user, so last_status becomes ``"ok (delivery failed)"`` instead of
+a plain ``"ok"`` that would hide the failure (#83993).
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -2132,7 +2136,11 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
             if job["id"] == job_id:
                 now = _hermes_now().isoformat()
                 job["last_run_at"] = now
-                job["last_status"] = status or ("ok" if success else "error")
+                job["last_status"] = status or (
+                    "ok (delivery failed)"
+                    if (success and delivery_error)
+                    else ("ok" if success else "error")
+                )
                 job["last_error"] = error if not success else None
                 # A healthy run means the configuration validates again — drop
                 # the preflight alert-dedup marker so a FUTURE config break

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -180,6 +180,11 @@ def cron_list(show_all: bool = False):
             last_run = job.get("last_run_at", "?")
             if last_status == "ok":
                 status_display = color("ok", Colors.GREEN)
+            elif last_status == "ok (delivery failed)":
+                # Issue #83993: the agent ran, but the output never reached
+                # the user — warn visibly instead of showing a clean "ok".
+                # The delivery error detail is printed below.
+                status_display = color("ok (delivery failed)", Colors.YELLOW)
             else:
                 status_display = color(f"{last_status}: {job.get('last_error', '?')}", Colors.RED)
             print(f"    Last run:  {last_run}  {status_display}")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -480,9 +480,39 @@ class TestMarkJobRun:
         job = create_job(prompt="Report", schedule="every 1h")
         mark_job_run(job["id"], success=True, delivery_error="platform 'telegram' not configured")
         updated = get_job(job["id"])
-        assert updated["last_status"] == "ok"
+        assert updated["last_status"] == "ok (delivery failed)"
         assert updated["last_error"] is None
         assert updated["last_delivery_error"] == "platform 'telegram' not configured"
+
+    def test_delivery_failure_never_hidden_under_ok(self, tmp_cron_dir):
+        """Issue #83993: delivery outcome must be visible in last_status.
+
+        A job that ran fine but whose output never reached the user (rate
+        limit, stale session, live-adapter send error falling back to a
+        standalone path with no configured channel) must NOT be recorded as
+        a plain "ok" — the user would never know the delivery failed.
+        """
+        # Job ran ok + delivery ok -> "ok"
+        ok_job = create_job(prompt="A", schedule="every 1h")
+        mark_job_run(ok_job["id"], success=True)
+        assert get_job(ok_job["id"])["last_status"] == "ok"
+
+        # Job ran ok + delivery failed -> NOT plain "ok"; status signals it
+        failed_delivery = create_job(prompt="B", schedule="every 1h")
+        mark_job_run(
+            failed_delivery["id"], success=True,
+            delivery_error="send failed: 502",
+        )
+        updated = get_job(failed_delivery["id"])
+        assert updated["last_status"] != "ok"
+        assert updated["last_status"] == "ok (delivery failed)"
+        assert updated["last_error"] is None
+        assert updated["last_delivery_error"] == "send failed: 502"
+
+        # Job failed -> "error" unchanged
+        failed_job = create_job(prompt="C", schedule="every 1h")
+        mark_job_run(failed_job["id"], success=False, error="timeout")
+        assert get_job(failed_job["id"])["last_status"] == "error"
 
 
     def test_recurring_cron_not_disabled_when_croniter_missing(self, tmp_cron_dir, monkeypatch):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -770,10 +770,14 @@ def _run_claimed_job(
             release_running_job(job_id)
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
+        # A delivery failure (job ran, output never reached the user) must
+        # not come back as a success with no reason — surface the delivery
+        # error so the calling agent knows the output was dropped (#83993).
+        run_error = refreshed.get("last_error") or refreshed.get("last_delivery_error")
         return {
             "claimed": True,
             "success": bool(processed and ok),
-            "error": refreshed.get("last_error"),
+            "error": run_error,
         }
 
     except Exception as e:


### PR DESCRIPTION
## Summary
When a cron job's task succeeds but delivery to the messaging platform fails (rate limit, stale session, transient network, live-adapter send error), the job was recorded as `last_status: ok` with the only failure signal buried in `last_delivery_error`. When the live-adapter send fails, delivery silently falls back to the standalone path — the user never knows the output was dropped.

## Change
- `cron/jobs.py::mark_job_run()`: derived status now considers delivery — `"ok (delivery failed)"` when `success and delivery_error` (never a clean `ok` hiding a dropped delivery); explicit `status` overrides still win. Docstring documents the contract.
- `hermes_cli/cron.py`: detail view shows `ok (delivery failed)` in yellow (no more ugly RED branch with `last_error: None`).
- `tools/cronjob_tools.py`: `_execute_job_now` reflects the delivery-aware status.
- `tests/cron/test_jobs.py`: new cases — job ok + delivery failed → `ok (delivery failed)`; job ok + delivery ok → `ok`; job failed → `error`.

## Verification
- `tests/cron/test_jobs.py -k "delivery or status"`: **5 passed**.

Closes #83993