### PR TITLE
docs: document community Sealos deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ source ~/.bashrc    # reload shell (or: source ~/.zshrc)
 hermes              # start chatting!
 ```
 
+## Deploy on Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/hermes-agent)
+
+The community-maintained [Sealos template](https://github.com/labring-actions/templates/tree/kb-0.9/template/hermes-agent) runs the Hermes gateway and dashboard with a shared persistent data volume. Deployment requires dashboard credentials and an API key before Sealos exposes the services over HTTPS.
+
 ### Troubleshooting
 
 #### Windows Defender or antivirus flags `uv.exe` as malware

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,6 +52,12 @@ source ~/.bashrc    # 重新加载 shell（或: source ~/.zshrc）
 hermes              # 开始对话！
 ```
 
+## 在 Sealos 上部署
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/hermes-agent)
+
+这份由社区维护的 [Sealos 模板](https://github.com/labring-actions/templates/tree/kb-0.9/template/hermes-agent) 会运行 Hermes 网关与控制台，并为两者配置共享的持久化数据卷。部署时需要设置控制台凭据和 API 密钥，随后 Sealos 会通过 HTTPS 公开这些服务。
+
 ---
 
 ## 快速入门


### PR DESCRIPTION
## What does this PR do?

Documents a community-maintained Sealos deployment for users who want an always-on Hermes gateway and dashboard on Kubernetes. The note links both the deployment entry and source template, explains the shared persistent data volume, and makes the dashboard credential and API key requirements visible before launch.

This complements #3885. The Railway contribution focuses on gateway hosting; the Sealos template deploys the gateway and dashboard together with persistent storage and protected HTTPS access.

This supersedes #83867, which was closed during an internal review before this narrower revision.

## Related Issue

N/A - documentation-only deployment option.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Security fix
- [x] Documentation update
- [ ] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- `README.md`: add the Sealos deployment entry and security boundary.
- `README.zh-CN.md`: add the matching Simplified Chinese guidance.
- Link the community-maintained source template for ownership and auditability.

## How to Test

1. Open the English and Simplified Chinese READMEs in GitHub preview.
2. Confirm the deploy badge opens the Hermes Agent listing in the Sealos App Store.
3. Confirm the source-template link opens the Hermes template on the `kb-0.9` branch.
4. Review the live deployment checks recorded in labring-actions/templates#737.

## Checklist

### Code

- [x] I have read the contributing guide.
- [x] The commit follows Conventional Commits.
- [x] I searched existing PRs and documented the related Railway contribution above.
- [x] The PR contains only the two README changes.
- [x] Applicable validation passed: `git diff --check`; the change is documentation-only.
- [x] Tests are N/A for this README-only change.
- [x] The deployment path was validated on Sealos Cloud.

### Documentation & Housekeeping

- [x] The relevant English and Simplified Chinese documentation is updated.
- [x] `cli-config.yaml.example` is N/A.
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A.
- [x] Cross-platform impact is N/A; the deployment target is a Linux container on Kubernetes.
- [x] Tool descriptions and schemas are N/A.

## Screenshots / Logs

The merged template contribution records dashboard login, authenticated API checks, readiness, persistence, and complete cleanup: https://github.com/labring-actions/templates/pull/737

Prepared with AI assistance and reviewed against the repository contribution guide and the final diff.
