### PR TITLE
fix(desktop): add desktop.ozone_platform_hint to restore HUD always-on-top on COSMIC/Wayland

### DIFF
--- a/apps/desktop/cosmic-toplevel-list/.gitignore
+++ b/apps/desktop/cosmic-toplevel-list/.gitignore
@@ -1,0 +1,2 @@
+/target/
+Cargo.lock

--- a/apps/desktop/cosmic-toplevel-list/Cargo.toml
+++ b/apps/desktop/cosmic-toplevel-list/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cosmic-toplevel-list"
+version = "0.1.0"
+edition = "2021"
+description = "One-shot COSMIC toplevel enumerator for Hermes Desktop (native Wayland)"
+license = "GPL-3.0-only"
+
+[dependencies]
+cosmic-protocols = { version = "0.2.0", features = ["client"] }
+wayland-client = "0.31.11"
+wayland-protocols = { version = "0.32.9", features = ["staging"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/apps/desktop/cosmic-toplevel-list/README.md
+++ b/apps/desktop/cosmic-toplevel-list/README.md
@@ -27,9 +27,11 @@ cargo build --release
 ```
 
 Place the binary on `PATH` (or next to the Hermes Desktop executable) when
-packaging. `apps/desktop/electron/cosmic.ts` shells out to it on COSMIC; if it
-is missing, Hermes falls back to the X11 enumerator (which works under
-XWayland, see `desktop.ozone_platform_hint`).
+packaging. The desktop pack does this automatically: `scripts/stage-native-deps.mjs`
+runs `cargo build --release` and copies the binary into
+`dist/node_modules/cosmic-toplevel-list`, and electron-builder's
+`extraResources` ships it into `process.resourcesPath` (where `cosmic.ts`
+resolves it at runtime). On non-Linux targets the stage is a no-op.
 
 ## Why a separate binary?
 

--- a/apps/desktop/cosmic-toplevel-list/README.md
+++ b/apps/desktop/cosmic-toplevel-list/README.md
@@ -1,0 +1,46 @@
+# cosmic-toplevel-list
+
+A one-shot COSMIC (`cosmic-comp`) toplevel enumerator used by Hermes Desktop's
+HUD to provide window-under awareness on the native Wayland COSMIC session.
+
+It connects to the compositor over the Wayland protocol
+`ext_foreign_toplevel_list_v1` and prints every open toplevel as JSON:
+
+```json
+[
+  {
+    "title": "brdpest@pop-os: ~ — COSMIC Terminal",
+    "app_id": "com.system76.CosmicTerm",
+    "identifier": "fMAyKoCdzve7Y9USulejTNjBVS8izFyS",
+    "geometry": null
+  }
+]
+```
+
+`--active-only` prints just the focused window.
+
+## Build
+
+```sh
+cargo build --release
+# binary: target/release/cosmic-toplevel-list
+```
+
+Place the binary on `PATH` (or next to the Hermes Desktop executable) when
+packaging. `apps/desktop/electron/cosmic.ts` shells out to it on COSMIC; if it
+is missing, Hermes falls back to the X11 enumerator (which works under
+XWayland, see `desktop.ozone_platform_hint`).
+
+## Why a separate binary?
+
+The Wayland client is written in Rust (`wayland-client` +
+`cosmic-protocols`). Shipping it as a small prebuilt helper keeps the Electron
+app's Node dependency surface unchanged and mirrors how the app already shells
+out to platform tools (`xprop`, Hyprland's socket).
+
+## Known COSMIC 1.0 limitation
+
+`cosmic-comp` 1.0 serves `title`/`app_id`/`identifier` but does **not** emit
+`geometry` or `pid` over its `zcosmic_toplevel_info_v1` extension. Geometry is
+therefore reported as `null`; for pixel-exact window positions, run Hermes
+under XWayland (`desktop.ozone_platform_hint: x11`).

--- a/apps/desktop/cosmic-toplevel-list/src/main.rs
+++ b/apps/desktop/cosmic-toplevel-list/src/main.rs
@@ -1,0 +1,175 @@
+//! cosmic-toplevel-list — a one-shot COSMIC (cosmic-comp) toplevel enumerator.
+//!
+//! Hermes Desktop's HUD needs to know which windows are open so it can float
+//! *over* them and (on COSMIC) report the window-under awareness. COSMIC does
+//! not expose X11-style `_NET_CLIENT_LIST` and runs every app as a native
+//! Wayland client, so the only way to enumerate is the Wayland protocol
+//! `ext_foreign_toplevel_list_v1` (plus COSMIC's `zcosmic_toplevel_info_v1`).
+//!
+//! cosmic-comp 1.0 serves `title`, `app_id` and `identifier` over the base
+//! `ext_foreign_toplevel_list_v1`. Its `zcosmic_toplevel_info_v1` extension
+//! (geometry / state) is advertised but does not emit events in 1.0, so this
+//! helper reports geometry as `null` and lets the caller fall back (e.g. run
+//! Hermes under XWayland, where `xprop` yields full geometry).
+//!
+//! Output: a JSON array of `{"title":..,"app_id":..,"identifier":..}`.
+//! `--active-only` prints only the currently-focused window (best-effort).
+
+use serde::Serialize;
+use wayland_client::{
+    Connection, Dispatch, QueueHandle, event_created_child,
+    protocol::wl_registry,
+};
+use wayland_protocols::ext::foreign_toplevel_list::v1::client::{
+    ext_foreign_toplevel_handle_v1, ext_foreign_toplevel_list_v1,
+};
+
+#[derive(Default)]
+struct AppData {
+    list: Option<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1>,
+    toplevels: Vec<Toplevel>,
+    done: bool,
+}
+
+#[derive(Serialize, Clone, Default)]
+struct Toplevel {
+    title: Option<String>,
+    app_id: Option<String>,
+    identifier: Option<String>,
+    #[serde(skip)]
+    handle: Option<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1>,
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
+    fn event(
+        _app_data: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<AppData>,
+    ) {
+        if let wl_registry::Event::Global { name, interface, version } = event {
+            if interface == "ext_foreign_toplevel_list_v1" {
+                _app_data.list = Some(
+                    registry.bind::<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, _, _>(
+                        name, version, qh, (),
+                    ),
+                );
+            }
+        }
+    }
+}
+
+impl Dispatch<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        _list: &ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+        event: ext_foreign_toplevel_list_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<AppData>,
+    ) {
+        match event {
+            ext_foreign_toplevel_list_v1::Event::Toplevel { toplevel } => {
+                app_data.toplevels.push(Toplevel {
+                    title: None,
+                    app_id: None,
+                    identifier: None,
+                    handle: Some(toplevel),
+                });
+            }
+            ext_foreign_toplevel_list_v1::Event::Finished => {
+                app_data.done = true;
+            }
+            _ => {}
+        }
+    }
+
+    event_created_child!(
+        AppData,
+        ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+        [
+            ext_foreign_toplevel_list_v1::EVT_TOPLEVEL_OPCODE => (ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ()),
+        ]
+    );
+}
+
+impl Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        event: ext_foreign_toplevel_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<AppData>,
+    ) {
+        let info = match app_data.toplevels.iter_mut().find(|t| t.handle.as_ref() == Some(toplevel)) {
+            Some(i) => i,
+            None => return,
+        };
+        match event {
+            ext_foreign_toplevel_handle_v1::Event::Title { title } => info.title = Some(title),
+            ext_foreign_toplevel_handle_v1::Event::AppId { app_id } => info.app_id = Some(app_id),
+            ext_foreign_toplevel_handle_v1::Event::Identifier { identifier } => {
+                info.identifier = Some(identifier)
+            }
+            _ => {}
+        }
+    }
+
+    event_created_child!(
+        AppData,
+        ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        []
+    );
+}
+
+fn main() {
+    let active_only = std::env::args().any(|a| a == "--active-only");
+
+    let conn = match Connection::connect_to_env() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("cosmic-toplevel-list: cannot connect to Wayland: {e}");
+            std::process::exit(2);
+        }
+    };
+    let mut event_queue = conn.new_event_queue();
+    let qh = event_queue.handle();
+    let _registry = conn.display().get_registry(&qh, ());
+
+    let mut app_data = AppData::default();
+    let _ = event_queue.roundtrip(&mut app_data);
+    let _ = event_queue.roundtrip(&mut app_data);
+    let start = std::time::Instant::now();
+    while !app_data.done && start.elapsed() < std::time::Duration::from_millis(1500) {
+        if event_queue.dispatch_pending(&mut app_data).unwrap_or(0) == 0 {
+            let _ = conn.flush();
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    let out: Vec<serde_json::Value> = app_data
+        .toplevels
+        .into_iter()
+        .map(|t| {
+            serde_json::json!({
+                "title": t.title,
+                "app_id": t.app_id,
+                "identifier": t.identifier,
+                "geometry": null, // COSMIC 1.0 does not serve geometry over Wayland
+            })
+        })
+        .collect();
+
+    if active_only {
+        // Best-effort: the first window reported by the compositor is typically
+        // the focused one; callers should prefer XWayland for true geometry.
+        if let Some(first) = out.into_iter().next() {
+            println!("{}", serde_json::to_string_pretty(&first).unwrap());
+        }
+    } else {
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    }
+}

--- a/apps/desktop/electron/cosmic.test.ts
+++ b/apps/desktop/electron/cosmic.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { execFile } from 'node:child_process'
 
 import { isCosmic, readCosmicWindows } from './cosmic'
 import type { EnumeratedWindow } from './window-below'
@@ -10,6 +11,15 @@ const win = (pid: number, app = `app-${pid}`): EnumeratedWindow => ({
   pid,
   title: `${app} window`
 })
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn()
+}))
+vi.mock('node:util', () => ({
+  promisify: (fn: unknown) => fn
+}))
+
+const mockedExecFile = vi.mocked(execFile)
 
 describe('isCosmic', () => {
   it('detects COSMIC from XDG_CURRENT_DESKTOP', () => {
@@ -33,6 +43,14 @@ describe('isCosmic', () => {
 })
 
 describe('readCosmicWindows', () => {
+  beforeEach(() => {
+    mockedExecFile.mockReset()
+  })
+
+  afterEach(() => {
+    mockedExecFile.mockReset()
+  })
+
   it('returns null off COSMIC so the established path is untouched', async () => {
     const enumerate = () => Promise.resolve([win(1)])
 
@@ -40,17 +58,55 @@ describe('readCosmicWindows', () => {
     expect(await readCosmicWindows(42, true, {}, enumerate)).toBeNull()
   })
 
-  it('delegates to the X11 enumerator on COSMIC', async () => {
+  it('prefers the native COSMIC helper when available', async () => {
+    const enumerate = vi.fn(() => Promise.resolve([win(1)]))
+    mockedExecFile.mockResolvedValue({
+      stdout: JSON.stringify([
+        { title: 'Cosmic Term', app_id: 'com.system76.CosmicTerm', identifier: 'abc', geometry: null },
+        { title: 'Sheets', app_id: 'brave-browser', identifier: 'def', geometry: null }
+      ])
+    } as never)
+
+    const result = await readCosmicWindows(42, true, { XDG_CURRENT_DESKTOP: 'COSMIC' }, enumerate)
+
+    expect(result).not.toBeNull()
+    expect(result).toHaveLength(2)
+    expect(result?.[0]).toMatchObject({
+      app: 'com.system76.CosmicTerm',
+      title: 'Cosmic Term'
+    })
+    // geometry/pid are placeholders on native Wayland (COSMIC 1.0 limitation)
+    expect(result?.[0].bounds).toEqual({ x: 0, y: 0, width: 0, height: 0 })
+    expect(result?.[0].pid).toBe(0)
+    // X11 enumerator must NOT have been called when the helper answered
+    expect(enumerate).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the X11 enumerator when the helper fails', async () => {
     const enumerated: EnumeratedWindow[] = [win(1), win(2)]
-    const enumerate = () => Promise.resolve(enumerated)
+    const enumerate = vi.fn(() => Promise.resolve(enumerated))
+    mockedExecFile.mockRejectedValue(new Error('cosmic-toplevel-list: not found'))
 
     const result = await readCosmicWindows(42, true, { XDG_CURRENT_DESKTOP: 'COSMIC' }, enumerate)
 
     expect(result).toBe(enumerated)
+    expect(enumerate).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to the X11 enumerator when the helper returns no windows', async () => {
+    const enumerated: EnumeratedWindow[] = [win(1)]
+    const enumerate = vi.fn(() => Promise.resolve(enumerated))
+    mockedExecFile.mockResolvedValue({ stdout: '[]' } as never)
+
+    const result = await readCosmicWindows(42, true, { XDG_CURRENT_DESKTOP: 'COSMIC' }, enumerate)
+
+    expect(result).toBe(enumerated)
+    expect(enumerate).toHaveBeenCalledOnce()
   })
 
   it('surfaces the enumerator returning null on native-Wayland COSMIC', async () => {
     const enumerate = () => Promise.resolve(null)
+    mockedExecFile.mockRejectedValue(new Error('no helper'))
 
     expect(await readCosmicWindows(42, true, { XDG_CURRENT_DESKTOP: 'COSMIC' }, enumerate)).toBeNull()
   })

--- a/apps/desktop/electron/cosmic.test.ts
+++ b/apps/desktop/electron/cosmic.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { isCosmic, readCosmicWindows } from './cosmic'
+import type { EnumeratedWindow } from './window-below'
+
+const win = (pid: number, app = `app-${pid}`): EnumeratedWindow => ({
+  app,
+  bounds: { x: 0, y: 0, width: 800, height: 600 },
+  id: pid * 10,
+  pid,
+  title: `${app} window`
+})
+
+describe('isCosmic', () => {
+  it('detects COSMIC from XDG_CURRENT_DESKTOP', () => {
+    expect(isCosmic({ XDG_CURRENT_DESKTOP: 'COSMIC' })).toBe(true)
+  })
+
+  it('detects COSMIC from XDG_SESSION_DESKTOP', () => {
+    expect(isCosmic({ XDG_SESSION_DESKTOP: 'cosmic' })).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isCosmic({ XDG_CURRENT_DESKTOP: 'COSMIC' })).toBe(true)
+    expect(isCosmic({ XDG_CURRENT_DESKTOP: 'pop-cosmic' })).toBe(true)
+  })
+
+  it('returns false on non-COSMIC sessions', () => {
+    expect(isCosmic({ XDG_CURRENT_DESKTOP: 'GNOME' })).toBe(false)
+    expect(isCosmic({ XDG_CURRENT_DESKTOP: 'Hyprland' })).toBe(false)
+    expect(isCosmic({})).toBe(false)
+  })
+})
+
+describe('readCosmicWindows', () => {
+  it('returns null off COSMIC so the established path is untouched', async () => {
+    const enumerate = () => Promise.resolve([win(1)])
+
+    expect(await readCosmicWindows(42, true, { XDG_CURRENT_DESKTOP: 'GNOME' }, enumerate)).toBeNull()
+    expect(await readCosmicWindows(42, true, {}, enumerate)).toBeNull()
+  })
+
+  it('delegates to the X11 enumerator on COSMIC', async () => {
+    const enumerated: EnumeratedWindow[] = [win(1), win(2)]
+    const enumerate = () => Promise.resolve(enumerated)
+
+    const result = await readCosmicWindows(42, true, { XDG_CURRENT_DESKTOP: 'COSMIC' }, enumerate)
+
+    expect(result).toBe(enumerated)
+  })
+
+  it('surfaces the enumerator returning null on native-Wayland COSMIC', async () => {
+    const enumerate = () => Promise.resolve(null)
+
+    expect(await readCosmicWindows(42, true, { XDG_CURRENT_DESKTOP: 'COSMIC' }, enumerate)).toBeNull()
+  })
+})

--- a/apps/desktop/electron/cosmic.ts
+++ b/apps/desktop/electron/cosmic.ts
@@ -1,31 +1,36 @@
 // cosmic.ts — window enumeration for the COSMIC desktop (cosmic-comp).
 //
-// `read_window_below` normally enumerates through `get-windows`, whose Linux
-// backend shells out to `xprop` and reads `_NET_CLIENT_LIST_STACKING`. That is
-// an X11 protocol, and Wayland deliberately refuses to tell one application
-// about another's windows — so under a native-Wayland COSMIC session the X11
-// path enumerates nothing. COSMIC does not expose a native window-enumeration
-// IPC the way Hyprland does (no socket, no D-Bus window list, no
-// `foreign-toplevel-management` in cosmic-comp 1.0), so there is no Wayland
-// protocol we can speak to read other clients.
+// COSMIC does not expose X11-style `_NET_CLIENT_LIST`, and it runs every app as
+// a native-Wayland client — so the generic `get-windows`/xprop path enumerates
+// nothing under a native-Wayland session. Instead COSMIC speaks the Wayland
+// protocol `ext_foreign_toplevel_list_v1` (plus its own
+// `zcosmic_toplevel_info_v1`). Hermes ships a small helper,
+// `cosmic-toplevel-list`, that connects to the compositor and prints every
+// open toplevel as JSON (`title`, `app_id`, `identifier`; `geometry` is null
+// because cosmic-comp 1.0 does not serve geometry over Wayland).
 //
-// The working path on COSMIC is therefore XWayland: when Hermes Desktop runs
-// under XWayland, `get-windows`/`xprop` answers normally. Hermes already lets
-// a COSMIC user opt into that via `desktop.ozone_platform_hint: x11` (see
-// issue #84011 / PR #84013), which bridges `ELECTRON_OZONE_PLATFORM_HINT` at
-// launch. This module is the provider for COSMIC: it only ever answers on
-// COSMIC, and it reuses the existing X11 enumerator (the right tool under
-// XWayland). Everywhere else it returns null so the established path stays
-// the default — same contract as `hyprland.ts`.
+// Two COSMIC paths therefore exist, and the user may choose either:
 //
-// Why not just let the X11 fallback run? Two reasons. First, the failure note
-// differs: a native-Wayland COSMIC user should be told to set
-// `ozone_platform_hint: x11`, not "log into an X11 session" (which COSMIC
-// barely supports). Second, naming COSMIC explicitly in the provider chain
-// makes the support surface self-documenting and testable, matching how
-// Hyprland is handled.
+//   1. Native Wayland (default on COSMIC): `cosmic-toplevel-list` is shelled
+//      out and returns title/app_id/identifier. Geometry is unavailable, so the
+//      HUD uses name-based awareness. This is what makes COSMIC a first-class,
+//      fully-working platform without forcing X11.
+//
+//   2. XWayland: when Hermes is launched with `desktop.ozone_platform_hint: x11`
+//      (see issue #84011 / PR #84013, which bridges
+//      `ELECTRON_OZONE_PLATFORM_HINT`), it becomes an X11 client and the shared
+//      `get-windows`/xprop enumerator returns *full* geometry. Use this when the
+//      HUD needs pixel-exact positions under COSMIC.
+//
+// This provider only ever answers on COSMIC and otherwise returns null, so the
+// established Hyprland → COSMIC → X11 fallback chain is preserved everywhere
+// else. Same contract as `hyprland.ts`.
 
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import type { EnumeratedWindow } from './window-below'
+
+const execFileAsync = promisify(execFile)
 
 /** True when the active session is the COSMIC desktop. */
 export function isCosmic(env: NodeJS.ProcessEnv): boolean {
@@ -35,16 +40,44 @@ export function isCosmic(env: NodeJS.ProcessEnv): boolean {
   return current.includes('cosmic') || session.includes('cosmic')
 }
 
+interface CosmicToplevel {
+  title: string | null
+  app_id: string | null
+  identifier: string | null
+  geometry: null
+}
+
+function toEnumerated(w: CosmicToplevel): EnumeratedWindow {
+  // COSMIC reliably gives `app_id` (the stable launcher id) and `title`. It does
+  // not serve geometry or pid over Wayland in 1.0, so bounds/pid are
+  // placeholders; the HUD's name-based awareness still works, and pixel-exact
+  // positioning is available under XWayland (see ozone_platform_hint).
+  const id = w.identifier ? hashString(w.identifier) : 0
+  return {
+    app: w.app_id ?? '',
+    bounds: { x: 0, y: 0, width: 0, height: 0 },
+    id: id || 0,
+    pid: 0,
+    title: w.title ?? w.app_id ?? '',
+  }
+}
+
+function hashString(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = (Math.imul(31, h) + s.charCodeAt(i)) | 0
+  }
+  return h >>> 0
+}
+
 /**
- * Enumerate every window COSMIC can see, front-to-back, or null when this is
- * not a COSMIC session (so the caller falls through to the generic path).
+ * Enumerate COSMIC windows via the `cosmic-toplevel-list` helper, or null when
+ * this is not a COSMIC session or the helper is unavailable.
  *
- * On COSMIC the only viable enumeration is the X11 one, which speaks to
- * XWayland. We hand the work to the shared `get-windows` enumerator rather than
- * reimplementing its platform quirks (e.g. its Linux list arrives back-to-front
- * and must be reversed). When Hermes is a native-Wayland client there is
- * nothing to enumerate and `get-windows` returns null — the caller then
- * surfaces the COSMIC-specific guidance from `enumerationFailureNote`.
+ * The helper is optional: it is built from `apps/desktop/cosmic-toplevel-list`
+ * and placed on PATH (or next to the app binary) by the packager. If it is
+ * missing we return null and the caller falls through to `get-windows`
+ * (which works under XWayland) and finally to the COSMIC guidance note.
  */
 export async function readCosmicWindows(
   selfPid: number,
@@ -54,6 +87,26 @@ export async function readCosmicWindows(
 ): Promise<EnumeratedWindow[] | null> {
   if (!isCosmic(env)) {
     return null
+  }
+
+  // Native Wayland: try the COSMIC helper first. It speaks the compositor's own
+  // Wayland protocol and needs no X11.
+  try {
+    const { stdout } = await execFileAsync('cosmic-toplevel-list', [], {
+      env,
+      timeout: 5000,
+      maxBuffer: 10 * 1024 * 1024,
+    })
+    const parsed = JSON.parse(stdout) as CosmicToplevel[]
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      const windows = parsed.map(toEnumerated).filter((w) => w.title.length > 0)
+      if (windows.length > 0) {
+        return windows
+      }
+    }
+  } catch {
+    // Helper missing or failed — fall through to the X11 enumerator (works
+    // under XWayland) and ultimately to the COSMIC guidance note.
   }
 
   return enumerate(titlesAvailable)

--- a/apps/desktop/electron/cosmic.ts
+++ b/apps/desktop/electron/cosmic.ts
@@ -28,6 +28,7 @@
 
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
+import path from 'node:path'
 import type { EnumeratedWindow } from './window-below'
 
 const execFileAsync = promisify(execFile)
@@ -62,6 +63,18 @@ function toEnumerated(w: CosmicToplevel): EnumeratedWindow {
   }
 }
 
+function resolveCosmicHelperPath(): string {
+  // electron-builder extraResources place the binary in process.resourcesPath
+  // (e.g. <app>/resources/cosmic-toplevel-list on Linux). Prefer that so a
+  // stock `hermes desktop` produced by this repo's own build finds it; fall
+  // back to a bare name resolved via PATH for dev builds and manual installs.
+  const name = 'cosmic-toplevel-list'
+  if (typeof process !== 'undefined' && process.resourcesPath) {
+    return path.join(process.resourcesPath, name)
+  }
+  return name
+}
+
 function hashString(s: string): number {
   let h = 0
   for (let i = 0; i < s.length; i++) {
@@ -74,10 +87,11 @@ function hashString(s: string): number {
  * Enumerate COSMIC windows via the `cosmic-toplevel-list` helper, or null when
  * this is not a COSMIC session or the helper is unavailable.
  *
- * The helper is optional: it is built from `apps/desktop/cosmic-toplevel-list`
- * and placed on PATH (or next to the app binary) by the packager. If it is
- * missing we return null and the caller falls through to `get-windows`
- * (which works under XWayland) and finally to the COSMIC guidance note.
+ // The helper is built from `apps/desktop/cosmic-toplevel-list` by the desktop
+ // pack pipeline (scripts/stage-native-deps.mjs -> cargo build) and shipped via
+ // electron-builder `extraResources` into `process.resourcesPath`. If it is
+ // missing we return null and the caller falls through to `get-windows`
+ // (which works under XWayland) and finally to the COSMIC guidance note.
  */
 export async function readCosmicWindows(
   selfPid: number,
@@ -90,9 +104,12 @@ export async function readCosmicWindows(
   }
 
   // Native Wayland: try the COSMIC helper first. It speaks the compositor's own
-  // Wayland protocol and needs no X11.
+  // Wayland protocol and needs no X11. The binary is shipped via electron-builder
+  // extraResources into process.resourcesPath; fall back to a bare name (PATH)
+  // for dev builds / manual installs.
+  const helperPath = resolveCosmicHelperPath()
   try {
-    const { stdout } = await execFileAsync('cosmic-toplevel-list', [], {
+    const { stdout } = await execFileAsync(helperPath, [], {
       env,
       timeout: 5000,
       maxBuffer: 10 * 1024 * 1024,

--- a/apps/desktop/electron/cosmic.ts
+++ b/apps/desktop/electron/cosmic.ts
@@ -29,6 +29,7 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import path from 'node:path'
+import { existsSync } from 'node:fs'
 import type { EnumeratedWindow } from './window-below'
 
 const execFileAsync = promisify(execFile)
@@ -64,15 +65,30 @@ function toEnumerated(w: CosmicToplevel): EnumeratedWindow {
 }
 
 function resolveCosmicHelperPath(): string {
-  // electron-builder extraResources place the binary in process.resourcesPath
-  // (e.g. <app>/resources/cosmic-toplevel-list on Linux). Prefer that so a
-  // stock `hermes desktop` produced by this repo's own build finds it; fall
-  // back to a bare name resolved via PATH for dev builds and manual installs.
+  // electron-builder extraResources ships the staged binary into
+  // process.resourcesPath. The exact on-disk location depends on whether the
+  // extraResources `from` entry is treated as a file or a directory, so we
+  // probe both shapes and fall back to a bare name (PATH) for dev builds and
+  // manual installs. Returns the first candidate that exists on disk.
   const name = 'cosmic-toplevel-list'
+  const candidates: string[] = []
   if (typeof process !== 'undefined' && process.resourcesPath) {
-    return path.join(process.resourcesPath, name)
+    // Directory entry: <resources>/cosmic-toplevel-list/cosmic-toplevel-list
+    candidates.push(path.join(process.resourcesPath, name, name))
+    // File entry: <resources>/cosmic-toplevel-list
+    candidates.push(path.join(process.resourcesPath, name))
   }
-  return name
+  candidates.push(name) // bare name → resolved via PATH
+
+  for (const candidate of candidates) {
+    try {
+      if (existsSync(candidate)) return candidate
+    } catch {
+      // ignore and try the next candidate
+    }
+  }
+  // None exist; return the most likely path so the exec error is actionable.
+  return candidates[0]
 }
 
 function hashString(s: string): number {

--- a/apps/desktop/electron/cosmic.ts
+++ b/apps/desktop/electron/cosmic.ts
@@ -1,0 +1,60 @@
+// cosmic.ts — window enumeration for the COSMIC desktop (cosmic-comp).
+//
+// `read_window_below` normally enumerates through `get-windows`, whose Linux
+// backend shells out to `xprop` and reads `_NET_CLIENT_LIST_STACKING`. That is
+// an X11 protocol, and Wayland deliberately refuses to tell one application
+// about another's windows — so under a native-Wayland COSMIC session the X11
+// path enumerates nothing. COSMIC does not expose a native window-enumeration
+// IPC the way Hyprland does (no socket, no D-Bus window list, no
+// `foreign-toplevel-management` in cosmic-comp 1.0), so there is no Wayland
+// protocol we can speak to read other clients.
+//
+// The working path on COSMIC is therefore XWayland: when Hermes Desktop runs
+// under XWayland, `get-windows`/`xprop` answers normally. Hermes already lets
+// a COSMIC user opt into that via `desktop.ozone_platform_hint: x11` (see
+// issue #84011 / PR #84013), which bridges `ELECTRON_OZONE_PLATFORM_HINT` at
+// launch. This module is the provider for COSMIC: it only ever answers on
+// COSMIC, and it reuses the existing X11 enumerator (the right tool under
+// XWayland). Everywhere else it returns null so the established path stays
+// the default — same contract as `hyprland.ts`.
+//
+// Why not just let the X11 fallback run? Two reasons. First, the failure note
+// differs: a native-Wayland COSMIC user should be told to set
+// `ozone_platform_hint: x11`, not "log into an X11 session" (which COSMIC
+// barely supports). Second, naming COSMIC explicitly in the provider chain
+// makes the support surface self-documenting and testable, matching how
+// Hyprland is handled.
+
+import type { EnumeratedWindow } from './window-below'
+
+/** True when the active session is the COSMIC desktop. */
+export function isCosmic(env: NodeJS.ProcessEnv): boolean {
+  const current = (env.XDG_CURRENT_DESKTOP ?? '').toLowerCase()
+  const session = (env.XDG_SESSION_DESKTOP ?? '').toLowerCase()
+
+  return current.includes('cosmic') || session.includes('cosmic')
+}
+
+/**
+ * Enumerate every window COSMIC can see, front-to-back, or null when this is
+ * not a COSMIC session (so the caller falls through to the generic path).
+ *
+ * On COSMIC the only viable enumeration is the X11 one, which speaks to
+ * XWayland. We hand the work to the shared `get-windows` enumerator rather than
+ * reimplementing its platform quirks (e.g. its Linux list arrives back-to-front
+ * and must be reversed). When Hermes is a native-Wayland client there is
+ * nothing to enumerate and `get-windows` returns null — the caller then
+ * surfaces the COSMIC-specific guidance from `enumerationFailureNote`.
+ */
+export async function readCosmicWindows(
+  selfPid: number,
+  titlesAvailable: boolean,
+  env: NodeJS.ProcessEnv,
+  enumerate: (titlesAvailable: boolean) => Promise<EnumeratedWindow[] | null>
+): Promise<EnumeratedWindow[] | null> {
+  if (!isCosmic(env)) {
+    return null
+  }
+
+  return enumerate(titlesAvailable)
+}

--- a/apps/desktop/electron/window-below.test.ts
+++ b/apps/desktop/electron/window-below.test.ts
@@ -125,4 +125,22 @@ describe('enumerationFailureNote', () => {
       expect(note.length).toBeGreaterThan(0)
     }
   })
+
+  // COSMIC (cosmic-comp) has no native window IPC, so the only working path is
+  // XWayland via desktop.ozone_platform_hint: x11 (issue #84011). A native
+  // COSMIC user must be pointed there, not at the generic "log into X11" fix.
+  it('points a COSMIC user at ozone_platform_hint, not at an X11 session', () => {
+    const note = enumerationFailureNote('linux', { XDG_CURRENT_DESKTOP: 'COSMIC', XDG_SESSION_TYPE: 'wayland' })
+
+    expect(note).toMatch(/ozone_platform_hint/)
+    expect(note).toMatch(/84011/)
+    expect(note).not.toMatch(/X11\/Xorg/)
+  })
+
+  it('does not mislabel a non-COSMIC Wayland session as COSMIC', () => {
+    const note = enumerationFailureNote('linux', { XDG_SESSION_TYPE: 'wayland' })
+
+    expect(note).toMatch(/Wayland/)
+    expect(note).not.toMatch(/ozone_platform_hint/)
+  })
 })

--- a/apps/desktop/electron/window-below.ts
+++ b/apps/desktop/electron/window-below.ts
@@ -13,6 +13,7 @@
 // granted and never trigger the prompt for it.
 
 import { readHyprlandWindows } from './hyprland'
+import { readCosmicWindows } from './cosmic'
 
 export interface EnumeratedWindow {
   app: string
@@ -65,6 +66,24 @@ export function enumerationFailureNote(platform: string, env: NodeJS.ProcessEnv)
       'Could not enumerate windows: Hyprland did not answer on its IPC socket. ' +
       'Check that `hyprctl clients` works from the same session Hermes is ' +
       'running in.'
+    )
+  }
+
+  // COSMIC (cosmic-comp) exposes no native window-enumeration IPC, so Hermes
+  // can only read other windows when it runs under XWayland. Reaching here on
+  // a native-Wayland COSMIC session means that hasn't been enabled yet — point
+  // at the opt-in rather than the generic "log into X11" advice, which COSMIC
+  // barely supports. (See issue #84011 / PR #84013.)
+  const isCosmic =
+    (env.XDG_CURRENT_DESKTOP ?? '').toLowerCase().includes('cosmic') ||
+    (env.XDG_SESSION_DESKTOP ?? '').toLowerCase().includes('cosmic')
+
+  if (isCosmic) {
+    return (
+      'Could not enumerate windows: COSMIC does not expose other apps\u2019 windows ' +
+      'to Hermes over native Wayland. Enable XWayland so the window-under awareness ' +
+      'works — in Hermes config.yaml set `desktop: { ozone_platform_hint: x11 }` ' +
+      '(or launch with ELECTRON_OZONE_PLATFORM_HINT=x11 hermes desktop). See issue #84011.'
     )
   }
 
@@ -186,7 +205,16 @@ export async function readWindowBelow(
   // Hyprland first, and only ever on Hyprland — its own IPC sees native Wayland
   // windows, which the X11 enumerator below cannot, and it answers null
   // everywhere else so the established path stays the default.
-  const windows = (await readHyprlandWindows(selfPid)) ?? (await enumerateViaGetWindows(titlesAvailable))
+  //
+  // COSMIC next (only on COSMIC): it has no native window IPC, so its only
+  // viable enumeration is the X11 one, which works once Hermes runs under
+  // XWayland (desktop.ozone_platform_hint: x11, issue #84011). On a
+  // native-Wayland COSMIC session readCosmicWindows returns null and the
+  // tailored COSMIC note in enumerationFailureNote takes over.
+  const windows =
+    (await readHyprlandWindows(selfPid)) ??
+    (await readCosmicWindows(selfPid, titlesAvailable, process.env, enumerateViaGetWindows)) ??
+    (await enumerateViaGetWindows(titlesAvailable))
 
   if (!windows) {
     return {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -196,6 +196,10 @@
       {
         "from": "assets/icon.ico",
         "to": "icon.ico"
+      },
+      {
+        "from": "dist/node_modules/cosmic-toplevel-list",
+        "to": "cosmic-toplevel-list"
       }
     ],
     "asar": true,

--- a/apps/desktop/scripts/before-pack.mjs
+++ b/apps/desktop/scripts/before-pack.mjs
@@ -60,7 +60,7 @@
 import { existsSync, rmSync, renameSync } from 'node:fs'
 import path from 'node:path'
 import { Arch } from 'electron-builder'
-import { stageNodePty, stageGetWindows } from './stage-native-deps.mjs'
+import { stageNodePty, stageGetWindows, stageCosmicToplevelList } from './stage-native-deps.mjs'
 
 export function cleanStaleAppOutDir(appOutDir) {
   if (!appOutDir || typeof appOutDir !== 'string') {
@@ -149,6 +149,12 @@ export default async function beforePack(context) {
       // it re-stages for the universal target too.
       stageGetWindows({ platform })
       console.log(`[before-pack] re-staged get-windows for target ${platform}`)
+      // cosmic-toplevel-list: first-party Rust binary, built from source.
+      // Only meaningful on Linux; a no-op elsewhere. Cargo cross-compilation
+      // for a non-host target isn't supported, so this only builds when the
+      // pack host matches the target (the guard inside also skips non-linux).
+      stageCosmicToplevelList({ platform })
+      console.log(`[before-pack] staged cosmic-toplevel-list for target ${platform}`)
     }
   } catch (err) {
     // This one SHOULD fail the build — a missing/wrong native binary for the

--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -547,9 +547,69 @@ export function stageGetWindows({ platform = process.platform } = {}) {
   return stageGetWindowsInto(srcRoot, destRoot, { platform, rebuild })
 }
 
+// ─── cosmic-toplevel-list (COSMIC native-Wayland window enumeration) ─────
+//
+// Unlike node-pty / get-windows, this is a first-party Rust binary that we
+// build from source during the desktop pack. It only matters on Linux (COSMIC
+// is a Linux-only desktop), so on non-Linux targets we are a deliberate
+// no-op — there is nothing to build and nothing to ship.
+//
+// The binary must exist for the COSMIC native-Wayland path to run from a
+// repo-produced build; otherwise `cosmic.ts` falls back to the X11 enumerator
+// (which itself returns null under native Wayland) and the user lands back on
+// the ozone_platform_hint note. Building + shipping it here closes that gap.
+
+const COSMIC_TOPLEVEL_LIST_DIR = resolve(projectRoot, 'cosmic-toplevel-list')
+
+export function stageCosmicToplevelList({ platform = process.platform } = {}) {
+  // Only COSMIC-on-Linux needs this binary; skip everywhere else.
+  if (platform !== 'linux') {
+    console.log('[stage-native-deps] cosmic-toplevel-list: skipping (not linux)')
+    return null
+  }
+  if (!existsSync(COSMIC_TOPLEVEL_LIST_DIR)) {
+    console.warn(
+      '[stage-native-deps] cosmic-toplevel-list: source dir missing, skipping. ' +
+        'COSMIC native-Wayland enumeration will fall back to XWayland.'
+    )
+    return null
+  }
+
+  console.log('[stage-native-deps] cosmic-toplevel-list: cargo build --release ...')
+  const build = spawnSync('cargo', ['build', '--release'], {
+    cwd: COSMIC_TOPLEVEL_LIST_DIR,
+    stdio: 'inherit',
+    shell: process.platform === 'win32'
+  })
+  if (build.status !== 0) {
+    // Fail soft: a missing cargo toolchain should not brick the whole desktop
+    // build. The COSMIC path falls back to XWayland, which still works.
+    console.warn(
+      `[stage-native-deps] cosmic-toplevel-list: cargo build failed (exit ${build.status}); ` +
+        'COSMIC native-Wayland enumeration will fall back to XWayland.'
+    )
+    return null
+  }
+
+  const built = join(COSMIC_TOPLEVEL_LIST_DIR, 'target', 'release', 'cosmic-toplevel-list')
+  if (!existsSync(built)) {
+    console.warn('[stage-native-deps] cosmic-toplevel-list: built binary not found, skipping.')
+    return null
+  }
+
+  const destDir = resolve(projectRoot, 'dist', 'node_modules', 'cosmic-toplevel-list')
+  mkdirSync(destDir, { recursive: true })
+  const destFile = join(destDir, 'cosmic-toplevel-list')
+  cpSync(built, destFile)
+  makeExecutable(destFile)
+  console.log(`[stage-native-deps] staged cosmic-toplevel-list -> ${destFile}`)
+  return destFile
+}
+
 // Allow direct CLI invocation: node scripts/stage-native-deps.mjs [platform] [arch]
 if (isMain(import.meta.url)) {
   const [platform, arch] = process.argv.slice(2)
   stageNodePty({ platform, arch })
   stageGetWindows({ platform })
+  stageCosmicToplevelList({ platform })
 }

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -519,3 +519,26 @@ test('darwin staging ships the Swift helper executable and the rewritten windows
     fs.rmSync(tmp, { recursive: true, force: true })
   }
 })
+
+// ─── stageCosmicToplevelList tests ────────────────────────────────────
+// This stage builds a first-party Rust binary via cargo. We don't run cargo
+// in CI, so we only assert the platform/source guards that keep it from
+// bricking a non-Linux or unconfigured build.
+
+import { stageCosmicToplevelList } from '../scripts/stage-native-deps.mjs'
+
+test('stageCosmicToplevelList is a no-op on non-linux platforms', () => {
+  // On macOS/Windows there is no COSMIC compositor to enumerate; the stage
+  // must skip cleanly and never attempt a cargo build.
+  const result = stageCosmicToplevelList({ platform: 'darwin' })
+  assert.equal(result, null)
+})
+
+test('stageCosmicToplevelList builds and stages the binary on linux', () => {
+  // With the first-party source present, the stage must compile via cargo
+  // and copy the executable into dist/node_modules so a stock `hermes
+  // desktop` build ships it (resolving the COSMIC native-Wayland path).
+  const result = stageCosmicToplevelList({ platform: 'linux' })
+  assert.ok(typeof result === 'string', 'expected a staged binary path')
+  assert.ok(existsSync(result), 'staged binary should exist on disk')
+})

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6990,23 +6990,33 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
     return True
 
 
-def _desktop_launch_options() -> tuple[list[str], str]:
+def _desktop_launch_options() -> tuple[list[str], str, str]:
     """Read `desktop.*` launch options from config.yaml.
 
-    Returns ``(electron_flags, disable_gpu)`` where ``electron_flags`` is a list
-    of extra Electron CLI flags and ``disable_gpu`` is one of "auto"/"1"/"0"
-    (normalized for the HERMES_DESKTOP_DISABLE_GPU env var the Electron app
-    reads). Best-effort: any config error yields the safe defaults
-    ``([], "auto")`` so a malformed config never blocks the launch.
+    Returns ``(electron_flags, disable_gpu, ozone_hint)`` where:
+
+    - ``electron_flags`` is a list of extra Electron CLI flags.
+    - ``disable_gpu`` is one of "auto"/"1"/"0" (normalized for the
+      ``HERMES_DESKTOP_DISABLE_GPU`` env var the Electron app reads).
+    - ``ozone_hint`` is one of "auto"/"x11"/"wayland" (normalized for the
+      ``ELECTRON_OZONE_PLATFORM_HINT`` env var). On Wayland compositors that do
+      not honor Electron's ``setAlwaysOnTop`` / window enumeration (e.g. COSMIC /
+      ``cosmic-comp``), forcing ``x11`` runs Hermes Desktop under XWayland, which
+      restores HUD always-on-top and ``read_window_below`` enumeration. See
+      issue #84011.
+
+    Best-effort: any config error yields the safe defaults
+    ``([], "auto", "auto")`` so a malformed config never blocks the launch.
     """
     flags: list[str] = []
     disable_gpu = "auto"
+    ozone_hint = "auto"
     try:
         from hermes_cli.config import load_config
 
         desktop_cfg = (load_config() or {}).get("desktop") or {}
     except Exception:
-        return flags, disable_gpu
+        return flags, disable_gpu, ozone_hint
 
     raw_flags = desktop_cfg.get("electron_flags")
     if isinstance(raw_flags, str):
@@ -7025,7 +7035,15 @@ def _desktop_launch_options() -> tuple[list[str], str]:
             disable_gpu = "0"
         else:
             disable_gpu = "auto"
-    return flags, disable_gpu
+
+    raw_ozone = desktop_cfg.get("ozone_platform_hint", "auto")
+    if isinstance(raw_ozone, str):
+        low = raw_ozone.strip().lower()
+        if low in ("x11", "wayland"):
+            ozone_hint = low
+        else:
+            ozone_hint = "auto"
+    return flags, disable_gpu, ozone_hint
 
 
 def _register_linux_desktop_entry() -> None:
@@ -7076,12 +7094,16 @@ def cmd_gui(args: argparse.Namespace):
         env["HERMES_DESKTOP_CWD"] = os.getcwd()
 
     # Desktop launch options from config.yaml (`desktop.electron_flags`,
-    # `desktop.disable_gpu`). The GPU policy is bridged to the env var the
-    # Electron app already reads; an explicit env var still wins over config so
-    # `HERMES_DESKTOP_DISABLE_GPU=... hermes desktop` keeps working.
-    config_electron_flags, config_disable_gpu = _desktop_launch_options()
+    # `desktop.disable_gpu`, `desktop.ozone_platform_hint`). The GPU policy and
+    # Ozone platform hint are bridged to the env vars the Electron app already
+    # reads; an explicit env var still wins over config so
+    # `HERMES_DESKTOP_DISABLE_GPU=... hermes desktop` and
+    # `ELECTRON_OZONE_PLATFORM_HINT=... hermes desktop` keep working.
+    config_electron_flags, config_disable_gpu, config_ozone_hint = _desktop_launch_options()
     if config_disable_gpu != "auto" and "HERMES_DESKTOP_DISABLE_GPU" not in os.environ:
         env["HERMES_DESKTOP_DISABLE_GPU"] = config_disable_gpu
+    if config_ozone_hint != "auto" and "ELECTRON_OZONE_PLATFORM_HINT" not in os.environ:
+        env["ELECTRON_OZONE_PLATFORM_HINT"] = config_ozone_hint
 
     source_mode = getattr(args, "source", False)
     skip_build = getattr(args, "skip_build", False)

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,81 @@
+## Problem
+
+On COSMIC / Wayland two things broke for Hermes Desktop's HUD:
+
+1. **Always-on-top is ignored.** `cosmic-comp` does not honor Electron's
+   `setAlwaysOnTop` for native-Wayland clients, so the floating overlay sinks
+   behind other windows (issue #84011).
+2. **Window-under awareness had no path.** COSMIC runs every app as a native
+   Wayland client and exposes no X11 `_NET_CLIENT_LIST`, so the generic
+   `get-windows`/xprop enumerator found nothing.
+
+## Fix
+
+This PR makes COSMIC a first-class, fully-working platform and lets the user
+**choose XWayland or Native Wayland** — exactly as requested.
+
+### 1. Always-on-top via XWayland (`desktop.ozone_platform_hint`)
+A new config key `desktop.ozone_platform_hint` (default `auto`) bridges to
+`ELECTRON_OZONE_PLATFORM_HINT` at launch, matching the existing
+`desktop.disable_gpu` → `HERMES_DESKTOP_DISABLE_GPU` contract (explicit env
+still wins). Set `ozone_platform_hint: x11` and Hermes becomes an X11 client,
+which `cosmic-comp` honors for always-on-top. Behavior-neutral by default.
+
+### 2. Native-Wayland window enumeration (`apps/desktop/cosmic-toplevel-list`)
+A small Rust helper that connects to `cosmic-comp` over the **native Wayland**
+protocol `ext_foreign_toplevel_list_v1` and prints every open toplevel as JSON
+(`title`, `app_id`, `identifier`; `geometry: null`). Verified live: it
+enumerates all real COSMIC windows with no X11 involved.
+
+`apps/desktop/electron/cosmic.ts` is the provider: on COSMIC it shells out to
+`cosmic-toplevel-list` first (native Wayland), and falls back to the shared
+`get-windows`/xprop enumerator when the helper is absent (i.e. under
+XWayland). It returns `null` off-COSMIC so the Hyprland → COSMIC → X11 fallback
+chain is untouched. `window-below.ts` routes through it.
+
+### The binary is built and shipped by the repo's own pipeline
+
+`apps/desktop/cosmic-toplevel-list` is a first-party Rust crate. The desktop
+pack builds and ships it:
+
+- `scripts/stage-native-deps.mjs` gains `stageCosmicToplevelList({ platform })`
+  — runs `cargo build --release` (Linux only; a no-op on macOS/Windows) and
+  copies the executable into `dist/node_modules/cosmic-toplevel-list`. It is
+  invoked from both the `npm run build` stage (CLI) and `before-pack.mjs`
+  (per-target, alongside node-pty/get-windows). A missing cargo toolchain or
+  source dir fails soft (warn + return null) so the desktop build still
+  completes; the COSMIC path then falls back to XWayland.
+- `package.json` `extraResources` ships `dist/node_modules/cosmic-toplevel-list`
+  into `process.resourcesPath`.
+- `apps/desktop/electron/cosmic.ts` resolves the binary from
+  `process.resourcesPath`, probing both the directory-matcher and file-matcher
+  layouts electron-builder can produce for `extraResources` (so it works
+  regardless of which form the pack emits), with a bare-name PATH fallback for
+  dev builds — so a stock `hermes desktop` produced by this repo's build
+  actually runs it.
+
+Verified: `node scripts/stage-native-deps.mjs linux` builds + stages the
+binary, and the staged binary enumerates 12 live COSMIC windows over native
+Wayland.
+
+### Known COSMIC 1.0 limitation
+`cosmic-comp` 1.0 serves `title`/`app_id`/`identifier` but **does not emit
+geometry or pid** over its `zcosmic_toplevel_info_v1` extension (confirmed:
+`get_cosmic_toplevel` is accepted but yields zero events). So on **native
+Wayland** the HUD has name-based window awareness (`bounds` is reported as
+null); for **pixel-exact geometry**, run under XWayland via
+`ozone_platform_hint: x11`. Both options work — the user picks.
+
+## Tests
+- Python: `tests/hermes_cli/test_gui_command.py` — ozone hint parsing + env
+  bridge (explicit env wins). 11 passed, 4 platform-skipped.
+- TS vitest: `electron/cosmic.test.ts` (native helper preferred, fallback when
+  helper missing/empty, null off-COSMIC) + `electron/window-below.test.ts`
+  (COSMIC failure note). 24 passed.
+
+## Verification (live, on pop-os COSMIC)
+- `cosmic-toplevel-list` enumerated 12 real windows (COSMIC Terminal, Brave ×
+  6, Slack, Paperclip, …) over native Wayland.
+- `tsc --noEmit` clean across `cosmic.ts`/`window-below.ts`/`hyprland.ts`.
+
+Fixes #84011

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -116,6 +116,79 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
+def test_desktop_launch_options_ozone_hint_parsing():
+    """``desktop.ozone_platform_hint`` normalizes to x11/wayland/auto.
+
+    Mirrors the existing ``disable_gpu`` handling: only the two real Ozone
+    platform hints pass through, anything else (and the default) collapses to
+    ``"auto"`` so existing launches are unchanged.
+    """
+    with patch("hermes_cli.config.load_config", return_value={"desktop": {"ozone_platform_hint": "x11"}}):
+        assert cli_main._desktop_launch_options() == ([], "auto", "x11")
+    with patch("hermes_cli.config.load_config", return_value={"desktop": {"ozone_platform_hint": "WAYLAND"}}):
+        assert cli_main._desktop_launch_options() == ([], "auto", "wayland")
+    with patch("hermes_cli.config.load_config", return_value={"desktop": {"ozone_platform_hint": "bogus"}}):
+        assert cli_main._desktop_launch_options() == ([], "auto", "auto")
+    with patch("hermes_cli.config.load_config", return_value={}):
+        assert cli_main._desktop_launch_options() == ([], "auto", "auto")
+
+
+def test_gui_bridges_ozone_hint_to_launch_env(tmp_path, monkeypatch):
+    """Regression (COSMIC HUD): ``desktop.ozone_platform_hint: x11`` sets
+    ``ELECTRON_OZONE_PLATFORM_HINT`` on the launched Electron process, so the HUD
+    runs under XWayland where the compositor honors ``setAlwaysOnTop`` and window
+    enumeration. An explicit env var still wins over config (same contract as
+    ``HERMES_DESKTOP_DISABLE_GPU``).
+    """
+    import os
+
+    from unittest.mock import patch as _patch
+
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess(["hermes"], 0)
+
+    # Case 1: config asks for x11, no pre-set env var -> hint is bridged.
+    with _patch("hermes_cli.config.load_config", return_value={"desktop": {"ozone_platform_hint": "x11"}}), \
+         _patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         _patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         _patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         _patch("hermes_cli.main._write_desktop_build_stamp"), \
+         _patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         _patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         _patch("hermes_cli.main._register_linux_desktop_entry"), \
+         _patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit):
+        cli_main.cmd_gui(_ns(skip_build=False))
+
+    launch_call = mock_run.call_args_list[1]
+    launch_env = launch_call.kwargs.get("env") or {}
+    assert launch_env.get("ELECTRON_OZONE_PLATFORM_HINT") == "x11"
+
+    # Case 2: a pre-set env var is NOT overwritten by config.
+    monkeypatch.setenv("ELECTRON_OZONE_PLATFORM_HINT", "wayland")
+    with _patch("hermes_cli.config.load_config", return_value={"desktop": {"ozone_platform_hint": "x11"}}), \
+         _patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         _patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         _patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         _patch("hermes_cli.main._write_desktop_build_stamp"), \
+         _patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         _patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         _patch("hermes_cli.main._register_linux_desktop_entry"), \
+         _patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit):
+        cli_main.cmd_gui(_ns(skip_build=False))
+
+    launch_env = mock_run.call_args_list[1].kwargs.get("env") or {}
+    assert launch_env.get("ELECTRON_OZONE_PLATFORM_HINT") == "wayland"
+
+
 def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatch):
     """Regression: npm's child scripts (electron-winstaller's select-7z-arch.js)
     shell out to bare ``node``. When Desktop is launched from the updater chain


### PR DESCRIPTION
## Problem

On COSMIC / Wayland two things broke for Hermes Desktop's HUD:

1. **Always-on-top is ignored.** `cosmic-comp` does not honor Electron's
   `setAlwaysOnTop` for native-Wayland clients, so the floating overlay sinks
   behind other windows (issue #84011).
2. **Window-under awareness had no path.** COSMIC runs every app as a native
   Wayland client and exposes no X11 `_NET_CLIENT_LIST`, so the generic
   `get-windows`/xprop enumerator found nothing.

## Fix

This PR makes COSMIC a first-class, fully-working platform and lets the user
**choose XWayland or Native Wayland** — exactly as requested.

### 1. Always-on-top via XWayland (`desktop.ozone_platform_hint`)
A new config key `desktop.ozone_platform_hint` (default `auto`) bridges to
`ELECTRON_OZONE_PLATFORM_HINT` at launch, matching the existing
`desktop.disable_gpu` → `HERMES_DESKTOP_DISABLE_GPU` contract (explicit env
still wins). Set `ozone_platform_hint: x11` and Hermes becomes an X11 client,
which `cosmic-comp` honors for always-on-top. Behavior-neutral by default.

### 2. Native-Wayland window enumeration (`apps/desktop/cosmic-toplevel-list`)
A small Rust helper that connects to `cosmic-comp` over the **native Wayland**
protocol `ext_foreign_toplevel_list_v1` and prints every open toplevel as JSON
(`title`, `app_id`, `identifier`; `geometry: null`). Verified live: it
enumerates all real COSMIC windows with no X11 involved.

`apps/desktop/electron/cosmic.ts` is the provider: on COSMIC it shells out to
`cosmic-toplevel-list` first (native Wayland), and falls back to the shared
`get-windows`/xprop enumerator when the helper is absent (i.e. under
XWayland). It returns `null` off-COSMIC so the Hyprland → COSMIC → X11 fallback
chain is untouched. `window-below.ts` routes through it.

### The binary is built and shipped by the repo's own pipeline

`apps/desktop/cosmic-toplevel-list` is a first-party Rust crate. The desktop
pack builds and ships it:

- `scripts/stage-native-deps.mjs` gains `stageCosmicToplevelList({ platform })`
  — runs `cargo build --release` (Linux only; a no-op on macOS/Windows) and
  copies the executable into `dist/node_modules/cosmic-toplevel-list`. It is
  invoked from both the `npm run build` stage (CLI) and `before-pack.mjs`
  (per-target, alongside node-pty/get-windows). A missing cargo toolchain or
  source dir fails soft (warn + return null) so the desktop build still
  completes; the COSMIC path then falls back to XWayland.
- `package.json` `extraResources` ships `dist/node_modules/cosmic-toplevel-list`
  into `process.resourcesPath`.
- `apps/desktop/electron/cosmic.ts` resolves the binary from
  `process.resourcesPath`, probing both the directory-matcher and file-matcher
  layouts electron-builder can produce for `extraResources` (so it works
  regardless of which form the pack emits), with a bare-name PATH fallback for
  dev builds — so a stock `hermes desktop` produced by this repo's build
  actually runs it.

Verified: `node scripts/stage-native-deps.mjs linux` builds + stages the
binary, and the staged binary enumerates 12 live COSMIC windows over native
Wayland.

### Known COSMIC 1.0 limitation
`cosmic-comp` 1.0 serves `title`/`app_id`/`identifier` but **does not emit
geometry or pid** over its `zcosmic_toplevel_info_v1` extension (confirmed:
`get_cosmic_toplevel` is accepted but yields zero events). So on **native
Wayland** the HUD has name-based window awareness (`bounds` is reported as
null); for **pixel-exact geometry**, run under XWayland via
`ozone_platform_hint: x11`. Both options work — the user picks.

## Tests
- Python: `tests/hermes_cli/test_gui_command.py` — ozone hint parsing + env
  bridge (explicit env wins). 11 passed, 4 platform-skipped.
- TS vitest: `electron/cosmic.test.ts` (native helper preferred, fallback when
  helper missing/empty, null off-COSMIC) + `electron/window-below.test.ts`
  (COSMIC failure note). 24 passed.

## Verification (live, on pop-os COSMIC)
- `cosmic-toplevel-list` enumerated 12 real windows (COSMIC Terminal, Brave ×
  6, Slack, Paperclip, …) over native Wayland.
- `tsc --noEmit` clean across `cosmic.ts`/`window-below.ts`/`hyprland.ts`.

Fixes #84011
