### PR TITLE
feat(kanban): distinguish task artifacts from attachments

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -581,9 +581,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_attach.add_argument("--name", default=None,
                           help="Stored filename (default: the source file's basename)")
     p_attach.add_argument("--author", default=None,
-                          help="uploaded_by label (default: $HERMES_PROFILE or 'user')")
+                           help="uploaded_by label (default: $HERMES_PROFILE or 'user')")
+    p_attach.add_argument(
+        "--type",
+        dest="attachment_type",
+        choices=sorted(kb.VALID_ATTACHMENT_TYPES),
+        default=kb.DEFAULT_HUMAN_ATTACHMENT_TYPE,
+        help="File purpose (default: attachment for user-provided task context)",
+    )
 
-    p_attachments = sub.add_parser("attachments", help="List a task's attachments")
+    p_attachments = sub.add_parser("attachments", help="List a task's attachments and artifacts")
     p_attachments.add_argument("task_id")
     p_attachments.add_argument("--json", action="store_true")
 
@@ -2148,11 +2155,15 @@ def _cmd_attach(args: argparse.Namespace) -> int:
                 data,
                 content_type=content_type,
                 uploaded_by=uploaded_by,
+                attachment_type=args.attachment_type,
             )
     except kb.AttachmentTooLarge as exc:
         print(f"kanban: {exc}", file=sys.stderr)
         return 1
-    print(f"Attached {name} to {args.task_id} (attachment {att_id}, {len(data)} bytes)")
+    print(
+        f"Attached {name} to {args.task_id} "
+        f"({args.attachment_type} {att_id}, {len(data)} bytes)"
+    )
     return 0
 
 
@@ -2173,6 +2184,7 @@ def _cmd_attachments(args: argparse.Namespace) -> int:
                 "uploaded_by": a.uploaded_by,
                 "stored_path": a.stored_path,
                 "created_at": a.created_at,
+                "attachment_type": a.attachment_type,
             }
             for a in atts
         ], indent=2))
@@ -2180,10 +2192,13 @@ def _cmd_attachments(args: argparse.Namespace) -> int:
     if not atts:
         print(f"No attachments on {args.task_id}")
         return 0
-    print(f"Attachments on {args.task_id}:")
+    print(f"Attachments and artifacts on {args.task_id}:")
     for a in atts:
         ct = a.content_type or "-"
-        print(f"  [{a.id}] {a.filename}  ({a.size} bytes, {ct}, by {a.uploaded_by or '-'})")
+        print(
+            f"  [{a.id}] [{a.attachment_type}] {a.filename}  "
+            f"({a.size} bytes, {ct}, by {a.uploaded_by or '-'})"
+        )
         print(f"        {a.stored_path}")
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -160,6 +160,28 @@ def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
+ATTACHMENT_TYPE_ATTACHMENT = "attachment"
+ATTACHMENT_TYPE_ARTIFACT = "artifact"
+VALID_ATTACHMENT_TYPES = frozenset(
+    {ATTACHMENT_TYPE_ATTACHMENT, ATTACHMENT_TYPE_ARTIFACT}
+)
+
+# Defaults follow the actor's domain intent rather than cosmetic consistency:
+# human uploads provide task context, while worker tool uploads publish task
+# outputs. Callers can always override the classification explicitly.
+DEFAULT_HUMAN_ATTACHMENT_TYPE = ATTACHMENT_TYPE_ATTACHMENT
+DEFAULT_WORKER_ATTACHMENT_TYPE = ATTACHMENT_TYPE_ARTIFACT
+
+
+def _sqlite_string_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+_ATTACHMENT_TYPE_CHECK_SQL = (
+    "attachment_type TEXT CHECK (attachment_type IN ("
+    + ", ".join(_sqlite_string_literal(value) for value in sorted(VALID_ATTACHMENT_TYPES))
+    + "))"
+)
 
 
 def _assert_not_delegated_child_mutation() -> None:
@@ -1313,6 +1335,7 @@ class Attachment:
     size: int
     uploaded_by: Optional[str]
     created_at: int
+    attachment_type: str
 
 
 @dataclass
@@ -1329,7 +1352,7 @@ class Event:
 # Schema
 # ---------------------------------------------------------------------------
 
-SCHEMA_SQL = """
+SCHEMA_SQL = f"""
 CREATE TABLE IF NOT EXISTS tasks (
     id                   TEXT PRIMARY KEY,
     title                TEXT NOT NULL,
@@ -1491,7 +1514,8 @@ CREATE TABLE IF NOT EXISTS task_attachments (
     content_type TEXT,
     size         INTEGER NOT NULL DEFAULT 0,
     uploaded_by  TEXT,
-    created_at   INTEGER NOT NULL
+    created_at   INTEGER NOT NULL,
+    {_ATTACHMENT_TYPE_CHECK_SQL}
 );
 
 -- Subscription from a gateway source (platform + chat + thread) to a
@@ -2533,6 +2557,22 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
 
     Called by ``init_db`` so opening an old DB is always safe.
     """
+    attachment_cols = {
+        row["name"] for row in conn.execute("PRAGMA table_info(task_attachments)")
+    }
+    if attachment_cols and "attachment_type" not in attachment_cols:
+        # NULL deliberately means "attachment" at read time. That preserves
+        # every legacy row and keeps downgraded/older writers compatible when
+        # they insert without knowing about this nullable column. Some focused
+        # migration tests exercise a minimal schema without the attachments
+        # table, so skip this additive migration until that table exists.
+        _add_column_if_missing(
+            conn,
+            "task_attachments",
+            "attachment_type",
+            _ATTACHMENT_TYPE_CHECK_SQL,
+        )
+
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     if "tenant" not in cols:
         _add_column_if_missing(conn, "tasks", "tenant", "tenant TEXT")
@@ -4103,6 +4143,15 @@ def _collision_free_path(dest_dir: Path, safe_name: str) -> Path:
     return dest_dir / candidate
 
 
+def normalize_attachment_type(value: Optional[str]) -> str:
+    """Return the canonical task-file type, treating legacy NULL as input."""
+    normalized = value or DEFAULT_HUMAN_ATTACHMENT_TYPE
+    if normalized not in VALID_ATTACHMENT_TYPES:
+        choices = ", ".join(sorted(VALID_ATTACHMENT_TYPES))
+        raise ValueError(f"attachment_type must be one of: {choices}")
+    return normalized
+
+
 def store_attachment_bytes(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4111,6 +4160,7 @@ def store_attachment_bytes(
     *,
     content_type: Optional[str] = None,
     uploaded_by: Optional[str] = None,
+    attachment_type: str = DEFAULT_HUMAN_ATTACHMENT_TYPE,
     board: Optional[str] = None,
     max_bytes: Optional[int] = None,
 ) -> int:
@@ -4131,6 +4181,7 @@ def store_attachment_bytes(
     after the blob is written (e.g. the task disappeared) the orphaned blob
     is removed before re-raising.
     """
+    attachment_type = normalize_attachment_type(attachment_type)
     if max_bytes is None:
         max_bytes = KANBAN_ATTACHMENT_MAX_BYTES
     if len(data) > max_bytes:
@@ -4151,6 +4202,7 @@ def store_attachment_bytes(
             content_type=content_type,
             size=len(data),
             uploaded_by=uploaded_by,
+            attachment_type=attachment_type,
         )
     except Exception:
         # Don't leave an orphan blob if the metadata insert fails (most
@@ -4171,6 +4223,7 @@ def add_attachment(
     content_type: Optional[str] = None,
     size: int = 0,
     uploaded_by: Optional[str] = None,
+    attachment_type: str = DEFAULT_HUMAN_ATTACHMENT_TYPE,
 ) -> int:
     """Record a file attachment for a task. Returns the new attachment id.
 
@@ -4178,6 +4231,7 @@ def add_attachment(
     first (under :func:`task_attachments_dir`); this only persists the
     metadata row and appends an ``attached`` event.
     """
+    attachment_type = normalize_attachment_type(attachment_type)
     if not filename or not filename.strip():
         raise ValueError("attachment filename is required")
     if not stored_path or not stored_path.strip():
@@ -4190,8 +4244,8 @@ def add_attachment(
             raise ValueError(f"unknown task {task_id}")
         cur = conn.execute(
             "INSERT INTO task_attachments "
-            "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at, attachment_type) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 task_id,
                 filename.strip(),
@@ -4200,13 +4254,19 @@ def add_attachment(
                 int(size),
                 uploaded_by,
                 now,
+                attachment_type,
             ),
         )
         _append_event(
             conn,
             task_id,
             "attached",
-            {"filename": filename.strip(), "size": int(size), "by": uploaded_by},
+            {
+                "filename": filename.strip(),
+                "size": int(size),
+                "by": uploaded_by,
+                "attachment_type": attachment_type,
+            },
         )
         return int(cur.lastrowid or 0)
 
@@ -4226,6 +4286,7 @@ def list_attachments(conn: sqlite3.Connection, task_id: str) -> list[Attachment]
             size=r["size"] or 0,
             uploaded_by=r["uploaded_by"],
             created_at=r["created_at"],
+            attachment_type=normalize_attachment_type(r["attachment_type"]),
         )
         for r in rows
     ]
@@ -4246,6 +4307,7 @@ def get_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Att
         size=r["size"] or 0,
         uploaded_by=r["uploaded_by"],
         created_at=r["created_at"],
+        attachment_type=normalize_attachment_type(r["attachment_type"]),
     )
 
 
@@ -5765,15 +5827,27 @@ def _insert_completion_attachment(
     """Record a worker-produced artifact in the existing attachment table."""
     conn.execute(
         "INSERT INTO task_attachments "
-        "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
-        "VALUES (?, ?, ?, NULL, ?, 'kanban_complete', ?)",
-        (task_id, filename, stored_path, size, created_at),
+        "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at, attachment_type) "
+        "VALUES (?, ?, ?, NULL, ?, 'kanban_complete', ?, ?)",
+        (
+            task_id,
+            filename,
+            stored_path,
+            size,
+            created_at,
+            ATTACHMENT_TYPE_ARTIFACT,
+        ),
     )
     _append_event(
         conn,
         task_id,
         "attached",
-        {"filename": filename, "size": size, "by": "kanban_complete"},
+        {
+            "filename": filename,
+            "size": size,
+            "by": "kanban_complete",
+            "attachment_type": ATTACHMENT_TYPE_ARTIFACT,
+        },
     )
 
 
@@ -11073,7 +11147,15 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     # full file-tool access, can read them directly (read_file, terminal
     # `pdftotext`, etc.). On the local terminal backend the path resolves
     # as-is; remote backends need the kanban attachments dir mounted.
-    attachments = list_attachments(conn, task_id)
+    task_files = list_attachments(conn, task_id)
+    attachments = [
+        item for item in task_files
+        if item.attachment_type == ATTACHMENT_TYPE_ATTACHMENT
+    ]
+    artifacts = [
+        item for item in task_files
+        if item.attachment_type == ATTACHMENT_TYPE_ARTIFACT
+    ]
     if attachments:
         lines.append("## Attachments")
         lines.append(
@@ -11085,6 +11167,21 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             size_str = f", {size_kb} KB" if size_kb else ""
             ctype = f", {att.content_type}" if att.content_type else ""
             lines.append(f"- `{att.filename}`{ctype}{size_str} → `{att.stored_path}`")
+        lines.append("")
+
+    if artifacts:
+        lines.append("## Artifacts")
+        lines.append(
+            "Files generated by this task. Read them with the file/terminal "
+            "tools at the absolute paths below:"
+        )
+        for artifact in artifacts:
+            size_kb = max(1, (artifact.size + 1023) // 1024) if artifact.size else 0
+            size_str = f", {size_kb} KB" if size_kb else ""
+            ctype = f", {artifact.content_type}" if artifact.content_type else ""
+            lines.append(
+                f"- `{artifact.filename}`{ctype}{size_str} → `{artifact.stored_path}`"
+            )
         lines.append("")
 
     # Prior attempts — show closed runs so a retrying worker sees the

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3755,20 +3755,24 @@
     return (n / (1024 * 1024)).toFixed(1) + " MB";
   }
 
-  // Attachments section in the task drawer (#35338). Upload button +
-  // list with download links and a delete (×) per row. The download
-  // link hits GET /attachments/:id which streams the file; the worker
-  // context surfaces the same files' absolute paths so a kanban worker
-  // can read them with the file/terminal tools.
-  function AttachmentsSection(props) {
+  // Task files in the drawer (#35338, #83960). Input attachments and
+  // worker-generated artifacts share storage/download/delete mechanics, but
+  // render in separate groups so their role in the task lifecycle is clear.
+  function TaskFilesSection(props) {
     const i18n = props.i18n;
-    const atts = props.attachments || [];
+    const files = props.attachments || [];
+    const attachments = files.filter(function (a) {
+      return !a.attachment_type || a.attachment_type === "attachment";
+    });
+    const artifacts = files.filter(function (a) {
+      return a.attachment_type === "artifact";
+    });
     const fileRef = useRef(null);
     const [dlErr, setDlErr] = useState(null);
     // Download via authenticated fetch → blob → synthetic anchor click.
     // A plain <a href> can't carry the auth the dashboard middleware requires,
     // so fetch authenticated and hand the browser a blob URL instead.
-    function downloadAttachment(a) {
+    function downloadTaskFile(a) {
       // SDK.authedFetch handles auth in BOTH modes (loopback token header /
       // gated cookie) and applies the dashboard base-path prefix. The old
       // hand-rolled Authorization:Bearer + credentials:'same-origin' sent an
@@ -3796,73 +3800,96 @@
         })
         .catch(function (e) { setDlErr(String(e.message || e)); });
     }
-    return h("div", { className: "hermes-kanban-section" },
-      h("div", { className: "hermes-kanban-section-head" },
-        `${tx(i18n, "attachments", "Attachments")} (${atts.length})`),
-      h("input", {
-        ref: fileRef,
-        type: "file",
-        multiple: true,
-        style: { display: "none" },
-        onChange: function (e) {
-          if (props.onUpload) props.onUpload(e.target.files);
-          // Reset so selecting the same file again re-triggers onChange.
-          try { e.target.value = ""; } catch (_e) { /* ignore */ }
+    function renderRows(items, emptyKey, emptyLabel, removeKey, removeLabel,
+        confirmKey, confirmLabel) {
+      if (items.length === 0) {
+        return h("div", { className: "text-xs text-muted-foreground" },
+          tx(i18n, emptyKey, emptyLabel));
+      }
+      return items.map(function (a) {
+        return h("div", {
+          key: a.id,
+          className: "flex items-center justify-between gap-2 py-1 text-sm",
         },
-      }),
-      h("div", { className: "flex items-center gap-2 mb-2" },
-        h(Button, {
-          size: "sm",
-          variant: "outline",
-          disabled: !!props.uploadBusy,
-          onClick: function () { if (fileRef.current) fileRef.current.click(); },
-        }, props.uploadBusy
-            ? tx(i18n, "uploading", "Uploading…")
-            : tx(i18n, "uploadFile", "Upload file")),
-      ),
-      (props.uploadErr || dlErr)
-        ? h("div", { className: "text-xs text-destructive mb-2" }, props.uploadErr || dlErr)
-        : null,
-      atts.length === 0
-        ? h("div", { className: "text-xs text-muted-foreground" },
-            tx(i18n, "noAttachments", "— no attachments —"))
-        : atts.map(function (a) {
-            return h("div", {
-              key: a.id,
-              className: "flex items-center justify-between gap-2 py-1 text-sm",
+          h("button", {
+            type: "button",
+            className: "hermes-kanban-attachment-link truncate",
+            title: a.filename,
+            onClick: function () { downloadTaskFile(a); },
+          }, a.filename),
+          h("span", { className: "text-xs text-muted-foreground whitespace-nowrap" },
+            _fmtBytes(a.size)),
+          h("button", {
+            type: "button",
+            className: "hermes-kanban-drawer-close",
+            title: tx(i18n, removeKey, removeLabel),
+            onClick: function () {
+              const title = tx(i18n, removeKey, removeLabel);
+              const description = tx(i18n, confirmKey, confirmLabel);
+              if (props.requestDialog) {
+                props.requestDialog({
+                  kind: "confirm",
+                  title: title,
+                  description: description,
+                  confirmLabel: tx(i18n, "common.delete", "Delete"),
+                  destructive: true,
+                }).then(function (r) {
+                  if (r.confirmed && props.onDelete) props.onDelete(a.id);
+                }).catch(function () { /* cancelled */ });
+              } else if (window.confirm(description)) {
+                if (props.onDelete) props.onDelete(a.id);
+              }
             },
-              h("button", {
-                type: "button",
-                className: "hermes-kanban-attachment-link truncate",
-                title: a.filename,
-                onClick: function () { downloadAttachment(a); },
-              }, a.filename),
-              h("span", { className: "text-xs text-muted-foreground whitespace-nowrap" },
-                _fmtBytes(a.size)),
-              h("button", {
-                type: "button",
-                className: "hermes-kanban-drawer-close",
-                title: tx(i18n, "removeAttachment", "Remove attachment"),
-                onClick: function () {
-                  if (props.requestDialog) {
-                    props.requestDialog({
-                      kind: "confirm",
-                      title: tx(i18n, "removeAttachment", "Remove attachment"),
-                      description: tx(i18n, "confirmRemoveAttachment",
-                        "Remove this attachment?"),
-                      confirmLabel: tx(i18n, "common.delete", "Delete"),
-                      destructive: true,
-                    }).then(function (r) {
-                      if (r.confirmed && props.onDelete) props.onDelete(a.id);
-                    }).catch(function () { /* cancelled */ });
-                  } else if (window.confirm(tx(i18n, "confirmRemoveAttachment",
-                      "Remove this attachment?"))) {
-                    if (props.onDelete) props.onDelete(a.id);
-                  }
-                },
-              }, "×"),
-            );
-          }),
+          }, "×"),
+        );
+      });
+    }
+    return h(React.Fragment, null,
+      h("div", { className: "hermes-kanban-section" },
+        h("div", { className: "hermes-kanban-section-head" },
+          `${tx(i18n, "attachments", "Attachments")} (${attachments.length})`),
+        h("input", {
+          ref: fileRef,
+          type: "file",
+          multiple: true,
+          style: { display: "none" },
+          onChange: function (e) {
+            if (props.onUpload) props.onUpload(e.target.files);
+            // Reset so selecting the same file again re-triggers onChange.
+            try { e.target.value = ""; } catch (_e) { /* ignore */ }
+          },
+        }),
+        h("div", { className: "flex items-center gap-2 mb-2" },
+          h(Button, {
+            size: "sm",
+            variant: "outline",
+            disabled: !!props.uploadBusy,
+            onClick: function () { if (fileRef.current) fileRef.current.click(); },
+          }, props.uploadBusy
+              ? tx(i18n, "uploading", "Uploading…")
+              : tx(i18n, "uploadFile", "Upload file")),
+        ),
+        (props.uploadErr || dlErr)
+          ? h("div", { className: "text-xs text-destructive mb-2" }, props.uploadErr || dlErr)
+          : null,
+        renderRows(
+          attachments,
+          "noAttachments", "— no attachments —",
+          "removeAttachment", "Remove attachment",
+          "confirmRemoveAttachment", "Remove this attachment?",
+        ),
+      ),
+      h("div", { className: "hermes-kanban-section" },
+        h("div", { className: "hermes-kanban-section-head" },
+          `${tx(i18n, "artifacts", "Artifacts")} (${artifacts.length})`),
+        renderRows(
+          artifacts,
+          "noArtifacts", "— no artifacts —",
+          "removeArtifact", "Remove artifact",
+          "confirmRemoveArtifact",
+          "Permanently remove this generated artifact? This cannot be undone, and later workers may rely on it.",
+        ),
+      ),
     );
   }
 
@@ -4001,7 +4028,7 @@
           );
         }),
       ) : null,
-      h(AttachmentsSection, {
+      h(TaskFilesSection, {
         attachments: attachments,
         boardSlug: props.boardSlug,
         onUpload: props.onUpload,
@@ -4781,6 +4808,7 @@
   // Register
   // -------------------------------------------------------------------------
 
+  KanbanPage.TaskFilesSection = TaskFilesSection;
   if (window.__HERMES_PLUGINS__ && typeof window.__HERMES_PLUGINS__.register === "function") {
     window.__HERMES_PLUGINS__.register("kanban", KanbanPage);
   }

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -209,6 +209,7 @@ def _attachment_dict(a: kanban_db.Attachment) -> dict[str, Any]:
         "uploaded_by": a.uploaded_by,
         "stored_path": a.stored_path,
         "created_at": a.created_at,
+        "attachment_type": a.attachment_type,
     }
 
 
@@ -717,12 +718,15 @@ async def upload_task_attachment(
     file: UploadFile = File(...),
     board: Optional[str] = Query(None),
     uploaded_by: Optional[str] = Form(None),
+    attachment_type: str = Form(kanban_db.DEFAULT_HUMAN_ATTACHMENT_TYPE),
 ):
     """Store an uploaded file for a task and record its metadata.
 
     The blob lands under ``attachments_root(board)/<task_id>/`` with a
-    sanitised, collision-resolved name. The worker reads it via the
-    absolute path surfaced in ``build_worker_context``.
+    sanitised, collision-resolved name. Human/dashboard uploads default to
+    input attachments; callers can explicitly mark generated output as an
+    artifact. The worker reads it via the absolute path surfaced in
+    ``build_worker_context``.
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
@@ -730,6 +734,9 @@ async def upload_task_attachment(
         if kanban_db.get_task(conn, task_id) is None:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
 
+        # Validate before creating the task directory or streaming bytes so a
+        # malformed multipart request cannot leave an orphaned blob behind.
+        attachment_type = kanban_db.normalize_attachment_type(attachment_type)
         safe_name = _safe_attachment_name(file.filename or "")
 
         # Stream to disk with a hard size cap so a huge upload can't fill
@@ -772,6 +779,7 @@ async def upload_task_attachment(
             content_type=file.content_type,
             size=total,
             uploaded_by=(uploaded_by or "dashboard"),
+            attachment_type=attachment_type,
         )
         att = kanban_db.get_attachment(conn, att_id)
         return {"attachment": _attachment_dict(att) if att else None}

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -607,8 +607,8 @@ def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
     assert run.metadata["artifacts"] == [str(persisted)]
     with kb.connect() as conn:
         attachments = kb.list_attachments(conn, t)
-    assert [(a.filename, a.stored_path) for a in attachments] == [
-        ("chart.png", str(persisted.resolve()))
+    assert [(a.filename, a.stored_path, a.attachment_type) for a in attachments] == [
+        ("chart.png", str(persisted.resolve()), "artifact")
     ]
 
 

--- a/tests/plugins/test_kanban_attachments.py
+++ b/tests/plugins/test_kanban_attachments.py
@@ -13,6 +13,8 @@ The plugin router is attached to a bare FastAPI app — same approach as
 from __future__ import annotations
 
 import importlib.util
+import json
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -97,6 +99,7 @@ def test_add_list_get_delete_attachment(kanban_home, tmp_path):
         assert a.size == len(b"%PDF-1.4 fake")
         assert a.uploaded_by == "tester"
         assert a.stored_path == str(blob)
+        assert a.attachment_type == "attachment"
 
         got = kb.get_attachment(conn, att_id)
         assert got is not None and got.id == att_id
@@ -108,6 +111,108 @@ def test_add_list_get_delete_attachment(kanban_home, tmp_path):
         assert kb.get_attachment(conn, att_id) is None
     finally:
         conn.close()
+
+
+def test_fresh_attachment_type_constraint_tracks_declared_policy(kanban_home, tmp_path):
+    conn = kb.connect()
+    try:
+        task_id = _make_task(conn, title="fresh-constraint")
+        for index, attachment_type in enumerate(sorted(kb.VALID_ATTACHMENT_TYPES), 1):
+            conn.execute(
+                "INSERT INTO task_attachments "
+                "(task_id, filename, stored_path, size, created_at, attachment_type) "
+                "VALUES (?, ?, ?, 0, ?, ?)",
+                (
+                    task_id,
+                    f"valid-{index}.txt",
+                    str(tmp_path / f"fresh-valid-{index}.txt"),
+                    index,
+                    attachment_type,
+                ),
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO task_attachments "
+                "(task_id, filename, stored_path, size, created_at, attachment_type) "
+                "VALUES (?, 'invalid.txt', ?, 0, 99, 'unknown')",
+                (task_id, str(tmp_path / "fresh-invalid.txt")),
+            )
+    finally:
+        conn.close()
+
+
+def test_attachment_type_migration_is_idempotent_and_legacy_rows_remain_inputs(
+    kanban_home, tmp_path,
+):
+    """A pre-type board upgrades in place, and old writers stay compatible."""
+    db_path = tmp_path / "legacy-attachments.db"
+    kb.init_db(db_path)
+    with kb.connect(db_path) as conn:
+        task_id = _make_task(conn, title="legacy")
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_attachments)")
+        }
+        if "attachment_type" in columns:
+            conn.execute("ALTER TABLE task_attachments DROP COLUMN attachment_type")
+        conn.execute(
+            "INSERT INTO task_attachments "
+            "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
+            "VALUES (?, 'legacy.txt', ?, 'text/plain', 6, 'old-version', 1)",
+            (task_id, str(tmp_path / "legacy.txt")),
+        )
+        conn.commit()
+
+    kb.init_db(db_path)
+    kb.init_db(db_path)
+    with kb.connect(db_path) as conn:
+        info = {
+            row["name"]: row for row in conn.execute("PRAGMA table_info(task_attachments)")
+        }
+        assert "attachment_type" in info
+        assert info["attachment_type"]["notnull"] == 0
+        assert info["attachment_type"]["dflt_value"] is None
+
+        legacy = kb.list_attachments(conn, task_id)
+        assert [(item.filename, item.attachment_type) for item in legacy] == [
+            ("legacy.txt", "attachment"),
+        ]
+
+        # Simulate a downgraded/older Hermes binary that omits the new column.
+        conn.execute(
+            "INSERT INTO task_attachments "
+            "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
+            "VALUES (?, 'old-writer.txt', ?, 'text/plain', 1, 'old-version', 2)",
+            (task_id, str(tmp_path / "old-writer.txt")),
+        )
+        conn.commit()
+        assert [item.attachment_type for item in kb.list_attachments(conn, task_id)] == [
+            "attachment",
+            "attachment",
+        ]
+
+        # The additive migration and fresh schema share one generated CHECK
+        # policy: every declared type must be accepted, while unknown values
+        # still fail at SQLite's persistence boundary.
+        for index, attachment_type in enumerate(sorted(kb.VALID_ATTACHMENT_TYPES), 3):
+            conn.execute(
+                "INSERT INTO task_attachments "
+                "(task_id, filename, stored_path, size, created_at, attachment_type) "
+                "VALUES (?, ?, ?, 0, ?, ?)",
+                (
+                    task_id,
+                    f"valid-{index}.txt",
+                    str(tmp_path / f"valid-{index}.txt"),
+                    index,
+                    attachment_type,
+                ),
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO task_attachments "
+                "(task_id, filename, stored_path, size, created_at, attachment_type) "
+                "VALUES (?, 'invalid.txt', ?, 0, 99, 'unknown')",
+                (task_id, str(tmp_path / "invalid.txt")),
+            )
 
 
 def test_delete_attachment_missing_returns_none(kanban_home):
@@ -158,6 +263,36 @@ def test_worker_context_lists_attachments_with_absolute_path(kanban_home):
         conn.close()
 
 
+def test_worker_context_labels_inputs_and_generated_artifacts_separately(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = _make_task(conn, title="render report")
+        kb.add_attachment(
+            conn,
+            task_id,
+            filename="brief.txt",
+            stored_path="/tmp/brief.txt",
+            attachment_type="attachment",
+        )
+        kb.add_attachment(
+            conn,
+            task_id,
+            filename="report.pdf",
+            stored_path="/tmp/report.pdf",
+            attachment_type="artifact",
+        )
+
+        ctx = kb.build_worker_context(conn, task_id)
+        attachments_block, artifacts_block = ctx.split("## Artifacts", 1)
+        assert "## Attachments" in attachments_block
+        assert "brief.txt" in attachments_block
+        assert "report.pdf" not in attachments_block
+        assert "Files generated by this task" in artifacts_block
+        assert "report.pdf" in artifacts_block
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # REST surface — upload / list / download / delete round-trip
 # ---------------------------------------------------------------------------
@@ -182,6 +317,7 @@ def test_upload_list_download_delete_roundtrip(client):
     att = r.json()["attachment"]
     assert att["filename"] == "notes.txt"
     assert att["size"] == len(content)
+    assert att["attachment_type"] == "attachment"
     att_id = att["id"]
 
     # List (drawer also embeds it in GET /tasks/:id)
@@ -205,6 +341,50 @@ def test_upload_list_download_delete_roundtrip(client):
     assert client.get(
         f"/api/plugins/kanban/tasks/{task_id}/attachments"
     ).json()["attachments"] == []
+
+
+def test_upload_list_detail_and_download_artifact_roundtrip(client):
+    task_id = _create_task_via_api(client)
+    content = b"generated report"
+
+    created = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/attachments",
+        files={"file": ("report.txt", content, "text/plain")},
+        data={"attachment_type": "artifact"},
+    )
+    assert created.status_code == 200, created.text
+    artifact = created.json()["attachment"]
+    assert artifact["attachment_type"] == "artifact"
+
+    listed = client.get(
+        f"/api/plugins/kanban/tasks/{task_id}/attachments"
+    ).json()["attachments"]
+    assert [(item["filename"], item["attachment_type"]) for item in listed] == [
+        ("report.txt", "artifact"),
+    ]
+    detail = client.get(f"/api/plugins/kanban/tasks/{task_id}").json()
+    assert detail["attachments"][0]["attachment_type"] == "artifact"
+
+    downloaded = client.get(
+        f"/api/plugins/kanban/attachments/{artifact['id']}"
+    )
+    assert downloaded.status_code == 200
+    assert downloaded.content == content
+
+
+def test_upload_rejects_unknown_attachment_type_without_leaving_a_blob(client):
+    task_id = _create_task_via_api(client)
+    response = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/attachments",
+        files={"file": ("bad.txt", b"bad", "text/plain")},
+        data={"attachment_type": "output"},
+    )
+    assert response.status_code == 400
+    assert "attachment_type" in response.json()["detail"]
+    assert client.get(
+        f"/api/plugins/kanban/tasks/{task_id}/attachments"
+    ).json()["attachments"] == []
+    assert not kb.task_attachments_dir(task_id).exists()
 
 
 def test_upload_sanitizes_traversal_filename(client):
@@ -243,6 +423,7 @@ def test_store_attachment_bytes_roundtrip(kanban_home):
         assert a.filename == "doc.txt"
         assert a.size == len(b"some bytes")
         assert a.uploaded_by == "tester"
+        assert a.attachment_type == "attachment"
         assert Path(a.stored_path).read_bytes() == b"some bytes"
         assert Path(a.stored_path).resolve().is_relative_to(
             kb.task_attachments_dir(task_id).resolve()
@@ -277,6 +458,7 @@ def test_cli_attach_attachments_and_rm(kanban_home, tmp_path):
         assert len(atts) == 1
         att_id = atts[0].id
         assert atts[0].filename == "upload.txt"
+        assert atts[0].attachment_type == kb.DEFAULT_HUMAN_ATTACHMENT_TYPE
         assert Path(atts[0].stored_path).read_bytes() == b"cli file body"
     finally:
         conn.close()
@@ -292,4 +474,29 @@ def test_cli_attach_attachments_and_rm(kanban_home, tmp_path):
     finally:
         conn.close()
 
+
+def test_cli_can_create_and_label_an_artifact(kanban_home, tmp_path):
+    from hermes_cli.kanban import run_slash
+
+    conn = kb.connect()
+    try:
+        task_id = _make_task(conn, title="cli-artifact")
+    finally:
+        conn.close()
+
+    src = tmp_path / "result.json"
+    src.write_text('{"ok": true}', encoding="utf-8")
+    created = run_slash(f"attach {task_id} {src} --type artifact")
+    assert "artifact" in created.lower()
+
+    conn = kb.connect()
+    try:
+        artifact = kb.list_attachments(conn, task_id)[0]
+        assert artifact.attachment_type == "artifact"
+    finally:
+        conn.close()
+
+    listed = run_slash(f"attachments {task_id}")
+    assert "artifact" in listed.lower()
+    assert "result.json" in listed
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -976,8 +976,61 @@ def test_maybe_auto_subscribe_swallows_add_notify_sub_failure(monkeypatch, worke
 
 
 # ---------------------------------------------------------------------------
-# Attachments — kanban_attach / kanban_attach_url / kanban_attachments
+# Attachments and artifacts — kanban_attach / kanban_attach_url / kanban_attachments
 # ---------------------------------------------------------------------------
+
+
+def test_attach_defaults_to_artifact_and_list_exposes_type(worker_env):
+    import base64
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    for schema in (kt.KANBAN_ATTACH_SCHEMA, kt.KANBAN_ATTACH_URL_SCHEMA):
+        type_schema = schema["parameters"]["properties"]["attachment_type"]
+        assert set(type_schema["enum"]) == kb.VALID_ATTACHMENT_TYPES
+        assert type_schema["default"] == kb.DEFAULT_WORKER_ATTACHMENT_TYPE
+
+    payload = b"generated report"
+    created = json.loads(
+        kt._handle_attach(
+            {
+                "filename": "report.txt",
+                "content_base64": base64.b64encode(payload).decode("ascii"),
+                "content_type": "text/plain",
+            }
+        )
+    )
+    assert created["ok"] is True
+    assert created["attachment_type"] == "artifact"
+
+    explicit_input = json.loads(
+        kt._handle_attach(
+            {
+                "filename": "brief.txt",
+                "content_base64": base64.b64encode(b"input context").decode("ascii"),
+                "attachment_type": "attachment",
+            }
+        )
+    )
+    assert explicit_input["ok"] is True
+    assert explicit_input["attachment_type"] == "attachment"
+
+    listed = json.loads(kt._handle_attachments({}))
+    assert [item["attachment_type"] for item in listed["attachments"]] == [
+        "artifact",
+        "attachment",
+    ]
+
+    conn = kb.connect()
+    try:
+        artifact, attachment = kb.list_attachments(conn, worker_env)
+        assert artifact.attachment_type == "artifact"
+        assert attachment.attachment_type == "attachment"
+        assert Path(artifact.stored_path).read_bytes() == payload
+    finally:
+        conn.close()
 
 
 @pytest.fixture
@@ -1130,6 +1183,7 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
     try:
         atts = kb.list_attachments(conn, worker_env)
         assert [a.filename for a in atts] == ["spec.pdf"]
+        assert atts[0].attachment_type == "artifact"
         assert atts[0].content_type == "application/pdf"
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1116,12 +1116,14 @@ def _handle_comment(args: dict, **kw) -> str:
 
 
 def _handle_attach(args: dict, **kw) -> str:
-    """Attach an inline (base64) file to a task.
+    """Store an inline (base64) task artifact.
 
     Mirrors the dashboard's upload endpoint for the agent surface: decode
     the payload, enforce the shared size cap, write it under the per-task
     attachments dir, and record the metadata row — all via
     ``kanban_db.store_attachment_bytes`` so the three surfaces stay in lockstep.
+    Worker-created files default to artifacts; callers can explicitly classify
+    a file as an input attachment when needed.
     """
     from hermes_cli import kanban_db as kb
 
@@ -1149,6 +1151,7 @@ def _handle_attach(args: dict, **kw) -> str:
     except (binascii.Error, ValueError) as e:
         return tool_error(f"content_base64 is not valid base64: {e}")
     content_type = args.get("content_type")
+    attachment_type = args.get("attachment_type") or kb.DEFAULT_WORKER_ATTACHMENT_TYPE
     board = args.get("board")
     try:
         _, conn = _connect(board=board)
@@ -1160,9 +1163,15 @@ def _handle_attach(args: dict, **kw) -> str:
                 data,
                 content_type=content_type,
                 uploaded_by="agent",
+                attachment_type=attachment_type,
                 board=board,
             )
-            return _ok(task_id=tid, attachment_id=att_id, size=len(data))
+            return _ok(
+                task_id=tid,
+                attachment_id=att_id,
+                attachment_type=attachment_type,
+                size=len(data),
+            )
         finally:
             conn.close()
     except kb.AttachmentTooLarge as e:
@@ -1239,11 +1248,12 @@ def _download_url_with_cap(url: str, max_bytes: int) -> tuple[bytes, Optional[st
 
 
 def _handle_attach_url(args: dict, **kw) -> str:
-    """Attach a file fetched server-side from a URL.
+    """Store a URL-backed task artifact.
 
     The agent passes a URL; Hermes downloads it (with the shared size cap)
-    and stores it as a real attachment. Useful when the agent has a link
-    rather than the bytes. Only http/https URLs are accepted.
+    and stores it as a real task file. Worker-created files default to artifacts;
+    callers can explicitly classify a file as an input attachment. Only
+    http/https URLs are accepted.
     """
     from hermes_cli import kanban_db as kb
 
@@ -1269,6 +1279,7 @@ def _handle_attach_url(args: dict, **kw) -> str:
         leaf = unquote(urlparse(url).path.rsplit("/", 1)[-1]).strip()
         filename = leaf or "download"
     content_type = args.get("content_type")
+    attachment_type = args.get("attachment_type") or kb.DEFAULT_WORKER_ATTACHMENT_TYPE
     board = args.get("board")
     try:
         data, fetched_ct = _download_url_with_cap(url, kb.KANBAN_ATTACHMENT_MAX_BYTES)
@@ -1287,9 +1298,15 @@ def _handle_attach_url(args: dict, **kw) -> str:
                 data,
                 content_type=content_type or fetched_ct,
                 uploaded_by="agent",
+                attachment_type=attachment_type,
                 board=board,
             )
-            return _ok(task_id=tid, attachment_id=att_id, size=len(data))
+            return _ok(
+                task_id=tid,
+                attachment_id=att_id,
+                attachment_type=attachment_type,
+                size=len(data),
+            )
         finally:
             conn.close()
     except kb.AttachmentTooLarge as e:
@@ -1327,6 +1344,7 @@ def _handle_attachments(args: dict, **kw) -> str:
                         "uploaded_by": a.uploaded_by,
                         "stored_path": a.stored_path,
                         "created_at": a.created_at,
+                        "attachment_type": a.attachment_type,
                     }
                     for a in atts
                 ],
@@ -2036,12 +2054,12 @@ KANBAN_COMMENT_SCHEMA = {
 KANBAN_ATTACH_SCHEMA = {
     "name": "kanban_attach",
     "description": (
-        "Attach a file to a task by passing its bytes inline (base64). "
-        "Use for genuine file artifacts the next worker or a human should "
-        "be able to download — generated reports, images, exports. The "
-        "file is stored as a real attachment (not a comment link) under "
-        "the task's attachments dir, capped at 25 MB. Prefer "
-        "kanban_attach_url when you only have a URL."
+        "Store a task artifact by passing its bytes inline (base64). Use for "
+        "genuine worker outputs the next worker or a human should be able to "
+        "download — generated reports, images, exports. The file is stored "
+        "under the task's attachments directory, capped at 25 MB. Prefer "
+        "kanban_attach_url when you only have a URL. Set attachment_type only "
+        "when intentionally adding an input attachment instead."
     ),
     "parameters": {
         "type": "object",
@@ -2065,6 +2083,14 @@ KANBAN_ATTACH_SCHEMA = {
                 "type": "string",
                 "description": "Optional MIME type (e.g. 'application/pdf').",
             },
+            "attachment_type": {
+                "type": "string",
+                "enum": ["attachment", "artifact"],
+                "default": "artifact",
+                "description": (
+                    "File purpose. Defaults to 'artifact' for worker-produced files."
+                ),
+            },
             "board": _board_schema_prop(),
         },
         "required": ["filename", "content_base64"],
@@ -2074,10 +2100,11 @@ KANBAN_ATTACH_SCHEMA = {
 KANBAN_ATTACH_URL_SCHEMA = {
     "name": "kanban_attach_url",
     "description": (
-        "Attach a file to a task by URL — Hermes downloads it server-side "
-        "and stores it as a real attachment (capped at 25 MB). Use when "
-        "you have a link rather than the bytes. Only http/https URLs are "
-        "accepted."
+        "Store a task artifact by URL — Hermes downloads it server-side and "
+        "keeps it under the task's attachments directory (capped at 25 MB). "
+        "Use when you have a worker-output link rather than the bytes. Only "
+        "http/https URLs are accepted. Set attachment_type only when "
+        "intentionally adding an input attachment instead."
     ),
     "parameters": {
         "type": "object",
@@ -2104,6 +2131,14 @@ KANBAN_ATTACH_URL_SCHEMA = {
                     "Content-Type the server returns."
                 ),
             },
+            "attachment_type": {
+                "type": "string",
+                "enum": ["attachment", "artifact"],
+                "default": "artifact",
+                "description": (
+                    "File purpose. Defaults to 'artifact' for worker-produced files."
+                ),
+            },
             "board": _board_schema_prop(),
         },
         "required": ["url"],
@@ -2113,8 +2148,9 @@ KANBAN_ATTACH_URL_SCHEMA = {
 KANBAN_ATTACHMENTS_SCHEMA = {
     "name": "kanban_attachments",
     "description": (
-        "List the files attached to a task: id, filename, content_type, "
-        "size, who uploaded it, and the absolute on-disk path you can read."
+        "List a task's input attachments and generated artifacts: id, filename, "
+        "attachment_type, content_type, size, who uploaded it, and the absolute "
+        "on-disk path you can read."
     ),
     "parameters": {
         "type": "object",

--- a/web/src/lib/kanban-task-files-plugin.test.ts
+++ b/web/src/lib/kanban-task-files-plugin.test.ts
@@ -1,0 +1,175 @@
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+type ElementNode = {
+  type?: unknown;
+  props?: Record<string, unknown> | null;
+  children?: unknown[];
+};
+
+type RegisteredKanbanPage = {
+  TaskFilesSection: (props: Record<string, unknown>) => unknown;
+};
+
+function loadKanbanPage(): RegisteredKanbanPage {
+  const registration: { page?: RegisteredKanbanPage } = {};
+  const createElement = (
+    type: unknown,
+    props: Record<string, unknown> | null,
+    ...children: unknown[]
+  ): ElementNode => ({
+    type,
+    props,
+    children: children.flat(Number.POSITIVE_INFINITY),
+  });
+
+  const sandbox = {
+    console,
+    window: {
+      confirm: () => true,
+      localStorage: { getItem: () => null, setItem: () => undefined },
+      __HERMES_PLUGINS__: {
+        register: (_name: string, component: RegisteredKanbanPage) => {
+          registration.page = component;
+        },
+      },
+      __HERMES_PLUGIN_SDK__: {
+        React: {
+          createElement,
+          Fragment: "fragment",
+          Component: class {
+            props: unknown;
+            state = {};
+            constructor(props: unknown) {
+              this.props = props;
+            }
+          },
+        },
+        components: {
+          Card: "Card",
+          CardContent: "CardContent",
+          Badge: "Badge",
+          Button: "Button",
+          Input: "Input",
+          Label: "Label",
+          Select: "Select",
+          SelectOption: "SelectOption",
+        },
+        hooks: {
+          useState: (initial: unknown) => [
+            typeof initial === "function" ? (initial as () => unknown)() : initial,
+            () => undefined,
+          ],
+          useEffect: () => undefined,
+          useCallback: (fn: unknown) => fn,
+          useMemo: (fn: () => unknown) => fn(),
+          useRef: (value: unknown) => ({ current: value }),
+        },
+        utils: {
+          cn: (...parts: unknown[]) => parts.filter(Boolean).join(" "),
+          timeAgo: () => "",
+        },
+        fetchJSON: () => Promise.resolve({}),
+        authedFetch: () => Promise.resolve({ ok: true }),
+      },
+    },
+  };
+
+  const bundle = path.resolve(
+    import.meta.dirname,
+    "../../../plugins/kanban/dashboard/dist/index.js",
+  );
+  vm.runInNewContext(fs.readFileSync(bundle, "utf8"), sandbox, { filename: bundle });
+
+  const page = registration.page;
+  if (!page) throw new Error("Kanban plugin did not register its page");
+  expect(typeof page.TaskFilesSection).toBe("function");
+  return page;
+}
+
+function collectText(node: unknown, texts: string[] = []): string[] {
+  if (node == null || typeof node === "boolean") return texts;
+  if (typeof node === "string" || typeof node === "number") {
+    texts.push(String(node));
+    return texts;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectText(child, texts));
+    return texts;
+  }
+  collectText((node as ElementNode).children, texts);
+  return texts;
+}
+
+function findByTitle(node: unknown, title: string): ElementNode | undefined {
+  if (node == null || typeof node !== "object") return undefined;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const match = findByTitle(child, title);
+      if (match) return match;
+    }
+    return undefined;
+  }
+  const element = node as ElementNode;
+  if (element.props?.title === title) return element;
+  return findByTitle(element.children, title);
+}
+
+describe("Kanban task files plugin", () => {
+  it("renders input attachments and generated artifacts as distinct groups", () => {
+    const page = loadKanbanPage();
+    const tree = page.TaskFilesSection({
+      i18n: null,
+      attachments: [
+        { id: 1, filename: "brief.txt", size: 5, attachment_type: "attachment" },
+        { id: 2, filename: "report.pdf", size: 9, attachment_type: "artifact" },
+        { id: 3, filename: "legacy.txt", size: 1, attachment_type: null },
+      ],
+      onUpload: () => undefined,
+      onDelete: () => undefined,
+      uploadBusy: false,
+    });
+
+    const text = collectText(tree).join(" ");
+    expect(text).toContain("Attachments (2)");
+    expect(text).toContain("Artifacts (1)");
+    expect(text.indexOf("brief.txt")).toBeLessThan(text.indexOf("Artifacts (1)"));
+    expect(text.indexOf("Artifacts (1)")).toBeLessThan(text.indexOf("report.pdf"));
+  });
+
+  it("uses the in-app destructive dialog and warns that artifact deletion is irreversible", async () => {
+    const page = loadKanbanPage();
+    const requestDialog = vi.fn().mockResolvedValue({ confirmed: true });
+    const onDelete = vi.fn();
+    const tree = page.TaskFilesSection({
+      i18n: null,
+      attachments: [
+        { id: 7, filename: "result.json", size: 12, attachment_type: "artifact" },
+      ],
+      onUpload: () => undefined,
+      onDelete,
+      requestDialog,
+      uploadBusy: false,
+    });
+
+    const removeButton = findByTitle(tree, "Remove artifact");
+    expect(removeButton).toBeDefined();
+    const onClick = removeButton?.props?.onClick;
+    expect(typeof onClick).toBe("function");
+    (onClick as () => void)();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(requestDialog).toHaveBeenCalledWith({
+      kind: "confirm",
+      title: "Remove artifact",
+      description:
+        "Permanently remove this generated artifact? This cannot be undone, and later workers may rely on it.",
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    expect(onDelete).toHaveBeenCalledWith(7);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #83960.

Kanban task files currently share one storage table and one UI list, even though files supplied to a task and files generated by its worker have different lifecycle meaning. This change adds a backward-compatible `attachment_type` discriminator and carries it through storage, REST, CLI, model tools, worker context, and the dashboard.

The column is nullable by design: existing rows and older writers that omit it continue to behave as input attachments. Completion outputs and files added by Kanban worker tools are recorded as artifacts by default. The dashboard and worker prompt render the two categories separately while preserving the existing authenticated download/delete and path-containment mechanisms.

## Related Issue

Fixes #83960

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`
  - Adds an idempotent nullable `attachment_type` migration with constrained `attachment`/`artifact` values.
  - Treats legacy `NULL` rows as attachments at read time.
  - Marks collected task-completion outputs as artifacts.
- `hermes_cli/kanban.py`, `tools/kanban_tools.py`
  - Expose file type in list/create flows; worker-produced files default to artifacts.
  - Validate the requested type before writing a file.
- `plugins/kanban/dashboard/plugin_api.py`, `plugins/kanban/dashboard/dist/index.js`
  - Serialize the type and render separate Attachments and Artifacts sections.
- Tests cover migration compatibility, legacy rows, DB/REST/CLI/tool round trips, completion collection, worker context grouping, and real bundled dashboard rendering.

## How to Test

```bash
.venv/bin/python -m pytest \
  tests/plugins/test_kanban_attachments.py \
  tests/hermes_cli/test_kanban_db.py \
  tests/tools/test_kanban_tools.py \
  -q -o 'addopts='
# 73 passed, 1 skipped

npm --workspace web exec -- vitest run src/lib/kanban-task-files-plugin.test.ts
# 1 passed

npm --workspace web run typecheck
npm --workspace web run build
npm --workspace web exec -- eslint src/lib/kanban-task-files-plugin.test.ts

.venv/bin/ruff check \
  hermes_cli/kanban.py hermes_cli/kanban_db.py \
  plugins/kanban/dashboard/plugin_api.py \
  tests/hermes_cli/test_kanban_db.py \
  tests/plugins/test_kanban_attachments.py \
  tests/tools/test_kanban_tools.py tools/kanban_tools.py
node --check plugins/kanban/dashboard/dist/index.js
git diff --check
```

Mutation evidence: changing the artifact classifier to classify attachments instead made the new Vitest regression fail; restoring the implementation returned it to green.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant focused automated checks listed above
- [x] I've added tests for my changes
- [x] I've tested on my platform: CachyOS Linux, Python 3.11, Node.js 25

### Documentation & Housekeeping

- [x] Documentation update — N/A; the existing Kanban attachment commands/tools now report the file role directly
- [x] `cli-config.yaml.example` update — N/A; no config key was added
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no workflow or architecture policy changed
- [x] Cross-platform impact considered — schema and path handling remain platform-neutral; existing authenticated file transport is reused
- [x] Tool descriptions/schemas updated — existing Kanban attachment tool descriptions now state that worker outputs are artifacts

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

No screenshot: the change is covered by a behavioral test that executes the registered Kanban dashboard bundle and asserts separate Attachments/Artifacts groups. Focused Python, Vitest, typecheck, build, Ruff, ESLint, Node syntax, and diff checks all passed. The repository-wide Python suite was not run.
