### PR TITLE
fix(kanban): preserve decomposed worker settings

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7006,7 +7006,9 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, workspace_kind, workspace_path, "
+            "skills, max_retries, model_override, provider_override, "
+            "reasoning_effort "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -7055,8 +7057,9 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, skills, "
+                " max_retries, model_override, provider_override, reasoning_effort) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -7067,6 +7070,11 @@ def decompose_triage_task(
                     tenant,
                     now,
                     (author or "decomposer"),
+                    root_row["skills"],
+                    root_row["max_retries"],
+                    root_row["model_override"],
+                    root_row["provider_override"],
+                    root_row["reasoning_effort"],
                 ),
             )
             _append_event(

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -88,5 +88,30 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decompose_children_inherit_worker_settings(kanban_home):
+    with kb.connect() as conn:
+        root = kb.create_task(
+            conn,
+            title="bounded worker",
+            triage=True,
+            skills=["github-code-review"],
+            max_retries=4,
+            model_override="test-model",
+            provider_override="test-provider",
+            reasoning_effort="high",
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="orchestrator",
+            children=[{"title": "child", "assignee": "worker"}],
+        )
+        child = kb.get_task(conn, child_ids[0])
+
+    assert child.skills == ["github-code-review"]
+    assert child.max_retries == 4
+    assert child.model_override == "test-model"
+    assert child.provider_override == "test-provider"
+    assert child.reasoning_effort == "high"
 
 


### PR DESCRIPTION
`decompose_triage_task()` bypasses `create_task()` and drops skills, retry, model, provider, and reasoning settings.

Copies them into child rows.

Proof: new test RED on f51aa6a9b (`skills=None`); 3/3 green after.

No overlap: #54104 #61232 #70865 #75601.