### PR TITLE
feat(hindsight): add head-tail recall queries

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -73,7 +73,7 @@ Config file: `~/.hermes/hindsight/config.json`
 | `recall_max_tokens` | `4096` | Maximum tokens for recall results |
 | `recall_max_input_chars` | `800` | Maximum input query length for auto-recall |
 | `recall_query_strategy` | `prefix` | Long-query composition: `prefix` keeps the legacy prefix-only cap; opt-in `head_tail` preserves both the start and trailing intent |
-| `recall_query_head_chars` | `200` | Characters reserved for the start of a truncated `head_tail` query; the rest of `recall_max_input_chars` comes from the end |
+| `recall_query_head_chars` | `200` | Characters reserved for the start of a truncated `head_tail` query; a newline separates head and tail, and the remaining `recall_max_input_chars` budget comes from the end. Degenerate bounded values are warned about at initialization. |
 | `recall_prompt_preamble` | — | Custom preamble for recalled memories in context |
 | `recall_tags` | — | Tags to filter when searching memories |
 | `recall_tags_match` | `any` | Tag matching mode: `any` / `all` / `any_strict` / `all_strict` |

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -72,6 +72,8 @@ Config file: `~/.hermes/hindsight/config.json`
 | `recall_prefetch_method` | `recall` | Auto-recall method: `recall` (raw facts) or `reflect` (LLM synthesis) |
 | `recall_max_tokens` | `4096` | Maximum tokens for recall results |
 | `recall_max_input_chars` | `800` | Maximum input query length for auto-recall |
+| `recall_query_strategy` | `prefix` | Long-query composition: `prefix` keeps the legacy prefix-only cap; opt-in `head_tail` preserves both the start and trailing intent |
+| `recall_query_head_chars` | `200` | Characters reserved for the start of a truncated `head_tail` query; the rest of `recall_max_input_chars` comes from the end |
 | `recall_prompt_preamble` | — | Custom preamble for recalled memories in context |
 | `recall_tags` | — | Tags to filter when searching memories |
 | `recall_tags_match` | `any` | Tag matching mode: `any` / `all` / `any_strict` / `all_strict` |
@@ -79,6 +81,20 @@ Config file: `~/.hermes/hindsight/config.json`
 | `auto_recall` | `true` | Automatically recall memories before each turn |
 | `recall_sync` | `false` | Recall synchronously against the *current* message each turn (higher relevance, adds recall latency). Default off: recall runs in the background and is injected on the next turn. |
 | `recall_indicator` | `true` | Show a `👁️ Hindsight — recalled N memories` status line when auto-recall injects memory. Turn off for customer-facing agents. |
+
+For prompts that put logs or background before the actual request, opt in to
+intent-preserving composition without raising the hard query cap:
+
+```json
+{
+  "recall_max_input_chars": 800,
+  "recall_query_strategy": "head_tail",
+  "recall_query_head_chars": 200
+}
+```
+
+Queries at or below the cap are unchanged. The default `prefix` strategy keeps
+existing behavior for backward compatibility.
 
 > **Behavior change — `recall_types` defaults to `observation` only.**
 >

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1748,7 +1748,8 @@ class HindsightMemoryProvider(MemoryProvider):
         # when a turn is dispatched to the writer. Same off switch rationale.
         self._retain_indicator = bool(self._config.get("retain_indicator", True))
         self._recall_max_input_chars = max(
-            0, int(self._config.get("recall_max_input_chars", 800))
+            0,
+            _parse_int_setting(self._config.get("recall_max_input_chars"), 800),
         )
         strategy = str(self._config.get("recall_query_strategy", "prefix")).strip().lower()
         if strategy not in {"prefix", "head_tail"}:
@@ -1758,9 +1759,47 @@ class HindsightMemoryProvider(MemoryProvider):
             )
             strategy = "prefix"
         self._recall_query_strategy = strategy
-        self._recall_query_head_chars = max(
-            0, int(self._config.get("recall_query_head_chars", 200))
-        )
+        raw_head_chars = self._config.get("recall_query_head_chars")
+        if self._recall_query_strategy == "head_tail" and self._recall_max_input_chars:
+            parsed_head_chars = _parse_int_setting(raw_head_chars, 200)
+        else:
+            # Head allocation is irrelevant for prefix queries and an unlimited
+            # cap. Keep malformed dormant values quiet until they can affect a
+            # bounded head_tail query.
+            try:
+                parsed_head_chars = (
+                    200 if raw_head_chars is None or raw_head_chars == ""
+                    else int(raw_head_chars)
+                )
+            except (TypeError, ValueError):
+                parsed_head_chars = 200
+        self._recall_query_head_chars = max(0, parsed_head_chars)
+        if self._recall_query_strategy == "head_tail" and self._recall_max_input_chars:
+            cap = self._recall_max_input_chars
+            if cap < 3:
+                logger.warning(
+                    "Hindsight recall_max_input_chars=%d is too small to keep "
+                    "head_tail fragments separate; truncated queries will use "
+                    "trailing characters only.",
+                    cap,
+                )
+            elif self._recall_query_head_chars <= 0:
+                logger.warning(
+                    "Hindsight recall_query_head_chars=%d does not preserve a head "
+                    "fragment; truncated head_tail queries will use trailing "
+                    "characters only.",
+                    self._recall_query_head_chars,
+                )
+            elif self._recall_query_head_chars > cap - 2:
+                logger.warning(
+                    "Hindsight recall_query_head_chars=%d must be at most %d for "
+                    "recall_max_input_chars=%d; using %d so the newline separator "
+                    "and tail both fit.",
+                    self._recall_query_head_chars,
+                    cap - 2,
+                    cap,
+                    cap - 2,
+                )
         self._retain_async = self._config.get("retain_async", True)
         self._prefetch_waits_for_retain = self._config.get("prefetch_waits_for_retain", True)
         self._prefetch_retain_drain_timeout = float(
@@ -1901,9 +1940,7 @@ class HindsightMemoryProvider(MemoryProvider):
         text. Shared by the background prefetch worker (``queue_prefetch``) and
         the opt-in synchronous path (``prefetch`` when ``recall_sync`` is on).
         """
-        # Truncate query to max chars
-        if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
-            query = query[:self._recall_max_input_chars]
+        query = self._compose_recall_query(query)
         try:
             if self._prefetch_method == "reflect":
                 logger.debug("Recall: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
@@ -1994,17 +2031,17 @@ class HindsightMemoryProvider(MemoryProvider):
         if not cap or original_len <= cap:
             composed = query
         elif self._recall_query_strategy == "head_tail":
-            if cap == 1:
-                composed = query[-1:]
+            if cap < 3 or self._recall_query_head_chars <= 0:
+                composed = query[-cap:]
             else:
-                head_chars = min(self._recall_query_head_chars, cap - 1)
-                tail_chars = cap - head_chars
-                composed = query[:head_chars] + query[-tail_chars:]
+                head_chars = min(self._recall_query_head_chars, cap - 2)
+                tail_chars = cap - head_chars - 1
+                composed = query[:head_chars] + "\n" + query[-tail_chars:]
         else:
             composed = query[:cap]
 
         logger.debug(
-            "Prefetch query composed: strategy=%s, original_query_len=%d, "
+            "Recall query composed: strategy=%s, original_query_len=%d, "
             "sent_query_len=%d, truncated=%s",
             self._recall_query_strategy,
             original_len,
@@ -2020,7 +2057,6 @@ class HindsightMemoryProvider(MemoryProvider):
             return
         if self._recall_disabled():
             return
-        query = self._compose_recall_query(query)
 
         def _run():
             # Ensure the just-completed turn's retain is recall-visible on the

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -878,6 +878,8 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_types: list[str] = ["observation"]
         self._recall_prompt_preamble = ""
         self._recall_max_input_chars = 800
+        self._recall_query_strategy = "prefix"
+        self._recall_query_head_chars = 200
 
         # Bank
         self._bank_mission = ""
@@ -1224,6 +1226,8 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
+            {"key": "recall_query_strategy", "description": "How long auto-recall queries are capped: 'prefix' preserves legacy prefix-only truncation; 'head_tail' keeps the configured prefix plus the trailing intent", "default": "prefix", "choices": ["prefix", "head_tail"]},
+            {"key": "recall_query_head_chars", "description": "Characters reserved for the start of a truncated head_tail auto-recall query; the remaining cap is taken from the end", "default": 200},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
@@ -1743,7 +1747,20 @@ class HindsightMemoryProvider(MemoryProvider):
         # Companion retain indicator: "👁️ Hindsight — saving to memory…" emitted
         # when a turn is dispatched to the writer. Same off switch rationale.
         self._retain_indicator = bool(self._config.get("retain_indicator", True))
-        self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        self._recall_max_input_chars = max(
+            0, int(self._config.get("recall_max_input_chars", 800))
+        )
+        strategy = str(self._config.get("recall_query_strategy", "prefix")).strip().lower()
+        if strategy not in {"prefix", "head_tail"}:
+            logger.warning(
+                "Unknown Hindsight recall_query_strategy %r; using 'prefix'.",
+                strategy,
+            )
+            strategy = "prefix"
+        self._recall_query_strategy = strategy
+        self._recall_query_head_chars = max(
+            0, int(self._config.get("recall_query_head_chars", 200))
+        )
         self._retain_async = self._config.get("retain_async", True)
         self._prefetch_waits_for_retain = self._config.get("prefetch_waits_for_retain", True)
         self._prefetch_retain_drain_timeout = float(
@@ -1763,9 +1780,11 @@ class HindsightMemoryProvider(MemoryProvider):
                          self._bank_id_template, self._agent_identity, self._agent_workspace,
                          self._platform, self._user_id, self._bank_id)
         logger.debug("Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
-                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
+                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, "
+                     "recall_query_strategy=%s, recall_query_head_chars=%d, tags=%s, recall_tags=%s",
                      self._auto_retain, self._auto_recall, self._retain_every_n_turns,
                      self._retain_async, self._retain_context, self._recall_max_tokens, self._recall_max_input_chars,
+                     self._recall_query_strategy, self._recall_query_head_chars,
                      self._tags, self._recall_tags)
 
         # For local mode, start the embedded daemon in the background so it
@@ -1968,6 +1987,32 @@ class HindsightMemoryProvider(MemoryProvider):
             return None
         return RecallStatus(provider_label="Hindsight", count=self._last_recall_count, glyph=_HINDSIGHT_GLYPH)
 
+    def _compose_recall_query(self, query: str) -> str:
+        """Apply the configured deterministic auto-recall query cap."""
+        cap = self._recall_max_input_chars
+        original_len = len(query)
+        if not cap or original_len <= cap:
+            composed = query
+        elif self._recall_query_strategy == "head_tail":
+            if cap == 1:
+                composed = query[-1:]
+            else:
+                head_chars = min(self._recall_query_head_chars, cap - 1)
+                tail_chars = cap - head_chars
+                composed = query[:head_chars] + query[-tail_chars:]
+        else:
+            composed = query[:cap]
+
+        logger.debug(
+            "Prefetch query composed: strategy=%s, original_query_len=%d, "
+            "sent_query_len=%d, truncated=%s",
+            self._recall_query_strategy,
+            original_len,
+            len(composed),
+            len(composed) < original_len,
+        )
+        return composed
+
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         # In synchronous mode prefetch() does a live recall each turn, so
         # there's nothing to prime in the background.
@@ -1975,6 +2020,7 @@ class HindsightMemoryProvider(MemoryProvider):
             return
         if self._recall_disabled():
             return
+        query = self._compose_recall_query(query)
 
         def _run():
             # Ensure the just-completed turn's retain is recall-visible on the

--- a/plugins/memory/hindsight/config_schema.py
+++ b/plugins/memory/hindsight/config_schema.py
@@ -89,7 +89,7 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             label="Recall query head characters",
             kind=KIND_TEXT,
             default="200",
-            description="Characters reserved for the start of a truncated head + tail query.",
+            description="Characters reserved for the start; a newline separates it from the tail.",
             inline=True,
         ),
     ),

--- a/plugins/memory/hindsight/config_schema.py
+++ b/plugins/memory/hindsight/config_schema.py
@@ -72,5 +72,25 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             ),
             inline=True,
         ),
+        ProviderField(
+            key="recall_query_strategy",
+            label="Recall query strategy",
+            kind=KIND_SELECT,
+            default="prefix",
+            description="Keep the legacy prefix cap or preserve both the start and trailing intent.",
+            options=(
+                ProviderFieldOption("prefix", "Prefix"),
+                ProviderFieldOption("head_tail", "Head + tail"),
+            ),
+            inline=True,
+        ),
+        ProviderField(
+            key="recall_query_head_chars",
+            label="Recall query head characters",
+            kind=KIND_TEXT,
+            default="200",
+            description="Characters reserved for the start of a truncated head + tail query.",
+            inline=True,
+        ),
     ),
 )

--- a/tests/plugins/memory/test_hindsight_config_schema.py
+++ b/tests/plugins/memory/test_hindsight_config_schema.py
@@ -18,6 +18,8 @@ def test_hindsight_is_declared():
         "api_url",
         "bank_id",
         "recall_budget",
+        "recall_query_strategy",
+        "recall_query_head_chars",
     }
 
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -585,6 +585,25 @@ class TestPrefetch:
         assert "fresh memory" in result
         p._client.arecall.assert_called_once()
 
+    @pytest.mark.parametrize("strategy", ["prefix", "head_tail"])
+    def test_recall_sync_sends_composed_capped_query(
+        self, provider_with_config, strategy
+    ):
+        p = provider_with_config(
+            recall_sync=True,
+            recall_max_input_chars=64,
+            recall_query_strategy=strategy,
+            recall_query_head_chars=16,
+        )
+        query = "Zephyr context: " + ("x" * 200) + " Which rollback code is active?"
+
+        p.prefetch(query)
+
+        sent_query = p._client.arecall.call_args.kwargs["query"]
+        expected = query[:64] if strategy == "prefix" else query[:16] + "\n" + query[-47:]
+        assert sent_query == expected
+        assert len(sent_query) == 64
+
     def test_recall_sync_skips_background_queue(self, provider_with_config):
         # With sync recall there's nothing to prime in the background.
         p = provider_with_config(recall_sync=True)
@@ -641,7 +660,7 @@ class TestPrefetch:
 
         composed = p._compose_recall_query(query)
 
-        assert composed.startswith(query[:20])
+        assert composed == query[:20] + "\n" + query[-59:]
         assert composed.endswith("What is Project Zephyr's rollback code?")
         assert len(composed) == 80
 
@@ -649,8 +668,8 @@ class TestPrefetch:
         ("cap", "expected"),
         [
             (1, "f"),
-            (2, "af"),
-            (3, "abf"),
+            (2, "ef"),
+            (3, "a\nf"),
         ],
     )
     def test_head_tail_handles_tiny_caps(
@@ -663,6 +682,83 @@ class TestPrefetch:
         )
 
         assert p._compose_recall_query("abcdef") == expected
+
+    @pytest.mark.parametrize(
+        ("head_chars", "warning_fragment"),
+        [
+            (0, "does not preserve a head fragment"),
+            (8, "must be at most 6"),
+        ],
+    )
+    def test_head_tail_surfaces_degenerate_head_config(
+        self, provider_with_config, caplog, head_chars, warning_fragment
+    ):
+        with caplog.at_level("WARNING", logger="plugins.memory.hindsight"):
+            provider_with_config(
+                recall_max_input_chars=8,
+                recall_query_strategy="head_tail",
+                recall_query_head_chars=head_chars,
+            )
+
+        assert warning_fragment in caplog.text
+
+    def test_malformed_head_config_warns_and_uses_default(
+        self, provider_with_config, caplog
+    ):
+        with caplog.at_level("WARNING", logger="plugins.memory.hindsight"):
+            p = provider_with_config(
+                recall_max_input_chars=800,
+                recall_query_strategy="head_tail",
+                recall_query_head_chars="not-an-integer",
+            )
+
+        assert "Invalid integer Hindsight setting" in caplog.text
+        assert p._recall_query_head_chars == 200
+
+    def test_unknown_query_strategy_warns_and_falls_back_to_prefix(
+        self, provider_with_config, caplog
+    ):
+        with caplog.at_level("WARNING", logger="plugins.memory.hindsight"):
+            p = provider_with_config(
+                recall_max_input_chars=8,
+                recall_query_strategy="middle",
+            )
+
+        assert "Unknown Hindsight recall_query_strategy" in caplog.text
+        assert p._compose_recall_query("abcdefghijk") == "abcdefgh"
+
+    @pytest.mark.parametrize("strategy", ["prefix", "head_tail"])
+    def test_zero_cap_is_unlimited(self, provider_with_config, strategy):
+        p = provider_with_config(
+            recall_max_input_chars=0,
+            recall_query_strategy=strategy,
+            recall_query_head_chars=0,
+        )
+        query = "背景😀 " + ("noise " * 200) + "最后的问题是什么？🔐"
+
+        assert p._compose_recall_query(query) == query
+
+    @pytest.mark.parametrize(
+        ("strategy", "cap", "head_chars"),
+        [
+            ("prefix", 8, 0),
+            ("prefix", 8, "not-an-integer"),
+            ("head_tail", 0, 0),
+            ("head_tail", 0, "not-an-integer"),
+            ("head_tail", 8, 3),
+        ],
+    )
+    def test_recall_query_config_does_not_warn_when_head_is_irrelevant_or_valid(
+        self, provider_with_config, caplog, strategy, cap, head_chars
+    ):
+        with caplog.at_level("WARNING", logger="plugins.memory.hindsight"):
+            provider_with_config(
+                recall_max_input_chars=cap,
+                recall_query_strategy=strategy,
+                recall_query_head_chars=head_chars,
+            )
+
+        assert caplog.text == ""
 
     def test_head_tail_counts_cjk_emoji_and_code_as_python_characters(
         self, provider_with_config
@@ -728,7 +824,7 @@ class TestPrefetch:
         p._prefetch_thread.join(timeout=5.0)
 
         sent_query = p._client.arecall.call_args.kwargs["query"]
-        assert sent_query.startswith(query[:16])
+        assert sent_query == query[:16] + "\n" + query[-47:]
         assert sent_query.endswith("Which rollback code is active?")
         assert len(sent_query) == 64
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -262,6 +262,8 @@ class TestConfig:
         assert provider._retain_every_n_turns == 1
         assert provider._recall_max_tokens == 4096
         assert provider._recall_max_input_chars == 800
+        assert provider._recall_query_strategy == "prefix"
+        assert provider._recall_query_head_chars == 200
         assert provider._tags is None
         assert provider._observation_scopes is None
         assert provider._recall_tags is None
@@ -300,6 +302,8 @@ class TestConfig:
             recall_types=["world", "experience"],
             recall_prompt_preamble="Custom preamble:",
             recall_max_input_chars=500,
+            recall_query_strategy="head_tail",
+            recall_query_head_chars=125,
             bank_mission="Test agent mission",
         )
         assert p._tags == ["tag1", "tag2"]
@@ -318,6 +322,8 @@ class TestConfig:
         assert p._recall_types == ["world", "experience"]
         assert p._recall_prompt_preamble == "Custom preamble:"
         assert p._recall_max_input_chars == 500
+        assert p._recall_query_strategy == "head_tail"
+        assert p._recall_query_head_chars == 125
         assert p._bank_mission == "Test agent mission"
 
     def test_retain_source_defaults_empty(self, provider):
@@ -598,6 +604,133 @@ class TestPrefetch:
         p.queue_prefetch("test")
         # Should not start a thread
         assert p._prefetch_thread is None
+
+    @pytest.mark.parametrize("strategy", ["prefix", "head_tail"])
+    def test_recall_query_at_or_below_cap_is_unchanged(
+        self, provider_with_config, strategy
+    ):
+        p = provider_with_config(
+            recall_max_input_chars=8,
+            recall_query_strategy=strategy,
+            recall_query_head_chars=3,
+        )
+
+        assert p._compose_recall_query("12345678") == "12345678"
+        assert p._compose_recall_query("short") == "short"
+
+    def test_prefix_strategy_preserves_legacy_truncation(self, provider_with_config):
+        p = provider_with_config(
+            recall_max_input_chars=8,
+            recall_query_strategy="prefix",
+            recall_query_head_chars=3,
+        )
+
+        assert p._compose_recall_query("abcdefghijk") == "abcdefgh"
+
+    def test_head_tail_preserves_start_and_trailing_intent(self, provider_with_config):
+        p = provider_with_config(
+            recall_max_input_chars=80,
+            recall_query_strategy="head_tail",
+            recall_query_head_chars=20,
+        )
+        query = (
+            "Project Zephyr context"
+            + (" unrelated-background" * 30)
+            + " What is Project Zephyr's rollback code?"
+        )
+
+        composed = p._compose_recall_query(query)
+
+        assert composed.startswith(query[:20])
+        assert composed.endswith("What is Project Zephyr's rollback code?")
+        assert len(composed) == 80
+
+    @pytest.mark.parametrize(
+        ("cap", "expected"),
+        [
+            (1, "f"),
+            (2, "af"),
+            (3, "abf"),
+        ],
+    )
+    def test_head_tail_handles_tiny_caps(
+        self, provider_with_config, cap, expected
+    ):
+        p = provider_with_config(
+            recall_max_input_chars=cap,
+            recall_query_strategy="head_tail",
+            recall_query_head_chars=200,
+        )
+
+        assert p._compose_recall_query("abcdef") == expected
+
+    def test_head_tail_counts_cjk_emoji_and_code_as_python_characters(
+        self, provider_with_config
+    ):
+        p = provider_with_config(
+            recall_max_input_chars=60,
+            recall_query_strategy="head_tail",
+            recall_query_head_chars=18,
+        )
+        query = (
+            "背景😀\n```python\n"
+            + ("print('noise')\n" * 20)
+            + "```\n问题：项目 Zephyr 的回滚码是什么？🔐"
+        )
+
+        composed = p._compose_recall_query(query)
+
+        assert composed.startswith(query[:18])
+        assert composed.endswith("问题：项目 Zephyr 的回滚码是什么？🔐")
+        assert len(composed) == 60
+
+    def test_head_tail_covers_head_and_tail_topics_but_not_middle_noise(
+        self, provider_with_config
+    ):
+        p = provider_with_config(
+            recall_max_input_chars=72,
+            recall_query_strategy="head_tail",
+            recall_query_head_chars=30,
+        )
+        query = (
+            "Topic A: which deploy failed? "
+            + ("head filler " * 20)
+            + "MIDDLE_ONLY_QUESTION "
+            + ("tail filler " * 20)
+            + "Topic B: what rollback code should I use?"
+        )
+
+        composed = p._compose_recall_query(query)
+
+        assert "Topic A: which deploy failed?" in composed
+        assert "Topic B: what rollback code should I use?" in composed
+        assert "MIDDLE_ONLY_QUESTION" not in composed
+        assert len(composed) <= 72
+
+    def test_memory_manager_production_caller_sends_composed_query(
+        self, provider_with_config
+    ):
+        from agent.memory_manager import MemoryManager
+
+        p = provider_with_config(
+            recall_max_input_chars=64,
+            recall_query_strategy="head_tail",
+            recall_query_head_chars=16,
+            prefetch_waits_for_retain=False,
+        )
+        manager = MemoryManager()
+        manager.add_provider(p)
+        query = "Zephyr logs: " + ("x" * 200) + " Which rollback code is active?"
+
+        manager.queue_prefetch_all(query, session_id="test-session")
+        assert manager.flush_pending(timeout=5.0)
+        assert p._prefetch_thread is not None
+        p._prefetch_thread.join(timeout=5.0)
+
+        sent_query = p._client.arecall.call_args.kwargs["query"]
+        assert sent_query.startswith(query[:16])
+        assert sent_query.endswith("Which rollback code is active?")
+        assert len(sent_query) == 64
 
     def test_prefetch_waits_for_pending_retain_before_recall(self, provider):
         """The background prefetch must wait for queued retains to drain so the
@@ -1325,6 +1458,7 @@ class TestConfigSchema:
             "auto_recall", "auto_retain",
             "retain_every_n_turns", "retain_async", "retain_context",
             "recall_max_tokens", "recall_max_input_chars",
+            "recall_query_strategy", "recall_query_head_chars",
             "recall_prompt_preamble",
         }
         assert expected_keys.issubset(keys), f"Missing: {expected_keys - keys}"


### PR DESCRIPTION
## What does this PR do?

Fixes #83928.

Hindsight currently caps long automatic recall queries by keeping only their prefix. That bounds recall cost, but it can discard the user's actual question when logs, code, or background come first.

This PR adds an opt-in `head_tail` composition strategy that keeps a configurable prefix and uses the rest of the existing `recall_max_input_chars` budget for trailing intent. The existing `prefix` strategy remains the default. The separator counts toward the exact cap, tiny limits are deterministic, and the same composition path is used by synchronous and background prefetch.

## Related Issue

Fixes #83928

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`
  - adds validated `recall_query_strategy` and `recall_query_head_chars` settings;
  - composes bounded automatic recall queries through one deterministic helper shared by sync/background paths;
  - preserves legacy prefix truncation by default;
  - falls back safely for malformed or unknown configuration and warns only when relevant.
- `plugins/memory/hindsight/config_schema.py`
  - exposes the strategy and reserved-head settings in the provider configuration surface.
- `plugins/memory/hindsight/README.md`
  - documents both settings, defaults, compatibility behavior, and an opt-in example.
- Tests cover exact separator-inclusive caps, cap `0`, tiny caps, malformed settings, CJK, emoji, combining characters, sync/background parity, and the production caller path.

## How to Test

1. Configure Hindsight with `recall_max_input_chars: 800`, `recall_query_strategy: head_tail`, and `recall_query_head_chars: 200`.
2. Send a prompt longer than 800 characters with background first and the explicit question at the end. The recall query should contain both the configured head and trailing question while remaining at or below 800 Python characters.
3. Run:

```bash
python -m pytest \
  tests/plugins/memory/test_hindsight_config_schema.py \
  tests/plugins/memory/test_hindsight_provider.py \
  -o 'addopts=' -q

python -m ruff check \
  plugins/memory/hindsight/__init__.py \
  plugins/memory/hindsight/config_schema.py \
  tests/plugins/memory/test_hindsight_config_schema.py \
  tests/plugins/memory/test_hindsight_provider.py

python -m compileall -q \
  plugins/memory/hindsight \
  tests/plugins/memory/test_hindsight_config_schema.py \
  tests/plugins/memory/test_hindsight_provider.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run the complete repository test suite — focused and adjacent memory-provider suites were used for this isolated plugin change
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Relevant Hindsight documentation updated
- [x] `cli-config.yaml.example` N/A — these settings belong to the Hindsight provider config
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A
- [x] Cross-platform impact considered — implementation uses platform-neutral Python string operations
- [x] Provider configuration schema updated

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

No UI screenshot is needed for this provider configuration feature.

Verification on exact candidate `5f35a9151124c2215d8235282f0ef9ef3f877af9`:

- focused and adjacent implementation verification: **188 passed**;
- broader memory-provider run: **459 passed, 1 baseline failure** (`test_mem0_v3.py::...test_is_available_platform_needs_key`), reproduced unchanged on the frozen base;
- independent Spec review: **PASS**, including **4,059** exhaustive composition cases;
- independent Standards review: **PASS**, including **4,550** exhaustive cap/head combinations;
- Ruff: **passed**;
- `compileall`: **passed**;
- `git diff --check`: **passed**.
