### PR TITLE
refactor(mcp_tool): extract provenance slice R5-1 into tools/mcp_provenance.py

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/tests/tools/test_mcp_provenance_seams.py
+++ b/tests/tools/test_mcp_provenance_seams.py
@@ -1,0 +1,70 @@
+"""Seam regressions for the extracted MCP provenance helpers."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tools import mcp_provenance, mcp_tool
+
+
+def test_provenance_helpers_are_exact_legacy_reexports():
+    assert mcp_tool._track_mcp_tool_server is mcp_provenance._track_mcp_tool_server
+    assert mcp_tool._forget_mcp_tool_server is mcp_provenance._forget_mcp_tool_server
+
+
+def test_provenance_helpers_resolve_authoritative_state_at_call_time(monkeypatch):
+    state = {"mcp__srv__existing": "old-server"}
+    lock = threading.Lock()
+    monkeypatch.setattr(mcp_tool, "_mcp_tool_server_names", state)
+    monkeypatch.setattr(mcp_tool, "_lock", lock)
+
+    mcp_provenance._track_mcp_tool_server("mcp__srv__existing", "new-server")
+    mcp_tool._track_mcp_tool_server("mcp__srv__new", "raw-server")
+    assert state == {
+        "mcp__srv__existing": "new-server",
+        "mcp__srv__new": "raw-server",
+    }
+
+    mcp_provenance._forget_mcp_tool_server("mcp__srv__existing")
+    mcp_tool._forget_mcp_tool_server("mcp__srv__missing")
+    assert state == {"mcp__srv__new": "raw-server"}
+
+
+def test_provenance_helpers_handle_overwrite_and_idempotent_forget(monkeypatch):
+    state = {}
+    monkeypatch.setattr(mcp_tool, "_mcp_tool_server_names", state)
+    monkeypatch.setattr(mcp_tool, "_lock", threading.Lock())
+
+    mcp_tool._track_mcp_tool_server("tool", "server-a")
+    mcp_tool._track_mcp_tool_server("tool", "server-b")
+    mcp_tool._track_mcp_tool_server("other", "server-c")
+    assert state == {"tool": "server-b", "other": "server-c"}
+
+    mcp_provenance._forget_mcp_tool_server("tool")
+    mcp_provenance._forget_mcp_tool_server("tool")
+    assert state == {"other": "server-c"}
+
+
+def test_original_namespace_monkeypatch_intercepts_registration():
+    from tools.registry import ToolRegistry
+
+    registry = ToolRegistry()
+    server = mcp_tool.MCPServerTask("srv")
+    server.session = MagicMock()
+    server._tools = [
+        SimpleNamespace(
+            name="read_file",
+            description="Read a file",
+            inputSchema={"type": "object", "properties": {}},
+        )
+    ]
+
+    with patch("tools.registry.registry", registry), patch(
+        "tools.mcp_tool._track_mcp_tool_server"
+    ) as track:
+        registered = mcp_tool._register_server_tools(
+            "srv", server, {"tools": {"resources": False, "prompts": False}}
+        )
+
+    assert registered == ["mcp__srv__read_file"]
+    track.assert_called_once_with("mcp__srv__read_file", "srv")

--- a/tools/mcp_provenance.py
+++ b/tools/mcp_provenance.py
@@ -1,0 +1,19 @@
+"""Compatibility-preserving MCP tool provenance helpers."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _track_mcp_tool_server(tool_name: str, server_name: str) -> None:
+    """Remember the exact raw MCP server that registered *tool_name*."""
+    from tools.mcp_tool import _lock, _mcp_tool_server_names
+    with _lock:
+        _mcp_tool_server_names[tool_name] = server_name
+
+
+def _forget_mcp_tool_server(tool_name: str) -> None:
+    """Forget MCP server provenance for a deregistered tool."""
+    from tools.mcp_tool import _lock, _mcp_tool_server_names
+    with _lock:
+        _mcp_tool_server_names.pop(tool_name, None)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4568,6 +4568,8 @@ _mcp_thread: Optional[threading.Thread] = None
 # _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
 _lock = threading.Lock()
 
+from tools.mcp_provenance import _track_mcp_tool_server, _forget_mcp_tool_server
+
 # ---------------------------------------------------------------------------
 # Cross-process MCP discovery guard
 # ---------------------------------------------------------------------------
@@ -6186,16 +6188,6 @@ _UTILITY_CAPABILITY_ATTRS = {
 }
 
 
-def _track_mcp_tool_server(tool_name: str, server_name: str) -> None:
-    """Remember the exact raw MCP server that registered *tool_name*."""
-    with _lock:
-        _mcp_tool_server_names[tool_name] = server_name
-
-
-def _forget_mcp_tool_server(tool_name: str) -> None:
-    """Forget MCP server provenance for a deregistered tool."""
-    with _lock:
-        _mcp_tool_server_names.pop(tool_name, None)
 
 
 def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dict) -> List[dict]:


### PR DESCRIPTION
## Summary

Byte-verbatim extraction of slice R5-1 from `tools/mcp_tool.py` (7,731 lines at pin `ee4bb75b532e932a1055d9a710802a7435163b6a`) into a new module, per the repo-wide god-file sharding policy.

- **Moved:** `_track_mcp_tool_server`, `_forget_mcp_tool_server` (lines 6189–6198, 10 lines, server→tool provenance tracking) → `tools/mcp_provenance.py`
- **Golden sha (window at pin):** `6441f59770e5dfdbadc60909454be8eae38adad5d07da43ff2624458f5c202b0` — byte-verbatim (strip-normalized per the contract's sanctioned deferred-import seam: the two `from tools.mcp_tool import _lock, _mcp_tool_server_names` in-body lines are contract-mandated; stripped window == pin window, byte-identical, re-verified from the committed blob)
- **Seam:** identity-preserving re-export in `tools/mcp_tool.py` AFTER module-level state definitions (`from tools.mcp_provenance import _track_mcp_tool_server, _forget_mcp_tool_server`, plain binding) — no public rename, no stale duplicate, all 7 in-file call sites + test consumers resolve through the original namespace, `patch("tools.mcp_tool._track_mcp_tool_server")` monkeypatch authority intact (runtime-verified)
- **Entangled names preserved:** `_mcp_tool_server_names`/`_lock` stay authoritative in `tools/mcp_tool` (external reach-ins: cli.py:12126, gateway/run.py:20961, tests) — deferred imports at call time, no circular import
- **Seam tests:** `tests/tools/test_mcp_provenance_seams.py` — object identity both names + monkeypatch-transparency test (4 passed)
- **Zero behavior change.** Diff: `tools/mcp_tool.py` 2 insertions / 10 deletions; new module; seam test.

## Method

5×2×3 double-blind decomposition (per the All Gods Must Die mandate): 5 blind region analysts → 5 blind adversarial witnesses → 5 consensus adjudicators → blind implementer → 2 blind re-reviewers, both **APPROVED**:

- Review 1: `C:/tmp/tg-Feature Package/mcp-tool/review/R5-review-1.md` (13,244 B) — all 7 battery gates PASS (strip-normalized golden, seam identity, orphan, monkeypatch transparency, collateral audit, differential suite, mutation control)
- Review 2: `C:/tmp/tg-Feature Package/mcp-tool/review/R5-review-2.md` (10,689 B) — APPROVED, all gates

Suite evidence: pristine-pin baseline 2 failed / 486 passed / 5 skipped (both Windows-env-dependent); post-extraction identical 2-failure set + seam tests. No new failures.

## Coordination table

| Item | Value |
|---|---|
| Pin | `ee4bb75b532e932a1055d9a710802a7435163b6a` (origin/main) |
| Slice | R5-1 (region 5, lines 6185–7731) |
| Window | 6189–6198 (10 lines) |
| Module | `tools/mcp_provenance.py` |
| Golden sha | `6441f59770e5dfdbadc60909454be8eae38adad5d07da43ff2624458f5c202b0` |
| Colliders | NONE — #83354, #83393, #83559, #83575, #83641, #83760, #83860, #83917 hunks all outside window (re-verified at extraction) |
| Dependencies | none |
| Conflicts | none |
| Merge position | standalone; no stacking |

## Dedup statement

No prior extraction of this window exists. Open-PR census for `tools/mcp_tool.py` (live-verified via GraphQL): #83354, #83393 (external) + Feature Package siblings #83559, #83575, #83641, #83760, #83860, #83917 — none touch 6189–6198. No duplicate work.

## Credit

- Author: Axl Ibiza, MBA (DCO-signed commit `51021ad14e3`)
- Method: All Gods Must Die 5×2×3 (blind lanes, consensus contracts, blind re-review)

## 

This slice is governed by the mcp_tool : `C:/tmp/tg-Feature Package/locks/LOCK-mcp_tool.md` (posted on #78642). Former whole: 7,731 lines. Mess issues: #5467, #5468. Fixer roster: #83354, #83393.

Part of #78642
Part of #78647