### PR TITLE
fix(kanban): release respawn guard for closed PRs

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -689,7 +689,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_unblock.add_argument(
         "--reason",
         default=None,
-        help="Optional reason/note — recorded as a comment before unblocking. Quote multi-word reasons.",
+        help="Optional reason/note — recorded as a comment after unblocking. Quote multi-word reasons.",
+    )
+    p_unblock.add_argument(
+        "--ci-repair-pr",
+        default=None,
+        help=(
+            "Authorize exactly one repair worker for this already-commented PR URL. "
+            "The next claim or terminal transition consumes the authorization."
+        ),
     )
     p_unblock.add_argument("task_ids", nargs="+")
 
@@ -2516,16 +2524,20 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
     reason = getattr(args, "reason", None)
     if reason is not None:
         reason = reason.strip() or None
-    author = _profile_author() if reason else None
+    author = _profile_author() if reason else ""
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
-            if not kb.unblock_task(conn, tid):
+            if not kb.unblock_task(
+                conn,
+                tid,
+                active_pr_url=getattr(args, "ci_repair_pr", None),
+            ):
                 failed.append(tid)
                 print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
                 print(f"Unblocked {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -87,7 +87,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Callable, Iterable, Mapping, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -8014,12 +8014,23 @@ _RESPAWN_GUARD_SUCCESS_WINDOW = 3600  # 1 hour
 # for operators who want a tighter/looser probe cadence.
 DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 300  # 5 minutes
 
-# Within this window a GitHub PR URL in a comment blocks re-spawn.
+# Within this window a GitHub PR URL in a comment is checked before re-spawn.
 _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
+
+# Live PR state is checked at most once per URL per interval. Dispatcher ticks
+# commonly run every minute, so caching both successful and failed lookups keeps
+# a GitHub outage (or many ready tasks referencing one PR) from creating a
+# request storm. The cache is process-local because the guard is advisory and
+# every dispatcher process already serializes its own board ticks.
+_RESPAWN_GUARD_PR_STATE_CACHE_TTL = 600  # 10 minutes
+_RESPAWN_GUARD_PR_STATE_CACHE_MAX = 256
+_RESPAWN_GUARD_PR_STATE_CACHE: dict[
+    tuple[str, int], tuple[float, Optional[str], Callable[[str], str]]
+] = {}
 
 # Pattern matching a GitHub PR URL in task comments.
 _RESPAWN_GUARD_PR_URL_RE = re.compile(
-    r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+",
+    r"https?://github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/pull/(?P<number>\d+)",
     re.IGNORECASE,
 )
 
@@ -8074,7 +8085,7 @@ class DispatchResult:
 
     Reasons: ``"blocker_auth"`` (quota/auth error — also auto-blocked),
     ``"recent_success"`` (completed run within guard window),
-    ``"active_pr"`` (GitHub PR URL in a recent comment)."""
+    ``"active_pr"`` (open or unresolvable GitHub PR in a recent comment)."""
     rate_limited: list[str] = field(default_factory=list)
     """Task ids whose workers bailed on a provider rate-limit / quota wall
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
@@ -9397,8 +9408,82 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
+def _resolve_github_pr_state(pr_url: str) -> str:
+    """Return ``open``, ``closed``, or ``merged`` for a GitHub PR URL.
+
+    ``gh api`` reuses the operator's existing GitHub authentication (including
+    keychain-backed credentials for private repositories) without adding token
+    handling to the dispatcher. Callers fail closed if gh is unavailable or the
+    lookup cannot be completed.
+    """
+    match = _RESPAWN_GUARD_PR_URL_RE.fullmatch(pr_url)
+    if match is None:
+        raise ValueError("unsupported GitHub pull request URL")
+    endpoint = (
+        f"repos/{match.group('owner')}/{match.group('repo')}"
+        f"/pulls/{match.group('number')}"
+    )
+    completed = subprocess.run(
+        [
+            "gh", "api", endpoint,
+            "--jq", 'if .merged_at then "merged" else .state end',
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError("GitHub PR state lookup failed")
+    state = completed.stdout.strip().lower()
+    if state not in {"open", "closed", "merged"}:
+        raise RuntimeError("GitHub PR state lookup returned an unknown state")
+    return state
+
+
+def _cached_github_pr_state(
+    pr_url: str,
+    resolver: Callable[[str], str],
+) -> Optional[str]:
+    """Resolve PR state with a bounded TTL cache; ``None`` means unknown."""
+    now = time.monotonic()
+    # Keep the resolver itself in the cache value so its id cannot be reused
+    # while the entry is alive (important for injected test/custom resolvers).
+    key = (pr_url.casefold(), id(resolver))
+    cached = _RESPAWN_GUARD_PR_STATE_CACHE.get(key)
+    if cached is not None and cached[0] > now:
+        return cached[1]
+
+    try:
+        state = resolver(pr_url).strip().lower()
+        if state not in {"open", "closed", "merged"}:
+            raise ValueError(f"unknown PR state: {state!r}")
+    except Exception as exc:
+        _log.debug("GitHub PR state lookup failed for %s: %s", pr_url, exc)
+        state = None
+
+    # Remove expired entries first, then cap insertion-order growth. Failures
+    # are cached too: fail-closed must not become retry-every-minute.
+    expired = [cache_key for cache_key, value in _RESPAWN_GUARD_PR_STATE_CACHE.items()
+               if value[0] <= now]
+    for cache_key in expired:
+        _RESPAWN_GUARD_PR_STATE_CACHE.pop(cache_key, None)
+    while len(_RESPAWN_GUARD_PR_STATE_CACHE) >= _RESPAWN_GUARD_PR_STATE_CACHE_MAX:
+        _RESPAWN_GUARD_PR_STATE_CACHE.pop(next(iter(_RESPAWN_GUARD_PR_STATE_CACHE)))
+    _RESPAWN_GUARD_PR_STATE_CACHE[key] = (
+        now + _RESPAWN_GUARD_PR_STATE_CACHE_TTL,
+        state,
+        resolver,
+    )
+    return state
+
+
 def check_respawn_guard(
-    conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    lane: str = "ready",
+    pr_state_resolver: Optional[Callable[[str], str]] = None,
 ) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -9447,8 +9532,8 @@ def check_respawn_guard(
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) and its live state is open or
+        cannot be resolved. A merged or closed PR no longer suppresses work.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -9536,14 +9621,20 @@ def check_respawn_guard(
         if not requeued_after:
             return "recent_success"
 
-    # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # 4. A recent, still-open GitHub PR means a prior worker's work is active.
+    #    Lookup failures fail closed to preserve the duplicate-PR safety guard.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    resolver = pr_state_resolver or _resolve_github_pr_state
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+        if not c["body"]:
+            continue
+        for match in _RESPAWN_GUARD_PR_URL_RE.finditer(c["body"]):
+            state = _cached_github_pr_state(match.group(0), resolver)
+            if state not in {"closed", "merged"}:
+                return "active_pr"
 
     return None
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -87,7 +87,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Callable, Iterable, Mapping, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -7636,12 +7636,23 @@ _RESPAWN_GUARD_SUCCESS_WINDOW = 3600  # 1 hour
 # for operators who want a tighter/looser probe cadence.
 DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 300  # 5 minutes
 
-# Within this window a GitHub PR URL in a comment blocks re-spawn.
+# Within this window a GitHub PR URL in a comment is checked before re-spawn.
 _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
+
+# Live PR state is checked at most once per URL per interval. Dispatcher ticks
+# commonly run every minute, so caching both successful and failed lookups keeps
+# a GitHub outage (or many ready tasks referencing one PR) from creating a
+# request storm. The cache is process-local because the guard is advisory and
+# every dispatcher process already serializes its own board ticks.
+_RESPAWN_GUARD_PR_STATE_CACHE_TTL = 600  # 10 minutes
+_RESPAWN_GUARD_PR_STATE_CACHE_MAX = 256
+_RESPAWN_GUARD_PR_STATE_CACHE: dict[
+    tuple[str, int], tuple[float, Optional[str], Callable[[str], str]]
+] = {}
 
 # Pattern matching a GitHub PR URL in task comments.
 _RESPAWN_GUARD_PR_URL_RE = re.compile(
-    r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+",
+    r"https?://github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/pull/(?P<number>\d+)",
     re.IGNORECASE,
 )
 
@@ -7696,7 +7707,7 @@ class DispatchResult:
 
     Reasons: ``"blocker_auth"`` (quota/auth error — also auto-blocked),
     ``"recent_success"`` (completed run within guard window),
-    ``"active_pr"`` (GitHub PR URL in a recent comment)."""
+    ``"active_pr"`` (open or unresolvable GitHub PR in a recent comment)."""
     rate_limited: list[str] = field(default_factory=list)
     """Task ids whose workers bailed on a provider rate-limit / quota wall
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
@@ -8984,8 +8995,82 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
+def _resolve_github_pr_state(pr_url: str) -> str:
+    """Return ``open``, ``closed``, or ``merged`` for a GitHub PR URL.
+
+    ``gh api`` reuses the operator's existing GitHub authentication (including
+    keychain-backed credentials for private repositories) without adding token
+    handling to the dispatcher. Callers fail closed if gh is unavailable or the
+    lookup cannot be completed.
+    """
+    match = _RESPAWN_GUARD_PR_URL_RE.fullmatch(pr_url)
+    if match is None:
+        raise ValueError("unsupported GitHub pull request URL")
+    endpoint = (
+        f"repos/{match.group('owner')}/{match.group('repo')}"
+        f"/pulls/{match.group('number')}"
+    )
+    completed = subprocess.run(
+        [
+            "gh", "api", endpoint,
+            "--jq", 'if .merged_at then "merged" else .state end',
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError("GitHub PR state lookup failed")
+    state = completed.stdout.strip().lower()
+    if state not in {"open", "closed", "merged"}:
+        raise RuntimeError("GitHub PR state lookup returned an unknown state")
+    return state
+
+
+def _cached_github_pr_state(
+    pr_url: str,
+    resolver: Callable[[str], str],
+) -> Optional[str]:
+    """Resolve PR state with a bounded TTL cache; ``None`` means unknown."""
+    now = time.monotonic()
+    # Keep the resolver itself in the cache value so its id cannot be reused
+    # while the entry is alive (important for injected test/custom resolvers).
+    key = (pr_url.casefold(), id(resolver))
+    cached = _RESPAWN_GUARD_PR_STATE_CACHE.get(key)
+    if cached is not None and cached[0] > now:
+        return cached[1]
+
+    try:
+        state = resolver(pr_url).strip().lower()
+        if state not in {"open", "closed", "merged"}:
+            raise ValueError(f"unknown PR state: {state!r}")
+    except Exception as exc:
+        _log.debug("GitHub PR state lookup failed for %s: %s", pr_url, exc)
+        state = None
+
+    # Remove expired entries first, then cap insertion-order growth. Failures
+    # are cached too: fail-closed must not become retry-every-minute.
+    expired = [cache_key for cache_key, value in _RESPAWN_GUARD_PR_STATE_CACHE.items()
+               if value[0] <= now]
+    for cache_key in expired:
+        _RESPAWN_GUARD_PR_STATE_CACHE.pop(cache_key, None)
+    while len(_RESPAWN_GUARD_PR_STATE_CACHE) >= _RESPAWN_GUARD_PR_STATE_CACHE_MAX:
+        _RESPAWN_GUARD_PR_STATE_CACHE.pop(next(iter(_RESPAWN_GUARD_PR_STATE_CACHE)))
+    _RESPAWN_GUARD_PR_STATE_CACHE[key] = (
+        now + _RESPAWN_GUARD_PR_STATE_CACHE_TTL,
+        state,
+        resolver,
+    )
+    return state
+
+
 def check_respawn_guard(
-    conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    lane: str = "ready",
+    pr_state_resolver: Optional[Callable[[str], str]] = None,
 ) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -9034,8 +9119,8 @@ def check_respawn_guard(
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) and its live state is open or
+        cannot be resolved. A merged or closed PR no longer suppresses work.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -9123,14 +9208,20 @@ def check_respawn_guard(
         if not requeued_after:
             return "recent_success"
 
-    # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # 4. A recent, still-open GitHub PR means a prior worker's work is active.
+    #    Lookup failures fail closed to preserve the duplicate-PR safety guard.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    resolver = pr_state_resolver or _resolve_github_pr_state
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+        if not c["body"]:
+            continue
+        for match in _RESPAWN_GUARD_PR_URL_RE.finditer(c["body"]):
+            state = _cached_github_pr_state(match.group(0), resolver)
+            if state not in {"closed", "merged"}:
+                return "active_pr"
 
     return None
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6898,7 +6898,12 @@ def _landing_status_after_parents(conn: sqlite3.Connection, task_id: str) -> str
     return "todo" if undone_parents else "ready"
 
 
-def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def unblock_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    active_pr_url: Optional[str] = None,
+) -> bool:
     """Transition ``blocked``/``scheduled`` to its safe resumable phase.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
@@ -6907,9 +6912,33 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     the leaked run is closed as ``reclaimed`` inside the same txn so the
     runs invariant (``current_run_id IS NULL`` ⇔ run row in terminal
     state) holds for the rest of this function's lifetime.
+
+    ``active_pr_url`` is an explicit, one-shot CI-repair admission for the
+    same PR already recorded in a recent task comment. The authorization is
+    stored structurally on the ``unblocked`` event and consumed by the next
+    claim or terminal transition; ordinary unblocks leave the duplicate-PR
+    guard intact.
     """
     now = int(time.time())
     with write_txn(conn):
+        admitted_pr_url: Optional[str] = None
+        if active_pr_url is not None:
+            admitted_pr_url = _canonical_github_pr_url(active_pr_url)
+            if admitted_pr_url is None:
+                return False
+            pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+            evidence = conn.execute(
+                "SELECT body FROM task_comments "
+                "WHERE task_id = ? AND created_at >= ?",
+                (task_id, pr_cutoff),
+            ).fetchall()
+            if not any(
+                _canonical_github_pr_url(match.group(0)) == admitted_pr_url
+                for comment in evidence
+                if comment["body"]
+                for match in _RESPAWN_GUARD_PR_URL_RE.finditer(comment["body"])
+            ):
+                return False
         current = conn.execute(
             "SELECT status FROM tasks WHERE id = ?",
             (task_id,),
@@ -6948,14 +6977,12 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         )
         if cur.rowcount != 1:
             return False
-        _append_event(
-            conn, task_id, "unblocked",
-            (
-                {"status": new_status, "resume_status": resume_status}
-                if new_status != "ready" or resume_status != "ready"
-                else None
-            ),
-        )
+        payload: dict[str, Any] = {}
+        if new_status != "ready" or resume_status != "ready":
+            payload.update({"status": new_status, "resume_status": resume_status})
+        if admitted_pr_url is not None:
+            payload["active_pr_admission"] = {"url": admitted_pr_url}
+        _append_event(conn, task_id, "unblocked", payload or None)
         return True
 
 
@@ -8033,6 +8060,70 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     r"https?://github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/pull/(?P<number>\d+)",
     re.IGNORECASE,
 )
+
+# State transitions that revoke an unused repair admission. ``claimed`` is the
+# normal consumer; terminal/requeue events prevent an old admission surviving a
+# lifecycle boundary and authorizing a later, unrelated run.
+_ACTIVE_PR_ADMISSION_CONSUMING_EVENTS = (
+    "claimed",
+    "completed",
+    "blocked",
+    "archived",
+    "gave_up",
+    "timed_out",
+    "crashed",
+    "reclaimed",
+    "scheduled",
+    "review_requested",
+    "review_reopened",
+    "changes_requested",
+    "status",
+)
+
+
+def _canonical_github_pr_url(pr_url: str) -> Optional[str]:
+    """Return a stable identity for a supported GitHub pull-request URL."""
+    match = _RESPAWN_GUARD_PR_URL_RE.fullmatch(str(pr_url).strip().rstrip("/"))
+    if match is None:
+        return None
+    return (
+        "https://github.com/"
+        f"{match.group('owner').casefold()}/{match.group('repo').casefold()}"
+        f"/pull/{int(match.group('number'))}"
+    )
+
+
+def _has_unconsumed_active_pr_admission(
+    conn: sqlite3.Connection,
+    task_id: str,
+    pr_url: str,
+) -> bool:
+    """Whether the latest matching repair admission has not crossed a run boundary."""
+    canonical_url = _canonical_github_pr_url(pr_url)
+    if canonical_url is None:
+        return False
+    for event in conn.execute(
+        "SELECT id, payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'unblocked' ORDER BY id DESC",
+        (task_id,),
+    ).fetchall():
+        try:
+            payload = json.loads(event["payload"]) if event["payload"] else {}
+        except (json.JSONDecodeError, TypeError):
+            continue
+        admission = payload.get("active_pr_admission") if isinstance(payload, dict) else None
+        if not isinstance(admission, dict):
+            continue
+        if _canonical_github_pr_url(admission.get("url", "")) != canonical_url:
+            continue
+        placeholders = ", ".join("?" for _ in _ACTIVE_PR_ADMISSION_CONSUMING_EVENTS)
+        consumed = conn.execute(
+            "SELECT 1 FROM task_events "
+            f"WHERE task_id = ? AND id > ? AND kind IN ({placeholders}) LIMIT 1",
+            (task_id, int(event["id"]), *_ACTIVE_PR_ADMISSION_CONSUMING_EVENTS),
+        ).fetchone()
+        return consumed is None
+    return False
 
 
 @dataclass
@@ -9449,7 +9540,10 @@ def _cached_github_pr_state(
     now = time.monotonic()
     # Keep the resolver itself in the cache value so its id cannot be reused
     # while the entry is alive (important for injected test/custom resolvers).
-    key = (pr_url.casefold(), id(resolver))
+    # Canonicalizing bounds requests when equivalent spellings of the same PR
+    # appear across tasks/comments (http/https, case, or a zero-padded number).
+    cache_url = _canonical_github_pr_url(pr_url) or pr_url.casefold()
+    key = (cache_url, id(resolver))
     cached = _RESPAWN_GUARD_PR_STATE_CACHE.get(key)
     if cached is not None and cached[0] > now:
         return cached[1]
@@ -9632,6 +9726,8 @@ def check_respawn_guard(
         if not c["body"]:
             continue
         for match in _RESPAWN_GUARD_PR_URL_RE.finditer(c["body"]):
+            if _has_unconsumed_active_pr_admission(conn, task_id, match.group(0)):
+                continue
             state = _cached_github_pr_state(match.group(0), resolver)
             if state not in {"closed", "merged"}:
                 return "active_pr"

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -70,6 +70,50 @@ def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     assert "Cannot operate on a closed database" not in output
 
 
+def test_unblock_cli_records_structured_ci_repair_admission(kanban_home):
+    pr_url = "https://github.com/NousResearch/hermes-agent/pull/123"
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="repair", assignee="worker")
+        kb.add_comment(conn, task_id, "worker", f"Opened {pr_url}")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="CI failed",
+            expected_run_id=claimed.current_run_id,
+        )
+
+    output = kc.run_slash(
+        f"unblock --ci-repair-pr {pr_url} --reason 'retry failed CI' {task_id}"
+    )
+    assert f"Unblocked {task_id}" in output
+
+    with kb.connect_closing() as conn:
+        unblocked = [
+            event for event in kb.list_events(conn, task_id)
+            if event.kind == "unblocked"
+        ][-1]
+        assert unblocked.payload is not None
+        assert unblocked.payload["active_pr_admission"] == {
+            "url": "https://github.com/nousresearch/hermes-agent/pull/123"
+        }
+
+
+def test_unblock_cli_failure_does_not_append_reason_comment(kanban_home):
+    pr_url = "https://github.com/NousResearch/hermes-agent/pull/123"
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="repair", assignee="worker")
+        before = kb.list_comments(conn, task_id)
+
+    output = kc.run_slash(
+        f"unblock --ci-repair-pr {pr_url} --reason 'retry failed CI' {task_id}"
+    )
+    assert f"cannot unblock {task_id}" in output
+    with kb.connect_closing() as conn:
+        assert kb.list_comments(conn, task_id) == before
+
+
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
     kb.create_board("alpha")
     kb.create_board("beta")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -510,6 +510,80 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+def _task_with_pr_comment(conn, url="https://github.com/NousResearch/hermes-agent/pull/123"):
+    task_id = kb.create_task(conn, title="PR-backed task", assignee="worker")
+    kb.add_comment(conn, task_id, "worker", f"Opened {url}")
+    return task_id
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ("open", "active_pr"),
+        ("merged", None),
+        ("closed", None),
+    ],
+)
+def test_respawn_guard_resolves_live_pr_state(kanban_home, state, expected):
+    """Only an actually-open PR should suppress a ready task."""
+    with kb.connect() as conn:
+        task_id = _task_with_pr_comment(conn)
+
+        assert kb.check_respawn_guard(
+            conn,
+            task_id,
+            pr_state_resolver=lambda _url: state,
+        ) == expected
+
+
+def test_respawn_guard_fails_closed_when_pr_lookup_fails(kanban_home):
+    calls = 0
+
+    def unavailable(_url):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("GitHub unavailable")
+
+    with kb.connect() as conn:
+        task_id = _task_with_pr_comment(conn)
+
+        assert kb.check_respawn_guard(
+            conn,
+            task_id,
+            pr_state_resolver=unavailable,
+        ) == "active_pr"
+        assert kb.check_respawn_guard(
+            conn,
+            task_id,
+            pr_state_resolver=unavailable,
+        ) == "active_pr"
+
+    assert calls == 1, "failed lookups should be cached to avoid retry storms"
+
+
+def test_respawn_guard_caches_pr_state_lookups(kanban_home):
+    calls = []
+
+    def resolve(url):
+        calls.append(url)
+        return "open"
+
+    with kb.connect() as conn:
+        task_id = _task_with_pr_comment(
+            conn,
+            "http://github.com/NousResearch/hermes-agent/pull/456",
+        )
+
+        assert kb.check_respawn_guard(
+            conn, task_id, pr_state_resolver=resolve,
+        ) == "active_pr"
+        assert kb.check_respawn_guard(
+            conn, task_id, pr_state_resolver=resolve,
+        ) == "active_pr"
+
+    assert calls == ["http://github.com/NousResearch/hermes-agent/pull/456"]
+
+
 
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -568,26 +568,128 @@ def test_respawn_guard_caches_pr_state_lookups(kanban_home):
         calls.append(url)
         return "open"
 
+    first = "http://github.com/NousResearch/hermes-agent/pull/00456"
+    equivalent = "https://github.com/nousresearch/HERMES-AGENT/pull/456"
+    assert kb._cached_github_pr_state(first, resolve) == "open"
+    assert kb._cached_github_pr_state(equivalent, resolve) == "open"
+    assert calls == [first]
+
+
+def test_explicit_ci_repair_unblock_admits_same_pr_exactly_once(kanban_home):
+    """A structured repair admission bypasses active_pr until one claim consumes it."""
+    pr_url = "https://github.com/NousResearch/hermes-agent/pull/123"
+
     with kb.connect() as conn:
-        task_id = _task_with_pr_comment(
+        task_id = _task_with_pr_comment(conn, pr_url)
+        original = kb.claim_task(conn, task_id)
+        assert original is not None
+        assert kb.block_task(
             conn,
-            "http://github.com/NousResearch/hermes-agent/pull/456",
+            task_id,
+            reason="CI failed",
+            expected_run_id=original.current_run_id,
         )
 
+        assert kb.unblock_task(conn, task_id, active_pr_url=pr_url)
+        unblocked = [
+            event for event in kb.list_events(conn, task_id)
+            if event.kind == "unblocked"
+        ][-1]
+        assert unblocked.payload is not None
+        assert unblocked.payload["active_pr_admission"] == {
+            "url": "https://github.com/nousresearch/hermes-agent/pull/123"
+        }
         assert kb.check_respawn_guard(
-            conn, task_id, pr_state_resolver=resolve,
-        ) == "active_pr"
+            conn,
+            task_id,
+            pr_state_resolver=lambda _url: (_ for _ in ()).throw(
+                AssertionError("authorized PR should not require a live lookup")
+            ),
+        ) is None
+
+        repair = kb.claim_task(conn, task_id)
+        assert repair is not None
         assert kb.check_respawn_guard(
-            conn, task_id, pr_state_resolver=resolve,
+            conn,
+            task_id,
+            pr_state_resolver=lambda _url: "open",
+        ) == "active_pr"
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="repair worker stopped",
+            kind="transient",
+            expected_run_id=repair.current_run_id,
+        )
+        assert kb.unblock_task(conn, task_id)
+        assert kb.check_respawn_guard(
+            conn,
+            task_id,
+            pr_state_resolver=lambda _url: "open",
         ) == "active_pr"
 
-    assert calls == ["http://github.com/NousResearch/hermes-agent/pull/456"]
+        # A later explicit admission is a new one-shot authorization.
+        held = kb.claim_task(conn, task_id)
+        assert held is not None
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="CI failed again",
+            kind="capability",
+            expected_run_id=held.current_run_id,
+        )
+        assert kb.unblock_task(conn, task_id, active_pr_url=pr_url)
+        assert kb.check_respawn_guard(
+            conn,
+            task_id,
+            pr_state_resolver=lambda _url: "open",
+        ) is None
 
 
+def test_ci_repair_admission_is_revoked_by_terminal_transition(kanban_home):
+    """An unused admission cannot survive completion into a future lifecycle."""
+    pr_url = "https://github.com/NousResearch/hermes-agent/pull/123"
+    with kb.connect() as conn:
+        task_id = _task_with_pr_comment(conn, pr_url)
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="CI failed",
+            expected_run_id=claimed.current_run_id,
+        )
+        assert kb.unblock_task(conn, task_id, active_pr_url=pr_url)
+        assert kb._has_unconsumed_active_pr_admission(conn, task_id, pr_url)
+
+        assert kb.complete_task(conn, task_id, summary="cancelled repair")
+        assert not kb._has_unconsumed_active_pr_admission(conn, task_id, pr_url)
 
 
+def test_ci_repair_unblock_requires_prior_matching_pr_evidence(kanban_home):
+    """Admissions are task-local and cannot target an unrecorded PR."""
+    evidenced_url = "https://github.com/NousResearch/hermes-agent/pull/123"
+    unrelated_url = "https://github.com/NousResearch/hermes-agent/pull/999"
 
+    with kb.connect() as conn:
+        task_id = _task_with_pr_comment(conn, evidenced_url)
+        other_task_id = _task_with_pr_comment(conn, unrelated_url)
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="CI failed",
+            expected_run_id=claimed.current_run_id,
+        )
 
+        assert not kb.unblock_task(conn, task_id, active_pr_url=unrelated_url)
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+        assert not kb._has_unconsumed_active_pr_admission(
+            conn, other_task_id, evidenced_url
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- resolve live GitHub PR state before applying the Kanban `active_pr` respawn guard
- fail closed when GitHub state cannot be resolved
- cache successful and failed lookups for 10 minutes with a bounded process-local cache, keyed by canonical PR identity
- add `hermes kanban unblock --ci-repair-pr <url>` as a narrow, durable one-shot admission for repairing the same PR already recorded on the task
- store the admission structurally on the `unblocked` event; the next claim or terminal lifecycle transition consumes it
- preserve ordinary open-PR duplicate protection and avoid writing an unblock reason comment when the unblock fails

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py -q` — 326 passed, 6 skipped (platform-specific)
- `uvx ruff check hermes_cli/kanban_db.py hermes_cli/kanban.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py` — passed
- `git diff --check` — passed
- `uvx ty check hermes_cli/kanban_db.py hermes_cli/kanban.py` — 16 pre-existing diagnostics; none on changed lines

## Scope / ordering
This fixes active-PR repair admission and remains independent of #98193's pending finalizer fix. Neither PR should be treated as replacing the other.
