### PR TITLE
fix(browser): strip PYTHONPATH from browser-use child env

### DIFF
--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -52,7 +52,17 @@ def _blocked_url_in_code(code: str) -> Optional[str]:
 def _base_subprocess_env() -> dict:
     from tools.browser_tool import _build_browser_env
 
-    return _build_browser_env()
+    env = _build_browser_env()
+    # The browser-use CLI runs in its own Python environment (uv tool /
+    # uvx), NOT the Hermes venv.  Hermes sets PYTHONPATH to its own
+    # site-packages (see tools/environments/local.py), and a child Python
+    # interpreter honors it ahead of its own site-packages — on this
+    # machine that made browser-use import the Hermes venv's
+    # pydantic_core, a CPython-3.11 binary that a 3.12 interpreter can't
+    # load (ModuleNotFoundError: pydantic_core._pydantic_core).  Strip the
+    # var so the CLI resolves its own dependencies.
+    env.pop("PYTHONPATH", None)
+    return env
 
 
 def _read_browser_cfg() -> dict:


### PR DESCRIPTION
## Problem

On Windows, `browser_exec` (Browser Use mode) crashes with `ModuleNotFoundError: No module named pydantic_core._pydantic_core`.

## Root cause

The browser-use CLI runs in its own Python environment (uv tool / uvx), but Hermes sets `PYTHONPATH` to its own site-packages in the parent process. A child Python interpreter honors `PYTHONPATH` **ahead of** its own site-packages, so browser-use ends up importing pydantic from the Hermes venv — a CPython-3.11 binary that a 3.12 interpreter cannot load (pydantic_core is a compiled extension, platform/version specific).

## Fix

Strip `PYTHONPATH` in `_base_subprocess_env()` so the CLI resolves its own dependencies regardless of the host Hermes environment.

## Verification

- `scripts/run_tests.sh` on the 3 browser-use test files: **63 passed, 0 failed** (10 platform-specific failures excluded — they fail identically before/after this change on Windows because they use POSIX shell-script fake CLIs and POSIX path regexes).
- Manual: `env -u PYTHONPATH browser-use --version` -> `0.1.8` (fails with the reported error otherwise).

## Impact

Windows-only manifestation, but the fix is safe everywhere: the browser-use CLI has never needed the Hermes PYTHONPATH.