### PR TITLE
fix(desktop): don't require npm to launch an up-to-date packaged app

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7152,7 +7152,7 @@ def cmd_gui(args: argparse.Namespace):
             build_label = "source build" if source_mode else "packaged app"
             print(f"✓ Desktop {build_label} is up to date (content stamp matches)")
         else:
-            _ensure_npm()
+            npm = _ensure_npm()
             print("→ Installing desktop workspace dependencies...")
             # Put the Hermes-managed Node on PATH so npm's child scripts (which
             # shell out to bare `node`, e.g. electron-winstaller's
@@ -7271,6 +7271,13 @@ def cmd_gui(args: argparse.Namespace):
             # Build succeeded — write the stamp so next run can skip
             _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)
 
+    # A source-mode launch needs npm below; resolve it before the
+    # desktop-entry side effect so a missing-npm run exits without first
+    # (re)writing the launcher entry, matching the old eager check's
+    # exit-before-side-effects ordering.
+    if source_mode and not getattr(args, "build_only", False):
+        npm = _ensure_npm()
+
     # Linux: register the app in the desktop launcher, so Hermes shows up
     # in the application menu with its icon. Best-effort and idempotent.
     # A failure must never stop the app from launching.
@@ -7297,7 +7304,7 @@ def cmd_gui(args: argparse.Namespace):
         return
 
     if source_mode:
-        _ensure_npm()
+        npm = _ensure_npm()
         print("→ Launching Hermes Desktop from source build...")
         launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
         sys.exit(launch_result.returncode)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7103,14 +7103,22 @@ def cmd_gui(args: argparse.Namespace):
 
     packaged_executable = _desktop_packaged_executable(desktop_dir)
 
-    if source_mode or not skip_build:
-        npm = _resolve_node_runtime_npm()
-        if not npm:
-            print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
-            print("Install Node.js, then run:  hermes gui")
-            sys.exit(1)
-    else:
-        npm = None
+    # Resolve npm lazily: a launch whose packaged app is already up to date
+    # (the common case, including desktop-launcher starts outside a login
+    # shell, where fnm/nvm PATH customizations are absent) must not require
+    # Node.js at all — only builds and source-mode launches do.
+    npm: str | None = None
+
+    def _ensure_npm() -> str:
+        nonlocal npm
+        if npm is None:
+            resolved = _resolve_node_runtime_npm()
+            if not resolved:
+                print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
+                print("Install Node.js, then run:  hermes gui")
+                sys.exit(1)
+            npm = resolved
+        return npm
 
     if skip_build:
         if source_mode:
@@ -7144,6 +7152,7 @@ def cmd_gui(args: argparse.Namespace):
             build_label = "source build" if source_mode else "packaged app"
             print(f"✓ Desktop {build_label} is up to date (content stamp matches)")
         else:
+            _ensure_npm()
             print("→ Installing desktop workspace dependencies...")
             # Put the Hermes-managed Node on PATH so npm's child scripts (which
             # shell out to bare `node`, e.g. electron-winstaller's
@@ -7289,6 +7298,7 @@ def cmd_gui(args: argparse.Namespace):
 
     if source_mode:
         print("→ Launching Hermes Desktop from source build...")
+        _ensure_npm()
         launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
         sys.exit(launch_result.returncode)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7297,8 +7297,8 @@ def cmd_gui(args: argparse.Namespace):
         return
 
     if source_mode:
-        print("→ Launching Hermes Desktop from source build...")
         _ensure_npm()
+        print("→ Launching Hermes Desktop from source build...")
         launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
         sys.exit(launch_result.returncode)
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -149,6 +149,30 @@ def test_up_to_date_packaged_gui_launch_skips_npm_resolution(tmp_path, monkeypat
     assert mock_run.call_args.kwargs["cwd"] == desktop_dir
 
 
+def test_source_launch_without_npm_fails_before_desktop_entry_write(tmp_path, monkeypatch):
+    """A doomed source-mode launch must exit before any side effects.
+
+    Lazy npm resolution moved the missing-npm exit later in cmd_gui; the
+    resolve is hoisted above _register_linux_desktop_entry() so a failed run
+    can't leave a freshly (re)written launcher entry behind, matching the old
+    eager check's exit-before-side-effects ordering.
+    """
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value=None), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._register_linux_desktop_entry") as mock_register, \
+         patch("hermes_cli.main.subprocess.run") as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(source=True))
+
+    assert exc.value.code == 1
+    mock_register.assert_not_called()
+    mock_run.assert_not_called()
+
+
 def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatch):
     """Regression: npm's child scripts (electron-winstaller's select-7z-arch.js)
     shell out to bare ``node``. When Desktop is launched from the updater chain

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -116,6 +116,39 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
+def test_up_to_date_packaged_gui_launch_skips_npm_resolution(tmp_path, monkeypatch):
+    """An up-to-date packaged launch must not require Node/npm at all.
+
+    Regression: npm was resolved before the content-stamp check, so a current
+    packaged app refused to launch whenever npm was absent — e.g. a
+    desktop-launcher start outside a login shell, where fnm/nvm PATH
+    customizations never apply. Resolution returning None here doubles as a
+    trap: if the launch path resolved npm, cmd_gui would exit 1.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value=None) as mock_resolve, \
+         patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main._register_linux_desktop_entry"), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    mock_resolve.assert_not_called()
+    mock_install.assert_not_called()
+    assert mock_run.call_count == 1
+    assert mock_run.call_args.args[0] == [str(packaged_exe)]
+    assert mock_run.call_args.kwargs["cwd"] == desktop_dir
+
+
 def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatch):
     """Regression: npm's child scripts (electron-winstaller's select-7z-arch.js)
     shell out to bare ``node``. When Desktop is launched from the updater chain


### PR DESCRIPTION
## Problem

`hermes desktop` resolves and hard-requires npm **before** the content-stamp check in `cmd_gui`. When npm is not on PATH it prints `Desktop GUI requires Node.js/npm ...` and exits 1 — even when the packaged app is already up to date and zero build work would happen.

This makes the app unlaunchable from any graphical session that lacks login-shell PATH customizations (fnm/nvm/mise shims): XDG desktop entries, rofi/wofi, application menus. The failure is silent from the user's perspective (no TTY attached). Reproduced on Hyprland: `hermes desktop` works from a terminal (fnm PATH present), does nothing from rofi.

Users can't work around it by editing the `.desktop` `Exec` either — `_register_linux_desktop_entry()` rewrites the entry from `resolve_exec_command()` on every launch.

## Relationship to #72999

Supersedes #72999, which fixes the same premise but went stale: its tests anchor on test functions removed from main by `39975613` and the PR is now conflicting. This PR carries the same production semantics (with a single `_ensure_npm()` helper instead of duplicated resolve-and-error blocks) and addresses the hermes-sweeper feedback left there:

- ✅ Lazy npm resolution in `cmd_gui`, kept immediately before an actual build or source launch.
- ✅ Regression test recreated against retained coverage (`test_up_to_date_packaged_gui_launch_skips_npm_resolution`): an up-to-date packaged launch never calls `_resolve_node_runtime_npm`, never installs dependencies, and launches the packaged executable.
- ✅ The `test_desktop_exe_integrity.py` mock-seam change from #72999 is already on current main (the surviving build test patches `_resolve_node_runtime_npm` directly).

## Fix

Resolve npm lazily via a `_ensure_npm()` helper:

- **Build branch** (stamp mismatch / `--force-build`): requires npm, unchanged error + exit 1 when missing.
- **Source-mode launch** (`npm exec electron`): requires npm, resolved before the launch banner prints.
- **Up-to-date packaged app launch** (the common case): never touches npm.

## Verification

- Launched `hermes desktop` with a session-like environment (no npm on PATH, no fnm shims): previously exited 1 with the npm error; now launches and the window appears.
- `scripts/run_tests.sh tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_desktop_exe_integrity.py`: 11 passed, 0 failed (8 platform-specific skips), including the new regression test.
- Ruff, `scripts/check-windows-footguns.py`, and `git diff --check` clean.
