### PR TITLE
fix(delegation): treat literal 'auto' model/provider as inherit-from-parent

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1343,8 +1343,8 @@ delegation:
                                               # The parent TUI owns stdin, so blocking would deadlock; non-interactive resolution is required.
                                               # Both choices emit a logger.warning audit line. Flip to true only for cron/batch pipelines.
   # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true). Set false for strict intersection.
-  # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
-  # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
+  # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty or "auto" = inherit parent)
+  # provider: "openrouter"                    # Override provider for subagents (empty or "auto" = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
   #                                           # Cost tip: keep the parent on a frontier model and pin

--- a/tests/tools/test_delegate_auto_sentinel.py
+++ b/tests/tools/test_delegate_auto_sentinel.py
@@ -1,0 +1,134 @@
+"""Literal ``"auto"`` sentinel normalization for ``delegation.model`` /
+``delegation.provider``.
+
+Background: ``cli-config.yaml.example`` documents ``empty = inherit parent``
+for both keys, but users and setup flows commonly write the sentinel
+``"auto"`` with the same intent. Before this fix the non-empty string was
+treated as an explicit override:
+
+  - ``provider="auto"`` reached ``resolve_runtime_provider(requested="auto")``,
+    which matches no configured provider and silently reroutes subagents
+    through the fallback chain — spending an unrelated provider's balance.
+  - ``model="auto"`` was passed verbatim to the child AIAgent and then to the
+    wire; the API rejects it (HTTP 401 "Model auto is not supported"), so
+    every subagent spawn fails immediately.
+
+The fix maps the literal ``"auto"`` (case-insensitive, stripped) to ``None``
+so the documented inherit-from-parent path applies — mirroring the
+auxiliary-path sentinel handling in ``agent/auxiliary_client.py`` and the
+cron-job normalization in ``cron/scheduler.py``.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Ensure project root is importable.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tools.delegate_tool import (
+    _normalize_auto_sentinel,
+    _resolve_delegation_credentials,
+)
+
+
+class TestNormalizeAutoSentinel:
+    def test_literal_auto_maps_to_none(self):
+        assert _normalize_auto_sentinel("auto") is None
+
+    def test_case_and_whitespace_insensitive(self):
+        assert _normalize_auto_sentinel("AUTO") is None
+        assert _normalize_auto_sentinel(" Auto ") is None
+
+    def test_empty_and_missing_map_to_none(self):
+        assert _normalize_auto_sentinel(None) is None
+        assert _normalize_auto_sentinel("") is None
+        assert _normalize_auto_sentinel("   ") is None
+
+    def test_real_values_pass_through_stripped(self):
+        assert _normalize_auto_sentinel("openrouter") == "openrouter"
+        assert _normalize_auto_sentinel("  kimi-k2.6  ") == "kimi-k2.6"
+        assert _normalize_auto_sentinel("automatic-model") == "automatic-model"
+
+
+class TestDelegationCredentialsAutoSentinel:
+    """``delegation.model: auto`` / ``delegation.provider: auto`` must behave
+    exactly like the documented empty values: the child inherits everything
+    from the parent agent and no runtime-provider resolution is attempted."""
+
+    def _parent(self):
+        parent = MagicMock()
+        parent.model = "parent-model"
+        parent.provider = "parent-provider"
+        parent.base_url = "https://parent.example/v1"
+        return parent
+
+    def test_auto_on_both_axes_inherits_from_parent(self):
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider"
+        ) as mock_resolve:
+            creds = _resolve_delegation_credentials(
+                {"model": "auto", "provider": "auto"}, self._parent()
+            )
+        assert creds["model"] is None, (
+            "literal 'auto' must normalize to inherit-parent, got "
+            f"{creds['model']!r} (it would reach the wire and be rejected)"
+        )
+        assert creds["provider"] is None
+        assert creds["base_url"] is None
+        assert creds["api_key"] is None
+        mock_resolve.assert_not_called()
+
+    def test_auto_is_case_insensitive(self):
+        creds = _resolve_delegation_credentials(
+            {"model": " AUTO ", "provider": "Auto"}, self._parent()
+        )
+        assert creds["model"] is None
+        assert creds["provider"] is None
+
+    def test_auto_matches_documented_empty_behavior(self):
+        """Regression: the sentinel must be indistinguishable from empty."""
+        empty = _resolve_delegation_credentials({}, self._parent())
+        auto = _resolve_delegation_credentials(
+            {"model": "auto", "provider": "auto"}, self._parent()
+        )
+        assert auto == empty
+
+    def test_explicit_override_still_wins(self):
+        """A real (non-'auto') provider pin resolves full credentials."""
+        runtime = {
+            "api_key": "test-key",
+            "base_url": "https://openrouter.example/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "request_overrides": {},
+            "max_output_tokens": None,
+        }
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=runtime,
+        ) as mock_resolve:
+            creds = _resolve_delegation_credentials(
+                {"model": "child-model", "provider": "openrouter"},
+                self._parent(),
+            )
+        assert creds["model"] == "child-model"
+        assert creds["provider"] == "openrouter"
+        assert creds["api_key"] == "test-key"
+        mock_resolve.assert_called_once()
+        kwargs = mock_resolve.call_args.kwargs
+        assert kwargs["requested"] == "openrouter"
+        assert kwargs["target_model"] == "child-model"
+
+    def test_provider_auto_with_pinned_model_still_inherits_provider(self):
+        """model pinned + provider='auto': the model override survives while
+        the provider axis falls back to parent inheritance."""
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider"
+        ) as mock_resolve:
+            creds = _resolve_delegation_credentials(
+                {"model": "child-model", "provider": "auto"}, self._parent()
+            )
+        assert creds["model"] == "child-model"
+        assert creds["provider"] is None
+        mock_resolve.assert_not_called()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3898,6 +3898,29 @@ def _resolve_child_credential_pool(
     return None
 
 
+def _normalize_auto_sentinel(value) -> Optional[str]:
+    """Treat the literal ``"auto"`` sentinel as "inherit from parent".
+
+    ``delegation.model`` / ``delegation.provider`` document ``empty = inherit
+    parent``. Users (and setup flows) frequently write the sentinel ``"auto"``
+    to mean the same thing, but without normalization the non-empty string is
+    treated as an explicit override: ``provider="auto"`` reaches
+    ``resolve_runtime_provider(requested="auto")`` (which matches no configured
+    provider and silently reroutes through the fallback chain), and
+    ``model="auto"`` is passed verbatim to the child AIAgent and then to the
+    wire, where the API rejects it (HTTP 401 "Model auto is not supported") on
+    every subagent spawn. "auto" is not a model or provider literally named
+    "auto"; map it to ``None`` so the documented inherit-from-parent path
+    applies. Mirrors the auxiliary-path sentinel handling in
+    ``agent/auxiliary_client.py`` and the cron-job normalization in
+    ``cron/scheduler.py``.
+    """
+    text = str(value or "").strip()
+    if text.lower() == "auto":
+        return None
+    return text or None
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -3919,8 +3942,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
     Raises ValueError with a user-friendly message on credential failure.
     """
-    configured_model = str(cfg.get("model") or "").strip() or None
-    configured_provider = str(cfg.get("provider") or "").strip() or None
+    configured_model = _normalize_auto_sentinel(cfg.get("model"))
+    configured_provider = _normalize_auto_sentinel(cfg.get("provider"))
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
     configured_api_mode = str(cfg.get("api_mode") or "").strip().lower() or None


### PR DESCRIPTION
## What does this PR do?

Normalizes the literal `"auto"` sentinel in `delegation.model` / `delegation.provider` to the documented *inherit from parent* behavior, instead of treating it as an explicit override that reaches the wire.

`cli-config.yaml.example` documents `empty = inherit parent` for both keys, but users and setup flows commonly write `"auto"` with the same intent. Without normalization:

- `model="auto"` is passed verbatim to the child `AIAgent` and rejected by the API (HTTP 401 `Model auto is not supported`) — **every subagent spawn fails** (non-retryable).
- `provider="auto"` reaches `resolve_runtime_provider(requested="auto")`, matches no configured provider, and silently reroutes subagents through the fallback chain — spending an unrelated provider's balance.

The fix adds `_normalize_auto_sentinel()` (maps literal `"auto"`, case-insensitive/stripped, to `None`) and applies it to both axes at the top of `_resolve_delegation_credentials()`. Explicit real overrides pass through untouched. This mirrors the auxiliary-path sentinel contract in `agent/auxiliary_client.py` and the cron-job normalization in `cron/scheduler.py` (#83596 / companion PR).

## Related Issue

Fixes #84007

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py`:
  - new `_normalize_auto_sentinel()` helper
  - `_resolve_delegation_credentials()`: normalize `delegation.model` / `delegation.provider` before override branching, so `"auto"` takes the documented inherit-from-parent path
- `cli-config.yaml.example`: document `empty or "auto" = inherit parent` for both keys
- `tests/tools/test_delegate_auto_sentinel.py`: 9 new tests (helper unit tests, inherit behavior, case-insensitivity, sentinel == empty equivalence, explicit-override passthrough, mixed pin/auto)

## How to Test

1. Configure `delegation: {model: auto, provider: auto}` and delegate any task — before the fix every child fails with `HTTP 401: Model auto is not supported`; after the fix children inherit the parent's model/provider.
2. `pytest tests/tools/test_delegate_auto_sentinel.py -q` — 9 passed.
3. `pytest tests/tools/test_delegate.py tests/tools/test_async_delegation.py tests/tools/test_delegate_batch_validation.py tests/tools/test_delegate_toolset_scope.py -q` — 101 passed (no regressions); `ruff check` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

> Note: ran the delegation-focused suites listed above (110 passed total incl. the new tests) plus `ruff check` on changed files; the change is contained to `_resolve_delegation_credentials`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Field evidence before the fix (`agent.log`, three parallel subagents dying identically):

```text
INFO [20260811_234418_cb5612] agent.turn_context: conversation turn: session=20260811_234418_cb5612 model=auto provider=<provider> platform=subagent
ERROR [20260811_234418_cb5612] agent.conversation_loop: [subagent-1] Non-retryable client error: Error code: 401 - {'type': 'error', 'error': {'type': 'ModelError', 'message': 'Model auto is not supported'}}
```
