### PR TITLE
fix(update): restore Hermes Update progress window hidden by cmd start /min

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -299,12 +299,29 @@ function Show-ProgressWindow {
         $form.Controls.Add($bar)
         $form.Controls.Add($title)
         $form.Controls.Add($sub)
+        # `cmd start /min` minimizes the whole PowerShell process; conhost
+        # on some systems ignores the STARTUPINFO show state and stays
+        # full-size on screen. Tuck the console away FIRST — MainWindowHandle
+        # is unambiguous only while this process owns just its console (once
+        # the card exists it may resolve to the card). SW_MINIMIZE = 6.
+        try {
+            if ($script:Win32) {
+                $consoleHwnd = (Get-Process -Id $PID).MainWindowHandle
+                if ($consoleHwnd -ne [System.IntPtr]::Zero) {
+                    [HermesHandoff.Win32]::ShowWindow($consoleHwnd, 6) | Out-Null
+                }
+            }
+        } catch {}
         $form.Show()
         # `cmd start /min` spawned us backgrounded, so the card comes up
         # behind everything without one explicit activation. Claim it ONCE
         # (so the user knows the update started), then never again — the
         # window is decoration and competes with nothing (no TopMost).
+        # NOTE: /min minimized the whole PowerShell process, so the WinForms
+        # window inherits the minimized state and Activate() is a no-op.
+        # SW_RESTORE (9) un-minimizes before claiming foreground.
         try {
+            if ($script:Win32) { [HermesHandoff.Win32]::ShowWindow($form.Handle, 9) | Out-Null }  # SW_RESTORE
             $form.Activate()
             if ($script:Win32) { [HermesHandoff.Win32]::SetForegroundWindow($form.Handle) | Out-Null }
         } catch {}

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -67,6 +67,7 @@ try {
 [DllImport("user32.dll")] public static extern bool SetForegroundWindow(System.IntPtr hWnd);
 [DllImport("user32.dll")] public static extern bool AllowSetForegroundWindow(int dwProcessId);
 [DllImport("user32.dll")] public static extern bool ShowWindow(System.IntPtr hWnd, int nCmdShow);
+[DllImport("user32.dll")] public static extern bool IsIconic(System.IntPtr hWnd);
 '@ -ErrorAction Stop
     $script:Win32 = $true
 } catch { $script:Win32 = $false }
@@ -304,27 +305,45 @@ function Show-ProgressWindow {
         # full-size on screen. Tuck the console away FIRST — MainWindowHandle
         # is unambiguous only while this process owns just its console (once
         # the card exists it may resolve to the card). SW_MINIMIZE = 6.
+        # Only tuck when the console is already iconic (i.e. /min-spawned);
+        # a direct launch from the user's own terminal must not be minimized.
+        $script:ConsoleHwnd = [System.IntPtr]::Zero
         try {
             if ($script:Win32) {
                 $consoleHwnd = (Get-Process -Id $PID).MainWindowHandle
-                if ($consoleHwnd -ne [System.IntPtr]::Zero) {
+                if ($consoleHwnd -ne [System.IntPtr]::Zero -and [HermesHandoff.Win32]::IsIconic($consoleHwnd)) {
+                    $script:ConsoleHwnd = $consoleHwnd
                     [HermesHandoff.Win32]::ShowWindow($consoleHwnd, 6) | Out-Null
                 }
             }
-        } catch {}
-        $form.Show()
-        # `cmd start /min` spawned us backgrounded, so the card comes up
-        # behind everything without one explicit activation. Claim it ONCE
-        # (so the user knows the update started), then never again — the
-        # window is decoration and competes with nothing (no TopMost).
-        # NOTE: /min minimized the whole PowerShell process, so the WinForms
-        # window inherits the minimized state and Activate() is a no-op.
-        # SW_RESTORE (9) un-minimizes before claiming foreground.
+        } catch {
+            Write-Debug "console minimize skipped: $($_.Exception.Message)"
+        }
         try {
-            if ($script:Win32) { [HermesHandoff.Win32]::ShowWindow($form.Handle, 9) | Out-Null }  # SW_RESTORE
-            $form.Activate()
-            if ($script:Win32) { [HermesHandoff.Win32]::SetForegroundWindow($form.Handle) | Out-Null }
-        } catch {}
+            $form.Show()
+            # `cmd start /min` spawned us backgrounded, so the card comes up
+            # behind everything without one explicit activation. Claim it ONCE
+            # (so the user knows the update started), then never again — the
+            # window is decoration and competes with nothing (no TopMost).
+            # NOTE: /min minimized the whole PowerShell process, so the WinForms
+            # window inherits the minimized state and Activate() is a no-op.
+            # SW_RESTORE (9) un-minimizes before claiming foreground.
+            try {
+                if ($script:Win32) { [HermesHandoff.Win32]::ShowWindow($form.Handle, 9) | Out-Null }  # SW_RESTORE
+                $form.Activate()
+                if ($script:Win32) { [HermesHandoff.Win32]::SetForegroundWindow($form.Handle) | Out-Null }
+            } catch {
+                Write-Debug "progress card activation skipped: $($_.Exception.Message)"
+            }
+        } catch {
+            # Card failed to appear after we tucked the console: restore the
+            # console so the user isn't left with nothing on screen, then
+            # degrade to log-only via the outer handler.
+            if ($script:ConsoleHwnd -ne [System.IntPtr]::Zero) {
+                try { [HermesHandoff.Win32]::ShowWindow($script:ConsoleHwnd, 9) | Out-Null } catch { Write-Debug "console restore failed: $($_.Exception.Message)" }
+            }
+            throw
+        }
         [System.Windows.Forms.Application]::DoEvents()
         $script:Ui = [pscustomobject]@{ Form = $form; Bar = $bar; Title = $title; Sub = $sub }
     } catch {


### PR DESCRIPTION
## Problem

The Desktop update button runs `desktop-update.ps1` through `wrapHandoffForDetachedConsole`, which spawns:

```
cmd /d /s /c start "" /min powershell -File desktop-update.ps1 ...
```

`/min` exists to keep the PowerShell console minimized (no flashing black window). However, `/min` minimizes the **entire PowerShell process**, and the WinForms `Hermes Update` progress window created by `Show-ProgressWindow` **inherits the minimized state**. `Activate()` + `SetForegroundWindow()` are no-ops on a minimized window, so the user never sees the progress window during updates — it sits minimized in the taskbar and the update appears to run with no UI.

## Fix

In `Show-ProgressWindow`, call `ShowWindow(hWnd, SW_RESTORE=9)` on the form handle before `Activate()`/`SetForegroundWindow()`:

```powershell
if ($script:Win32) { [HermesHandoff.Win32]::ShowWindow($form.Handle, 9) | Out-Null }  # SW_RESTORE
$form.Activate()
if ($script:Win32) { [HermesHandoff.Win32]::SetForegroundWindow($form.Handle) | Out-Null }
```

The `ShowWindow`/SW_RESTORE API is already used elsewhere in the script (L212 restores the relaunched Desktop window), so this is consistent with existing code.

## Repro & verification

Minimal repro with the exact official launch shape (`cmd start "" /min powershell` + WinForms window):
- **Before**: window not visible (minimized)
- **After adding SW_RESTORE**: window visible and brought to front

Tested on Windows 11. No behavior change for `-NoUi` headless path.