### PR TITLE
fix(console): preserve Windows paths in _split_line

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -14,6 +14,7 @@ import functools
 import importlib
 import io
 import json
+import os
 import shlex
 import sys
 from dataclasses import dataclass
@@ -116,11 +117,20 @@ def _table_summary(summary: str, *, limit: int = 76) -> str:
     return f"{summary[: limit - 3].rstrip()}..."
 
 
-def _split_line(line: str) -> list[str]:
+def _split_line(line: str, *, posix: bool | None = None) -> list[str]:
+    # On POSIX shlex treats backslash as an escape character, so a Windows
+    # path like C:\Users\me\out.jsonl silently loses its backslashes. Use
+    # posix=False on Windows so backslashes survive, then strip the quotes
+    # that posix=False leaves around quoted tokens.
+    if posix is None:
+        posix = os.name != "nt"
     try:
-        return shlex.split(line, comments=False, posix=True)
+        parts = shlex.split(line, comments=False, posix=posix)
     except ValueError as exc:
         raise ConsoleCommandError(f"Could not parse command: {exc}") from exc
+    if not posix:
+        parts = [p[1:-1] if len(p) > 1 and p[0] == p[-1] and p[0] in "\"'" else p for p in parts]
+    return parts
 
 
 def _contains_shell_syntax(line: str, tokens: Sequence[str]) -> bool:

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -504,3 +504,28 @@ def test_execute_handler_string_exit_returns_error_not_crash(_isolate_hermes_hom
 
     assert result.status == "error"
     assert result.output
+
+
+def test_split_line_preserves_windows_paths():
+    """#83934: on Windows, shlex must not swallow backslashes.
+
+    With posix=True (the old behaviour) every backslash in a Windows path is
+    treated as an escape and stripped, so `sessions export C:\\Users\\me\\out`
+    silently wrote to a mangled relative filename. With posix=False the path
+    survives intact, and quotes left on quoted tokens are stripped."""
+    from hermes_cli import console_engine as ce
+
+    tokens = ce._split_line(r"sessions export C:\Users\me\Desktop\out.jsonl", posix=False)
+    assert tokens == ["sessions", "export", r"C:\Users\me\Desktop\out.jsonl"]
+
+    # quoted token still loses its surrounding quotes
+    quoted = ce._split_line(r'sessions export "C:\my path\out.jsonl"', posix=False)
+    assert quoted == ["sessions", "export", r"C:\my path\out.jsonl"]
+
+
+def test_split_line_preserves_posix_behaviour():
+    """POSIX splitting is unchanged: backslash stays an escape char."""
+    from hermes_cli import console_engine as ce
+
+    tokens = ce._split_line("sessions export /tmp/out.jsonl", posix=True)
+    assert tokens == ["sessions", "export", "/tmp/out.jsonl"]


### PR DESCRIPTION
## Summary

`hermes console` parsed command lines with `shlex.split(line, comments=False, posix=True)`. In POSIX mode a backslash is an escape character, so on **Windows** every `\` in a path was silently swallowed — a command like `sessions export C:\Users\me\Desktop\out.jsonl` "succeeded" but wrote to a mangled relative filename in the cwd instead.

This was invisible in CI because the affected tests run on POSIX where backslash is a valid path char, and on Windows the assertions still passed (they read a pre-written file) while the export went elsewhere.

## Changes

`hermes_cli/console_engine.py` — `_split_line`:
- Split with `posix=False` when `os.name == "nt"` so Windows backslashes survive.
- Strip the quotes that `posix=False` leaves around quoted tokens (the suggested approach from the issue).
- POSIX behaviour is unchanged: `os.name != "nt"` still picks `posix=True`.

Added an explicit `posix:` keyword param defaulting to the platform check, so the platform-specific path is unit-testable without monkeypatching `os.name` (which breaks pytest's path rendering on a POSIX host).

## Tests

Two new tests in `tests/hermes_cli/test_console_engine.py`:
- `test_split_line_preserves_windows_paths` — a Windows path survives intact (including quoted tokens losing only their quotes).
- `test_split_line_preserves_posix_behaviour` — POSIX splitting is unchanged.

Verified the test genuinely catches the bug: reverting to `posix=True` fails it with exactly the mangled path from the report (`'C:UsersmeDesktopout.jsonl'`).

Full `tests/hermes_cli/test_console_engine.py` suite: **12 passed**.

Closes #83934
