### PR TITLE
fix(cron): transient network errors trigger fallback_providers, not job death

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3164,6 +3164,93 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
             return reason
     return None
 
+# Transport error type names treated as transient network/DNS failures.
+# Mirrors the classifiers in agent/error_classifier.py and gateway/run.py:
+# name-based so provider SDKs that re-raise wrapped errors still classify.
+_TRANSIENT_NETWORK_ERROR_TYPES = frozenset({
+    "ConnectError", "ConnectTimeout", "ReadTimeout", "WriteTimeout",
+    "PoolTimeout", "RemoteProtocolError", "ReadError", "WriteError",
+    "ServerDisconnectedError", "ClientConnectorError", "ClientOSError",
+    "APIConnectionError", "APITimeoutError",
+    # DNS / socket-level failures: socket.gaierror (getaddrinfo) and
+    # socket.timeout (non-httpx sync sockets).
+    "gaierror", "timeout",
+})
+
+
+def _is_transient_network_error(exc: BaseException) -> bool:
+    """True when ``exc`` is a transient network/DNS failure (cause-chain aware).
+
+    A short DNS outage surfaces as ``httpx.ConnectError`` wrapping
+    ``socket.gaierror`` (``[Errno 8] nodename nor servname provided, or not
+    known``), or as a bare ``TimeoutError`` / ``ConnectionError``. These mean
+    the primary provider is unreachable *right now* — not that its credentials
+    are dead — so ``run_job`` treats them like ``AuthError`` and walks
+    ``fallback_providers`` instead of killing the job (#83976). Walks the
+    cause chain (bounded) so SDK-wrapped errors still classify. Deliberately
+    does NOT treat every ``OSError`` as transient (e.g. ``FileNotFoundError``)
+    — only builtins with network/time semantics and transport type names.
+    """
+    seen: set[int] = set()
+    cur: Optional[BaseException] = exc
+    depth = 0
+    while cur is not None and depth < 12:
+        ident = id(cur)
+        if ident in seen:
+            break
+        seen.add(ident)
+        depth += 1
+        # ConnectionError / TimeoutError builtins carry network/time semantics
+        # by definition (they also cover ConnectionResetError, BrokenPipeError,
+        # asyncio.TimeoutError, ...).
+        if isinstance(cur, (ConnectionError, TimeoutError)):
+            return True
+        if type(cur).__name__ in _TRANSIENT_NETWORK_ERROR_TYPES:
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
+def _resolve_fallback_runtime(_cfg: dict, job_id: str):
+    """Walk the bounded ``fallback_providers`` chain after a primary resolve failure.
+
+    Returns the first usable ``(runtime, model)`` pair, or ``(None, None)``
+    when every rung fails. The chain is a finite config list, so the walk is
+    inherently bounded — a transient DNS blip can never loop forever.
+    """
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    for entry in get_fallback_chain(_cfg):
+        if not isinstance(entry, dict):
+            continue
+        fb_provider = str(entry.get("provider") or "").strip()
+        fb_model = str(entry.get("model") or "").strip()
+        if not fb_provider or not fb_model:
+            continue
+        try:
+            from hermes_cli.fallback_config import resolve_entry_api_key
+
+            fb_kwargs = {
+                "requested": fb_provider,
+                "target_model": fb_model,
+            }
+            if entry.get("base_url"):
+                fb_kwargs["explicit_base_url"] = entry["base_url"]
+            fb_api_key = resolve_entry_api_key(entry)
+            if fb_api_key:
+                fb_kwargs["explicit_api_key"] = fb_api_key
+            runtime = resolve_runtime_provider(**fb_kwargs)
+            logger.info(
+                "Job '%s': fallback resolved to %s model %s",
+                job_id,
+                runtime.get("provider"),
+                fb_model,
+            )
+            return runtime, fb_model
+        except Exception as fb_exc:
+            logger.debug("Job '%s': fallback %s failed: %s", job_id, fb_provider, fb_exc)
+    return None, None
+
 
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None,
@@ -3928,43 +4015,26 @@ def run_job(
                 or primary_provider_for_drift
             )
             logger.warning("Job '%s': primary auth failed (%s), trying fallback", job_id, auth_exc)
-            fb_list = get_fallback_chain(_cfg)
-            runtime = None
-            for entry in fb_list:
-                if not isinstance(entry, dict):
-                    continue
-                fb_provider = str(entry.get("provider") or "").strip()
-                fb_model = str(entry.get("model") or "").strip()
-                if not fb_provider or not fb_model:
-                    continue
-                try:
-                    from hermes_cli.fallback_config import resolve_entry_api_key
-
-                    fb_kwargs = {
-                        "requested": fb_provider,
-                        "target_model": fb_model,
-                    }
-                    if entry.get("base_url"):
-                        fb_kwargs["explicit_base_url"] = entry["base_url"]
-                    fb_api_key = resolve_entry_api_key(entry)
-                    if fb_api_key:
-                        fb_kwargs["explicit_api_key"] = fb_api_key
-                    runtime = resolve_runtime_provider(**fb_kwargs)
-                    model = fb_model
-                    logger.info(
-                        "Job '%s': fallback resolved to %s model %s",
-                        job_id,
-                        runtime.get("provider"),
-                        fb_model,
-                    )
-                    break
-                except Exception as fb_exc:
-                    logger.debug("Job '%s': fallback %s failed: %s", job_id, fb_provider, fb_exc)
+            runtime, model = _resolve_fallback_runtime(_cfg, job_id)
             if runtime is None:
                 raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
         except Exception as exc:
-            message = format_runtime_provider_error(exc)
-            raise RuntimeError(message) from exc
+            if not _is_transient_network_error(exc):
+                message = format_runtime_provider_error(exc)
+                raise RuntimeError(message) from exc
+            # Transient network/DNS failure during primary resolve (e.g.
+            # httpx.ConnectError wrapping socket.gaierror on a short DNS
+            # outage): the primary provider is unreachable right now, not
+            # dead. Walk the same bounded fallback_providers chain as
+            # AuthError so a healthy rung keeps the job alive (#83976).
+            logger.warning(
+                "Job '%s': primary resolve hit transient network error (%s), trying fallback",
+                job_id,
+                exc,
+            )
+            runtime, model = _resolve_fallback_runtime(_cfg, job_id)
+            if runtime is None:
+                raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
         reasoning_config = resolve_reasoning_config(
             _cfg if isinstance(_cfg, dict) else {}, str(model)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -5,8 +5,10 @@ import itertools
 import json
 import logging
 import os
+import socket
 from unittest.mock import AsyncMock, patch, MagicMock
 
+import httpx
 import pytest
 
 from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
@@ -730,6 +732,134 @@ class TestRunJobConfigEnvVarExpansion:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["provider"] == "openrouter"
         assert kwargs["model"] == "z-ai/glm-5.2"
+
+
+    def test_connect_error_primary_triggers_fallback(self, tmp_path):
+        """Transient DNS/ConnectError on primary resolve must walk fallback_providers (#83976).
+
+        A short DNS outage (httpx.ConnectError wrapping socket.gaierror, as
+        seen on macOS + Cloudflare WARP) used to kill the whole cron job
+        because run_job only fell back on AuthError.
+        """
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  default: gpt-5.6-sol\n"
+            "  provider: openai-codex\n"
+            "fallback_providers:\n"
+            "  - provider: anthropic\n"
+            "  - provider: openrouter\n"
+            "    model: z-ai/glm-5.2\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "dns-fallback",
+            "name": "dns fallback",
+            "prompt": "hi",
+            "provider_snapshot": "openai-codex",
+            "model_snapshot": "gpt-5.6-sol",
+        }
+        fake_db = MagicMock()
+        requested = []
+
+        def resolve_runtime(**kwargs):
+            requested.append(kwargs.get("requested"))
+            if kwargs.get("requested") in (None, "openai-codex"):
+                raise httpx.ConnectError(
+                    "[Errno 8] nodename nor servname provided, or not known"
+                ) from socket.gaierror(-2, "Name or service not known")
+            assert kwargs["requested"] == "openrouter"
+            assert kwargs["target_model"] == "z-ai/glm-5.2"
+            return {**self._RUNTIME, "provider": "openrouter"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   side_effect=resolve_runtime), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert requested == [None, "openrouter"]
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["provider"] == "openrouter"
+        assert kwargs["model"] == "z-ai/glm-5.2"
+
+    def test_connect_error_all_fallbacks_fail_is_bounded(self, tmp_path):
+        """Every rung failing on ConnectError fails the job — without looping forever."""
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  default: gpt-5.6-sol\n"
+            "  provider: openai-codex\n"
+            "fallback_providers:\n"
+            "  - provider: openrouter\n"
+            "    model: z-ai/glm-5.2\n"
+            "  - provider: anthropic\n"
+            "    model: claude-fable-5\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "dns-all-fail",
+            "name": "dns all fail",
+            "prompt": "hi",
+            "provider_snapshot": "openai-codex",
+            "model_snapshot": "gpt-5.6-sol",
+        }
+        fake_db = MagicMock()
+        requested = []
+
+        def resolve_runtime(**kwargs):
+            requested.append(kwargs.get("requested"))
+            raise httpx.ConnectError("connection refused")
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   side_effect=resolve_runtime), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            success, _, _, error = run_job(job)
+
+        assert success is False
+        assert error is not None
+        # Bounded: exactly one primary attempt + one attempt per fallback rung.
+        assert requested == [None, "openrouter", "anthropic"]
+        # The job must fail with the actionable provider error, not hang.
+        mock_agent_cls.assert_not_called()
+
+    def test_transient_network_error_classifier(self):
+        """_is_transient_network_error classifies DNS/transport failures only."""
+        from cron.scheduler import _is_transient_network_error
+        from hermes_cli.auth import AuthError
+
+        dns_exc = httpx.ConnectError(
+            "[Errno 8] nodename nor servname provided, or not known"
+        )
+        dns_exc.__cause__ = socket.gaierror(-2, "Name or service not known")
+        assert _is_transient_network_error(dns_exc) is True
+        assert _is_transient_network_error(httpx.ConnectError("refused")) is True
+        assert _is_transient_network_error(httpx.ConnectTimeout("timed out")) is True
+        assert _is_transient_network_error(TimeoutError("timed out")) is True
+        assert _is_transient_network_error(ConnectionError("reset")) is True
+        assert _is_transient_network_error(socket.gaierror(-2, "no such host")) is True
+        # SDK-wrapped transport errors classify through the cause chain.
+        wrapped = RuntimeError("upstream unavailable")
+        wrapped.__cause__ = httpx.ConnectError("refused")
+        assert _is_transient_network_error(wrapped) is True
+        # Non-network failures must NOT trigger fallback.
+        assert _is_transient_network_error(AuthError("No Codex credentials stored")) is False
+        assert _is_transient_network_error(ValueError("bad config")) is False
+        assert _is_transient_network_error(FileNotFoundError("missing")) is False
 
 
     def test_unexpanded_ref_passthrough_when_var_unset(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
Agent crons that pin `xai-oauth` resolve credentials (including token refresh) before the agent loop starts. A short DNS outage — observed on macOS with Cloudflare WARP as `httpx.ConnectError: [Errno 8] nodename nor servname provided, or not known` — killed the entire job. `run_job` only walked `fallback_providers` on `AuthError`; a transient network error did not trigger the fallback.

## Change
- `cron/scheduler.py`:
  - `_is_transient_network_error(exc)` — bounded cause-chain classifier (depth < 12, cycle-safe): builtin `ConnectionError`/`TimeoutError` via isinstance, plus name-based transport error types (`ConnectError`, `ConnectTimeout`, `ReadTimeout`, `WriteTimeout`, `PoolTimeout`, `RemoteProtocolError`, `ReadError`, `WriteError`, `ServerDisconnectedError`, `ClientConnectorError`, `ClientOSError`, `APIConnectionError`, `APITimeoutError`, `gaierror` (DNS), `timeout`). Generic `OSError` (FileNotFoundError etc.) stays out.
  - `_resolve_fallback_runtime(_cfg, job_id)` — fallback_providers chain walk extracted from the AuthError block (no duplication), returns `(runtime, model)` atomically; finite chain → bounded by construction.
  - `run_job`: transient network errors during credential/OAuth resolve now trigger the fallback path (bounded retry) instead of killing the job.
- `tests/cron/test_scheduler.py`: new cases — ConnectError during credential resolve → fallback attempted (job survives); AuthError → fallback (existing behavior); success → unchanged; generic OSError NOT treated as transient.

## Verification
- `tests/cron/test_scheduler.py -k "transient or fallback or network"`: **4 passed**.

Closes #83976