### PR TITLE
fix(desktop): keep completion selection visible

### DIFF
--- a/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
@@ -25,11 +25,44 @@ function renderPopover(kind: '@' | '/', loading = false) {
   return { ...rendered, onHover, onPick }
 }
 
-describe('ComposerTriggerPopover i18n', () => {
-  afterEach(() => {
-    cleanup()
-  })
+function slashItem(command: string) {
+  return {
+    id: command,
+    type: 'slash',
+    label: command.slice(1),
+    metadata: { command, display: command, group: 'Skills', meta: '', rawText: command }
+  }
+}
 
+function rect(top: number, bottom: number): DOMRect {
+  return {
+    bottom,
+    height: bottom - top,
+    left: 0,
+    right: 320,
+    toJSON: () => ({}),
+    top,
+    width: 320,
+    x: 0,
+    y: top
+  }
+}
+
+function mockDrawerViewport(drawer: HTMLElement) {
+  Object.defineProperty(drawer, 'clientHeight', { configurable: true, value: 200 })
+  Object.defineProperty(drawer, 'clientTop', { configurable: true, value: 1 })
+  vi.spyOn(drawer, 'getBoundingClientRect').mockReturnValue(rect(100, 302))
+}
+
+function mockRowPosition(row: HTMLElement, top: number, bottom: number) {
+  return vi.spyOn(row, 'getBoundingClientRect').mockReturnValue(rect(top, bottom))
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ComposerTriggerPopover i18n', () => {
   it('renders localized empty lookup copy for @ references', () => {
     const { container } = renderPopover('@')
 
@@ -53,5 +86,117 @@ describe('ComposerTriggerPopover i18n', () => {
 
     expect(screen.getByText('没有匹配项。')).toBeTruthy()
     expect(container.textContent).toContain('/help')
+  })
+})
+
+describe('ComposerTriggerPopover keyboard scrolling', () => {
+  const items = [slashItem('/first'), slashItem('/second'), slashItem('/third')]
+
+  function popover(activeIndex: number, onHover = vi.fn(), nextItems = items) {
+    return (
+      <I18nProvider configClient={null} initialLocale="en">
+        <ComposerTriggerPopover
+          activeIndex={activeIndex}
+          items={nextItems}
+          kind="/"
+          loading={false}
+          onHover={onHover}
+          onPick={vi.fn()}
+        />
+      </I18nProvider>
+    )
+  }
+
+  it('keeps keyboard navigation visible and restores the group header on wrap', () => {
+    const { container, rerender } = render(popover(0))
+    const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
+    const ancestor = drawer.parentElement as HTMLElement
+    const secondRow = screen.getAllByRole('button')[1]
+
+    mockDrawerViewport(drawer)
+    mockRowPosition(secondRow, 290, 330)
+    ancestor.scrollTop = 48
+    drawer.scrollTop = 96
+    rerender(popover(1))
+
+    const activeRow = container.querySelector('[data-highlighted]') as HTMLElement
+
+    expect(activeRow.textContent).toContain('/second')
+    expect(drawer.scrollTop).toBe(125)
+    expect(ancestor.scrollTop).toBe(48)
+
+    drawer.scrollTop = 96
+    rerender(popover(0))
+
+    expect(drawer.scrollTop).toBe(0)
+  })
+
+  it('uses the nearest drawer edge for upward, visible, and oversized rows', () => {
+    const { container, rerender } = render(popover(0))
+    const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
+    const rows = screen.getAllByRole('button')
+
+    mockDrawerViewport(drawer)
+    mockRowPosition(rows[1], 80, 120)
+    const thirdRowRect = mockRowPosition(rows[2], 150, 180)
+
+    drawer.scrollTop = 50
+    rerender(popover(1))
+    expect(drawer.scrollTop).toBe(29)
+
+    rerender(popover(2))
+    expect(drawer.scrollTop).toBe(29)
+
+    thirdRowRect.mockReturnValue(rect(80, 340))
+    drawer.scrollTop = 50
+    rerender(popover(2, vi.fn(), [...items]))
+    expect(drawer.scrollTop).toBe(50)
+
+    thirdRowRect.mockReturnValue(rect(150, 400))
+    rerender(popover(2, vi.fn(), [...items, slashItem('/fourth')]))
+    expect(drawer.scrollTop).toBe(99)
+
+    thirdRowRect.mockReturnValue(rect(0, 250))
+    drawer.scrollTop = 100
+    rerender(popover(2, vi.fn(), [...items, slashItem('/fifth')]))
+    expect(drawer.scrollTop).toBe(49)
+  })
+
+  it('does not scroll for a hover echo and consumes the hover marker', () => {
+    const onHover = vi.fn()
+    const { container, rerender } = render(popover(0, onHover))
+    const rows = screen.getAllByRole('button')
+    const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
+
+    mockDrawerViewport(drawer)
+    mockRowPosition(rows[2], 311, 331)
+    drawer.scrollTop = 40
+    fireEvent.mouseEnter(rows[2])
+    expect(onHover).toHaveBeenCalledWith(2)
+
+    rerender(popover(2, onHover))
+    expect(drawer.scrollTop).toBe(40)
+
+    rerender(popover(0, onHover))
+    rerender(popover(2, onHover))
+
+    expect(drawer.scrollTop).toBe(30)
+    expect((container.querySelector('[data-highlighted]') as HTMLElement).textContent).toContain('/third')
+  })
+
+  it('does not leave a stale hover marker when the active row is hovered', () => {
+    const onHover = vi.fn()
+    const { container, rerender } = render(popover(1, onHover))
+    const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
+    const activeRow = screen.getAllByRole('button')[1]
+
+    mockDrawerViewport(drawer)
+    mockRowPosition(activeRow, 311, 331)
+    fireEvent.mouseEnter(activeRow)
+    expect(onHover).toHaveBeenCalledWith(1)
+
+    rerender(popover(1, onHover, [...items, slashItem('/fourth')]))
+
+    expect(drawer.scrollTop).toBe(30)
   })
 })

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -1,5 +1,5 @@
 import type { Unstable_TriggerItem } from '@assistant-ui/core'
-import { Fragment } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 
 import { referenceKind, referenceStyle } from '@/components/assistant-ui/reference-kinds'
 import { Codicon } from '@/components/ui/codicon'
@@ -91,6 +91,62 @@ export function ComposerTriggerPopover({
   const copy = t.composer
   const isSlash = kind === '/'
   const isEmoji = kind === ':'
+  const listRef = useRef<HTMLDivElement>(null)
+  const hoverIndexRef = useRef(-1)
+
+  // Only keyboard navigation should move the drawer. A hover echo already points
+  // at a visible row and scrolling it can shift another row under the pointer.
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  useEffect(() => {
+    const list = listRef.current
+
+    if (!list) {
+      return
+    }
+
+    const isHoverEcho = activeIndex === hoverIndexRef.current
+
+    hoverIndexRef.current = -1
+
+    if (isHoverEcho) {
+      return
+    }
+
+    if (activeIndex === 0) {
+      // `nearest` keeps the first row visible but can leave its group header
+      // clipped, so wrapping to the beginning restores the complete top edge.
+      list.scrollTop = 0
+
+      return
+    }
+
+    const highlighted = list.querySelector<HTMLElement>('[data-highlighted]')
+
+    if (!highlighted) {
+      return
+    }
+
+    // Keep scrolling local to the drawer. `scrollIntoView` may also move the
+    // transcript or window because it operates on every scrollable ancestor.
+    const listRect = list.getBoundingClientRect()
+    const highlightedRect = highlighted.getBoundingClientRect()
+    const visibleTop = listRect.top + list.clientTop
+    const visibleBottom = visibleTop + list.clientHeight
+    const topDelta = highlightedRect.top - visibleTop
+    const bottomDelta = highlightedRect.bottom - visibleBottom
+    const overflowsTop = topDelta < 0
+    const overflowsBottom = bottomDelta > 0
+
+    // A row that is fully visible needs no movement. An oversized row that
+    // spans both edges already covers the viewport, so moving it would not
+    // reveal the whole row and would only add churn. Otherwise align whichever
+    // edge requires the shorter movement, matching `block: nearest` semantics.
+    if (overflowsTop === overflowsBottom) {
+      return
+    }
+
+    list.scrollTop += Math.abs(topDelta) < Math.abs(bottomDelta) ? topDelta : bottomDelta
+  }, [activeIndex, items])
 
   let lastGroup: string | undefined
 
@@ -100,6 +156,7 @@ export function ComposerTriggerPopover({
       data-slot="composer-completion-drawer"
       data-state="open"
       onMouseDown={event => event.preventDefault()}
+      ref={listRef}
       role="listbox"
     >
       {scope && <div className={cn(GROUP_HEADER_CLASS, 'pt-0.5')}>{referenceStyle(scope).label}</div>}
@@ -146,7 +203,12 @@ export function ComposerTriggerPopover({
                 className={ROW_CLASS}
                 data-highlighted={active ? '' : undefined}
                 onClick={() => onPick(item)}
-                onMouseEnter={() => onHover(index)}
+                onMouseEnter={() => {
+                  // React bails out when hovering the already-active row. Do
+                  // not leave a marker behind for a later items refresh.
+                  hoverIndexRef.current = index === activeIndex ? -1 : index
+                  onHover(index)
+                }}
                 type="button"
               >
                 {isEmoji ? (


### PR DESCRIPTION
## What does this PR do?

Keeps the highlighted row visible while navigating the Desktop composer's shared completion drawer with ArrowUp/ArrowDown.

The drawer now applies nearest-edge geometry directly to its own `scrollTop`, restores `scrollTop = 0` when navigation returns to the first item so its group header is visible, and suppresses scrolling for hover-driven highlight echoes so rows do not move under the pointer. This keeps outer transcript/window scroll positions untouched. Because the fix lives in `ComposerTriggerPopover`, it covers the main composer and the inline edit composer without duplicating behavior in either consumer.

## Related Issue

Fixes #72644

> Competing implementations exist in #37823 and #72645. This submission was intentionally rebuilt and verified from current `main` (`f51aa6a9b5ce514e15f8e337777f522fd5cc6fa2`) at the request of the contributor. It preserves the current shared completion component and all current `/`, `@`, and `:` consumers.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/trigger-popover.tsx`
  - track the completion drawer element and the one-shot hover source;
  - scroll keyboard-selected rows with drawer-local nearest-edge geometry;
  - restore the complete top edge when selection returns to index 0.
- `apps/desktop/src/app/chat/composer/trigger-popover.test.tsx`
  - add regression coverage for downward/upward scrolling, borders, oversized rows, outer-scroll isolation, top wrapping, hover suppression, and stale hover-marker consumption.

## How to Test

1. Open Hermes Desktop, focus the composer, and type `/` so more results are present than fit in the drawer.
2. Press ArrowDown repeatedly. The highlighted row remains fully visible and the drawer's `scrollTop` advances.
3. Press ArrowUp back to the first result. The drawer returns to `scrollTop = 0`, including the leading group header.
4. Move the pointer between rows. Hover changes the highlight without moving the drawer under the pointer.

Verified locally:

- `LANG=en_US.utf8 LC_ALL=en_US.utf8 NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-scroll-final4-localstorage.json' npm --workspace apps/desktop exec -- vitest run src/app/chat/composer` — **37 files, 304 tests passed**
- `NODE_ENV=test npm --workspace apps/desktop run typecheck` — **passed**
- `npm --workspace apps/desktop run lint` — **0 errors** (88 pre-existing warnings)
- `npm --workspace apps/desktop run test:desktop:platforms` — **88 files passed, 1 skipped; 1035 tests passed, 2 skipped**
- `npm --workspace apps/desktop run build` — **passed**, build stamp points to candidate `1ea1deb94771`
- Live Electron/CDP check with 214 slash results — after 20 ArrowDown presses, `scrollTop` changed from `0` to `261.11` and the highlighted row was fully inside the drawer; returning to the first result restored `scrollTop` to `0`.

The unrestricted UI suite produced 4 locale-sensitive formatting failures outside this diff (billing and number formatting). Running the exact three affected files on the untouched parent produced the same 4 failures; all 106 affected tests pass with `LANG=en_US.utf8 LC_ALL=en_US.utf8`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - Searched; overlapping PRs are explicitly disclosed above, and this independently verified current-main submission is intentional.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - N/A: renderer-only TypeScript change; the relevant Desktop suites are listed above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux (Wayland)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live renderer instrumentation after 20 ArrowDown presses:

```json
{
  "before": { "scrollTop": 0, "clientHeight": 350, "scrollHeight": 6116, "rows": 214 },
  "after": { "scrollTop": 261.1111145019531, "activeFullyVisible": true },
  "returnedToFirst": { "scrollTop": 0, "firstText": "Session" }
}
```
