### PR TITLE
fix(compressor): preserve async delegation results across compaction

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1105,6 +1105,27 @@ def _content_text_for_contains(content: Any) -> str:
     return str(content)
 
 
+# Headers of synthetic user-role rows produced when a background
+# ``delegate_task`` (or fan-out batch) completes and its result is injected
+# back into the parent session (see ``tools/process_registry.py``
+# ``format_process_notification``).  Both single and batch variants carry the
+# delegation ID after the em-dash, e.g. ``[ASYNC DELEGATION BATCH COMPLETE — deleg_ab12cd]``.
+# The dash is NOT part of the match so both the em-dash emitted today and any
+# ASCII-hyphen variant survive a re-match.
+_ASYNC_DELEGATION_COMPLETE_MARKERS = (
+    "[ASYNC DELEGATION COMPLETE",
+    "[ASYNC DELEGATION BATCH COMPLETE",
+)
+
+# How many most-recent delegation completion rows the tail anchor preserves
+# verbatim across compaction (bounded so a session that dispatches many
+# subagents can't blow the tail budget).  Overridable per-instance via
+# ``max_tail_delegation_completions`` (getattr-guarded for bare ``__new__``
+# test doubles, mirroring ``min_tail_user_messages``).
+_MAX_TAIL_DELEGATION_COMPLETIONS = 3
+
+
+
 def _append_text_to_content(content: Any, text: str, *, prepend: bool = False) -> Any:
     """Append or prepend plain text to message content safely.
 
@@ -4699,6 +4720,35 @@ This compaction should PRIORITISE preserving all information related to the focu
         return not cls._is_blank_user_turn(message)
 
     @classmethod
+    def _is_delegation_completion_message(cls, message: Any) -> bool:
+        """Return whether *message* is an async delegation result row.
+
+        Background ``delegate_task`` results are injected back into the parent
+        session as synthetic user-role rows whose text opens with
+        ``[ASYNC DELEGATION COMPLETE — <id>]`` (single) or
+        ``[ASYNC DELEGATION BATCH COMPLETE — <id>]`` (fan-out).  The TUI
+        gateway additionally stamps ``display_kind="async_delegation_complete"``,
+        but the API-server wake path does not, so the content header is the
+        authoritative signal.
+
+        Only the user-role requirement is enforced so an assistant reply that
+        merely *quotes* a delegation header (e.g. "the reviewer said...") is
+        never mistaken for a result row.  A ``display_kind`` match is accepted
+        as an OR so rows whose header got normalized/reformatted downstream
+        still count.
+        """
+        if not isinstance(message, dict):
+            return False
+        if message.get("display_kind") == "async_delegation_complete":
+            return True
+        if message.get("role") != "user":
+            return False
+        if cls._has_compressed_summary_metadata(message):
+            return False
+        text = _content_text_for_contains(message.get("content")).strip()
+        return any(text.startswith(marker) for marker in _ASYNC_DELEGATION_COMPLETE_MARKERS)
+
+    @classmethod
     def _blank_echo_indices_after(
         cls, messages: List[Dict[str, Any]], user_idx: int
     ) -> set[int]:
@@ -5338,6 +5388,57 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Safety: never go back into the head region.
         return max(new_cut, head_end + 1)
 
+    def _ensure_last_delegation_completions_in_tail(
+        self,
+        messages: List[Dict[str, Any]],
+        cut_idx: int,
+        head_end: int,
+    ) -> int:
+        """Guarantee recent async delegation results stay in the protected tail.
+
+        A ``delegate_task`` result lands as a synthetic user-role row and the
+        agent then keeps working (fixing issues, committing, answering the
+        user).  By the time the next compaction fires, that result row is no
+        longer the last user message and the token-budget walk can push it
+        into the summarised middle — the summariser rolls it up, the agent's
+        next context no longer contains the verdict, and the agent concludes
+        "the subagent result hasn't landed" and re-does the delegated work.
+
+        Fix: walk backward from the end collecting the most recent
+        ``[ASYNC DELEGATION ... COMPLETE]`` rows (bounded by
+        ``max_tail_delegation_completions``, default 3) and pull ``cut_idx``
+        back to the earliest one found so the whole run lands in the tail
+        verbatim.  A delegation row is a user message, i.e. a clean boundary —
+        ``_align_boundary_backward`` is intentionally NOT called, matching
+        ``_ensure_last_user_message_in_tail`` (#22566 reasoning).  The anchor
+        only walks ``cut_idx`` backward, so chaining after the user/assistant
+        anchors is monotonic — the tail can only grow, never shrink.
+        """
+        max_count = getattr(self, "max_tail_delegation_completions", _MAX_TAIL_DELEGATION_COMPLETIONS)
+        if not isinstance(max_count, int) or isinstance(max_count, bool) or max_count <= 0:
+            max_count = _MAX_TAIL_DELEGATION_COMPLETIONS
+        found: list[int] = []
+        for i in range(len(messages) - 1, head_end - 1, -1):
+            if self._is_delegation_completion_message(messages[i]):
+                found.append(i)
+                if len(found) >= max_count:
+                    break
+        if not found:
+            return cut_idx
+        earliest = min(found)
+        if earliest >= cut_idx:
+            # Already in the tail — nothing to do.
+            return cut_idx
+        if not self.quiet_mode:
+            logger.debug(
+                "Anchoring tail cut to delegation completion(s) at %s "
+                "(was %d) so subagent results survive compaction",
+                found,
+                cut_idx,
+            )
+        # Safety: never go back into the head region.
+        return max(earliest, head_end + 1)
+
     def _ensure_last_user_message_in_tail(
         self,
         messages: List[Dict[str, Any]],
@@ -5613,6 +5714,14 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Each anchor only walks ``cut_idx`` backward, so chaining them is
         # monotonic — the tail can only grow, never shrink.
         cut_idx = self._ensure_last_assistant_message_in_tail(messages, cut_idx, head_end)
+
+        # Ensure recent async delegation result rows stay in the tail so a
+        # background subagent's verdict is never summarised away before the
+        # agent has finished acting on it (the "result hasn't landed"
+        # re-do-the-work failure mode).  Monotonic like the anchors above.
+        cut_idx = self._ensure_last_delegation_completions_in_tail(
+            messages, cut_idx, head_end
+        )
 
         # Extend to the last N actionable user messages when configured
         # (compression.min_tail_user_messages > 1).  This prevents the
@@ -6550,12 +6659,19 @@ This compaction should PRIORITISE preserving all information related to the focu
         # A double role collision can merge the summary into the first tail
         # row. Keep an actionable user event out of that position by retaining
         # the genuinely older assistant/tool bridge when one exists.
-        if compress_end == latest_actionable_idx:
-            bridge_idx = latest_actionable_idx - 1
+        # The same protection extends to async delegation result rows anchored
+        # into the tail by ``_ensure_last_delegation_completions_in_tail``:
+        # merging the summary into the result row would bury the subagent's
+        # verdict under the ``[PRIOR CONTEXT]`` header and recreate the
+        # "the result hasn't landed" re-do-the-work failure mode.
+        _first_tail_actionable = compress_end < len(messages) and (
+            compress_end == latest_actionable_idx
+            or self._is_delegation_completion_message(messages[compress_end])
+        )
+        if _first_tail_actionable:
+            bridge_idx = compress_end - 1
             if bridge_idx >= 0 and messages[bridge_idx].get("role") == "tool":
-                bridge_idx = self._align_boundary_backward(
-                    messages, latest_actionable_idx
-                )
+                bridge_idx = self._align_boundary_backward(messages, compress_end)
             elif bridge_idx < 0 or messages[bridge_idx].get("role") != "assistant":
                 bridge_idx = -1
             if bridge_idx > compress_start:
@@ -7128,6 +7244,21 @@ This compaction should PRIORITISE preserving all information related to the focu
                     # The summary must be part of the first user-visible
                     # message for Anthropic/Bedrock, but the real tail request
                     # still has to appear *after* the summary boundary.
+                    prefix = summary + "\n\n" + _SUMMARY_END_MARKER + "\n\n"
+                    msg["content"] = _append_text_to_content(
+                        old_content,
+                        prefix,
+                        prepend=True,
+                    )
+                elif self._is_delegation_completion_message(msg):
+                    # Delegation carrier fallback (no assistant/tool bridge
+                    # exists to absorb the summary): the carrier row IS a live
+                    # subagent result whose verdict must stay actionable.
+                    # Keep the result text intact AFTER the summary +
+                    # end-marker boundary instead of burying it under the
+                    # PRIOR CONTEXT header — the model is instructed to
+                    # respond to the message after the end marker.  Only
+                    # reachable when the bridge retarget above found nothing.
                     prefix = summary + "\n\n" + _SUMMARY_END_MARKER + "\n\n"
                     msg["content"] = _append_text_to_content(
                         old_content,

--- a/tests/agent/test_compressor_delegation_tail_anchor.py
+++ b/tests/agent/test_compressor_delegation_tail_anchor.py
@@ -1,0 +1,363 @@
+"""Regression tests: async delegation results survive context compaction.
+
+The failure mode: a background ``delegate_task`` result lands as a synthetic
+user-role row, the agent keeps working after it (fixing issues, answering the
+user), and by the next compaction the token-budget tail walk pushes the result
+row into the summarised middle.  The summariser rolls it up; the agent's next
+context no longer contains the verdict and it concludes "the subagent result
+hasn't landed" and re-does the delegated work.
+
+The tail anchor added in ``_find_tail_cut_by_tokens``
+(``_ensure_last_delegation_completions_in_tail``) pulls the cut back to the
+most recent delegation completion row(s) so they survive verbatim.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    SUMMARY_PREFIX,
+    _SUMMARY_END_MARKER,
+    ContextCompressor,
+)
+
+
+@pytest.fixture()
+def compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        instance = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+    instance.tail_token_budget = 10
+    return instance
+
+
+def _append_tool_run(messages: list[dict], prefix: str, count: int = 6) -> None:
+    for index in range(count):
+        call_id = f"{prefix}-{index}"
+        messages.extend(
+            [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "function": {"name": "read_file", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": "x" * 400,
+                },
+            ]
+        )
+
+
+def _compress(compressor: ContextCompressor, messages: list[dict]) -> list[dict]:
+    with patch.object(
+        compressor,
+        "_generate_summary",
+        return_value=f"{SUMMARY_PREFIX}\nsummary of older work",
+    ):
+        return compressor.compress(messages, current_tokens=90_000)
+
+
+def _completion_rows(result: list[dict], completion: str) -> list[dict]:
+    return [message for message in result if message.get("content") == completion]
+
+
+# ---------------------------------------------------------------------------
+# Core regression: the result is NOT the last user message, yet must survive
+# ---------------------------------------------------------------------------
+
+
+def test_delegation_completion_survives_when_not_last_user_message(compressor):
+    completion = (
+        "[ASYNC DELEGATION BATCH COMPLETE — deleg_ab12cd]\n"
+        "The independent reviewer verdict: FAIL with 3 critical issues."
+    )
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "initial request"},
+        {"role": "assistant", "content": "initial reply"},
+    ]
+    # Older middle turns that the token budget (10) could never protect.
+    messages += [
+        {"role": "user", "content": f"older question {index}"}
+        if index % 2 == 0
+        else {"role": "assistant", "content": f"older reply {index}"}
+        for index in range(6)
+    ]
+    # The result lands...
+    messages.append({"role": "user", "content": completion})
+    # ...the agent keeps working after it...
+    messages.append({"role": "assistant", "content": "the reviewer is right, fixing"})
+    _append_tool_run(messages, "work")
+    # ...and the user keeps talking, so the completion is NOT the last user row.
+    messages.append({"role": "user", "content": "what did the reviewer find?"})
+    messages.append({"role": "assistant", "content": "three critical issues, fixing now"})
+
+    result = _compress(compressor, messages)
+
+    rows = _completion_rows(result, completion)
+    assert len(rows) == 1
+    assert not rows[0].get(COMPRESSED_SUMMARY_METADATA_KEY)
+    # The middle was genuinely summarised (otherwise the test proves nothing).
+    summary_rows = [
+        message for message in result if message.get(COMPRESSED_SUMMARY_METADATA_KEY)
+    ]
+    assert len(summary_rows) == 1
+    # The work done AFTER the result arrived must also survive.
+    assert result[-1].get("content") == "three critical issues, fixing now"
+
+
+def test_single_delegation_completion_survives_verbatim(compressor):
+    completion = (
+        "[ASYNC DELEGATION COMPLETE — deleg_ef34gh]\n"
+        "Subagent finished; full task source below."
+    )
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "initial request"},
+        {"role": "assistant", "content": "initial reply"},
+        {"role": "user", "content": "older work 1"},
+        {"role": "assistant", "content": "older reply 1"},
+        {"role": "user", "content": "older work 2"},
+        {"role": "assistant", "content": "older reply 2"},
+        {"role": "user", "content": completion},
+        {"role": "assistant", "content": "acting on the result"},
+        {"role": "user", "content": "later question"},
+        {"role": "assistant", "content": "later reply"},
+    ]
+
+    result = _compress(compressor, messages)
+
+    rows = _completion_rows(result, completion)
+    assert len(rows) == 1
+    assert not rows[0].get(COMPRESSED_SUMMARY_METADATA_KEY)
+
+
+def test_recompression_keeps_delegation_completion_verbatim(compressor):
+    """A second compression pass must not summarise the anchored result."""
+    completion = (
+        "[ASYNC DELEGATION BATCH COMPLETE — deleg_ij56kl]\n"
+        "Fan-out of 2 subagents finished; consolidated results below."
+    )
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "initial request"},
+        {"role": "assistant", "content": "initial reply"},
+    ]
+    # Older middle turns that the tiny token budget could never protect.
+    messages += [
+        {"role": "user", "content": f"older question {index}"}
+        if index % 2 == 0
+        else {"role": "assistant", "content": f"older reply {index}"}
+        for index in range(6)
+    ]
+    # The result lands deep in the transcript...
+    messages.append({"role": "user", "content": completion})
+    messages.append({"role": "assistant", "content": "working from the completion"})
+    _append_tool_run(messages, "tail")
+    messages += [
+        {"role": "user", "content": "next question"},
+        {"role": "assistant", "content": "next reply"},
+    ]
+
+    first = _compress(compressor, messages)
+    rows = _completion_rows(first, completion)
+    assert len(rows) == 1
+    assert not rows[0].get(COMPRESSED_SUMMARY_METADATA_KEY)
+
+    second = _compress(compressor, first)
+    rows = _completion_rows(second, completion)
+    assert len(rows) == 1
+    assert not rows[0].get(COMPRESSED_SUMMARY_METADATA_KEY)
+
+
+# ---------------------------------------------------------------------------
+# Marker recognition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "[ASYNC DELEGATION COMPLETE — deleg_aa11]\nresult",
+        "[ASYNC DELEGATION COMPLETE - deleg_aa11]\nresult",  # ASCII hyphen
+        "[ASYNC DELEGATION BATCH COMPLETE — deleg_bb22]\nresult",
+        "[ASYNC DELEGATION BATCH COMPLETE - deleg_bb22]\nresult",
+        "[ASYNC DELEGATION COMPLETE — deleg_cc33]",
+    ],
+)
+def test_delegation_completion_markers_recognized(compressor, content):
+    assert compressor._is_delegation_completion_message(
+        {"role": "user", "content": content}
+    )
+
+
+def test_display_kind_marker_recognized_without_header(compressor):
+    assert compressor._is_delegation_completion_message(
+        {
+            "role": "user",
+            "content": "opaque delegation context",
+            "display_kind": "async_delegation_complete",
+        }
+    )
+
+
+def test_assistant_quote_of_header_is_not_a_completion_row(compressor):
+    # An assistant reply that merely quotes the header must not be anchored.
+    assert not compressor._is_delegation_completion_message(
+        {
+            "role": "assistant",
+            "content": '[ASYNC DELEGATION COMPLETE — deleg_dd44] said FAIL, fixing',
+        }
+    )
+
+
+def test_plain_user_message_is_not_a_completion_row(compressor):
+    assert not compressor._is_delegation_completion_message(
+        {"role": "user", "content": "can you review the plugin?"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anchor behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_anchor_is_noop_without_delegation_completions(compressor):
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": "more"},
+        {"role": "assistant", "content": "reply"},
+    ]
+    cut = compressor._find_tail_cut_by_tokens(messages, head_end=1)
+    assert compressor._ensure_last_delegation_completions_in_tail(
+        messages, cut, head_end=1
+    ) == cut
+
+
+def test_anchor_is_noop_when_completion_already_in_tail(compressor):
+    completion = "[ASYNC DELEGATION COMPLETE — deleg_ee55]\nresult"
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": completion},
+        {"role": "assistant", "content": "acting"},
+    ]
+    cut = len(messages) - 2  # tail starts AT the completion
+    assert compressor._ensure_last_delegation_completions_in_tail(
+        messages, cut, head_end=1
+    ) == cut
+
+
+def test_anchor_pulls_cut_back_to_earliest_of_recent_completions(compressor):
+    first = "[ASYNC DELEGATION COMPLETE — deleg_ff66]\noldest result"
+    second = "[ASYNC DELEGATION BATCH COMPLETE — deleg_gg77]\nnewer result"
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": first},
+        {"role": "assistant", "content": "handled oldest"},
+        {"role": "user", "content": second},
+        {"role": "assistant", "content": "handled newest"},
+    ]
+    cut = len(messages)  # tail empty — both completions in the middle region
+    new_cut = compressor._ensure_last_delegation_completions_in_tail(
+        messages, cut, head_end=1
+    )
+    # Both completions are anchored; cut lands at the earliest one.
+    assert new_cut == 3
+    assert messages[new_cut].get("content") == first
+
+
+def test_anchor_respects_max_tail_delegation_completions(compressor):
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    for index in range(4):
+        messages.append(
+            {
+                "role": "user",
+                "content": f"[ASYNC DELEGATION COMPLETE — deleg_0{index}]\nresult {index}",
+            }
+        )
+        messages.append({"role": "assistant", "content": f"handled {index}"})
+
+    compressor.max_tail_delegation_completions = 2
+    cut = len(messages)
+    new_cut = compressor._ensure_last_delegation_completions_in_tail(
+        messages, cut, head_end=1
+    )
+    # Completions sit at indices 3, 5, 7, 9 (deleg_00..deleg_03).  Walking
+    # backward from the end, the 2 most recent are 9 and 7, so the cut lands
+    # at 7 — the OLDEST anchored one — NOT all the way back at 3.
+    assert new_cut == 7
+    assert "[ASYNC DELEGATION COMPLETE — deleg_02]" in messages[new_cut]["content"]
+
+
+# ---------------------------------------------------------------------------
+# No-bridge edge: summary must merge INTO the completion row WITHOUT burying
+# the verdict under the [PRIOR CONTEXT] header
+# ---------------------------------------------------------------------------
+
+
+def test_no_bridge_merge_keeps_verdict_after_summary_boundary(compressor):
+    completion = (
+        "[ASYNC DELEGATION COMPLETE — deleg_hh88]\n"
+        "The verdict: FAIL with 3 critical issues."
+    )
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "initial request"},
+        {"role": "assistant", "content": "initial reply"},
+        # One compressible middle turn — NO assistant bridge before the
+        # completion, so the summary must merge INTO the completion row.
+        {"role": "user", "content": "middle work"},
+        {"role": "user", "content": completion},
+        {"role": "assistant", "content": "acting on the result"},
+        {"role": "user", "content": "later question"},
+        {"role": "assistant", "content": "later reply"},
+    ]
+
+    result = _compress(compressor, messages)
+
+    merged_rows = [
+        message
+        for message in result
+        if message.get(COMPRESSED_SUMMARY_METADATA_KEY)
+    ]
+    assert len(merged_rows) == 1
+    merged_content = merged_rows[0].get("content", "")
+    # The verdict text survives intact, placed AFTER the summary boundary so
+    # the model treats it as the actionable message to respond to...
+    assert completion in merged_content
+    assert _SUMMARY_END_MARKER in merged_content
+    assert merged_content.index(completion) > merged_content.index(_SUMMARY_END_MARKER)
+    # ...and it is NOT buried under the reference-only PRIOR CONTEXT header.
+    assert "[PRIOR CONTEXT" not in merged_content
+    # Alternation is preserved (no adjacent user rows in the output).
+    for previous, current in zip(result, result[1:]):
+        assert (previous.get("role"), current.get("role")) != ("user", "user")


### PR DESCRIPTION
Async delegation results injected back into a session (single and batch variants) could be summarized away or merged into a PRIOR CONTEXT block during context compaction, making the agent conclude a completed result never landed. Fix anchors the most recent delegation completion rows in the protected tail, extends the bridge guard so the verdict is never absorbed into the summary assembler's role-collision merge, and adds a delegation-aware merge fallback. Includes 16 regression tests.