### PR TITLE
fix(desktop): prevent navigation from stealing focus

### DIFF
--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -203,6 +203,22 @@ test('chatWindowWebPreferences leaves background throttling to the runtime strea
   assert.equal('backgroundThrottling' in prefs, false)
 })
 
+test('chat renderer navigation stays passive while explicit window actions may focus', () => {
+  const prefs = chatWindowWebPreferences('/tmp/preload.cjs')
+
+  // In-page/SPA navigation can happen while a transcript keeps streaming. It
+  // must not use Electron's default navigation focus path to activate Hermes.
+  assert.equal(prefs.focusOnNavigation, false)
+
+  // Re-opening a session is an explicit user action and must still raise the
+  // existing window; the passive navigation guard does not disable that path.
+  const registry = createSessionWindowRegistry()
+  const win = makeFakeWindow()
+  registry.openOrFocus('s1', () => win)
+  registry.openOrFocus('s1', () => win)
+  assert.equal(win.calls.focus, 1)
+})
+
 test('chatWindowWebPreferences passes the preload path through and keeps the hardened defaults', () => {
   const prefs = chatWindowWebPreferences('/some/preload.cjs')
 

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -37,6 +37,12 @@ const SESSION_WINDOW_MIN_HEIGHT = 620
 // session is silent" bug. Manual voice-start worked only because the button
 // click counted as the gesture. This is a native app the user deliberately
 // launched; there is no drive-by-autoplay concern to protect against.
+//
+// `focusOnNavigation: false` keeps renderer-driven work passive. Electron's
+// default is true, so an in-page/SPA navigation can activate a blurred chat
+// window while its transcript is streaming. Explicit user actions still call
+// the main-process window focus paths (session re-open, notification/deep-link,
+// app activation), preserving intentional raises without background focus theft.
 function chatWindowWebPreferences(preloadPath: string) {
   return {
     preload: preloadPath,
@@ -45,7 +51,8 @@ function chatWindowWebPreferences(preloadPath: string) {
     sandbox: true,
     nodeIntegration: false,
     devTools: true,
-    autoplayPolicy: 'no-user-gesture-required' as const
+    autoplayPolicy: 'no-user-gesture-required' as const,
+    focusOnNavigation: false
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Prevents renderer navigation in Desktop chat windows from implicitly activating Hermes while a conversation is streaming. Electron enables `focusOnNavigation` by default, so an in-page/SPA navigation can raise a blurred chat window and interrupt a foreground Windows native dialog.

The shared chat-window preferences now disable that implicit focus path. Existing main-process focus calls are intentionally unchanged, so explicit actions such as reopening a session, clicking a notification/deep link, or activating the app can still raise the window.

## Related Issue

Fixes #83998

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/session-windows.ts`: set `focusOnNavigation: false` for shared chat-window `webPreferences`.
- `apps/desktop/electron/session-windows.test.ts`: cover passive renderer navigation and preserve explicit user-initiated session focus.

## How to Test

1. Run `NODE_ENV=test npm --workspace apps/desktop exec -- vitest run --project electron electron/session-windows.test.ts` (17 tests pass).
2. Run `NODE_ENV=test npm --workspace apps/desktop run test:desktop:platforms` (88 files pass, 1 skipped; 1036 tests pass, 2 skipped).
3. Run the Desktop typecheck, changed-file ESLint, and production build commands listed below.

Regression proof:

- **RED:** before the production change, the new test failed with `focusOnNavigation` being `undefined` instead of `false`.
- **GREEN:** with the change, the focused file passes all 17 tests.
- **Mutation/sabotage:** changing the option to `true` made the regression test fail (`true !== false`); restoring `false` made it pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this Desktop TypeScript-only change; the full repository Python suite was not run
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux, Node 22.23.2, Electron 40.10.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing contract or API changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Verification completed locally:

```text
NODE_ENV=test npm --workspace apps/desktop exec -- vitest run --project electron electron/session-windows.test.ts
  1 file passed, 17 tests passed

NODE_ENV=test npm --workspace apps/desktop run test:desktop:platforms
  88 files passed, 1 skipped; 1036 tests passed, 2 skipped

NODE_ENV=test npm --workspace apps/desktop run typecheck
  passed

NODE_ENV=test npm --workspace apps/desktop exec -- eslint electron/session-windows.ts electron/session-windows.test.ts
  passed

NODE_ENV=production npm --workspace apps/desktop run build
  passed (renderer, Electron main/preload, postbuild assertion)

git diff --check
  passed
```

Platform caveat: the behavior contract and Electron configuration were tested on Linux only. I did **not** reproduce the native save/confirm-dialog interaction on a real Windows machine; Windows foreground/dialog behavior still needs CI or reviewer validation on Windows.
