### PR TITLE
fix(desktop): render durable cron run output

### DIFF
--- a/apps/desktop/src/api/cron.ts
+++ b/apps/desktop/src/api/cron.ts
@@ -41,11 +41,13 @@ export function getCronJob(jobId: string): Promise<CronJob> {
   })
 }
 
-export async function getCronJobRuns(jobId: string, limit = 20): Promise<SessionInfo[]> {
+export async function getCronJobRuns(jobId: string, limit = 20, profile?: string): Promise<SessionInfo[]> {
+  const owner = profile ? `&profile=${encodeURIComponent(profile)}` : ''
+
   const { runs } = await hermesApi<{ runs: SessionInfo[] }>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs?limit=${limit}`
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs?limit=${limit}${owner}`
   })
 
   return runs ?? []

--- a/apps/desktop/src/api/cron.ts
+++ b/apps/desktop/src/api/cron.ts
@@ -3,6 +3,8 @@ import type {
   CronDeliveryTarget,
   CronJob,
   CronJobCreatePayload,
+  CronJobOutput,
+  CronJobOutputDetail,
   CronJobUpdates,
   SessionInfo
 } from '@/types/hermes'
@@ -47,6 +49,27 @@ export async function getCronJobRuns(jobId: string, limit = 20): Promise<Session
   })
 
   return runs ?? []
+}
+
+export async function getCronJobOutputs(jobId: string, limit = 20, profile?: string): Promise<CronJobOutput[]> {
+  const owner = profile ? `&profile=${encodeURIComponent(profile)}` : ''
+  const { outputs } = await hermesApi<{ outputs: CronJobOutput[] }>({
+    ...profileScoped(),
+    ...connectionScoped(),
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/outputs?limit=${limit}${owner}`
+  })
+
+  return outputs ?? []
+}
+
+export function getCronJobOutput(jobId: string, outputId: string, profile?: string): Promise<CronJobOutputDetail> {
+  const owner = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+
+  return hermesApi<CronJobOutputDetail>({
+    ...profileScoped(),
+    ...connectionScoped(),
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/outputs/${encodeURIComponent(outputId)}${owner}`
+  })
 }
 
 // The single source of truth for cron delivery targets (local + configured

--- a/apps/desktop/src/api/cron.ts
+++ b/apps/desktop/src/api/cron.ts
@@ -53,6 +53,7 @@ export async function getCronJobRuns(jobId: string, limit = 20): Promise<Session
 
 export async function getCronJobOutputs(jobId: string, limit = 20, profile?: string): Promise<CronJobOutput[]> {
   const owner = profile ? `&profile=${encodeURIComponent(profile)}` : ''
+
   const { outputs } = await hermesApi<{ outputs: CronJobOutput[] }>({
     ...profileScoped(),
     ...connectionScoped(),

--- a/apps/desktop/src/api/cron.ts
+++ b/apps/desktop/src/api/cron.ts
@@ -9,79 +9,98 @@ import type {
   SessionInfo
 } from '@/types/hermes'
 
-import { connectionScoped, hermesApi, profileScoped, STARTUP_REQUEST_TIMEOUT_MS } from './client'
+import {
+  connectionScoped,
+  getApiRequestConnection,
+  hermesApi,
+  profileScoped,
+  STARTUP_REQUEST_TIMEOUT_MS
+} from './client'
 
-// The cron trigger endpoint intentionally waits for the whole job so its
-// response reflects the persisted execution result. Agent jobs can run far
-// longer than the Electron fetch default; keep this override local to the one
-// synchronous long-operation endpoint rather than weakening all API timeouts.
 const CRON_TRIGGER_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000
 
-function ownerQuery(profile?: string): string {
-  return profile ? `?profile=${encodeURIComponent(profile)}` : ''
+export interface CronOwnerScope {
+  connectionId?: null | string
+  profile?: null | string
 }
 
-// Cron jobs are stored per-profile (<HERMES_HOME>/cron/jobs.json), and the
-// backend's list endpoint defaults to 'all'. Pass a concrete profile key to
-// list just that profile's jobs, or 'all' for the unified cross-profile view.
-// Omitting the arg keeps the legacy 'all' default for non-profile callers.
-// profileScoped() still rides along for backend-process routing.
-export function getCronJobs(profile?: string): Promise<CronJob[]> {
-  const suffix = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+export type CronOwner = CronOwnerScope | string | undefined
 
-  return hermesApi<CronJob[]>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs${suffix}`,
+/** Resolve once at call entry. Object owners are authoritative (including
+ * explicit local/null); legacy strings retain the ambient gateway behavior. */
+function cronOwner(owner?: CronOwner): {
+  connectionId: null | string | undefined
+  profile: string | undefined
+  requestScope: { connectionId?: null | string; profile?: null | string }
+} {
+  if (owner && typeof owner === 'object') {
+    const profile = owner.profile?.trim() || undefined
+    const connectionId = owner.connectionId?.trim() || null
+
+    return { connectionId, profile, requestScope: { connectionId, profile: profile ?? null } }
+  }
+
+  return {
+    connectionId: getApiRequestConnection(),
+    profile: owner?.trim() || undefined,
+    requestScope: { ...profileScoped(), ...connectionScoped() }
+  }
+}
+
+function ownerQuery(scope: ReturnType<typeof cronOwner>, separator: '?' | '&' = '?'): string {
+  return scope.profile ? `${separator}profile=${encodeURIComponent(scope.profile)}` : ''
+}
+
+export async function getCronJobs(owner?: CronOwner): Promise<CronJob[]> {
+  const scope = cronOwner(owner)
+  const jobs = await hermesApi<CronJob[]>({
+    ...scope.requestScope,
+    path: `/api/cron/jobs${ownerQuery(scope)}`,
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
+
+  // The backend row is profile-qualified but the connection is a Desktop
+  // transport fact. Stamp it at the boundary so list identity and every later
+  // focus/read/mutation remain pinned to the backend that returned the row.
+  return Array.isArray(jobs) ? jobs.map(job => ({ ...job, connection_id: scope.connectionId ?? null })) : []
 }
 
-export function getCronJob(jobId: string, profile?: string): Promise<CronJob> {
+export function getCronJob(jobId: string, owner?: CronOwner): Promise<CronJob> {
+  const scope = cronOwner(owner)
   return hermesApi<CronJob>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${ownerQuery(profile)}`
+    ...scope.requestScope,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${ownerQuery(scope)}`
   })
 }
 
-export async function getCronJobRuns(jobId: string, limit = 20, profile?: string): Promise<SessionInfo[]> {
-  const owner = profile ? `&profile=${encodeURIComponent(profile)}` : ''
-
+export async function getCronJobRuns(jobId: string, limit = 20, owner?: CronOwner): Promise<SessionInfo[]> {
+  const scope = cronOwner(owner)
   const { runs } = await hermesApi<{ runs: SessionInfo[] }>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs?limit=${limit}${owner}`
+    ...scope.requestScope,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs?limit=${limit}${ownerQuery(scope, '&')}`
   })
 
   return runs ?? []
 }
 
-export async function getCronJobOutputs(jobId: string, limit = 20, profile?: string): Promise<CronJobOutput[]> {
-  const owner = profile ? `&profile=${encodeURIComponent(profile)}` : ''
-
+export async function getCronJobOutputs(jobId: string, limit = 20, owner?: CronOwner): Promise<CronJobOutput[]> {
+  const scope = cronOwner(owner)
   const { outputs } = await hermesApi<{ outputs: CronJobOutput[] }>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/outputs?limit=${limit}${owner}`
+    ...scope.requestScope,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/outputs?limit=${limit}${ownerQuery(scope, '&')}`
   })
 
   return outputs ?? []
 }
 
-export function getCronJobOutput(jobId: string, outputId: string, profile?: string): Promise<CronJobOutputDetail> {
-  const owner = profile ? `?profile=${encodeURIComponent(profile)}` : ''
-
+export function getCronJobOutput(jobId: string, outputId: string, owner?: CronOwner): Promise<CronJobOutputDetail> {
+  const scope = cronOwner(owner)
   return hermesApi<CronJobOutputDetail>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/outputs/${encodeURIComponent(outputId)}${owner}`
+    ...scope.requestScope,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/outputs/${encodeURIComponent(outputId)}${ownerQuery(scope)}`
   })
 }
 
-// The single source of truth for cron delivery targets (local + configured
-// gateways). Both the manual cron editor and the blueprint dialog use this so
-// they never offer a platform that isn't connected. Mirrors the dashboard.
 export async function getCronDeliveryTargets(): Promise<CronDeliveryTarget[]> {
   const { targets } = await hermesApi<{ targets: CronDeliveryTarget[] }>({
     ...profileScoped(),
@@ -92,74 +111,58 @@ export async function getCronDeliveryTargets(): Promise<CronDeliveryTarget[]> {
   return targets ?? []
 }
 
-export function createCronJob(body: CronJobCreatePayload, profile?: string): Promise<CronJob> {
-  return hermesApi<CronJob>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs${ownerQuery(profile)}`,
-    method: 'POST',
-    body
-  })
+export function createCronJob(body: CronJobCreatePayload, owner?: CronOwner): Promise<CronJob> {
+  const scope = cronOwner(owner)
+  return hermesApi<CronJob>({ ...scope.requestScope, path: `/api/cron/jobs${ownerQuery(scope)}`, method: 'POST', body })
 }
 
-export function updateCronJob(jobId: string, updates: CronJobUpdates, profile?: string): Promise<CronJob> {
+export function updateCronJob(jobId: string, updates: CronJobUpdates, owner?: CronOwner): Promise<CronJob> {
+  const scope = cronOwner(owner)
   return hermesApi<CronJob>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${ownerQuery(profile)}`,
+    ...scope.requestScope,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${ownerQuery(scope)}`,
     method: 'PUT',
     body: { updates }
   })
 }
 
-export function pauseCronJob(jobId: string, profile?: string): Promise<CronJob> {
+export function pauseCronJob(jobId: string, owner?: CronOwner): Promise<CronJob> {
+  const scope = cronOwner(owner)
   return hermesApi<CronJob>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/pause${ownerQuery(profile)}`,
+    ...scope.requestScope,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/pause${ownerQuery(scope)}`,
     method: 'POST'
   })
 }
 
-export function resumeCronJob(jobId: string, profile?: string): Promise<CronJob> {
+export function resumeCronJob(jobId: string, owner?: CronOwner): Promise<CronJob> {
+  const scope = cronOwner(owner)
   return hermesApi<CronJob>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/resume${ownerQuery(profile)}`,
+    ...scope.requestScope,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/resume${ownerQuery(scope)}`,
     method: 'POST'
   })
 }
 
-export function triggerCronJob(jobId: string, profile?: string): Promise<CronJob> {
+export function triggerCronJob(jobId: string, owner?: CronOwner): Promise<CronJob> {
+  const scope = cronOwner(owner)
   return hermesApi<CronJob>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger${ownerQuery(profile)}`,
+    ...scope.requestScope,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger${ownerQuery(scope)}`,
     method: 'POST',
     timeoutMs: CRON_TRIGGER_REQUEST_TIMEOUT_MS
   })
 }
 
-export function deleteCronJob(jobId: string, profile?: string): Promise<{ ok: boolean }> {
+export function deleteCronJob(jobId: string, owner?: CronOwner): Promise<{ ok: boolean }> {
+  const scope = cronOwner(owner)
   return hermesApi<{ ok: boolean }>({
-    ...profileScoped(),
-    ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${ownerQuery(profile)}`,
+    ...scope.requestScope,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${ownerQuery(scope)}`,
     method: 'DELETE'
   })
 }
 
-// Automation Blueprints — parameterized cron templates the backend serves from
-// cron/blueprint_catalog.py. getAutomationBlueprints returns the gallery
-// (deliver options already rewritten to this machine's configured gateways);
-// instantiateAutomationBlueprint fills the slots and creates a real cron job via
-// the same create_job path as createCronJob.
-//
-// Profile-scoping is intentionally asymmetric: the GET catalog is global (the
-// list endpoint takes no profile — only deliver options are rewritten from the
-// configured gateways), so it carries only the profileScoped() header for
-// routing. instantiate creates a real per-profile job, so it names the target
-// profile explicitly via ?profile=. This mirrors the dashboard's api.ts.
 export function getAutomationBlueprints(): Promise<{ blueprints: AutomationBlueprint[] }> {
   return hermesApi<{ blueprints: AutomationBlueprint[] }>({
     ...profileScoped(),

--- a/apps/desktop/src/api/cron.ts
+++ b/apps/desktop/src/api/cron.ts
@@ -17,6 +17,10 @@ import { connectionScoped, hermesApi, profileScoped, STARTUP_REQUEST_TIMEOUT_MS 
 // synchronous long-operation endpoint rather than weakening all API timeouts.
 const CRON_TRIGGER_REQUEST_TIMEOUT_MS = 24 * 60 * 60 * 1000
 
+function ownerQuery(profile?: string): string {
+  return profile ? `?profile=${encodeURIComponent(profile)}` : ''
+}
+
 // Cron jobs are stored per-profile (<HERMES_HOME>/cron/jobs.json), and the
 // backend's list endpoint defaults to 'all'. Pass a concrete profile key to
 // list just that profile's jobs, or 'all' for the unified cross-profile view.
@@ -33,11 +37,11 @@ export function getCronJobs(profile?: string): Promise<CronJob[]> {
   })
 }
 
-export function getCronJob(jobId: string): Promise<CronJob> {
+export function getCronJob(jobId: string, profile?: string): Promise<CronJob> {
   return hermesApi<CronJob>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}`
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${ownerQuery(profile)}`
   })
 }
 
@@ -88,59 +92,59 @@ export async function getCronDeliveryTargets(): Promise<CronDeliveryTarget[]> {
   return targets ?? []
 }
 
-export function createCronJob(body: CronJobCreatePayload): Promise<CronJob> {
+export function createCronJob(body: CronJobCreatePayload, profile?: string): Promise<CronJob> {
   return hermesApi<CronJob>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: '/api/cron/jobs',
+    path: `/api/cron/jobs${ownerQuery(profile)}`,
     method: 'POST',
     body
   })
 }
 
-export function updateCronJob(jobId: string, updates: CronJobUpdates): Promise<CronJob> {
+export function updateCronJob(jobId: string, updates: CronJobUpdates, profile?: string): Promise<CronJob> {
   return hermesApi<CronJob>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${ownerQuery(profile)}`,
     method: 'PUT',
     body: { updates }
   })
 }
 
-export function pauseCronJob(jobId: string): Promise<CronJob> {
+export function pauseCronJob(jobId: string, profile?: string): Promise<CronJob> {
   return hermesApi<CronJob>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/pause`,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/pause${ownerQuery(profile)}`,
     method: 'POST'
   })
 }
 
-export function resumeCronJob(jobId: string): Promise<CronJob> {
+export function resumeCronJob(jobId: string, profile?: string): Promise<CronJob> {
   return hermesApi<CronJob>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/resume`,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/resume${ownerQuery(profile)}`,
     method: 'POST'
   })
 }
 
-export function triggerCronJob(jobId: string): Promise<CronJob> {
+export function triggerCronJob(jobId: string, profile?: string): Promise<CronJob> {
   return hermesApi<CronJob>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger`,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger${ownerQuery(profile)}`,
     method: 'POST',
     timeoutMs: CRON_TRIGGER_REQUEST_TIMEOUT_MS
   })
 }
 
-export function deleteCronJob(jobId: string): Promise<{ ok: boolean }> {
+export function deleteCronJob(jobId: string, profile?: string): Promise<{ ok: boolean }> {
   return hermesApi<{ ok: boolean }>({
     ...profileScoped(),
     ...connectionScoped(),
-    path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}${ownerQuery(profile)}`,
     method: 'DELETE'
   })
 }

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -29,7 +29,7 @@ import {
   type SessionProfileRoute
 } from '@/store/session-request-router'
 import {
-  $sessionStates,
+  getSessionState,
   isSessionRemote,
   patchSessionTile,
   sessionTileDelegate,
@@ -131,6 +131,8 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
   runtimeIdRef.current = runtimeId
   const storedIdRef = useRef(storedSessionId)
   storedIdRef.current = storedSessionId
+  const readOwnedState = () =>
+    getSessionState(runtimeIdRef.current, sessionTileOwnerRoute(storedIdRef.current) ?? undefined)
   // A tile IS its session (see the comment on the useSubmitPrompt call below)
   // A tile owns one stable stored/runtime pair, so seed the shared ownership
   // cache explicitly rather than relying on the primary route cache.
@@ -155,7 +157,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
     () =>
       ({
         get current() {
-          return $sessionStates.get()[runtimeIdRef.current]?.busy ?? false
+          return readOwnedState()?.busy ?? false
         },
         set current(_value: boolean) {
           // Owned by session state.
@@ -170,7 +172,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
     []
   )
 
-  const readState = useCallback(() => $sessionStates.get()[runtimeIdRef.current], [])
+  const readState = useCallback(readOwnedState, [])
   const readMessages = useCallback(() => readState()?.messages ?? [], [readState])
 
   // Tile session RPCs must follow the tile's composite owner even when the
@@ -195,7 +197,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
   // away (see listTileSessionRow).
   const listTileSession = useCallback((preview: string) => {
     const runtimeId = runtimeIdRef.current
-    const state = $sessionStates.get()[runtimeId]
+    const state = readOwnedState()
 
     listTileSessionRow({
       cwd: state?.cwd,

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -53,7 +53,9 @@ import {
   $sessionTileDelegateRevision,
   $sessionTiles,
   closeSessionTile,
+  getSessionState,
   patchSessionTile,
+  runtimeStateKey,
   type SessionTile,
   sessionTileDelegate,
   sessionTileOwnerRoute
@@ -104,9 +106,11 @@ function buildTileView(storedSessionId: string): SessionView {
     tiles => tiles.find(t => t.storedSessionId === storedSessionId)?.runtimeId ?? null
   )
 
-  const $state = computed([$runtimeId, $sessionStates], (runtimeId, states) =>
-    runtimeId ? states[runtimeId] : undefined
-  )
+  const $state = computed([$sessionTiles, $sessionStates], (tiles, states) => {
+    const tile = tiles.find(t => t.storedSessionId === storedSessionId)
+
+    return tile?.runtimeId ? states[runtimeStateKey(tile.runtimeId, tile.ownerRoute)] : undefined
+  })
 
   const $messages = computed($state, state => state?.messages ?? NO_MESSAGES)
 
@@ -476,8 +480,8 @@ const $confirmCloseTile = atom<null | string>(null)
 /** The tile closer, gated: a quiet session closes immediately; a busy or
  *  input-blocked one asks first. One state read — the tile's runtime slice. */
 export function requestCloseSessionTile(storedSessionId: string): void {
-  const runtimeId = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)?.runtimeId
-  const state = runtimeId ? $sessionStates.get()[runtimeId] : undefined
+  const tile = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)
+  const state = tile?.runtimeId ? getSessionState(tile.runtimeId, tile.ownerRoute) : undefined
 
   if (state?.busy || state?.awaitingResponse || state?.needsInput) {
     $confirmCloseTile.set(storedSessionId)

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -14,7 +14,7 @@ import { useI18n } from '@/i18n'
 import { fmtDayTime, relativeTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { confirm } from '@/store/confirm'
-import { updateCronJobs } from '@/store/cron'
+import { cronJobIdentity, updateCronJobs } from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
 import { $selectedStoredSessionId } from '@/store/session'
@@ -79,9 +79,9 @@ interface SidebarCronJobsSectionProps {
   // Open a durable no-agent output in the full Cron page.
   onOpenOutput: (jobId: string, outputId: string, profile?: string) => void
   // Agent-backed jobs retain their real conversation-session navigation.
-  onOpenSession: (sessionId: string) => void
+  onOpenSession: (sessionId: string, profile?: string) => void
   // Open the full Cron page focused on this job (manage / full history).
-  onManageJob: (jobId: string) => void
+  onManageJob: (jobId: string, profile?: string) => void
   // Fire the job now.
   onTriggerJob: (jobId: string) => Promise<void>
   onToggle: () => void
@@ -101,7 +101,7 @@ export function SidebarCronJobsSection({
 }: SidebarCronJobsSectionProps) {
   const [nowMs, setNowMs] = useState(() => Date.now())
   // Single-open inline peek so the section stays scannable.
-  const [peekJobId, setPeekJobId] = useState<null | string>(null)
+  const [peekJobKey, setPeekJobKey] = useState<null | string>(null)
   // Rows revealed so far; starts compact, grows in steps via "load more".
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_JOBS)
   const [triggeringJobIds, setTriggeringJobIds] = useState<ReadonlySet<string>>(() => new Set())
@@ -202,20 +202,24 @@ export function SidebarCronJobsSection({
       </div>
       {open && (
         <SidebarGroupContent className="scrollbar-fade flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 compact:max-h-none compact:overflow-visible">
-          {shown.map(job => (
-            <CronJobSidebarRow
-              busy={triggeringJobIds.has(job.id)}
-              expanded={peekJobId === job.id}
-              job={job}
-              key={job.id}
-              nowMs={nowMs}
-              onManage={() => onManageJob(job.id)}
-              onOpenOutput={onOpenOutput}
-              onOpenSession={onOpenSession}
-              onTogglePeek={() => setPeekJobId(prev => (prev === job.id ? null : job.id))}
-              onTrigger={() => triggerJob(job.id)}
-            />
-          ))}
+          {shown.map(job => {
+            const jobKey = cronJobIdentity(job)
+
+            return (
+              <CronJobSidebarRow
+                busy={triggeringJobIds.has(job.id)}
+                expanded={peekJobKey === jobKey}
+                job={job}
+                key={jobKey}
+                nowMs={nowMs}
+                onManage={() => onManageJob(job.id, job.profile)}
+                onOpenOutput={onOpenOutput}
+                onOpenSession={onOpenSession}
+                onTogglePeek={() => setPeekJobKey(prev => (prev === jobKey ? null : jobKey))}
+                onTrigger={() => triggerJob(job.id)}
+              />
+            )
+          })}
           {hiddenCount > 0 && (
             <SidebarLoadMoreRow
               onClick={() => setVisibleCount(count => count + LOAD_MORE_STEP)}
@@ -245,7 +249,7 @@ function CronJobSidebarRow({
   nowMs: number
   onManage: () => void
   onOpenOutput: (jobId: string, outputId: string, profile?: string) => void
-  onOpenSession: (sessionId: string) => void
+  onOpenSession: (sessionId: string, profile?: string) => void
   onTogglePeek: () => void
   onTrigger: () => void
 }) {
@@ -412,7 +416,7 @@ export function CronJobSidebarRuns({
   jobId: string
   noAgent: boolean
   onOpenOutput: (jobId: string, outputId: string, profile?: string) => void
-  onOpenSession: (sessionId: string) => void
+  onOpenSession: (sessionId: string, profile?: string) => void
   profile?: string
 }) {
   const { t } = useI18n()
@@ -439,7 +443,7 @@ export function CronJobSidebarRuns({
 
       const request = noAgent
         ? loadOutputs()
-        : getCronJobRuns(jobId, PEEK_RUN_LIMIT).then<CronSidebarRun[]>(sessions =>
+        : getCronJobRuns(jobId, PEEK_RUN_LIMIT, profile).then<CronSidebarRun[]>(sessions =>
             sessions.length > 0
               ? sessions.map(session => ({
                   createdAt: session.last_active || session.started_at,
@@ -513,7 +517,7 @@ export function CronJobSidebarRuns({
               )}
               key={run.id}
               onClick={() =>
-                run.kind === 'output' ? onOpenOutput(jobId, run.id, profile) : onOpenSession(run.id)
+                run.kind === 'output' ? onOpenOutput(jobId, run.id, profile) : onOpenSession(run.id, profile)
               }
               type="button"
             >

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -9,7 +9,7 @@ import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import { Tip } from '@/components/ui/tooltip'
-import { deleteCronJob, getCronJobRuns, pauseCronJob, resumeCronJob, type SessionInfo } from '@/hermes'
+import { type CronJobOutput, deleteCronJob, getCronJobOutputs, pauseCronJob, resumeCronJob } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { fmtDayTime, relativeTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
@@ -17,7 +17,6 @@ import { confirm } from '@/store/confirm'
 import { updateCronJobs } from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
-import { $selectedStoredSessionId } from '@/store/session'
 import type { CronJob } from '@/types/hermes'
 
 import { jobState, jobTitle, STATE_DOT } from '../../cron/job-state'
@@ -32,7 +31,7 @@ const INACTIVE_STATES = new Set(['completed', 'disabled', 'error', 'paused'])
 // without turning the sidebar into the full Cron page.
 const PEEK_RUN_LIMIT = 5
 
-// Runs are written by the background scheduler tick. cron.changed reloads the
+// Outputs are written by the background scheduler tick. cron.changed reloads the
 // open peek immediately on event-capable backends (poll drops to a backstop);
 // older backends keep the legacy cadence.
 const PEEK_POLL_INTERVAL_MS = 8000
@@ -70,8 +69,8 @@ interface SidebarCronJobsSectionProps {
   jobs: CronJob[]
   label: string
   max?: number
-  // Open a run session's chat (1 click to output).
-  onOpenRun: (sessionId: string) => void
+  // Open the full Cron page focused on this durable output.
+  onOpenRun: (jobId: string, outputId: string, profile?: string) => void
   // Open the full Cron page focused on this job (manage / full history).
   onManageJob: (jobId: string) => void
   // Fire the job now.
@@ -233,7 +232,7 @@ function CronJobSidebarRow({
   job: CronJob
   nowMs: number
   onManage: () => void
-  onOpenRun: (sessionId: string) => void
+  onOpenRun: (jobId: string, outputId: string, profile?: string) => void
   onTogglePeek: () => void
   onTrigger: () => void
 }) {
@@ -377,35 +376,50 @@ function CronJobSidebarRow({
           </Tip>
         </SidebarRowShell>
       </ActionsContextMenu>
-      {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} />}
+      {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} profile={job.profile} />}
     </div>
   )
 }
 
-function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (sessionId: string) => void }) {
+export function CronJobSidebarRuns({
+  jobId,
+  onOpenRun,
+  profile
+}: {
+  jobId: string
+  onOpenRun: (jobId: string, outputId: string, profile?: string) => void
+  profile?: string
+}) {
   const { t } = useI18n()
   const c = t.cron
-  const selectedSessionId = useStore($selectedStoredSessionId)
+
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
-  const [runs, setRuns] = useState<null | SessionInfo[]>(null)
+  const [runs, setRuns] = useState<null | CronJobOutput[]>(null)
+  const [runsError, setRunsError] = useState(false)
   const visible = usePaneVisible()
 
   useEffect(() => {
     let cancelled = false
+    let latestRequestId = 0
 
-    const load = () =>
-      getCronJobRuns(jobId, PEEK_RUN_LIMIT)
+    const load = () => {
+      const requestId = ++latestRequestId
+
+      return getCronJobOutputs(jobId, PEEK_RUN_LIMIT, profile)
         .then(result => {
-          if (!cancelled) {
+          if (!cancelled && requestId === latestRequestId) {
+            setRunsError(false)
             setRuns(result)
           }
         })
         .catch(() => {
-          if (!cancelled) {
+          if (!cancelled && requestId === latestRequestId) {
+            setRunsError(true)
             setRuns(prev => prev ?? [])
           }
         })
+    }
 
     // Hidden pane: skip the peek entirely — no initial load, no interval.
     // `visible` is in the dep array, so becoming visible re-runs this effect
@@ -432,11 +446,13 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
       window.clearInterval(intervalId)
     }
     // cronChangeTick: a fired run reloads the peek immediately.
-  }, [changeEventsAvailable, cronChangeTick, jobId, visible])
+  }, [changeEventsAvailable, cronChangeTick, jobId, profile, visible])
 
   return (
     <div className="mb-1 ml-[1.375rem] flex flex-col gap-px">
-      {runs === null ? (
+      {runsError ? (
+        <div className="py-1 pl-1 text-[0.6875rem] text-destructive">{c.failedLoad}</div>
+      ) : runs === null ? (
         <div className="flex items-center gap-1.5 py-1 pl-1 text-[0.6875rem] text-(--ui-text-tertiary)">
           <GlyphSpinner ariaLabel={c.loading} className="text-[0.75rem]" />
         </div>
@@ -446,17 +462,12 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
         <>
           {runs.map(run => (
             <button
-              className={cn(
-                'truncate rounded-md px-1.5 py-0.5 text-left text-[0.6875rem] tabular-nums focus-visible:bg-(--chrome-action-hover) focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
-                run.id === selectedSessionId
-                  ? 'bg-(--ui-row-active-background) text-foreground'
-                  : 'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-foreground'
-              )}
+              className="truncate rounded-md px-1.5 py-0.5 text-left text-[0.6875rem] text-(--ui-text-secondary) tabular-nums hover:bg-(--chrome-action-hover) hover:text-foreground focus-visible:bg-(--chrome-action-hover) focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               key={run.id}
-              onClick={() => onOpenRun(run.id)}
+              onClick={() => onOpenRun(jobId, run.id, profile)}
               type="button"
             >
-              {formatRunTime(run.last_active || run.started_at)}
+              {formatRunTime(run.created_at)}
             </button>
           ))}
         </>

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -14,7 +14,7 @@ import { useI18n } from '@/i18n'
 import { fmtDayTime, relativeTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { confirm } from '@/store/confirm'
-import { cronJobIdentity, updateCronJobs } from '@/store/cron'
+import { cronJobIdentity, removeCronJobForOwner, replaceCronJobForOwner, updateCronJobs } from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
 import { $selectedStoredSessionId } from '@/store/session'
@@ -83,7 +83,7 @@ interface SidebarCronJobsSectionProps {
   // Open the full Cron page focused on this job (manage / full history).
   onManageJob: (jobId: string, profile?: string) => void
   // Fire the job now.
-  onTriggerJob: (jobId: string) => Promise<void>
+  onTriggerJob: (jobId: string, profile?: string) => Promise<void>
   onToggle: () => void
   open: boolean
 }
@@ -104,7 +104,7 @@ export function SidebarCronJobsSection({
   const [peekJobKey, setPeekJobKey] = useState<null | string>(null)
   // Rows revealed so far; starts compact, grows in steps via "load more".
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_JOBS)
-  const [triggeringJobIds, setTriggeringJobIds] = useState<ReadonlySet<string>>(() => new Set())
+  const [triggeringJobKeys, setTriggeringJobKeys] = useState<ReadonlySet<string>>(() => new Set())
   const triggerControllerRef = useRef<CronTriggerController | null>(null)
 
   // eslint-disable-next-line no-restricted-syntax -- controller mount identity, not an atom mirror
@@ -114,7 +114,7 @@ export function SidebarCronJobsSection({
         return
       }
 
-      setTriggeringJobIds(current => {
+      setTriggeringJobKeys(current => {
         const next = new Set(current)
 
         if (running) {
@@ -134,14 +134,16 @@ export function SidebarCronJobsSection({
     }
   }, [])
 
-  const triggerJob = (jobId: string) => {
+  const triggerJob = (job: CronJob) => {
     const controller = triggerControllerRef.current
 
     if (!controller) {
       return
     }
 
-    void controller.run(jobId, () => onTriggerJob(jobId)).catch(() => undefined)
+    const jobKey = cronJobIdentity(job)
+
+    void controller.run(jobKey, () => onTriggerJob(job.id, job.profile)).catch(() => undefined)
   }
 
   const visible = usePaneVisible()
@@ -207,7 +209,7 @@ export function SidebarCronJobsSection({
 
             return (
               <CronJobSidebarRow
-                busy={triggeringJobIds.has(job.id)}
+                busy={triggeringJobKeys.has(jobKey)}
                 expanded={peekJobKey === jobKey}
                 job={job}
                 key={jobKey}
@@ -216,7 +218,7 @@ export function SidebarCronJobsSection({
                 onOpenOutput={onOpenOutput}
                 onOpenSession={onOpenSession}
                 onTogglePeek={() => setPeekJobKey(prev => (prev === jobKey ? null : jobKey))}
-                onTrigger={() => triggerJob(job.id)}
+                onTrigger={() => triggerJob(job)}
               />
             )
           })}
@@ -268,8 +270,8 @@ function CronJobSidebarRow({
   // row updates in place.
   const togglePause = async () => {
     try {
-      const updated = isPaused ? await resumeCronJob(job.id) : await pauseCronJob(job.id)
-      updateCronJobs(rows => rows.map(row => (row.id === job.id ? updated : row)))
+      const updated = isPaused ? await resumeCronJob(job.id, job.profile) : await pauseCronJob(job.id, job.profile)
+      updateCronJobs(rows => replaceCronJobForOwner(rows, job, updated))
       notify({ kind: 'success', title: isPaused ? c.resumed : c.paused, message: label })
     } catch (err) {
       notifyError(err, c.failedUpdate)
@@ -289,8 +291,8 @@ function CronJobSidebarRow({
     }
 
     try {
-      await deleteCronJob(job.id)
-      updateCronJobs(rows => rows.filter(row => row.id !== job.id))
+      await deleteCronJob(job.id, job.profile)
+      updateCronJobs(rows => removeCronJobForOwner(rows, job))
       notify({ kind: 'success', title: c.deleted, message: label })
     } catch (err) {
       notifyError(err, c.failedDelete)

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -14,11 +14,17 @@ import { useI18n } from '@/i18n'
 import { fmtDayTime, relativeTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { confirm } from '@/store/confirm'
-import { cronJobIdentity, removeCronJobForOwner, replaceCronJobForOwner, updateCronJobs } from '@/store/cron'
+import {
+  cronJobIdentity,
+  cronJobOwner,
+  removeCronJobForOwner,
+  replaceCronJobForOwner,
+  updateCronJobs
+} from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
 import { $selectedStoredSessionId } from '@/store/session'
-import type { CronJob } from '@/types/hermes'
+import type { CronJob, SessionInfo } from '@/types/hermes'
 
 import { jobState, jobTitle, STATE_DOT } from '../../cron/job-state'
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
@@ -70,6 +76,7 @@ interface CronSidebarRun {
   createdAt?: null | number
   id: string
   kind: 'output' | 'session'
+  session?: SessionInfo
 }
 
 interface SidebarCronJobsSectionProps {
@@ -77,13 +84,13 @@ interface SidebarCronJobsSectionProps {
   label: string
   max?: number
   // Open a durable no-agent output in the full Cron page.
-  onOpenOutput: (jobId: string, outputId: string, profile?: string) => void
+  onOpenOutput: (jobId: string, outputId: string, profile?: string, connectionId?: null | string) => void
   // Agent-backed jobs retain their real conversation-session navigation.
-  onOpenSession: (sessionId: string, profile?: string) => void
+  onOpenSession: (sessionId: string, owner?: SessionInfo | string) => void
   // Open the full Cron page focused on this job (manage / full history).
-  onManageJob: (jobId: string, profile?: string) => void
+  onManageJob: (jobId: string, profile?: string, connectionId?: null | string) => void
   // Fire the job now.
-  onTriggerJob: (jobId: string, profile?: string) => Promise<void>
+  onTriggerJob: (jobId: string, profile?: string, connectionId?: null | string) => Promise<void>
   onToggle: () => void
   open: boolean
 }
@@ -143,7 +150,7 @@ export function SidebarCronJobsSection({
 
     const jobKey = cronJobIdentity(job)
 
-    void controller.run(jobKey, () => onTriggerJob(job.id, job.profile)).catch(() => undefined)
+    void controller.run(jobKey, () => onTriggerJob(job.id, job.profile, job.connection_id)).catch(() => undefined)
   }
 
   const visible = usePaneVisible()
@@ -214,7 +221,7 @@ export function SidebarCronJobsSection({
                 job={job}
                 key={jobKey}
                 nowMs={nowMs}
-                onManage={() => onManageJob(job.id, job.profile)}
+                onManage={() => onManageJob(job.id, job.profile, job.connection_id)}
                 onOpenOutput={onOpenOutput}
                 onOpenSession={onOpenSession}
                 onTogglePeek={() => setPeekJobKey(prev => (prev === jobKey ? null : jobKey))}
@@ -250,8 +257,8 @@ function CronJobSidebarRow({
   job: CronJob
   nowMs: number
   onManage: () => void
-  onOpenOutput: (jobId: string, outputId: string, profile?: string) => void
-  onOpenSession: (sessionId: string, profile?: string) => void
+  onOpenOutput: (jobId: string, outputId: string, profile?: string, connectionId?: null | string) => void
+  onOpenSession: (sessionId: string, owner?: SessionInfo | string) => void
   onTogglePeek: () => void
   onTrigger: () => void
 }) {
@@ -270,7 +277,9 @@ function CronJobSidebarRow({
   // row updates in place.
   const togglePause = async () => {
     try {
-      const updated = isPaused ? await resumeCronJob(job.id, job.profile) : await pauseCronJob(job.id, job.profile)
+      const updated = isPaused
+        ? await resumeCronJob(job.id, cronJobOwner(job))
+        : await pauseCronJob(job.id, cronJobOwner(job))
       updateCronJobs(rows => replaceCronJobForOwner(rows, job, updated))
       notify({ kind: 'success', title: isPaused ? c.resumed : c.paused, message: label })
     } catch (err) {
@@ -291,7 +300,7 @@ function CronJobSidebarRow({
     }
 
     try {
-      await deleteCronJob(job.id, job.profile)
+      await deleteCronJob(job.id, cronJobOwner(job))
       updateCronJobs(rows => removeCronJobForOwner(rows, job))
       notify({ kind: 'success', title: c.deleted, message: label })
     } catch (err) {
@@ -397,6 +406,7 @@ function CronJobSidebarRow({
       </ActionsContextMenu>
       {expanded && (
         <CronJobSidebarRuns
+          connectionId={job.connection_id}
           jobId={job.id}
           noAgent={Boolean(job.no_agent)}
           onOpenOutput={onOpenOutput}
@@ -409,16 +419,18 @@ function CronJobSidebarRow({
 }
 
 export function CronJobSidebarRuns({
+  connectionId,
   jobId,
   noAgent,
   onOpenOutput,
   onOpenSession,
   profile
 }: {
+  connectionId?: null | string
   jobId: string
   noAgent: boolean
-  onOpenOutput: (jobId: string, outputId: string, profile?: string) => void
-  onOpenSession: (sessionId: string, profile?: string) => void
+  onOpenOutput: (jobId: string, outputId: string, profile?: string, connectionId?: null | string) => void
+  onOpenSession: (sessionId: string, owner?: SessionInfo | string) => void
   profile?: string
 }) {
   const { t } = useI18n()
@@ -439,18 +451,25 @@ export function CronJobSidebarRuns({
       const requestId = ++latestRequestId
 
       const loadOutputs = (): Promise<CronSidebarRun[]> =>
-        getCronJobOutputs(jobId, PEEK_RUN_LIMIT, profile).then(outputs =>
-          outputs.map(output => ({ createdAt: output.created_at, id: output.id, kind: 'output' }))
+        getCronJobOutputs(jobId, PEEK_RUN_LIMIT, connectionId === undefined ? profile : { connectionId, profile }).then(
+          outputs => outputs.map(output => ({ createdAt: output.created_at, id: output.id, kind: 'output' }))
         )
 
       const request = noAgent
         ? loadOutputs()
-        : getCronJobRuns(jobId, PEEK_RUN_LIMIT, profile).then<CronSidebarRun[]>(sessions =>
+        : getCronJobRuns(jobId, PEEK_RUN_LIMIT, connectionId === undefined ? profile : { connectionId, profile }).then<
+            CronSidebarRun[]
+          >(sessions =>
             sessions.length > 0
               ? sessions.map(session => ({
                   createdAt: session.last_active || session.started_at,
                   id: session.id,
-                  kind: 'session'
+                  kind: 'session',
+                  session: {
+                    ...session,
+                    connection_id: connectionId ?? undefined,
+                    profile: profile ?? session.profile
+                  }
                 }))
               : loadOutputs()
           )
@@ -495,7 +514,7 @@ export function CronJobSidebarRuns({
       window.clearInterval(intervalId)
     }
     // cronChangeTick: a fired run reloads the peek immediately.
-  }, [changeEventsAvailable, cronChangeTick, jobId, noAgent, profile, visible])
+  }, [changeEventsAvailable, connectionId, cronChangeTick, jobId, noAgent, profile, visible])
 
   return (
     <div className="mb-1 ml-[1.375rem] flex flex-col gap-px">
@@ -519,7 +538,9 @@ export function CronJobSidebarRuns({
               )}
               key={run.id}
               onClick={() =>
-                run.kind === 'output' ? onOpenOutput(jobId, run.id, profile) : onOpenSession(run.id, profile)
+                run.kind === 'output'
+                  ? onOpenOutput(jobId, run.id, profile, connectionId)
+                  : onOpenSession(run.id, run.session)
               }
               type="button"
             >

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -9,7 +9,7 @@ import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import { Tip } from '@/components/ui/tooltip'
-import { type CronJobOutput, deleteCronJob, getCronJobOutputs, pauseCronJob, resumeCronJob } from '@/hermes'
+import { deleteCronJob, getCronJobOutputs, getCronJobRuns, pauseCronJob, resumeCronJob } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { fmtDayTime, relativeTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
@@ -17,6 +17,7 @@ import { confirm } from '@/store/confirm'
 import { updateCronJobs } from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
+import { $selectedStoredSessionId } from '@/store/session'
 import type { CronJob } from '@/types/hermes'
 
 import { jobState, jobTitle, STATE_DOT } from '../../cron/job-state'
@@ -65,12 +66,20 @@ function formatRunTime(seconds?: null | number): string {
   return Number.isNaN(date.valueOf()) ? '—' : fmtDayTime.format(date)
 }
 
+interface CronSidebarRun {
+  createdAt?: null | number
+  id: string
+  kind: 'output' | 'session'
+}
+
 interface SidebarCronJobsSectionProps {
   jobs: CronJob[]
   label: string
   max?: number
-  // Open the full Cron page focused on this durable output.
-  onOpenRun: (jobId: string, outputId: string, profile?: string) => void
+  // Open a durable no-agent output in the full Cron page.
+  onOpenOutput: (jobId: string, outputId: string, profile?: string) => void
+  // Agent-backed jobs retain their real conversation-session navigation.
+  onOpenSession: (sessionId: string) => void
   // Open the full Cron page focused on this job (manage / full history).
   onManageJob: (jobId: string) => void
   // Fire the job now.
@@ -84,7 +93,8 @@ export function SidebarCronJobsSection({
   label,
   max = 50,
   onManageJob,
-  onOpenRun,
+  onOpenOutput,
+  onOpenSession,
   onTriggerJob,
   onToggle,
   open
@@ -200,7 +210,8 @@ export function SidebarCronJobsSection({
               key={job.id}
               nowMs={nowMs}
               onManage={() => onManageJob(job.id)}
-              onOpenRun={onOpenRun}
+              onOpenOutput={onOpenOutput}
+              onOpenSession={onOpenSession}
               onTogglePeek={() => setPeekJobId(prev => (prev === job.id ? null : job.id))}
               onTrigger={() => triggerJob(job.id)}
             />
@@ -223,7 +234,8 @@ function CronJobSidebarRow({
   job,
   nowMs,
   onManage,
-  onOpenRun,
+  onOpenOutput,
+  onOpenSession,
   onTogglePeek,
   onTrigger
 }: {
@@ -232,7 +244,8 @@ function CronJobSidebarRow({
   job: CronJob
   nowMs: number
   onManage: () => void
-  onOpenRun: (jobId: string, outputId: string, profile?: string) => void
+  onOpenOutput: (jobId: string, outputId: string, profile?: string) => void
+  onOpenSession: (sessionId: string) => void
   onTogglePeek: () => void
   onTrigger: () => void
 }) {
@@ -376,26 +389,39 @@ function CronJobSidebarRow({
           </Tip>
         </SidebarRowShell>
       </ActionsContextMenu>
-      {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} profile={job.profile} />}
+      {expanded && (
+        <CronJobSidebarRuns
+          jobId={job.id}
+          noAgent={Boolean(job.no_agent)}
+          onOpenOutput={onOpenOutput}
+          onOpenSession={onOpenSession}
+          profile={job.profile}
+        />
+      )}
     </div>
   )
 }
 
 export function CronJobSidebarRuns({
   jobId,
-  onOpenRun,
+  noAgent,
+  onOpenOutput,
+  onOpenSession,
   profile
 }: {
   jobId: string
-  onOpenRun: (jobId: string, outputId: string, profile?: string) => void
+  noAgent: boolean
+  onOpenOutput: (jobId: string, outputId: string, profile?: string) => void
+  onOpenSession: (sessionId: string) => void
   profile?: string
 }) {
   const { t } = useI18n()
   const c = t.cron
 
+  const selectedSessionId = useStore($selectedStoredSessionId)
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
-  const [runs, setRuns] = useState<null | CronJobOutput[]>(null)
+  const [runs, setRuns] = useState<null | CronSidebarRun[]>(null)
   const [runsError, setRunsError] = useState(false)
   const visible = usePaneVisible()
 
@@ -406,7 +432,24 @@ export function CronJobSidebarRuns({
     const load = () => {
       const requestId = ++latestRequestId
 
-      return getCronJobOutputs(jobId, PEEK_RUN_LIMIT, profile)
+      const loadOutputs = (): Promise<CronSidebarRun[]> =>
+        getCronJobOutputs(jobId, PEEK_RUN_LIMIT, profile).then(outputs =>
+          outputs.map(output => ({ createdAt: output.created_at, id: output.id, kind: 'output' }))
+        )
+
+      const request = noAgent
+        ? loadOutputs()
+        : getCronJobRuns(jobId, PEEK_RUN_LIMIT).then<CronSidebarRun[]>(sessions =>
+            sessions.length > 0
+              ? sessions.map(session => ({
+                  createdAt: session.last_active || session.started_at,
+                  id: session.id,
+                  kind: 'session'
+                }))
+              : loadOutputs()
+          )
+
+      return request
         .then(result => {
           if (!cancelled && requestId === latestRequestId) {
             setRunsError(false)
@@ -446,7 +489,7 @@ export function CronJobSidebarRuns({
       window.clearInterval(intervalId)
     }
     // cronChangeTick: a fired run reloads the peek immediately.
-  }, [changeEventsAvailable, cronChangeTick, jobId, profile, visible])
+  }, [changeEventsAvailable, cronChangeTick, jobId, noAgent, profile, visible])
 
   return (
     <div className="mb-1 ml-[1.375rem] flex flex-col gap-px">
@@ -462,12 +505,19 @@ export function CronJobSidebarRuns({
         <>
           {runs.map(run => (
             <button
-              className="truncate rounded-md px-1.5 py-0.5 text-left text-[0.6875rem] text-(--ui-text-secondary) tabular-nums hover:bg-(--chrome-action-hover) hover:text-foreground focus-visible:bg-(--chrome-action-hover) focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              className={cn(
+                'truncate rounded-md px-1.5 py-0.5 text-left text-[0.6875rem] tabular-nums focus-visible:bg-(--chrome-action-hover) focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
+                run.kind === 'session' && run.id === selectedSessionId
+                  ? 'bg-(--ui-row-active-background) text-foreground'
+                  : 'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-foreground'
+              )}
               key={run.id}
-              onClick={() => onOpenRun(jobId, run.id, profile)}
+              onClick={() =>
+                run.kind === 'output' ? onOpenOutput(jobId, run.id, profile) : onOpenSession(run.id)
+              }
               type="button"
             >
-              {formatRunTime(run.created_at)}
+              {formatRunTime(run.createdAt)}
             </button>
           ))}
         </>

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -8,14 +8,13 @@ import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import { Tip } from '@/components/ui/tooltip'
-import { deleteCronJob, getCronJobRuns, pauseCronJob, resumeCronJob, type SessionInfo } from '@/hermes'
+import { type CronJobOutput, deleteCronJob, getCronJobOutputs, pauseCronJob, resumeCronJob } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { fmtDayTime, relativeTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { updateCronJobs } from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
-import { $selectedStoredSessionId } from '@/store/session'
 import type { CronJob } from '@/types/hermes'
 
 import { jobState, jobTitle, STATE_DOT } from '../../cron/job-state'
@@ -29,7 +28,7 @@ const INACTIVE_STATES = new Set(['completed', 'disabled', 'error', 'paused'])
 // without turning the sidebar into the full Cron page.
 const PEEK_RUN_LIMIT = 5
 
-// Runs are written by the background scheduler tick. cron.changed reloads the
+// Outputs are written by the background scheduler tick. cron.changed reloads the
 // open peek immediately on event-capable backends (poll drops to a backstop);
 // older backends keep the legacy cadence.
 const PEEK_POLL_INTERVAL_MS = 8000
@@ -67,8 +66,8 @@ interface SidebarCronJobsSectionProps {
   jobs: CronJob[]
   label: string
   max?: number
-  // Open a run session's chat (1 click to output).
-  onOpenRun: (sessionId: string) => void
+  // Open the full Cron page focused on this durable output.
+  onOpenRun: (jobId: string, outputId: string, profile?: string) => void
   // Open the full Cron page focused on this job (manage / full history).
   onManageJob: (jobId: string) => void
   // Fire the job now.
@@ -188,7 +187,7 @@ function CronJobSidebarRow({
   job: CronJob
   nowMs: number
   onManage: () => void
-  onOpenRun: (sessionId: string) => void
+  onOpenRun: (jobId: string, outputId: string, profile?: string) => void
   onTogglePeek: () => void
   onTrigger: () => void
 }) {
@@ -319,35 +318,50 @@ function CronJobSidebarRow({
           </div>
         </div>
       </ActionsContextMenu>
-      {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} />}
+      {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} profile={job.profile} />}
     </div>
   )
 }
 
-function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (sessionId: string) => void }) {
+export function CronJobSidebarRuns({
+  jobId,
+  onOpenRun,
+  profile
+}: {
+  jobId: string
+  onOpenRun: (jobId: string, outputId: string, profile?: string) => void
+  profile?: string
+}) {
   const { t } = useI18n()
   const c = t.cron
-  const selectedSessionId = useStore($selectedStoredSessionId)
+
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
-  const [runs, setRuns] = useState<null | SessionInfo[]>(null)
+  const [runs, setRuns] = useState<null | CronJobOutput[]>(null)
+  const [runsError, setRunsError] = useState(false)
   const visible = usePaneVisible()
 
   useEffect(() => {
     let cancelled = false
+    let latestRequestId = 0
 
-    const load = () =>
-      getCronJobRuns(jobId, PEEK_RUN_LIMIT)
+    const load = () => {
+      const requestId = ++latestRequestId
+
+      return getCronJobOutputs(jobId, PEEK_RUN_LIMIT, profile)
         .then(result => {
-          if (!cancelled) {
+          if (!cancelled && requestId === latestRequestId) {
+            setRunsError(false)
             setRuns(result)
           }
         })
         .catch(() => {
-          if (!cancelled) {
+          if (!cancelled && requestId === latestRequestId) {
+            setRunsError(true)
             setRuns(prev => prev ?? [])
           }
         })
+    }
 
     // Hidden pane: skip the peek entirely — no initial load, no interval.
     // `visible` is in the dep array, so becoming visible re-runs this effect
@@ -374,11 +388,13 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
       window.clearInterval(intervalId)
     }
     // cronChangeTick: a fired run reloads the peek immediately.
-  }, [changeEventsAvailable, cronChangeTick, jobId, visible])
+  }, [changeEventsAvailable, cronChangeTick, jobId, profile, visible])
 
   return (
     <div className="mb-1 ml-[1.375rem] flex flex-col gap-px">
-      {runs === null ? (
+      {runsError ? (
+        <div className="py-1 pl-1 text-[0.6875rem] text-destructive">{c.failedLoad}</div>
+      ) : runs === null ? (
         <div className="flex items-center gap-1.5 py-1 pl-1 text-[0.6875rem] text-(--ui-text-tertiary)">
           <GlyphSpinner ariaLabel={c.loading} className="text-[0.75rem]" />
         </div>
@@ -388,17 +404,12 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
         <>
           {runs.map(run => (
             <button
-              className={cn(
-                'truncate rounded-md px-1.5 py-0.5 text-left text-[0.6875rem] tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
-                run.id === selectedSessionId
-                  ? 'bg-(--ui-row-active-background) text-foreground'
-                  : 'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-foreground'
-              )}
+              className="truncate rounded-md px-1.5 py-0.5 text-left text-[0.6875rem] text-(--ui-text-secondary) tabular-nums hover:bg-(--chrome-action-hover) hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               key={run.id}
-              onClick={() => onOpenRun(run.id)}
+              onClick={() => onOpenRun(jobId, run.id, profile)}
               type="button"
             >
-              {formatRunTime(run.last_active || run.started_at)}
+              {formatRunTime(run.created_at)}
             </button>
           ))}
         </>

--- a/apps/desktop/src/app/chat/sidebar/cron-run-output.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-run-output.test.tsx
@@ -46,7 +46,7 @@ describe('CronJobSidebarRuns', () => {
     fireEvent.click(await screen.findByRole('button'))
 
     expect(getCronJobOutputs).toHaveBeenCalledWith('report-job', 5, 'worker_alpha')
-    expect(onOpenOutput).toHaveBeenCalledWith('report-job', '2026-08-11_09-00-00', 'worker_alpha')
+    expect(onOpenOutput).toHaveBeenCalledWith('report-job', '2026-08-11_09-00-00', 'worker_alpha', undefined)
     expect(getCronJobRuns).not.toHaveBeenCalled()
   })
 
@@ -71,18 +71,16 @@ describe('CronJobSidebarRuns', () => {
     const onOpenSession = vi.fn()
 
     render(
-      <CronJobSidebarRuns
-        jobId="report-job"
-        noAgent={false}
-        onOpenOutput={vi.fn()}
-        onOpenSession={onOpenSession}
-      />
+      <CronJobSidebarRuns jobId="report-job" noAgent={false} onOpenOutput={vi.fn()} onOpenSession={onOpenSession} />
     )
 
     fireEvent.click(await screen.findByRole('button'))
 
     expect(getCronJobRuns).toHaveBeenCalledWith('report-job', 5, undefined)
-    expect(onOpenSession).toHaveBeenCalledWith('cron_report-job_20260811_090000', undefined)
+    expect(onOpenSession).toHaveBeenCalledWith(
+      'cron_report-job_20260811_090000',
+      expect.objectContaining({ connection_id: undefined, profile: undefined })
+    )
     expect(getCronJobOutputs).not.toHaveBeenCalled()
   })
 
@@ -120,7 +118,10 @@ describe('CronJobSidebarRuns', () => {
     fireEvent.click(await screen.findByRole('button'))
 
     expect(getCronJobRuns).toHaveBeenCalledWith('shared-job', 5, 'worker_alpha')
-    expect(onOpenSession).toHaveBeenCalledWith('cron_shared-job_20260811_090000', 'worker_alpha')
+    expect(onOpenSession).toHaveBeenCalledWith(
+      'cron_shared-job_20260811_090000',
+      expect.objectContaining({ connection_id: undefined, profile: 'worker_alpha' })
+    )
   })
 
   it('falls back to durable output when an agent run has no stored session', async () => {
@@ -147,7 +148,7 @@ describe('CronJobSidebarRuns', () => {
 
     fireEvent.click(await screen.findByRole('button'))
 
-    expect(onOpenOutput).toHaveBeenCalledWith('report-job', '2026-08-11_09-00-00', 'worker_alpha')
+    expect(onOpenOutput).toHaveBeenCalledWith('report-job', '2026-08-11_09-00-00', 'worker_alpha', undefined)
   })
 
   it('does not describe a failed output request as an empty history', async () => {

--- a/apps/desktop/src/app/chat/sidebar/cron-run-output.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-run-output.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getCronJobOutputs } from '@/hermes'
+import { TRANSLATIONS } from '@/i18n'
+
+import { CronJobSidebarRuns } from './cron-jobs-section'
+
+vi.mock('@/components/pane-shell/pane-visibility', () => ({
+  usePaneVisible: () => true
+}))
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getCronJobOutputs: vi.fn()
+}))
+
+describe('CronJobSidebarRuns', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('opens the durable output instead of a cron chat session', async () => {
+    vi.mocked(getCronJobOutputs).mockResolvedValue([
+      {
+        byte_size: 72,
+        created_at: 1_786_435_200,
+        filename: '2026-08-11_09-00-00.md',
+        id: '2026-08-11_09-00-00'
+      }
+    ])
+    const onOpenRun = vi.fn()
+
+    render(<CronJobSidebarRuns jobId="report-job" onOpenRun={onOpenRun} profile="worker_alpha" />)
+
+    fireEvent.click(await screen.findByRole('button'))
+
+    expect(getCronJobOutputs).toHaveBeenCalledWith('report-job', 5, 'worker_alpha')
+    expect(onOpenRun).toHaveBeenCalledWith('report-job', '2026-08-11_09-00-00', 'worker_alpha')
+  })
+
+  it('does not describe a failed output request as an empty history', async () => {
+    vi.mocked(getCronJobOutputs).mockRejectedValue(new Error('profile backend unavailable'))
+
+    render(<CronJobSidebarRuns jobId="report-job" onOpenRun={vi.fn()} />)
+
+    expect(await screen.findByText(TRANSLATIONS.en.cron.failedLoad)).toBeTruthy()
+    expect(screen.queryByText(TRANSLATIONS.en.cron.noRuns)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/cron-run-output.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-run-output.test.tsx
@@ -81,9 +81,46 @@ describe('CronJobSidebarRuns', () => {
 
     fireEvent.click(await screen.findByRole('button'))
 
-    expect(getCronJobRuns).toHaveBeenCalledWith('report-job', 5)
-    expect(onOpenSession).toHaveBeenCalledWith('cron_report-job_20260811_090000')
+    expect(getCronJobRuns).toHaveBeenCalledWith('report-job', 5, undefined)
+    expect(onOpenSession).toHaveBeenCalledWith('cron_report-job_20260811_090000', undefined)
     expect(getCronJobOutputs).not.toHaveBeenCalled()
+  })
+
+  it('pins an agent-backed run lookup and open to the owning profile when job ids are shared', async () => {
+    vi.mocked(getCronJobRuns).mockResolvedValue([
+      {
+        ended_at: null,
+        id: 'cron_shared-job_20260811_090000',
+        input_tokens: 0,
+        is_active: false,
+        last_active: 1_786_435_200,
+        message_count: 1,
+        model: null,
+        output_tokens: 0,
+        preview: null,
+        profile: 'worker_alpha',
+        source: 'cron',
+        started_at: 1_786_435_000,
+        title: 'Report',
+        tool_call_count: 0
+      }
+    ])
+    const onOpenSession = vi.fn()
+
+    render(
+      <CronJobSidebarRuns
+        jobId="shared-job"
+        noAgent={false}
+        onOpenOutput={vi.fn()}
+        onOpenSession={onOpenSession}
+        profile="worker_alpha"
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button'))
+
+    expect(getCronJobRuns).toHaveBeenCalledWith('shared-job', 5, 'worker_alpha')
+    expect(onOpenSession).toHaveBeenCalledWith('cron_shared-job_20260811_090000', 'worker_alpha')
   })
 
   it('falls back to durable output when an agent run has no stored session', async () => {

--- a/apps/desktop/src/app/chat/sidebar/cron-run-output.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-run-output.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { getCronJobOutputs } from '@/hermes'
+import { getCronJobOutputs, getCronJobRuns } from '@/hermes'
 import { TRANSLATIONS } from '@/i18n'
 
 import { CronJobSidebarRuns } from './cron-jobs-section'
@@ -12,7 +12,8 @@ vi.mock('@/components/pane-shell/pane-visibility', () => ({
 
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  getCronJobOutputs: vi.fn()
+  getCronJobOutputs: vi.fn(),
+  getCronJobRuns: vi.fn()
 }))
 
 describe('CronJobSidebarRuns', () => {
@@ -21,7 +22,7 @@ describe('CronJobSidebarRuns', () => {
     vi.clearAllMocks()
   })
 
-  it('opens the durable output instead of a cron chat session', async () => {
+  it('opens durable output for a no-agent cron run', async () => {
     vi.mocked(getCronJobOutputs).mockResolvedValue([
       {
         byte_size: 72,
@@ -30,20 +31,92 @@ describe('CronJobSidebarRuns', () => {
         id: '2026-08-11_09-00-00'
       }
     ])
-    const onOpenRun = vi.fn()
+    const onOpenOutput = vi.fn()
 
-    render(<CronJobSidebarRuns jobId="report-job" onOpenRun={onOpenRun} profile="worker_alpha" />)
+    render(
+      <CronJobSidebarRuns
+        jobId="report-job"
+        noAgent
+        onOpenOutput={onOpenOutput}
+        onOpenSession={vi.fn()}
+        profile="worker_alpha"
+      />
+    )
 
     fireEvent.click(await screen.findByRole('button'))
 
     expect(getCronJobOutputs).toHaveBeenCalledWith('report-job', 5, 'worker_alpha')
-    expect(onOpenRun).toHaveBeenCalledWith('report-job', '2026-08-11_09-00-00', 'worker_alpha')
+    expect(onOpenOutput).toHaveBeenCalledWith('report-job', '2026-08-11_09-00-00', 'worker_alpha')
+    expect(getCronJobRuns).not.toHaveBeenCalled()
+  })
+
+  it('keeps agent-backed runs connected to their real conversation sessions', async () => {
+    vi.mocked(getCronJobRuns).mockResolvedValue([
+      {
+        ended_at: null,
+        id: 'cron_report-job_20260811_090000',
+        input_tokens: 0,
+        is_active: false,
+        last_active: 1_786_435_200,
+        message_count: 1,
+        model: null,
+        output_tokens: 0,
+        preview: null,
+        source: 'cron',
+        started_at: 1_786_435_000,
+        title: 'Report',
+        tool_call_count: 0
+      }
+    ])
+    const onOpenSession = vi.fn()
+
+    render(
+      <CronJobSidebarRuns
+        jobId="report-job"
+        noAgent={false}
+        onOpenOutput={vi.fn()}
+        onOpenSession={onOpenSession}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button'))
+
+    expect(getCronJobRuns).toHaveBeenCalledWith('report-job', 5)
+    expect(onOpenSession).toHaveBeenCalledWith('cron_report-job_20260811_090000')
+    expect(getCronJobOutputs).not.toHaveBeenCalled()
+  })
+
+  it('falls back to durable output when an agent run has no stored session', async () => {
+    vi.mocked(getCronJobRuns).mockResolvedValue([])
+    vi.mocked(getCronJobOutputs).mockResolvedValue([
+      {
+        byte_size: 72,
+        created_at: 1_786_435_200,
+        filename: '2026-08-11_09-00-00.md',
+        id: '2026-08-11_09-00-00'
+      }
+    ])
+    const onOpenOutput = vi.fn()
+
+    render(
+      <CronJobSidebarRuns
+        jobId="report-job"
+        noAgent={false}
+        onOpenOutput={onOpenOutput}
+        onOpenSession={vi.fn()}
+        profile="worker_alpha"
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button'))
+
+    expect(onOpenOutput).toHaveBeenCalledWith('report-job', '2026-08-11_09-00-00', 'worker_alpha')
   })
 
   it('does not describe a failed output request as an empty history', async () => {
     vi.mocked(getCronJobOutputs).mockRejectedValue(new Error('profile backend unavailable'))
 
-    render(<CronJobSidebarRuns jobId="report-job" onOpenRun={vi.fn()} />)
+    render(<CronJobSidebarRuns jobId="report-job" noAgent onOpenOutput={vi.fn()} onOpenSession={vi.fn()} />)
 
     expect(await screen.findByText(TRANSLATIONS.en.cron.failedLoad)).toBeTruthy()
     expect(screen.queryByText(TRANSLATIONS.en.cron.noRuns)).toBeNull()

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -305,7 +305,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onNewSessionSplit: (dir: SplitDir) => void
   onManageCronJob: (jobId: string, profile?: string) => void
   onOpenCronRun: (jobId: string, outputId: string, profile?: string) => void
-  onTriggerCronJob: (jobId: string) => Promise<void>
+  onTriggerCronJob: (jobId: string, profile?: string) => Promise<void>
 }
 
 export function ChatSidebar({

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -303,9 +303,9 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onNewSessionInWorkspace: (path: null | string) => void
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void
-  onManageCronJob: (jobId: string, profile?: string) => void
-  onOpenCronRun: (jobId: string, outputId: string, profile?: string) => void
-  onTriggerCronJob: (jobId: string, profile?: string) => Promise<void>
+  onManageCronJob: (jobId: string, profile?: string, connectionId?: null | string) => void
+  onOpenCronRun: (jobId: string, outputId: string, profile?: string, connectionId?: null | string) => void
+  onTriggerCronJob: (jobId: string, profile?: string, connectionId?: null | string) => Promise<void>
 }
 
 export function ChatSidebar({

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -296,14 +296,14 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onNavigate: (item: SidebarNavItem) => void
   onLoadMoreSessions: () => Promise<void> | void
   onLoadMoreMessaging?: (platform: string) => Promise<void> | void
-  onResumeSession: (sessionId: string, session?: SessionInfo) => void
+  onResumeSession: (sessionId: string, owner?: SessionInfo | string) => void
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
   onBranchSession: (sessionId: string) => void
   onNewSessionInWorkspace: (path: null | string) => void
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void
-  onManageCronJob: (jobId: string) => void
+  onManageCronJob: (jobId: string, profile?: string) => void
   onOpenCronRun: (jobId: string, outputId: string, profile?: string) => void
   onTriggerCronJob: (jobId: string) => Promise<void>
 }

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -304,6 +304,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void
   onManageCronJob: (jobId: string) => void
+  onOpenCronRun: (jobId: string, outputId: string, profile?: string) => void
   onTriggerCronJob: (jobId: string) => Promise<void>
 }
 
@@ -319,6 +320,7 @@ export function ChatSidebar({
   onNewSessionInWorkspace,
   onNewSessionSplit,
   onManageCronJob,
+  onOpenCronRun,
   onTriggerCronJob
 }: ChatSidebarProps) {
   const { t } = useI18n()
@@ -1875,7 +1877,7 @@ export function ChatSidebar({
                 jobs={cronJobs}
                 label={s.cronJobs}
                 onManageJob={onManageCronJob}
-                onOpenRun={onResumeSession}
+                onOpenRun={onOpenCronRun}
                 onToggle={() => setSidebarCronOpen(!cronOpen)}
                 onTriggerJob={onTriggerCronJob}
                 open={cronOpen}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1877,7 +1877,8 @@ export function ChatSidebar({
                 jobs={cronJobs}
                 label={s.cronJobs}
                 onManageJob={onManageCronJob}
-                onOpenRun={onOpenCronRun}
+                onOpenOutput={onOpenCronRun}
+                onOpenSession={onResumeSession}
                 onToggle={() => setSidebarCronOpen(!cronOpen)}
                 onTriggerJob={onTriggerCronJob}
                 open={cronOpen}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -275,6 +275,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   /** Create a brand-new session and open it as a tile on `dir`. */
   onNewSessionSplit: (dir: SplitDir) => void
   onManageCronJob: (jobId: string) => void
+  onOpenCronRun: (jobId: string, outputId: string, profile?: string) => void
   onTriggerCronJob: (jobId: string) => void
 }
 
@@ -290,6 +291,7 @@ export function ChatSidebar({
   onNewSessionInWorkspace,
   onNewSessionSplit,
   onManageCronJob,
+  onOpenCronRun,
   onTriggerCronJob
 }: ChatSidebarProps) {
   const { t } = useI18n()
@@ -1748,7 +1750,7 @@ export function ChatSidebar({
                 jobs={cronJobs}
                 label={s.cronJobs}
                 onManageJob={onManageCronJob}
-                onOpenRun={onResumeSession}
+                onOpenRun={onOpenCronRun}
                 onToggle={() => setSidebarCronOpen(!cronOpen)}
                 onTriggerJob={onTriggerCronJob}
                 open={cronOpen}

--- a/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
@@ -5,10 +5,13 @@ import { $activeSessionId, $selectedStoredSessionId, $unreadFinishedSessionIds }
 import {
   $attentionSessionIds,
   $sessionStates,
+  $stalledSessionIds,
   $workingSessionIds,
   clearAllSessionStates,
   getRecentlySettledSessionIds,
-  publishSessionState
+  getSessionState,
+  publishSessionState,
+  SESSION_WATCHDOG_TIMEOUT_MS
 } from '@/store/session-states'
 
 import { rehydrateLiveSessionStatuses, resetLiveRuntimeTracking } from './use-background-sync'
@@ -134,28 +137,42 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
   })
 
   it('keeps same-profile live bookkeeping isolated across connections', () => {
+    const now = Date.now()
     rehydrateLiveSessionStatuses(
-      { sessions: [{ id: 'runtime-shared', session_key: 'stored-shared', status: 'working' }] },
-      Date.now(),
+      {
+        sessions: [
+          {
+            id: 'runtime-shared',
+            last_active: (now - SESSION_WATCHDOG_TIMEOUT_MS) / 1000,
+            session_key: 'stored-shared',
+            status: 'working'
+          }
+        ]
+      },
+      now,
       'default',
       'connection-a'
     )
 
-    const ownerB = {
-      ...createClientSessionState('stored-shared'),
-      awaitingResponse: true,
-      busy: true,
-      connectionId: 'connection-b',
-      profile: 'default'
-    }
+    rehydrateLiveSessionStatuses(
+      {
+        sessions: [{ id: 'runtime-shared', last_active: now / 1000, session_key: 'stored-shared', status: 'working' }]
+      },
+      now,
+      'default',
+      'connection-b'
+    )
 
-    publishSessionState('runtime-shared', ownerB)
+    expect(getSessionState('runtime-shared', { connectionId: 'connection-a', profile: 'default' })?.busy).toBe(true)
+    expect(getSessionState('runtime-shared', { connectionId: 'connection-b', profile: 'default' })?.busy).toBe(true)
+    expect($stalledSessionIds.get()).toEqual(['stored-shared'])
 
-    rehydrateLiveSessionStatuses({ sessions: [] }, Date.now(), 'default', 'connection-a')
+    rehydrateLiveSessionStatuses({ sessions: [] }, now, 'default', 'connection-a')
 
-    expect($sessionStates.get()['runtime-shared']).toBe(ownerB)
-    expect(ownerB.busy).toBe(true)
-    expect(ownerB.awaitingResponse).toBe(true)
+    expect(getSessionState('runtime-shared', { connectionId: 'connection-a', profile: 'default' })?.busy).toBe(false)
+    expect(getSessionState('runtime-shared', { connectionId: 'connection-b', profile: 'default' })?.busy).toBe(true)
+    expect(getSessionState('runtime-shared')).toBeUndefined()
+    expect($stalledSessionIds.get()).toEqual([])
   })
 
   it('leaves runtimes this poll never seeded alone', () => {

--- a/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
@@ -7,6 +7,7 @@ import {
   $sessionStates,
   $workingSessionIds,
   clearAllSessionStates,
+  getRecentlySettledSessionIds,
   publishSessionState
 } from '@/store/session-states'
 
@@ -48,6 +49,66 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
     rehydrateLiveSessionStatuses({ sessions: [] })
 
     expect($workingSessionIds.get()).toEqual([])
+  })
+
+  it('keeps a conflicting current owner untouched while reaping a true disappearance', () => {
+    const openTool = (toolCallId: string) =>
+      ({
+        type: 'tool-call',
+        toolCallId,
+        toolName: 'patch',
+        args: {},
+        argsText: '{}'
+      }) as never
+
+    const originalOwner = {
+      ...createClientSessionState('stored-a'),
+      awaitingResponse: true,
+      busy: true,
+      messages: [
+        { id: 'shared-message', role: 'assistant' as const, parts: [openTool('call-shared')], pending: false }
+      ],
+      profile: 'default'
+    }
+
+    const vanishedOwner = {
+      ...createClientSessionState('stored-gone'),
+      awaitingResponse: true,
+      busy: true,
+      messages: [{ id: 'gone-message', role: 'assistant' as const, parts: [openTool('call-gone')], pending: false }],
+      profile: 'default'
+    }
+
+    publishSessionState('runtime-shared', originalOwner)
+    publishSessionState('runtime-gone', vanishedOwner)
+    $activeSessionId.set('runtime-shared')
+
+    rehydrateLiveSessionStatuses({
+      sessions: [
+        { id: 'runtime-shared', session_key: 'stored-a', status: 'working' },
+        { id: 'runtime-gone', session_key: 'stored-gone', status: 'working' }
+      ]
+    })
+
+    // The runtime is still occupied in this profile, but the durable owner no
+    // longer matches. That conflict is not proof that stored-a disappeared.
+    rehydrateLiveSessionStatuses({
+      sessions: [{ id: 'runtime-shared', session_key: 'stored-b', status: 'working' }]
+    })
+
+    const sharedState = $sessionStates.get()['runtime-shared']
+
+    expect(sharedState).toBe(originalOwner)
+    expect(sharedState.busy).toBe(true)
+    expect(sharedState.awaitingResponse).toBe(true)
+    expect((sharedState.messages[0].parts[0] as { result?: unknown }).result).toBeUndefined()
+    expect(getRecentlySettledSessionIds()).not.toContain('stored-a')
+    expect($unreadFinishedSessionIds.get()).not.toContain('stored-a')
+
+    // Control: an actually absent sibling is still settled and sealed.
+    expect($workingSessionIds.get()).not.toContain('stored-gone')
+    expect(getRecentlySettledSessionIds()).toContain('stored-gone')
+    expect($unreadFinishedSessionIds.get()).toContain('stored-gone')
   })
 
   it('fires the unread "your turn" marker for a vanished background session', () => {

--- a/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
@@ -133,6 +133,31 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
     expect($attentionSessionIds.get()).toEqual([])
   })
 
+  it('keeps same-profile live bookkeeping isolated across connections', () => {
+    rehydrateLiveSessionStatuses(
+      { sessions: [{ id: 'runtime-shared', session_key: 'stored-shared', status: 'working' }] },
+      Date.now(),
+      'default',
+      'connection-a'
+    )
+
+    const ownerB = {
+      ...createClientSessionState('stored-shared'),
+      awaitingResponse: true,
+      busy: true,
+      connectionId: 'connection-b',
+      profile: 'default'
+    }
+
+    publishSessionState('runtime-shared', ownerB)
+
+    rehydrateLiveSessionStatuses({ sessions: [] }, Date.now(), 'default', 'connection-a')
+
+    expect($sessionStates.get()['runtime-shared']).toBe(ownerB)
+    expect(ownerB.busy).toBe(true)
+    expect(ownerB.awaitingResponse).toBe(true)
+  })
+
   it('leaves runtimes this poll never seeded alone', () => {
     // A background PROFILE's sessions are served by a different gateway and
     // never appear in this profile's active_list. Reaping them would dark out

--- a/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
@@ -10,7 +10,7 @@ import {
   publishSessionState
 } from '@/store/session-states'
 
-import { rehydrateLiveSessionStatuses } from './use-background-sync'
+import { rehydrateLiveSessionStatuses, resetLiveRuntimeTracking } from './use-background-sync'
 
 /**
  * `session.active_list` is the authoritative snapshot of what is RUNNING in the
@@ -25,12 +25,14 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
     vi.useFakeTimers()
     $selectedStoredSessionId.set(null)
     $unreadFinishedSessionIds.set([])
+    resetLiveRuntimeTracking()
   })
 
   afterEach(() => {
     vi.clearAllTimers()
     vi.useRealTimers()
     clearAllSessionStates()
+    resetLiveRuntimeTracking()
     $unreadFinishedSessionIds.set([])
     $activeSessionId.set(null)
   })
@@ -98,7 +100,8 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
       ...createClientSessionState('stored-tools'),
       busy: true,
       awaitingResponse: true,
-      messages: [{ id: 'a1', role: 'assistant', parts: [openTool], pending: false } as never]
+      messages: [{ id: 'a1', role: 'assistant', parts: [openTool], pending: false } as never],
+      profile: 'default'
     })
 
     // Keep the runtime referenced so the settled state stays in the store
@@ -121,7 +124,8 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
     publishSessionState('runtime-await', {
       ...createClientSessionState('stored-await'),
       awaitingResponse: true,
-      busy: false
+      busy: false,
+      profile: 'default'
     })
 
     $activeSessionId.set('runtime-await')

--- a/apps/desktop/src/app/contrib/hooks/live-status-spinner.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/live-status-spinner.test.ts
@@ -48,12 +48,16 @@ describe('rehydrateLiveSessionStatuses — seeding a turn the renderer never saw
     expect($workingSessionIds.get()).toContain('stored-cold')
   })
 
-  it('shows the spinner when a runtime id is recycled onto a new stored session', () => {
+  it('shows the spinner after an explicit backend reset recycles a runtime id', () => {
     // A respawned backend can mint the same runtime id for a different stored
-    // session. The row for the NEW stored id must light up, not the stale one.
+    // session. Its gateway-wipe path explicitly drops renderer state and poll
+    // bookkeeping; the poll itself must not silently transfer ownership.
     rehydrateLiveSessionStatuses({
       sessions: [{ id: 'runtime-1', session_key: 'stored-old', status: 'working' }]
     })
+
+    clearAllSessionStates()
+    resetLiveRuntimeTracking()
 
     rehydrateLiveSessionStatuses({
       sessions: [{ id: 'runtime-1', session_key: 'stored-new', status: 'working' }]

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -59,7 +59,8 @@ function transcript(answer: string, sessionId = ACTIVE_STORED_ID) {
 
 function makeRefresh(
   resolveSession: ActiveTranscriptRefreshDeps['resolveSession'] = () => ({ profile: 'default' }),
-  selectedProfile = 'default'
+  selectedProfile = 'default',
+  connectionId: null | string = null
 ) {
   const activeSessionIdRef = { current: ACTIVE_RUNTIME_ID as string | null }
   const selectedStoredSessionIdRef = { current: ACTIVE_STORED_ID as string | null }
@@ -68,19 +69,26 @@ function makeRefresh(
   const requestSequenceRef = { current: 0 }
   const signatureRef = { current: new Map<string, string>() }
   const state = createClientSessionState(ACTIVE_STORED_ID)
+  state.connectionId = connectionId
   state.profile = selectedProfile
   const states = new Map([[ACTIVE_RUNTIME_ID, state]])
 
-  const sessionStateHasOwner = vi.fn((sessionId: string, owner: { profile: string; storedSessionId: string }) => {
-    const current = states.get(sessionId)
+  const sessionStateHasOwner = vi.fn(
+    (sessionId: string, owner: { connectionId?: null | string; profile: string; storedSessionId: string }) => {
+      const current = states.get(sessionId)
 
-    return current?.profile === owner.profile && current.storedSessionId === owner.storedSessionId
-  })
+      return (
+        current?.profile === owner.profile &&
+        current.storedSessionId === owner.storedSessionId &&
+        (!current.connectionId || !owner.connectionId || current.connectionId === owner.connectionId)
+      )
+    }
+  )
 
   const updateOwnedSessionState = vi.fn(
     (
       sessionId: string,
-      owner: { profile: string; storedSessionId: string },
+      owner: { connectionId?: null | string; profile: string; storedSessionId: string },
       updater: (value: typeof state) => typeof state
     ) => {
       const current = states.get(sessionId)
@@ -131,11 +139,13 @@ function useSyncHarness({
   activeStoredSessionId: string | null
   refreshActiveTranscript: () => Promise<void>
 }) {
-  const updateSessionState: Parameters<typeof useBackgroundSync>[0]['updateSessionState'] = vi.fn(
-    (sessionId, updater) => {
-      const current = {} as Parameters<typeof updater>[0]
+  const updateOwnedSessionState: Parameters<typeof useBackgroundSync>[0]['updateOwnedSessionState'] = vi.fn(
+    (_sessionId, _owner, updater) => {
+      const current = createClientSessionState(ACTIVE_STORED_ID)
 
-      return updater(current)
+      void updater(current)
+
+      return true
     }
   )
 
@@ -153,7 +163,8 @@ function useSyncHarness({
     refreshHermesConfig: vi.fn(),
     refreshMessagingSessions: vi.fn(),
     refreshSessions: vi.fn(),
-    updateSessionState,
+    sessionStateHasOwner: vi.fn(() => true),
+    updateOwnedSessionState,
     requestGateway: vi.fn(async () => ({ sessions: [] })) as never
   })
 }
@@ -250,16 +261,19 @@ describe('active transcript refresh', () => {
 
     let updaterCallCount = 0
 
-    const updateSessionState: Parameters<typeof reconcileTileTranscriptsForTest>[0]['updateSessionState'] = vi.fn(
-      (sessionId, updater) => {
+    const updateOwnedSessionState: Parameters<typeof reconcileTileTranscriptsForTest>[0]['updateOwnedSessionState'] =
+      vi.fn((sessionId, _owner, updater) => {
         updaterCallCount += 1
-        const current = {} as Parameters<typeof updater>[0]
+        const current = states.get(sessionId)
 
-        return updater(current)
-      }
-    )
+        if (!current) {
+          return false
+        }
 
-    void updateSessionState
+        states.set(sessionId, updater(current))
+
+        return true
+      })
 
     const signatureRef = { current: new Map<string, string>() }
     const requestSequenceRef = { current: 0 }
@@ -288,13 +302,67 @@ describe('active transcript refresh', () => {
         busyRef,
         requestSequenceRef,
         signatureRef,
-        updateSessionState
+        sessionStateHasOwner: vi.fn(() => true),
+        updateOwnedSessionState
       })
     })
 
     // Behavior assertions:
     expect(updaterCallCount).toBeGreaterThan(0)
-    expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID)
+    expect(states.get(TILE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'background delivery answer'
+    })
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID, 'default')
+  })
+
+  it('does not publish a delayed tile transcript after the same root is reclaimed by another connection', async () => {
+    const tile = {
+      ownerRoute: { connectionId: 'connection-a', profile: 'default' },
+      runtimeId: 'runtime-tile-shared',
+      storedSessionId: 'stored-tile-shared'
+    }
+
+    const stateA = createClientSessionState(tile.storedSessionId)
+    stateA.connectionId = 'connection-a'
+    stateA.profile = 'default'
+    const states = new Map([[tile.runtimeId, stateA]])
+    let resolve: ((value: unknown) => void) | undefined
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+
+    const sessionStateHasOwner = vi.fn((runtimeId: string, owner: { connectionId?: null | string }) => {
+      const current = states.get(runtimeId)
+
+      return current?.connectionId === owner.connectionId
+    })
+
+    const updateOwnedSessionState = vi.fn(() => false)
+
+    const request = reconcileTileTranscriptsForTest({
+      busyRef: { current: false },
+      requestSequenceRef: { current: 0 },
+      sessionStateHasOwner,
+      signatureRef: { current: new Map() },
+      tiles: [tile],
+      updateOwnedSessionState
+    })
+
+    const stateB = createClientSessionState(tile.storedSessionId)
+    stateB.connectionId = 'connection-b'
+    stateB.profile = 'default'
+    states.set(tile.runtimeId, stateB)
+    resolve?.(transcript('stale tile', tile.storedSessionId))
+    await request
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(tile.storedSessionId, {
+      connectionId: 'connection-a',
+      profile: 'default'
+    })
+    expect(updateOwnedSessionState).not.toHaveBeenCalled()
+    expect(states.get(tile.runtimeId)).toBe(stateB)
   })
 
   it('skips the tile fetch entirely when nothing changed (signature-gated)', async () => {
@@ -319,9 +387,9 @@ describe('active transcript refresh', () => {
     // Compute the same signature the reconcile will compute, and pre-seed it.
     const preSignature = sessionMessagesSignature(pre.messages as never)
 
-    signatureRef.current.set(`tile:${TILE_STORED_ID}`, preSignature)
+    signatureRef.current.set(`tile:${JSON.stringify(['', 'default', TILE_STORED_ID])}`, preSignature)
 
-    const updateSessionState = vi.fn()
+    const updateOwnedSessionState = vi.fn()
     const busyRef = { current: false }
     const requestSequenceRef = { current: 0 }
 
@@ -331,11 +399,12 @@ describe('active transcript refresh', () => {
         busyRef,
         requestSequenceRef,
         signatureRef,
-        updateSessionState
+        sessionStateHasOwner: vi.fn(() => true),
+        updateOwnedSessionState
       })
     })
 
-    expect(updateSessionState).not.toHaveBeenCalled()
+    expect(updateOwnedSessionState).not.toHaveBeenCalled()
   })
 
   it('refreshes a local/Desktop session when sessions.changed ticks', async () => {
@@ -542,8 +611,8 @@ describe('reconcileActiveTranscript', () => {
     })
     expect(fixture.updateSessionState).toHaveBeenCalledWith(
       ACTIVE_RUNTIME_ID,
-      { profile: 'bot-b', storedSessionId: ownerBStoredSessionId },
-      expect.any(Function),
+      { connectionId: ownerBRoute.connectionId, profile: 'bot-b', storedSessionId: ownerBStoredSessionId },
+      expect.any(Function)
     )
     expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
       text: 'owner B answer'
@@ -640,6 +709,33 @@ describe('reconcileActiveTranscript', () => {
     resolve?.(transcript('stale default answer'))
     await request
 
+    expect(fixture.updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('drops a delayed same-root response when the runtime is reclaimed by another connection', async () => {
+    const ownerA = { connectionId: 'connection-a', profile: 'default' }
+    const fixture = makeRefresh(() => ({ ownerRoute: ownerA, profile: 'default' }), 'default', ownerA.connectionId)
+    let resolve: ((value: unknown) => void) | undefined
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+
+    const request = fixture.refresh()
+    const reclaimed = createClientSessionState(ACTIVE_STORED_ID)
+    reclaimed.connectionId = 'connection-b'
+    reclaimed.profile = 'default'
+    reclaimed.messages = [
+      { id: 'connection-b-existing', parts: [{ text: 'connection B', type: 'text' }], role: 'assistant' }
+    ]
+    fixture.states.set(ACTIVE_RUNTIME_ID, reclaimed)
+
+    resolve?.(transcript('stale connection A'))
+    await request
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, ownerA)
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)).toBe(reclaimed)
     expect(fixture.updateSessionState).not.toHaveBeenCalled()
   })
 
@@ -888,11 +984,17 @@ describe('typing-aware sessions.changed deferral', () => {
       // transcript path, so the updater just runs against a throwaway state —
       // but it must live in `stable` like every other prop, since a fresh
       // identity per render would re-run the connect-reseed effect.
-      updateSessionState: vi.fn(
+      sessionStateHasOwner: vi.fn(() => true),
+      updateOwnedSessionState: vi.fn(
         (
           _sessionId: string,
+          _owner: unknown,
           updater: (state: ReturnType<typeof createClientSessionState>) => ReturnType<typeof createClientSessionState>
-        ) => updater(createClientSessionState(ACTIVE_STORED_ID))
+        ) => {
+          void updater(createClientSessionState(ACTIVE_STORED_ID))
+
+          return true
+        }
       )
     }
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -14,10 +14,13 @@ import {
 } from '@/store/session'
 import {
   $attentionSessionIds,
+  $sessionStates,
   $stalledSessionIds,
   $workingSessionIds,
   clearAllSessionStates,
-  SESSION_WATCHDOG_TIMEOUT_MS
+  publishSessionState,
+  SESSION_WATCHDOG_TIMEOUT_MS,
+  setSessionStalled
 } from '@/store/session-states'
 
 import {
@@ -28,6 +31,7 @@ import {
   reconcileTileTranscripts as reconcileTileTranscriptsForTest,
   rehydrateLiveSessionStatuses,
   resetTypingActivityTracking,
+  resetLiveRuntimeTracking,
   resolveActiveTranscriptSession,
   useBackgroundSync,
   windowIsActivelyViewed
@@ -188,6 +192,7 @@ afterEach(() => {
   vi.restoreAllMocks()
   clearAllSessionStates()
   resetTypingActivityTracking()
+  resetLiveRuntimeTracking()
 })
 
 describe('active transcript refresh', () => {
@@ -700,6 +705,7 @@ describe('rehydrateLiveSessionStatuses', () => {
     expect($workingSessionIds.get()).toEqual(['overnight-exam-learning', 'temporary-file-cleanup'])
     expect($stalledSessionIds.get()).toEqual(['overnight-exam-learning'])
     expect($attentionSessionIds.get()).toEqual([])
+    expect($sessionStates.get()['runtime-overnight']?.profile).toBe('default')
   })
 
   it('restores a waiting turn as working and needing attention', () => {
@@ -724,6 +730,140 @@ describe('rehydrateLiveSessionStatuses', () => {
     expect($workingSessionIds.get()).toEqual([])
     expect($attentionSessionIds.get()).toEqual([])
     expect($stalledSessionIds.get()).toEqual([])
+  })
+
+  it('does not rewrite a same-id state owned by another profile', () => {
+    const foreign = {
+      ...createClientSessionState('shared-stored'),
+      awaitingResponse: true,
+      busy: true,
+      messages: [
+        { id: 'meta-message', parts: [{ text: 'meta transcript', type: 'text' as const }], role: 'assistant' as const }
+      ],
+      profile: 'meta'
+    }
+
+    const sibling = {
+      ...createClientSessionState('shared-stored'),
+      busy: true,
+      profile: 'default'
+    }
+
+    publishSessionState('shared-runtime', foreign)
+    publishSessionState('sibling-runtime', sibling)
+    setSessionStalled('shared-stored', true)
+
+    rehydrateLiveSessionStatuses(
+      {
+        sessions: [
+          {
+            id: 'shared-runtime',
+            last_active: 1_800_000_000,
+            session_key: 'shared-stored',
+            status: 'waiting'
+          }
+        ]
+      },
+      1_800_000_000_000,
+      'default'
+    )
+
+    expect($sessionStates.get()['shared-runtime']).toBe(foreign)
+    expect($sessionStates.get()['sibling-runtime']).toBe(sibling)
+    expect($stalledSessionIds.get()).toContain('shared-stored')
+  })
+
+  it('does not rewrite either side of runtime or stored-id sibling collisions', () => {
+    const runtimeOwner = {
+      ...createClientSessionState('stored-owner'),
+      busy: true,
+      profile: 'default'
+    }
+
+    const storedIdSibling = {
+      ...createClientSessionState('incoming-stored'),
+      busy: true,
+      profile: 'default'
+    }
+
+    publishSessionState('incoming-runtime', runtimeOwner)
+    publishSessionState('sibling-runtime', storedIdSibling)
+
+    rehydrateLiveSessionStatuses(
+      {
+        sessions: [{ id: 'incoming-runtime', session_key: 'incoming-stored', status: 'waiting' }]
+      },
+      1_800_000_000_000,
+      'default'
+    )
+
+    expect($sessionStates.get()['incoming-runtime']).toBe(runtimeOwner)
+    expect($sessionStates.get()['sibling-runtime']).toBe(storedIdSibling)
+  })
+
+  it('does not ABA-reap a same runtime and stored id reclaimed by another profile', () => {
+    rehydrateLiveSessionStatuses(
+      {
+        sessions: [{ id: 'shared-runtime', session_key: 'shared-stored', status: 'working' }]
+      },
+      1_800_000_000_000,
+      'default'
+    )
+
+    const foreign = {
+      ...createClientSessionState('shared-stored'),
+      awaitingResponse: true,
+      busy: true,
+      messages: [
+        { id: 'meta-message', parts: [{ text: 'meta transcript', type: 'text' as const }], role: 'assistant' as const }
+      ],
+      profile: 'meta'
+    }
+
+    const sibling = {
+      ...createClientSessionState('shared-stored'),
+      busy: true,
+      profile: 'default'
+    }
+
+    publishSessionState('shared-runtime', foreign)
+    publishSessionState('sibling-runtime', sibling)
+
+    rehydrateLiveSessionStatuses({ sessions: [] }, 1_800_000_001_000, 'default')
+
+    expect($sessionStates.get()['shared-runtime']).toBe(foreign)
+    expect($sessionStates.get()['sibling-runtime']).toBe(sibling)
+  })
+
+  it('does not ABA-reap a runtime reclaimed by a sibling stored session', () => {
+    rehydrateLiveSessionStatuses(
+      {
+        sessions: [{ id: 'shared-runtime', session_key: 'original-stored', status: 'working' }]
+      },
+      1_800_000_000_000,
+      'default'
+    )
+
+    const replacement = {
+      ...createClientSessionState('replacement-stored'),
+      awaitingResponse: true,
+      busy: true,
+      profile: 'default'
+    }
+
+    const sibling = {
+      ...createClientSessionState('original-stored'),
+      busy: true,
+      profile: 'default'
+    }
+
+    publishSessionState('shared-runtime', replacement)
+    publishSessionState('sibling-runtime', sibling)
+
+    rehydrateLiveSessionStatuses({ sessions: [] }, 1_800_000_001_000, 'default')
+
+    expect($sessionStates.get()['shared-runtime']).toBe(replacement)
+    expect($sessionStates.get()['sibling-runtime']).toBe(sibling)
   })
 })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -53,9 +53,13 @@ function transcript(answer: string, sessionId = ACTIVE_STORED_ID) {
   }
 }
 
-function makeRefresh(resolveSession: ActiveTranscriptRefreshDeps['resolveSession'] = () => ({ profile: 'default' })) {
+function makeRefresh(
+  resolveSession: ActiveTranscriptRefreshDeps['resolveSession'] = () => ({ profile: 'default' }),
+  selectedProfile = 'default'
+) {
   const activeSessionIdRef = { current: ACTIVE_RUNTIME_ID as string | null }
   const selectedStoredSessionIdRef = { current: ACTIVE_STORED_ID as string | null }
+  const selectedStoredSessionProfileRef = { current: selectedProfile as string | null }
   const busyRef = { current: false }
   const requestSequenceRef = { current: 0 }
   const signatureRef = { current: new Map<string, string>() }
@@ -80,11 +84,21 @@ function makeRefresh(resolveSession: ActiveTranscriptRefreshDeps['resolveSession
       requestSequenceRef,
       resolveSession,
       selectedStoredSessionIdRef,
+      selectedStoredSessionProfileRef,
       signatureRef,
       updateSessionState
     })
 
-  return { activeSessionIdRef, busyRef, refresh, selectedStoredSessionIdRef, state, states, updateSessionState }
+  return {
+    activeSessionIdRef,
+    busyRef,
+    refresh,
+    selectedStoredSessionIdRef,
+    selectedStoredSessionProfileRef,
+    state,
+    states,
+    updateSessionState
+  }
 }
 
 function useSyncHarness({
@@ -322,7 +336,7 @@ describe('active transcript refresh', () => {
         targetProfile: 'must-not-rewrite-visible-row'
       } as never
     ])
-    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    const fixture = makeRefresh(resolveActiveTranscriptSession, 'desktop-profile')
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('external answer') as never)
 
     renderSync(fixture.refresh)
@@ -424,7 +438,7 @@ describe('reconcileActiveTranscript', () => {
       targetProfile: 'wrong-target'
     })
     setMessagingSessions([{ id: ACTIVE_STORED_ID, profile: 'messaging-profile', source: 'telegram' } as never])
-    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    const fixture = makeRefresh(resolveActiveTranscriptSession, 'messaging-profile')
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('telegram answer') as never)
 
     await fixture.refresh()
@@ -447,7 +461,7 @@ describe('reconcileActiveTranscript', () => {
       mode: 'remote',
       profile: 'bot'
     })
-    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    const fixture = makeRefresh(resolveActiveTranscriptSession, 'bot')
     fixture.selectedStoredSessionIdRef.current = ambiguousStoredSessionId
 
     await fixture.refresh()
@@ -463,7 +477,7 @@ describe('reconcileActiveTranscript', () => {
       mode: 'remote',
       profile: 'presentation-profile'
     })
-    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    const fixture = makeRefresh(resolveActiveTranscriptSession, 'presentation-profile')
     fixture.selectedStoredSessionIdRef.current = hiddenStoredSessionId
 
     await fixture.refresh()
@@ -493,7 +507,7 @@ describe('reconcileActiveTranscript', () => {
       targetProfile: 'bot-a'
     })
     setSessionOwnerHint(ownerBStoredSessionId, ownerBRoute)
-    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    const fixture = makeRefresh(resolveActiveTranscriptSession, 'bot-b')
     fixture.selectedStoredSessionIdRef.current = ownerBStoredSessionId
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('owner B answer', ownerBStoredSessionId) as never)
 
@@ -512,6 +526,20 @@ describe('reconcileActiveTranscript', () => {
     expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
       text: 'owner B answer'
     })
+  })
+
+  it('resolves duplicate ids through the selected profile owner', async () => {
+    setSessions([
+      { id: ACTIVE_STORED_ID, profile: 'default', source: 'desktop' } as never,
+      { id: ACTIVE_STORED_ID, profile: 'meta', source: 'desktop' } as never
+    ])
+    const fixture = makeRefresh(resolveActiveTranscriptSession, 'meta')
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('meta answer') as never)
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, 'meta')
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({ text: 'meta answer' })
   })
 
   it('publishes changed authoritative messages once without duplicates', async () => {
@@ -571,6 +599,23 @@ describe('reconcileActiveTranscript', () => {
     fixture.selectedStoredSessionIdRef.current = 'stored-other'
     fixture.activeSessionIdRef.current = 'runtime-other'
     resolve?.(transcript('stale answer'))
+    await request
+
+    expect(fixture.updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('discards a same-id response when only the selected profile changes in flight', async () => {
+    const fixture = makeRefresh()
+    let resolve: ((value: unknown) => void) | undefined
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+
+    const request = fixture.refresh()
+    fixture.selectedStoredSessionProfileRef.current = 'meta'
+    resolve?.(transcript('stale default answer'))
     await request
 
     expect(fixture.updateSessionState).not.toHaveBeenCalled()

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -64,18 +64,32 @@ function makeRefresh(
   const requestSequenceRef = { current: 0 }
   const signatureRef = { current: new Map<string, string>() }
   const state = createClientSessionState(ACTIVE_STORED_ID)
+  state.profile = selectedProfile
   const states = new Map([[ACTIVE_RUNTIME_ID, state]])
 
-  const updateSessionStateRef = {
-    updateSessionState: vi.fn((sessionId: string, updater: (value: typeof state) => typeof state) => {
-      const next = updater(states.get(sessionId) ?? createClientSessionState(ACTIVE_STORED_ID))
-      states.set(sessionId, next)
+  const sessionStateHasOwner = vi.fn((sessionId: string, owner: { profile: string; storedSessionId: string }) => {
+    const current = states.get(sessionId)
 
-      return next
-    })
-  }
+    return current?.profile === owner.profile && current.storedSessionId === owner.storedSessionId
+  })
 
-  const { updateSessionState } = updateSessionStateRef
+  const updateOwnedSessionState = vi.fn(
+    (
+      sessionId: string,
+      owner: { profile: string; storedSessionId: string },
+      updater: (value: typeof state) => typeof state
+    ) => {
+      const current = states.get(sessionId)
+
+      if (!current || !sessionStateHasOwner(sessionId, owner)) {
+        return false
+      }
+
+      states.set(sessionId, updater(current))
+
+      return sessionStateHasOwner(sessionId, owner)
+    }
+  )
 
   const refresh = () =>
     reconcileActiveTranscript({
@@ -85,8 +99,9 @@ function makeRefresh(
       resolveSession,
       selectedStoredSessionIdRef,
       selectedStoredSessionProfileRef,
+      sessionStateHasOwner,
       signatureRef,
-      updateSessionState
+      updateOwnedSessionState
     })
 
   return {
@@ -97,7 +112,7 @@ function makeRefresh(
     selectedStoredSessionProfileRef,
     state,
     states,
-    updateSessionState
+    updateSessionState: updateOwnedSessionState
   }
 }
 
@@ -619,6 +634,34 @@ describe('reconcileActiveTranscript', () => {
     await request
 
     expect(fixture.updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('drops a delayed ABA response when the cache runtime is reclaimed by another profile', async () => {
+    const fixture = makeRefresh()
+    let resolve: ((value: unknown) => void) | undefined
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+
+    const request = fixture.refresh()
+    const reclaimedState = createClientSessionState(ACTIVE_STORED_ID)
+    reclaimedState.profile = 'meta'
+    reclaimedState.messages = [
+      { id: 'meta-existing', parts: [{ text: 'meta existing answer', type: 'text' }], role: 'assistant' }
+    ]
+    fixture.states.set(ACTIVE_RUNTIME_ID, reclaimedState)
+
+    // The mutable selection refs end at their captured values (ABA), while the
+    // cache slot with the same ids now belongs to a different profile.
+    resolve?.(transcript('stale default answer'))
+    await request
+
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)).toBe(reclaimedState)
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'meta existing answer'
+    })
   })
 })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -207,6 +207,24 @@ afterEach(() => {
 })
 
 describe('active transcript reconciliation', () => {
+  it.each([
+    ['remote-first', [{ connection_id: 'remote-a' }, {}]],
+    ['local-first', [{}, { connection_id: 'remote-a' }]]
+  ] as const)('keeps an explicit local owner local with duplicate rows (%s)', (_order, owners) => {
+    setSessions(
+      owners.map(owner => ({
+        ...owner,
+        id: ACTIVE_STORED_ID,
+        profile: 'default'
+      })) as never
+    )
+
+    expect(resolveActiveTranscriptSession(ACTIVE_STORED_ID, 'default', null)).toEqual({
+      ownerRoute: undefined,
+      profile: 'default'
+    })
+  })
+
   it('resolves same-profile same-id rows by the selected connection owner', () => {
     setSessions([
       { connection_id: 'connection-a', id: ACTIVE_STORED_ID, profile: 'default' } as never,

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -30,8 +30,8 @@ import {
   reconcileActiveTranscript,
   reconcileTileTranscripts as reconcileTileTranscriptsForTest,
   rehydrateLiveSessionStatuses,
-  resetTypingActivityTracking,
   resetLiveRuntimeTracking,
+  resetTypingActivityTracking,
   resolveActiveTranscriptSession,
   useBackgroundSync,
   windowIsActivelyViewed
@@ -214,8 +214,9 @@ describe('active transcript refresh', () => {
     $activeSessionId.set(ACTIVE_RUNTIME_ID)
     $selectedStoredSessionId.set(hiddenStoredSessionId)
     setSessionOwnerHint(hiddenStoredSessionId, ownerRoute)
-    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    const fixture = makeRefresh(resolveActiveTranscriptSession, 'bot-profile')
     fixture.selectedStoredSessionIdRef.current = hiddenStoredSessionId
+    fixture.state.storedSessionId = hiddenStoredSessionId
     vi.mocked(getLatestSessionMessages).mockResolvedValue(
       transcript('hidden external answer', hiddenStoredSessionId) as never
     )
@@ -529,6 +530,7 @@ describe('reconcileActiveTranscript', () => {
     setSessionOwnerHint(ownerBStoredSessionId, ownerBRoute)
     const fixture = makeRefresh(resolveActiveTranscriptSession, 'bot-b')
     fixture.selectedStoredSessionIdRef.current = ownerBStoredSessionId
+    fixture.state.storedSessionId = ownerBStoredSessionId
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('owner B answer', ownerBStoredSessionId) as never)
 
     await fixture.refresh()
@@ -540,8 +542,8 @@ describe('reconcileActiveTranscript', () => {
     })
     expect(fixture.updateSessionState).toHaveBeenCalledWith(
       ACTIVE_RUNTIME_ID,
+      { profile: 'bot-b', storedSessionId: ownerBStoredSessionId },
       expect.any(Function),
-      ownerBStoredSessionId
     )
     expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
       text: 'owner B answer'

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -206,7 +206,20 @@ afterEach(() => {
   resetLiveRuntimeTracking()
 })
 
-describe('active transcript refresh', () => {
+describe('active transcript reconciliation', () => {
+  it('resolves same-profile same-id rows by the selected connection owner', () => {
+    setSessions([
+      { connection_id: 'connection-a', id: ACTIVE_STORED_ID, profile: 'default' } as never,
+      { connection_id: 'connection-b', id: ACTIVE_STORED_ID, profile: 'default' } as never
+    ])
+
+    expect(resolveActiveTranscriptSession(ACTIVE_STORED_ID, 'default', 'connection-a')?.ownerRoute?.connectionId).toBe(
+      'connection-a'
+    )
+    expect(resolveActiveTranscriptSession(ACTIVE_STORED_ID, 'default', 'connection-b')?.ownerRoute?.connectionId).toBe(
+      'connection-b'
+    )
+  })
   beforeEach(() => {
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('answer') as never)
   })

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -1,15 +1,22 @@
 import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
 import { $activeSessionId } from '@/store/session'
+import { $sessionStates, clearAllSessionStates, publishSessionState } from '@/store/session-states'
 
 import { useBackgroundSync } from './use-background-sync'
 
 const noop = () => undefined
-const requestGateway = async () => ({ sessions: [] })
+const defaultRequestGateway = async () => ({ sessions: [] })
 
-function render(activeGatewayProfile: string, activeConnectionId: string, refreshSessions: () => Promise<void>) {
+function render(
+  activeGatewayProfile: string,
+  activeConnectionId: string,
+  refreshSessions: () => Promise<void>,
+  requestGateway: Parameters<typeof useBackgroundSync>[0]['requestGateway'] = defaultRequestGateway
+) {
   return renderHook(
     ({ connectionId, profile }: { connectionId: string; profile: string }) => {
       useBackgroundSync({
@@ -26,7 +33,9 @@ function render(activeGatewayProfile: string, activeConnectionId: string, refres
         refreshHermesConfig: noop,
         refreshMessagingSessions: noop,
         refreshSessions,
-        requestGateway
+        requestGateway,
+        sessionStateHasOwner: () => true,
+        updateOwnedSessionState: () => true
       })
     },
     { initialProps: { connectionId: activeConnectionId, profile: activeGatewayProfile } }
@@ -40,6 +49,7 @@ describe('useBackgroundSync profile-scoped session refresh', () => {
     $changeEventsAvailable.set(false)
     $cronChangeTick.set(0)
     $sessionsChangeTick.set(0)
+    clearAllSessionStates()
   })
 
   afterEach(() => {
@@ -72,5 +82,50 @@ describe('useBackgroundSync profile-scoped session refresh', () => {
 
     await act(async () => undefined)
     expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a delayed active_list response when the same profile switches connections', async () => {
+    let resolveConnectionA: ((value: unknown) => void) | undefined
+
+    const requestGateway = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveConnectionA = resolve
+          })
+      )
+      .mockResolvedValue({ sessions: [] })
+
+    const hook = render(
+      'default',
+      'connection-a',
+      vi.fn(async () => undefined),
+      requestGateway
+    )
+
+    await act(async () => undefined)
+    hook.rerender({ connectionId: 'connection-b', profile: 'default' })
+    await act(async () => undefined)
+
+    const ownerB = {
+      ...createClientSessionState('stored-shared'),
+      awaitingResponse: true,
+      busy: true,
+      connectionId: 'connection-b',
+      profile: 'default'
+    }
+
+    publishSessionState('runtime-shared', ownerB)
+
+    await act(async () => {
+      resolveConnectionA?.({
+        sessions: [{ id: 'runtime-shared', session_key: 'stored-shared', status: 'working' }]
+      })
+      await Promise.resolve()
+    })
+
+    expect(requestGateway).toHaveBeenCalledTimes(2)
+    expect($sessionStates.get()['runtime-shared']).toBe(ownerB)
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
 import { $activeSessionId } from '@/store/session'
-import { $sessionStates, clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import { clearAllSessionStates, getSessionState, publishSessionState } from '@/store/session-states'
 
 import { useBackgroundSync } from './use-background-sync'
 
@@ -126,6 +126,6 @@ describe('useBackgroundSync profile-scoped session refresh', () => {
     })
 
     expect(requestGateway).toHaveBeenCalledTimes(2)
-    expect($sessionStates.get()['runtime-shared']).toBe(ownerB)
+    expect(getSessionState('runtime-shared', { connectionId: 'connection-b', profile: 'default' })).toBe(ownerB)
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -8,7 +8,7 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
 import { $onBattery, batteryPollInterval } from '@/store/power'
-import { refreshActiveProfile } from '@/store/profile'
+import { normalizeProfileKey, refreshActiveProfile } from '@/store/profile'
 import {
   $activeSessionId,
   $busy,
@@ -38,10 +38,24 @@ interface ActiveTranscriptSession {
 }
 
 /** Resolve an active transcript from visible rows or its unique hidden owner. */
-export function resolveActiveTranscriptSession(storedSessionId: string): ActiveTranscriptSession | undefined {
+export function resolveActiveTranscriptSession(
+  storedSessionId: string,
+  ownerProfile: string
+): ActiveTranscriptSession | undefined {
+  const owner = normalizeProfileKey(ownerProfile)
   const visible =
-    $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
-    $messagingSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+    $sessions
+      .get()
+      .find(
+        session =>
+          sessionMatchesStoredId(session, storedSessionId) && normalizeProfileKey(session.profile) === owner
+      ) ??
+    $messagingSessions
+      .get()
+      .find(
+        session =>
+          sessionMatchesStoredId(session, storedSessionId) && normalizeProfileKey(session.profile) === owner
+      )
 
   if (visible) {
     return { profile: visible.profile }
@@ -49,7 +63,9 @@ export function resolveActiveTranscriptSession(storedSessionId: string): ActiveT
 
   const ownerRoute = getSessionOwnerHint(storedSessionId)
 
-  return ownerRoute ? { ownerRoute, profile: ownerRoute.profile } : undefined
+  return ownerRoute && normalizeProfileKey(ownerRoute.targetProfile ?? ownerRoute.profile) === owner
+    ? { ownerRoute, profile: ownerRoute.profile }
+    : undefined
 }
 
 export interface ActiveTranscriptRefreshDeps {
@@ -57,7 +73,8 @@ export interface ActiveTranscriptRefreshDeps {
   busyRef: MutableRefObject<boolean>
   requestSequenceRef: MutableRefObject<number>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
-  resolveSession: (storedSessionId: string) => ActiveTranscriptSession | null | undefined
+  selectedStoredSessionProfileRef: MutableRefObject<string | null>
+  resolveSession: (storedSessionId: string, ownerProfile: string) => ActiveTranscriptSession | null | undefined
   signatureRef: MutableRefObject<Map<string, string>>
   updateSessionState: (
     sessionId: string,
@@ -173,17 +190,19 @@ export async function reconcileActiveTranscript({
   requestSequenceRef,
   resolveSession,
   selectedStoredSessionIdRef,
+  selectedStoredSessionProfileRef,
   signatureRef,
   updateSessionState
 }: ActiveTranscriptRefreshDeps): Promise<void> {
   const storedSessionId = selectedStoredSessionIdRef.current
+  const storedSessionProfile = selectedStoredSessionProfileRef.current
   const runtimeSessionId = activeSessionIdRef.current
 
-  if (!storedSessionId || !runtimeSessionId || busyRef.current) {
+  if (!storedSessionId || !storedSessionProfile || !runtimeSessionId || busyRef.current) {
     return
   }
 
-  const stored = resolveSession(storedSessionId)
+  const stored = resolveSession(storedSessionId, storedSessionProfile)
 
   if (!stored) {
     return
@@ -206,6 +225,7 @@ export async function reconcileActiveTranscript({
       requestId !== requestSequenceRef.current ||
       busyRef.current ||
       selectedStoredSessionIdRef.current !== storedSessionId ||
+      selectedStoredSessionProfileRef.current !== storedSessionProfile ||
       activeSessionIdRef.current !== runtimeSessionId
     ) {
       return

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -29,6 +29,7 @@ import {
   setSessionStalled
 } from '@/store/session-states'
 
+import type { SessionStateOwner } from '../../session/session-state-cache'
 import type { ClientSessionState } from '../../types'
 import type { GatewayRequester } from '../types'
 
@@ -75,12 +76,13 @@ export interface ActiveTranscriptRefreshDeps {
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   selectedStoredSessionProfileRef: MutableRefObject<string | null>
   resolveSession: (storedSessionId: string, ownerProfile: string) => ActiveTranscriptSession | null | undefined
+  sessionStateHasOwner: (sessionId: string, owner: SessionStateOwner) => boolean
   signatureRef: MutableRefObject<Map<string, string>>
-  updateSessionState: (
+  updateOwnedSessionState: (
     sessionId: string,
-    updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
-  ) => ClientSessionState
+    owner: SessionStateOwner,
+    updater: (state: ClientSessionState) => ClientSessionState
+  ) => boolean
 }
 
 /**
@@ -191,8 +193,9 @@ export async function reconcileActiveTranscript({
   resolveSession,
   selectedStoredSessionIdRef,
   selectedStoredSessionProfileRef,
+  sessionStateHasOwner,
   signatureRef,
-  updateSessionState
+  updateOwnedSessionState
 }: ActiveTranscriptRefreshDeps): Promise<void> {
   const storedSessionId = selectedStoredSessionIdRef.current
   const storedSessionProfile = selectedStoredSessionProfileRef.current
@@ -247,20 +250,25 @@ export async function reconcileActiveTranscript({
       return
     }
 
-    signatureRef.current.set(signatureKey, signature)
     const messages = toChatMessages(latest.messages)
+    const owner = { profile: storedSessionProfile, storedSessionId }
 
-    updateSessionState(
-      runtimeSessionId,
-      state => ({
+    if (
+      !updateOwnedSessionState(runtimeSessionId, owner, state => ({
         ...state,
         // The refresh re-reads only the newest tail page; graft it onto any
         // older pages "Show earlier" already backfilled instead of clobbering
         // them (see transcript-backfill).
         messages: preserveLocalAssistantErrors(graftRefreshedTailOntoBackfill(messages, state.messages), state.messages)
-      }),
-      storedSessionId
-    )
+      })) ||
+      !sessionStateHasOwner(runtimeSessionId, owner)
+    ) {
+      return
+    }
+
+    // Only suppress a future refresh after this snapshot was actually accepted
+    // by the captured composite cache owner.
+    signatureRef.current.set(signatureKey, signature)
   } catch {
     // Non-fatal: the next change event or manual resume can hydrate the view.
   }

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -44,6 +44,7 @@ export function resolveActiveTranscriptSession(
   ownerProfile: string
 ): ActiveTranscriptSession | undefined {
   const owner = normalizeProfileKey(ownerProfile)
+
   const visible =
     $sessions
       .get()

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -29,7 +29,7 @@ import {
   setSessionStalled
 } from '@/store/session-states'
 
-import type { SessionStateOwner } from '../../session/session-state-cache'
+import { sessionStateMatchesOwner, type SessionStateOwner } from '../../session/session-state-cache'
 import type { ClientSessionState } from '../../types'
 import type { GatewayRequester } from '../types'
 
@@ -323,11 +323,11 @@ interface LiveSessionStatusResponse {
   sessions?: LiveSessionStatusItem[]
 }
 
-// Runtime ids this poll has seen live, per gateway profile. A profile only
-// ever reaps what its OWN snapshot previously reported: background profiles are
-// served by different gateways and never appear in this profile's active_list,
-// so an unscoped reap would dark out every other profile's running rows.
-const liveRuntimeIdsByProfile = new Map<string, Set<string>>()
+// Runtime → stored-session ownership this poll has seen live, per gateway
+// profile. Keeping both ids is load-bearing: a runtime id can be reused between
+// snapshots, including by another profile, and the old snapshot must not reap
+// or rewrite the replacement (ABA).
+const liveRuntimeOwnersByProfile = new Map<string, Map<string, string>>()
 
 // Renderer-wide keyboard warmth, tracked at module scope like the live-runtime
 // bookkeeping above: any keydown anywhere in the window marks activity, and a
@@ -373,7 +373,8 @@ export function rehydrateLiveSessionStatuses(
   nowMs = Date.now(),
   profileKey = 'default'
 ): void {
-  const seen = new Set<string>()
+  const ownerProfile = normalizeProfileKey(profileKey)
+  const seen = new Map<string, string>()
 
   for (const session of response.sessions ?? []) {
     const runtimeSessionId = session.id?.trim()
@@ -385,9 +386,17 @@ export function rehydrateLiveSessionStatuses(
       continue
     }
 
-    seen.add(runtimeSessionId)
-
     const existing = $sessionStates.get()[runtimeSessionId]
+    const owner = { profile: ownerProfile, storedSessionId }
+
+    // Runtime ids are transport-local and can collide or be reused. Once a
+    // slot exists, this snapshot may touch it only when BOTH durable owner
+    // coordinates still match. Unknown profile provenance also fails closed.
+    if (existing && !sessionStateMatchesOwner(existing, owner)) {
+      continue
+    }
+
+    seen.set(runtimeSessionId, storedSessionId)
 
     // A turn we just submitted is not yet running as far as the backend is
     // concerned, so the snapshot honestly reports it idle — but the local
@@ -406,8 +415,10 @@ export function rehydrateLiveSessionStatuses(
       existing.busy !== busy ||
       existing.needsInput !== needsInput
     ) {
+      const ownedState = existing ?? { ...createClientSessionState(storedSessionId), profile: ownerProfile }
+
       publishSessionState(runtimeSessionId, {
-        ...(existing ?? createClientSessionState(storedSessionId)),
+        ...ownedState,
         busy,
         needsInput,
         storedSessionId
@@ -437,17 +448,21 @@ export function rehydrateLiveSessionStatuses(
   // path so the busy→idle transition fires — that edge is what clears the
   // spinner AND marks the row unread ("your turn"). Only ids this profile
   // previously saw are eligible, so another profile's live rows are untouched.
-  const previouslyLive = liveRuntimeIdsByProfile.get(profileKey)
+  const previouslyLive = liveRuntimeOwnersByProfile.get(ownerProfile)
 
   if (previouslyLive) {
-    for (const runtimeSessionId of previouslyLive) {
-      if (seen.has(runtimeSessionId)) {
+    for (const [runtimeSessionId, storedSessionId] of previouslyLive) {
+      if (seen.get(runtimeSessionId) === storedSessionId) {
         continue
       }
 
       const existing = $sessionStates.get()[runtimeSessionId]
+      const owner = { profile: ownerProfile, storedSessionId }
 
-      if (existing?.busy || existing?.needsInput || existing?.awaitingResponse) {
+      if (
+        sessionStateMatchesOwner(existing, owner) &&
+        (existing.busy || existing.needsInput || existing.awaitingResponse)
+      ) {
         publishSessionState(runtimeSessionId, {
           ...existing,
           awaitingResponse: false,
@@ -466,14 +481,14 @@ export function rehydrateLiveSessionStatuses(
     }
   }
 
-  liveRuntimeIdsByProfile.set(profileKey, seen)
+  liveRuntimeOwnersByProfile.set(ownerProfile, seen)
 }
 
 /** Forget every profile's live-runtime bookkeeping. A gateway wipe already
  *  drops the session states these ids point at, so a carried-over set would
  *  only reap runtimes that no longer exist. */
 export function resetLiveRuntimeTracking(): void {
-  liveRuntimeIdsByProfile.clear()
+  liveRuntimeOwnersByProfile.clear()
 }
 
 interface BackgroundSyncParams {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -47,7 +47,10 @@ export function resolveActiveTranscriptSession(
   ownerConnectionId?: null | string
 ): ActiveTranscriptSession | undefined {
   const owner = normalizeProfileKey(ownerProfile)
-  const connectionId = ownerConnectionId?.trim() || null
+  const connectionId = ownerConnectionId === undefined ? undefined : ownerConnectionId?.trim() || null
+
+  const matchesConnection = (route: SessionProfileRoute | undefined) =>
+    connectionId === undefined || (connectionId === null ? route === undefined : route?.connectionId === connectionId)
 
   const matchesOwner = (session: SessionInfo) => {
     const route = sessionOwnerRouteFromRow(session)
@@ -55,7 +58,7 @@ export function resolveActiveTranscriptSession(
     return (
       sessionMatchesStoredId(session, storedSessionId) &&
       normalizeProfileKey(session.profile) === owner &&
-      (!connectionId || route?.connectionId === connectionId)
+      matchesConnection(route)
     )
   }
 
@@ -69,7 +72,7 @@ export function resolveActiveTranscriptSession(
 
   return ownerRoute &&
     normalizeProfileKey(ownerRoute.targetProfile ?? ownerRoute.profile) === owner &&
-    (!connectionId || ownerRoute.connectionId === connectionId)
+    matchesConnection(ownerRoute)
     ? { ownerRoute, profile: ownerRoute.profile }
     : undefined
 }

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -1,3 +1,4 @@
+import { registryBackendScopeKey } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
@@ -20,7 +21,7 @@ import {
   sessionMatchesStoredId,
   setCurrentCwd
 } from '@/store/session'
-import type { SessionProfileRoute } from '@/store/session-request-router'
+import { sessionOwnerRouteFromRow, type SessionProfileRoute } from '@/store/session-request-router'
 import {
   $sessionStates,
   $sessionTiles,
@@ -49,18 +50,16 @@ export function resolveActiveTranscriptSession(
     $sessions
       .get()
       .find(
-        session =>
-          sessionMatchesStoredId(session, storedSessionId) && normalizeProfileKey(session.profile) === owner
+        session => sessionMatchesStoredId(session, storedSessionId) && normalizeProfileKey(session.profile) === owner
       ) ??
     $messagingSessions
       .get()
       .find(
-        session =>
-          sessionMatchesStoredId(session, storedSessionId) && normalizeProfileKey(session.profile) === owner
+        session => sessionMatchesStoredId(session, storedSessionId) && normalizeProfileKey(session.profile) === owner
       )
 
   if (visible) {
-    return { profile: visible.profile }
+    return { ownerRoute: sessionOwnerRouteFromRow(visible), profile: visible.profile }
   }
 
   const ownerRoute = getSessionOwnerHint(storedSessionId)
@@ -106,24 +105,42 @@ export async function reconcileTileTranscripts({
   requestSequenceRef,
   busyRef,
   signatureRef,
-  updateSessionState,
+  sessionStateHasOwner,
+  updateOwnedSessionState,
+  defaultScope,
   tiles: tilesOverride
 }: {
   busyRef: MutableRefObject<boolean>
   requestSequenceRef: MutableRefObject<number>
   signatureRef: MutableRefObject<Map<string, string>>
-  tiles?: Array<{ storedSessionId: string; runtimeId?: string }>
-  updateSessionState: (
+  defaultScope?: { connectionId?: null | string; profile: string }
+  sessionStateHasOwner: (sessionId: string, owner: SessionStateOwner) => boolean
+  tiles?: Array<{ ownerRoute?: SessionProfileRoute; storedSessionId: string; runtimeId?: string }>
+  updateOwnedSessionState: (
     sessionId: string,
-    updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
-  ) => ClientSessionState
+    owner: SessionStateOwner,
+    updater: (state: ClientSessionState) => ClientSessionState
+  ) => boolean
 }): Promise<void> {
   const tiles = tilesOverride ?? $sessionTiles.get()
 
   for (const tile of tiles) {
     const storedSessionId = tile.storedSessionId
     const runtimeSessionId = tile.runtimeId
+
+    const ownerProfile = normalizeProfileKey(
+      tile.ownerRoute?.targetProfile ?? tile.ownerRoute?.profile ?? defaultScope?.profile
+    )
+
+    const owner: SessionStateOwner = {
+      connectionId: tile.ownerRoute?.connectionId ?? defaultScope?.connectionId,
+      profile: ownerProfile,
+      storedSessionId
+    }
+
+    const profileScope: ProfileScope = owner.connectionId
+      ? { connectionId: owner.connectionId, profile: owner.profile }
+      : owner.profile
 
     if (!runtimeSessionId) {
       // Resume not yet bound — the tile's own stream owns the view.
@@ -143,14 +160,20 @@ export async function reconcileTileTranscripts({
 
     // With a tiles override (test path), the live $sessionTiles check can't
     // see the synthetic tile — treat override tiles as present.
-    const stillPresent = tilesOverride
-      ? tilesOverride.some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
-      : $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
+    const stillPresent = () =>
+      (tilesOverride ?? $sessionTiles.get()).some(
+        t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId
+      )
 
     try {
-      const latest = await getLatestSessionMessages(storedSessionId)
+      const latest = await getLatestSessionMessages(storedSessionId, profileScope)
 
-      if (requestId !== requestSequenceRef.current || busyRef.current || !stillPresent) {
+      if (
+        requestId !== requestSequenceRef.current ||
+        busyRef.current ||
+        !stillPresent() ||
+        !sessionStateHasOwner(runtimeSessionId, owner)
+      ) {
         // Tile closed or superseded mid-read — discard AND prune its
         // signature so the map doesn't grow one entry per ever-opened tile
         // for the app's lifetime (#94255 review point 3).
@@ -159,27 +182,28 @@ export async function reconcileTileTranscripts({
         continue
       }
 
-      const signatureKey = `tile:${storedSessionId}`
+      const signatureKey = `tile:${JSON.stringify([owner.connectionId ?? '', owner.profile, storedSessionId])}`
       const signature = sessionMessagesSignature(latest.messages)
 
       if (signatureRef.current.get(signatureKey) === signature) {
         continue
       }
 
-      signatureRef.current.set(signatureKey, signature)
       const messages = toChatMessages(latest.messages)
 
-      updateSessionState(
-        runtimeSessionId,
-        state => ({
+      if (
+        !updateOwnedSessionState(runtimeSessionId, owner, state => ({
           ...state,
           messages: preserveLocalAssistantErrors(
             graftRefreshedTailOntoBackfill(messages, state.messages),
             state.messages
           )
-        }),
-        storedSessionId
-      )
+        }))
+      ) {
+        continue
+      }
+
+      signatureRef.current.set(signatureKey, signature)
     } catch {
       // Non-fatal: the next change event retries.
     }
@@ -230,7 +254,12 @@ export async function reconcileActiveTranscript({
       busyRef.current ||
       selectedStoredSessionIdRef.current !== storedSessionId ||
       selectedStoredSessionProfileRef.current !== storedSessionProfile ||
-      activeSessionIdRef.current !== runtimeSessionId
+      activeSessionIdRef.current !== runtimeSessionId ||
+      !sessionStateHasOwner(runtimeSessionId, {
+        connectionId: stored.ownerRoute?.connectionId,
+        profile: storedSessionProfile,
+        storedSessionId
+      })
     ) {
       return
     }
@@ -252,7 +281,12 @@ export async function reconcileActiveTranscript({
     }
 
     const messages = toChatMessages(latest.messages)
-    const owner = { profile: storedSessionProfile, storedSessionId }
+
+    const owner: SessionStateOwner = {
+      connectionId: stored.ownerRoute?.connectionId,
+      profile: storedSessionProfile,
+      storedSessionId
+    }
 
     if (
       !updateOwnedSessionState(runtimeSessionId, owner, state => ({
@@ -324,11 +358,11 @@ interface LiveSessionStatusResponse {
   sessions?: LiveSessionStatusItem[]
 }
 
-// Runtime → stored-session ownership this poll has seen live, per gateway
-// profile. Keeping both ids is load-bearing: a runtime id can be reused between
-// snapshots, including by another profile, and the old snapshot must not reap
+// Runtime → stored-session ownership this poll has seen live, per backend
+// connection/profile scope. Keeping both ids is load-bearing: a runtime id can be reused between
+// snapshots, including by another backend scope, and the old snapshot must not reap
 // or rewrite the replacement (ABA).
-const liveRuntimeOwnersByProfile = new Map<string, Map<string, string>>()
+const liveRuntimeOwnersByScope = new Map<string, Map<string, string>>()
 
 // Renderer-wide keyboard warmth, tracked at module scope like the live-runtime
 // bookkeeping above: any keydown anywhere in the window marks activity, and a
@@ -372,9 +406,12 @@ export function resetTypingActivityTracking(): void {
 export function rehydrateLiveSessionStatuses(
   response: LiveSessionStatusResponse,
   nowMs = Date.now(),
-  profileKey = 'default'
+  profileKey = 'default',
+  connectionId: null | string = null
 ): void {
   const ownerProfile = normalizeProfileKey(profileKey)
+  const ownerConnectionId = connectionId?.trim() || null
+  const ownerScope = registryBackendScopeKey(ownerConnectionId, ownerProfile)
   const occupiedRuntimeIds = new Set<string>()
   const seen = new Map<string, string>()
 
@@ -395,7 +432,7 @@ export function rehydrateLiveSessionStatuses(
     occupiedRuntimeIds.add(runtimeSessionId)
 
     const existing = $sessionStates.get()[runtimeSessionId]
-    const owner = { profile: ownerProfile, storedSessionId }
+    const owner = { connectionId: ownerConnectionId, profile: ownerProfile, storedSessionId }
 
     // Runtime ids are transport-local and can collide or be reused. Once a
     // slot exists, this snapshot may touch it only when BOTH durable owner
@@ -423,7 +460,11 @@ export function rehydrateLiveSessionStatuses(
       existing.busy !== busy ||
       existing.needsInput !== needsInput
     ) {
-      const ownedState = existing ?? { ...createClientSessionState(storedSessionId), profile: ownerProfile }
+      const ownedState = existing ?? {
+        ...createClientSessionState(storedSessionId),
+        connectionId: ownerConnectionId,
+        profile: ownerProfile
+      }
 
       publishSessionState(runtimeSessionId, {
         ...ownedState,
@@ -454,9 +495,9 @@ export function rehydrateLiveSessionStatuses(
   // has ended: the gateway reaps a session out of `_sessions` when its turn
   // completes and its transport goes away. Settle it through the normal publish
   // path so the busy→idle transition fires — that edge is what clears the
-  // spinner AND marks the row unread ("your turn"). Only ids this profile
-  // previously saw are eligible, so another profile's live rows are untouched.
-  const previouslyLive = liveRuntimeOwnersByProfile.get(ownerProfile)
+  // spinner AND marks the row unread ("your turn"). Only ids this backend
+  // scope previously saw are eligible, so another scope's live rows are untouched.
+  const previouslyLive = liveRuntimeOwnersByScope.get(ownerScope)
 
   if (previouslyLive) {
     for (const [runtimeSessionId, storedSessionId] of previouslyLive) {
@@ -465,7 +506,7 @@ export function rehydrateLiveSessionStatuses(
       }
 
       const existing = $sessionStates.get()[runtimeSessionId]
-      const owner = { profile: ownerProfile, storedSessionId }
+      const owner = { connectionId: ownerConnectionId, profile: ownerProfile, storedSessionId }
 
       if (
         sessionStateMatchesOwner(existing, owner) &&
@@ -489,14 +530,14 @@ export function rehydrateLiveSessionStatuses(
     }
   }
 
-  liveRuntimeOwnersByProfile.set(ownerProfile, seen)
+  liveRuntimeOwnersByScope.set(ownerScope, seen)
 }
 
-/** Forget every profile's live-runtime bookkeeping. A gateway wipe already
+/** Forget every backend scope's live-runtime bookkeeping. A gateway wipe already
  *  drops the session states these ids point at, so a carried-over set would
  *  only reap runtimes that no longer exist. */
 export function resetLiveRuntimeTracking(): void {
-  liveRuntimeOwnersByProfile.clear()
+  liveRuntimeOwnersByScope.clear()
 }
 
 interface BackgroundSyncParams {
@@ -514,11 +555,12 @@ interface BackgroundSyncParams {
   refreshMessagingSessions: () => Promise<unknown> | unknown
   refreshSessions: () => Promise<unknown> | unknown
   requestGateway: GatewayRequester
-  updateSessionState: (
+  sessionStateHasOwner: (sessionId: string, owner: SessionStateOwner) => boolean
+  updateOwnedSessionState: (
     sessionId: string,
-    updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
-  ) => ClientSessionState
+    owner: SessionStateOwner,
+    updater: (state: ClientSessionState) => ClientSessionState
+  ) => boolean
 }
 
 /** Poll a callback while the tab is visible, on `intervalMs`; re-checks on tab
@@ -587,7 +629,8 @@ export function useBackgroundSync({
   refreshMessagingSessions,
   refreshSessions,
   requestGateway,
-  updateSessionState
+  sessionStateHasOwner,
+  updateOwnedSessionState
 }: BackgroundSyncParams): void {
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
@@ -699,7 +742,7 @@ export function useBackgroundSync({
         const response = await requestGateway<LiveSessionStatusResponse>('session.active_list', {})
 
         if (!cancelled) {
-          rehydrateLiveSessionStatuses(response, Date.now(), activeGatewayProfile)
+          rehydrateLiveSessionStatuses(response, Date.now(), activeGatewayProfile, activeConnectionId)
         }
       } catch {
         // Older gateways may not expose session.active_list. Live stream events
@@ -722,7 +765,14 @@ export function useBackgroundSync({
     }
     // sessionsChangeTick: each sessions.changed broadcast re-seeds immediately
     // via the effect re-run (already coalesced to 2s server-side).
-  }, [activeGatewayProfile, changeEventsAvailable, gatewayState, requestGateway, sessionsChangeTick])
+  }, [
+    activeConnectionId,
+    activeGatewayProfile,
+    changeEventsAvailable,
+    gatewayState,
+    requestGateway,
+    sessionsChangeTick
+  ])
 
   // sessions.changed also means the *stored* list may have new rows (a cron
   // run's session, an inbound messaging turn creating a thread). The full list
@@ -755,7 +805,9 @@ export function useBackgroundSync({
         },
         requestSequenceRef: tileRequestSequenceRef,
         signatureRef: tileSignatureRef,
-        updateSessionState
+        defaultScope: { connectionId: activeConnectionId, profile: activeGatewayProfile },
+        sessionStateHasOwner,
+        updateOwnedSessionState
       })
     }
 
@@ -819,7 +871,10 @@ export function useBackgroundSync({
     refreshMessagingSessions,
     refreshSessions,
     requestActiveTranscriptRefresh,
-    updateSessionState
+    activeConnectionId,
+    activeGatewayProfile,
+    sessionStateHasOwner,
+    updateOwnedSessionState
   ])
 
   // Keyboard warmth for the deferral above: capture phase on window. Any

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -23,12 +23,13 @@ import {
 } from '@/store/session'
 import { sessionOwnerRouteFromRow, type SessionProfileRoute } from '@/store/session-request-router'
 import {
-  $sessionStates,
   $sessionTiles,
+  getSessionState,
   publishSessionState,
   SESSION_WATCHDOG_TIMEOUT_MS,
   setSessionStalled
 } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
 
 import { sessionStateMatchesOwner, type SessionStateOwner } from '../../session/session-state-cache'
 import type { ClientSessionState } from '../../types'
@@ -42,21 +43,23 @@ interface ActiveTranscriptSession {
 /** Resolve an active transcript from visible rows or its unique hidden owner. */
 export function resolveActiveTranscriptSession(
   storedSessionId: string,
-  ownerProfile: string
+  ownerProfile: string,
+  ownerConnectionId?: null | string
 ): ActiveTranscriptSession | undefined {
   const owner = normalizeProfileKey(ownerProfile)
+  const connectionId = ownerConnectionId?.trim() || null
 
-  const visible =
-    $sessions
-      .get()
-      .find(
-        session => sessionMatchesStoredId(session, storedSessionId) && normalizeProfileKey(session.profile) === owner
-      ) ??
-    $messagingSessions
-      .get()
-      .find(
-        session => sessionMatchesStoredId(session, storedSessionId) && normalizeProfileKey(session.profile) === owner
-      )
+  const matchesOwner = (session: SessionInfo) => {
+    const route = sessionOwnerRouteFromRow(session)
+
+    return (
+      sessionMatchesStoredId(session, storedSessionId) &&
+      normalizeProfileKey(session.profile) === owner &&
+      (!connectionId || route?.connectionId === connectionId)
+    )
+  }
+
+  const visible = $sessions.get().find(matchesOwner) ?? $messagingSessions.get().find(matchesOwner)
 
   if (visible) {
     return { ownerRoute: sessionOwnerRouteFromRow(visible), profile: visible.profile }
@@ -64,7 +67,9 @@ export function resolveActiveTranscriptSession(
 
   const ownerRoute = getSessionOwnerHint(storedSessionId)
 
-  return ownerRoute && normalizeProfileKey(ownerRoute.targetProfile ?? ownerRoute.profile) === owner
+  return ownerRoute &&
+    normalizeProfileKey(ownerRoute.targetProfile ?? ownerRoute.profile) === owner &&
+    (!connectionId || ownerRoute.connectionId === connectionId)
     ? { ownerRoute, profile: ownerRoute.profile }
     : undefined
 }
@@ -431,13 +436,17 @@ export function rehydrateLiveSessionStatuses(
     // misclassify the rejected replacement as disappearance of the old owner.
     occupiedRuntimeIds.add(runtimeSessionId)
 
-    const existing = $sessionStates.get()[runtimeSessionId]
+    const existing = getSessionState(runtimeSessionId, {
+      connectionId: ownerConnectionId,
+      profile: ownerProfile
+    })
+
     const owner = { connectionId: ownerConnectionId, profile: ownerProfile, storedSessionId }
 
     // Runtime ids are transport-local and can collide or be reused. Once a
     // slot exists, this snapshot may touch it only when BOTH durable owner
     // coordinates still match. Unknown profile provenance also fails closed.
-    if (existing && !sessionStateMatchesOwner(existing, owner)) {
+    if (!ownerConnectionId && existing && !sessionStateMatchesOwner(existing, owner)) {
       continue
     }
 
@@ -475,7 +484,7 @@ export function rehydrateLiveSessionStatuses(
     }
 
     if (!working) {
-      setSessionStalled(storedSessionId, false)
+      setSessionStalled(storedSessionId, false, owner)
 
       continue
     }
@@ -488,7 +497,7 @@ export function rehydrateLiveSessionStatuses(
       lastActiveMs > 0 &&
       nowMs - lastActiveMs >= SESSION_WATCHDOG_TIMEOUT_MS
 
-    setSessionStalled(storedSessionId, isQuiet)
+    setSessionStalled(storedSessionId, isQuiet, owner)
   }
 
   // A runtime this profile's snapshot reported live LAST poll but not this one
@@ -505,7 +514,11 @@ export function rehydrateLiveSessionStatuses(
         continue
       }
 
-      const existing = $sessionStates.get()[runtimeSessionId]
+      const existing = getSessionState(runtimeSessionId, {
+        connectionId: ownerConnectionId,
+        profile: ownerProfile
+      })
+
       const owner = { connectionId: ownerConnectionId, profile: ownerProfile, storedSessionId }
 
       if (

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -374,6 +374,7 @@ export function rehydrateLiveSessionStatuses(
   profileKey = 'default'
 ): void {
   const ownerProfile = normalizeProfileKey(profileKey)
+  const occupiedRuntimeIds = new Set<string>()
   const seen = new Map<string, string>()
 
   for (const session of response.sessions ?? []) {
@@ -385,6 +386,12 @@ export function rehydrateLiveSessionStatuses(
     if (!runtimeSessionId || !storedSessionId) {
       continue
     }
+
+    // Even when the durable owner conflicts with the renderer cache, this
+    // profile's current snapshot proves the runtime slot is occupied. Record
+    // that fact before the fail-closed owner check so the absence reaper cannot
+    // misclassify the rejected replacement as disappearance of the old owner.
+    occupiedRuntimeIds.add(runtimeSessionId)
 
     const existing = $sessionStates.get()[runtimeSessionId]
     const owner = { profile: ownerProfile, storedSessionId }
@@ -452,7 +459,7 @@ export function rehydrateLiveSessionStatuses(
 
   if (previouslyLive) {
     for (const [runtimeSessionId, storedSessionId] of previouslyLive) {
-      if (seen.get(runtimeSessionId) === storedSessionId) {
+      if (occupiedRuntimeIds.has(runtimeSessionId)) {
         continue
       }
 

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -81,6 +81,7 @@ describe('useDesktopIntegrations', () => {
     profileReady = false,
     resumeExhaustedSessionId = null as string | null,
     routedSessionId = null as string | null,
+    routedSessionProfile = null as string | null,
     sessions = [] as readonly SessionInfo[]
   } = {}) {
     return renderHook(
@@ -90,6 +91,7 @@ describe('useDesktopIntegrations', () => {
         profileReady,
         resumeExhaustedSessionId,
         routedSessionId,
+        routedSessionProfile,
         sessions
       }: {
         activeProfile: string
@@ -97,6 +99,7 @@ describe('useDesktopIntegrations', () => {
         profileReady: boolean
         resumeExhaustedSessionId: string | null
         routedSessionId: string | null
+        routedSessionProfile?: string | null
         sessions: readonly SessionInfo[]
       }) =>
         useDesktopIntegrations({
@@ -109,6 +112,7 @@ describe('useDesktopIntegrations', () => {
           refreshSessions: vi.fn(),
           resumeExhaustedSessionId,
           routedSessionId,
+          routedSessionProfile,
           runtimeIdByStoredSessionId: { current: new Map() },
           sessions
         }),
@@ -119,6 +123,7 @@ describe('useDesktopIntegrations', () => {
           profileReady,
           resumeExhaustedSessionId,
           routedSessionId,
+          routedSessionProfile,
           sessions
         }
       }
@@ -172,6 +177,7 @@ describe('useDesktopIntegrations', () => {
         profileReady: true,
         resumeExhaustedSessionId: null,
         routedSessionId: null,
+        routedSessionProfile: null,
         sessions: [session({ id: 'remembered-session', profile: 'default' })]
       })
 
@@ -330,6 +336,7 @@ describe('useDesktopIntegrations', () => {
         profileReady: true,
         resumeExhaustedSessionId: null,
         routedSessionId: 'ops-session',
+        routedSessionProfile: null,
         sessions
       })
 
@@ -338,6 +345,26 @@ describe('useDesktopIntegrations', () => {
 
       // Coder's remembered session should still be there.
       expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.coder')).toBe('coder-session')
+    })
+
+    it('remembers a profile-qualified same-id route under its owner, not the ambient profile', () => {
+      const sessions = [
+        session({ id: 'shared-session', profile: 'default' }),
+        session({ id: 'shared-session', profile: 'meta' })
+      ]
+
+      render({
+        activeProfile: 'default',
+        locationPathname: '/shared-session?profile=meta',
+        profileReady: true,
+        routedSessionId: 'shared-session',
+        routedSessionProfile: 'meta',
+        sessions
+      })
+
+      expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.meta')).toBe('shared-session')
+      expect(window.localStorage.getItem('hermes.desktop.lastRoute.profile.meta')).toBe('/shared-session?profile=meta')
+      expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.default')).toBeNull()
     })
 
     it('does NOT overwrite remembered state when session ownership fails validation', () => {
@@ -386,6 +413,7 @@ describe('useDesktopIntegrations', () => {
         locationPathname: '/settings',
         profileReady: true,
         routedSessionId: null,
+        routedSessionProfile: null,
         sessions: []
       })
 
@@ -396,6 +424,7 @@ describe('useDesktopIntegrations', () => {
         profileReady: true,
         resumeExhaustedSessionId: null,
         routedSessionId: null,
+        routedSessionProfile: null,
         sessions: []
       })
 

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -29,7 +29,14 @@ import { isBrowserWindow, isHudWindow, isSecondaryWindow } from '@/store/windows
 import type { SessionInfo } from '@/types/hermes'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
-import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionRoute } from '../../routes'
+import {
+  appViewForPath,
+  isOverlayView,
+  NEW_CHAT_ROUTE,
+  routeSessionId,
+  routeSessionProfile,
+  sessionRoute
+} from '../../routes'
 
 type RememberedSession = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>
 
@@ -43,6 +50,7 @@ interface DesktopIntegrationsParams {
   refreshSessions: () => Promise<unknown> | unknown
   resumeExhaustedSessionId: null | string
   routedSessionId: null | string
+  routedSessionProfile?: null | string
   runtimeIdByStoredSessionId: { readonly current: Map<string, string> }
   sessions: readonly RememberedSession[]
 }
@@ -62,6 +70,7 @@ export function useDesktopIntegrations({
   refreshSessions,
   resumeExhaustedSessionId,
   routedSessionId,
+  routedSessionProfile = null,
   runtimeIdByStoredSessionId,
   sessions
 }: DesktopIntegrationsParams): void {
@@ -107,6 +116,7 @@ export function useDesktopIntegrations({
       if (locationPathname === NEW_CHAT_ROUTE) {
         const route = getRememberedRoute(activeProfile)
         const routeSession = route ? routeSessionId(route) : null
+        const routeOwner = route ? (routeSessionProfile(route) ?? activeProfile) : activeProfile
         const last = getRememberedSessionId(activeProfile)
 
         const restorableNonSessionRoute =
@@ -126,7 +136,7 @@ export function useDesktopIntegrations({
           route &&
           route !== NEW_CHAT_ROUTE &&
           !isOverlayView(appViewForPath(route)) &&
-          (!routeSession || sessionBelongsToProfile(sessions, routeSession, activeProfile))
+          (!routeSession || sessionBelongsToProfile(sessions, routeSession, routeOwner))
         ) {
           navigate(route, { replace: true })
 
@@ -157,27 +167,31 @@ export function useDesktopIntegrations({
     // non-overlay route (a page like /skills, or a session route) per profile.
     // Session-shaped routes require an explicit matching owner; unresolved and
     // wrong-profile rows must not replace known-safe navigation.
-    if (routedSessionId && sessionBelongsToProfile(sessions, routedSessionId, activeProfile)) {
-      setRememberedSessionId(routedSessionId, activeProfile)
-      setRememberedRoute(locationPathname, activeProfile)
+    const routeOwner = routedSessionProfile ?? activeProfile
+
+    if (routedSessionId && sessionBelongsToProfile(sessions, routedSessionId, routeOwner)) {
+      setRememberedSessionId(routedSessionId, routeOwner)
+      setRememberedRoute(locationPathname, routeOwner)
     } else if (!routedSessionId && !isOverlayView(appViewForPath(locationPathname))) {
       setRememberedRoute(locationPathname, activeProfile)
     }
-  }, [activeProfile, locationPathname, navigate, profileReady, routedSessionId, sessions])
+  }, [activeProfile, locationPathname, navigate, profileReady, routedSessionId, routedSessionProfile, sessions])
 
   useEffect(() => {
     if (!profileReady || !resumeExhaustedSessionId) {
       return
     }
 
-    if (getRememberedSessionId(activeProfile) === resumeExhaustedSessionId) {
-      setRememberedSessionId(null, activeProfile)
+    const routeOwner = routedSessionProfile ?? activeProfile
+
+    if (getRememberedSessionId(routeOwner) === resumeExhaustedSessionId) {
+      setRememberedSessionId(null, routeOwner)
     }
 
-    if (routeSessionId(getRememberedRoute(activeProfile) ?? '') === resumeExhaustedSessionId) {
-      setRememberedRoute(null, activeProfile)
+    if (routeSessionId(getRememberedRoute(routeOwner) ?? '') === resumeExhaustedSessionId) {
+      setRememberedRoute(null, routeOwner)
     }
-  }, [activeProfile, profileReady, resumeExhaustedSessionId])
+  }, [activeProfile, profileReady, resumeExhaustedSessionId, routedSessionProfile])
 
   // Native-notification click -> jump to the session WHERE IT ALREADY IS (open
   // tile / main), else beside what's loaded rather than over it — the click

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { SessionRuntimeIndex } from '@/app/session/session-state-cache'
 import type * as HermesModule from '@/hermes'
 import { setSessionOwnerHint, setSessions } from '@/store/session'
 import { sessionTileDelegate } from '@/store/session-states'
@@ -254,7 +255,7 @@ describe('useSessionTileDelegate resumeTile', () => {
     setSessions([row({ id: 'stored-c', profile: 'default' })])
 
     const liveState = { busy: false, messages: [{ id: 'm1' }], storedSessionId: 'stored-c' }
-    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-c', 'runtime-dead']]) }
+    const runtimeIdByStoredSessionIdRef = { current: new SessionRuntimeIndex([['stored-c', 'runtime-dead']]) }
     const sessionStateByRuntimeIdRef = { current: new Map([['runtime-dead', liveState]]) }
 
     const requestGateway = vi.fn(async () => ({}) as never)
@@ -270,6 +271,36 @@ describe('useSessionTileDelegate resumeTile', () => {
     // The next resume goes cold instead of reusing the dead binding.
     const runtimeId = await sessionTileDelegate()!.resumeTile('stored-c')
     expect(runtimeId).toBe('runtime-fresh')
+  })
+
+  it('prunes stale owner-qualified bindings while preserving a healthy connection', () => {
+    const runtimeIndex = new SessionRuntimeIndex()
+
+    runtimeIndex.setOwned('stored-a', 'runtime-a', { connectionId: 'connection-a', profile: 'default' })
+    runtimeIndex.setOwned('stored-b', 'runtime-b', { connectionId: 'connection-b', profile: 'default' })
+    runtimeIndex.setOwned('stored-shared', 'runtime-shared-a', {
+      connectionId: 'connection-a',
+      profile: 'default'
+    })
+    runtimeIndex.setOwned('stored-shared', 'runtime-shared-b', {
+      connectionId: 'connection-b',
+      profile: 'default'
+    })
+
+    renderTile(
+      vi.fn(async () => ({}) as never),
+      {
+        runtimeIdByStoredSessionIdRef: { current: runtimeIndex }
+      }
+    )
+
+    sessionTileDelegate()!.invalidateRuntimeBindings!(new Set(['stored-b']))
+
+    expect([...runtimeIndex.entries()]).toEqual([['stored-b', 'runtime-b']])
+    expect(runtimeIndex.getOwned('stored-a', { connectionId: 'connection-a', profile: 'default' })).toBeUndefined()
+    expect(runtimeIndex.getOwned('stored-b', { connectionId: 'connection-b', profile: 'default' })).toBe('runtime-b')
+    expect(runtimeIndex.getOwned('stored-shared', { connectionId: 'connection-a', profile: 'default' })).toBeUndefined()
+    expect(runtimeIndex.getOwned('stored-shared', { connectionId: 'connection-b', profile: 'default' })).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -128,9 +128,9 @@ export function useSessionTileDelegate({
       // re-bind a tile to a dead runtime; live bindings re-record from
       // post-reconnect events and fresh resumes.
       invalidateRuntimeBindings: preserveStoredSessionIds => {
-        for (const storedSessionId of runtimeIdByStoredSessionIdRef.current.keys()) {
+        for (const storedSessionId of new Set(runtimeIdByStoredSessionIdRef.current.keys())) {
           if (!preserveStoredSessionIds?.has(storedSessionId)) {
-            runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+            runtimeIdByStoredSessionIdRef.current.deleteAll(storedSessionId)
           }
         }
       },

--- a/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $activeGatewayProfile } from '@/store/profile'
+import { setSessions } from '@/store/session'
+
+import { useStoredSessionHydration } from './use-stored-session-hydration'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal()),
+  getLatestSessionMessages: vi.fn()
+}))
+
+const { getLatestSessionMessages } = await import('@/hermes')
+
+const sharedId = 'shared-session'
+
+function transcript(answer: string) {
+  return {
+    messages: [
+      { content: 'question', role: 'user', timestamp: 1 },
+      { content: answer, role: 'assistant', timestamp: 2 }
+    ],
+    session_id: sharedId
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  setSessions([])
+  $activeGatewayProfile.set('default')
+  vi.clearAllMocks()
+})
+
+describe('useStoredSessionHydration profile ownership', () => {
+  it('hydrates the selected profile when duplicate stored ids coexist', async () => {
+    setSessions([
+      { id: sharedId, profile: 'default', title: 'Default duplicate' } as never,
+      { id: sharedId, profile: 'meta', title: 'Selected owner' } as never
+    ])
+    $activeGatewayProfile.set('default')
+
+    const activeSessionIdRef = { current: 'runtime-meta' as string | null }
+    const selectedStoredSessionIdRef = { current: sharedId as string | null }
+    const selectedStoredSessionProfileRef = { current: 'meta' as string | null }
+    const states = new Map([['runtime-meta', createClientSessionState(sharedId)]])
+
+    const updateSessionState = vi.fn((runtimeId, updater, storedSessionId) => {
+      const previous = states.get(runtimeId) ?? createClientSessionState(storedSessionId)
+      const next = updater(previous)
+      states.set(runtimeId, next)
+
+      return next
+    })
+
+    vi.mocked(getLatestSessionMessages).mockImplementation(async (_storedId, profile) =>
+      profile === 'meta' ? (transcript('meta answer') as never) : (transcript('wrong default answer') as never)
+    )
+
+    const { result } = renderHook(() =>
+      useStoredSessionHydration({
+        activeSessionIdRef,
+        selectedStoredSessionIdRef,
+        selectedStoredSessionProfileRef,
+        updateSessionState
+      })
+    )
+
+    await result.current()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(sharedId, 'meta')
+    expect(updateSessionState).toHaveBeenCalledWith('runtime-meta', expect.any(Function), sharedId)
+    expect(states.get('runtime-meta')?.messages.at(-1)?.parts[0]).toMatchObject({ text: 'meta answer' })
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.test.tsx
@@ -1,9 +1,10 @@
-import { cleanup, renderHook } from '@testing-library/react'
+import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $activeGatewayProfile } from '@/store/profile'
 import { setSessions } from '@/store/session'
+import { $todosBySession, clearSessionTodos, setSessionTodos } from '@/store/todos'
 
 import { useStoredSessionHydration } from './use-stored-session-hydration'
 
@@ -29,6 +30,7 @@ function transcript(answer: string) {
 afterEach(() => {
   cleanup()
   setSessions([])
+  clearSessionTodos('runtime-shared')
   $activeGatewayProfile.set('default')
   vi.clearAllMocks()
 })
@@ -72,5 +74,102 @@ describe('useStoredSessionHydration profile ownership', () => {
     expect(getLatestSessionMessages).toHaveBeenCalledWith(sharedId, 'meta')
     expect(updateSessionState).toHaveBeenCalledWith('runtime-meta', expect.any(Function), sharedId)
     expect(states.get('runtime-meta')?.messages.at(-1)?.parts[0]).toMatchObject({ text: 'meta answer' })
+  })
+
+  it('drops a delayed same-id response after its profile owner switches', async () => {
+    let resolveRequest: ((value: ReturnType<typeof transcript>) => void) | undefined
+
+    const request = new Promise<ReturnType<typeof transcript>>(resolve => {
+      resolveRequest = resolve
+    })
+
+    vi.mocked(getLatestSessionMessages).mockReturnValue(request as never)
+
+    const activeSessionIdRef = { current: 'runtime-shared' as string | null }
+    const selectedStoredSessionIdRef = { current: sharedId as string | null }
+    const selectedStoredSessionProfileRef = { current: 'default' as string | null }
+    const initialState = createClientSessionState(sharedId)
+    initialState.profile = 'meta'
+    initialState.messages = [
+      {
+        id: 'meta-existing',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'meta existing answer' }]
+      }
+    ]
+    const states = new Map([['runtime-shared', initialState]])
+
+    const updateSessionState = vi.fn((runtimeId, updater) => {
+      const previous = states.get(runtimeId)!
+      const next = updater(previous)
+      states.set(runtimeId, next)
+
+      return next
+    })
+
+    const metaTodos = [{ content: 'meta task', id: 'meta-todo', status: 'in_progress' as const }]
+    setSessionTodos('runtime-shared', metaTodos)
+
+    const { result } = renderHook(() =>
+      useStoredSessionHydration({
+        activeSessionIdRef,
+        selectedStoredSessionIdRef,
+        selectedStoredSessionProfileRef,
+        updateSessionState
+      })
+    )
+
+    const hydration = result.current()
+
+    // Same durable and runtime ids, different profile owner: neither id alone
+    // can distinguish the request that is now stale.
+    selectedStoredSessionProfileRef.current = 'meta'
+    $activeGatewayProfile.set('meta')
+
+    await act(async () => {
+      resolveRequest?.(transcript('stale default answer'))
+      await hydration
+    })
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(sharedId, 'default')
+    expect(updateSessionState).not.toHaveBeenCalled()
+    expect(states.get('runtime-shared')?.messages.at(-1)?.parts[0]).toMatchObject({ text: 'meta existing answer' })
+    expect($todosBySession.get()['runtime-shared']).toEqual(metaTodos)
+  })
+
+  it('revalidates ownership again before publishing hydrated todos', async () => {
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('default answer') as never)
+
+    const activeSessionIdRef = { current: 'runtime-shared' as string | null }
+    const selectedStoredSessionIdRef = { current: sharedId as string | null }
+    const selectedStoredSessionProfileRef = { current: 'default' as string | null }
+    const state = createClientSessionState(sharedId)
+    const metaTodos = [{ content: 'meta task', id: 'meta-todo', status: 'in_progress' as const }]
+
+    const updateSessionState = vi.fn((_runtimeId, updater) => {
+      const next = updater(state)
+
+      // Model a synchronous profile-switch subscriber firing while the message
+      // publication notifies stores. The sibling todo publication must recheck.
+      selectedStoredSessionProfileRef.current = 'meta'
+      $activeGatewayProfile.set('meta')
+      setSessionTodos('runtime-shared', metaTodos)
+
+      return next
+    })
+
+    const { result } = renderHook(() =>
+      useStoredSessionHydration({
+        activeSessionIdRef,
+        selectedStoredSessionIdRef,
+        selectedStoredSessionProfileRef,
+        updateSessionState
+      })
+    )
+
+    await act(async () => result.current())
+
+    expect(updateSessionState).toHaveBeenCalledOnce()
+    expect($todosBySession.get()['runtime-shared']).toEqual(metaTodos)
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.test.tsx
@@ -30,6 +30,14 @@ function transcript(answer: string) {
 }
 
 function ownerTools(states: Map<string, TestSessionState>) {
+  const getSessionStateOwner = vi.fn((runtimeId: string) => {
+    const state = states.get(runtimeId)
+
+    return state?.profile && state.storedSessionId
+      ? { connectionId: state.connectionId, profile: state.profile, storedSessionId: state.storedSessionId }
+      : null
+  })
+
   const sessionStateHasOwner = vi.fn((runtimeId: string, owner: { profile: string; storedSessionId: string }) => {
     const state = states.get(runtimeId)
 
@@ -54,7 +62,7 @@ function ownerTools(states: Map<string, TestSessionState>) {
     }
   )
 
-  return { sessionStateHasOwner, updateOwnedSessionState }
+  return { getSessionStateOwner, sessionStateHasOwner, updateOwnedSessionState }
 }
 
 afterEach(() => {
@@ -79,7 +87,7 @@ describe('useStoredSessionHydration profile ownership', () => {
     const initialState = createClientSessionState(sharedId)
     initialState.profile = 'meta'
     const states = new Map([['runtime-meta', initialState]])
-    const { sessionStateHasOwner, updateOwnedSessionState } = ownerTools(states)
+    const { getSessionStateOwner, sessionStateHasOwner, updateOwnedSessionState } = ownerTools(states)
 
     vi.mocked(getLatestSessionMessages).mockImplementation(async (_storedId, profile) =>
       profile === 'meta' ? (transcript('meta answer') as never) : (transcript('wrong default answer') as never)
@@ -88,6 +96,7 @@ describe('useStoredSessionHydration profile ownership', () => {
     const { result } = renderHook(() =>
       useStoredSessionHydration({
         activeSessionIdRef,
+        getSessionStateOwner,
         selectedStoredSessionIdRef,
         selectedStoredSessionProfileRef,
         sessionStateHasOwner,
@@ -100,7 +109,7 @@ describe('useStoredSessionHydration profile ownership', () => {
     expect(getLatestSessionMessages).toHaveBeenCalledWith(sharedId, 'meta')
     expect(updateOwnedSessionState).toHaveBeenCalledWith(
       'runtime-meta',
-      { profile: 'meta', storedSessionId: sharedId },
+      { connectionId: null, profile: 'meta', storedSessionId: sharedId },
       expect.any(Function)
     )
     expect(states.get('runtime-meta')?.messages.at(-1)?.parts[0]).toMatchObject({ text: 'meta answer' })
@@ -119,7 +128,7 @@ describe('useStoredSessionHydration profile ownership', () => {
     const selectedStoredSessionIdRef = { current: sharedId as string | null }
     const selectedStoredSessionProfileRef = { current: 'default' as string | null }
     const initialState = createClientSessionState(sharedId)
-    initialState.profile = 'meta'
+    initialState.profile = 'default'
     initialState.messages = [
       {
         id: 'meta-existing',
@@ -128,13 +137,14 @@ describe('useStoredSessionHydration profile ownership', () => {
       }
     ]
     const states = new Map([['runtime-shared', initialState]])
-    const { sessionStateHasOwner, updateOwnedSessionState } = ownerTools(states)
+    const { getSessionStateOwner, sessionStateHasOwner, updateOwnedSessionState } = ownerTools(states)
     const metaTodos = [{ content: 'meta task', id: 'meta-todo', status: 'in_progress' as const }]
     setSessionTodos('runtime-shared', metaTodos)
 
     const { result } = renderHook(() =>
       useStoredSessionHydration({
         activeSessionIdRef,
+        getSessionStateOwner,
         selectedStoredSessionIdRef,
         selectedStoredSessionProfileRef,
         sessionStateHasOwner,
@@ -143,6 +153,7 @@ describe('useStoredSessionHydration profile ownership', () => {
     )
 
     const hydration = result.current()
+    initialState.profile = 'meta'
     selectedStoredSessionProfileRef.current = 'meta'
     $activeGatewayProfile.set('meta')
 
@@ -172,11 +183,12 @@ describe('useStoredSessionHydration profile ownership', () => {
     const initialState = createClientSessionState(sharedId)
     initialState.profile = 'default'
     const states = new Map([['runtime-shared', initialState]])
-    const { sessionStateHasOwner, updateOwnedSessionState } = ownerTools(states)
+    const { getSessionStateOwner, sessionStateHasOwner, updateOwnedSessionState } = ownerTools(states)
 
     const { result } = renderHook(() =>
       useStoredSessionHydration({
         activeSessionIdRef,
+        getSessionStateOwner,
         selectedStoredSessionIdRef,
         selectedStoredSessionProfileRef,
         sessionStateHasOwner,
@@ -210,6 +222,76 @@ describe('useStoredSessionHydration profile ownership', () => {
     expect($todosBySession.get()['runtime-shared']).toEqual(metaTodos)
   })
 
+  it('drops a delayed same-root response when the runtime is reclaimed by another connection', async () => {
+    let resolveRequest: ((value: ReturnType<typeof transcript>) => void) | undefined
+
+    const request = new Promise<ReturnType<typeof transcript>>(resolve => {
+      resolveRequest = resolve
+    })
+
+    vi.mocked(getLatestSessionMessages).mockReturnValue(request as never)
+
+    const activeSessionIdRef = { current: 'runtime-shared' as string | null }
+    const selectedStoredSessionIdRef = { current: sharedId as string | null }
+    const selectedStoredSessionProfileRef = { current: 'default' as string | null }
+    const stateA = createClientSessionState(sharedId)
+    stateA.profile = 'default'
+    stateA.connectionId = 'connection-a'
+    const states = new Map([['runtime-shared', stateA]])
+
+    const sessionStateHasOwner = vi.fn(
+      (runtimeId: string, owner: { connectionId?: null | string; profile: string; storedSessionId: string }) => {
+        const state = states.get(runtimeId)
+
+        return (
+          state?.profile === owner.profile &&
+          state.storedSessionId === owner.storedSessionId &&
+          (!state.connectionId || !owner.connectionId || state.connectionId === owner.connectionId)
+        )
+      }
+    )
+
+    const getSessionStateOwner = vi.fn((runtimeId: string) => {
+      const state = states.get(runtimeId)
+
+      return state?.profile && state.storedSessionId
+        ? { connectionId: state.connectionId, profile: state.profile, storedSessionId: state.storedSessionId }
+        : null
+    })
+
+    const updateOwnedSessionState = vi.fn(() => false)
+
+    const { result } = renderHook(() =>
+      useStoredSessionHydration({
+        activeSessionIdRef,
+        getSessionStateOwner,
+        selectedStoredSessionIdRef,
+        selectedStoredSessionProfileRef,
+        sessionStateHasOwner,
+        updateOwnedSessionState
+      })
+    )
+
+    const hydration = result.current()
+    const stateB = createClientSessionState(sharedId)
+    stateB.profile = 'default'
+    stateB.connectionId = 'connection-b'
+    stateB.messages = [{ id: 'b-existing', role: 'assistant', parts: [{ type: 'text', text: 'connection B' }] }]
+    states.set('runtime-shared', stateB)
+
+    await act(async () => {
+      resolveRequest?.(transcript('stale connection A'))
+      await hydration
+    })
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(sharedId, {
+      connectionId: 'connection-a',
+      profile: 'default'
+    })
+    expect(states.get('runtime-shared')).toBe(stateB)
+    expect(updateOwnedSessionState).not.toHaveBeenCalled()
+  })
+
   it('revalidates cache ownership again before publishing hydrated todos', async () => {
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('default answer') as never)
 
@@ -219,7 +301,8 @@ describe('useStoredSessionHydration profile ownership', () => {
     const state = createClientSessionState(sharedId)
     state.profile = 'default'
     const metaTodos = [{ content: 'meta task', id: 'meta-todo', status: 'in_progress' as const }]
-    const sessionStateHasOwner = vi.fn(() => false)
+    const sessionStateHasOwner = vi.fn().mockReturnValueOnce(true).mockReturnValue(false)
+    const getSessionStateOwner = vi.fn(() => ({ profile: 'default', storedSessionId: sharedId }))
 
     const updateOwnedSessionState = vi.fn((_runtimeId, _owner, updater) => {
       const next = updater(state)
@@ -235,6 +318,7 @@ describe('useStoredSessionHydration profile ownership', () => {
     const { result } = renderHook(() =>
       useStoredSessionHydration({
         activeSessionIdRef,
+        getSessionStateOwner,
         selectedStoredSessionIdRef,
         selectedStoredSessionProfileRef,
         sessionStateHasOwner,
@@ -245,7 +329,7 @@ describe('useStoredSessionHydration profile ownership', () => {
     await act(async () => result.current())
 
     expect(updateOwnedSessionState).toHaveBeenCalledOnce()
-    expect(sessionStateHasOwner).toHaveBeenCalledOnce()
+    expect(sessionStateHasOwner).toHaveBeenCalledTimes(2)
     expect($todosBySession.get()['runtime-shared']).toEqual(metaTodos)
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.test.tsx
@@ -17,6 +17,8 @@ const { getLatestSessionMessages } = await import('@/hermes')
 
 const sharedId = 'shared-session'
 
+type TestSessionState = ReturnType<typeof createClientSessionState>
+
 function transcript(answer: string) {
   return {
     messages: [
@@ -25,6 +27,34 @@ function transcript(answer: string) {
     ],
     session_id: sharedId
   }
+}
+
+function ownerTools(states: Map<string, TestSessionState>) {
+  const sessionStateHasOwner = vi.fn((runtimeId: string, owner: { profile: string; storedSessionId: string }) => {
+    const state = states.get(runtimeId)
+
+    return state?.profile === owner.profile && state.storedSessionId === owner.storedSessionId
+  })
+
+  const updateOwnedSessionState = vi.fn(
+    (
+      runtimeId: string,
+      owner: { profile: string; storedSessionId: string },
+      updater: (state: TestSessionState) => TestSessionState
+    ) => {
+      const previous = states.get(runtimeId)
+
+      if (previous?.profile !== owner.profile || previous.storedSessionId !== owner.storedSessionId) {
+        return false
+      }
+
+      states.set(runtimeId, updater(previous))
+
+      return sessionStateHasOwner(runtimeId, owner)
+    }
+  )
+
+  return { sessionStateHasOwner, updateOwnedSessionState }
 }
 
 afterEach(() => {
@@ -46,15 +76,10 @@ describe('useStoredSessionHydration profile ownership', () => {
     const activeSessionIdRef = { current: 'runtime-meta' as string | null }
     const selectedStoredSessionIdRef = { current: sharedId as string | null }
     const selectedStoredSessionProfileRef = { current: 'meta' as string | null }
-    const states = new Map([['runtime-meta', createClientSessionState(sharedId)]])
-
-    const updateSessionState = vi.fn((runtimeId, updater, storedSessionId) => {
-      const previous = states.get(runtimeId) ?? createClientSessionState(storedSessionId)
-      const next = updater(previous)
-      states.set(runtimeId, next)
-
-      return next
-    })
+    const initialState = createClientSessionState(sharedId)
+    initialState.profile = 'meta'
+    const states = new Map([['runtime-meta', initialState]])
+    const { sessionStateHasOwner, updateOwnedSessionState } = ownerTools(states)
 
     vi.mocked(getLatestSessionMessages).mockImplementation(async (_storedId, profile) =>
       profile === 'meta' ? (transcript('meta answer') as never) : (transcript('wrong default answer') as never)
@@ -65,14 +90,19 @@ describe('useStoredSessionHydration profile ownership', () => {
         activeSessionIdRef,
         selectedStoredSessionIdRef,
         selectedStoredSessionProfileRef,
-        updateSessionState
+        sessionStateHasOwner,
+        updateOwnedSessionState
       })
     )
 
     await result.current()
 
     expect(getLatestSessionMessages).toHaveBeenCalledWith(sharedId, 'meta')
-    expect(updateSessionState).toHaveBeenCalledWith('runtime-meta', expect.any(Function), sharedId)
+    expect(updateOwnedSessionState).toHaveBeenCalledWith(
+      'runtime-meta',
+      { profile: 'meta', storedSessionId: sharedId },
+      expect.any(Function)
+    )
     expect(states.get('runtime-meta')?.messages.at(-1)?.parts[0]).toMatchObject({ text: 'meta answer' })
   })
 
@@ -98,15 +128,7 @@ describe('useStoredSessionHydration profile ownership', () => {
       }
     ]
     const states = new Map([['runtime-shared', initialState]])
-
-    const updateSessionState = vi.fn((runtimeId, updater) => {
-      const previous = states.get(runtimeId)!
-      const next = updater(previous)
-      states.set(runtimeId, next)
-
-      return next
-    })
-
+    const { sessionStateHasOwner, updateOwnedSessionState } = ownerTools(states)
     const metaTodos = [{ content: 'meta task', id: 'meta-todo', status: 'in_progress' as const }]
     setSessionTodos('runtime-shared', metaTodos)
 
@@ -115,14 +137,12 @@ describe('useStoredSessionHydration profile ownership', () => {
         activeSessionIdRef,
         selectedStoredSessionIdRef,
         selectedStoredSessionProfileRef,
-        updateSessionState
+        sessionStateHasOwner,
+        updateOwnedSessionState
       })
     )
 
     const hydration = result.current()
-
-    // Same durable and runtime ids, different profile owner: neither id alone
-    // can distinguish the request that is now stale.
     selectedStoredSessionProfileRef.current = 'meta'
     $activeGatewayProfile.set('meta')
 
@@ -132,30 +152,84 @@ describe('useStoredSessionHydration profile ownership', () => {
     })
 
     expect(getLatestSessionMessages).toHaveBeenCalledWith(sharedId, 'default')
-    expect(updateSessionState).not.toHaveBeenCalled()
+    expect(updateOwnedSessionState).not.toHaveBeenCalled()
     expect(states.get('runtime-shared')?.messages.at(-1)?.parts[0]).toMatchObject({ text: 'meta existing answer' })
     expect($todosBySession.get()['runtime-shared']).toEqual(metaTodos)
   })
 
-  it('revalidates ownership again before publishing hydrated todos', async () => {
+  it('drops a delayed ABA response when the cache runtime is reclaimed by another profile', async () => {
+    let resolveRequest: ((value: ReturnType<typeof transcript>) => void) | undefined
+
+    const request = new Promise<ReturnType<typeof transcript>>(resolve => {
+      resolveRequest = resolve
+    })
+
+    vi.mocked(getLatestSessionMessages).mockReturnValue(request as never)
+
+    const activeSessionIdRef = { current: 'runtime-shared' as string | null }
+    const selectedStoredSessionIdRef = { current: sharedId as string | null }
+    const selectedStoredSessionProfileRef = { current: 'default' as string | null }
+    const initialState = createClientSessionState(sharedId)
+    initialState.profile = 'default'
+    const states = new Map([['runtime-shared', initialState]])
+    const { sessionStateHasOwner, updateOwnedSessionState } = ownerTools(states)
+
+    const { result } = renderHook(() =>
+      useStoredSessionHydration({
+        activeSessionIdRef,
+        selectedStoredSessionIdRef,
+        selectedStoredSessionProfileRef,
+        sessionStateHasOwner,
+        updateOwnedSessionState
+      })
+    )
+
+    const hydration = result.current()
+    const reclaimedState = createClientSessionState(sharedId)
+    reclaimedState.profile = 'meta'
+    reclaimedState.messages = [
+      {
+        id: 'meta-existing',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'meta existing answer' }]
+      }
+    ]
+    states.set('runtime-shared', reclaimedState)
+    const metaTodos = [{ content: 'meta task', id: 'meta-todo', status: 'in_progress' as const }]
+    setSessionTodos('runtime-shared', metaTodos)
+
+    // Selection refs ABA back to their captured values, but the cache slot is
+    // now owned by another profile with the same runtime and stored ids.
+    await act(async () => {
+      resolveRequest?.(transcript('stale default answer'))
+      await hydration
+    })
+
+    expect(states.get('runtime-shared')).toBe(reclaimedState)
+    expect(states.get('runtime-shared')?.messages.at(-1)?.parts[0]).toMatchObject({ text: 'meta existing answer' })
+    expect($todosBySession.get()['runtime-shared']).toEqual(metaTodos)
+  })
+
+  it('revalidates cache ownership again before publishing hydrated todos', async () => {
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('default answer') as never)
 
     const activeSessionIdRef = { current: 'runtime-shared' as string | null }
     const selectedStoredSessionIdRef = { current: sharedId as string | null }
     const selectedStoredSessionProfileRef = { current: 'default' as string | null }
     const state = createClientSessionState(sharedId)
+    state.profile = 'default'
     const metaTodos = [{ content: 'meta task', id: 'meta-todo', status: 'in_progress' as const }]
+    const sessionStateHasOwner = vi.fn(() => false)
 
-    const updateSessionState = vi.fn((_runtimeId, updater) => {
+    const updateOwnedSessionState = vi.fn((_runtimeId, _owner, updater) => {
       const next = updater(state)
 
-      // Model a synchronous profile-switch subscriber firing while the message
+      // Model a synchronous cache-reclaim subscriber firing while the message
       // publication notifies stores. The sibling todo publication must recheck.
-      selectedStoredSessionProfileRef.current = 'meta'
-      $activeGatewayProfile.set('meta')
+      void next
       setSessionTodos('runtime-shared', metaTodos)
 
-      return next
+      return true
     })
 
     const { result } = renderHook(() =>
@@ -163,13 +237,15 @@ describe('useStoredSessionHydration profile ownership', () => {
         activeSessionIdRef,
         selectedStoredSessionIdRef,
         selectedStoredSessionProfileRef,
-        updateSessionState
+        sessionStateHasOwner,
+        updateOwnedSessionState
       })
     )
 
     await act(async () => result.current())
 
-    expect(updateSessionState).toHaveBeenCalledOnce()
+    expect(updateOwnedSessionState).toHaveBeenCalledOnce()
+    expect(sessionStateHasOwner).toHaveBeenCalledOnce()
     expect($todosBySession.get()['runtime-shared']).toEqual(metaTodos)
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.ts
@@ -18,6 +18,7 @@ type UpdateOwnedSessionState = (
 
 interface StoredSessionHydrationOptions {
   activeSessionIdRef: MutableRefObject<string | null>
+  getSessionStateOwner: (sessionId: string) => SessionStateOwner | null
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   selectedStoredSessionProfileRef: MutableRefObject<string | null>
   sessionStateHasOwner: (sessionId: string, owner: SessionStateOwner) => boolean
@@ -31,9 +32,10 @@ export type StoredSessionHydrator = (
   storedSessionProfile?: string | null
 ) => Promise<void>
 
-/** Re-read persisted history for one profile-qualified runtime owner. */
+/** Re-read persisted history for one connection/profile-qualified runtime owner. */
 export function useStoredSessionHydration({
   activeSessionIdRef,
+  getSessionStateOwner,
   selectedStoredSessionIdRef,
   selectedStoredSessionProfileRef,
   sessionStateHasOwner,
@@ -54,7 +56,15 @@ export function useStoredSessionHydration({
       // are profile-local, so looking the owner up by bare id can read a same-id
       // transcript from another profile and graft it onto this runtime.
       const ownerProfile = normalizeProfileKey(storedSessionProfile)
-      const owner = { profile: ownerProfile, storedSessionId }
+      const owner = getSessionStateOwner(runtimeSessionId)
+
+      if (!owner || owner.profile !== ownerProfile || owner.storedSessionId !== storedSessionId) {
+        return
+      }
+
+      const profileScope = owner.connectionId
+        ? { connectionId: owner.connectionId, profile: owner.profile }
+        : owner.profile
 
       const isCurrentOwner = () =>
         selectedStoredSessionIdRef.current === storedSessionId &&
@@ -63,13 +73,13 @@ export function useStoredSessionHydration({
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
-          const latest = await getLatestSessionMessages(storedSessionId, ownerProfile)
+          const latest = await getLatestSessionMessages(storedSessionId, profileScope)
           const messages = toChatMessages(latest.messages)
 
           // The request belongs to the exact profile + durable id + runtime
           // captured before its first await. A same-id profile switch can reuse
           // either id, so all three axes must still match at publication time.
-          if (!isCurrentOwner()) {
+          if (!isCurrentOwner() || !sessionStateHasOwner(runtimeSessionId, owner)) {
             return
           }
 
@@ -114,6 +124,7 @@ export function useStoredSessionHydration({
     },
     [
       activeSessionIdRef,
+      getSessionStateOwner,
       selectedStoredSessionIdRef,
       selectedStoredSessionProfileRef,
       sessionStateHasOwner,

--- a/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.ts
@@ -4,7 +4,7 @@ import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
 import { getLatestSessionMessages } from '@/hermes'
 import { preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { latestSessionTodos } from '@/lib/todos'
-import { $activeGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 
 import type { ClientSessionState } from '../../types'
@@ -50,12 +50,24 @@ export function useStoredSessionHydration({
       // Capture profile + stored id together before the first await. Stored ids
       // are profile-local, so looking the owner up by bare id can read a same-id
       // transcript from another profile and graft it onto this runtime.
-      const ownerProfile = storedSessionProfile?.trim() || 'default'
+      const ownerProfile = normalizeProfileKey(storedSessionProfile)
+
+      const isCurrentOwner = () =>
+        selectedStoredSessionIdRef.current === storedSessionId &&
+        activeSessionIdRef.current === runtimeSessionId &&
+        normalizeProfileKey(selectedStoredSessionProfileRef.current ?? $activeGatewayProfile.get()) === ownerProfile
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
           const latest = await getLatestSessionMessages(storedSessionId, ownerProfile)
           const messages = toChatMessages(latest.messages)
+
+          // The request belongs to the exact profile + durable id + runtime
+          // captured before its first await. A same-id profile switch can reuse
+          // either id, so all three axes must still match at publication time.
+          if (!isCurrentOwner()) {
+            return
+          }
 
           updateSessionState(
             runtimeSessionId,
@@ -72,6 +84,13 @@ export function useStoredSessionHydration({
           )
 
           const restored = todosForHydration(latestSessionTodos(messages))
+
+          // updateSessionState can synchronously notify subscribers. Revalidate
+          // again before publishing the sibling todo projection so a switch in
+          // that notification cannot graft this owner's tasks onto the next one.
+          if (!isCurrentOwner()) {
+            return
+          }
 
           if (restored) {
             setSessionTodos(runtimeSessionId, restored)

--- a/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.ts
@@ -1,0 +1,94 @@
+import { type MutableRefObject, useCallback } from 'react'
+
+import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
+import { getLatestSessionMessages } from '@/hermes'
+import { preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { latestSessionTodos } from '@/lib/todos'
+import { $activeGatewayProfile } from '@/store/profile'
+import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
+
+import type { ClientSessionState } from '../../types'
+
+type UpdateSessionState = (
+  sessionId: string,
+  updater: (state: ClientSessionState) => ClientSessionState,
+  storedSessionId?: string | null
+) => ClientSessionState
+
+interface StoredSessionHydrationOptions {
+  activeSessionIdRef: MutableRefObject<string | null>
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
+  selectedStoredSessionProfileRef: MutableRefObject<string | null>
+  updateSessionState: UpdateSessionState
+}
+
+export type StoredSessionHydrator = (
+  attempts?: number,
+  storedSessionId?: string | null,
+  runtimeSessionId?: string | null,
+  storedSessionProfile?: string | null
+) => Promise<void>
+
+/** Re-read persisted history for one profile-qualified runtime owner. */
+export function useStoredSessionHydration({
+  activeSessionIdRef,
+  selectedStoredSessionIdRef,
+  selectedStoredSessionProfileRef,
+  updateSessionState
+}: StoredSessionHydrationOptions): StoredSessionHydrator {
+  return useCallback(
+    async (
+      attempts = 1,
+      storedSessionId = selectedStoredSessionIdRef.current,
+      runtimeSessionId = activeSessionIdRef.current,
+      storedSessionProfile = selectedStoredSessionProfileRef.current ?? $activeGatewayProfile.get()
+    ) => {
+      if (!storedSessionId || !runtimeSessionId) {
+        return
+      }
+
+      // Capture profile + stored id together before the first await. Stored ids
+      // are profile-local, so looking the owner up by bare id can read a same-id
+      // transcript from another profile and graft it onto this runtime.
+      const ownerProfile = storedSessionProfile?.trim() || 'default'
+
+      for (let index = 0; index < Math.max(1, attempts); index += 1) {
+        try {
+          const latest = await getLatestSessionMessages(storedSessionId, ownerProfile)
+          const messages = toChatMessages(latest.messages)
+
+          updateSessionState(
+            runtimeSessionId,
+            state => ({
+              ...state,
+              // Post-turn rehydrate reads only the newest tail page — graft it
+              // onto any backfilled older pages instead of dropping them.
+              messages: preserveLocalAssistantErrors(
+                graftRefreshedTailOntoBackfill(messages, state.messages),
+                state.messages
+              )
+            }),
+            storedSessionId
+          )
+
+          const restored = todosForHydration(latestSessionTodos(messages))
+
+          if (restored) {
+            setSessionTodos(runtimeSessionId, restored)
+          } else {
+            clearSessionTodos(runtimeSessionId)
+          }
+
+          return
+        } catch {
+          // Best-effort fallback when live stream payloads are empty.
+        }
+
+        if (index < attempts - 1) {
+          await new Promise(resolve => window.setTimeout(resolve, 250))
+        }
+      }
+    },
+    [activeSessionIdRef, selectedStoredSessionIdRef, selectedStoredSessionProfileRef, updateSessionState]
+  )
+}

--- a/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-stored-session-hydration.ts
@@ -7,19 +7,21 @@ import { latestSessionTodos } from '@/lib/todos'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 
+import type { SessionStateOwner } from '../../session/session-state-cache'
 import type { ClientSessionState } from '../../types'
 
-type UpdateSessionState = (
+type UpdateOwnedSessionState = (
   sessionId: string,
-  updater: (state: ClientSessionState) => ClientSessionState,
-  storedSessionId?: string | null
-) => ClientSessionState
+  owner: SessionStateOwner,
+  updater: (state: ClientSessionState) => ClientSessionState
+) => boolean
 
 interface StoredSessionHydrationOptions {
   activeSessionIdRef: MutableRefObject<string | null>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   selectedStoredSessionProfileRef: MutableRefObject<string | null>
-  updateSessionState: UpdateSessionState
+  sessionStateHasOwner: (sessionId: string, owner: SessionStateOwner) => boolean
+  updateOwnedSessionState: UpdateOwnedSessionState
 }
 
 export type StoredSessionHydrator = (
@@ -34,7 +36,8 @@ export function useStoredSessionHydration({
   activeSessionIdRef,
   selectedStoredSessionIdRef,
   selectedStoredSessionProfileRef,
-  updateSessionState
+  sessionStateHasOwner,
+  updateOwnedSessionState
 }: StoredSessionHydrationOptions): StoredSessionHydrator {
   return useCallback(
     async (
@@ -51,6 +54,7 @@ export function useStoredSessionHydration({
       // are profile-local, so looking the owner up by bare id can read a same-id
       // transcript from another profile and graft it onto this runtime.
       const ownerProfile = normalizeProfileKey(storedSessionProfile)
+      const owner = { profile: ownerProfile, storedSessionId }
 
       const isCurrentOwner = () =>
         selectedStoredSessionIdRef.current === storedSessionId &&
@@ -69,26 +73,26 @@ export function useStoredSessionHydration({
             return
           }
 
-          updateSessionState(
-            runtimeSessionId,
-            state => ({
-              ...state,
-              // Post-turn rehydrate reads only the newest tail page — graft it
-              // onto any backfilled older pages instead of dropping them.
-              messages: preserveLocalAssistantErrors(
-                graftRefreshedTailOntoBackfill(messages, state.messages),
-                state.messages
-              )
-            }),
-            storedSessionId
-          )
+          const published = updateOwnedSessionState(runtimeSessionId, owner, state => ({
+            ...state,
+            // Post-turn rehydrate reads only the newest tail page — graft it
+            // onto any backfilled older pages instead of dropping them.
+            messages: preserveLocalAssistantErrors(
+              graftRefreshedTailOntoBackfill(messages, state.messages),
+              state.messages
+            )
+          }))
+
+          if (!published) {
+            return
+          }
 
           const restored = todosForHydration(latestSessionTodos(messages))
 
-          // updateSessionState can synchronously notify subscribers. Revalidate
-          // again before publishing the sibling todo projection so a switch in
-          // that notification cannot graft this owner's tasks onto the next one.
-          if (!isCurrentOwner()) {
+          // Session publication can synchronously notify subscribers. Revalidate
+          // both mutable selection and the installed cache owner before writing
+          // the sibling todo projection.
+          if (!isCurrentOwner() || !sessionStateHasOwner(runtimeSessionId, owner)) {
             return
           }
 
@@ -108,6 +112,12 @@ export function useStoredSessionHydration({
         }
       }
     },
-    [activeSessionIdRef, selectedStoredSessionIdRef, selectedStoredSessionProfileRef, updateSessionState]
+    [
+      activeSessionIdRef,
+      selectedStoredSessionIdRef,
+      selectedStoredSessionProfileRef,
+      sessionStateHasOwner,
+      updateOwnedSessionState
+    ]
   )
 }

--- a/apps/desktop/src/app/contrib/latest-actions.test.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.test.ts
@@ -43,6 +43,7 @@ function makeSidebarActions(): SidebarActions {
     onNavigate: vi.fn(),
     onNewSessionInWorkspace: vi.fn(),
     onNewSessionSplit: vi.fn(),
+    onOpenCronRun: vi.fn(),
     onResumeSession: vi.fn(),
     onTriggerCronJob: vi.fn()
   }

--- a/apps/desktop/src/app/contrib/latest-actions.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.ts
@@ -66,6 +66,7 @@ export function latestSidebarActions(actions: SidebarActions): SidebarActions {
     onNavigate: (...args) => actions.onNavigate(...args),
     onNewSessionInWorkspace: (...args) => actions.onNewSessionInWorkspace(...args),
     onNewSessionSplit: (...args) => actions.onNewSessionSplit(...args),
+    onOpenCronRun: (...args) => actions.onOpenCronRun(...args),
     onResumeSession: (...args) => actions.onResumeSession(...args),
     onTriggerCronJob: (...args) => actions.onTriggerCronJob(...args)
   }

--- a/apps/desktop/src/app/contrib/types.ts
+++ b/apps/desktop/src/app/contrib/types.ts
@@ -20,6 +20,7 @@ export type SidebarActions = Pick<
   | 'onNavigate'
   | 'onNewSessionInWorkspace'
   | 'onNewSessionSplit'
+  | 'onOpenCronRun'
   | 'onResumeSession'
   | 'onTriggerCronJob'
 >

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -13,7 +13,6 @@ import { useQueryClient } from '@tanstack/react-query'
 import { type CSSProperties, lazy, type ReactNode, Suspense, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router'
 
-import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
 import { ConfirmHost } from '@/components/confirm-host'
@@ -33,10 +32,8 @@ import { FloatingPet } from '@/components/pet/floating-pet'
 import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { SendDiagnosticsHost } from '@/components/send-diagnostics-dialog'
 import { emitGatewayEvent } from '@/contrib/events'
-import { getLatestSessionMessages } from '@/hermes'
-import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { type ChatMessage, chatMessageText } from '@/lib/chat-messages'
 import { isMessagingSource } from '@/lib/session-source'
-import { latestSessionTodos } from '@/lib/todos'
 import { activateWakeIndicator } from '@/lib/wake-indicator'
 import { playWakeSound } from '@/lib/wake-sound'
 import { $billingSettingsRequest } from '@/store/billing-block'
@@ -78,7 +75,6 @@ import {
   setBusy,
   setMessages
 } from '@/store/session'
-import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isBrowserWindow, isHudWindow } from '@/store/windows'
 import { useSkinCommand } from '@/themes/use-skin-command'
@@ -147,6 +143,7 @@ import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
 import { usePetBridge } from './hooks/use-pet-bridge'
 import { useQuickEntryBridge } from './hooks/use-quick-entry-bridge'
 import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
+import { useStoredSessionHydration } from './hooks/use-stored-session-hydration'
 import { McpInstallDeepLinkDialog } from './mcp-install-deeplink-dialog'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { createSessionRpcDispatcher } from './session-rpc-dispatcher'
@@ -373,58 +370,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     return () => dispose?.()
   }, [])
 
-  // Post-turn rehydrate from stored history (same behavior as DesktopController,
-  // including finished-todos restoration).
-  const hydrateFromStoredSession = useCallback(
-    async (
-      attempts = 1,
-      storedSessionId = selectedStoredSessionIdRef.current,
-      runtimeSessionId = activeSessionIdRef.current
-    ) => {
-      if (!storedSessionId || !runtimeSessionId) {
-        return
-      }
-
-      const storedProfile = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
-
-      for (let index = 0; index < Math.max(1, attempts); index += 1) {
-        try {
-          const latest = await getLatestSessionMessages(storedSessionId, storedProfile)
-          const messages = toChatMessages(latest.messages)
-          updateSessionState(
-            runtimeSessionId,
-            state => ({
-              ...state,
-              // Post-turn rehydrate reads only the newest tail page — graft it
-              // onto any backfilled older pages instead of dropping them.
-              messages: preserveLocalAssistantErrors(
-                graftRefreshedTailOntoBackfill(messages, state.messages),
-                state.messages
-              )
-            }),
-            storedSessionId
-          )
-
-          const restored = todosForHydration(latestSessionTodos(messages))
-
-          if (restored) {
-            setSessionTodos(runtimeSessionId, restored)
-          } else {
-            clearSessionTodos(runtimeSessionId)
-          }
-
-          return
-        } catch {
-          // Best-effort fallback when live stream payloads are empty.
-        }
-
-        if (index < attempts - 1) {
-          await new Promise(resolve => window.setTimeout(resolve, 250))
-        }
-      }
-    },
-    [activeSessionIdRef, selectedStoredSessionIdRef, updateSessionState]
-  )
+  // Post-turn/recovery history belongs to the selected profile + stored id,
+  // not whichever duplicate row happens to appear first in the all-profile list.
+  const hydrateFromStoredSession = useStoredSessionHydration({
+    activeSessionIdRef,
+    selectedStoredSessionIdRef,
+    selectedStoredSessionProfileRef,
+    updateSessionState
+  })
 
   // Refresh any active transcript changed by another process. Signature-gated
   // so a no-change event does not churn the thread.
@@ -436,10 +389,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         requestSequenceRef: activeTranscriptRequestSequenceRef,
         resolveSession: resolveActiveTranscriptSession,
         selectedStoredSessionIdRef,
+        selectedStoredSessionProfileRef,
         signatureRef: activeTranscriptSignatureRef,
         updateSessionState
       }),
-    [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, updateSessionState]
+    [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, selectedStoredSessionProfileRef, updateSessionState]
   )
 
   const { handleGatewayEvent } = useMessageStream({

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -951,15 +951,15 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onEdit: editMessage,
     onLoadMoreMessaging: loadMoreMessagingForPlatform,
     onLoadMoreSessions: loadMoreSessions,
-    onManageCronJob: (jobId, profile) => {
-      setCronFocusJobId(jobId, profile)
+    onManageCronJob: (jobId, profile, connectionId) => {
+      setCronFocusJobId(jobId, profile, connectionId)
       navigate(CRON_ROUTE)
     },
     onNavigate: selectSidebarItem,
     onNewSessionInWorkspace: path => startSessionInWorkspace(path, { openTab: true }),
     onNewSessionSplit: dir => void openNewSessionTile(dir),
-    onOpenCronRun: (jobId, outputId, profile) => {
-      setCronFocusOutput(jobId, outputId, profile)
+    onOpenCronRun: (jobId, outputId, profile, connectionId) => {
+      setCronFocusOutput(jobId, outputId, profile, connectionId)
       navigate(CRON_ROUTE)
     },
     onPasteClipboardImage: opts => composer.pasteClipboardImage(opts),
@@ -1002,8 +1002,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onThreadMessagesChange: handleThreadMessagesChange,
     onToggleSelectedPin: toggleSelectedPin,
     onTranscribeAudio: transcribeVoiceAudio,
-    onTriggerCronJob: (jobId, profile) =>
-      triggerAndRefreshCronJobs(jobId, profileScope === ALL_PROFILES ? 'all' : profileScope, profile)
+    onTriggerCronJob: (jobId, profile, connectionId) =>
+      triggerAndRefreshCronJobs(jobId, profileScope === ALL_PROFILES ? 'all' : profileScope, {
+        connectionId,
+        profile
+      })
         .then(() => undefined)
         .catch(() => undefined),
     getGateway: () => gatewayRef.current,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -105,6 +105,7 @@ import {
   CRON_ROUTE,
   navigateToWorkspacePage,
   routeSessionId,
+  routeSessionProfile,
   sessionRoute,
   SETTINGS_ROUTE,
   syncWorkspaceRoute
@@ -229,7 +230,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const profileScope = useStore($profileScope)
   const boot = useStore($desktopBoot)
 
-  const routedSessionId = routeSessionId(location.pathname)
+  const routeTarget = `${location.pathname}${location.search}`
+  const routedSessionId = routeSessionId(routeTarget)
+  const routedSessionProfile = routeSessionProfile(routeTarget)
   const routedSessionIdRef = useRef(routedSessionId)
 
   routedSessionIdRef.current = routedSessionId
@@ -278,6 +281,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     resetViewSync,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,
+    selectedStoredSessionProfileRef,
     sessionStateByRuntimeIdRef,
     syncSessionStateToView,
     updateSessionState
@@ -500,6 +504,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
+    selectedStoredSessionProfileRef,
     sessionStateByRuntimeIdRef,
     syncSessionStateToView,
     updateSessionState
@@ -718,15 +723,17 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     currentView,
     freshDraftReady,
     gatewayState,
-    locationPathname: location.pathname,
+    locationPathname: routeTarget,
     resumeSession,
     resumeFailedSessionId,
     resumeExhaustedSessionId,
     sessionResumeRequest,
     routedSessionId,
+    routedSessionProfile,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
+    selectedStoredSessionProfileRef,
     startFreshSessionDraft
   })
 
@@ -839,12 +846,13 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     activeProfile: normalizeProfileKey(activeGatewayProfile),
     chatOpen,
     hasPreview: Boolean(previewTarget),
-    locationPathname: location.pathname,
+    locationPathname: routeTarget,
     navigate,
     profileReady: boot.phase === 'renderer.ready',
     refreshSessions,
     resumeExhaustedSessionId,
     routedSessionId,
+    routedSessionProfile,
     runtimeIdByStoredSessionId: runtimeIdByStoredSessionIdRef,
     sessions
   })
@@ -1015,7 +1023,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       openSession(sessionId, navigate)
     },
-    onRetryResume: sessionId => void resumeSession(sessionId, true),
+    onRetryResume: sessionId =>
+      void resumeSession(
+        sessionId,
+        true,
+        routedSessionId === sessionId ? (routedSessionProfile ?? undefined) : undefined
+      ),
     onSteer: steerPrompt,
     onSubmit: submitText,
     onThreadMessagesChange: handleThreadMessagesChange,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -392,7 +392,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         activeSessionIdRef,
         busyRef,
         requestSequenceRef: activeTranscriptRequestSequenceRef,
-        resolveSession: resolveActiveTranscriptSession,
+        resolveSession: (storedSessionId, ownerProfile) =>
+          resolveActiveTranscriptSession(
+            storedSessionId,
+            ownerProfile,
+            activeSessionIdRef.current ? getSessionStateOwner(activeSessionIdRef.current)?.connectionId : undefined
+          ),
         selectedStoredSessionIdRef,
         selectedStoredSessionProfileRef,
         sessionStateHasOwner,
@@ -402,6 +407,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     [
       activeSessionIdRef,
       busyRef,
+      getSessionStateOwner,
       selectedStoredSessionIdRef,
       selectedStoredSessionProfileRef,
       sessionStateHasOwner,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -279,8 +279,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,
     selectedStoredSessionProfileRef,
+    sessionStateHasOwner,
     sessionStateByRuntimeIdRef,
     syncSessionStateToView,
+    updateOwnedSessionState,
     updateSessionState
   } = useSessionStateCache({
     activeSessionId,
@@ -376,7 +378,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     activeSessionIdRef,
     selectedStoredSessionIdRef,
     selectedStoredSessionProfileRef,
-    updateSessionState
+    sessionStateHasOwner,
+    updateOwnedSessionState
   })
 
   // Refresh any active transcript changed by another process. Signature-gated
@@ -390,10 +393,18 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         resolveSession: resolveActiveTranscriptSession,
         selectedStoredSessionIdRef,
         selectedStoredSessionProfileRef,
+        sessionStateHasOwner,
         signatureRef: activeTranscriptSignatureRef,
-        updateSessionState
+        updateOwnedSessionState
       }),
-    [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, selectedStoredSessionProfileRef, updateSessionState]
+    [
+      activeSessionIdRef,
+      busyRef,
+      selectedStoredSessionIdRef,
+      selectedStoredSessionProfileRef,
+      sessionStateHasOwner,
+      updateOwnedSessionState
+    ]
   )
 
   const { handleGatewayEvent } = useMessageStream({
@@ -988,8 +999,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onThreadMessagesChange: handleThreadMessagesChange,
     onToggleSelectedPin: toggleSelectedPin,
     onTranscribeAudio: transcribeVoiceAudio,
-    onTriggerCronJob: jobId =>
-      triggerAndRefreshCronJobs(jobId, profileScope === ALL_PROFILES ? 'all' : profileScope)
+    onTriggerCronJob: (jobId, profile) =>
+      triggerAndRefreshCronJobs(jobId, profileScope === ALL_PROFILES ? 'all' : profileScope, profile)
         .then(() => undefined)
         .catch(() => undefined),
     getGateway: () => gatewayRef.current,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -43,7 +43,7 @@ import { $billingSettingsRequest } from '@/store/billing-block'
 import { $desktopBoot } from '@/store/boot'
 import { requestVoiceConversationStart } from '@/store/composer'
 import { $activeConnectionId } from '@/store/connections'
-import { $cronReviewRequest, setCronFocusJobId } from '@/store/cron'
+import { $cronReviewRequest, setCronFocusJobId, setCronFocusOutput } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { notify, notifyError } from '@/store/notifications'
 import { $previewTarget } from '@/store/preview'
@@ -982,6 +982,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onNavigate: selectSidebarItem,
     onNewSessionInWorkspace: path => startSessionInWorkspace(path, { openTab: true }),
     onNewSessionSplit: dir => void openNewSessionTile(dir),
+    onOpenCronRun: (jobId, outputId, profile) => {
+      setCronFocusOutput(jobId, outputId, profile)
+      navigate(CRON_ROUTE)
+    },
     onPasteClipboardImage: opts => composer.pasteClipboardImage(opts),
     onPickFiles: () => void composer.pickContextPaths('file'),
     onPickFolders: () => void composer.pickContextPaths('folder'),
@@ -1214,10 +1218,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       {cronOpen && (
         <Suspense fallback={null}>
-          <CronView
-            onClose={closeOverlayToPreviousRoute}
-            onOpenSession={sessionId => openSession(sessionId, navigate)}
-          />
+          <CronView onClose={closeOverlayToPreviousRoute} />
         </Suspense>
       )}
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -975,8 +975,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onEdit: editMessage,
     onLoadMoreMessaging: loadMoreMessagingForPlatform,
     onLoadMoreSessions: loadMoreSessions,
-    onManageCronJob: jobId => {
-      setCronFocusJobId(jobId)
+    onManageCronJob: (jobId, profile) => {
+      setCronFocusJobId(jobId, profile)
       navigate(CRON_ROUTE)
     },
     onNavigate: selectSidebarItem,
@@ -1001,13 +1001,13 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     // previewing profile A and the resume dials profile B. Pin the row's own
     // (connection, profile) as the resume owner before navigating; untagged
     // rows (single-profile installs, legacy pages) keep the id-only path.
-    onResumeSession: (sessionId, session) => {
-      const rowProfile = session?.profile?.trim()
+    onResumeSession: (sessionId, owner) => {
+      const rowProfile = (typeof owner === 'string' ? owner : owner?.profile)?.trim()
 
       if (rowProfile) {
         requestSessionResume(sessionId, {
-          connectionId: session?.connection_id?.trim() || 'local',
-          ...(session?.connection_id?.trim() ? {} : { mode: 'local' as const }),
+          connectionId: (typeof owner === 'object' ? owner.connection_id?.trim() : '') || 'local',
+          ...(typeof owner === 'object' && owner.connection_id?.trim() ? {} : { mode: 'local' as const }),
           profile: rowProfile,
           targetProfile: rowProfile
         })

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -275,6 +275,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     activeSessionIdRef,
     ensureSessionState,
     getRuntimeIdForStoredSession,
+    getSessionStateOwner,
     resetViewSync,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,
@@ -376,6 +377,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // not whichever duplicate row happens to appear first in the all-profile list.
   const hydrateFromStoredSession = useStoredSessionHydration({
     activeSessionIdRef,
+    getSessionStateOwner,
     selectedStoredSessionIdRef,
     selectedStoredSessionProfileRef,
     sessionStateHasOwner,
@@ -799,7 +801,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     refreshMessagingSessions,
     refreshSessions,
     requestGateway,
-    updateSessionState
+    sessionStateHasOwner,
+    updateOwnedSessionState
   })
 
   // Electron-main / OS / cross-window integrations: update polling, ⌘W close,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -34,7 +34,7 @@ import { playWakeSound } from '@/lib/wake-sound'
 import { $billingSettingsRequest } from '@/store/billing-block'
 import { $desktopBoot } from '@/store/boot'
 import { requestVoiceConversationStart } from '@/store/composer'
-import { setCronFocusJobId } from '@/store/cron'
+import { setCronFocusJobId, setCronFocusOutput } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $previewTarget } from '@/store/preview'
 import {
@@ -886,6 +886,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onNavigate: selectSidebarItem,
     onNewSessionInWorkspace: path => startSessionInWorkspace(path, { openTab: true }),
     onNewSessionSplit: dir => void openNewSessionTile(dir),
+    onOpenCronRun: (jobId, outputId, profile) => {
+      setCronFocusOutput(jobId, outputId, profile)
+      navigate(CRON_ROUTE)
+    },
     onPasteClipboardImage: opts => composer.pasteClipboardImage(opts),
     onPickFiles: () => void composer.pickContextPaths('file'),
     onPickFolders: () => void composer.pickContextPaths('folder'),
@@ -1093,10 +1097,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       {cronOpen && (
         <Suspense fallback={null}>
-          <CronView
-            onClose={closeOverlayToPreviousRoute}
-            onOpenSession={sessionId => openSession(sessionId, navigate)}
-          />
+          <CronView onClose={closeOverlayToPreviousRoute} />
         </Suspense>
       )}
 

--- a/apps/desktop/src/app/cron/cron-actions.test.ts
+++ b/apps/desktop/src/app/cron/cron-actions.test.ts
@@ -31,8 +31,8 @@ describe('triggerAndRefreshCronJobs', () => {
 
     const result = await triggerAndRefreshCronJobs('deleted-one-shot', 'work')
 
-    expect(triggerCronJob).toHaveBeenCalledWith('deleted-one-shot', 'work')
-    expect(getCronJobs).toHaveBeenCalledWith('work')
+    expect(triggerCronJob).toHaveBeenCalledWith('deleted-one-shot', { connectionId: null, profile: 'work' })
+    expect(getCronJobs).toHaveBeenCalledWith({ connectionId: null, profile: 'work' })
     expect(result).toEqual({ jobs: authoritative, refreshError: null, stale: false })
   })
 
@@ -53,7 +53,7 @@ describe('triggerAndRefreshCronJobs', () => {
     await triggerAndRefreshCronJobs('shared-job', 'all', 'worker_alpha')
 
     expect(triggerCronJob).toHaveBeenCalledWith('shared-job', 'worker_alpha')
-    expect(getCronJobs).toHaveBeenCalledWith('all')
+    expect(getCronJobs).toHaveBeenCalledWith({ connectionId: null, profile: 'all' })
   })
 
   it('still rejects when the trigger itself fails', async () => {

--- a/apps/desktop/src/app/cron/cron-actions.test.ts
+++ b/apps/desktop/src/app/cron/cron-actions.test.ts
@@ -31,7 +31,7 @@ describe('triggerAndRefreshCronJobs', () => {
 
     const result = await triggerAndRefreshCronJobs('deleted-one-shot', 'work')
 
-    expect(triggerCronJob).toHaveBeenCalledWith('deleted-one-shot')
+    expect(triggerCronJob).toHaveBeenCalledWith('deleted-one-shot', 'work')
     expect(getCronJobs).toHaveBeenCalledWith('work')
     expect(result).toEqual({ jobs: authoritative, refreshError: null, stale: false })
   })
@@ -44,6 +44,16 @@ describe('triggerAndRefreshCronJobs', () => {
     const result = await triggerAndRefreshCronJobs('job-1', 'all')
 
     expect(result).toEqual({ jobs: null, refreshError, stale: false })
+  })
+
+  it('routes an aggregated duplicate-id trigger to the row owner profile', async () => {
+    triggerCronJob.mockResolvedValue({ id: 'shared-job', state: 'scheduled' })
+    getCronJobs.mockResolvedValue([])
+
+    await triggerAndRefreshCronJobs('shared-job', 'all', 'worker_alpha')
+
+    expect(triggerCronJob).toHaveBeenCalledWith('shared-job', 'worker_alpha')
+    expect(getCronJobs).toHaveBeenCalledWith('all')
   })
 
   it('still rejects when the trigger itself fails', async () => {

--- a/apps/desktop/src/app/cron/cron-actions.ts
+++ b/apps/desktop/src/app/cron/cron-actions.ts
@@ -1,4 +1,4 @@
-import { type CronJob, getApiRequestConnection, getCronJobs, triggerCronJob } from '@/hermes'
+import { type CronJob, type CronOwner, getApiRequestConnection, getCronJobs, triggerCronJob } from '@/hermes'
 import {
   beginCronJobsAction,
   beginCronJobsRequest,
@@ -18,13 +18,17 @@ export interface CronMutationRefreshResult<T> extends CronTriggerRefreshResult {
   value: T | null
 }
 
-function cronRequestScope(profile: string): string {
-  return `${getApiRequestConnection() ?? ''}\u0000${profile}`
+function cronRequestScope(profile: string, connectionId: null | string): string {
+  return `${connectionId ?? ''}\u0000${profile}`
 }
 
-async function refreshForGeneration(profile: string, request: CronJobsRequest): Promise<CronTriggerRefreshResult> {
+async function refreshForGeneration(
+  profile: string,
+  connectionId: null | string,
+  request: CronJobsRequest
+): Promise<CronTriggerRefreshResult> {
   try {
-    const jobs = await getCronJobs(profile)
+    const jobs = await getCronJobs({ connectionId, profile })
 
     if (!commitCronJobsRequest(request, jobs)) {
       return { jobs: null, refreshError: null, stale: true }
@@ -41,14 +45,16 @@ async function refreshForGeneration(profile: string, request: CronJobsRequest): 
 }
 
 export function refreshCronJobs(profile: string): Promise<CronTriggerRefreshResult> {
-  return refreshForGeneration(profile, beginCronJobsRequest(cronRequestScope(profile)))
+  const connectionId = getApiRequestConnection()
+  return refreshForGeneration(profile, connectionId, beginCronJobsRequest(cronRequestScope(profile, connectionId)))
 }
 
 export async function mutateAndRefreshCronJobs<T>(
   profile: string,
   mutate: () => Promise<T>
 ): Promise<CronMutationRefreshResult<T>> {
-  const scopeToken = beginCronJobsAction(cronRequestScope(profile))
+  const connectionId = getApiRequestConnection()
+  const scopeToken = beginCronJobsAction(cronRequestScope(profile, connectionId))
   let value: T
 
   try {
@@ -65,7 +71,11 @@ export async function mutateAndRefreshCronJobs<T>(
     return { jobs: null, refreshError: null, stale: true, value: null }
   }
 
-  const refreshed = await refreshCronJobs(profile)
+  const refreshed = await refreshForGeneration(
+    profile,
+    connectionId,
+    beginCronJobsRequest(cronRequestScope(profile, connectionId))
+  )
 
   if (!isCronJobsScopeCurrent(scopeToken)) {
     return { jobs: null, refreshError: null, stale: true, value: null }
@@ -90,10 +100,12 @@ export async function mutateAndRefreshCronJobs<T>(
 export async function triggerAndRefreshCronJobs(
   jobId: string,
   profile: 'all' | string,
-  ownerProfile?: string
+  owner?: CronOwner
 ): Promise<CronTriggerRefreshResult> {
-  const owner = ownerProfile ?? (profile === 'all' ? undefined : profile)
-  const { value: _value, ...result } = await mutateAndRefreshCronJobs(profile, () => triggerCronJob(jobId, owner))
+  const resolvedOwner = owner ?? (profile === 'all' ? undefined : { connectionId: getApiRequestConnection(), profile })
+  const { value: _value, ...result } = await mutateAndRefreshCronJobs(profile, () =>
+    triggerCronJob(jobId, resolvedOwner)
+  )
 
   return result
 }

--- a/apps/desktop/src/app/cron/cron-actions.ts
+++ b/apps/desktop/src/app/cron/cron-actions.ts
@@ -89,9 +89,11 @@ export async function mutateAndRefreshCronJobs<T>(
  */
 export async function triggerAndRefreshCronJobs(
   jobId: string,
-  profile: 'all' | string
+  profile: 'all' | string,
+  ownerProfile?: string
 ): Promise<CronTriggerRefreshResult> {
-  const { value: _value, ...result } = await mutateAndRefreshCronJobs(profile, () => triggerCronJob(jobId))
+  const owner = ownerProfile ?? (profile === 'all' ? undefined : profile)
+  const { value: _value, ...result } = await mutateAndRefreshCronJobs(profile, () => triggerCronJob(jobId, owner))
 
   return result
 }

--- a/apps/desktop/src/app/cron/cron-run-output.test.tsx
+++ b/apps/desktop/src/app/cron/cron-run-output.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getCronJobOutput, getCronJobOutputs } from '@/hermes'
+import { TRANSLATIONS } from '@/i18n'
+import { $cronFocus } from '@/store/cron'
+
+import { CronJobRuns } from './index'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getCronJobOutput: vi.fn(),
+  getCronJobOutputs: vi.fn()
+}))
+
+describe('CronJobRuns', () => {
+  afterEach(() => {
+    cleanup()
+    $cronFocus.set(null)
+    vi.clearAllMocks()
+  })
+
+  it('loads and renders the durable markdown output when a run is clicked', async () => {
+    vi.mocked(getCronJobOutputs).mockResolvedValue([
+      {
+        byte_size: 72,
+        created_at: 1_786_435_200,
+        filename: '2026-08-11_09-00-00.md',
+        id: '2026-08-11_09-00-00'
+      }
+    ])
+    vi.mocked(getCronJobOutput).mockResolvedValue({
+      byte_size: 72,
+      content: '# Report\n\n| Name | Value |\n| --- | --- |\n| ok | 1 |\n\n[Details](https://example.com)',
+      created_at: 1_786_435_200,
+      filename: '2026-08-11_09-00-00.md',
+      id: '2026-08-11_09-00-00',
+      profile: 'worker_alpha'
+    })
+
+    render(<CronJobRuns c={TRANSLATIONS.en.cron} jobId="report-job" profile="worker_alpha" />)
+
+    const run = await screen.findByRole('button', { name: /2026-08-11_09-00-00\.md/ })
+    fireEvent.click(run)
+
+    expect(getCronJobOutputs).toHaveBeenCalledWith('report-job', 20, 'worker_alpha')
+    expect(getCronJobOutput).toHaveBeenCalledWith('report-job', '2026-08-11_09-00-00', 'worker_alpha')
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Report' })).toBeTruthy())
+    expect(screen.getByRole('cell', { name: 'ok' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Details' }).getAttribute('href')).toBe('https://example.com/')
+  })
+
+  it('distinguishes a failed output listing from an empty run history', async () => {
+    vi.mocked(getCronJobOutputs).mockRejectedValue(new Error('profile backend unavailable'))
+
+    render(<CronJobRuns c={TRANSLATIONS.en.cron} jobId="report-job" />)
+
+    expect(await screen.findByText(TRANSLATIONS.en.cron.failedLoad)).toBeTruthy()
+    expect(screen.queryByText(TRANSLATIONS.en.cron.noRuns)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/cron/cron-run-output.test.tsx
+++ b/apps/desktop/src/app/cron/cron-run-output.test.tsx
@@ -194,9 +194,7 @@ describe('CronJobRuns', () => {
       </QueryClientProvider>
     )
 
-    await waitFor(() =>
-      expect(getCronJobOutput).toHaveBeenCalledWith('shared-job', 'worker-output', 'worker_alpha')
-    )
+    await waitFor(() => expect(getCronJobOutput).toHaveBeenCalledWith('shared-job', 'worker-output', 'worker_alpha'))
     expect(await screen.findByRole('heading', { name: 'Worker output' })).toBeTruthy()
     expect($cronFocus.get()).toBeNull()
   })

--- a/apps/desktop/src/app/cron/cron-run-output.test.tsx
+++ b/apps/desktop/src/app/cron/cron-run-output.test.tsx
@@ -58,4 +58,36 @@ describe('CronJobRuns', () => {
     expect(await screen.findByText(TRANSLATIONS.en.cron.failedLoad)).toBeTruthy()
     expect(screen.queryByText(TRANSLATIONS.en.cron.noRuns)).toBeNull()
   })
+
+  it('reports and consumes a focus target whose retained output is gone', async () => {
+    vi.mocked(getCronJobOutputs).mockResolvedValue([])
+    $cronFocus.set({
+      jobId: 'report-job',
+      outputId: '2026-08-10_09-00-00',
+      profile: 'worker_alpha'
+    })
+
+    render(<CronJobRuns c={TRANSLATIONS.en.cron} jobId="report-job" profile="worker_alpha" />)
+
+    expect((await screen.findByRole('status')).textContent).toContain('2026-08-10_09-00-00.md')
+    expect(getCronJobOutput).not.toHaveBeenCalled()
+    await waitFor(() => expect($cronFocus.get()).toBeNull())
+  })
+
+  it('keeps an output focus target when the run listing fails transiently', async () => {
+    const focusTarget = {
+      jobId: 'report-job',
+      outputId: '2026-08-10_09-00-00',
+      profile: 'worker_alpha'
+    }
+
+    vi.mocked(getCronJobOutputs).mockRejectedValue(new Error('profile backend unavailable'))
+    $cronFocus.set(focusTarget)
+
+    render(<CronJobRuns c={TRANSLATIONS.en.cron} jobId="report-job" profile="worker_alpha" />)
+
+    expect(await screen.findByText(TRANSLATIONS.en.cron.failedLoad)).toBeTruthy()
+    expect($cronFocus.get()).toEqual(focusTarget)
+    expect(screen.queryByRole('status')).toBeNull()
+  })
 })

--- a/apps/desktop/src/app/cron/cron-run-output.test.tsx
+++ b/apps/desktop/src/app/cron/cron-run-output.test.tsx
@@ -1,22 +1,39 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { getCronJobOutput, getCronJobOutputs } from '@/hermes'
+import { getAutomationBlueprints, getCronJobOutput, getCronJobOutputs, getCronJobs } from '@/hermes'
 import { TRANSLATIONS } from '@/i18n'
-import { $cronFocus } from '@/store/cron'
+import { $cronFocus, setCronJobs } from '@/store/cron'
+import { setShowAllProfiles } from '@/store/profile'
 
-import { CronJobRuns } from './index'
+import { CronJobRuns, CronView } from './index'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
 
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
+  getAutomationBlueprints: vi.fn(),
   getCronJobOutput: vi.fn(),
-  getCronJobOutputs: vi.fn()
+  getCronJobOutputs: vi.fn(),
+  getCronJobs: vi.fn()
 }))
 
 describe('CronJobRuns', () => {
   afterEach(() => {
     cleanup()
     $cronFocus.set(null)
+    setShowAllProfiles(false)
+    setCronJobs([])
+    vi.unstubAllGlobals()
     vi.clearAllMocks()
   })
 
@@ -89,5 +106,98 @@ describe('CronJobRuns', () => {
     expect(await screen.findByText(TRANSLATIONS.en.cron.failedLoad)).toBeTruthy()
     expect($cronFocus.get()).toEqual(focusTarget)
     expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('cannot publish a late output detail after the job profile scope changes', async () => {
+    const staleDetail = deferred<Awaited<ReturnType<typeof getCronJobOutput>>>()
+
+    vi.mocked(getCronJobOutputs).mockImplementation(async (_jobId, _limit, profile) => [
+      {
+        byte_size: 72,
+        created_at: profile === 'worker_alpha' ? 1_786_435_200 : 1_786_521_600,
+        filename: `${profile}.md`,
+        id: `${profile}-output`
+      }
+    ])
+    vi.mocked(getCronJobOutput).mockReturnValue(staleDetail.promise)
+
+    const view = render(<CronJobRuns c={TRANSLATIONS.en.cron} jobId="shared-job" profile="worker_alpha" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /worker_alpha\.md/ }))
+    view.rerender(<CronJobRuns c={TRANSLATIONS.en.cron} jobId="shared-job" profile="worker_beta" />)
+
+    expect(await screen.findByRole('button', { name: /worker_beta\.md/ })).toBeTruthy()
+
+    await act(async () => {
+      staleDetail.resolve({
+        byte_size: 72,
+        content: '# Wrong profile output',
+        created_at: 1_786_435_200,
+        filename: 'worker_alpha.md',
+        id: 'worker_alpha-output',
+        profile: 'worker_alpha'
+      })
+      await staleDetail.promise
+    })
+
+    expect(screen.queryByRole('heading', { name: 'Wrong profile output' })).toBeNull()
+    expect(screen.queryByText(TRANSLATIONS.en.cron.failedLoad)).toBeNull()
+  })
+
+  it('opens a focused duplicate-id job from the owning profile in the full Cron view', async () => {
+    const jobs = [
+      {
+        enabled: true,
+        id: 'shared-job',
+        name: 'Default report',
+        profile: 'default',
+        schedule: { expr: '0 9 * * *' }
+      },
+      {
+        enabled: true,
+        id: 'shared-job',
+        name: 'Worker report',
+        profile: 'worker_alpha',
+        schedule: { expr: '0 9 * * *' }
+      }
+    ] as never
+
+    setShowAllProfiles(true)
+    setCronJobs(jobs)
+    $cronFocus.set({ jobId: 'shared-job', outputId: 'worker-output', profile: 'worker_alpha' })
+    vi.mocked(getCronJobs).mockResolvedValue(jobs)
+    vi.mocked(getAutomationBlueprints).mockResolvedValue({ blueprints: [] })
+    vi.mocked(getCronJobOutputs).mockImplementation(async (_jobId, _limit, profile) =>
+      profile === 'worker_alpha'
+        ? [{ byte_size: 72, created_at: 1_786_435_200, filename: 'worker-output.md', id: 'worker-output' }]
+        : [{ byte_size: 72, created_at: 1_786_435_200, filename: 'default-output.md', id: 'default-output' }]
+    )
+    vi.mocked(getCronJobOutput).mockResolvedValue({
+      byte_size: 72,
+      content: '# Worker output',
+      created_at: 1_786_435_200,
+      filename: 'worker-output.md',
+      id: 'worker-output',
+      profile: 'worker_alpha'
+    })
+    vi.stubGlobal('CSS', { escape: (value: string) => value.replace(/["\\]/g, '\\$&') })
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn()
+    })
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CronView onClose={vi.fn()} />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() =>
+      expect(getCronJobOutput).toHaveBeenCalledWith('shared-job', 'worker-output', 'worker_alpha')
+    )
+    expect(await screen.findByRole('heading', { name: 'Worker output' })).toBeTruthy()
+    expect($cronFocus.get()).toBeNull()
   })
 })

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -875,6 +875,7 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
   const [output, setOutput] = useState<null | string>(null)
   const [outputError, setOutputError] = useState(false)
   const [outputLoading, setOutputLoading] = useState(false)
+  const [focusUnavailable, setFocusUnavailable] = useState<null | string>(null)
   const outputRequestRef = useRef(0)
   const focusTarget = useStore($cronFocus)
   const changeEventsAvailable = useStore($changeEventsAvailable)
@@ -884,6 +885,7 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
     async (outputId: string) => {
       const requestId = ++outputRequestRef.current
 
+      setFocusUnavailable(null)
       setSelectedOutputId(outputId)
       setOutput(null)
       setOutputError(false)
@@ -960,6 +962,7 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
   useEffect(() => {
     if (
       runs === null ||
+      runsError ||
       focusTarget?.jobId !== jobId ||
       (focusTarget.profile && focusTarget.profile !== profile) ||
       !focusTarget.outputId
@@ -969,10 +972,17 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
 
     if (runs.some(run => run.id === focusTarget.outputId)) {
       void openOutput(focusTarget.outputId)
+    } else {
+      ++outputRequestRef.current
+      setSelectedOutputId(null)
+      setOutput(null)
+      setOutputError(false)
+      setOutputLoading(false)
+      setFocusUnavailable(focusTarget.outputId)
     }
 
     setCronFocusJobId(null)
-  }, [focusTarget, jobId, openOutput, profile, runs])
+  }, [focusTarget, jobId, openOutput, profile, runs, runsError])
 
   return (
     <div>
@@ -1009,6 +1019,11 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
           ))}
         </div>
       )}
+      {focusUnavailable ? (
+        <p className="mt-2 text-xs text-muted-foreground" role="status">
+          {c.outputUnavailable(focusUnavailable)}
+        </p>
+      ) : null}
       {selectedOutputId ? (
         <div className="mt-3 min-h-16 rounded-md border border-(--ui-stroke-tertiary) bg-background p-3">
           {outputLoading ? (

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -448,36 +448,39 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
 
   const totalCount = jobs.length
 
-  function beginJobBusy(jobId: string): symbol {
-    const token = Symbol(jobId)
+  function beginJobBusy(job: CronJob): symbol {
+    const jobKey = cronJobIdentity(job)
+    const token = Symbol(jobKey)
 
-    setBusyJobTokens(current => new Map(current).set(jobId, token))
+    setBusyJobTokens(current => new Map(current).set(jobKey, token))
 
     return token
   }
 
-  function endJobBusy(jobId: string, token: symbol): void {
+  function endJobBusy(job: CronJob, token: symbol): void {
+    const jobKey = cronJobIdentity(job)
+
     setBusyJobTokens(current => {
-      if (current.get(jobId) !== token) {
+      if (current.get(jobKey) !== token) {
         return current
       }
 
       const next = new Map(current)
 
-      next.delete(jobId)
+      next.delete(jobKey)
 
       return next
     })
   }
 
   async function handlePauseResume(job: CronJob) {
-    const busyToken = beginJobBusy(job.id)
+    const busyToken = beginJobBusy(job)
 
     try {
       const isPaused = jobState(job) === 'paused'
 
       const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
-        isPaused ? resumeCronJob(job.id) : pauseCronJob(job.id)
+        isPaused ? resumeCronJob(job.id, job.profile) : pauseCronJob(job.id, job.profile)
       )
 
       if (stale) {
@@ -496,13 +499,13 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
     } catch (err) {
       notifyError(err, c.failedUpdate)
     } finally {
-      endJobBusy(job.id, busyToken)
+      endJobBusy(job, busyToken)
     }
   }
 
   async function handleTrigger(job: CronJob) {
     const viewProfile = profile
-    const key = `${viewProfile}:${job.id}`
+    const key = cronJobIdentity(job)
     const controller = triggerControllerRef.current
 
     if (!controller) {
@@ -512,7 +515,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
     try {
       const run = await controller.run(
         key,
-        () => triggerAndRefreshCronJobs(job.id, viewProfile),
+        () => triggerAndRefreshCronJobs(job.id, viewProfile, job.profile),
         () => notify({ kind: 'info', title: c.triggerNow, message: truncate(jobTitle(job), 60) })
       )
 
@@ -549,7 +552,9 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
       return
     }
 
-    const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () => deleteCronJob(pendingDelete.id))
+    const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
+      deleteCronJob(pendingDelete.id, pendingDelete.profile)
+    )
 
     if (stale) {
       return
@@ -569,13 +574,18 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
         refreshError,
         stale
       } = await mutateAndRefreshCronJobs(profile, () =>
-        createCronJob({
-          prompt: values.prompt,
-          schedule: values.schedule,
-          name: values.name || undefined,
-          deliver: values.deliver || DEFAULT_DELIVER,
-          ...(values.model.trim() ? { model: values.model.trim(), provider: values.provider.trim() || undefined } : {})
-        })
+        createCronJob(
+          {
+            prompt: values.prompt,
+            schedule: values.schedule,
+            name: values.name || undefined,
+            deliver: values.deliver || DEFAULT_DELIVER,
+            ...(values.model.trim()
+              ? { model: values.model.trim(), provider: values.provider.trim() || undefined }
+              : {})
+          },
+          profileScope === ALL_PROFILES ? 'default' : profileScope
+        )
       )
 
       if (stale || !created) {
@@ -595,7 +605,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
         refreshError,
         stale
       } = await mutateAndRefreshCronJobs(profile, () =>
-        updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }))
+        updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }), editor.job.profile)
       )
 
       if (stale || !updated) {
@@ -708,7 +718,9 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
 
           {selectedJob ? (
             <CronJobDetail
-              busy={busyJobTokens.has(selectedJob.id) || triggeringJobKeys.has(`${profile}:${selectedJob.id}`)}
+              busy={
+                busyJobTokens.has(cronJobIdentity(selectedJob)) || triggeringJobKeys.has(cronJobIdentity(selectedJob))
+              }
               c={c}
               job={selectedJob}
               onPauseResume={() => void handlePauseResume(selectedJob)}

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -34,21 +35,23 @@ import {
   createCronJob,
   type CronDeliveryTarget,
   type CronJob,
+  type CronJobOutput,
   deleteCronJob,
   getAutomationBlueprints,
   getCronDeliveryTargets,
-  getCronJobRuns,
+  getCronJobOutput,
+  getCronJobOutputs,
   instantiateAutomationBlueprint,
   pauseCronJob,
   resumeCronJob,
-  type SessionInfo,
   updateCronJob
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
 import { requestModelOptions } from '@/lib/model-options'
 import { asText } from '@/lib/text'
-import { $cronFocusJobId, $cronJobs, invalidateCronJobsRequests, setCronFocusJobId } from '@/store/cron'
+import { cn } from '@/lib/utils'
+import { $cronFocus, $cronJobs, invalidateCronJobsRequests, setCronFocusJobId } from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
 import { $profileScope, ALL_PROFILES } from '@/store/profile'
@@ -291,11 +294,10 @@ function matchesQuery(job: CronJob, q: string): boolean {
 
 interface CronViewProps extends React.ComponentProps<'section'> {
   onClose: () => void
-  onOpenSession?: (sessionId: string) => void
   setStatusbarItemGroup?: SetStatusbarItemGroup
 }
 
-export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setStatusbarItemGroup }: CronViewProps) {
+export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGroup }: CronViewProps) {
   const { t } = useI18n()
   const c = t.cron
   // Source of truth is the shared atom (also fed by the controller poll), so the
@@ -340,7 +342,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   // Set when a job is opened from the sidebar so we scroll it into view once the
   // row exists. Cleared after the scroll fires.
   const pendingScrollRef = useRef<null | string>(null)
-  const focusJobId = useStore($cronFocusJobId)
+  const focusTarget = useStore($cronFocus)
 
   const [editor, setEditor] = useState<EditorState>({ mode: 'closed' })
   const [pendingDelete, setPendingDelete] = useState<CronJob | null>(null)
@@ -380,19 +382,25 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   // normally doesn't re-trigger it.
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (!focusJobId) {
+    if (!focusTarget) {
       return
     }
 
-    const match = jobs.find(job => job.id === focusJobId || jobName(job) === focusJobId)
+    const match = jobs.find(
+      job =>
+        (job.id === focusTarget.jobId || jobName(job) === focusTarget.jobId) &&
+        (!focusTarget.profile || job.profile === focusTarget.profile)
+    )
 
     if (match) {
       setSelectedJobId(match.id)
       pendingScrollRef.current = match.id
     }
 
-    setCronFocusJobId(null)
-  }, [focusJobId, jobs])
+    if (!focusTarget.outputId) {
+      setCronFocusJobId(null)
+    }
+  }, [focusTarget, jobs])
 
   const visibleJobs = useMemo(
     () => jobs.filter(job => matchesQuery(job, query.trim())).sort((a, b) => jobTitle(a).localeCompare(jobTitle(b))),
@@ -701,7 +709,6 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
               busy={busyJobTokens.has(selectedJob.id) || triggeringJobKeys.has(`${profile}:${selectedJob.id}`)}
               c={c}
               job={selectedJob}
-              onOpenSession={onOpenSession}
               onPauseResume={() => void handlePauseResume(selectedJob)}
               onTrigger={() => void handleTrigger(selectedJob)}
             />
@@ -781,14 +788,12 @@ function CronJobDetail({
   busy,
   c,
   job,
-  onOpenSession,
   onPauseResume,
   onTrigger
 }: {
   busy: boolean
   c: Translations['cron']
   job: CronJob
-  onOpenSession?: (sessionId: string) => void
   onPauseResume: () => void
   onTrigger: () => void
 }) {
@@ -841,7 +846,7 @@ function CronJobDetail({
         </section>
       ) : null}
 
-      <CronJobRuns c={c} jobId={job.id} onOpenSession={onOpenSession} />
+      <CronJobRuns c={c} jobId={job.id} key={`${job.profile ?? ''}:${job.id}`} profile={job.profile} />
     </PanelDetail>
   )
 }
@@ -856,41 +861,74 @@ function formatRunTime(seconds?: null | number): string {
   return Number.isNaN(date.valueOf()) ? '—' : date.toLocaleString()
 }
 
-// Runs are produced by the background scheduler tick. cron.changed /
-// sessions.changed broadcasts re-load immediately on event-capable backends
+// Outputs are produced by the background scheduler tick. cron.changed
+// broadcasts re-load immediately on event-capable backends
 // (the tick dep below), so the poll drops to a slow backstop there; older
 // backends keep the legacy cadence.
 const RUNS_POLL_INTERVAL_MS = 8000
 const RUNS_BACKSTOP_INTERVAL_MS = 60_000
 
-function CronJobRuns({
-  c,
-  jobId,
-  onOpenSession
-}: {
-  c: Translations['cron']
-  jobId: string
-  onOpenSession?: (sessionId: string) => void
-}) {
-  const [runs, setRuns] = useState<null | SessionInfo[]>(null)
+export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jobId: string; profile?: string }) {
+  const [runs, setRuns] = useState<null | CronJobOutput[]>(null)
+  const [runsError, setRunsError] = useState(false)
+  const [selectedOutputId, setSelectedOutputId] = useState<null | string>(null)
+  const [output, setOutput] = useState<null | string>(null)
+  const [outputError, setOutputError] = useState(false)
+  const [outputLoading, setOutputLoading] = useState(false)
+  const outputRequestRef = useRef(0)
+  const focusTarget = useStore($cronFocus)
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
 
+  const openOutput = useCallback(
+    async (outputId: string) => {
+      const requestId = ++outputRequestRef.current
+
+      setSelectedOutputId(outputId)
+      setOutput(null)
+      setOutputError(false)
+      setOutputLoading(true)
+
+      try {
+        const detail = await getCronJobOutput(jobId, outputId, profile)
+
+        if (outputRequestRef.current === requestId) {
+          setOutput(detail.content)
+        }
+      } catch {
+        if (outputRequestRef.current === requestId) {
+          setOutputError(true)
+        }
+      } finally {
+        if (outputRequestRef.current === requestId) {
+          setOutputLoading(false)
+        }
+      }
+    },
+    [jobId, profile]
+  )
+
   useEffect(() => {
     let cancelled = false
+    let latestRequestId = 0
 
-    const load = () =>
-      getCronJobRuns(jobId)
+    const load = () => {
+      const requestId = ++latestRequestId
+
+      return getCronJobOutputs(jobId, 20, profile)
         .then(result => {
-          if (!cancelled) {
+          if (!cancelled && requestId === latestRequestId) {
+            setRunsError(false)
             setRuns(result)
           }
         })
         .catch(() => {
-          if (!cancelled) {
+          if (!cancelled && requestId === latestRequestId) {
+            setRunsError(true)
             setRuns(prev => prev ?? [])
           }
         })
+    }
 
     void load()
 
@@ -917,7 +955,24 @@ function CronJobRuns({
       document.removeEventListener('visibilitychange', onVisible)
     }
     // cronChangeTick: a fired run moves jobs.json bookkeeping → reload now.
-  }, [changeEventsAvailable, cronChangeTick, jobId])
+  }, [changeEventsAvailable, cronChangeTick, jobId, profile])
+
+  useEffect(() => {
+    if (
+      runs === null ||
+      focusTarget?.jobId !== jobId ||
+      (focusTarget.profile && focusTarget.profile !== profile) ||
+      !focusTarget.outputId
+    ) {
+      return
+    }
+
+    if (runs.some(run => run.id === focusTarget.outputId)) {
+      void openOutput(focusTarget.outputId)
+    }
+
+    setCronFocusJobId(null)
+  }, [focusTarget, jobId, openOutput, profile, runs])
 
   return (
     <div>
@@ -925,7 +980,9 @@ function CronJobRuns({
         {c.runHistory}
         {runs && runs.length > 0 ? ` · ${runs.length}` : ''}
       </PanelSectionLabel>
-      {runs === null ? (
+      {runsError ? (
+        <p className="py-1 text-xs text-destructive">{c.failedLoad}</p>
+      ) : runs === null ? (
         <div className="flex items-center gap-1.5 py-1 text-xs text-muted-foreground">
           <Codicon name="loading" size="0.75rem" spinning />
         </div>
@@ -935,19 +992,37 @@ function CronJobRuns({
         <div className="flex flex-col gap-px">
           {runs.map(run => (
             <button
-              className="row-hover flex items-center justify-between gap-3 rounded-md px-2 py-1 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              aria-expanded={selectedOutputId === run.id}
+              className={cn(
+                'row-hover flex items-center justify-between gap-3 rounded-md px-2 py-1 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
+                selectedOutputId === run.id && 'bg-(--ui-row-active-background)'
+              )}
               key={run.id}
-              onClick={() => onOpenSession?.(run.id)}
+              onClick={() => void openOutput(run.id)}
               type="button"
             >
-              <span className="truncate text-foreground/85">{run.title?.trim() || run.preview?.trim() || run.id}</span>
+              <span className="truncate text-foreground/85">{run.filename}</span>
               <span className="shrink-0 text-[0.62rem] text-muted-foreground/55 tabular-nums">
-                {formatRunTime(run.last_active || run.started_at)}
+                {formatRunTime(run.created_at)}
               </span>
             </button>
           ))}
         </div>
       )}
+      {selectedOutputId ? (
+        <div className="mt-3 min-h-16 rounded-md border border-(--ui-stroke-tertiary) bg-background p-3">
+          {outputLoading ? (
+            <div className="flex items-center gap-1.5 py-2 text-xs text-muted-foreground">
+              <Codicon name="loading" size="0.75rem" spinning />
+              {c.loading}
+            </div>
+          ) : outputError ? (
+            <p className="py-2 text-xs text-destructive">{c.failedLoad}</p>
+          ) : output !== null ? (
+            <MarkdownTextContent containerClassName="text-sm" disableArtifacts isRunning={false} text={output} />
+          ) : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -51,7 +51,14 @@ import { AlertTriangle } from '@/lib/icons'
 import { requestModelOptions } from '@/lib/model-options'
 import { asText } from '@/lib/text'
 import { cn } from '@/lib/utils'
-import { $cronFocus, $cronJobs, cronJobIdentity, invalidateCronJobsRequests, setCronFocusJobId } from '@/store/cron'
+import {
+  $cronFocus,
+  $cronJobs,
+  cronJobIdentity,
+  cronJobOwner,
+  invalidateCronJobsRequests,
+  setCronFocusJobId
+} from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
 import { $profileScope, ALL_PROFILES } from '@/store/profile'
@@ -389,7 +396,8 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
     const match = jobs.find(
       job =>
         (job.id === focusTarget.jobId || jobName(job) === focusTarget.jobId) &&
-        (!focusTarget.profile || job.profile === focusTarget.profile)
+        (!focusTarget.profile || job.profile === focusTarget.profile) &&
+        (focusTarget.connectionId === undefined || (job.connection_id ?? null) === focusTarget.connectionId)
     )
 
     if (match) {
@@ -480,7 +488,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
       const isPaused = jobState(job) === 'paused'
 
       const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
-        isPaused ? resumeCronJob(job.id, job.profile) : pauseCronJob(job.id, job.profile)
+        isPaused ? resumeCronJob(job.id, cronJobOwner(job)) : pauseCronJob(job.id, cronJobOwner(job))
       )
 
       if (stale) {
@@ -515,7 +523,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
     try {
       const run = await controller.run(
         key,
-        () => triggerAndRefreshCronJobs(job.id, viewProfile, job.profile),
+        () => triggerAndRefreshCronJobs(job.id, viewProfile, cronJobOwner(job)),
         () => notify({ kind: 'info', title: c.triggerNow, message: truncate(jobTitle(job), 60) })
       )
 
@@ -553,7 +561,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
     }
 
     const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
-      deleteCronJob(pendingDelete.id, pendingDelete.profile)
+      deleteCronJob(pendingDelete.id, cronJobOwner(pendingDelete))
     )
 
     if (stale) {
@@ -605,7 +613,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
         refreshError,
         stale
       } = await mutateAndRefreshCronJobs(profile, () =>
-        updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }), editor.job.profile)
+        updateCronJob(editor.job.id, cronEditorUpdates(values, { scriptOnlyJob }), cronJobOwner(editor.job))
       )
 
       if (stale || !updated) {
@@ -860,7 +868,13 @@ function CronJobDetail({
         </section>
       ) : null}
 
-      <CronJobRuns c={c} jobId={job.id} key={`${job.profile ?? ''}:${job.id}`} profile={job.profile} />
+      <CronJobRuns
+        c={c}
+        connectionId={job.connection_id}
+        jobId={job.id}
+        key={cronJobIdentity(job)}
+        profile={job.profile}
+      />
     </PanelDetail>
   )
 }
@@ -882,7 +896,17 @@ function formatRunTime(seconds?: null | number): string {
 const RUNS_POLL_INTERVAL_MS = 8000
 const RUNS_BACKSTOP_INTERVAL_MS = 60_000
 
-export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jobId: string; profile?: string }) {
+export function CronJobRuns({
+  c,
+  connectionId,
+  jobId,
+  profile
+}: {
+  c: Translations['cron']
+  connectionId?: null | string
+  jobId: string
+  profile?: string
+}) {
   const [runs, setRuns] = useState<null | CronJobOutput[]>(null)
   const [runsError, setRunsError] = useState(false)
   const [selectedOutputId, setSelectedOutputId] = useState<null | string>(null)
@@ -906,7 +930,7 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
     setOutputError(false)
     setOutputLoading(false)
     setFocusUnavailable(null)
-  }, [jobId, profile])
+  }, [connectionId, jobId, profile])
 
   const openOutput = useCallback(
     async (outputId: string) => {
@@ -919,7 +943,11 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
       setOutputLoading(true)
 
       try {
-        const detail = await getCronJobOutput(jobId, outputId, profile)
+        const detail = await getCronJobOutput(
+          jobId,
+          outputId,
+          connectionId === undefined ? profile : { connectionId, profile }
+        )
 
         if (outputRequestRef.current === requestId) {
           setOutput(detail.content)
@@ -934,7 +962,7 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
         }
       }
     },
-    [jobId, profile]
+    [connectionId, jobId, profile]
   )
 
   useEffect(() => {
@@ -944,7 +972,7 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
     const load = () => {
       const requestId = ++latestRequestId
 
-      return getCronJobOutputs(jobId, 20, profile)
+      return getCronJobOutputs(jobId, 20, connectionId === undefined ? profile : { connectionId, profile })
         .then(result => {
           if (!cancelled && requestId === latestRequestId) {
             setRunsError(false)
@@ -984,7 +1012,7 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
       document.removeEventListener('visibilitychange', onVisible)
     }
     // cronChangeTick: a fired run moves jobs.json bookkeeping → reload now.
-  }, [changeEventsAvailable, cronChangeTick, jobId, profile])
+  }, [changeEventsAvailable, connectionId, cronChangeTick, jobId, profile])
 
   useEffect(() => {
     if (
@@ -992,6 +1020,7 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
       runsError ||
       focusTarget?.jobId !== jobId ||
       (focusTarget.profile && focusTarget.profile !== profile) ||
+      (focusTarget.connectionId !== undefined && focusTarget.connectionId !== (connectionId ?? null)) ||
       !focusTarget.outputId
     ) {
       return
@@ -1009,7 +1038,7 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
     }
 
     setCronFocusJobId(null)
-  }, [focusTarget, jobId, openOutput, profile, runs, runsError])
+  }, [connectionId, focusTarget, jobId, openOutput, profile, runs, runsError])
 
   return (
     <div>

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -2,7 +2,7 @@ import { createCronTriggerController, type CronTriggerController } from '@hermes
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { PageLoader } from '@/components/page-loader'
@@ -51,7 +51,7 @@ import { AlertTriangle } from '@/lib/icons'
 import { requestModelOptions } from '@/lib/model-options'
 import { asText } from '@/lib/text'
 import { cn } from '@/lib/utils'
-import { $cronFocus, $cronJobs, invalidateCronJobsRequests, setCronFocusJobId } from '@/store/cron'
+import { $cronFocus, $cronJobs, cronJobIdentity, invalidateCronJobsRequests, setCronFocusJobId } from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
 import { $profileScope, ALL_PROFILES } from '@/store/profile'
@@ -338,7 +338,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
   }, [])
 
   // Master/detail: the job whose schedule + run history fill the right pane.
-  const [selectedJobId, setSelectedJobId] = useState<null | string>(null)
+  const [selectedJobKey, setSelectedJobKey] = useState<null | string>(null)
   // Set when a job is opened from the sidebar so we scroll it into view once the
   // row exists. Cleared after the scroll fires.
   const pendingScrollRef = useRef<null | string>(null)
@@ -393,8 +393,10 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
     )
 
     if (match) {
-      setSelectedJobId(match.id)
-      pendingScrollRef.current = match.id
+      const matchKey = cronJobIdentity(match)
+
+      setSelectedJobKey(matchKey)
+      pendingScrollRef.current = matchKey
     }
 
     if (!focusTarget.outputId) {
@@ -425,8 +427,8 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
   // Detail always reflects a concrete job: the explicitly selected one, else the
   // first visible row, so the right pane is never empty while jobs exist.
   const selectedJob = useMemo(
-    () => visibleJobs.find(job => job.id === selectedJobId) ?? visibleJobs[0] ?? null,
-    [visibleJobs, selectedJobId]
+    () => visibleJobs.find(job => cronJobIdentity(job) === selectedJobKey) ?? visibleJobs[0] ?? null,
+    [visibleJobs, selectedJobKey]
   )
 
   // Scroll a sidebar-opened job into view once its list row is mounted.
@@ -434,7 +436,7 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
   useEffect(() => {
     const target = pendingScrollRef.current
 
-    if (!target || selectedJob?.id !== target) {
+    if (!target || !selectedJob || cronJobIdentity(selectedJob) !== target) {
       return
     }
 
@@ -670,15 +672,15 @@ export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGrou
           >
             {visibleJobs.map(job => (
               <CronJobListRow
-                active={selectedJob?.id === job.id}
+                active={Boolean(selectedJob && cronJobIdentity(selectedJob) === cronJobIdentity(job))}
                 job={job}
-                key={job.id}
+                key={cronJobIdentity(job)}
                 menuItems={[
                   { icon: 'edit', label: c.edit, onSelect: () => setEditor({ mode: 'edit', job }) },
                   { icon: 'trash', label: t.common.delete, onSelect: () => setPendingDelete(job), tone: 'danger' }
                 ]}
                 menuLabel={c.manage}
-                onSelect={() => setSelectedJobId(job.id)}
+                onSelect={() => setSelectedJobKey(cronJobIdentity(job))}
               />
             ))}
             {visibleJobs.length === 0 && (
@@ -778,7 +780,7 @@ function CronJobListRow({
       menuItems={menuItems}
       menuLabel={menuLabel}
       onSelect={onSelect}
-      rowKey={job.id}
+      rowKey={cronJobIdentity(job)}
       title={jobTitle(job)}
     />
   )
@@ -880,6 +882,19 @@ export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jo
   const focusTarget = useStore($cronFocus)
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
+
+  // Invalidate both an in-flight detail read and the previous scope's rendered
+  // selection as soon as this instance is reused for another profile/job.
+  useLayoutEffect(() => {
+    ++outputRequestRef.current
+    setRuns(null)
+    setRunsError(false)
+    setSelectedOutputId(null)
+    setOutput(null)
+    setOutputError(false)
+    setOutputLoading(false)
+    setFocusUnavailable(null)
+  }, [jobId, profile])
 
   const openOutput = useCallback(
     async (outputId: string) => {

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -32,15 +33,16 @@ import {
   createCronJob,
   type CronDeliveryTarget,
   type CronJob,
+  type CronJobOutput,
   deleteCronJob,
   getAutomationBlueprints,
   getCronDeliveryTargets,
-  getCronJobRuns,
+  getCronJobOutput,
+  getCronJobOutputs,
   getCronJobs,
   instantiateAutomationBlueprint,
   pauseCronJob,
   resumeCronJob,
-  type SessionInfo,
   triggerCronJob,
   updateCronJob
 } from '@/hermes'
@@ -48,7 +50,8 @@ import { type Translations, useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
 import { requestModelOptions } from '@/lib/model-options'
 import { asText } from '@/lib/text'
-import { $cronFocusJobId, $cronJobs, setCronFocusJobId, setCronJobs, updateCronJobs } from '@/store/cron'
+import { cn } from '@/lib/utils'
+import { $cronFocus, $cronJobs, setCronFocusJobId, setCronJobs, updateCronJobs } from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
 import { $profileScope, ALL_PROFILES } from '@/store/profile'
@@ -286,11 +289,10 @@ function matchesQuery(job: CronJob, q: string): boolean {
 
 interface CronViewProps extends React.ComponentProps<'section'> {
   onClose: () => void
-  onOpenSession?: (sessionId: string) => void
   setStatusbarItemGroup?: SetStatusbarItemGroup
 }
 
-export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setStatusbarItemGroup }: CronViewProps) {
+export function CronView({ onClose, setStatusbarItemGroup: _setStatusbarItemGroup }: CronViewProps) {
   const { t } = useI18n()
   const c = t.cron
   // Source of truth is the shared atom (also fed by the controller poll), so the
@@ -305,7 +307,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   // Set when a job is opened from the sidebar so we scroll it into view once the
   // row exists. Cleared after the scroll fires.
   const pendingScrollRef = useRef<null | string>(null)
-  const focusJobId = useStore($cronFocusJobId)
+  const focusTarget = useStore($cronFocus)
 
   const [editor, setEditor] = useState<EditorState>({ mode: 'closed' })
   const [pendingDelete, setPendingDelete] = useState<CronJob | null>(null)
@@ -337,19 +339,25 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   // normally doesn't re-trigger it.
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (!focusJobId) {
+    if (!focusTarget) {
       return
     }
 
-    const match = jobs.find(job => job.id === focusJobId || jobName(job) === focusJobId)
+    const match = jobs.find(
+      job =>
+        (job.id === focusTarget.jobId || jobName(job) === focusTarget.jobId) &&
+        (!focusTarget.profile || job.profile === focusTarget.profile)
+    )
 
     if (match) {
       setSelectedJobId(match.id)
       pendingScrollRef.current = match.id
     }
 
-    setCronFocusJobId(null)
-  }, [focusJobId, jobs])
+    if (!focusTarget.outputId) {
+      setCronFocusJobId(null)
+    }
+  }, [focusTarget, jobs])
 
   const visibleJobs = useMemo(
     () => jobs.filter(job => matchesQuery(job, query.trim())).sort((a, b) => jobTitle(a).localeCompare(jobTitle(b))),
@@ -528,7 +536,6 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
               busy={busyJobId === selectedJob.id}
               c={c}
               job={selectedJob}
-              onOpenSession={onOpenSession}
               onPauseResume={() => void handlePauseResume(selectedJob)}
               onTrigger={() => void handleTrigger(selectedJob)}
             />
@@ -605,14 +612,12 @@ function CronJobDetail({
   busy,
   c,
   job,
-  onOpenSession,
   onPauseResume,
   onTrigger
 }: {
   busy: boolean
   c: Translations['cron']
   job: CronJob
-  onOpenSession?: (sessionId: string) => void
   onPauseResume: () => void
   onTrigger: () => void
 }) {
@@ -665,7 +670,7 @@ function CronJobDetail({
         </section>
       ) : null}
 
-      <CronJobRuns c={c} jobId={job.id} onOpenSession={onOpenSession} />
+      <CronJobRuns c={c} jobId={job.id} key={`${job.profile ?? ''}:${job.id}`} profile={job.profile} />
     </PanelDetail>
   )
 }
@@ -680,41 +685,74 @@ function formatRunTime(seconds?: null | number): string {
   return Number.isNaN(date.valueOf()) ? '—' : date.toLocaleString()
 }
 
-// Runs are produced by the background scheduler tick. cron.changed /
-// sessions.changed broadcasts re-load immediately on event-capable backends
+// Outputs are produced by the background scheduler tick. cron.changed
+// broadcasts re-load immediately on event-capable backends
 // (the tick dep below), so the poll drops to a slow backstop there; older
 // backends keep the legacy cadence.
 const RUNS_POLL_INTERVAL_MS = 8000
 const RUNS_BACKSTOP_INTERVAL_MS = 60_000
 
-function CronJobRuns({
-  c,
-  jobId,
-  onOpenSession
-}: {
-  c: Translations['cron']
-  jobId: string
-  onOpenSession?: (sessionId: string) => void
-}) {
-  const [runs, setRuns] = useState<null | SessionInfo[]>(null)
+export function CronJobRuns({ c, jobId, profile }: { c: Translations['cron']; jobId: string; profile?: string }) {
+  const [runs, setRuns] = useState<null | CronJobOutput[]>(null)
+  const [runsError, setRunsError] = useState(false)
+  const [selectedOutputId, setSelectedOutputId] = useState<null | string>(null)
+  const [output, setOutput] = useState<null | string>(null)
+  const [outputError, setOutputError] = useState(false)
+  const [outputLoading, setOutputLoading] = useState(false)
+  const outputRequestRef = useRef(0)
+  const focusTarget = useStore($cronFocus)
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
 
+  const openOutput = useCallback(
+    async (outputId: string) => {
+      const requestId = ++outputRequestRef.current
+
+      setSelectedOutputId(outputId)
+      setOutput(null)
+      setOutputError(false)
+      setOutputLoading(true)
+
+      try {
+        const detail = await getCronJobOutput(jobId, outputId, profile)
+
+        if (outputRequestRef.current === requestId) {
+          setOutput(detail.content)
+        }
+      } catch {
+        if (outputRequestRef.current === requestId) {
+          setOutputError(true)
+        }
+      } finally {
+        if (outputRequestRef.current === requestId) {
+          setOutputLoading(false)
+        }
+      }
+    },
+    [jobId, profile]
+  )
+
   useEffect(() => {
     let cancelled = false
+    let latestRequestId = 0
 
-    const load = () =>
-      getCronJobRuns(jobId)
+    const load = () => {
+      const requestId = ++latestRequestId
+
+      return getCronJobOutputs(jobId, 20, profile)
         .then(result => {
-          if (!cancelled) {
+          if (!cancelled && requestId === latestRequestId) {
+            setRunsError(false)
             setRuns(result)
           }
         })
         .catch(() => {
-          if (!cancelled) {
+          if (!cancelled && requestId === latestRequestId) {
+            setRunsError(true)
             setRuns(prev => prev ?? [])
           }
         })
+    }
 
     void load()
 
@@ -741,7 +779,24 @@ function CronJobRuns({
       document.removeEventListener('visibilitychange', onVisible)
     }
     // cronChangeTick: a fired run moves jobs.json bookkeeping → reload now.
-  }, [changeEventsAvailable, cronChangeTick, jobId])
+  }, [changeEventsAvailable, cronChangeTick, jobId, profile])
+
+  useEffect(() => {
+    if (
+      runs === null ||
+      focusTarget?.jobId !== jobId ||
+      (focusTarget.profile && focusTarget.profile !== profile) ||
+      !focusTarget.outputId
+    ) {
+      return
+    }
+
+    if (runs.some(run => run.id === focusTarget.outputId)) {
+      void openOutput(focusTarget.outputId)
+    }
+
+    setCronFocusJobId(null)
+  }, [focusTarget, jobId, openOutput, profile, runs])
 
   return (
     <div>
@@ -749,7 +804,9 @@ function CronJobRuns({
         {c.runHistory}
         {runs && runs.length > 0 ? ` · ${runs.length}` : ''}
       </PanelSectionLabel>
-      {runs === null ? (
+      {runsError ? (
+        <p className="py-1 text-xs text-destructive">{c.failedLoad}</p>
+      ) : runs === null ? (
         <div className="flex items-center gap-1.5 py-1 text-xs text-muted-foreground">
           <Codicon name="loading" size="0.75rem" spinning />
         </div>
@@ -759,19 +816,37 @@ function CronJobRuns({
         <div className="flex flex-col gap-px">
           {runs.map(run => (
             <button
-              className="row-hover flex items-center justify-between gap-3 rounded-md px-2 py-1 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              aria-expanded={selectedOutputId === run.id}
+              className={cn(
+                'row-hover flex items-center justify-between gap-3 rounded-md px-2 py-1 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
+                selectedOutputId === run.id && 'bg-(--ui-row-active-background)'
+              )}
               key={run.id}
-              onClick={() => onOpenSession?.(run.id)}
+              onClick={() => void openOutput(run.id)}
               type="button"
             >
-              <span className="truncate text-foreground/85">{run.title?.trim() || run.preview?.trim() || run.id}</span>
+              <span className="truncate text-foreground/85">{run.filename}</span>
               <span className="shrink-0 text-[0.62rem] text-muted-foreground/55 tabular-nums">
-                {formatRunTime(run.last_active || run.started_at)}
+                {formatRunTime(run.created_at)}
               </span>
             </button>
           ))}
         </div>
       )}
+      {selectedOutputId ? (
+        <div className="mt-3 min-h-16 rounded-md border border-(--ui-stroke-tertiary) bg-background p-3">
+          {outputLoading ? (
+            <div className="flex items-center gap-1.5 py-2 text-xs text-muted-foreground">
+              <Codicon name="loading" size="0.75rem" spinning />
+              {c.loading}
+            </div>
+          ) : outputError ? (
+            <p className="py-2 text-xs text-destructive">{c.failedLoad}</p>
+          ) : output !== null ? (
+            <MarkdownTextContent containerClassName="text-sm" disableArtifacts isRunning={false} text={output} />
+          ) : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/desktop/src/app/routes.test.ts
+++ b/apps/desktop/src/app/routes.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { NEW_CHAT_ROUTE, primaryRouteSelectedSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
+import {
+  NEW_CHAT_ROUTE,
+  primaryRouteSelectedSessionId,
+  routeSessionId,
+  routeSessionProfile,
+  sessionRoute,
+  SETTINGS_ROUTE
+} from './routes'
 
 const SESS_A = 'sess-a'
 const SESS_B = 'sess-b'
@@ -26,5 +33,20 @@ describe('primaryRouteSelectedSessionId', () => {
 
   it('returns null on a non-chat route with no store selection', () => {
     expect(primaryRouteSelectedSessionId(SETTINGS_ROUTE, null)).toBeNull()
+  })
+})
+
+describe('profile-qualified session routes', () => {
+  it('round-trips the profile owner independently from the stored id', () => {
+    const route = sessionRoute('same/id?', 'research ops')
+
+    expect(route).toBe('/same%2Fid%3F?profile=research%20ops')
+    expect(routeSessionId(route)).toBe('same/id?')
+    expect(routeSessionProfile(route)).toBe('research ops')
+  })
+
+  it('keeps legacy profile-less routes profile-less', () => {
+    expect(sessionRoute(SESS_A)).toBe('/sess-a')
+    expect(routeSessionProfile(sessionRoute(SESS_A))).toBeNull()
   })
 })

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -164,6 +164,26 @@ export function routeSessionId(pathname: string): string | null {
   return id && !id.includes('/') ? decodeURIComponent(id) : null
 }
 
+/** Owning profile carried by a profile-qualified session route. Session ids are
+ * profile-local, so this query value is part of the route's durable identity. */
+export function routeSessionProfile(to: string): string | null {
+  if (!routeSessionId(to)) {
+    return null
+  }
+
+  const queryStart = to.indexOf('?')
+
+  if (queryStart === -1) {
+    return null
+  }
+
+  const hashStart = to.indexOf('#', queryStart)
+  const query = to.slice(queryStart + 1, hashStart === -1 ? undefined : hashStart)
+  const profile = new URLSearchParams(query).get('profile')?.trim()
+
+  return profile || null
+}
+
 /**
  * The primary composer's durable scope key candidate: the route is the source
  * of truth for which chat is on screen, so prefer its (stable) stored session
@@ -181,8 +201,11 @@ export function primaryRouteSelectedSessionId(pathname: string, storeSelectedSes
   return routeSessionId(pathname) ?? storeSelectedSessionId
 }
 
-export function sessionRoute(sessionId: string): string {
-  return `${SESSION_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`
+export function sessionRoute(sessionId: string, ownerProfile?: null | string): string {
+  const route = `${SESSION_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`
+  const profile = ownerProfile?.trim()
+
+  return profile ? `${route}?profile=${encodeURIComponent(profile)}` : route
 }
 
 export function appViewForPath(pathname: string): AppView {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -2,6 +2,7 @@ import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
+import { normalizeProfileKey } from '@/store/profile'
 import { followActiveSessionCwd } from '@/store/projects'
 import {
   $activeSessionId,
@@ -81,7 +82,7 @@ function sessionInfoDescribesSelectedSession(storedSessionId: string | undefined
  * keeping the durable selection untouched. A live turn on the old runtime
  * (overlap window during a manual switch) refuses the adoption.
  */
-function maybeRebindPaneToRebuiltRuntime(ctx: GatewayEventContext): boolean {
+function maybeRebindPaneToRebuiltRuntime(ctx: GatewayEventContext, eventProfile: string): boolean {
   const { deps, explicitSid, isActiveEvent, payload } = ctx
 
   if (!explicitSid || isActiveEvent || typeof payload?.stored_session_id !== 'string') {
@@ -96,6 +97,10 @@ function maybeRebindPaneToRebuiltRuntime(ctx: GatewayEventContext): boolean {
 
   const activeId = $activeSessionId.get()
   const oldState = activeId ? deps.sessionStateByRuntimeIdRef.current.get(activeId) : undefined
+
+  if (normalizeProfileKey(oldState?.profile ?? deps.activeGatewayProfile) !== eventProfile) {
+    return false
+  }
 
   // Only a dead old runtime may be adopted over: hijacking a streaming turn
   // would split one conversation's events across two panes.
@@ -125,12 +130,23 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
   } = deps
 
   if (event.type === 'session.info') {
+    const eventProfile = normalizeProfileKey(event.profile)
+    const installedState = sessionId ? sessionStateByRuntimeIdRef.current.get(sessionId) : undefined
+
+    // Runtime ids are only unique inside one profile gateway. If another
+    // profile happens to mint the foreground runtime id, its session.info must
+    // not rewrite that state's owner, rotate its stored id, or trigger any
+    // foreground-only side effect/navigation.
+    if (installedState?.profile && normalizeProfileKey(installedState.profile) !== eventProfile) {
+      return true
+    }
+
     // A rebuilt runtime (mid-conversation model/provider switch) speaks under
     // a NEW session_id. Before scoping anything by isActiveEvent, check
     // whether this event is the rebuilt runtime announcing itself for the
     // conversation already on screen — if so, re-bind the pane so every
     // subsequent isActiveEvent gate keeps matching (#93942 scenario B).
-    const rebound = maybeRebindPaneToRebuiltRuntime(ctx)
+    const rebound = maybeRebindPaneToRebuiltRuntime(ctx, eventProfile)
 
     // Apply session-scoped fields when the event targets the active
     // session, OR when it's a global broadcast and we have no session.
@@ -234,7 +250,8 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
           branch: statePatch.branch ?? state.branch,
           cwd: statePatch.cwd ?? state.cwd
         }),
-        payload?.stored_session_id || undefined
+        payload?.stored_session_id || undefined,
+        eventProfile
       )
     }
 
@@ -353,7 +370,8 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
             turnLive: false
           }
         },
-        payload?.stored_session_id || undefined
+        payload?.stored_session_id || undefined,
+        eventProfile
       )
 
       if (recoveredWithoutPayload) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -371,7 +371,12 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
         // reads its history when the user opens it, and hydrating every one
         // of them here would fan a REST call out per idle session.
         if (isActiveEvent) {
-          void hydrateFromStoredSession(3, nextState.storedSessionId, sessionId)
+          void hydrateFromStoredSession(
+            3,
+            nextState.storedSessionId,
+            sessionId,
+            nextState.profile ?? activeGatewayProfile
+          )
         }
       }
     }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -1,3 +1,4 @@
+import { sessionRuntimeStateMatchesOwner } from '@/app/session/session-state-cache'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
@@ -83,7 +84,7 @@ function sessionInfoDescribesSelectedSession(storedSessionId: string | undefined
  * (overlap window during a manual switch) refuses the adoption.
  */
 function maybeRebindPaneToRebuiltRuntime(ctx: GatewayEventContext, eventProfile: string): boolean {
-  const { deps, explicitSid, isActiveEvent, payload } = ctx
+  const { deps, event, explicitSid, isActiveEvent, payload } = ctx
 
   if (!explicitSid || isActiveEvent || typeof payload?.stored_session_id !== 'string') {
     return false
@@ -98,7 +99,11 @@ function maybeRebindPaneToRebuiltRuntime(ctx: GatewayEventContext, eventProfile:
   const activeId = $activeSessionId.get()
   const oldState = activeId ? deps.sessionStateByRuntimeIdRef.current.get(activeId) : undefined
 
-  if (normalizeProfileKey(oldState?.profile ?? deps.activeGatewayProfile) !== eventProfile) {
+  if (
+    oldState?.profile
+      ? !sessionRuntimeStateMatchesOwner(oldState, { connectionId: event.connectionId, profile: eventProfile })
+      : normalizeProfileKey(deps.activeGatewayProfile) !== eventProfile
+  ) {
     return false
   }
 
@@ -137,7 +142,13 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
     // profile happens to mint the foreground runtime id, its session.info must
     // not rewrite that state's owner, rotate its stored id, or trigger any
     // foreground-only side effect/navigation.
-    if (installedState?.profile && normalizeProfileKey(installedState.profile) !== eventProfile) {
+    if (
+      installedState?.profile &&
+      !sessionRuntimeStateMatchesOwner(installedState, {
+        connectionId: event.connectionId,
+        profile: eventProfile
+      })
+    ) {
       return true
     }
 
@@ -251,7 +262,8 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
           cwd: statePatch.cwd ?? state.cwd
         }),
         payload?.stored_session_id || undefined,
-        eventProfile
+        eventProfile,
+        event.connectionId
       )
     }
 
@@ -371,7 +383,8 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
           }
         },
         payload?.stored_session_id || undefined,
-        eventProfile
+        eventProfile,
+        event.connectionId
       )
 
       if (recoveredWithoutPayload) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -27,7 +27,8 @@ export interface GatewayEventDeps {
   hydrateFromStoredSession: (
     attempts?: number,
     storedSessionId?: string | null,
-    runtimeSessionId?: string | null
+    runtimeSessionId?: string | null,
+    storedSessionProfile?: string | null
   ) => Promise<void>
   queryClient: QueryClient
   refreshHermesConfig: () => Promise<void>

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -38,7 +38,8 @@ export interface GatewayEventDeps {
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
+    storedSessionId?: string | null,
+    ownerProfile?: string
   ) => ClientSessionState
   upsertToolCall: (
     sessionId: string,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -39,7 +39,8 @@ export interface GatewayEventDeps {
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
     storedSessionId?: string | null,
-    ownerProfile?: string
+    ownerProfile?: string,
+    ownerConnectionId?: null | string
   ) => ClientSessionState
   upsertToolCall: (
     sessionId: string,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -51,7 +51,8 @@ interface MessageStreamOptions {
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
+    storedSessionId?: string | null,
+    ownerProfile?: string
   ) => ClientSessionState
 }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -41,7 +41,8 @@ interface MessageStreamOptions {
   hydrateFromStoredSession: (
     attempts?: number,
     storedSessionId?: string | null,
-    runtimeSessionId?: string | null
+    runtimeSessionId?: string | null,
+    storedSessionProfile?: string | null
   ) => Promise<void>
   queryClient: QueryClient
   refreshHermesConfig: () => Promise<void>
@@ -769,7 +770,12 @@ export function useMessageStream({
       }
 
       if (shouldHydrate) {
-        void hydrateFromStoredSession(3, completedState.storedSessionId, sessionId)
+        void hydrateFromStoredSession(
+          3,
+          completedState.storedSessionId,
+          sessionId,
+          completedState.profile ?? activeGatewayProfile
+        )
       }
 
       dispatchNativeNotification({
@@ -779,7 +785,7 @@ export function useMessageStream({
         title: translateNow('notifications.native.turnDoneTitle')
       })
     },
-    [hydrateFromStoredSession, scheduleSessionsRefresh, updateSessionState]
+    [activeGatewayProfile, hydrateFromStoredSession, scheduleSessionsRefresh, updateSessionState]
   )
 
   const failAssistantMessage = useCallback(

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-ownership.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-ownership.test.tsx
@@ -1,0 +1,137 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render } from '@testing-library/react'
+import { type MutableRefObject, useEffect, useRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import {
+  $activeSessionStoredIdRotation,
+  setActiveSessionId,
+  setActiveSessionStoredIdRotation,
+  setSelectedStoredSessionId
+} from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useSessionStateCache } from '../use-session-state-cache'
+
+import { useMessageStream } from './index'
+
+const RUNTIME_ID = 'runtime-collision'
+const FOREGROUND_STORED_ID = 'default-stored'
+
+interface HarnessHandle {
+  dispatch: (event: RpcEvent) => void
+  state: () => ClientSessionState | undefined
+}
+
+function Harness({ onReady }: { onReady: (handle: HarnessHandle) => void }) {
+  const busyRef: MutableRefObject<boolean> = { current: false }
+  const queryClientRef = useRef(new QueryClient())
+
+  const cache = useSessionStateCache({
+    activeSessionId: RUNTIME_ID,
+    busyRef,
+    selectedStoredSessionId: FOREGROUND_STORED_ID,
+    setAwaitingResponse: () => undefined,
+    setBusy: () => undefined,
+    setMessages: () => undefined
+  })
+
+  const { sessionStateByRuntimeIdRef, updateSessionState } = cache
+
+  const stream = useMessageStream({
+    activeGatewayProfile: 'default',
+    activeSessionIdRef: cache.activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState
+  })
+
+  useEffect(() => {
+    updateSessionState(
+      RUNTIME_ID,
+      state => ({ ...state, branch: 'foreground', profile: 'default' }),
+      FOREGROUND_STORED_ID
+    )
+    onReady({
+      dispatch: stream.handleGatewayEvent,
+      state: () => sessionStateByRuntimeIdRef.current.get(RUNTIME_ID)
+    })
+  }, [onReady, sessionStateByRuntimeIdRef, stream.handleGatewayEvent, updateSessionState])
+
+  return null
+}
+
+describe('session.info profile ownership', () => {
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+    setActiveSessionStoredIdRotation(null)
+    setSelectedStoredSessionId(null)
+    vi.restoreAllMocks()
+  })
+
+  it('rejects a colliding background profile before it can rotate the foreground runtime', () => {
+    let handle: HarnessHandle | null = null
+
+    setActiveSessionId(RUNTIME_ID)
+    setSelectedStoredSessionId(FOREGROUND_STORED_ID)
+    render(<Harness onReady={value => (handle = value)} />)
+
+    const foreground = handle!.state()
+
+    act(() => {
+      handle!.dispatch({
+        payload: {
+          branch: 'background',
+          running: true,
+          stored_session_id: 'meta-stored-next'
+        },
+        profile: 'meta',
+        session_id: RUNTIME_ID,
+        type: 'session.info'
+      })
+    })
+
+    expect(handle!.state()).toBe(foreground)
+    expect(handle!.state()).toMatchObject({
+      branch: 'foreground',
+      busy: false,
+      profile: 'default',
+      storedSessionId: FOREGROUND_STORED_ID
+    })
+    expect($activeSessionStoredIdRotation.get()).toBeNull()
+  })
+
+  it('keeps same-profile compression rotation profile-qualified', () => {
+    let handle: HarnessHandle | null = null
+
+    setActiveSessionId(RUNTIME_ID)
+    setSelectedStoredSessionId(FOREGROUND_STORED_ID)
+    render(<Harness onReady={value => (handle = value)} />)
+
+    act(() => {
+      handle!.dispatch({
+        payload: { branch: 'continued', stored_session_id: 'default-stored-next' },
+        profile: 'default',
+        session_id: RUNTIME_ID,
+        type: 'session.info'
+      })
+    })
+
+    expect(handle!.state()).toMatchObject({
+      branch: 'continued',
+      profile: 'default',
+      storedSessionId: 'default-stored-next'
+    })
+    expect($activeSessionStoredIdRotation.get()).toEqual({
+      nextStoredSessionId: 'default-stored-next',
+      previousStoredSessionId: FOREGROUND_STORED_ID,
+      profile: 'default',
+      runtimeSessionId: RUNTIME_ID
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-ownership.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-ownership.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import {
+  $activeSessionId,
   $activeSessionStoredIdRotation,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
@@ -17,14 +18,15 @@ import { useSessionStateCache } from '../use-session-state-cache'
 import { useMessageStream } from './index'
 
 const RUNTIME_ID = 'runtime-collision'
+const REBUILT_RUNTIME_ID = 'runtime-rebuilt'
 const FOREGROUND_STORED_ID = 'default-stored'
 
 interface HarnessHandle {
   dispatch: (event: RpcEvent) => void
-  state: () => ClientSessionState | undefined
+  state: (runtimeId?: string) => ClientSessionState | undefined
 }
 
-function Harness({ onReady }: { onReady: (handle: HarnessHandle) => void }) {
+function Harness({ connectionId, onReady }: { connectionId?: string; onReady: (handle: HarnessHandle) => void }) {
   const busyRef: MutableRefObject<boolean> = { current: false }
   const queryClientRef = useRef(new QueryClient())
 
@@ -53,14 +55,14 @@ function Harness({ onReady }: { onReady: (handle: HarnessHandle) => void }) {
   useEffect(() => {
     updateSessionState(
       RUNTIME_ID,
-      state => ({ ...state, branch: 'foreground', profile: 'default' }),
+      state => ({ ...state, branch: 'foreground', connectionId: connectionId ?? null, profile: 'default' }),
       FOREGROUND_STORED_ID
     )
     onReady({
       dispatch: stream.handleGatewayEvent,
-      state: () => sessionStateByRuntimeIdRef.current.get(RUNTIME_ID)
+      state: (runtimeId = RUNTIME_ID) => sessionStateByRuntimeIdRef.current.get(runtimeId)
     })
-  }, [onReady, sessionStateByRuntimeIdRef, stream.handleGatewayEvent, updateSessionState])
+  }, [connectionId, onReady, sessionStateByRuntimeIdRef, stream.handleGatewayEvent, updateSessionState])
 
   return null
 }
@@ -128,10 +130,102 @@ describe('session.info profile ownership', () => {
       storedSessionId: 'default-stored-next'
     })
     expect($activeSessionStoredIdRotation.get()).toEqual({
+      connectionId: null,
       nextStoredSessionId: 'default-stored-next',
       previousStoredSessionId: FOREGROUND_STORED_ID,
       profile: 'default',
       runtimeSessionId: RUNTIME_ID
+    })
+  })
+
+  it('rejects a colliding runtime from another connection with the same profile', () => {
+    let handle: HarnessHandle | null = null
+
+    setActiveSessionId(RUNTIME_ID)
+    setSelectedStoredSessionId(FOREGROUND_STORED_ID)
+    render(<Harness connectionId="gateway-a" onReady={value => (handle = value)} />)
+
+    const foreground = handle!.state()
+
+    act(() => {
+      handle!.dispatch({
+        connectionId: 'gateway-b',
+        payload: { branch: 'foreign', running: true, stored_session_id: FOREGROUND_STORED_ID },
+        profile: 'default',
+        session_id: RUNTIME_ID,
+        type: 'session.info'
+      })
+    })
+
+    expect(handle!.state()).toBe(foreground)
+    expect(handle!.state()).toMatchObject({ branch: 'foreground', busy: false, connectionId: 'gateway-a' })
+  })
+
+  it('does not publish a stored-id rotation from another connection with the same profile', () => {
+    let handle: HarnessHandle | null = null
+
+    setActiveSessionId(RUNTIME_ID)
+    setSelectedStoredSessionId(FOREGROUND_STORED_ID)
+    render(<Harness connectionId="gateway-a" onReady={value => (handle = value)} />)
+
+    act(() => {
+      handle!.dispatch({
+        connectionId: 'gateway-b',
+        payload: { branch: 'foreign', stored_session_id: 'foreign-next' },
+        profile: 'default',
+        session_id: RUNTIME_ID,
+        type: 'session.info'
+      })
+    })
+
+    expect(handle!.state()?.storedSessionId).toBe(FOREGROUND_STORED_ID)
+    expect($activeSessionStoredIdRotation.get()).toBeNull()
+  })
+
+  it('does not adopt a rebuilt runtime announced by another connection with the same profile', () => {
+    let handle: HarnessHandle | null = null
+
+    setActiveSessionId(RUNTIME_ID)
+    setSelectedStoredSessionId(FOREGROUND_STORED_ID)
+    render(<Harness connectionId="gateway-a" onReady={value => (handle = value)} />)
+
+    act(() => {
+      handle!.dispatch({
+        connectionId: 'gateway-b',
+        payload: { stored_session_id: FOREGROUND_STORED_ID },
+        profile: 'default',
+        session_id: REBUILT_RUNTIME_ID,
+        type: 'session.info'
+      })
+    })
+
+    expect($activeSessionId.get()).toBe(RUNTIME_ID)
+    expect(handle!.state(REBUILT_RUNTIME_ID)).toBeUndefined()
+  })
+
+  it('adopts a rebuilt runtime announced by the same connection and profile', () => {
+    let handle: HarnessHandle | null = null
+
+    setActiveSessionId(RUNTIME_ID)
+    setSelectedStoredSessionId(FOREGROUND_STORED_ID)
+    render(<Harness connectionId="gateway-a" onReady={value => (handle = value)} />)
+
+    act(() => {
+      handle!.dispatch({
+        connectionId: 'gateway-a',
+        payload: { branch: 'rebuilt', stored_session_id: FOREGROUND_STORED_ID },
+        profile: 'default',
+        session_id: REBUILT_RUNTIME_ID,
+        type: 'session.info'
+      })
+    })
+
+    expect($activeSessionId.get()).toBe(REBUILT_RUNTIME_ID)
+    expect(handle!.state(REBUILT_RUNTIME_ID)).toMatchObject({
+      branch: 'rebuilt',
+      connectionId: 'gateway-a',
+      profile: 'default',
+      storedSessionId: FOREGROUND_STORED_ID
     })
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -36,8 +36,8 @@ function mountStream() {
   sessionStates = stream.states
 }
 
-const sessionInfo = (sessionId: string, payload: Record<string, unknown>) =>
-  act(() => stream.handleEvent({ payload, session_id: sessionId, type: 'session.info' }))
+const sessionInfo = (sessionId: string, payload: Record<string, unknown>, profile?: string) =>
+  act(() => stream.handleEvent({ payload, profile, session_id: sessionId, type: 'session.info' }))
 
 beforeEach(() => {
   sessionStates = null
@@ -254,10 +254,10 @@ describe('session.info settles a turn that produced no assistant payload', () =>
     startTurn(ACTIVE_SID)
     vi.useFakeTimers()
 
-    sessionInfo(ACTIVE_SID, { running: false })
+    sessionInfo(ACTIVE_SID, { running: false }, 'meta')
     // Later heartbeats hit the unchanged-state guard, so recovery is edge-only.
-    sessionInfo(ACTIVE_SID, { running: false })
-    sessionInfo(ACTIVE_SID, { running: false })
+    sessionInfo(ACTIVE_SID, { running: false }, 'meta')
+    sessionInfo(ACTIVE_SID, { running: false }, 'meta')
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(400)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -246,6 +246,10 @@ describe('session.info settles a turn that produced no assistant payload', () =>
 
   it('hydrates the foreground transcript once and coalesces the sidebar refresh', async () => {
     mountStream()
+    sessionStates!.set(ACTIVE_SID, {
+      ...createClientSessionState('shared-session'),
+      profile: 'meta'
+    })
 
     startTurn(ACTIVE_SID)
     vi.useFakeTimers()
@@ -260,11 +264,26 @@ describe('session.info settles a turn that produced no assistant payload', () =>
     })
 
     expect(hydrateFromStoredSession).toHaveBeenCalledTimes(1)
+    expect(hydrateFromStoredSession).toHaveBeenCalledWith(3, 'shared-session', ACTIVE_SID, 'meta')
     expect(refreshSessions).toHaveBeenCalledTimes(1)
   })
 })
 
 describe('message.complete sidebar refresh coalescing', () => {
+  it('carries the runtime profile into post-turn transcript hydration', () => {
+    mountStream()
+    sessionStates!.set(ACTIVE_SID, {
+      ...createClientSessionState('shared-session'),
+      adoptedRunningTurn: true,
+      busy: true,
+      profile: 'meta'
+    })
+
+    act(() => stream.handleEvent({ payload: { text: 'done' }, session_id: ACTIVE_SID, type: 'message.complete' }))
+
+    expect(hydrateFromStoredSession).toHaveBeenCalledWith(3, 'shared-session', ACTIVE_SID, 'meta')
+  })
+
   it('collapses near-simultaneous completions into one refresh', async () => {
     mountStream()
     vi.useFakeTimers()

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render } from '@testing-library/react'
-import type { MutableRefObject } from 'react'
+import { type MutableRefObject, useRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $resumeExhaustedSessionId, setResumeExhaustedSessionId } from '@/store/session'
@@ -26,19 +26,32 @@ interface HarnessProps {
   resumeExhaustedSessionId?: null | string
   sessionResumeRequest?: null | { ownerRoute?: SessionProfileRoute; sequence: number; sessionId: string }
   routedSessionId: null | string
+  routedSessionProfile?: null | string
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: null | string
   selectedStoredSessionIdRef: MutableRefObject<null | string>
+  selectedStoredSessionProfileRef?: MutableRefObject<null | string>
   startFreshSessionDraft: (focus: boolean) => unknown
 }
 
 function RouteResumeHarness({
   resumeFailedSessionId = null,
   resumeExhaustedSessionId = null,
+  routedSessionProfile = null,
   sessionResumeRequest = null,
+  selectedStoredSessionProfileRef,
   ...props
 }: HarnessProps) {
-  useRouteResume({ ...props, resumeExhaustedSessionId, resumeFailedSessionId, sessionResumeRequest })
+  const fallbackSelectedProfileRef = useRef<null | string>(null)
+
+  useRouteResume({
+    ...props,
+    resumeExhaustedSessionId,
+    resumeFailedSessionId,
+    routedSessionProfile,
+    selectedStoredSessionProfileRef: selectedStoredSessionProfileRef ?? fallbackSelectedProfileRef,
+    sessionResumeRequest
+  })
 
   return null
 }
@@ -312,6 +325,43 @@ describe('useRouteResume', () => {
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
   })
 
+  it('treats a profile-qualified same-id route as foreign and preserves its owner across reconnect', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-default' }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'shared-session' }
+    const selectedStoredSessionProfileRef: MutableRefObject<null | string> = { current: 'default' }
+
+    const props = {
+      activeSessionId: 'runtime-default',
+      activeSessionIdRef,
+      creatingSessionRef: { current: false },
+      currentView: 'chat',
+      freshDraftReady: false,
+      locationPathname: '/shared-session?profile=meta',
+      resumeSession,
+      routedSessionId: 'shared-session',
+      routedSessionProfile: 'meta',
+      runtimeIdByStoredSessionIdRef: { current: new Map([['shared-session', 'runtime-default']]) },
+      selectedStoredSessionId: 'shared-session',
+      selectedStoredSessionIdRef,
+      selectedStoredSessionProfileRef,
+      startFreshSessionDraft: vi.fn()
+    }
+
+    const { rerender } = render(<RouteResumeHarness {...props} gatewayState="open" />)
+
+    expect(resumeSession).toHaveBeenCalledTimes(1)
+    expect(resumeSession).toHaveBeenLastCalledWith('shared-session', true, 'meta')
+
+    // Model resumeSession's synchronous owner handoff, then a real reconnect.
+    selectedStoredSessionProfileRef.current = 'meta'
+    rerender(<RouteResumeHarness {...props} gatewayState="closed" />)
+    rerender(<RouteResumeHarness {...props} gatewayState="open" />)
+
+    expect(resumeSession).toHaveBeenCalledTimes(2)
+    expect(resumeSession).toHaveBeenLastCalledWith('shared-session', true, 'meta')
+  })
+
   it('re-resumes an already-active same route when a plugin explicitly requests hydration', () => {
     const resumeSession = vi.fn(async () => undefined)
     const startFreshSessionDraft = vi.fn()
@@ -510,6 +560,26 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     vi.advanceTimersByTime(1_000)
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+  })
+
+  it('retries a profile-qualified route on the owning profile', () => {
+    vi.useFakeTimers()
+    const resumeSession = vi.fn(async () => undefined)
+    const props = strandedProps(resumeSession)
+
+    render(
+      <RouteResumeHarness
+        {...props}
+        locationPathname="/session-1?profile=meta"
+        resumeFailedSessionId="session-1"
+        routedSessionProfile="meta"
+        selectedStoredSessionProfileRef={{ current: 'meta' }}
+      />
+    )
+    resumeSession.mockClear()
+
+    vi.advanceTimersByTime(1_000)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, 'meta')
   })
 
   it('does NOT retry a failed session that is not the routed one', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -524,7 +524,7 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
   // Common stranded-window props: gateway open, route on the session, no runtime
   // yet, and the ref already synced to the route (resumeSession sets it at entry
   // before failing) — the exact state that defeats the main effect's self-heal.
-  function strandedProps(resumeSession: (sid: string, focus: boolean) => Promise<unknown>) {
+  function strandedProps(resumeSession: (sid: string, focus: boolean, owner?: SessionOwnerScope) => Promise<unknown>) {
     return {
       activeSessionId: null,
       activeSessionIdRef: { current: null } as MutableRefObject<null | string>,
@@ -580,6 +580,28 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
 
     vi.advanceTimersByTime(1_000)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true, 'meta')
+  })
+
+  it('retries on the captured connection owner instead of the ambient source', () => {
+    vi.useFakeTimers()
+    const resumeSession = vi.fn(async () => undefined)
+    const ownerRoute: SessionProfileRoute = {
+      connectionId: 'source-a',
+      mode: 'remote',
+      profile: 'default'
+    }
+
+    render(
+      <RouteResumeHarness
+        {...strandedProps(resumeSession)}
+        resumeFailedSessionId="session-1"
+        sessionResumeRequest={{ ownerRoute, sequence: 1, sessionId: 'session-1' }}
+      />
+    )
+    resumeSession.mockClear()
+
+    vi.advanceTimersByTime(1_000)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, ownerRoute)
   })
 
   it('does NOT retry a failed session that is not the routed one', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -3,7 +3,7 @@ import { type MutableRefObject, useRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $resumeExhaustedSessionId, setResumeExhaustedSessionId } from '@/store/session'
-import type { SessionProfileRoute } from '@/store/session-request-router'
+import type { SessionOwnerScope, SessionProfileRoute } from '@/store/session-request-router'
 import { markSelectionRestore } from '@/store/session-states'
 
 import { useRouteResume } from './use-route-resume'
@@ -21,7 +21,7 @@ interface HarnessProps {
   freshDraftReady: boolean
   gatewayState: string
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>
+  resumeSession: (sessionId: string, focus: boolean, owner?: SessionOwnerScope) => Promise<unknown>
   resumeFailedSessionId?: null | string
   resumeExhaustedSessionId?: null | string
   sessionResumeRequest?: null | { ownerRoute?: SessionProfileRoute; sequence: number; sessionId: string }

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -196,6 +196,7 @@ export function useRouteResume({
 
         const ownerRoute =
           sessionResumeRequest?.sessionId === routedSessionId ? sessionResumeRequest.ownerRoute : undefined
+
         const resumeOwner = ownerRoute ?? routeOwnerProfile ?? undefined
 
         if (resumeOwner) {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -102,6 +102,7 @@ export function useRouteResume({
   // Per-session retry bookkeeping for the bounded auto-retry effect below.
   // Profile is part of the key because stored ids are only profile-local.
   const retrySessionIdRef = useRef<string | null>(null)
+  const retryOwnerRef = useRef<{ identity: string; owner: SessionOwnerScope } | null>(null)
   const retryAttemptRef = useRef(0)
   // Tracks the previous exhausted-latch value so we can detect its armed->cleared
   // edge. resumeSession clears $resumeExhaustedSessionId on a manual Retry /
@@ -111,7 +112,15 @@ export function useRouteResume({
   const prevResumeExhaustedRef = useRef<string | null>(null)
   const handledResumeRequestRef = useRef(0)
   const routeOwnerProfile = routedSessionProfile?.trim() || null
-  const routeSessionIdentity = routedSessionId ? `${routeOwnerProfile ?? ''}\0${routedSessionId}` : null
+
+  const requestedOwnerRoute =
+    sessionResumeRequest?.sessionId === routedSessionId ? sessionResumeRequest.ownerRoute : undefined
+
+  const routeOwnerConnection = typeof requestedOwnerRoute === 'object' ? requestedOwnerRoute.connectionId.trim() : ''
+
+  const routeSessionIdentity = routedSessionId
+    ? `${routeOwnerConnection}\0${routeOwnerProfile ?? ''}\0${routedSessionId}`
+    : null
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -199,6 +208,10 @@ export function useRouteResume({
 
         const resumeOwner = ownerRoute ?? routeOwnerProfile ?? undefined
 
+        if (routeSessionIdentity) {
+          retryOwnerRef.current = { identity: routeSessionIdentity, owner: resumeOwner }
+        }
+
         if (resumeOwner) {
           void resumeSession(routedSessionId, true, resumeOwner)
         } else {
@@ -229,6 +242,7 @@ export function useRouteResume({
     locationPathname,
     resumeSession,
     routeOwnerProfile,
+    routeSessionIdentity,
     sessionResumeRequest,
     routedSessionId,
     runtimeIdByStoredSessionIdRef,
@@ -331,8 +345,13 @@ export function useRouteResume({
       // re-renders with far fewer than MAX real attempts. (Point 3)
       retryAttemptRef.current += 1
 
-      if (routeOwnerProfile) {
-        void resumeSession(sessionId, true, routeOwnerProfile)
+      const capturedOwner =
+        retryOwnerRef.current?.identity === routeSessionIdentity
+          ? retryOwnerRef.current.owner
+          : (routeOwnerProfile ?? undefined)
+
+      if (capturedOwner) {
+        void resumeSession(sessionId, true, capturedOwner)
       } else {
         void resumeSession(sessionId, true)
       }

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -2,7 +2,7 @@ import { type MutableRefObject, useEffect, useRef } from 'react'
 
 import { isNewChatRoute } from '@/app/routes'
 import { type SessionResumeRequest, setResumeExhaustedSessionId } from '@/store/session'
-import type { SessionProfileRoute } from '@/store/session-request-router'
+import type { SessionOwnerScope } from '@/store/session-request-router'
 import { markSelectionRestore } from '@/store/session-states'
 
 interface RouteResumeOptions {
@@ -13,7 +13,7 @@ interface RouteResumeOptions {
   freshDraftReady: boolean
   gatewayState: string | undefined
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>
+  resumeSession: (sessionId: string, focus: boolean, owner?: SessionOwnerScope) => Promise<unknown>
   // Stored-session id whose most recent resume failed terminally (set by
   // useSessionActions, mirrored from $resumeFailedSessionId). While this equals
   // routedSessionId the window would otherwise latch on the loader forever, so
@@ -27,9 +27,11 @@ interface RouteResumeOptions {
   resumeExhaustedSessionId: string | null
   sessionResumeRequest: SessionResumeRequest | null
   routedSessionId: string | null
+  routedSessionProfile: string | null
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: string | null
   selectedStoredSessionIdRef: MutableRefObject<string | null>
+  selectedStoredSessionProfileRef: MutableRefObject<string | null>
   startFreshSessionDraft: (focus: boolean) => unknown
 }
 
@@ -81,9 +83,11 @@ export function useRouteResume({
   resumeExhaustedSessionId,
   sessionResumeRequest,
   routedSessionId,
+  routedSessionProfile,
   runtimeIdByStoredSessionIdRef,
   selectedStoredSessionId,
   selectedStoredSessionIdRef,
+  selectedStoredSessionProfileRef,
   startFreshSessionDraft
 }: RouteResumeOptions) {
   const lastPathnameRef = useRef<string | null>(null)
@@ -95,8 +99,8 @@ export function useRouteResume({
   // workspace (which would clobber the persisted active tab; ⌘R always landed
   // on main). Every later resume is a real navigation and homes as usual.
   const bootResumeRef = useRef(true)
-  // Per-session retry bookkeeping for the bounded auto-retry effect below. Keyed
-  // by the session id we're retrying so switching chats resets the counter.
+  // Per-session retry bookkeeping for the bounded auto-retry effect below.
+  // Profile is part of the key because stored ids are only profile-local.
   const retrySessionIdRef = useRef<string | null>(null)
   const retryAttemptRef = useRef(0)
   // Tracks the previous exhausted-latch value so we can detect its armed->cleared
@@ -106,6 +110,8 @@ export function useRouteResume({
   // never touches this latch, so it can't spuriously trigger the reset).
   const prevResumeExhaustedRef = useRef<string | null>(null)
   const handledResumeRequestRef = useRef(0)
+  const routeOwnerProfile = routedSessionProfile?.trim() || null
+  const routeSessionIdentity = routedSessionId ? `${routeOwnerProfile ?? ''}\0${routedSessionId}` : null
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -127,10 +133,15 @@ export function useRouteResume({
     if (routedSessionId) {
       const cachedRuntime = runtimeIdByStoredSessionIdRef.current.get(routedSessionId)
 
+      const selectedOwnerMatchesRoute =
+        routeOwnerProfile === null || routeOwnerProfile === selectedStoredSessionProfileRef.current
+
       const alreadyActive =
         routedSessionId === selectedStoredSessionIdRef.current &&
-        Boolean(cachedRuntime) &&
-        cachedRuntime === activeSessionIdRef.current
+        selectedOwnerMatchesRoute &&
+        (routeOwnerProfile !== null
+          ? activeSessionIdRef.current !== null
+          : Boolean(cachedRuntime) && cachedRuntime === activeSessionIdRef.current)
 
       const explicitlyRequested =
         sessionResumeRequest?.sessionId === routedSessionId &&
@@ -150,7 +161,10 @@ export function useRouteResume({
       // pathname flips to / (same null+/:sid signature). freshDraftReady is the
       // discriminator: it's true while heading into a blank new chat, false when
       // genuinely stranded on a routed session.
-      const stuckOnRoutedSession = routedSessionId !== selectedStoredSessionIdRef.current && !freshDraftReady
+      const stuckOnRoutedSession =
+        (routedSessionId !== selectedStoredSessionIdRef.current ||
+          (routeOwnerProfile !== null && routeOwnerProfile !== selectedStoredSessionProfileRef.current)) &&
+        !freshDraftReady
 
       // Resume when the route meaningfully changed, the gateway just opened, or
       // we're stranded on a routed session that never loaded. The first two
@@ -182,9 +196,10 @@ export function useRouteResume({
 
         const ownerRoute =
           sessionResumeRequest?.sessionId === routedSessionId ? sessionResumeRequest.ownerRoute : undefined
+        const resumeOwner = ownerRoute ?? routeOwnerProfile ?? undefined
 
-        if (ownerRoute) {
-          void resumeSession(routedSessionId, true, ownerRoute)
+        if (resumeOwner) {
+          void resumeSession(routedSessionId, true, resumeOwner)
         } else {
           void resumeSession(routedSessionId, true)
         }
@@ -212,11 +227,13 @@ export function useRouteResume({
     gatewayState,
     locationPathname,
     resumeSession,
+    routeOwnerProfile,
     sessionResumeRequest,
     routedSessionId,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
+    selectedStoredSessionProfileRef,
     startFreshSessionDraft
   ])
 
@@ -246,7 +263,7 @@ export function useRouteResume({
     prevResumeExhaustedRef.current = resumeExhaustedSessionId
 
     if (wasExhausted && wasExhausted === routedSessionId && resumeExhaustedSessionId !== wasExhausted) {
-      retrySessionIdRef.current = routedSessionId
+      retrySessionIdRef.current = routeSessionIdentity
       retryAttemptRef.current = 0
     }
 
@@ -264,7 +281,7 @@ export function useRouteResume({
       // the current route: that's the error state we want to keep showing).
       // resumeSession also clears it on a fresh attempt; this covers a plain
       // route-change away from the stranded window.
-      if (retrySessionIdRef.current !== routedSessionId) {
+      if (retrySessionIdRef.current !== routeSessionIdentity) {
         retrySessionIdRef.current = null
         retryAttemptRef.current = 0
         setResumeExhaustedSessionId(current => (current && current !== routedSessionId ? null : current))
@@ -274,8 +291,8 @@ export function useRouteResume({
     }
 
     // New stranded session id → reset the attempt counter.
-    if (retrySessionIdRef.current !== routedSessionId) {
-      retrySessionIdRef.current = routedSessionId
+    if (retrySessionIdRef.current !== routeSessionIdentity) {
+      retrySessionIdRef.current = routeSessionIdentity
       retryAttemptRef.current = 0
     }
 
@@ -298,6 +315,7 @@ export function useRouteResume({
       if (
         creatingSessionRef.current ||
         selectedStoredSessionIdRef.current !== sessionId ||
+        (routeOwnerProfile !== null && selectedStoredSessionProfileRef.current !== routeOwnerProfile) ||
         activeSessionIdRef.current !== null
       ) {
         return
@@ -311,7 +329,12 @@ export function useRouteResume({
       // having fired. A flapping backend could then hit MAX in a couple of
       // re-renders with far fewer than MAX real attempts. (Point 3)
       retryAttemptRef.current += 1
-      void resumeSession(sessionId, true)
+
+      if (routeOwnerProfile) {
+        void resumeSession(sessionId, true, routeOwnerProfile)
+      } else {
+        void resumeSession(sessionId, true)
+      }
     }, resumeRetryDelayMs(attempt))
 
     return () => clearTimeout(timer)
@@ -323,7 +346,10 @@ export function useRouteResume({
     resumeSession,
     resumeFailedSessionId,
     resumeExhaustedSessionId,
+    routeOwnerProfile,
+    routeSessionIdentity,
     routedSessionId,
-    selectedStoredSessionIdRef
+    selectedStoredSessionIdRef,
+    selectedStoredSessionProfileRef
   ])
 }

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -303,6 +303,7 @@ describe('active stored-session id rotation routing', () => {
       setActiveSessionStoredIdRotation({
         nextStoredSessionId: 'stored-A-next',
         previousStoredSessionId: 'stored-A',
+        profile: 'default',
         runtimeSessionId: 'runtime-A'
       })
     })
@@ -340,6 +341,7 @@ describe('active stored-session id rotation routing', () => {
       setActiveSessionStoredIdRotation({
         nextStoredSessionId: nextId,
         previousStoredSessionId: sharedId,
+        profile: 'meta',
         runtimeSessionId: 'runtime-meta'
       })
     })
@@ -347,6 +349,38 @@ describe('active stored-session id rotation routing', () => {
     await waitFor(() => expect(selectedStoredSessionIdRef.current).toBe(nextId))
     expect(selectedStoredSessionProfileRef.current).toBe('meta')
     expect(navigate).toHaveBeenCalledWith(sessionRoute(nextId, 'meta'), { replace: true })
+  })
+
+  it('rejects a stored-id rotation whose profile no longer owns the selected route', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'runtime-shared' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'stored-shared' }
+    const selectedStoredSessionProfileRef: MutableRefObject<string | null> = { current: 'default' }
+    const navigate = vi.fn()
+
+    setSelectedStoredSessionId('stored-shared')
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => 'stored-shared'}
+        navigate={navigate}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        selectedStoredSessionProfileRef={selectedStoredSessionProfileRef}
+      />
+    )
+
+    act(() => {
+      setActiveSessionStoredIdRotation({
+        nextStoredSessionId: 'meta-next',
+        previousStoredSessionId: 'stored-shared',
+        profile: 'meta',
+        runtimeSessionId: 'runtime-shared'
+      })
+    })
+
+    await waitFor(() => expect($activeSessionStoredIdRotation.get()).toBeNull())
+    expect(selectedStoredSessionIdRef.current).toBe('stored-shared')
+    expect($selectedStoredSessionId.get()).toBe('stored-shared')
+    expect(navigate).not.toHaveBeenCalled()
   })
 
   it('keeps draft on the previous tip when the new tip row is not loaded yet', async () => {
@@ -375,6 +409,7 @@ describe('active stored-session id rotation routing', () => {
       setActiveSessionStoredIdRotation({
         nextStoredSessionId: tipAfter,
         previousStoredSessionId: tipBefore,
+        profile: 'default',
         runtimeSessionId
       })
     })
@@ -417,6 +452,7 @@ describe('active stored-session id rotation routing', () => {
       setActiveSessionStoredIdRotation({
         nextStoredSessionId: tipAfter,
         previousStoredSessionId: tipBefore,
+        profile: 'default',
         runtimeSessionId
       })
     })
@@ -451,6 +487,7 @@ describe('active stored-session id rotation routing', () => {
       setActiveSessionStoredIdRotation({
         nextStoredSessionId: 'stored-A-next',
         previousStoredSessionId: 'stored-A',
+        profile: 'default',
         runtimeSessionId: 'runtime-A'
       })
     })
@@ -480,6 +517,7 @@ describe('active stored-session id rotation routing', () => {
       setActiveSessionStoredIdRotation({
         nextStoredSessionId: 'stored-A-next',
         previousStoredSessionId: 'stored-A',
+        profile: 'default',
         runtimeSessionId: 'runtime-A'
       })
     })
@@ -509,6 +547,7 @@ describe('active stored-session id rotation routing', () => {
       setActiveSessionStoredIdRotation({
         nextStoredSessionId: 'stored-A-next',
         previousStoredSessionId: 'stored-A',
+        profile: 'default',
         runtimeSessionId: 'runtime-A'
       })
     })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -77,6 +77,7 @@ import {
 } from '@/store/session-request-router'
 import { $sessionTiles, sessionTileOwnerRoute } from '@/store/session-states'
 import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
+import { clearTranscriptTails, saveTranscriptTail } from '@/store/transcript-tail-cache'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
 import { deferred } from '../../../test/deferred'
@@ -737,6 +738,7 @@ function ResumeHarness({
   requestGateway,
   runtimeIdByStoredSessionIdRef,
   selectedStoredSessionId = null,
+  selectedStoredSessionProfileRef,
   sessionStateByRuntimeIdRef
 }: {
   onStateUpdate?: (sessionId: string, state: ClientSessionState) => void
@@ -746,6 +748,7 @@ function ResumeHarness({
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
   selectedStoredSessionId?: string | null
+  selectedStoredSessionProfileRef?: MutableRefObject<string | null>
   sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
@@ -766,6 +769,7 @@ function ResumeHarness({
     runtimeIdByStoredSessionIdRef: runtimeMapRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef: ref<string | null>(selectedStoredSessionId),
+    selectedStoredSessionProfileRef,
     sessionStateByRuntimeIdRef: stateMapRef,
     syncSessionStateToView: vi.fn(),
     updateSessionState: (sessionId, updater, storedSessionId) => {
@@ -2029,6 +2033,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
       .mockResolvedValue({ messages: [] } as never)
     vi.mocked(requestGatewayForAgent).mockReset()
     clearClarifyRequest()
+    clearTranscriptTails()
     vi.mocked(requestGatewayForProfile).mockReset()
     setConnection(null)
     vi.restoreAllMocks()
@@ -2282,6 +2287,74 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(sessionStateByRuntimeIdRef.current.has('rt-recycled')).toBe(false)
   })
 
+  it('clears a foreign same-id selection and paints only the owner-qualified durable tail', async () => {
+    const sharedId = 'cron-shared-session'
+    const selectedProfileRef: MutableRefObject<string | null> = { current: 'default' }
+
+    const foreignMessage = {
+      id: 'default-live',
+      parts: [{ text: 'default transcript', type: 'text' }],
+      role: 'assistant'
+    } as never
+
+    const targetCachedMessage = {
+      id: 'meta-cached',
+      parts: [{ text: 'meta transcript', type: 'text' }],
+      role: 'assistant'
+    } as never
+
+    const prefetch = deferred<{ messages: never[]; session_id: string }>()
+    const resumed = deferred<SessionResumeResponse>()
+
+    setMessages([foreignMessage])
+    setSessions([
+      storedSession({ id: sharedId, message_count: 1, profile: 'default', title: 'Default duplicate' }),
+      storedSession({ id: sharedId, message_count: 1, profile: 'meta', title: 'Cron owner' })
+    ])
+    saveTranscriptTail(sharedId, [foreignMessage], 'default')
+    saveTranscriptTail(sharedId, [targetCachedMessage], 'meta')
+    vi.mocked(getLatestSessionMessages).mockReturnValue(prefetch.promise)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return resumed.promise as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(requestGatewayForProfile).mockImplementation(async (_profile, method) => requestGateway(method))
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean, ownerProfile?: string) => Promise<unknown>) | null =
+      null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        selectedStoredSessionId={sharedId}
+        selectedStoredSessionProfileRef={selectedProfileRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    const pendingResume = resume!(sharedId, true, 'meta')
+
+    await waitFor(() => expect($messages.get().map(message => message.id)).toEqual(['meta-cached']))
+    expect(selectedProfileRef.current).toBe('meta')
+    expect($messages.get()).not.toContain(foreignMessage)
+
+    prefetch.resolve({ messages: [], session_id: sharedId })
+    resumed.resolve({
+      info: {},
+      messages: [],
+      resumed: sharedId,
+      session_id: 'rt-meta',
+      session_key: sharedId
+    } as never)
+    await pendingResume
+  })
+
   it('does not activate a same-id runtime cache owned by another profile', async () => {
     const sharedId = 'cron-shared-session'
     const foreignRuntimeId = 'rt-default'
@@ -2335,9 +2408,8 @@ describe('resumeSession warm-cache mapping integrity', () => {
       requestGateway(method, { ...(params ?? {}), profile })
     )
 
-    let resume:
-      | ((storedSessionId: string, replaceRoute?: boolean, ownerProfile?: string) => Promise<unknown>)
-      | null = null
+    let resume: ((storedSessionId: string, replaceRoute?: boolean, ownerProfile?: string) => Promise<unknown>) | null =
+      null
 
     render(
       <ResumeHarness
@@ -2413,9 +2485,8 @@ describe('resumeSession warm-cache mapping integrity', () => {
       requestGateway(method, { ...(params ?? {}), profile })
     )
 
-    let resume:
-      | ((storedSessionId: string, replaceRoute?: boolean, ownerProfile?: string) => Promise<unknown>)
-      | null = null
+    let resume: ((storedSessionId: string, replaceRoute?: boolean, ownerProfile?: string) => Promise<unknown>) | null =
+      null
 
     render(
       <ResumeHarness
@@ -2428,10 +2499,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     await waitFor(() => expect(resume).not.toBeNull())
     await resume!(sharedId, true, 'meta')
 
-    expect(requestGateway).toHaveBeenCalledWith(
-      'session.activate',
-      expect.objectContaining({ session_id: 'rt-meta' })
-    )
+    expect(requestGateway).toHaveBeenCalledWith('session.activate', expect.objectContaining({ session_id: 'rt-meta' }))
     expect(requestGateway).not.toHaveBeenCalledWith(
       'session.activate',
       expect.objectContaining({ session_id: 'rt-default' })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -241,11 +241,13 @@ function StoredIdRotationHarness({
   activeSessionIdRef,
   getRoutedStoredSessionId,
   navigate,
+  selectedStoredSessionProfileRef,
   selectedStoredSessionIdRef
 }: {
   activeSessionIdRef: MutableRefObject<string | null>
   getRoutedStoredSessionId: () => null | string
   navigate: (to: string, options?: { replace?: boolean }) => void
+  selectedStoredSessionProfileRef?: MutableRefObject<string | null>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
@@ -264,6 +266,7 @@ function StoredIdRotationHarness({
     runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
     selectedStoredSessionId: selectedStoredSessionIdRef.current,
     selectedStoredSessionIdRef,
+    selectedStoredSessionProfileRef,
     sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
     updateSessionState: () => ({}) as ClientSessionState
@@ -308,6 +311,42 @@ describe('active stored-session id rotation routing', () => {
     expect($selectedStoredSessionId.get()).toBe('stored-A-next')
     expect(navigate).toHaveBeenCalledWith(sessionRoute('stored-A-next'), { replace: true })
     expect($activeSessionStoredIdRotation.get()).toBeNull()
+  })
+
+  it('preserves the selected owner profile when a qualified cron run rotates beside a same-id sibling', async () => {
+    const sharedId = 'cron-shared-session'
+    const nextId = 'cron-shared-session-next'
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'runtime-meta' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: sharedId }
+    const selectedStoredSessionProfileRef: MutableRefObject<string | null> = { current: 'meta' }
+    const navigate = vi.fn()
+
+    setSessions([
+      storedSession({ id: sharedId, profile: 'default' }),
+      storedSession({ id: sharedId, profile: 'meta' })
+    ])
+    setSelectedStoredSessionId(sharedId)
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => sharedId}
+        navigate={navigate}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        selectedStoredSessionProfileRef={selectedStoredSessionProfileRef}
+      />
+    )
+
+    act(() => {
+      setActiveSessionStoredIdRotation({
+        nextStoredSessionId: nextId,
+        previousStoredSessionId: sharedId,
+        runtimeSessionId: 'runtime-meta'
+      })
+    })
+
+    await waitFor(() => expect(selectedStoredSessionIdRef.current).toBe(nextId))
+    expect(selectedStoredSessionProfileRef.current).toBe('meta')
+    expect(navigate).toHaveBeenCalledWith(sessionRoute(nextId, 'meta'), { replace: true })
   })
 
   it('keeps draft on the previous tip when the new tip row is not loaded yet', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -239,18 +239,28 @@ describe('connection-qualified session deletion', () => {
 
 function StoredIdRotationHarness({
   activeSessionIdRef,
+  connectionId,
   getRoutedStoredSessionId,
   navigate,
   selectedStoredSessionProfileRef,
   selectedStoredSessionIdRef
 }: {
   activeSessionIdRef: MutableRefObject<string | null>
+  connectionId?: string
   getRoutedStoredSessionId: () => null | string
   navigate: (to: string, options?: { replace?: boolean }) => void
   selectedStoredSessionProfileRef?: MutableRefObject<string | null>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+  const installedState = createClientSessionState(selectedStoredSessionIdRef.current)
+  installedState.connectionId = connectionId ?? null
+  installedState.profile = selectedStoredSessionProfileRef?.current || 'default'
+  const stateMap = new Map<string, ClientSessionState>()
+
+  if (activeSessionIdRef.current) {
+    stateMap.set(activeSessionIdRef.current, installedState)
+  }
 
   useSessionActions({
     activeSessionId: activeSessionIdRef.current,
@@ -267,7 +277,7 @@ function StoredIdRotationHarness({
     selectedStoredSessionId: selectedStoredSessionIdRef.current,
     selectedStoredSessionIdRef,
     selectedStoredSessionProfileRef,
-    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    sessionStateByRuntimeIdRef: ref(stateMap),
     syncSessionStateToView: vi.fn(),
     updateSessionState: () => ({}) as ClientSessionState
   })
@@ -301,6 +311,7 @@ describe('active stored-session id rotation routing', () => {
 
     act(() => {
       setActiveSessionStoredIdRotation({
+        connectionId: null,
         nextStoredSessionId: 'stored-A-next',
         previousStoredSessionId: 'stored-A',
         profile: 'default',
@@ -322,10 +333,7 @@ describe('active stored-session id rotation routing', () => {
     const selectedStoredSessionProfileRef: MutableRefObject<string | null> = { current: 'meta' }
     const navigate = vi.fn()
 
-    setSessions([
-      storedSession({ id: sharedId, profile: 'default' }),
-      storedSession({ id: sharedId, profile: 'meta' })
-    ])
+    setSessions([storedSession({ id: sharedId, profile: 'default' }), storedSession({ id: sharedId, profile: 'meta' })])
     setSelectedStoredSessionId(sharedId)
     render(
       <StoredIdRotationHarness
@@ -339,6 +347,7 @@ describe('active stored-session id rotation routing', () => {
 
     act(() => {
       setActiveSessionStoredIdRotation({
+        connectionId: null,
         nextStoredSessionId: nextId,
         previousStoredSessionId: sharedId,
         profile: 'meta',
@@ -370,6 +379,7 @@ describe('active stored-session id rotation routing', () => {
 
     act(() => {
       setActiveSessionStoredIdRotation({
+        connectionId: null,
         nextStoredSessionId: 'meta-next',
         previousStoredSessionId: 'stored-shared',
         profile: 'meta',
@@ -380,6 +390,39 @@ describe('active stored-session id rotation routing', () => {
     await waitFor(() => expect($activeSessionStoredIdRotation.get()).toBeNull())
     expect(selectedStoredSessionIdRef.current).toBe('stored-shared')
     expect($selectedStoredSessionId.get()).toBe('stored-shared')
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('rejects a stored-id rotation whose connection no longer owns the runtime', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'runtime-shared' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'stored-shared' }
+    const selectedStoredSessionProfileRef: MutableRefObject<string | null> = { current: 'default' }
+    const navigate = vi.fn()
+
+    setSelectedStoredSessionId('stored-shared')
+    render(
+      <StoredIdRotationHarness
+        activeSessionIdRef={activeSessionIdRef}
+        connectionId="gateway-a"
+        getRoutedStoredSessionId={() => 'stored-shared'}
+        navigate={navigate}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        selectedStoredSessionProfileRef={selectedStoredSessionProfileRef}
+      />
+    )
+
+    act(() => {
+      setActiveSessionStoredIdRotation({
+        connectionId: 'gateway-b',
+        nextStoredSessionId: 'foreign-next',
+        previousStoredSessionId: 'stored-shared',
+        profile: 'default',
+        runtimeSessionId: 'runtime-shared'
+      })
+    })
+
+    await waitFor(() => expect($activeSessionStoredIdRotation.get()).toBeNull())
+    expect(selectedStoredSessionIdRef.current).toBe('stored-shared')
     expect(navigate).not.toHaveBeenCalled()
   })
 
@@ -407,6 +450,7 @@ describe('active stored-session id rotation routing', () => {
 
     act(() => {
       setActiveSessionStoredIdRotation({
+        connectionId: null,
         nextStoredSessionId: tipAfter,
         previousStoredSessionId: tipBefore,
         profile: 'default',
@@ -450,6 +494,7 @@ describe('active stored-session id rotation routing', () => {
 
     act(() => {
       setActiveSessionStoredIdRotation({
+        connectionId: null,
         nextStoredSessionId: tipAfter,
         previousStoredSessionId: tipBefore,
         profile: 'default',
@@ -485,6 +530,7 @@ describe('active stored-session id rotation routing', () => {
 
     act(() => {
       setActiveSessionStoredIdRotation({
+        connectionId: null,
         nextStoredSessionId: 'stored-A-next',
         previousStoredSessionId: 'stored-A',
         profile: 'default',
@@ -515,6 +561,7 @@ describe('active stored-session id rotation routing', () => {
 
     act(() => {
       setActiveSessionStoredIdRotation({
+        connectionId: null,
         nextStoredSessionId: 'stored-A-next',
         previousStoredSessionId: 'stored-A',
         profile: 'default',
@@ -545,6 +592,7 @@ describe('active stored-session id rotation routing', () => {
 
     act(() => {
       setActiveSessionStoredIdRotation({
+        connectionId: null,
         nextStoredSessionId: 'stored-A-next',
         previousStoredSessionId: 'stored-A',
         profile: 'default',
@@ -1450,6 +1498,7 @@ describe('resumeSession failure recovery', () => {
             awaitingResponse: false,
             branch: '',
             busy: false,
+            connectionId: null,
             cwd: '',
             fast: false,
             interimBoundaryPending: false,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -70,7 +70,11 @@ import {
   setSessions,
   setTurnStartedAt
 } from '@/store/session'
-import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
+import {
+  requestForSessionProfile,
+  type SessionOwnerScope,
+  type SessionProfileRoute
+} from '@/store/session-request-router'
 import { $sessionTiles, sessionTileOwnerRoute } from '@/store/session-states'
 import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
 
@@ -737,7 +741,7 @@ function ResumeHarness({
 }: {
   onStateUpdate?: (sessionId: string, state: ClientSessionState) => void
   onReady: (
-    resume: (storedSessionId: string, replaceRoute?: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>
+    resume: (storedSessionId: string, replaceRoute?: boolean, owner?: SessionOwnerScope) => Promise<unknown>
   ) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
@@ -1374,6 +1378,7 @@ describe('resumeSession failure recovery', () => {
             needsInput: false,
             pendingBranchGroup: null,
             personality: '',
+            profile: null,
             provider: '',
             reasoningEffort: '',
             sawAssistantPayload: false,
@@ -2275,6 +2280,163 @@ describe('resumeSession warm-cache mapping integrity', () => {
     // The corrupt mapping was purged so it can't mis-resolve again.
     expect(runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
     expect(sessionStateByRuntimeIdRef.current.has('rt-recycled')).toBe(false)
+  })
+
+  it('does not activate a same-id runtime cache owned by another profile', async () => {
+    const sharedId = 'cron-shared-session'
+    const foreignRuntimeId = 'rt-default'
+    const targetRuntimeId = 'rt-meta'
+
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([[sharedId, foreignRuntimeId]])
+    }
+
+    const foreignState = Object.assign(clientState(sharedId), { profile: 'default' })
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([[foreignRuntimeId, foreignState]])
+    }
+
+    $activeGatewayProfile.set('default')
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(async profile => {
+      $activeGatewayProfile.set(profile || 'default')
+    })
+    setSessions([
+      storedSession({ id: sharedId, profile: 'default', title: 'Default duplicate' }),
+      storedSession({ id: sharedId, profile: 'meta', title: 'Cron owner' })
+    ])
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: sharedId } as never)
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.activate') {
+        return {
+          session_id: params?.session_id,
+          session_key: sharedId,
+          resumed: sharedId,
+          messages: [],
+          info: {}
+        } as never
+      }
+
+      if (method === 'session.resume') {
+        return {
+          session_id: targetRuntimeId,
+          session_key: sharedId,
+          resumed: sharedId,
+          messages: [],
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(requestGatewayForProfile).mockImplementation(async (profile, method, params) =>
+      requestGateway(method, { ...(params ?? {}), profile })
+    )
+
+    let resume:
+      | ((storedSessionId: string, replaceRoute?: boolean, ownerProfile?: string) => Promise<unknown>)
+      | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!(sharedId, true, 'meta')
+
+    expect(ensureGatewayProfile).toHaveBeenCalledWith('meta')
+    expect(requestGateway).not.toHaveBeenCalledWith(
+      'session.activate',
+      expect.objectContaining({ session_id: foreignRuntimeId })
+    )
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.resume',
+      expect.objectContaining({ profile: 'meta', session_id: sharedId })
+    )
+    expect(sessionStateByRuntimeIdRef.current.has(foreignRuntimeId)).toBe(true)
+    expect(sessionStateByRuntimeIdRef.current.get(targetRuntimeId)?.profile).toBe('meta')
+
+    requestGateway.mockClear()
+    await resume!(sharedId, true, 'meta')
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.activate',
+      expect.objectContaining({ session_id: targetRuntimeId })
+    )
+    expect(requestGateway.mock.calls.map(([method]) => method)).not.toContain('session.resume')
+  })
+
+  it('activates only the profile-qualified warm runtime when same-id caches coexist', async () => {
+    const sharedId = 'cron-shared-session'
+
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([[sharedId, 'rt-default']])
+    }
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([
+        ['rt-default', Object.assign(clientState(sharedId), { profile: 'default' })],
+        ['rt-meta', Object.assign(clientState(sharedId), { profile: 'meta' })]
+      ])
+    }
+
+    setSessions([
+      storedSession({ id: sharedId, profile: 'default', title: 'Default duplicate' }),
+      storedSession({ id: sharedId, profile: 'meta', title: 'Cron owner' })
+    ])
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(async profile => {
+      $activeGatewayProfile.set(profile || 'default')
+    })
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: sharedId } as never)
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.activate') {
+        return {
+          session_id: params?.session_id,
+          session_key: sharedId,
+          resumed: sharedId,
+          messages: [],
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(requestGatewayForProfile).mockImplementation(async (profile, method, params) =>
+      requestGateway(method, { ...(params ?? {}), profile })
+    )
+
+    let resume:
+      | ((storedSessionId: string, replaceRoute?: boolean, ownerProfile?: string) => Promise<unknown>)
+      | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!(sharedId, true, 'meta')
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.activate',
+      expect.objectContaining({ session_id: 'rt-meta' })
+    )
+    expect(requestGateway).not.toHaveBeenCalledWith(
+      'session.activate',
+      expect.objectContaining({ session_id: 'rt-default' })
+    )
+    expect(requestGateway.mock.calls.map(([method]) => method)).not.toContain('session.resume')
   })
 
   it('paints the bounded latest transcript after the deferred resume acknowledgement', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -175,6 +175,7 @@ interface SessionActionsOptions {
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: string | null
   selectedStoredSessionIdRef: MutableRefObject<string | null>
+  selectedStoredSessionProfileRef?: MutableRefObject<string | null>
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
   syncSessionStateToView: (sessionId: string, state: ClientSessionState) => void
   updateSessionState: (
@@ -317,6 +318,7 @@ export function useSessionActions({
   runtimeIdByStoredSessionIdRef,
   selectedStoredSessionId,
   selectedStoredSessionIdRef,
+  selectedStoredSessionProfileRef,
   sessionStateByRuntimeIdRef,
   syncSessionStateToView,
   updateSessionState
@@ -324,6 +326,8 @@ export function useSessionActions({
   const { t } = useI18n()
   const copy = t.desktop
   const resumeRequestRef = useRef(0)
+  const fallbackSelectedProfileRef = useRef<string | null>(null)
+  const selectedProfileRef = selectedStoredSessionProfileRef ?? fallbackSelectedProfileRef
 
   // Follow auto-compression's stored-id rotation only while the exact runtime,
   // selection, and route intent still belong to the rotating conversation.
@@ -428,6 +432,7 @@ export function useSessionActions({
       activeSessionIdRef.current = null
       setSelectedStoredSessionId(null)
       selectedStoredSessionIdRef.current = null
+      selectedProfileRef.current = null
       setMessages([])
       setCurrentUsage({
         calls: 0,
@@ -468,7 +473,15 @@ export function useSessionActions({
       // Never clear the composer here — ChatBar's per-thread draft swap owns it.
       setFreshDraftReady(true)
     },
-    [activeSessionIdRef, busyRef, navigate, onFreshDraftRouteIntent, resetViewSync, selectedStoredSessionIdRef]
+    [
+      activeSessionIdRef,
+      busyRef,
+      navigate,
+      onFreshDraftRouteIntent,
+      resetViewSync,
+      selectedProfileRef,
+      selectedStoredSessionIdRef
+    ]
   )
 
   const createBackendSessionForSend = useCallback(
@@ -614,6 +627,7 @@ export function useSessionActions({
         const yoloArmed = $yoloActive.get()
         const runtimeInfo = applyRuntimeInfo(created.info)
         const runtimeProfile = normalizeProfileKey(typeof params.profile === 'string' ? params.profile : null)
+        selectedProfileRef.current = runtimeProfile
 
         updateSessionState(
           created.session_id,
@@ -642,6 +656,7 @@ export function useSessionActions({
       navigate,
       requestGateway,
       resetViewSync,
+      selectedProfileRef,
       selectedStoredSessionIdRef,
       updateSessionState
     ]
@@ -811,11 +826,24 @@ export function useSessionActions({
     async (storedSessionId: string, replaceRoute = false, capturedOwner?: SessionOwnerScope) => {
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
-      const resumedSameSelectedSession = selectedStoredSessionIdRef.current === storedSessionId
+      const requestedOwnerProfile =
+        typeof capturedOwner === 'string'
+          ? normalizeProfileKey(capturedOwner)
+          : capturedOwner
+            ? normalizeProfileKey(capturedOwner.profile)
+            : null
+      let resumeOwnerProfile = requestedOwnerProfile
+
+      const resumedSameSelectedSession =
+        selectedStoredSessionIdRef.current === storedSessionId &&
+        (requestedOwnerProfile === null || selectedProfileRef.current === requestedOwnerProfile)
+
       const resumeStartMessages = resumedSameSelectedSession ? $messages.get() : []
 
       const isCurrentResume = () =>
-        resumeRequestRef.current === requestId && selectedStoredSessionIdRef.current === storedSessionId
+        resumeRequestRef.current === requestId &&
+        selectedStoredSessionIdRef.current === storedSessionId &&
+        (resumeOwnerProfile === null || selectedProfileRef.current === resumeOwnerProfile)
 
       // Paint the click before the profile-resolve / gateway-swap awaits below,
       // so there's zero dead air: highlight the row instantly (the sidebar reads
@@ -830,6 +858,7 @@ export function useSessionActions({
       resetViewSync()
       setSelectedStoredSessionId(storedSessionId)
       selectedStoredSessionIdRef.current = storedSessionId
+      selectedProfileRef.current = requestedOwnerProfile
 
       // A session is EITHER the main thread OR a tile — never both. openSessionTile
       // enforces this from the tile side (it refuses to tile the selected session);
@@ -914,7 +943,7 @@ export function useSessionActions({
         return { runtimeId, state }
       }
 
-      if (!takeWarmCache(ownerProfile)) {
+      if (!takeWarmCache(requestedOwnerProfile ?? undefined)) {
         setActiveSessionId(null)
         activeSessionIdRef.current = null
         // History load is not turn-busy. Drop the previous session's leftover
@@ -953,6 +982,8 @@ export function useSessionActions({
       }
 
       const resolvedConnectionId = ownerRoute?.connectionId || storedForProfile?.connection_id || ambientConnectionId
+      resumeOwnerProfile = normalizeProfileKey(sessionProfile)
+      selectedProfileRef.current = resumeOwnerProfile
 
       // A row spliced from a CONNECTED registry gateway (#88880) carries its
       // owning connection. A row fetched directly after activating a registry
@@ -1379,7 +1410,7 @@ export function useSessionActions({
       if (!resumedSameSelectedSession && $messages.get().length === 0) {
         const cachedTail = loadTranscriptTail(storedSessionId, sessionRestScope)
 
-        if (cachedTail && selectedStoredSessionIdRef.current === storedSessionId) {
+        if (cachedTail && isCurrentResume()) {
           cachedTailPaint = cachedTail
           setMessages(cachedTail)
         }
@@ -1828,7 +1859,7 @@ export function useSessionActions({
           let stillListed = false
 
           try {
-            stillListed = Boolean(await resolveStoredSession(storedSessionId))
+            stillListed = Boolean(await resolveStoredSession(storedSessionId, sessionProfile))
           } catch {
             // Resolution itself failed — inconclusive, treat as not listed.
           }
@@ -1894,6 +1925,7 @@ export function useSessionActions({
       requestGateway,
       resetViewSync,
       runtimeIdByStoredSessionIdRef,
+      selectedProfileRef,
       selectedStoredSessionIdRef,
       sessionStateByRuntimeIdRef,
       startFreshSessionDraft,
@@ -2225,7 +2257,7 @@ export function useSessionActions({
         dropTranscriptTailEverywhere(storedSessionId)
         // Only after the RPC lands — the optimistic eviction above can roll
         // back, and a rolled-back row must keep its watermark/marker.
-        forgetSessionUnread(removedIds, profile)
+        forgetSessionUnread(removedIds, removed?.profile)
         clearQueuedPrompts(storedSessionId)
 
         if (closingRuntimeId) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -98,10 +98,7 @@ import {
   setYoloActive
 } from '@/store/session'
 import { isSessionOwnerResolutionError } from '@/store/session-owner-resolution'
-import {
-  requestForSessionProfile,
-  type SessionOwnerScope
-} from '@/store/session-request-router'
+import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import {
   $sessionTiles,
   closeSessionTile,
@@ -128,6 +125,7 @@ import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, Usag
 
 import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
+import { sessionRuntimeStateMatchesOwner } from '../../session-state-cache'
 import { sessionContextDrift } from '../session-context-drift'
 import { singleFlightSessionResume } from '../use-prompt-actions/single-flight-resume'
 
@@ -164,7 +162,12 @@ interface SessionActionsOptions {
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
   creatingSessionRef: MutableRefObject<boolean>
-  ensureSessionState: (sessionId: string, storedSessionId?: string | null) => ClientSessionState
+  ensureSessionState: (
+    sessionId: string,
+    storedSessionId?: string | null,
+    ownerProfile?: string,
+    ownerConnectionId?: null | string
+  ) => ClientSessionState
   getRouteToken: () => string
   getRoutedStoredSessionId: () => null | string
   navigate: NavigateFunction
@@ -180,7 +183,9 @@ interface SessionActionsOptions {
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
+    storedSessionId?: string | null,
+    ownerProfile?: string,
+    ownerConnectionId?: null | string
   ) => ClientSessionState
 }
 
@@ -347,9 +352,11 @@ export function useSessionActions({
 
     const selectedStoredSessionId = selectedStoredSessionIdRef.current
     const routedStoredSessionId = getRoutedStoredSessionId()
+    const installedRuntimeState = sessionStateByRuntimeIdRef.current.get(storedIdRotation.runtimeSessionId)
 
     if (
       activeSessionIdRef.current !== storedIdRotation.runtimeSessionId ||
+      !sessionRuntimeStateMatchesOwner(installedRuntimeState, storedIdRotation) ||
       normalizeProfileKey(selectedProfileRef.current) !== storedIdRotation.profile ||
       selectedStoredSessionId !== storedIdRotation.previousStoredSessionId ||
       (routedStoredSessionId !== null && routedStoredSessionId !== storedIdRotation.previousStoredSessionId)
@@ -393,6 +400,7 @@ export function useSessionActions({
     navigate,
     selectedProfileRef,
     selectedStoredSessionIdRef,
+    sessionStateByRuntimeIdRef,
     storedIdRotation
   ])
 
@@ -609,7 +617,8 @@ export function useSessionActions({
         resetViewSync()
         activeSessionIdRef.current = created.session_id
         selectedStoredSessionIdRef.current = stored
-        ensureSessionState(created.session_id, stored)
+        const runtimeProfile = normalizeProfileKey(typeof params.profile === 'string' ? params.profile : null)
+        ensureSessionState(created.session_id, stored, runtimeProfile, capturedRoute?.connectionId)
 
         if (stored) {
           createdThisRun.add(stored)
@@ -633,13 +642,14 @@ export function useSessionActions({
         setSessionStartedAt(Date.now())
         const yoloArmed = $yoloActive.get()
         const runtimeInfo = applyRuntimeInfo(created.info)
-        const runtimeProfile = normalizeProfileKey(typeof params.profile === 'string' ? params.profile : null)
         selectedProfileRef.current = runtimeProfile
 
         updateSessionState(
           created.session_id,
           state => ({ ...state, profile: runtimeProfile, ...(runtimeInfo ?? {}) }),
-          stored
+          stored,
+          runtimeProfile,
+          capturedRoute?.connectionId
         )
 
         // User may have armed YOLO on the new-chat draft before the runtime
@@ -792,7 +802,9 @@ export function useSessionActions({
         updateSessionState(
           created.session_id,
           state => ({ ...state, profile: runtimeProfile, ...(runtimeInfo ?? {}) }),
-          stored
+          stored,
+          runtimeProfile,
+          capturedRoute?.connectionId
         )
 
         openSessionTile(stored, dir, undefined, undefined, workspaceScope)
@@ -1239,7 +1251,9 @@ export function useSessionActions({
                   adoptedRunningTurn: state.adoptedRunningTurn || running,
                   turnStartedAt: running ? (activatedTurnStartedAt ?? state.turnStartedAt ?? Date.now()) : null
                 }),
-                storedSessionId
+                storedSessionId,
+                resumeOwnerProfile ?? undefined,
+                resolvedConnectionId || undefined
               )
 
               busyRef.current = running
@@ -1356,7 +1370,9 @@ export function useSessionActions({
                       }
                     : {})
                 }),
-                storedSessionId
+                storedSessionId,
+                resumeOwnerProfile ?? undefined,
+                resolvedConnectionId || undefined
               )
 
               syncSessionStateToView(cachedRuntimeId, activatedState)
@@ -1753,7 +1769,9 @@ export function useSessionActions({
                 }
               : {})
           }),
-          storedSessionId
+          storedSessionId,
+          resumeOwnerProfile ?? undefined,
+          resolvedConnectionId || undefined
         )
 
         // updateSessionState stages its view sync through requestAnimationFrame.

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -100,8 +100,7 @@ import {
 import { isSessionOwnerResolutionError } from '@/store/session-owner-resolution'
 import {
   requestForSessionProfile,
-  type SessionOwnerScope,
-  type SessionProfileRoute
+  type SessionOwnerScope
 } from '@/store/session-request-router'
 import {
   $sessionTiles,
@@ -385,9 +384,16 @@ export function useSessionActions({
     // chat still needs to follow the continuation. Update that selection in
     // place without navigating out of the surface the user deliberately opened.
     if (routedStoredSessionId === previousId) {
-      navigate(sessionRoute(nextId), { replace: true })
+      navigate(sessionRoute(nextId, selectedProfileRef.current), { replace: true })
     }
-  }, [activeSessionIdRef, getRoutedStoredSessionId, navigate, selectedStoredSessionIdRef, storedIdRotation])
+  }, [
+    activeSessionIdRef,
+    getRoutedStoredSessionId,
+    navigate,
+    selectedProfileRef,
+    selectedStoredSessionIdRef,
+    storedIdRotation
+  ])
 
   const startFreshSessionDraft = useCallback(
     (options: boolean | FreshSessionDraftOptions = false) => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -800,7 +800,7 @@ export function useSessionActions({
   }, [navigate, selectedStoredSessionId])
 
   const resumeSession = useCallback(
-    async (storedSessionId: string, replaceRoute = false, capturedOwner?: SessionProfileRoute) => {
+    async (storedSessionId: string, replaceRoute = false, capturedOwner?: SessionOwnerScope) => {
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
       const resumedSameSelectedSession = selectedStoredSessionIdRef.current === storedSessionId
@@ -891,7 +891,8 @@ export function useSessionActions({
       // gateway call (no-op when it's already on that profile / single-profile).
       // resolveStoredSession finds the row by id (cheap), so an uncached pasted
       // id loads as fast as a sidebar click instead of hanging on a list scan.
-      const ownerRoute = capturedOwner || getSessionOwnerHint(storedSessionId)
+      const hintedOwner = capturedOwner || getSessionOwnerHint(storedSessionId)
+      const ownerRoute = typeof hintedOwner === 'object' ? hintedOwner : undefined
       // A connection switch clears/reloads the session rows before this path
       // runs, so an untagged row belongs to the connection that supplied the
       // current list. Capture that source before the async metadata lookup. If
@@ -903,8 +904,9 @@ export function useSessionActions({
       const ambientConnectionId =
         ambientConnection?.mode === 'remote' ? ambientConnection.connectionId?.trim() || '' : ''
 
-      const storedForProfile = await resolveStoredSession(storedSessionId, ownerRoute)
-      const sessionProfile = storedForProfile?.profile
+      const storedForProfile = await resolveStoredSession(storedSessionId, hintedOwner)
+      const sessionProfile =
+        typeof hintedOwner === 'string' ? hintedOwner.trim() || storedForProfile?.profile : storedForProfile?.profile
 
       if (resumeRequestRef.current !== requestId) {
         return

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -350,6 +350,7 @@ export function useSessionActions({
 
     if (
       activeSessionIdRef.current !== storedIdRotation.runtimeSessionId ||
+      normalizeProfileKey(selectedProfileRef.current) !== storedIdRotation.profile ||
       selectedStoredSessionId !== storedIdRotation.previousStoredSessionId ||
       (routedStoredSessionId !== null && routedStoredSessionId !== storedIdRotation.previousStoredSessionId)
     ) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1621,9 +1621,12 @@ export function useSessionActions({
         // backend's own inflight projection is already inside
         // `preferredWithRuntimeChanges`, so this merge only adds the locally
         // recorded structure that the backend's text-only snapshot cannot carry.
-        const inFlightRecovery = recoverInFlightTurnJournal(storedSessionId, preferredWithRuntimeChanges, {
-          keepPending: resumedRunning
-        })
+        const inFlightRecovery = recoverInFlightTurnJournal(
+          storedSessionId,
+          normalizeProfileKey(sessionProfile),
+          preferredWithRuntimeChanges,
+          { keepPending: resumedRunning }
+        )
 
         recoveredInFlightTail = inFlightRecovery.applied
 
@@ -1787,6 +1790,7 @@ export function useSessionActions({
           // only carrier of a crashed turn's progress on this path.
           const fallbackRecovery = recoverInFlightTurnJournal(
             storedSessionId,
+            normalizeProfileKey(sessionProfile),
             reconcileAuthoritativeMessages(fallback.messages, previousMessages)
           )
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -613,10 +613,13 @@ export function useSessionActions({
         setSessionStartedAt(Date.now())
         const yoloArmed = $yoloActive.get()
         const runtimeInfo = applyRuntimeInfo(created.info)
+        const runtimeProfile = normalizeProfileKey(typeof params.profile === 'string' ? params.profile : null)
 
-        if (runtimeInfo) {
-          updateSessionState(created.session_id, state => ({ ...state, ...runtimeInfo }), stored)
-        }
+        updateSessionState(
+          created.session_id,
+          state => ({ ...state, profile: runtimeProfile, ...(runtimeInfo ?? {}) }),
+          stored
+        )
 
         // User may have armed YOLO on the new-chat draft before the runtime
         // session existed — apply it to the freshly created session.
@@ -763,7 +766,12 @@ export function useSessionActions({
         // Project "+" created a session while the main chat was occupied
         // (#76696). Split/side tiles deliberately stay isolated.
         const runtimeInfo = applyRuntimeInfo(created.info, { foreground: false })
-        updateSessionState(created.session_id, state => (runtimeInfo ? { ...state, ...runtimeInfo } : state), stored)
+        const runtimeProfile = normalizeProfileKey(typeof params.profile === 'string' ? params.profile : null)
+        updateSessionState(
+          created.session_id,
+          state => ({ ...state, profile: runtimeProfile, ...(runtimeInfo ?? {}) }),
+          stored
+        )
 
         openSessionTile(stored, dir, undefined, undefined, workspaceScope)
         patchSessionTile(stored, { runtimeId: created.session_id })
@@ -855,18 +863,50 @@ export function useSessionActions({
       // under the current route (the "open chat A, chat B loads" bug). On a
       // mismatch the mapping is cross-wired: purge both sides and report a miss
       // so the caller falls through to a full resume that rebinds a correct id.
-      const takeWarmCache = (): { runtimeId: string; state: ClientSessionState } | null => {
-        const runtimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
-        const state = runtimeId ? sessionStateByRuntimeIdRef.current.get(runtimeId) : undefined
+      const dropWarmCache = (runtimeId: string) => {
+        // The bare reverse index can only point at one same-id runtime. Do not
+        // erase another profile's valid binding when dropping this candidate.
+        if (runtimeIdByStoredSessionIdRef.current.get(storedSessionId) === runtimeId) {
+          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+        }
+
+        sessionStateByRuntimeIdRef.current.delete(runtimeId)
+        dropSessionState(runtimeId)
+      }
+
+      const takeWarmCache = (profile?: string): { runtimeId: string; state: ClientSessionState } | null => {
+        const expectedProfile = profile?.trim() ? normalizeProfileKey(profile) : null
+        let runtimeId: string | undefined
+        let state: ClientSessionState | undefined
+
+        if (expectedProfile) {
+          // Stored session ids are profile-local. The legacy reverse index is
+          // intentionally still bare for ordinary foreground routing, so an
+          // owner-qualified cron open must resolve from runtime provenance
+          // instead of trusting whichever same-id profile wrote that index last.
+          for (const [candidateRuntimeId, candidateState] of sessionStateByRuntimeIdRef.current.entries()) {
+            if (
+              candidateState.storedSessionId === storedSessionId &&
+              candidateState.profile !== null &&
+              normalizeProfileKey(candidateState.profile) === expectedProfile
+            ) {
+              runtimeId = candidateRuntimeId
+              state = candidateState
+
+              break
+            }
+          }
+        } else {
+          runtimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
+          state = runtimeId ? sessionStateByRuntimeIdRef.current.get(runtimeId) : undefined
+        }
 
         if (!runtimeId || !state) {
           return null
         }
 
         if (state.storedSessionId !== storedSessionId) {
-          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
-          sessionStateByRuntimeIdRef.current.delete(runtimeId)
-          dropSessionState(runtimeId)
+          dropWarmCache(runtimeId)
 
           return null
         }
@@ -874,7 +914,7 @@ export function useSessionActions({
         return { runtimeId, state }
       }
 
-      if (!takeWarmCache()) {
+      if (!takeWarmCache(ownerProfile)) {
         setActiveSessionId(null)
         activeSessionIdRef.current = null
         // History load is not turn-busy. Drop the previous session's leftover
@@ -972,14 +1012,14 @@ export function useSessionActions({
       // Re-check after the profile-resolve / gateway-swap awaits above: the
       // cache may have changed, and takeWarmCache re-validates belongs-to and
       // purges a cross-wired mapping before we trust the fast-path.
-      const warmHit = takeWarmCache()
+      const warmHit = takeWarmCache(sessionProfile)
 
       if (warmHit) {
         const cachedRuntimeId = warmHit.runtimeId
         const cachedState = warmHit.state
 
         const stored =
-          $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ?? storedForProfile
+          storedForProfile ?? $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
 
         let cachedViewState =
           !cachedState.model && stored?.model != null
@@ -1003,9 +1043,7 @@ export function useSessionActions({
         }
 
         if (sessionShouldHaveTranscript(stored) && cachedViewState.messages.length === 0) {
-          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
-          sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
-          dropSessionState(cachedRuntimeId)
+          dropWarmCache(cachedRuntimeId)
         } else {
           // Paint the warm cache immediately. The persisted transcript still
           // needs a refresh because a resumed runtime may carry only the
@@ -1071,9 +1109,7 @@ export function useSessionActions({
             }
 
             if (activated.session_key && activated.session_key !== storedSessionId) {
-              runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
-              sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
-              dropSessionState(cachedRuntimeId)
+              dropWarmCache(cachedRuntimeId)
             } else {
               const pendingApproval = restorePendingApproval(activated, cachedRuntimeId)
 
@@ -1309,9 +1345,7 @@ export function useSessionActions({
               return
             }
 
-            runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
-            sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
-            dropSessionState(cachedRuntimeId)
+            dropWarmCache(cachedRuntimeId)
           }
         }
       }
@@ -1635,6 +1669,7 @@ export function useSessionActions({
           resumed.session_id,
           state => ({
             ...state,
+            profile: normalizeProfileKey(sessionProfile),
             ...(runtimeInfo ?? {}),
             messages: visibleMessagesForView,
             busy: resumedRunning,
@@ -1936,6 +1971,7 @@ export function useSessionActions({
           branched.session_id,
           state => ({
             ...state,
+            profile: normalizeProfileKey(profile),
             messages: effectiveBranchMessages.map(({ source }) => source),
             busy: false,
             awaitingResponse: false

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -713,7 +713,7 @@ export function useSessionActions({
         const cwd =
           options?.cwd === null ? '' : typeof options?.cwd === 'string' ? options.cwd.trim() : resolveNewSessionCwd()
 
-        const params = {
+        const params: Record<string, unknown> = {
           ...(await desktopSessionCreateParams(cwd, capturedRoute)),
           ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
         }
@@ -826,12 +826,14 @@ export function useSessionActions({
     async (storedSessionId: string, replaceRoute = false, capturedOwner?: SessionOwnerScope) => {
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
+
       const requestedOwnerProfile =
         typeof capturedOwner === 'string'
           ? normalizeProfileKey(capturedOwner)
           : capturedOwner
             ? normalizeProfileKey(capturedOwner.profile)
             : null
+
       let resumeOwnerProfile = requestedOwnerProfile
 
       const resumedSameSelectedSession =
@@ -903,7 +905,10 @@ export function useSessionActions({
         dropSessionState(runtimeId)
       }
 
-      const takeWarmCache = (profile?: string): { runtimeId: string; state: ClientSessionState } | null => {
+      const takeWarmCache = (
+        profile?: string,
+        allowUnqualified = false
+      ): { runtimeId: string; state: ClientSessionState } | null => {
         const expectedProfile = profile?.trim() ? normalizeProfileKey(profile) : null
         let runtimeId: string | undefined
         let state: ClientSessionState | undefined
@@ -916,8 +921,9 @@ export function useSessionActions({
           for (const [candidateRuntimeId, candidateState] of sessionStateByRuntimeIdRef.current.entries()) {
             if (
               candidateState.storedSessionId === storedSessionId &&
-              candidateState.profile !== null &&
-              normalizeProfileKey(candidateState.profile) === expectedProfile
+              (candidateState.profile !== null
+                ? normalizeProfileKey(candidateState.profile) === expectedProfile
+                : allowUnqualified && runtimeIdByStoredSessionIdRef.current.get(storedSessionId) === candidateRuntimeId)
             ) {
               runtimeId = candidateRuntimeId
               state = candidateState
@@ -943,7 +949,9 @@ export function useSessionActions({
         return { runtimeId, state }
       }
 
-      if (!takeWarmCache(requestedOwnerProfile ?? undefined)) {
+      if (
+        !takeWarmCache(requestedOwnerProfile ?? undefined, Boolean(capturedOwner && typeof capturedOwner === 'object'))
+      ) {
         setActiveSessionId(null)
         activeSessionIdRef.current = null
         // History load is not turn-busy. Drop the previous session's leftover
@@ -974,6 +982,7 @@ export function useSessionActions({
         ambientConnection?.mode === 'remote' ? ambientConnection.connectionId?.trim() || '' : ''
 
       const storedForProfile = await resolveStoredSession(storedSessionId, hintedOwner)
+
       const sessionProfile =
         typeof hintedOwner === 'string' ? hintedOwner.trim() || storedForProfile?.profile : storedForProfile?.profile
 
@@ -1043,7 +1052,7 @@ export function useSessionActions({
       // Re-check after the profile-resolve / gateway-swap awaits above: the
       // cache may have changed, and takeWarmCache re-validates belongs-to and
       // purges a cross-wired mapping before we trust the fast-path.
-      const warmHit = takeWarmCache(sessionProfile)
+      const warmHit = takeWarmCache(sessionProfile, Boolean(ownerRoute))
 
       if (warmHit) {
         const cachedRuntimeId = warmHit.runtimeId
@@ -2261,7 +2270,7 @@ export function useSessionActions({
         dropTranscriptTailEverywhere(storedSessionId)
         // Only after the RPC lands — the optimistic eviction above can roll
         // back, and a rolled-back row must keep its watermark/marker.
-        forgetSessionUnread(removedIds, removed?.profile)
+        forgetSessionUnread(removedIds, profile)
         clearQueuedPrompts(storedSessionId)
 
         if (closingRuntimeId) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1656,6 +1656,7 @@ export function useSessionActions({
         const inFlightRecovery = recoverInFlightTurnJournal(
           storedSessionId,
           normalizeProfileKey(sessionProfile),
+          resolvedConnectionId || null,
           preferredWithRuntimeChanges,
           { keepPending: resumedRunning }
         )
@@ -1825,6 +1826,7 @@ export function useSessionActions({
           const fallbackRecovery = recoverInFlightTurnJournal(
             storedSessionId,
             normalizeProfileKey(sessionProfile),
+            resolvedConnectionId || null,
             reconcileAuthoritativeMessages(fallback.messages, previousMessages)
           )
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -46,6 +46,29 @@ describe('resolveStoredSession profile ownership', () => {
     expect(mockGetSession).not.toHaveBeenCalled()
   })
 
+  it('uses explicit run provenance to select the right same-id cached session', async () => {
+    $sessions.set([
+      session({ id: 'cron_shared_20260811', profile: 'default', title: 'wrong' }),
+      session({ id: 'cron_shared_20260811', profile: 'meta', title: 'right' })
+    ])
+
+    const resolved = await resolveStoredSession('cron_shared_20260811', 'meta')
+
+    expect(resolved?.title).toBe('right')
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('probes only the explicit owner when a same-id cached row belongs elsewhere', async () => {
+    $sessions.set([session({ id: 'cron_shared_20260811', profile: 'default', title: 'wrong' })])
+    mockGetSession.mockResolvedValueOnce(session({ id: 'cron_shared_20260811', title: 'right' }))
+
+    const resolved = await resolveStoredSession('cron_shared_20260811', 'meta')
+
+    expect(resolved).toMatchObject({ profile: 'meta', title: 'right' })
+    expect(mockGetSession).toHaveBeenCalledOnce()
+    expect(mockGetSession).toHaveBeenCalledWith('cron_shared_20260811', 'meta')
+  })
+
   it.each([
     ['cron', $cronSessions],
     ['messaging', $messagingSessions]

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -37,11 +37,7 @@ import type { SessionProfileRoute } from '@/store/session-request-router'
 // Re-exported for the many session-actions/tile call sites that already import
 // it from here; the canonical definition lives in @/store/session.
 export { sessionMatchesStoredId }
-import {
-  isSessionOwnerRoute,
-  sessionOwnerRouteFromRow,
-  type SessionOwnerScope
-} from '@/store/session-request-router'
+import { isSessionOwnerRoute, sessionOwnerRouteFromRow, type SessionOwnerScope } from '@/store/session-request-router'
 import { reportBackendContract, reportInstallMethodWarning } from '@/store/updates'
 import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, SessionRuntimeInfo } from '@/types/hermes'
 
@@ -1397,6 +1393,7 @@ export async function resolveStoredSession(
 ): Promise<SessionInfo | undefined> {
   const ownerRoute = isSessionOwnerRoute(owner) ? owner : undefined
   const requestedOwner = typeof owner === 'string' && owner.trim() ? normalizeProfileKey(owner) : undefined
+
   const cached = [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()].find(
     session =>
       sessionMatchesStoredId(session, storedSessionId) &&

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -37,7 +37,11 @@ import type { SessionProfileRoute } from '@/store/session-request-router'
 // Re-exported for the many session-actions/tile call sites that already import
 // it from here; the canonical definition lives in @/store/session.
 export { sessionMatchesStoredId }
-import { sessionOwnerRouteFromRow, type SessionOwnerScope } from '@/store/session-request-router'
+import {
+  isSessionOwnerRoute,
+  sessionOwnerRouteFromRow,
+  type SessionOwnerScope
+} from '@/store/session-request-router'
 import { reportBackendContract, reportInstallMethodWarning } from '@/store/updates'
 import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, SessionRuntimeInfo } from '@/types/hermes'
 
@@ -1389,10 +1393,14 @@ function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
 
 export async function resolveStoredSession(
   storedSessionId: string,
-  ownerRoute?: SessionProfileRoute
+  owner?: SessionOwnerScope
 ): Promise<SessionInfo | undefined> {
-  const cached = [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()].find(session =>
-    sessionMatchesStoredId(session, storedSessionId)
+  const ownerRoute = isSessionOwnerRoute(owner) ? owner : undefined
+  const requestedOwner = typeof owner === 'string' && owner.trim() ? normalizeProfileKey(owner) : undefined
+  const cached = [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()].find(
+    session =>
+      sessionMatchesStoredId(session, storedSessionId) &&
+      (!requestedOwner || normalizeProfileKey(session.profile) === requestedOwner)
   )
 
   if (ownerRoute) {
@@ -1420,6 +1428,25 @@ export async function resolveStoredSession(
     } catch {
       // An explicit owner is fail-closed. Probing the ambient or another
       // profile would turn a stale route into a cross-connection open.
+      return undefined
+    }
+  }
+
+  // A run-history row already carries immutable profile provenance. Honor it
+  // directly instead of probing the active/default backend first: cron session
+  // ids can collide when two profiles use the same job id and timestamp.
+  if (requestedOwner) {
+    if (cached) {
+      return cached
+    }
+
+    try {
+      const session = await getSession(storedSessionId, requestedOwner)
+      session.profile = requestedOwner
+      upsertResolvedSession(session, storedSessionId)
+
+      return session
+    } catch {
       return undefined
     }
   }

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -564,7 +564,7 @@ describe('refreshSessions batches slices into one request', () => {
       await scoped.result.current.refreshCronJobs()
     })
 
-    expect(getCronJobs).toHaveBeenLastCalledWith('work')
+    expect(getCronJobs).toHaveBeenLastCalledWith({ connectionId: null, profile: 'work' })
   })
 
   it('requests cron jobs for the unified scope', async () => {
@@ -574,7 +574,7 @@ describe('refreshSessions batches slices into one request', () => {
       await unified.result.current.refreshCronJobs()
     })
 
-    expect(getCronJobs).toHaveBeenLastCalledWith('all')
+    expect(getCronJobs).toHaveBeenLastCalledWith({ connectionId: null, profile: 'all' })
   })
 
   it('ignores an out-of-order cron-jobs response from the previous profile', async () => {
@@ -600,7 +600,10 @@ describe('refreshSessions batches slices into one request', () => {
       await workRefresh
     })
 
-    expect(getCronJobs.mock.calls.map(call => call[0])).toEqual(['work', 'personal'])
+    expect(getCronJobs.mock.calls.map(call => call[0])).toEqual([
+      { connectionId: null, profile: 'work' },
+      { connectionId: null, profile: 'personal' }
+    ])
     expect($cronJobs.get().map(job => job.id)).toEqual(['personal-job'])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -62,6 +62,7 @@ describe('useSessionStateCache — stored-id rotation provenance', () => {
     expect($activeSessionStoredIdRotation.get()).toEqual({
       nextStoredSessionId: 'stored-A-next',
       previousStoredSessionId: 'stored-A',
+      profile: 'default',
       runtimeSessionId: 'runtime-A'
     })
     expect(cache.runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -85,6 +85,67 @@ describe('useSessionStateCache — stored-id rotation provenance', () => {
     expect(cache.runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
     expect(cache.runtimeIdByStoredSessionIdRef.current.get('stored-A-next')).toBe('runtime-A')
   })
+
+  it('fails closed when an ABA runtime and stored id are now owned by another profile', () => {
+    let cache!: Cache
+    render(
+      <Harness
+        activeSessionId="runtime-shared"
+        onReady={value => (cache = value)}
+        selectedStoredSessionId="stored-shared"
+      />
+    )
+
+    act(() => {
+      cache.updateSessionState(
+        'runtime-shared',
+        state => ({
+          ...state,
+          profile: 'meta',
+          messages: [assistantText('meta-existing', 'meta existing answer')]
+        }),
+        'stored-shared'
+      )
+    })
+
+    const reclaimed = cache.sessionStateByRuntimeIdRef.current.get('runtime-shared')
+    let updaterCalled = false
+
+    act(() => {
+      expect(
+        cache.updateOwnedSessionState(
+          'runtime-shared',
+          { profile: 'default', storedSessionId: 'stored-shared' },
+          state => {
+            updaterCalled = true
+
+            return { ...state, messages: [assistantText('stale-default', 'stale default answer')] }
+          }
+        )
+      ).toBe(false)
+    })
+
+    expect(updaterCalled).toBe(false)
+    expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-shared')).toBe(reclaimed)
+    expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-shared')?.messages).toEqual([
+      assistantText('meta-existing', 'meta existing answer')
+    ])
+  })
+
+  it('does not create or rotate cache ownership for a rejected publication', () => {
+    let cache!: Cache
+    render(<Harness activeSessionId={null} onReady={value => (cache = value)} selectedStoredSessionId={null} />)
+
+    expect(
+      cache.updateOwnedSessionState(
+        'runtime-missing',
+        { profile: 'default', storedSessionId: 'stored-default' },
+        state => ({ ...state })
+      )
+    ).toBe(false)
+    expect(cache.sessionStateByRuntimeIdRef.current.has('runtime-missing')).toBe(false)
+    expect(cache.runtimeIdByStoredSessionIdRef.current.has('stored-default')).toBe(false)
+  })
 })
 
 function Harness({ activeSessionId, onReady, selectedStoredSessionId }: HarnessProps) {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -60,6 +60,7 @@ describe('useSessionStateCache — stored-id rotation provenance', () => {
     })
 
     expect($activeSessionStoredIdRotation.get()).toEqual({
+      connectionId: null,
       nextStoredSessionId: 'stored-A-next',
       previousStoredSessionId: 'stored-A',
       profile: 'default',

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -58,6 +58,9 @@ export function useSessionStateCache({
   const sessionTiles = useStore($sessionTiles)
   const activeSessionIdRef = useRef<string | null>(activeSessionId)
   const selectedStoredSessionIdRef = useRef<string | null>(selectedStoredSessionId)
+  // Stored ids are profile-local. Keep the owner beside the imperative
+  // selection ref so same-id profile switches cannot inherit transcript state.
+  const selectedStoredSessionProfileRef = useRef<string | null>(null)
 
   // Mirror the latest prop into its ref synchronously during render — not via
   // a passive useEffect, which only fires a frame after paint and left the
@@ -385,6 +388,7 @@ export function useSessionStateCache({
     resetViewSync,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,
+    selectedStoredSessionProfileRef,
     sessionStateByRuntimeIdRef: sessionStateByRuntimeIdRef as MutableRefObject<Map<string, ClientSessionState>>,
     syncSessionStateToView,
     updateSessionState

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -21,10 +21,11 @@ import {
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
-import { $sessionStates, $sessionTiles, publishSessionState, releaseSessionTranscript } from '@/store/session-states'
+import { $sessionTiles, getSessionState, publishSessionState, releaseSessionTranscript } from '@/store/session-states'
 
 import type { ClientSessionState } from '../../types'
 import {
+  SessionRuntimeIndex,
   sessionRuntimeStateMatchesOwner,
   SessionStateCache,
   sessionStateMatchesOwner,
@@ -92,7 +93,7 @@ export function useSessionStateCache({
     selectedStoredSessionIdRef.current = selectedStoredSessionId
   }
 
-  const runtimeIdByStoredSessionIdRef = useRef(new Map<string, string>())
+  const runtimeIdByStoredSessionIdRef = useRef(new SessionRuntimeIndex())
   const sessionStateByRuntimeIdRef = useRef<SessionStateCache>(null!)
 
   if (sessionStateByRuntimeIdRef.current === null) {
@@ -112,8 +113,8 @@ export function useSessionStateCache({
       // pinned megabytes of warm transcript per reconnect cycle behind
       // #isWarmSettled (#95189). Trust the cached in-flight flags only while
       // the authoritative store still claims work for the same runtime id.
-      isAuthoritativelyActive: runtimeId => {
-        const live = $sessionStates.get()[runtimeId]
+      isAuthoritativelyActive: (runtimeId, state) => {
+        const live = getSessionState(runtimeId, state)
 
         return Boolean(live && (live.busy || live.awaitingResponse))
       },
@@ -144,11 +145,18 @@ export function useSessionStateCache({
 
   const ensureSessionState = useCallback(
     (sessionId: string, storedSessionId?: string | null, ownerProfile?: string, ownerConnectionId?: null | string) => {
-      const existing = sessionStateCache.get(sessionId)
       const normalizedOwnerProfile = ownerProfile === undefined ? undefined : normalizeProfileKey(ownerProfile)
 
       const normalizedOwnerConnectionId =
         ownerConnectionId === undefined ? undefined : ownerConnectionId?.trim() || null
+
+      const existing =
+        normalizedOwnerProfile !== undefined && normalizedOwnerConnectionId
+          ? sessionStateCache.getOwned(sessionId, {
+              connectionId: normalizedOwnerConnectionId,
+              profile: normalizedOwnerProfile
+            })
+          : sessionStateCache.get(sessionId)
 
       if (existing) {
         const nextProfile = normalizedOwnerProfile ?? existing.profile
@@ -193,13 +201,26 @@ export function useSessionStateCache({
           }
 
           if (storedSessionId) {
-            runtimeIdByStoredSessionIdRef.current.set(storedSessionId, sessionId)
+            if (updated.connectionId && updated.profile) {
+              runtimeIdByStoredSessionIdRef.current.setOwned(storedSessionId, sessionId, {
+                connectionId: updated.connectionId,
+                profile: updated.profile
+              })
+            } else {
+              runtimeIdByStoredSessionIdRef.current.set(storedSessionId, sessionId)
+            }
+          }
+
+          if (ownerClaimed && updated.connectionId) {
+            sessionStateCache.delete(sessionId)
           }
 
           sessionStateCache.set(sessionId, updated)
+
+          return updated
         }
 
-        return sessionStateCache.get(sessionId)!
+        return existing
       }
 
       const created = {
@@ -209,7 +230,14 @@ export function useSessionStateCache({
       }
 
       if (storedSessionId) {
-        runtimeIdByStoredSessionIdRef.current.set(storedSessionId, sessionId)
+        if (created.connectionId && created.profile) {
+          runtimeIdByStoredSessionIdRef.current.setOwned(storedSessionId, sessionId, {
+            connectionId: created.connectionId,
+            profile: created.profile
+          })
+        } else {
+          runtimeIdByStoredSessionIdRef.current.set(storedSessionId, sessionId)
+        }
       }
 
       sessionStateCache.set(sessionId, created)
@@ -359,6 +387,13 @@ export function useSessionStateCache({
         return
       }
 
+      if (
+        previous.connectionId !== next.connectionId ||
+        normalizeProfileKey(previous.profile) !== normalizeProfileKey(next.profile)
+      ) {
+        sessionStateCache.delete(sessionId)
+      }
+
       sessionStateCache.set(sessionId, next)
       // Crash-survivable turn progress: journal the running turn's visible
       // tail (throttled localStorage write; cleared the moment the turn
@@ -387,7 +422,13 @@ export function useSessionStateCache({
       const normalizedOwnerConnectionId =
         ownerConnectionId === undefined ? undefined : ownerConnectionId?.trim() || null
 
-      const installed = sessionStateCache.get(sessionId)
+      const installed =
+        normalizedOwnerProfile !== undefined && normalizedOwnerConnectionId
+          ? (sessionStateCache.getOwned(sessionId, {
+              connectionId: normalizedOwnerConnectionId,
+              profile: normalizedOwnerProfile
+            }) ?? sessionStateCache.get(sessionId))
+          : sessionStateCache.get(sessionId)
 
       // Gateway runtime ids are transport-local and can collide across profile
       // sockets. A session.info publisher may claim an unowned state, but it may
@@ -429,7 +470,7 @@ export function useSessionStateCache({
 
   const sessionStateHasOwner = useCallback(
     (sessionId: string, owner: SessionStateOwner): boolean =>
-      sessionStateMatchesOwner(sessionStateCache.get(sessionId), owner),
+      sessionStateMatchesOwner(sessionStateCache.getOwned(sessionId, owner), owner),
     [sessionStateCache]
   )
 
@@ -457,7 +498,7 @@ export function useSessionStateCache({
       // Do not call ensureSessionState here: a stale async completion must not
       // create a cache entry or rotate/graft a stored id before ownership is
       // proven against the currently installed runtime state.
-      const previous = sessionStateCache.get(sessionId)
+      const previous = sessionStateCache.getOwned(sessionId, owner)
 
       if (!sessionStateMatchesOwner(previous, owner)) {
         return false

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -23,7 +23,7 @@ import {
 import { $sessionStates, $sessionTiles, publishSessionState, releaseSessionTranscript } from '@/store/session-states'
 
 import type { ClientSessionState } from '../../types'
-import { SessionStateCache } from '../session-state-cache'
+import { SessionStateCache, sessionStateMatchesOwner, type SessionStateOwner } from '../session-state-cache'
 
 import { chatMessageArraysEquivalent } from './use-session-actions/utils'
 
@@ -322,6 +322,32 @@ export function useSessionStateCache({
     []
   )
 
+  const commitSessionState = useCallback(
+    (sessionId: string, previous: ClientSessionState, next: ClientSessionState) => {
+      // If the updater returned the same reference, nothing changed for this
+      // session — skip the store write, publishSessionState, and view sync.
+      // The cache entry was already updated by ensureSessionState (if
+      // storedSessionId rotated); the caller gets its return value from the
+      // cache, so stale reads don't regress.
+      if (next === previous) {
+        return
+      }
+
+      sessionStateCache.set(sessionId, next)
+      // Crash-survivable turn progress: journal the running turn's visible
+      // tail (throttled localStorage write; cleared the moment the turn
+      // settles) so a renderer/app death mid-turn can be recovered on resume.
+      persistInFlightTurnState(next)
+      // Publishing to $sessionStates automatically fires transition side-effects
+      // (watchdog, settle grace, unread marker, compression id rotation) inside
+      // publishSessionState — no manual transition call needed.
+      publishSessionState(sessionId, next)
+      sessionStateCache.prune()
+      syncSessionStateToView(sessionId, next)
+    },
+    [sessionStateCache, syncSessionStateToView]
+  )
+
   const updateSessionState = useCallback(
     (
       sessionId: string,
@@ -336,30 +362,50 @@ export function useSessionStateCache({
       // $sessionStates and its computed atoms on every tick.
       const next = updater(previous)
 
-      // If the updater returned the same reference, nothing changed for this
-      // session — skip the store write, publishSessionState, and view sync.
-      // The cache entry was already updated by ensureSessionState (if
-      // storedSessionId rotated); the caller gets its return value from the
-      // cache, so stale reads don't regress.
-      if (next === previous) {
-        return previous
+      commitSessionState(sessionId, previous, next)
+
+      return next === previous ? previous : next
+    },
+    [commitSessionState, ensureSessionState]
+  )
+
+  const sessionStateHasOwner = useCallback(
+    (sessionId: string, owner: SessionStateOwner): boolean =>
+      sessionStateMatchesOwner(sessionStateCache.get(sessionId), owner),
+    [sessionStateCache]
+  )
+
+  const updateOwnedSessionState = useCallback(
+    (
+      sessionId: string,
+      owner: SessionStateOwner,
+      updater: (state: ClientSessionState) => ClientSessionState
+    ): boolean => {
+      // Do not call ensureSessionState here: a stale async completion must not
+      // create a cache entry or rotate/graft a stored id before ownership is
+      // proven against the currently installed runtime state.
+      const previous = sessionStateCache.get(sessionId)
+
+      if (!sessionStateMatchesOwner(previous, owner)) {
+        return false
       }
 
-      sessionStateCache.set(sessionId, next)
-      // Crash-survivable turn progress: journal the running turn's visible
-      // tail (throttled localStorage write; cleared the moment the turn
-      // settles) so a renderer/app death mid-turn can be recovered on resume.
-      persistInFlightTurnState(next)
-      // Publishing to $sessionStates automatically fires transition side-effects
-      // (watchdog, settle grace, unread marker, compression id rotation) inside
-      // publishSessionState — no manual transition call needed.
-      publishSessionState(sessionId, next)
-      sessionStateCache.prune()
-      syncSessionStateToView(sessionId, next)
+      const next = updater(previous)
 
-      return next
+      // Ownership is immutable for this publication primitive. A caller that
+      // needs to transfer ownership must use the explicit resume/setup path.
+      if (!sessionStateMatchesOwner(next, owner)) {
+        return false
+      }
+
+      commitSessionState(sessionId, previous, next)
+
+      // publishSessionState notifies synchronously. A subscriber may reclaim
+      // the same runtime id before this call returns, so report success only if
+      // the exact composite owner is still installed.
+      return sessionStateHasOwner(sessionId, owner)
     },
-    [ensureSessionState, sessionStateCache, syncSessionStateToView]
+    [commitSessionState, sessionStateCache, sessionStateHasOwner]
   )
 
   useEffect(() => {
@@ -389,8 +435,10 @@ export function useSessionStateCache({
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,
     selectedStoredSessionProfileRef,
+    sessionStateHasOwner,
     sessionStateByRuntimeIdRef: sessionStateByRuntimeIdRef as MutableRefObject<Map<string, ClientSessionState>>,
     syncSessionStateToView,
+    updateOwnedSessionState,
     updateSessionState
   }
 }

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -24,7 +24,12 @@ import {
 import { $sessionStates, $sessionTiles, publishSessionState, releaseSessionTranscript } from '@/store/session-states'
 
 import type { ClientSessionState } from '../../types'
-import { SessionStateCache, sessionStateMatchesOwner, type SessionStateOwner } from '../session-state-cache'
+import {
+  sessionRuntimeStateMatchesOwner,
+  SessionStateCache,
+  sessionStateMatchesOwner,
+  type SessionStateOwner
+} from '../session-state-cache'
 
 import { chatMessageArraysEquivalent } from './use-session-actions/utils'
 
@@ -138,14 +143,18 @@ export function useSessionStateCache({
   }, [busy, busyRef])
 
   const ensureSessionState = useCallback(
-    (sessionId: string, storedSessionId?: string | null, ownerProfile?: string) => {
+    (sessionId: string, storedSessionId?: string | null, ownerProfile?: string, ownerConnectionId?: null | string) => {
       const existing = sessionStateCache.get(sessionId)
       const normalizedOwnerProfile = ownerProfile === undefined ? undefined : normalizeProfileKey(ownerProfile)
 
+      const normalizedOwnerConnectionId =
+        ownerConnectionId === undefined ? undefined : ownerConnectionId?.trim() || null
+
       if (existing) {
         const nextProfile = normalizedOwnerProfile ?? existing.profile
+        const nextConnectionId = normalizedOwnerConnectionId ?? existing.connectionId
         const storedIdChanged = storedSessionId !== undefined && storedSessionId !== existing.storedSessionId
-        const ownerClaimed = nextProfile !== existing.profile
+        const ownerClaimed = nextProfile !== existing.profile || nextConnectionId !== existing.connectionId
 
         if (storedIdChanged || ownerClaimed) {
           // Stored id changed (e.g. auto-compression rotated it). Create a NEW
@@ -153,6 +162,7 @@ export function useSessionStateCache({
           // the PREVIOUS state to detect transitions (busy→idle, id rotation).
           const updated = {
             ...existing,
+            connectionId: nextConnectionId,
             profile: nextProfile,
             ...(storedIdChanged ? { storedSessionId: storedSessionId ?? null } : {})
           }
@@ -173,6 +183,7 @@ export function useSessionStateCache({
             // is a detach, not a rotation the route-follow effect should chase.
             if (storedSessionId && sessionId === $activeSessionId.get()) {
               setActiveSessionStoredIdRotation({
+                connectionId: updated.connectionId,
                 nextStoredSessionId: storedSessionId,
                 previousStoredSessionId: existing.storedSessionId,
                 profile: normalizeProfileKey(updated.profile),
@@ -193,6 +204,7 @@ export function useSessionStateCache({
 
       const created = {
         ...createClientSessionState(storedSessionId ?? null),
+        connectionId: normalizedOwnerConnectionId ?? null,
         profile: normalizedOwnerProfile ?? null
       }
 
@@ -367,9 +379,14 @@ export function useSessionStateCache({
       sessionId: string,
       updater: (state: ClientSessionState) => ClientSessionState,
       storedSessionId?: string | null,
-      ownerProfile?: string
+      ownerProfile?: string,
+      ownerConnectionId?: null | string
     ) => {
       const normalizedOwnerProfile = ownerProfile === undefined ? undefined : normalizeProfileKey(ownerProfile)
+
+      const normalizedOwnerConnectionId =
+        ownerConnectionId === undefined ? undefined : ownerConnectionId?.trim() || null
+
       const installed = sessionStateCache.get(sessionId)
 
       // Gateway runtime ids are transport-local and can collide across profile
@@ -381,17 +398,26 @@ export function useSessionStateCache({
         normalizedOwnerProfile !== undefined &&
         installed?.profile !== null &&
         installed?.profile !== undefined &&
-        normalizeProfileKey(installed.profile) !== normalizedOwnerProfile
+        !sessionRuntimeStateMatchesOwner(installed, {
+          connectionId: normalizedOwnerConnectionId,
+          profile: normalizedOwnerProfile
+        })
       ) {
         return installed
       }
 
-      const previous = ensureSessionState(sessionId, storedSessionId, normalizedOwnerProfile)
+      const previous = ensureSessionState(
+        sessionId,
+        storedSessionId,
+        normalizedOwnerProfile,
+        normalizedOwnerConnectionId
+      )
       // Give the updater the raw previous state so it can return the same
       // reference when nothing changed (the caller sees a no-op). Previously
       // the param was always a fresh spread, so every call looked like a
       // change — including periodic ~1/s session.info heartbeats that churn
       // $sessionStates and its computed atoms on every tick.
+
       const next = updater(previous)
 
       commitSessionState(sessionId, previous, next)

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -7,6 +7,7 @@ import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { persistInFlightTurnState } from '@/lib/inflight-turn-journal'
 import { setMutableRef } from '@/lib/mutable-ref'
+import { normalizeProfileKey } from '@/store/profile'
 import {
   $activeSessionId,
   $messages,
@@ -137,15 +138,24 @@ export function useSessionStateCache({
   }, [busy, busyRef])
 
   const ensureSessionState = useCallback(
-    (sessionId: string, storedSessionId?: string | null) => {
+    (sessionId: string, storedSessionId?: string | null, ownerProfile?: string) => {
       const existing = sessionStateCache.get(sessionId)
+      const normalizedOwnerProfile = ownerProfile === undefined ? undefined : normalizeProfileKey(ownerProfile)
 
       if (existing) {
-        if (storedSessionId !== undefined && storedSessionId !== existing.storedSessionId) {
+        const nextProfile = normalizedOwnerProfile ?? existing.profile
+        const storedIdChanged = storedSessionId !== undefined && storedSessionId !== existing.storedSessionId
+        const ownerClaimed = nextProfile !== existing.profile
+
+        if (storedIdChanged || ownerClaimed) {
           // Stored id changed (e.g. auto-compression rotated it). Create a NEW
           // state object rather than mutating in place — updateSessionState needs
           // the PREVIOUS state to detect transitions (busy→idle, id rotation).
-          const updated = { ...existing, storedSessionId }
+          const updated = {
+            ...existing,
+            profile: nextProfile,
+            ...(storedIdChanged ? { storedSessionId: storedSessionId ?? null } : {})
+          }
 
           // Drop the obsolete stored→runtime reverse mapping as soon as the id
           // rotates (e.g. auto-compression forks a continuation). Leaving the
@@ -156,7 +166,7 @@ export function useSessionStateCache({
           // now skips publishSessionState (and thus handleTransition) when the
           // updater is a no-op — fire it here so the route-follow effect still
           // tracks compression without needing a dummy state write.
-          if (existing.storedSessionId && existing.storedSessionId !== storedSessionId) {
+          if (storedIdChanged && existing.storedSessionId) {
             runtimeIdByStoredSessionIdRef.current.delete(existing.storedSessionId)
 
             // A rotation event needs a real next id — a null/cleared stored id
@@ -165,6 +175,7 @@ export function useSessionStateCache({
               setActiveSessionStoredIdRotation({
                 nextStoredSessionId: storedSessionId,
                 previousStoredSessionId: existing.storedSessionId,
+                profile: normalizeProfileKey(updated.profile),
                 runtimeSessionId: sessionId
               })
             }
@@ -180,7 +191,10 @@ export function useSessionStateCache({
         return sessionStateCache.get(sessionId)!
       }
 
-      const created = createClientSessionState(storedSessionId ?? null)
+      const created = {
+        ...createClientSessionState(storedSessionId ?? null),
+        profile: normalizedOwnerProfile ?? null
+      }
 
       if (storedSessionId) {
         runtimeIdByStoredSessionIdRef.current.set(storedSessionId, sessionId)
@@ -352,9 +366,27 @@ export function useSessionStateCache({
     (
       sessionId: string,
       updater: (state: ClientSessionState) => ClientSessionState,
-      storedSessionId?: string | null
+      storedSessionId?: string | null,
+      ownerProfile?: string
     ) => {
-      const previous = ensureSessionState(sessionId, storedSessionId)
+      const normalizedOwnerProfile = ownerProfile === undefined ? undefined : normalizeProfileKey(ownerProfile)
+      const installed = sessionStateCache.get(sessionId)
+
+      // Gateway runtime ids are transport-local and can collide across profile
+      // sockets. A session.info publisher may claim an unowned state, but it may
+      // never rotate or mutate a runtime already installed for another profile.
+      // Check before ensureSessionState: ensure can rotate the stored id and emit
+      // the route-follow edge even when the updater itself is a no-op.
+      if (
+        normalizedOwnerProfile !== undefined &&
+        installed?.profile !== null &&
+        installed?.profile !== undefined &&
+        normalizeProfileKey(installed.profile) !== normalizedOwnerProfile
+      ) {
+        return installed
+      }
+
+      const previous = ensureSessionState(sessionId, storedSessionId, normalizedOwnerProfile)
       // Give the updater the raw previous state so it can return the same
       // reference when nothing changed (the caller sees a no-op). Previously
       // the param was always a fresh spread, so every call looked like a
@@ -366,7 +398,7 @@ export function useSessionStateCache({
 
       return next === previous ? previous : next
     },
-    [commitSessionState, ensureSessionState]
+    [commitSessionState, ensureSessionState, sessionStateCache]
   )
 
   const sessionStateHasOwner = useCallback(

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -433,6 +433,21 @@ export function useSessionStateCache({
     [sessionStateCache]
   )
 
+  const getSessionStateOwner = useCallback(
+    (sessionId: string): SessionStateOwner | null => {
+      const state = sessionStateCache.get(sessionId)
+
+      return state?.profile && state.storedSessionId
+        ? {
+            connectionId: state.connectionId,
+            profile: normalizeProfileKey(state.profile),
+            storedSessionId: state.storedSessionId
+          }
+        : null
+    },
+    [sessionStateCache]
+  )
+
   const updateOwnedSessionState = useCallback(
     (
       sessionId: string,
@@ -488,6 +503,7 @@ export function useSessionStateCache({
   return {
     activeSessionIdRef,
     ensureSessionState,
+    getSessionStateOwner,
     getRuntimeIdForStoredSession,
     resetViewSync,
     runtimeIdByStoredSessionIdRef,

--- a/apps/desktop/src/app/session/session-state-cache.test.ts
+++ b/apps/desktop/src/app/session/session-state-cache.test.ts
@@ -24,6 +24,20 @@ describe('SessionStateCache', () => {
     $sessionTiles.set([])
   })
 
+  it('keeps identical runtime ids independent across connection owners', () => {
+    const cache = new SessionStateCache({ isReferenced: () => false, onEvict: () => undefined })
+    const ownerA = { ...settled('stored-a'), connectionId: 'connection-a', profile: 'default' }
+    const ownerB = { ...settled('stored-b'), connectionId: 'connection-b', profile: 'default' }
+
+    cache.set('runtime-shared', ownerA)
+    cache.set('runtime-shared', ownerB)
+
+    expect(cache.size).toBe(2)
+    expect(cache.getOwned('runtime-shared', ownerA)).toBe(ownerA)
+    expect(cache.getOwned('runtime-shared', ownerB)).toBe(ownerB)
+    expect(cache.get('runtime-shared')).toBeUndefined()
+  })
+
   it('bounds warm settled transcripts by LRU count and cleans ownership atomically', () => {
     const owners = new Map<string, string>()
     const evicted: string[] = []

--- a/apps/desktop/src/app/session/session-state-cache.test.ts
+++ b/apps/desktop/src/app/session/session-state-cache.test.ts
@@ -67,6 +67,36 @@ describe('SessionRuntimeIndex', () => {
     expect(index.deleteAll('stored-shared')).toBe(2)
     expect(index.size).toBe(0)
   })
+
+  it('counts direct and owner-qualified entries together for unqualified access', () => {
+    const index = new SessionRuntimeIndex()
+
+    index.set('stored-shared', 'runtime-primary')
+    index.setOwned('stored-shared', 'runtime-a', ownerA)
+
+    expect(index.size).toBe(2)
+    expect([...index.keys()]).toEqual(['stored-shared', 'stored-shared'])
+    expect(index.get('stored-shared')).toBeUndefined()
+    expect(index.delete('stored-shared')).toBe(false)
+    expect(index.size).toBe(2)
+    expect(index.getOwned('stored-shared', ownerA)).toBe('runtime-a')
+
+    expect(index.deleteAll('stored-shared')).toBe(2)
+    expect(index.size).toBe(0)
+  })
+
+  it('allows unqualified access when exactly one direct or owner-qualified entry exists', () => {
+    const index = new SessionRuntimeIndex()
+
+    index.set('stored-direct', 'runtime-direct')
+    expect(index.get('stored-direct')).toBe('runtime-direct')
+    expect(index.delete('stored-direct')).toBe(true)
+
+    index.setOwned('stored-owned', 'runtime-owned', ownerA)
+    expect(index.get('stored-owned')).toBe('runtime-owned')
+    expect(index.delete('stored-owned')).toBe(true)
+    expect(index.size).toBe(0)
+  })
 })
 
 describe('SessionStateCache', () => {

--- a/apps/desktop/src/app/session/session-state-cache.test.ts
+++ b/apps/desktop/src/app/session/session-state-cache.test.ts
@@ -5,7 +5,7 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $sessionStates, $sessionTiles, releaseSessionTranscript } from '@/store/session-states'
 
-import { SessionStateCache } from './session-state-cache'
+import { SessionRuntimeIndex, SessionStateCache } from './session-state-cache'
 
 function transcript(id: string, text = id): ChatMessage[] {
   return [
@@ -17,6 +17,57 @@ function transcript(id: string, text = id): ChatMessage[] {
 function settled(storedSessionId: string, text = storedSessionId): ClientSessionState {
   return { ...createClientSessionState(storedSessionId), messages: transcript(storedSessionId, text) }
 }
+
+describe('SessionRuntimeIndex', () => {
+  const ownerA = { connectionId: 'connection-a', profile: 'default' }
+  const ownerB = { connectionId: 'connection-b', profile: 'default' }
+
+  it('exposes public stored ids through every Map iteration surface', () => {
+    const index = new SessionRuntimeIndex()
+    const visited: Array<[string, string, Map<string, string>]> = []
+
+    index.setOwned('stored-a', 'runtime-a', ownerA)
+    index.setOwned('stored-b', 'runtime-b', ownerB)
+    index.forEach((runtimeId, storedSessionId, map) => visited.push([storedSessionId, runtimeId, map]))
+
+    expect(index.size).toBe(2)
+    expect([...index.keys()]).toEqual(['stored-a', 'stored-b'])
+    expect([...index.values()]).toEqual(['runtime-a', 'runtime-b'])
+    expect([...index.entries()]).toEqual([
+      ['stored-a', 'runtime-a'],
+      ['stored-b', 'runtime-b']
+    ])
+    expect([...index]).toEqual([...index.entries()])
+    expect(visited).toEqual([
+      ['stored-a', 'runtime-a', index],
+      ['stored-b', 'runtime-b', index]
+    ])
+  })
+
+  it('keeps duplicate public ids ambiguous while owner-qualified lookup and deletion stay exact', () => {
+    const index = new SessionRuntimeIndex()
+
+    index.setOwned('stored-shared', 'runtime-a', ownerA)
+    index.setOwned('stored-shared', 'runtime-b', ownerB)
+
+    expect(index.size).toBe(2)
+    expect([...index.keys()]).toEqual(['stored-shared', 'stored-shared'])
+    expect(index.get('stored-shared')).toBeUndefined()
+    expect(index.delete('stored-shared')).toBe(false)
+    expect(index.getOwned('stored-shared', ownerA)).toBe('runtime-a')
+    expect(index.getOwned('stored-shared', ownerB)).toBe('runtime-b')
+
+    expect(index.deleteOwned('stored-shared', ownerA)).toBe(true)
+    expect(index.get('stored-shared')).toBe('runtime-b')
+    expect(index.delete('stored-shared')).toBe(true)
+    expect(index.size).toBe(0)
+
+    index.setOwned('stored-shared', 'runtime-a', ownerA)
+    index.setOwned('stored-shared', 'runtime-b', ownerB)
+    expect(index.deleteAll('stored-shared')).toBe(2)
+    expect(index.size).toBe(0)
+  })
+})
 
 describe('SessionStateCache', () => {
   beforeEach(() => {

--- a/apps/desktop/src/app/session/session-state-cache.ts
+++ b/apps/desktop/src/app/session/session-state-cache.ts
@@ -3,6 +3,19 @@ import type { ClientSessionState } from '../types'
 export const DEFAULT_WARM_SESSION_TRANSCRIPT_COUNT = 24
 export const DEFAULT_WARM_SESSION_TRANSCRIPT_BYTES = 32 * 1024 * 1024
 
+export interface SessionStateOwner {
+  profile: string
+  storedSessionId: string
+}
+
+/** Fail closed: unknown profile provenance never aliases the default owner. */
+export function sessionStateMatchesOwner(
+  state: ClientSessionState | undefined,
+  owner: SessionStateOwner
+): state is ClientSessionState {
+  return state?.profile === owner.profile && state.storedSessionId === owner.storedSessionId
+}
+
 interface SessionStateCacheLimits {
   maxBytes?: number
   maxCount?: number

--- a/apps/desktop/src/app/session/session-state-cache.ts
+++ b/apps/desktop/src/app/session/session-state-cache.ts
@@ -63,11 +63,10 @@ function publicStoredId(key: string): string {
 
 export class SessionRuntimeIndex extends Map<string, string> {
   override get(storedSessionId: string): string | undefined {
-    const direct = super.get(storedSessionId)
-
-    if (direct) {
-      return direct
+    if (super.has(storedSessionId)) {
+      return super.get(storedSessionId)
     }
+
     const matches = [...super.entries()].filter(([key]) => publicStoredId(key) === storedSessionId)
 
     return matches.length === 1 ? matches[0][1] : undefined
@@ -81,9 +80,44 @@ export class SessionRuntimeIndex extends Map<string, string> {
     return this.get(storedSessionId) !== undefined
   }
 
+  override delete(storedSessionId: string): boolean {
+    if (super.has(storedSessionId)) {
+      return super.delete(storedSessionId)
+    }
+
+    const matches = [...super.keys()].filter(key => publicStoredId(key) === storedSessionId)
+
+    return matches.length === 1 ? super.delete(matches[0]) : false
+  }
+
+  deleteAll(storedSessionId: string): number {
+    const matches = [...super.keys()].filter(key => publicStoredId(key) === storedSessionId)
+
+    for (const key of matches) {
+      super.delete(key)
+    }
+
+    return matches.length
+  }
+
   override *entries(): MapIterator<[string, string]> {
     for (const [key, runtimeId] of super.entries()) {
       yield [publicStoredId(key), runtimeId]
+    }
+  }
+
+  override *keys(): MapIterator<string> {
+    for (const key of super.keys()) {
+      yield publicStoredId(key)
+    }
+  }
+
+  override forEach(
+    callbackfn: (value: string, key: string, map: Map<string, string>) => void,
+    thisArg?: unknown
+  ): void {
+    for (const [storedSessionId, runtimeId] of this.entries()) {
+      callbackfn.call(thisArg, runtimeId, storedSessionId, this)
     }
   }
 

--- a/apps/desktop/src/app/session/session-state-cache.ts
+++ b/apps/desktop/src/app/session/session-state-cache.ts
@@ -13,6 +13,93 @@ export interface SessionStateOwner {
 
 export type RuntimeSessionStateOwner = Pick<SessionStateOwner, 'connectionId' | 'profile'>
 
+const OWNED_RUNTIME_PREFIX = 'owner:'
+
+function ownedRuntimeKey(runtimeId: string, owner: RuntimeSessionStateOwner): string {
+  const connectionId = owner.connectionId?.trim()
+
+  return connectionId
+    ? `${OWNED_RUNTIME_PREFIX}${JSON.stringify([connectionId, owner.profile.trim() || 'default', runtimeId])}`
+    : runtimeId
+}
+
+function publicRuntimeId(key: string): string {
+  if (!key.startsWith(OWNED_RUNTIME_PREFIX)) {
+    return key
+  }
+
+  try {
+    const parsed = JSON.parse(key.slice(OWNED_RUNTIME_PREFIX.length)) as unknown[]
+
+    return typeof parsed[2] === 'string' ? parsed[2] : key
+  } catch {
+    return key
+  }
+}
+
+const OWNED_STORED_PREFIX = 'stored-owner:'
+
+function ownedStoredKey(storedSessionId: string, owner: RuntimeSessionStateOwner): string {
+  const connectionId = owner.connectionId?.trim()
+
+  return connectionId
+    ? `${OWNED_STORED_PREFIX}${JSON.stringify([connectionId, owner.profile.trim() || 'default', storedSessionId])}`
+    : storedSessionId
+}
+
+function publicStoredId(key: string): string {
+  if (!key.startsWith(OWNED_STORED_PREFIX)) {
+    return key
+  }
+
+  try {
+    const parsed = JSON.parse(key.slice(OWNED_STORED_PREFIX.length)) as unknown[]
+
+    return typeof parsed[2] === 'string' ? parsed[2] : key
+  } catch {
+    return key
+  }
+}
+
+export class SessionRuntimeIndex extends Map<string, string> {
+  override get(storedSessionId: string): string | undefined {
+    const direct = super.get(storedSessionId)
+
+    if (direct) {
+      return direct
+    }
+    const matches = [...super.entries()].filter(([key]) => publicStoredId(key) === storedSessionId)
+
+    return matches.length === 1 ? matches[0][1] : undefined
+  }
+
+  getOwned(storedSessionId: string, owner: RuntimeSessionStateOwner): string | undefined {
+    return super.get(ownedStoredKey(storedSessionId, owner))
+  }
+
+  override has(storedSessionId: string): boolean {
+    return this.get(storedSessionId) !== undefined
+  }
+
+  override *entries(): MapIterator<[string, string]> {
+    for (const [key, runtimeId] of super.entries()) {
+      yield [publicStoredId(key), runtimeId]
+    }
+  }
+
+  override [Symbol.iterator](): MapIterator<[string, string]> {
+    return this.entries()
+  }
+
+  setOwned(storedSessionId: string, runtimeId: string, owner: RuntimeSessionStateOwner): this {
+    return super.set(ownedStoredKey(storedSessionId, owner), runtimeId)
+  }
+
+  deleteOwned(storedSessionId: string, owner: RuntimeSessionStateOwner): boolean {
+    return super.delete(ownedStoredKey(storedSessionId, owner))
+  }
+}
+
 /** Runtime ids are source-local. Preserve legacy untagged-primary behavior,
  * but compare the composite registry scope whenever both sides name a source. */
 export function sessionRuntimeStateMatchesOwner(
@@ -94,26 +181,60 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
   }
 
   override get(runtimeId: string): ClientSessionState | undefined {
-    const state = super.get(runtimeId)
+    const direct = super.get(runtimeId)
+
+    const matches = direct
+      ? [[runtimeId, direct] as const]
+      : [...super.entries()].filter(([key]) => publicRuntimeId(key) === runtimeId)
+
+    const found = matches.length === 1 ? matches[0] : undefined
+    const state = found?.[1]
 
     if (state) {
-      this.#touch(runtimeId)
+      this.#touch(found![0])
     }
 
     return state
   }
 
   override set(runtimeId: string, state: ClientSessionState): this {
-    super.set(runtimeId, state)
-    this.#touch(runtimeId)
+    const key = ownedRuntimeKey(runtimeId, {
+      connectionId: state.connectionId,
+      profile: state.profile ?? 'default'
+    })
+
+    super.set(key, state)
+    this.#touch(key)
 
     return this
   }
 
   override delete(runtimeId: string): boolean {
-    this.#recency.delete(runtimeId)
+    const direct = super.has(runtimeId)
+      ? runtimeId
+      : [...super.keys()].filter(key => publicRuntimeId(key) === runtimeId)[0]
 
-    return super.delete(runtimeId)
+    if (
+      !direct ||
+      (!super.has(runtimeId) && [...super.keys()].filter(key => publicRuntimeId(key) === runtimeId).length !== 1)
+    ) {
+      return false
+    }
+
+    this.#recency.delete(direct)
+
+    return super.delete(direct)
+  }
+
+  getOwned(runtimeId: string, owner: RuntimeSessionStateOwner): ClientSessionState | undefined {
+    const key = ownedRuntimeKey(runtimeId, owner)
+    const state = super.get(key)
+
+    if (state) {
+      this.#touch(key)
+    }
+
+    return state
   }
 
   override clear(): void {
@@ -125,13 +246,15 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
     const candidates: Array<{ bytes: number; runtimeId: string; state: ClientSessionState; touched: number }> = []
     let bytes = 0
 
-    for (const [runtimeId, state] of this.entries()) {
+    for (const [stateKey, state] of this.entries()) {
+      const runtimeId = publicRuntimeId(stateKey)
+
       if (!this.#isWarmSettled(runtimeId, state)) {
         continue
       }
 
       const weight = transcriptBytes(state)
-      candidates.push({ bytes: weight, runtimeId, state, touched: this.#recency.get(runtimeId) ?? 0 })
+      candidates.push({ bytes: weight, runtimeId: stateKey, state, touched: this.#recency.get(stateKey) ?? 0 })
       bytes += weight
     }
 
@@ -159,7 +282,7 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
       this.#recency.delete(candidate.runtimeId)
       count -= 1
       bytes -= candidate.bytes
-      this.#callbacks.onEvict(candidate.runtimeId, candidate.state)
+      this.#callbacks.onEvict(publicRuntimeId(candidate.runtimeId), candidate.state)
     }
   }
 

--- a/apps/desktop/src/app/session/session-state-cache.ts
+++ b/apps/desktop/src/app/session/session-state-cache.ts
@@ -1,11 +1,37 @@
+import { registryBackendScopeKey } from '@hermes/shared'
+
 import type { ClientSessionState } from '../types'
 
 export const DEFAULT_WARM_SESSION_TRANSCRIPT_COUNT = 24
 export const DEFAULT_WARM_SESSION_TRANSCRIPT_BYTES = 32 * 1024 * 1024
 
 export interface SessionStateOwner {
+  connectionId?: null | string
   profile: string
   storedSessionId: string
+}
+
+export type RuntimeSessionStateOwner = Pick<SessionStateOwner, 'connectionId' | 'profile'>
+
+/** Runtime ids are source-local. Preserve legacy untagged-primary behavior,
+ * but compare the composite registry scope whenever both sides name a source. */
+export function sessionRuntimeStateMatchesOwner(
+  state: ClientSessionState | undefined,
+  owner: RuntimeSessionStateOwner
+): state is ClientSessionState {
+  if (!state?.profile || state.profile !== owner.profile) {
+    return false
+  }
+
+  const stateConnectionId = state.connectionId?.trim() || null
+  const ownerConnectionId = owner.connectionId?.trim() || null
+
+  return (
+    !stateConnectionId ||
+    !ownerConnectionId ||
+    registryBackendScopeKey(stateConnectionId, state.profile) ===
+      registryBackendScopeKey(ownerConnectionId, owner.profile)
+  )
 }
 
 /** Fail closed: unknown profile provenance never aliases the default owner. */
@@ -13,7 +39,7 @@ export function sessionStateMatchesOwner(
   state: ClientSessionState | undefined,
   owner: SessionStateOwner
 ): state is ClientSessionState {
-  return state?.profile === owner.profile && state.storedSessionId === owner.storedSessionId
+  return sessionRuntimeStateMatchesOwner(state, owner) && state.storedSessionId === owner.storedSessionId
 }
 
 interface SessionStateCacheLimits {

--- a/apps/desktop/src/app/session/session-state-cache.ts
+++ b/apps/desktop/src/app/session/session-state-cache.ts
@@ -63,10 +63,6 @@ function publicStoredId(key: string): string {
 
 export class SessionRuntimeIndex extends Map<string, string> {
   override get(storedSessionId: string): string | undefined {
-    if (super.has(storedSessionId)) {
-      return super.get(storedSessionId)
-    }
-
     const matches = [...super.entries()].filter(([key]) => publicStoredId(key) === storedSessionId)
 
     return matches.length === 1 ? matches[0][1] : undefined
@@ -81,10 +77,6 @@ export class SessionRuntimeIndex extends Map<string, string> {
   }
 
   override delete(storedSessionId: string): boolean {
-    if (super.has(storedSessionId)) {
-      return super.delete(storedSessionId)
-    }
-
     const matches = [...super.keys()].filter(key => publicStoredId(key) === storedSessionId)
 
     return matches.length === 1 ? super.delete(matches[0]) : false

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -173,6 +173,9 @@ export interface SidebarNavItem {
 
 export interface ClientSessionState {
   storedSessionId: string | null
+  /** Registry connection that owns this runtime. Null preserves the legacy
+   * untagged-primary path; compare it only when both sides are authoritative. */
+  connectionId: string | null
   /** Profile namespace that owns this runtime. Stored ids are only unique
    *  inside a profile, so a warm runtime is not safe to activate without it. */
   profile: string | null

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -173,6 +173,9 @@ export interface SidebarNavItem {
 
 export interface ClientSessionState {
   storedSessionId: string | null
+  /** Profile namespace that owns this runtime. Stored ids are only unique
+   *  inside a profile, so a warm runtime is not safe to activate without it. */
+  profile: string | null
   messages: ChatMessage[]
   branch: string
   cwd: string

--- a/apps/desktop/src/hermes-cron-scope.test.ts
+++ b/apps/desktop/src/hermes-cron-scope.test.ts
@@ -130,4 +130,26 @@ describe('cron helpers are profile-scoped', () => {
       profile: 'remote_gateway'
     })
   })
+
+  it('passes an explicit owner profile to every job mutation endpoint', () => {
+    const payload = { name: 'nightly', prompt: 'run', schedule: '0 3 * * *' } as never
+
+    void createCronJob(payload, 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs?profile=worker_alpha')
+
+    void updateCronJob('shared-job', { enabled: false } as never, 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs/shared-job?profile=worker_alpha')
+
+    void pauseCronJob('shared-job', 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs/shared-job/pause?profile=worker_alpha')
+
+    void resumeCronJob('shared-job', 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs/shared-job/resume?profile=worker_alpha')
+
+    void triggerCronJob('shared-job', 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs/shared-job/trigger?profile=worker_alpha')
+
+    void deleteCronJob('shared-job', 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs/shared-job?profile=worker_alpha')
+  })
 })

--- a/apps/desktop/src/hermes-cron-scope.test.ts
+++ b/apps/desktop/src/hermes-cron-scope.test.ts
@@ -4,6 +4,8 @@ import {
   createCronJob,
   deleteCronJob,
   getCronJob,
+  getCronJobOutput,
+  getCronJobOutputs,
   getCronJobRuns,
   getCronJobs,
   pauseCronJob,
@@ -46,6 +48,8 @@ describe('cron helpers are profile-scoped', () => {
 
     void getCronJobs()
     void getCronJob('job-1')
+    void getCronJobOutputs('job-1')
+    void getCronJobOutput('job-1', '2026-08-11_09-00-00')
     void getCronJobRuns('job-1')
     void createCronJob({ name: 'nightly', prompt: 'run', schedule: '0 3 * * *' } as never)
     void updateCronJob('job-1', { enabled: false } as never)
@@ -103,5 +107,21 @@ describe('cron helpers are profile-scoped', () => {
     // Omitting the arg keeps the legacy unfiltered path.
     void getCronJobs()
     expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs')
+  })
+
+  it('keeps the gateway profile separate from a run output owner profile', () => {
+    setApiRequestProfile('remote_gateway')
+
+    void getCronJobOutputs('job-1', 5, 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0]).toMatchObject({
+      path: '/api/cron/jobs/job-1/outputs?limit=5&profile=worker_alpha',
+      profile: 'remote_gateway'
+    })
+
+    void getCronJobOutput('job-1', '2026-08-11_09-00-00', 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0]).toMatchObject({
+      path: '/api/cron/jobs/job-1/outputs/2026-08-11_09-00-00?profile=worker_alpha',
+      profile: 'remote_gateway'
+    })
   })
 })

--- a/apps/desktop/src/hermes-cron-scope.test.ts
+++ b/apps/desktop/src/hermes-cron-scope.test.ts
@@ -23,7 +23,7 @@ import {
 // show up" bug), the counterpart to the backend-action-helper fix in
 // hermes-profile-scope.test.ts.
 describe('cron helpers are profile-scoped', () => {
-  const api = vi.fn(async (_req: { path: string; profile?: string }) => ({}) as never)
+  const api = vi.fn(async (_req: { connectionId?: null | string; path: string; profile?: string }) => ({}) as never)
 
   beforeEach(() => {
     ;(window as { hermesDesktop?: unknown }).hermesDesktop = { api }
@@ -151,5 +151,31 @@ describe('cron helpers are profile-scoped', () => {
 
     void deleteCronJob('shared-job', 'worker_alpha')
     expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs/shared-job?profile=worker_alpha')
+  })
+
+  it('pins same-id A/B job and output reads to their explicit origin', async () => {
+    api.mockImplementation(
+      async request => [{ enabled: true, id: 'shared-job', profile: 'default', source: request.connectionId }] as never
+    )
+
+    const jobsA = await getCronJobs({ connectionId: 'connection-a', profile: 'default' })
+    const jobsB = await getCronJobs({ connectionId: 'connection-b', profile: 'default' })
+
+    expect(jobsA[0]).toMatchObject({ connection_id: 'connection-a', id: 'shared-job' })
+    expect(jobsB[0]).toMatchObject({ connection_id: 'connection-b', id: 'shared-job' })
+
+    void getCronJobOutput('shared-job', 'same-output', { connectionId: 'connection-a', profile: 'default' })
+    void getCronJobOutput('shared-job', 'same-output', { connectionId: 'connection-b', profile: 'default' })
+
+    expect(api.mock.calls.at(-2)?.[0]).toMatchObject({
+      connectionId: 'connection-a',
+      path: '/api/cron/jobs/shared-job/outputs/same-output?profile=default',
+      profile: 'default'
+    })
+    expect(api.mock.calls.at(-1)?.[0]).toMatchObject({
+      connectionId: 'connection-b',
+      path: '/api/cron/jobs/shared-job/outputs/same-output?profile=default',
+      profile: 'default'
+    })
   })
 })

--- a/apps/desktop/src/hermes-cron-scope.test.ts
+++ b/apps/desktop/src/hermes-cron-scope.test.ts
@@ -112,6 +112,12 @@ describe('cron helpers are profile-scoped', () => {
   it('keeps the gateway profile separate from a run output owner profile', () => {
     setApiRequestProfile('remote_gateway')
 
+    void getCronJobRuns('job-1', 5, 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0]).toMatchObject({
+      path: '/api/cron/jobs/job-1/runs?limit=5&profile=worker_alpha',
+      profile: 'remote_gateway'
+    })
+
     void getCronJobOutputs('job-1', 5, 'worker_alpha')
     expect(api.mock.calls.at(-1)?.[0]).toMatchObject({
       path: '/api/cron/jobs/job-1/outputs?limit=5&profile=worker_alpha',

--- a/apps/desktop/src/hermes-cron-scope.test.ts
+++ b/apps/desktop/src/hermes-cron-scope.test.ts
@@ -4,6 +4,8 @@ import {
   createCronJob,
   deleteCronJob,
   getCronJob,
+  getCronJobOutput,
+  getCronJobOutputs,
   getCronJobRuns,
   getCronJobs,
   pauseCronJob,
@@ -44,6 +46,8 @@ describe('cron helpers are profile-scoped', () => {
 
     void getCronJobs()
     void getCronJob('job-1')
+    void getCronJobOutputs('job-1')
+    void getCronJobOutput('job-1', '2026-08-11_09-00-00')
     void getCronJobRuns('job-1')
     void createCronJob({ name: 'nightly', prompt: 'run', schedule: '0 3 * * *' } as never)
     void updateCronJob('job-1', { enabled: false } as never)
@@ -70,5 +74,21 @@ describe('cron helpers are profile-scoped', () => {
     // Omitting the arg keeps the legacy unfiltered path.
     void getCronJobs()
     expect(api.mock.calls.at(-1)?.[0].path).toBe('/api/cron/jobs')
+  })
+
+  it('keeps the gateway profile separate from a run output owner profile', () => {
+    setApiRequestProfile('remote_gateway')
+
+    void getCronJobOutputs('job-1', 5, 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0]).toMatchObject({
+      path: '/api/cron/jobs/job-1/outputs?limit=5&profile=worker_alpha',
+      profile: 'remote_gateway'
+    })
+
+    void getCronJobOutput('job-1', '2026-08-11_09-00-00', 'worker_alpha')
+    expect(api.mock.calls.at(-1)?.[0]).toMatchObject({
+      path: '/api/cron/jobs/job-1/outputs/2026-08-11_09-00-00?profile=worker_alpha',
+      profile: 'remote_gateway'
+    })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -51,6 +51,8 @@ export type {
   CronDeliveryTarget,
   CronJob,
   CronJobCreatePayload,
+  CronJobOutput,
+  CronJobOutputDetail,
   CronJobSchedule,
   CronJobUpdates,
   CuratorStatusResponse,

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -15,6 +15,8 @@ import type {
   CronDeliveryTarget,
   CronJob,
   CronJobCreatePayload,
+  CronJobOutput,
+  CronJobOutputDetail,
   CronJobUpdates,
   CuratorStatusResponse,
   CustomEndpointsResponse,
@@ -149,6 +151,8 @@ export type {
   CronDeliveryTarget,
   CronJob,
   CronJobCreatePayload,
+  CronJobOutput,
+  CronJobOutputDetail,
   CronJobSchedule,
   CronJobUpdates,
   CuratorStatusResponse,
@@ -1402,6 +1406,25 @@ export async function getCronJobRuns(jobId: string, limit = 20): Promise<Session
   })
 
   return runs ?? []
+}
+
+export async function getCronJobOutputs(jobId: string, limit = 20, profile?: string): Promise<CronJobOutput[]> {
+  const owner = profile ? `&profile=${encodeURIComponent(profile)}` : ''
+  const { outputs } = await window.hermesDesktop.api<{ outputs: CronJobOutput[] }>({
+    ...profileScoped(),
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/outputs?limit=${limit}${owner}`
+  })
+
+  return outputs ?? []
+}
+
+export function getCronJobOutput(jobId: string, outputId: string, profile?: string): Promise<CronJobOutputDetail> {
+  const owner = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+
+  return window.hermesDesktop.api<CronJobOutputDetail>({
+    ...profileScoped(),
+    path: `/api/cron/jobs/${encodeURIComponent(jobId)}/outputs/${encodeURIComponent(outputId)}${owner}`
+  })
 }
 
 // The single source of truth for cron delivery targets (local + configured

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1569,6 +1569,7 @@ export const ar = defineLocale({
     last: 'آخر تشغيل',
     next: 'التالي',
     noRuns: 'لا توجد تشغيلات',
+    outputUnavailable: outputId => `لم تعد نتيجة التشغيل «${outputId}.md» متاحة.`,
     manage: 'إدارة',
     showRuns: 'إظهار التشغيلات',
     hideRuns: 'إخفاء التشغيلات',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2030,6 +2030,7 @@ export const en: Translations = {
     last: 'Last:',
     next: 'Next:',
     noRuns: 'No runs yet',
+    outputUnavailable: outputId => `Run output “${outputId}.md” is no longer available.`,
     manage: 'Manage',
     showRuns: 'Show runs',
     hideRuns: 'Hide runs',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1714,6 +1714,7 @@ export const ja = defineLocale({
     last: '前回',
     next: '次回',
     noRuns: 'まだ実行されていません',
+    outputUnavailable: outputId => `実行出力「${outputId}.md」は利用できなくなりました。`,
     manage: '管理',
     showRuns: '実行履歴を表示',
     hideRuns: '実行履歴を隠す',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1701,6 +1701,7 @@ export interface Translations {
     last: string
     next: string
     noRuns: string
+    outputUnavailable: (outputId: string) => string
     manage: string
     showRuns: string
     hideRuns: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1652,6 +1652,7 @@ export const zhHant = defineLocale({
     last: '上次：',
     next: '下次：',
     noRuns: '尚無執行',
+    outputUnavailable: outputId => `執行輸出「${outputId}.md」已無法使用。`,
     manage: '管理',
     showRuns: '顯示執行記錄',
     hideRuns: '隱藏執行記錄',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2211,6 +2211,7 @@ export const zh: Translations = {
     last: '上次：',
     next: '下次：',
     noRuns: '尚无运行',
+    outputUnavailable: outputId => `运行输出“${outputId}.md”已不可用。`,
     manage: '管理',
     showRuns: '显示运行记录',
     hideRuns: '隐藏运行记录',

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -23,6 +23,7 @@ export function createClientSessionState(
 ): ClientSessionState {
   return {
     storedSessionId,
+    profile: null,
     messages,
     branch: '',
     cwd: '',

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -23,6 +23,7 @@ export function createClientSessionState(
 ): ClientSessionState {
   return {
     storedSessionId,
+    connectionId: null,
     profile: null,
     messages,
     branch: '',

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -13,27 +13,31 @@ import {
 
 const STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
 const LEGACY_STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v2:'
-const STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v3:'
-const MIGRATION_KEY = 'hermes.desktop.inflightTurnJournal.v3.migrated'
+const LEGACY_PROFILE_STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v3:'
+const STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v4:'
+const MIGRATION_KEY = 'hermes.desktop.inflightTurnJournal.v4.migrated'
 
-const sessionStorageKey = (storedSessionId: string, profile = 'default') =>
-  `${STORAGE_PREFIX}${encodeURIComponent(profile)}:${encodeURIComponent(storedSessionId)}`
+const sessionStorageKey = (storedSessionId: string, profile = 'default', connectionId: null | string = null) =>
+  `${STORAGE_PREFIX}${encodeURIComponent(connectionId ?? '')}:${encodeURIComponent(profile)}:${encodeURIComponent(storedSessionId)}`
+
+const legacyProfileSessionStorageKey = (storedSessionId: string, profile = 'default') =>
+  `${LEGACY_PROFILE_STORAGE_PREFIX}${encodeURIComponent(profile)}:${encodeURIComponent(storedSessionId)}`
 
 const legacySessionStorageKey = (storedSessionId: string) =>
   `${LEGACY_STORAGE_PREFIX}${encodeURIComponent(storedSessionId)}`
 
 const clearInFlightTurnJournal = (storedSessionId: null | string, profile = 'default') =>
-  clearJournal(storedSessionId, profile)
+  clearJournal(storedSessionId, profile, null)
 
 const readInFlightTurnJournal = (storedSessionId: null | string, profile = 'default') =>
-  readJournal(storedSessionId, profile)
+  readJournal(storedSessionId, profile, null)
 
 const recoverInFlightTurnJournal = (
   storedSessionId: null | string,
   baseMessages: ChatMessage[],
   options: { keepPending?: boolean } = {},
   profile = 'default'
-) => recoverJournal(storedSessionId, profile, baseMessages, options)
+) => recoverJournal(storedSessionId, profile, null, baseMessages, options)
 
 function user(id: string, text: string): ChatMessage {
   return { id, role: 'user', parts: [{ type: 'text', text }] }
@@ -60,6 +64,7 @@ function journalState(overrides: Partial<JournalableSessionState> = {}): Journal
     awaitingResponse: false,
     busy: true,
     messages: [user('u1', 'do the thing'), assistant('assistant-stream-1', 'partial answer', { pending: true })],
+    connectionId: null,
     profile: 'default',
     storedSessionId: 'stored-1',
     streamId: 'assistant-stream-1',
@@ -92,6 +97,7 @@ describe('persistInFlightTurnState', () => {
           user(`u-${index}`, `prompt-${index}`),
           assistant(`a-${index}`, `partial-${index}`, { pending: true })
         ],
+        connectionId: null,
         profile: 'default',
         streamId: `a-${index}`,
         turnStartedAt: index,
@@ -105,6 +111,7 @@ describe('persistInFlightTurnState', () => {
       sessionStorageKey('expired'),
       JSON.stringify({
         messages: [user('expired-u', 'expired'), assistant('expired-a', 'expired', { pending: true })],
+        connectionId: null,
         profile: 'default',
         streamId: 'expired-a',
         turnStartedAt: 0,
@@ -163,6 +170,7 @@ describe('persistInFlightTurnState', () => {
     persistInFlightTurnState(
       journalState({
         messages: [user('default-u', 'default prompt'), assistant('default-a', 'default partial', { pending: true })],
+        connectionId: null,
         profile: 'default',
         streamId: 'default-a'
       })
@@ -170,28 +178,60 @@ describe('persistInFlightTurnState', () => {
     persistInFlightTurnState(
       journalState({
         messages: [user('meta-u', 'meta prompt'), assistant('meta-a', 'meta partial', { pending: true })],
+        connectionId: null,
         profile: ' meta ',
         streamId: 'meta-a'
       })
     )
     vi.advanceTimersByTime(400)
 
-    expect(readJournal('stored-1', 'default')?.messages.at(-1)?.id).toBe('default-a')
-    expect(readJournal('stored-1', 'meta')?.messages.at(-1)?.id).toBe('meta-a')
+    expect(readJournal('stored-1', 'default', null)?.messages.at(-1)?.id).toBe('default-a')
+    expect(readJournal('stored-1', 'meta', null)?.messages.at(-1)?.id).toBe('meta-a')
     expect(window.localStorage.getItem(sessionStorageKey('stored-1', 'default'))).not.toBeNull()
     expect(window.localStorage.getItem(sessionStorageKey('stored-1', 'meta'))).not.toBeNull()
 
-    clearJournal('stored-1', 'default')
+    clearJournal('stored-1', 'default', null)
 
-    expect(readJournal('stored-1', 'default')).toBeNull()
-    expect(readJournal('stored-1', 'meta')?.messages.at(-1)?.id).toBe('meta-a')
+    expect(readJournal('stored-1', 'default', null)).toBeNull()
+    expect(readJournal('stored-1', 'meta', null)?.messages.at(-1)?.id).toBe('meta-a')
+  })
+
+  it('isolates overwrite, recovery, and clear for the same root across connections', () => {
+    persistInFlightTurnState(
+      journalState({
+        connectionId: 'connection-a',
+        messages: [user('a-u', 'A prompt'), assistant('a-stream', 'A partial', { pending: true })],
+        streamId: 'a-stream'
+      })
+    )
+    persistInFlightTurnState(
+      journalState({
+        connectionId: 'connection-b',
+        messages: [user('b-u', 'B prompt'), assistant('b-stream', 'B partial', { pending: true })],
+        streamId: 'b-stream'
+      })
+    )
+    vi.advanceTimersByTime(400)
+
+    expect(readJournal('stored-1', 'default', 'connection-a')?.streamId).toBe('a-stream')
+    expect(readJournal('stored-1', 'default', 'connection-b')?.streamId).toBe('b-stream')
+
+    const recoveredA = recoverJournal('stored-1', 'default', 'connection-a', [user('db-a', 'A prompt')])
+    expect(recoveredA.messages.at(-1)?.id).toBe('a-stream')
+    expect(recoverJournal('stored-1', 'default', 'connection-b', [user('db-a', 'A prompt')]).messages.at(-1)?.id).toBe(
+      'b-stream'
+    )
+
+    clearJournal('stored-1', 'default', 'connection-a')
+    expect(readJournal('stored-1', 'default', 'connection-a')).toBeNull()
+    expect(readJournal('stored-1', 'default', 'connection-b')?.streamId).toBe('b-stream')
   })
 
   it('fails closed when a journalable state has no proven profile owner', () => {
     persistInFlightTurnState(journalState({ profile: null }))
     vi.advanceTimersByTime(400)
 
-    expect(readJournal('stored-1', 'default')).toBeNull()
+    expect(readJournal('stored-1', 'default', null)).toBeNull()
   })
 
   it('journals the running turn tail after the throttle window', () => {
@@ -316,6 +356,7 @@ describe('persistInFlightTurnState', () => {
   it('does not parse the legacy aggregate when a pathological write discards its session', () => {
     const legacy = {
       messages: [user('legacy-u1', 'old prompt'), assistant('legacy-a1', 'old partial', { pending: true })],
+      connectionId: null,
       profile: 'default',
       streamId: 'legacy-a1',
       turnStartedAt: 1,
@@ -340,6 +381,7 @@ describe('persistInFlightTurnState', () => {
   it('preserves a tombstone while sweeping before legacy migration', () => {
     const legacy = {
       messages: [user('legacy-u1', 'old prompt'), assistant('legacy-a1', 'old partial', { pending: true })],
+      connectionId: null,
       profile: 'default',
       streamId: 'legacy-a1',
       turnStartedAt: 1,
@@ -470,6 +512,7 @@ describe('persistInFlightTurnState', () => {
           { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'prompt' }], attachmentRefs: '@file:bad' },
           { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'partial' }], pending: true }
         ],
+        connectionId: null,
         profile: 'default',
         streamId: 'a1',
         turnStartedAt: 1,
@@ -484,6 +527,23 @@ describe('persistInFlightTurnState', () => {
 })
 
 describe('legacy journal migration', () => {
+  it('keeps profile-only v3 records in the untagged-primary namespace', () => {
+    const legacy = {
+      connectionId: null,
+      messages: [user('u1', 'one'), assistant('a1', 'legacy partial', { pending: true })],
+      profile: 'default',
+      streamId: 'a1',
+      turnStartedAt: 1,
+      updatedAt: Date.now()
+    }
+
+    window.localStorage.setItem(legacyProfileSessionStorageKey('stored-1'), JSON.stringify(legacy))
+
+    expect(readJournal('stored-1', 'default', 'connection-a')).toBeNull()
+    expect(readJournal('stored-1', 'default', null)?.streamId).toBe('a1')
+    expect(window.localStorage.getItem(legacyProfileSessionStorageKey('stored-1'))).toBeNull()
+  })
+
   it('discards an unowned bare-id v2 snapshot instead of guessing the active profile', () => {
     const unowned = {
       messages: [user('u1', 'one'), assistant('a1', 'partial one', { pending: true })],
@@ -494,7 +554,7 @@ describe('legacy journal migration', () => {
 
     window.localStorage.setItem(legacySessionStorageKey('stored-1'), JSON.stringify(unowned))
     const base = [user('db-u0', 'earlier')]
-    const recovered = recoverJournal('stored-1', 'default', base)
+    const recovered = recoverJournal('stored-1', 'default', null, base)
 
     expect(recovered.applied).toBe(false)
     expect(recovered.messages).toBe(base)
@@ -505,6 +565,7 @@ describe('legacy journal migration', () => {
   it('migrates a bare-id v2 snapshot only when embedded profile provenance proves its owner', () => {
     const owned = {
       messages: [user('u1', 'one'), assistant('a1', 'meta partial', { pending: true })],
+      connectionId: null,
       profile: 'meta',
       streamId: 'a1',
       turnStartedAt: 1,
@@ -513,8 +574,8 @@ describe('legacy journal migration', () => {
 
     window.localStorage.setItem(legacySessionStorageKey('stored-1'), JSON.stringify(owned))
 
-    expect(readJournal('stored-1', 'default')).toBeNull()
-    expect(readJournal('stored-1', 'meta')).toEqual(owned)
+    expect(readJournal('stored-1', 'default', null)).toBeNull()
+    expect(readJournal('stored-1', 'meta', null)).toEqual(owned)
     expect(window.localStorage.getItem(legacySessionStorageKey('stored-1'))).toBeNull()
     expect(window.localStorage.getItem(sessionStorageKey('stored-1', 'meta'))).not.toBeNull()
   })
@@ -522,6 +583,7 @@ describe('legacy journal migration', () => {
   it('migrates the bounded v1 aggregate once and recovers its sessions', () => {
     const first = {
       messages: [user('u1', 'one'), assistant('a1', 'partial one', { pending: true })],
+      connectionId: null,
       profile: 'default',
       streamId: 'a1',
       turnStartedAt: 1,
@@ -547,6 +609,7 @@ describe('legacy journal migration', () => {
           pending: true
         }
       ],
+      connectionId: null,
       profile: 'default',
       streamId: 'a2',
       turnStartedAt: 2,
@@ -586,6 +649,7 @@ describe('legacy journal migration', () => {
 
     const legacyCurrent = {
       messages: [user('legacy-u1', 'old prompt'), assistant('legacy-a1', 'old partial', { pending: true })],
+      connectionId: null,
       profile: 'default',
       streamId: 'legacy-a1',
       turnStartedAt: 1,
@@ -594,6 +658,7 @@ describe('legacy journal migration', () => {
 
     const legacyOther = {
       messages: [user('u2', 'other prompt'), assistant('a2', 'other partial', { pending: true })],
+      connectionId: null,
       profile: 'default',
       streamId: 'a2',
       turnStartedAt: 2,
@@ -612,6 +677,7 @@ describe('legacy journal migration', () => {
   it('does not resurrect a legacy entry after that session settles before migration', () => {
     const legacyCurrent = {
       messages: [user('legacy-u1', 'old prompt'), assistant('legacy-a1', 'old partial', { pending: true })],
+      connectionId: null,
       profile: 'default',
       streamId: 'legacy-a1',
       turnStartedAt: 1,
@@ -620,6 +686,7 @@ describe('legacy journal migration', () => {
 
     const legacyOther = {
       messages: [user('u2', 'other prompt'), assistant('a2', 'other partial', { pending: true })],
+      connectionId: null,
       profile: 'default',
       streamId: 'a2',
       turnStartedAt: 2,
@@ -874,6 +941,7 @@ describe('mid-turn redirect corrections', () => {
         user('user-2', 'hurry up'),
         assistant('assistant-stream-1', 'Moving.', { pending: true })
       ],
+      connectionId: null,
       profile: 'default',
       storedSessionId: 'stored-redirect',
       streamId: 'assistant-stream-1',
@@ -900,6 +968,7 @@ describe('mid-turn redirect corrections', () => {
         user('user-1', 'the live prompt'),
         assistant('assistant-stream-1', 'Moving.', { pending: true })
       ],
+      connectionId: null,
       profile: 'default',
       storedSessionId: 'stored-boundary',
       streamId: 'assistant-stream-1',

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -2,20 +2,38 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
 import {
-  clearInFlightTurnJournal,
+  clearInFlightTurnJournal as clearJournal,
   type JournalableSessionState,
   mergeInFlightMessages,
   persistInFlightTurnState,
-  readInFlightTurnJournal,
-  recoverInFlightTurnJournal,
+  readInFlightTurnJournal as readJournal,
+  recoverInFlightTurnJournal as recoverJournal,
   resetInFlightTurnJournalStateForTests
 } from '@/lib/inflight-turn-journal'
 
 const STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
-const STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v2:'
-const MIGRATION_KEY = 'hermes.desktop.inflightTurnJournal.v2.migrated'
+const LEGACY_STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v2:'
+const STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v3:'
+const MIGRATION_KEY = 'hermes.desktop.inflightTurnJournal.v3.migrated'
 
-const sessionStorageKey = (storedSessionId: string) => `${STORAGE_PREFIX}${encodeURIComponent(storedSessionId)}`
+const sessionStorageKey = (storedSessionId: string, profile = 'default') =>
+  `${STORAGE_PREFIX}${encodeURIComponent(profile)}:${encodeURIComponent(storedSessionId)}`
+
+const legacySessionStorageKey = (storedSessionId: string) =>
+  `${LEGACY_STORAGE_PREFIX}${encodeURIComponent(storedSessionId)}`
+
+const clearInFlightTurnJournal = (storedSessionId: null | string, profile = 'default') =>
+  clearJournal(storedSessionId, profile)
+
+const readInFlightTurnJournal = (storedSessionId: null | string, profile = 'default') =>
+  readJournal(storedSessionId, profile)
+
+const recoverInFlightTurnJournal = (
+  storedSessionId: null | string,
+  baseMessages: ChatMessage[],
+  options: { keepPending?: boolean } = {},
+  profile = 'default'
+) => recoverJournal(storedSessionId, profile, baseMessages, options)
 
 function user(id: string, text: string): ChatMessage {
   return { id, role: 'user', parts: [{ type: 'text', text }] }
@@ -42,6 +60,7 @@ function journalState(overrides: Partial<JournalableSessionState> = {}): Journal
     awaitingResponse: false,
     busy: true,
     messages: [user('u1', 'do the thing'), assistant('assistant-stream-1', 'partial answer', { pending: true })],
+    profile: 'default',
     storedSessionId: 'stored-1',
     streamId: 'assistant-stream-1',
     turnStartedAt: 1000,
@@ -73,6 +92,7 @@ describe('persistInFlightTurnState', () => {
           user(`u-${index}`, `prompt-${index}`),
           assistant(`a-${index}`, `partial-${index}`, { pending: true })
         ],
+        profile: 'default',
         streamId: `a-${index}`,
         turnStartedAt: index,
         updatedAt: now - index * 1_000
@@ -85,6 +105,7 @@ describe('persistInFlightTurnState', () => {
       sessionStorageKey('expired'),
       JSON.stringify({
         messages: [user('expired-u', 'expired'), assistant('expired-a', 'expired', { pending: true })],
+        profile: 'default',
         streamId: 'expired-a',
         turnStartedAt: 0,
         updatedAt: now - 8 * 24 * 60 * 60 * 1_000
@@ -136,6 +157,41 @@ describe('persistInFlightTurnState', () => {
 
     expect(readInFlightTurnJournal('stored-1')).not.toBeNull()
     expect(readInFlightTurnJournal('stored-2')).toBeNull()
+  })
+
+  it('isolates snapshots and throttle state for the same stored id across profiles', () => {
+    persistInFlightTurnState(
+      journalState({
+        messages: [user('default-u', 'default prompt'), assistant('default-a', 'default partial', { pending: true })],
+        profile: 'default',
+        streamId: 'default-a'
+      })
+    )
+    persistInFlightTurnState(
+      journalState({
+        messages: [user('meta-u', 'meta prompt'), assistant('meta-a', 'meta partial', { pending: true })],
+        profile: ' meta ',
+        streamId: 'meta-a'
+      })
+    )
+    vi.advanceTimersByTime(400)
+
+    expect(readJournal('stored-1', 'default')?.messages.at(-1)?.id).toBe('default-a')
+    expect(readJournal('stored-1', 'meta')?.messages.at(-1)?.id).toBe('meta-a')
+    expect(window.localStorage.getItem(sessionStorageKey('stored-1', 'default'))).not.toBeNull()
+    expect(window.localStorage.getItem(sessionStorageKey('stored-1', 'meta'))).not.toBeNull()
+
+    clearJournal('stored-1', 'default')
+
+    expect(readJournal('stored-1', 'default')).toBeNull()
+    expect(readJournal('stored-1', 'meta')?.messages.at(-1)?.id).toBe('meta-a')
+  })
+
+  it('fails closed when a journalable state has no proven profile owner', () => {
+    persistInFlightTurnState(journalState({ profile: null }))
+    vi.advanceTimersByTime(400)
+
+    expect(readJournal('stored-1', 'default')).toBeNull()
   })
 
   it('journals the running turn tail after the throttle window', () => {
@@ -260,6 +316,7 @@ describe('persistInFlightTurnState', () => {
   it('does not parse the legacy aggregate when a pathological write discards its session', () => {
     const legacy = {
       messages: [user('legacy-u1', 'old prompt'), assistant('legacy-a1', 'old partial', { pending: true })],
+      profile: 'default',
       streamId: 'legacy-a1',
       turnStartedAt: 1,
       updatedAt: Date.now()
@@ -283,6 +340,7 @@ describe('persistInFlightTurnState', () => {
   it('preserves a tombstone while sweeping before legacy migration', () => {
     const legacy = {
       messages: [user('legacy-u1', 'old prompt'), assistant('legacy-a1', 'old partial', { pending: true })],
+      profile: 'default',
       streamId: 'legacy-a1',
       turnStartedAt: 1,
       updatedAt: Date.now()
@@ -412,6 +470,7 @@ describe('persistInFlightTurnState', () => {
           { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'prompt' }], attachmentRefs: '@file:bad' },
           { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'partial' }], pending: true }
         ],
+        profile: 'default',
         streamId: 'a1',
         turnStartedAt: 1,
         updatedAt: Date.now()
@@ -425,9 +484,45 @@ describe('persistInFlightTurnState', () => {
 })
 
 describe('legacy journal migration', () => {
+  it('discards an unowned bare-id v2 snapshot instead of guessing the active profile', () => {
+    const unowned = {
+      messages: [user('u1', 'one'), assistant('a1', 'partial one', { pending: true })],
+      streamId: 'a1',
+      turnStartedAt: 1,
+      updatedAt: Date.now()
+    }
+
+    window.localStorage.setItem(legacySessionStorageKey('stored-1'), JSON.stringify(unowned))
+    const base = [user('db-u0', 'earlier')]
+    const recovered = recoverJournal('stored-1', 'default', base)
+
+    expect(recovered.applied).toBe(false)
+    expect(recovered.messages).toBe(base)
+    expect(window.localStorage.getItem(legacySessionStorageKey('stored-1'))).toBeNull()
+    expect(window.localStorage.getItem(sessionStorageKey('stored-1'))).toBeNull()
+  })
+
+  it('migrates a bare-id v2 snapshot only when embedded profile provenance proves its owner', () => {
+    const owned = {
+      messages: [user('u1', 'one'), assistant('a1', 'meta partial', { pending: true })],
+      profile: 'meta',
+      streamId: 'a1',
+      turnStartedAt: 1,
+      updatedAt: Date.now()
+    }
+
+    window.localStorage.setItem(legacySessionStorageKey('stored-1'), JSON.stringify(owned))
+
+    expect(readJournal('stored-1', 'default')).toBeNull()
+    expect(readJournal('stored-1', 'meta')).toEqual(owned)
+    expect(window.localStorage.getItem(legacySessionStorageKey('stored-1'))).toBeNull()
+    expect(window.localStorage.getItem(sessionStorageKey('stored-1', 'meta'))).not.toBeNull()
+  })
+
   it('migrates the bounded v1 aggregate once and recovers its sessions', () => {
     const first = {
       messages: [user('u1', 'one'), assistant('a1', 'partial one', { pending: true })],
+      profile: 'default',
       streamId: 'a1',
       turnStartedAt: 1,
       updatedAt: Date.now()
@@ -452,6 +547,7 @@ describe('legacy journal migration', () => {
           pending: true
         }
       ],
+      profile: 'default',
       streamId: 'a2',
       turnStartedAt: 2,
       updatedAt: Date.now()
@@ -490,6 +586,7 @@ describe('legacy journal migration', () => {
 
     const legacyCurrent = {
       messages: [user('legacy-u1', 'old prompt'), assistant('legacy-a1', 'old partial', { pending: true })],
+      profile: 'default',
       streamId: 'legacy-a1',
       turnStartedAt: 1,
       updatedAt: Date.now() - 1_000
@@ -497,6 +594,7 @@ describe('legacy journal migration', () => {
 
     const legacyOther = {
       messages: [user('u2', 'other prompt'), assistant('a2', 'other partial', { pending: true })],
+      profile: 'default',
       streamId: 'a2',
       turnStartedAt: 2,
       updatedAt: Date.now()
@@ -514,6 +612,7 @@ describe('legacy journal migration', () => {
   it('does not resurrect a legacy entry after that session settles before migration', () => {
     const legacyCurrent = {
       messages: [user('legacy-u1', 'old prompt'), assistant('legacy-a1', 'old partial', { pending: true })],
+      profile: 'default',
       streamId: 'legacy-a1',
       turnStartedAt: 1,
       updatedAt: Date.now()
@@ -521,6 +620,7 @@ describe('legacy journal migration', () => {
 
     const legacyOther = {
       messages: [user('u2', 'other prompt'), assistant('a2', 'other partial', { pending: true })],
+      profile: 'default',
       streamId: 'a2',
       turnStartedAt: 2,
       updatedAt: Date.now()
@@ -774,6 +874,7 @@ describe('mid-turn redirect corrections', () => {
         user('user-2', 'hurry up'),
         assistant('assistant-stream-1', 'Moving.', { pending: true })
       ],
+      profile: 'default',
       storedSessionId: 'stored-redirect',
       streamId: 'assistant-stream-1',
       turnStartedAt: Date.now()
@@ -799,6 +900,7 @@ describe('mid-turn redirect corrections', () => {
         user('user-1', 'the live prompt'),
         assistant('assistant-stream-1', 'Moving.', { pending: true })
       ],
+      profile: 'default',
       storedSessionId: 'stored-boundary',
       streamId: 'assistant-stream-1',
       turnStartedAt: Date.now()

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -635,6 +635,40 @@ describe('legacy journal migration', () => {
     expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull()
   })
 
+  it('keeps legacy records retryable when a replacement write fails', () => {
+    const legacy = {
+      messages: [user('u1', 'one'), assistant('a1', 'partial', { pending: true })],
+      connectionId: null,
+      profile: 'default',
+      streamId: 'a1',
+      turnStartedAt: 1,
+      updatedAt: Date.now()
+    }
+    const legacyKey = legacyProfileSessionStorageKey('stored-1')
+    const replacementKey = sessionStorageKey('stored-1')
+    window.localStorage.setItem(legacyKey, JSON.stringify(legacy))
+
+    const originalSetItem = Storage.prototype.setItem
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === replacementKey) {
+        throw new DOMException('quota exceeded', 'QuotaExceededError')
+      }
+      return originalSetItem.call(this, key, value)
+    })
+
+    expect(readInFlightTurnJournal('stored-1')).toBeNull()
+    expect(window.localStorage.getItem(legacyKey)).not.toBeNull()
+    expect(window.localStorage.getItem(replacementKey)).toBeNull()
+    expect(window.localStorage.getItem(MIGRATION_KEY)).toBeNull()
+
+    setItem.mockRestore()
+
+    expect(readInFlightTurnJournal('stored-1')).toEqual(legacy)
+    expect(window.localStorage.getItem(legacyKey)).toBeNull()
+    expect(window.localStorage.getItem(replacementKey)).not.toBeNull()
+    expect(window.localStorage.getItem(MIGRATION_KEY)).toBe('1')
+  })
+
   it('drops an oversized legacy aggregate without parsing it', () => {
     window.localStorage.setItem(STORAGE_KEY, 'x'.repeat(2 * 1024 * 1024 + 1))
 

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -644,15 +644,31 @@ describe('legacy journal migration', () => {
       turnStartedAt: 1,
       updatedAt: Date.now()
     }
+
     const legacyKey = legacyProfileSessionStorageKey('stored-1')
     const replacementKey = sessionStorageKey('stored-1')
     window.localStorage.setItem(legacyKey, JSON.stringify(legacy))
 
-    const originalSetItem = Storage.prototype.setItem
-    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+    // Node 26 defines its own global Storage. Spy on the jsdom realm that owns
+    // window.localStorage so the quota failure remains deterministic there too.
+    let storagePrototype: null | object = window.localStorage
+
+    while (storagePrototype && !Object.prototype.hasOwnProperty.call(storagePrototype, 'setItem')) {
+      storagePrototype = Object.getPrototypeOf(storagePrototype) as null | object
+    }
+
+    if (!storagePrototype) {
+      throw new Error('localStorage setItem implementation not found')
+    }
+
+    const localStorageMethods = storagePrototype as Storage
+    const originalSetItem = localStorageMethods.setItem
+
+    const setItem = vi.spyOn(localStorageMethods, 'setItem').mockImplementation(function (this: Storage, key, value) {
       if (key === replacementKey) {
         throw new DOMException('quota exceeded', 'QuotaExceededError')
       }
+
       return originalSetItem.call(this, key, value)
     })
 

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -431,12 +431,6 @@ function migrateLegacyStore(store: Storage): void {
     return
   }
 
-  // Claim the migration before touching legacy state. If storage is failing,
-  // skip recovery rather than retrying expensive parsing on every read.
-  if (!writeRaw(store, LEGACY_MIGRATION_KEY, '1')) {
-    return
-  }
-
   const candidates: Array<[string, InFlightTurnSnapshot]> = []
   const legacySessionKeys: string[] = []
   const legacyProfileSessionKeys: string[] = []
@@ -457,7 +451,6 @@ function migrateLegacyStore(store: Storage): void {
 
   for (const key of legacySessionKeys) {
     const raw = readRaw(store, key)
-    removeRaw(store, key)
 
     if (!raw || raw === DISCARDED_SNAPSHOT_RAW) {
       continue
@@ -479,7 +472,6 @@ function migrateLegacyStore(store: Storage): void {
 
   for (const key of legacyProfileSessionKeys) {
     const raw = readRaw(store, key)
-    removeRaw(store, key)
 
     if (!raw || raw === DISCARDED_SNAPSHOT_RAW) {
       continue
@@ -502,7 +494,6 @@ function migrateLegacyStore(store: Storage): void {
   }
 
   const aggregateRaw = readRaw(store, LEGACY_STORAGE_KEY)
-  removeRaw(store, LEGACY_STORAGE_KEY)
 
   if (aggregateRaw && aggregateRaw.length <= MAX_LEGACY_STORE_CHARS) {
     try {
@@ -546,17 +537,32 @@ function migrateLegacyStore(store: Storage): void {
     return
   }
 
-  for (const [storedSessionId, snapshot] of candidates
-    .sort((left, right) => right[1].updatedAt - left[1].updatedAt)
-    .slice(0, Math.max(0, MAX_ENTRIES - existingKeys.size))) {
+  for (const [storedSessionId, snapshot] of candidates.sort((left, right) => right[1].updatedAt - left[1].updatedAt)) {
     const owner = journalOwner(storedSessionId, snapshot.profile, snapshot.connectionId)
     const messages = boundedMessages(snapshot.messages)
     const value = messages ? serializeSnapshot({ ...snapshot, messages }) : null
 
-    if (owner && value && readRaw(store, owner.key) === null && writeRaw(store, owner.key, value)) {
+    if (owner && value && readRaw(store, owner.key) === null) {
+      if (!writeRaw(store, owner.key, value)) {
+        return
+      }
+
       existingKeys.add(owner.key)
     }
   }
+
+  // Commit the migration only after every replacement record is durable. A
+  // quota/setItem failure leaves all legacy records and the marker untouched,
+  // so the next read can retry without data loss.
+  if (!writeRaw(store, LEGACY_MIGRATION_KEY, '1')) {
+    return
+  }
+
+  for (const key of [...legacySessionKeys, ...legacyProfileSessionKeys]) {
+    removeRaw(store, key)
+  }
+
+  removeRaw(store, LEGACY_STORAGE_KEY)
 }
 
 function discardSnapshot(store: Storage, key: string): void {

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -19,13 +19,14 @@ import { normalizeProfileKey } from '@/store/profile'
 
 const LEGACY_STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
 const LEGACY_STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v2:'
-const STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v3:'
-const LEGACY_MIGRATION_KEY = 'hermes.desktop.inflightTurnJournal.v3.migrated'
+const LEGACY_PROFILE_STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v3:'
+const STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v4:'
+const LEGACY_MIGRATION_KEY = 'hermes.desktop.inflightTurnJournal.v4.migrated'
 const DISCARDED_SNAPSHOT_RAW = '0'
 const STORE_VERSION = 1
 const MAX_SESSION_STORE_CHARS = 4 * 1024 * 1024
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
-// Keep the worst-case v3 namespace below a conservative localStorage budget
+// Keep the worst-case v4 namespace below a conservative localStorage budget
 // while retaining the 24 newest session slots for ordinary small snapshots.
 const MAX_ENTRY_CHARS = 160 * 1024
 const MAX_ENTRIES = Math.min(24, Math.floor(MAX_SESSION_STORE_CHARS / MAX_ENTRY_CHARS))
@@ -42,11 +43,12 @@ const MAX_USER_ATTACHMENT_REF_CHARS = 64 * 1024
 const PERSIST_THROTTLE_MS = 400
 
 // A renderer can accumulate one entry per session over its lifetime. Sweep the
-// bounded v3 namespace once on first journal access; never scan it on the
+// bounded v4 namespace once on first journal access; never scan it on the
 // 400ms streaming write path.
 let sessionStoreSwept = false
 
 export interface InFlightTurnSnapshot {
+  connectionId: null | string
   messages: ChatMessage[]
   profile: string
   streamId: null | string
@@ -57,6 +59,7 @@ export interface InFlightTurnSnapshot {
 export interface JournalableSessionState {
   awaitingResponse: boolean
   busy: boolean
+  connectionId: null | string
   messages: ChatMessage[]
   profile: null | string
   storedSessionId: null | string
@@ -88,21 +91,27 @@ function storage(): Storage | null {
 }
 
 interface JournalOwner {
+  connectionId: null | string
   key: string
   profile: string
 }
 
-function journalOwner(storedSessionId: string, profile: null | string | undefined): JournalOwner | null {
+function journalOwner(
+  storedSessionId: string,
+  profile: null | string | undefined,
+  connectionId: null | string | undefined
+): JournalOwner | null {
   if (profile === null || profile === undefined) {
     return null
   }
 
   try {
     const normalizedProfile = normalizeProfileKey(profile)
-    const encoded = `${encodeURIComponent(normalizedProfile)}:${encodeURIComponent(storedSessionId)}`
+    const normalizedConnectionId = connectionId?.trim() || null
+    const encoded = `${encodeURIComponent(normalizedConnectionId ?? '')}:${encodeURIComponent(normalizedProfile)}:${encodeURIComponent(storedSessionId)}`
 
     return storedSessionId && encoded.length <= MAX_SESSION_KEY_CHARS
-      ? { key: `${STORAGE_PREFIX}${encoded}`, profile: normalizedProfile }
+      ? { connectionId: normalizedConnectionId, key: `${STORAGE_PREFIX}${encoded}`, profile: normalizedProfile }
       : null
   } catch {
     return null
@@ -174,6 +183,7 @@ function isSnapshot(value: unknown): value is InFlightTurnSnapshot {
           (Array.isArray(message.attachmentRefs) && message.attachmentRefs.every(ref => typeof ref === 'string'))) &&
         (message.rowId === undefined || (typeof message.rowId === 'number' && Number.isFinite(message.rowId)))
     ) &&
+    (snapshot.connectionId === null || typeof snapshot.connectionId === 'string') &&
     typeof snapshot.profile === 'string' &&
     snapshot.profile === normalizeProfileKey(snapshot.profile) &&
     (snapshot.streamId === null || typeof snapshot.streamId === 'string') &&
@@ -183,7 +193,10 @@ function isSnapshot(value: unknown): value is InFlightTurnSnapshot {
   )
 }
 
-function parseSnapshot(raw: string, expectedProfile?: string): InFlightTurnSnapshot | null {
+function parseSnapshot(
+  raw: string,
+  expectedOwner?: Pick<JournalOwner, 'connectionId' | 'profile'>
+): InFlightTurnSnapshot | null {
   if (raw.length > MAX_ENTRY_CHARS) {
     return null
   }
@@ -191,7 +204,26 @@ function parseSnapshot(raw: string, expectedProfile?: string): InFlightTurnSnaps
   try {
     const parsed = JSON.parse(raw)
 
-    return isSnapshot(parsed) && (expectedProfile === undefined || parsed.profile === expectedProfile) ? parsed : null
+    return isSnapshot(parsed) &&
+      (expectedOwner === undefined ||
+        (parsed.profile === expectedOwner.profile && parsed.connectionId === expectedOwner.connectionId))
+      ? parsed
+      : null
+  } catch {
+    return null
+  }
+}
+
+function parseLegacySnapshot(raw: string): InFlightTurnSnapshot | null {
+  if (raw.length > MAX_ENTRY_CHARS) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<InFlightTurnSnapshot>
+    const candidate = { ...parsed, connectionId: null }
+
+    return isSnapshot(candidate) ? candidate : null
   } catch {
     return null
   }
@@ -407,6 +439,7 @@ function migrateLegacyStore(store: Storage): void {
 
   const candidates: Array<[string, InFlightTurnSnapshot]> = []
   const legacySessionKeys: string[] = []
+  const legacyProfileSessionKeys: string[] = []
 
   try {
     for (let index = 0; index < store.length; index += 1) {
@@ -414,6 +447,8 @@ function migrateLegacyStore(store: Storage): void {
 
       if (key?.startsWith(LEGACY_STORAGE_PREFIX)) {
         legacySessionKeys.push(key)
+      } else if (key?.startsWith(LEGACY_PROFILE_STORAGE_PREFIX)) {
+        legacyProfileSessionKeys.push(key)
       }
     }
   } catch {
@@ -430,11 +465,35 @@ function migrateLegacyStore(store: Storage): void {
 
     try {
       const storedSessionId = decodeURIComponent(key.slice(LEGACY_STORAGE_PREFIX.length))
-      const snapshot = parseSnapshot(raw)
+      const snapshot = parseLegacySnapshot(raw)
 
       // Bare-id v2 keys are ambiguous across profiles. Only an embedded,
       // canonical profile proves their owner strongly enough to migrate.
       if (storedSessionId && snapshot && !isExpired(snapshot)) {
+        candidates.push([storedSessionId, snapshot])
+      }
+    } catch {
+      // Malformed legacy keys/snapshots fail closed and stay discarded.
+    }
+  }
+
+  for (const key of legacyProfileSessionKeys) {
+    const raw = readRaw(store, key)
+    removeRaw(store, key)
+
+    if (!raw || raw === DISCARDED_SNAPSHOT_RAW) {
+      continue
+    }
+
+    try {
+      const [encodedProfile, encodedStoredSessionId] = key.slice(LEGACY_PROFILE_STORAGE_PREFIX.length).split(':')
+      const profile = normalizeProfileKey(decodeURIComponent(encodedProfile))
+      const storedSessionId = decodeURIComponent(encodedStoredSessionId)
+      const snapshot = parseLegacySnapshot(raw)
+
+      // Profile-qualified v3 data is still connection-ambiguous. Preserve it
+      // only in the untagged-primary namespace; known registry owners cannot read it.
+      if (storedSessionId && snapshot?.profile === profile && !isExpired(snapshot)) {
         candidates.push([storedSessionId, snapshot])
       }
     } catch {
@@ -458,8 +517,13 @@ function migrateLegacyStore(store: Storage): void {
         for (const [storedSessionId, candidate] of Object.entries(parsed.entries)) {
           // The v1 aggregate was keyed by bare stored id too. As above, accept
           // only records carrying their own canonical profile provenance.
-          if (isSnapshot(candidate) && !isExpired(candidate)) {
-            candidates.push([storedSessionId, candidate])
+          const snapshot =
+            candidate && typeof candidate === 'object'
+              ? ({ ...candidate, connectionId: null } as InFlightTurnSnapshot)
+              : null
+
+          if (isSnapshot(snapshot) && !isExpired(snapshot)) {
+            candidates.push([storedSessionId, snapshot])
           }
         }
       }
@@ -485,7 +549,7 @@ function migrateLegacyStore(store: Storage): void {
   for (const [storedSessionId, snapshot] of candidates
     .sort((left, right) => right[1].updatedAt - left[1].updatedAt)
     .slice(0, Math.max(0, MAX_ENTRIES - existingKeys.size))) {
-    const owner = journalOwner(storedSessionId, snapshot.profile)
+    const owner = journalOwner(storedSessionId, snapshot.profile, snapshot.connectionId)
     const messages = boundedMessages(snapshot.messages)
     const value = messages ? serializeSnapshot({ ...snapshot, messages }) : null
 
@@ -503,9 +567,13 @@ function discardSnapshot(store: Storage, key: string): void {
   removeRaw(store, key)
 }
 
-function readSnapshot(storedSessionId: string, profile: null | string): InFlightTurnSnapshot | null {
+function readSnapshot(
+  storedSessionId: string,
+  profile: null | string,
+  connectionId: null | string
+): InFlightTurnSnapshot | null {
   const store = storage()
-  const owner = journalOwner(storedSessionId, profile)
+  const owner = journalOwner(storedSessionId, profile, connectionId)
 
   if (!store || !owner) {
     return null
@@ -524,7 +592,7 @@ function readSnapshot(storedSessionId: string, profile: null | string): InFlight
     return null
   }
 
-  const snapshot = parseSnapshot(raw, owner.profile)
+  const snapshot = parseSnapshot(raw, owner)
 
   if (!snapshot || isExpired(snapshot)) {
     discardSnapshot(store, owner.key)
@@ -535,9 +603,9 @@ function readSnapshot(storedSessionId: string, profile: null | string): InFlight
   return snapshot
 }
 
-function removeSnapshot(storedSessionId: string, profile: null | string): void {
+function removeSnapshot(storedSessionId: string, profile: null | string, connectionId: null | string): void {
   const store = storage()
-  const owner = journalOwner(storedSessionId, profile)
+  const owner = journalOwner(storedSessionId, profile, connectionId)
 
   if (store && owner) {
     sweepSessionStore(store)
@@ -913,13 +981,14 @@ function writeSnapshot(owner: JournalOwner, state: JournalableSessionState): voi
 
   if (!messages) {
     // Keep the timer write path free of aggregate migration. This tiny invalid
-    // v3 value suppresses stale owner-scoped state until read/settle removes it.
+    // v4 value suppresses stale owner-scoped state until read/settle removes it.
     tombstoneUnlessRecoverable(store, owner.key)
 
     return
   }
 
   const raw = serializeSnapshot({
+    connectionId: owner.connectionId,
     messages,
     profile: owner.profile,
     streamId: state.streamId,
@@ -966,7 +1035,7 @@ export function persistInFlightTurnState(state: JournalableSessionState): void {
     return
   }
 
-  const owner = journalOwner(storedSessionId, state.profile)
+  const owner = journalOwner(storedSessionId, state.profile, state.connectionId)
 
   // Unknown provenance must never fall back to the mutable active profile.
   if (!owner) {
@@ -974,7 +1043,7 @@ export function persistInFlightTurnState(state: JournalableSessionState): void {
   }
 
   if (!state.busy && !state.awaitingResponse && !state.streamId) {
-    clearInFlightTurnJournal(storedSessionId, owner.profile)
+    clearInFlightTurnJournal(storedSessionId, owner.profile, owner.connectionId)
 
     return
   }
@@ -1002,13 +1071,14 @@ export function persistInFlightTurnState(state: JournalableSessionState): void {
 
 export function readInFlightTurnJournal(
   storedSessionId: null | string,
-  profile: null | string
+  profile: null | string,
+  connectionId: null | string
 ): InFlightTurnSnapshot | null {
   if (!storedSessionId) {
     return null
   }
 
-  return readSnapshot(storedSessionId, profile)
+  return readSnapshot(storedSessionId, profile, connectionId)
 }
 
 /** Fold a journaled in-flight tail back onto a restored transcript. A no-op
@@ -1016,10 +1086,11 @@ export function readInFlightTurnJournal(
 export function recoverInFlightTurnJournal(
   storedSessionId: null | string,
   profile: null | string,
+  connectionId: null | string,
   baseMessages: ChatMessage[],
   options: { keepPending?: boolean } = {}
 ): InFlightRecoveryResult {
-  const snapshot = readInFlightTurnJournal(storedSessionId, profile)
+  const snapshot = readInFlightTurnJournal(storedSessionId, profile, connectionId)
 
   if (!snapshot) {
     return {
@@ -1034,7 +1105,7 @@ export function recoverInFlightTurnJournal(
   const recovered = mergeInFlightMessages(baseMessages, snapshot.messages, options)
 
   if (recovered.caughtUp) {
-    clearInFlightTurnJournal(storedSessionId, profile)
+    clearInFlightTurnJournal(storedSessionId, profile, connectionId)
   }
 
   return {
@@ -1048,12 +1119,16 @@ export function recoverInFlightTurnJournal(
   }
 }
 
-export function clearInFlightTurnJournal(storedSessionId: null | string, profile: null | string): void {
+export function clearInFlightTurnJournal(
+  storedSessionId: null | string,
+  profile: null | string,
+  connectionId: null | string
+): void {
   if (!storedSessionId) {
     return
   }
 
-  const owner = journalOwner(storedSessionId, profile)
+  const owner = journalOwner(storedSessionId, profile, connectionId)
 
   if (!owner) {
     return
@@ -1068,5 +1143,5 @@ export function clearInFlightTurnJournal(storedSessionId: null | string, profile
 
   persistLatest.delete(owner.key)
 
-  removeSnapshot(storedSessionId, owner.profile)
+  removeSnapshot(storedSessionId, owner.profile, owner.connectionId)
 }

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -1,4 +1,5 @@
 import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/chat-messages'
+import { normalizeProfileKey } from '@/store/profile'
 
 /**
  * Crash-survivable in-flight turn journal.
@@ -17,13 +18,14 @@ import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/c
  */
 
 const LEGACY_STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
-const STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v2:'
-const LEGACY_MIGRATION_KEY = 'hermes.desktop.inflightTurnJournal.v2.migrated'
+const LEGACY_STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v2:'
+const STORAGE_PREFIX = 'hermes.desktop.inflightTurnJournal.v3:'
+const LEGACY_MIGRATION_KEY = 'hermes.desktop.inflightTurnJournal.v3.migrated'
 const DISCARDED_SNAPSHOT_RAW = '0'
 const STORE_VERSION = 1
 const MAX_SESSION_STORE_CHARS = 4 * 1024 * 1024
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
-// Keep the worst-case v2 namespace below a conservative localStorage budget
+// Keep the worst-case v3 namespace below a conservative localStorage budget
 // while retaining the 24 newest session slots for ordinary small snapshots.
 const MAX_ENTRY_CHARS = 160 * 1024
 const MAX_ENTRIES = Math.min(24, Math.floor(MAX_SESSION_STORE_CHARS / MAX_ENTRY_CHARS))
@@ -40,12 +42,13 @@ const MAX_USER_ATTACHMENT_REF_CHARS = 64 * 1024
 const PERSIST_THROTTLE_MS = 400
 
 // A renderer can accumulate one entry per session over its lifetime. Sweep the
-// bounded v2 namespace once on first journal access; never scan it on the
+// bounded v3 namespace once on first journal access; never scan it on the
 // 400ms streaming write path.
 let sessionStoreSwept = false
 
 export interface InFlightTurnSnapshot {
   messages: ChatMessage[]
+  profile: string
   streamId: null | string
   turnStartedAt: null | number
   updatedAt: number
@@ -55,6 +58,7 @@ export interface JournalableSessionState {
   awaitingResponse: boolean
   busy: boolean
   messages: ChatMessage[]
+  profile: null | string
   storedSessionId: null | string
   streamId: null | string
   turnStartedAt: null | number
@@ -83,11 +87,23 @@ function storage(): Storage | null {
   }
 }
 
-function sessionStorageKey(storedSessionId: string): null | string {
-  try {
-    const encoded = encodeURIComponent(storedSessionId)
+interface JournalOwner {
+  key: string
+  profile: string
+}
 
-    return encoded.length > 0 && encoded.length <= MAX_SESSION_KEY_CHARS ? `${STORAGE_PREFIX}${encoded}` : null
+function journalOwner(storedSessionId: string, profile: null | string | undefined): JournalOwner | null {
+  if (profile === null || profile === undefined) {
+    return null
+  }
+
+  try {
+    const normalizedProfile = normalizeProfileKey(profile)
+    const encoded = `${encodeURIComponent(normalizedProfile)}:${encodeURIComponent(storedSessionId)}`
+
+    return storedSessionId && encoded.length <= MAX_SESSION_KEY_CHARS
+      ? { key: `${STORAGE_PREFIX}${encoded}`, profile: normalizedProfile }
+      : null
   } catch {
     return null
   }
@@ -158,6 +174,8 @@ function isSnapshot(value: unknown): value is InFlightTurnSnapshot {
           (Array.isArray(message.attachmentRefs) && message.attachmentRefs.every(ref => typeof ref === 'string'))) &&
         (message.rowId === undefined || (typeof message.rowId === 'number' && Number.isFinite(message.rowId)))
     ) &&
+    typeof snapshot.profile === 'string' &&
+    snapshot.profile === normalizeProfileKey(snapshot.profile) &&
     (snapshot.streamId === null || typeof snapshot.streamId === 'string') &&
     (snapshot.turnStartedAt === null || typeof snapshot.turnStartedAt === 'number') &&
     typeof snapshot.updatedAt === 'number' &&
@@ -165,7 +183,7 @@ function isSnapshot(value: unknown): value is InFlightTurnSnapshot {
   )
 }
 
-function parseSnapshot(raw: string): InFlightTurnSnapshot | null {
+function parseSnapshot(raw: string, expectedProfile?: string): InFlightTurnSnapshot | null {
   if (raw.length > MAX_ENTRY_CHARS) {
     return null
   }
@@ -173,7 +191,7 @@ function parseSnapshot(raw: string): InFlightTurnSnapshot | null {
   try {
     const parsed = JSON.parse(raw)
 
-    return isSnapshot(parsed) ? parsed : null
+    return isSnapshot(parsed) && (expectedProfile === undefined || parsed.profile === expectedProfile) ? parsed : null
   } catch {
     return null
   }
@@ -381,108 +399,135 @@ function migrateLegacyStore(store: Storage): void {
     return
   }
 
-  const raw = readRaw(store, LEGACY_STORAGE_KEY)
-
-  if (raw === null) {
-    return
-  }
-
-  // Claim the migration before touching the aggregate. If storage is failing,
-  // skip legacy recovery rather than retrying an expensive parse on every read.
+  // Claim the migration before touching legacy state. If storage is failing,
+  // skip recovery rather than retrying expensive parsing on every read.
   if (!writeRaw(store, LEGACY_MIGRATION_KEY, '1')) {
     return
   }
 
-  // Release the multi-megabyte aggregate before allocating per-session v2
-  // entries. The captured string remains available for this one migration.
-  removeRaw(store, LEGACY_STORAGE_KEY)
-
-  if (!raw) {
-    return
-  }
-
-  if (raw.length > MAX_LEGACY_STORE_CHARS) {
-    return
-  }
+  const candidates: Array<[string, InFlightTurnSnapshot]> = []
+  const legacySessionKeys: string[] = []
 
   try {
-    const parsed = JSON.parse(raw) as Partial<JournalStore>
+    for (let index = 0; index < store.length; index += 1) {
+      const key = store.key(index)
 
-    if (
-      parsed.version !== STORE_VERSION ||
-      !parsed.entries ||
-      typeof parsed.entries !== 'object' ||
-      Array.isArray(parsed.entries)
-    ) {
-      return
+      if (key?.startsWith(LEGACY_STORAGE_PREFIX)) {
+        legacySessionKeys.push(key)
+      }
+    }
+  } catch {
+    // Enumeration failed: the aggregate path below can still be discarded.
+  }
+
+  for (const key of legacySessionKeys) {
+    const raw = readRaw(store, key)
+    removeRaw(store, key)
+
+    if (!raw || raw === DISCARDED_SNAPSHOT_RAW) {
+      continue
     }
 
-    const existingV2Keys = new Set<string>()
+    try {
+      const storedSessionId = decodeURIComponent(key.slice(LEGACY_STORAGE_PREFIX.length))
+      const snapshot = parseSnapshot(raw)
 
+      // Bare-id v2 keys are ambiguous across profiles. Only an embedded,
+      // canonical profile proves their owner strongly enough to migrate.
+      if (storedSessionId && snapshot && !isExpired(snapshot)) {
+        candidates.push([storedSessionId, snapshot])
+      }
+    } catch {
+      // Malformed legacy keys/snapshots fail closed and stay discarded.
+    }
+  }
+
+  const aggregateRaw = readRaw(store, LEGACY_STORAGE_KEY)
+  removeRaw(store, LEGACY_STORAGE_KEY)
+
+  if (aggregateRaw && aggregateRaw.length <= MAX_LEGACY_STORE_CHARS) {
+    try {
+      const parsed = JSON.parse(aggregateRaw) as Partial<JournalStore>
+
+      if (
+        parsed.version === STORE_VERSION &&
+        parsed.entries &&
+        typeof parsed.entries === 'object' &&
+        !Array.isArray(parsed.entries)
+      ) {
+        for (const [storedSessionId, candidate] of Object.entries(parsed.entries)) {
+          // The v1 aggregate was keyed by bare stored id too. As above, accept
+          // only records carrying their own canonical profile provenance.
+          if (isSnapshot(candidate) && !isExpired(candidate)) {
+            candidates.push([storedSessionId, candidate])
+          }
+        }
+      }
+    } catch {
+      // Malformed aggregate data is discarded.
+    }
+  }
+
+  const existingKeys = new Set<string>()
+
+  try {
     for (let index = 0; index < store.length; index += 1) {
       const key = store.key(index)
 
       if (key?.startsWith(STORAGE_PREFIX)) {
-        existingV2Keys.add(key)
-      }
-    }
-
-    const entries = Object.entries(parsed.entries)
-      .filter((entry): entry is [string, InFlightTurnSnapshot] => isSnapshot(entry[1]) && !isExpired(entry[1]))
-      .sort((a, b) => b[1].updatedAt - a[1].updatedAt)
-      .slice(0, Math.max(0, MAX_ENTRIES - existingV2Keys.size))
-
-    for (const [storedSessionId, snapshot] of entries) {
-      const key = sessionStorageKey(storedSessionId)
-      const messages = boundedMessages(snapshot.messages)
-      const value = messages ? serializeSnapshot({ ...snapshot, messages }) : null
-
-      // A v2 snapshot may have been written before the one-shot migration ran.
-      // Never replace newer per-session state with its stale v1 predecessor.
-      if (key && value && readRaw(store, key) === null) {
-        if (writeRaw(store, key, value)) {
-          existingV2Keys.add(key)
-        }
+        existingKeys.add(key)
       }
     }
   } catch {
-    // Malformed legacy data is discarded below.
+    return
+  }
+
+  for (const [storedSessionId, snapshot] of candidates
+    .sort((left, right) => right[1].updatedAt - left[1].updatedAt)
+    .slice(0, Math.max(0, MAX_ENTRIES - existingKeys.size))) {
+    const owner = journalOwner(storedSessionId, snapshot.profile)
+    const messages = boundedMessages(snapshot.messages)
+    const value = messages ? serializeSnapshot({ ...snapshot, messages }) : null
+
+    if (owner && value && readRaw(store, owner.key) === null && writeRaw(store, owner.key, value)) {
+      existingKeys.add(owner.key)
+    }
   }
 }
 
 function discardSnapshot(store: Storage, key: string): void {
-  // Migrate first so an existing v2 key suppresses its stale v1 predecessor,
-  // then remove the current session. This keeps every discard path from
-  // resurrecting legacy state on a later read.
+  // Migrate first, then remove the current profile-qualified session. This
+  // keeps every discard path from resurrecting owner-proven legacy state on a
+  // later read while ambiguous bare-id state remains discarded.
   migrateLegacyStore(store)
   removeRaw(store, key)
 }
 
-function readSnapshot(storedSessionId: string): InFlightTurnSnapshot | null {
+function readSnapshot(storedSessionId: string, profile: null | string): InFlightTurnSnapshot | null {
   const store = storage()
-  const key = sessionStorageKey(storedSessionId)
+  const owner = journalOwner(storedSessionId, profile)
 
-  if (!store || !key) {
+  if (!store || !owner) {
     return null
   }
 
   sweepSessionStore(store)
 
-  let raw = readRaw(store, key)
+  let raw = readRaw(store, owner.key)
 
   if (!raw) {
     migrateLegacyStore(store)
-    raw = readRaw(store, key)
+    raw = readRaw(store, owner.key)
   }
 
   if (!raw) {
     return null
   }
 
-  const snapshot = parseSnapshot(raw)
+  const snapshot = parseSnapshot(raw, owner.profile)
 
   if (!snapshot || isExpired(snapshot)) {
-    discardSnapshot(store, key)
+    discardSnapshot(store, owner.key)
 
     return null
   }
@@ -490,17 +535,17 @@ function readSnapshot(storedSessionId: string): InFlightTurnSnapshot | null {
   return snapshot
 }
 
-function removeSnapshot(storedSessionId: string): void {
+function removeSnapshot(storedSessionId: string, profile: null | string): void {
   const store = storage()
-  const key = sessionStorageKey(storedSessionId)
+  const owner = journalOwner(storedSessionId, profile)
 
-  if (store && key) {
+  if (store && owner) {
     sweepSessionStore(store)
 
     // Settling a session before the one-shot migration must clear its legacy
     // entry too; otherwise a later read can migrate and resurrect stale state.
     // This aggregate parse is terminal-transition work, never a stream write.
-    discardSnapshot(store, key)
+    discardSnapshot(store, owner.key)
   }
 }
 
@@ -849,7 +894,7 @@ export function resetInFlightTurnJournalStateForTests(): void {
   sessionStoreSwept = false
 }
 
-function writeSnapshot(storedSessionId: string, state: JournalableSessionState): void {
+function writeSnapshot(owner: JournalOwner, state: JournalableSessionState): void {
   const tail = recoverableTail(state.messages, state.streamId)
 
   if (tail.length === 0) {
@@ -857,9 +902,8 @@ function writeSnapshot(storedSessionId: string, state: JournalableSessionState):
   }
 
   const store = storage()
-  const key = sessionStorageKey(storedSessionId)
 
-  if (!store || !key) {
+  if (!store) {
     return
   }
 
@@ -869,15 +913,15 @@ function writeSnapshot(storedSessionId: string, state: JournalableSessionState):
 
   if (!messages) {
     // Keep the timer write path free of aggregate migration. This tiny invalid
-    // v2 value suppresses the stale v1 predecessor until read/settle performs
-    // the one-shot migration and removes it.
-    tombstoneUnlessRecoverable(store, key)
+    // v3 value suppresses stale owner-scoped state until read/settle removes it.
+    tombstoneUnlessRecoverable(store, owner.key)
 
     return
   }
 
   const raw = serializeSnapshot({
     messages,
+    profile: owner.profile,
     streamId: state.streamId,
     turnStartedAt: state.turnStartedAt,
     updatedAt: Date.now()
@@ -885,17 +929,15 @@ function writeSnapshot(storedSessionId: string, state: JournalableSessionState):
 
   if (!raw) {
     // Preserve an older bounded snapshot if the newest assistant row alone is
-    // too large. A tombstone is only needed when there is no recoverable v2
-    // value, so stale v1 state cannot be resurrected on a later read.
-    tombstoneUnlessRecoverable(store, key)
+    // too large. A tombstone is only needed when there is no recoverable value.
+    tombstoneUnlessRecoverable(store, owner.key)
 
     return
   }
 
-  if (!writeRaw(store, key, raw)) {
-    // A quota failure must not leave an older, misleading snapshot behind, or
-    // let the stale v1 predecessor be resurrected on a later read.
-    tombstoneUnlessRecoverable(store, key)
+  if (!writeRaw(store, owner.key, raw)) {
+    // A quota failure must not leave an older, misleading snapshot behind.
+    tombstoneUnlessRecoverable(store, owner.key)
   }
 }
 
@@ -924,49 +966,60 @@ export function persistInFlightTurnState(state: JournalableSessionState): void {
     return
   }
 
+  const owner = journalOwner(storedSessionId, state.profile)
+
+  // Unknown provenance must never fall back to the mutable active profile.
+  if (!owner) {
+    return
+  }
+
   if (!state.busy && !state.awaitingResponse && !state.streamId) {
-    clearInFlightTurnJournal(storedSessionId)
+    clearInFlightTurnJournal(storedSessionId, owner.profile)
 
     return
   }
 
-  persistLatest.set(storedSessionId, state)
+  persistLatest.set(owner.key, state)
 
-  if (persistTimers.has(storedSessionId)) {
+  if (persistTimers.has(owner.key)) {
     return
   }
 
   persistTimers.set(
-    storedSessionId,
+    owner.key,
     setTimeout(() => {
-      persistTimers.delete(storedSessionId)
-      const latest = persistLatest.get(storedSessionId)
+      persistTimers.delete(owner.key)
+      const latest = persistLatest.get(owner.key)
 
-      persistLatest.delete(storedSessionId)
+      persistLatest.delete(owner.key)
 
       if (latest) {
-        writeSnapshot(storedSessionId, latest)
+        writeSnapshot(owner, latest)
       }
     }, PERSIST_THROTTLE_MS)
   )
 }
 
-export function readInFlightTurnJournal(storedSessionId: null | string): InFlightTurnSnapshot | null {
+export function readInFlightTurnJournal(
+  storedSessionId: null | string,
+  profile: null | string
+): InFlightTurnSnapshot | null {
   if (!storedSessionId) {
     return null
   }
 
-  return readSnapshot(storedSessionId)
+  return readSnapshot(storedSessionId, profile)
 }
 
 /** Fold a journaled in-flight tail back onto a restored transcript. A no-op
  *  returns `baseMessages` by reference so callers keep their fast-path ref. */
 export function recoverInFlightTurnJournal(
   storedSessionId: null | string,
+  profile: null | string,
   baseMessages: ChatMessage[],
   options: { keepPending?: boolean } = {}
 ): InFlightRecoveryResult {
-  const snapshot = readInFlightTurnJournal(storedSessionId)
+  const snapshot = readInFlightTurnJournal(storedSessionId, profile)
 
   if (!snapshot) {
     return {
@@ -981,7 +1034,7 @@ export function recoverInFlightTurnJournal(
   const recovered = mergeInFlightMessages(baseMessages, snapshot.messages, options)
 
   if (recovered.caughtUp) {
-    clearInFlightTurnJournal(storedSessionId)
+    clearInFlightTurnJournal(storedSessionId, profile)
   }
 
   return {
@@ -995,19 +1048,25 @@ export function recoverInFlightTurnJournal(
   }
 }
 
-export function clearInFlightTurnJournal(storedSessionId: null | string): void {
+export function clearInFlightTurnJournal(storedSessionId: null | string, profile: null | string): void {
   if (!storedSessionId) {
     return
   }
 
-  const timer = persistTimers.get(storedSessionId)
+  const owner = journalOwner(storedSessionId, profile)
+
+  if (!owner) {
+    return
+  }
+
+  const timer = persistTimers.get(owner.key)
 
   if (timer) {
     clearTimeout(timer)
-    persistTimers.delete(storedSessionId)
+    persistTimers.delete(owner.key)
   }
 
-  persistLatest.delete(storedSessionId)
+  persistLatest.delete(owner.key)
 
-  removeSnapshot(storedSessionId)
+  removeSnapshot(storedSessionId, owner.profile)
 }

--- a/apps/desktop/src/store/cron.test.ts
+++ b/apps/desktop/src/store/cron.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { $cronJobs, beginCronJobsRequest, commitCronJobsRequest, setCronJobs, updateCronJobs } from './cron'
+import { $cronJobs, beginCronJobsRequest, commitCronJobsRequest, cronJobIdentity, setCronJobs, updateCronJobs } from './cron'
 
 const oldJob = { id: 'old' } as never
 const newJob = { id: 'new' } as never
@@ -35,5 +35,13 @@ describe('cron jobs request fencing', () => {
 
     expect(commitCronJobsRequest(poll, [oldJob])).toBe(false)
     expect($cronJobs.get()).toEqual([newJob])
+  })
+})
+
+describe('cron job owner identity', () => {
+  it('keeps duplicate job ids in different profiles distinct', () => {
+    expect(cronJobIdentity({ id: 'shared-job', profile: 'worker_alpha' })).not.toBe(
+      cronJobIdentity({ id: 'shared-job', profile: 'worker_beta' })
+    )
   })
 })

--- a/apps/desktop/src/store/cron.test.ts
+++ b/apps/desktop/src/store/cron.test.ts
@@ -48,6 +48,18 @@ describe('cron jobs request fencing', () => {
 })
 
 describe('cron job owner identity', () => {
+  it('keeps the same profile and job id on two connections distinct', () => {
+    const a = { connection_id: 'connection-a', id: 'shared-job', profile: 'default' }
+    const b = { connection_id: 'connection-b', id: 'shared-job', profile: 'default' }
+
+    expect(cronJobIdentity(a)).not.toBe(cronJobIdentity(b))
+    expect(removeCronJobForOwner([a, b] as never, a as never)).toEqual([b])
+    expect(replaceCronJobForOwner([a, b] as never, a as never, { ...a, state: 'paused' } as never)).toEqual([
+      { ...a, state: 'paused' },
+      b
+    ])
+  })
+
   it('keeps duplicate job ids in different profiles distinct', () => {
     expect(cronJobIdentity({ id: 'shared-job', profile: 'worker_alpha' })).not.toBe(
       cronJobIdentity({ id: 'shared-job', profile: 'worker_beta' })

--- a/apps/desktop/src/store/cron.test.ts
+++ b/apps/desktop/src/store/cron.test.ts
@@ -1,6 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { $cronJobs, beginCronJobsRequest, commitCronJobsRequest, cronJobIdentity, setCronJobs, updateCronJobs } from './cron'
+import {
+  $cronJobs,
+  beginCronJobsRequest,
+  commitCronJobsRequest,
+  cronJobIdentity,
+  removeCronJobForOwner,
+  replaceCronJobForOwner,
+  setCronJobs,
+  updateCronJobs
+} from './cron'
 
 const oldJob = { id: 'old' } as never
 const newJob = { id: 'new' } as never
@@ -43,5 +52,23 @@ describe('cron job owner identity', () => {
     expect(cronJobIdentity({ id: 'shared-job', profile: 'worker_alpha' })).not.toBe(
       cronJobIdentity({ id: 'shared-job', profile: 'worker_beta' })
     )
+  })
+
+  it('replaces only the matching profile when duplicate ids coexist', () => {
+    const alpha = { id: 'shared-job', profile: 'worker_alpha', state: 'scheduled' }
+    const beta = { id: 'shared-job', profile: 'worker_beta', state: 'scheduled' }
+    const pausedAlpha = { ...alpha, state: 'paused' }
+
+    expect(replaceCronJobForOwner([alpha, beta] as never, alpha as never, pausedAlpha as never)).toEqual([
+      pausedAlpha,
+      beta
+    ])
+  })
+
+  it('deletes only the matching profile when duplicate ids coexist', () => {
+    const alpha = { id: 'shared-job', profile: 'worker_alpha' }
+    const beta = { id: 'shared-job', profile: 'worker_beta' }
+
+    expect(removeCronJobForOwner([alpha, beta] as never, alpha as never)).toEqual([beta])
   })
 })

--- a/apps/desktop/src/store/cron.ts
+++ b/apps/desktop/src/store/cron.ts
@@ -4,7 +4,7 @@ import type { CronJob } from '@/types/hermes'
 
 // Cron *jobs* (not run sessions) power the sidebar "Cron jobs" section. Listing
 // the job — schedule, state, live next-run countdown — makes the job the
-// first-class entity; its runs (sessions) resolve under it in the cron detail.
+// first-class entity; its durable outputs resolve under it in the cron detail.
 export const $cronJobs = atom<CronJob[]>([])
 
 export interface CronJobsRequest {
@@ -85,8 +85,16 @@ export const updateCronJobs = (fn: (jobs: CronJob[]) => CronJob[]) => {
 // One-shot focus target: clicking "Manage" on a job sets this, then opens the
 // cron overlay, which reads it once to select + scroll to that job. Cleared
 // after consumption so re-opening cron normally doesn't re-focus a stale job.
-export const $cronFocusJobId = atom<null | string>(null)
-export const setCronFocusJobId = (id: null | string) => $cronFocusJobId.set(id)
+export interface CronFocusTarget {
+  jobId: string
+  outputId?: string
+  profile?: string
+}
+
+export const $cronFocus = atom<CronFocusTarget | null>(null)
+export const setCronFocusJobId = (id: null | string) => $cronFocus.set(id ? { jobId: id } : null)
+export const setCronFocusOutput = (jobId: string, outputId: string, profile?: string) =>
+  $cronFocus.set({ jobId, outputId, profile })
 
 // Shell-owned one-shot intent for stores without router context. Do not set a
 // focus id here: the cron overlay's first fetch may not have loaded that row.

--- a/apps/desktop/src/store/cron.ts
+++ b/apps/desktop/src/store/cron.ts
@@ -8,9 +8,14 @@ import type { CronJob } from '@/types/hermes'
 export const $cronJobs = atom<CronJob[]>([])
 
 /** Stable owner-qualified identity for aggregated cross-profile job lists. */
-export function cronJobIdentity(job: Pick<CronJob, 'id' | 'profile'>): string {
-  return JSON.stringify([job.profile?.trim() || 'default', job.id])
+export function cronJobIdentity(job: Pick<CronJob, 'connection_id' | 'id' | 'profile'>): string {
+  return JSON.stringify([job.connection_id?.trim() || '', job.profile?.trim() || 'default', job.id])
 }
+
+export const cronJobOwner = (job: Pick<CronJob, 'connection_id' | 'profile'>) => ({
+  connectionId: job.connection_id ?? null,
+  profile: job.profile
+})
 
 export interface CronJobsRequest {
   generation: number
@@ -105,16 +110,17 @@ export function removeCronJobForOwner(jobs: CronJob[], target: CronJob): CronJob
 // cron overlay, which reads it once to select + scroll to that job. Cleared
 // after consumption so re-opening cron normally doesn't re-focus a stale job.
 export interface CronFocusTarget {
+  connectionId?: null | string
   jobId: string
   outputId?: string
   profile?: string
 }
 
 export const $cronFocus = atom<CronFocusTarget | null>(null)
-export const setCronFocusJobId = (id: null | string, profile?: string) =>
-  $cronFocus.set(id ? { jobId: id, profile } : null)
-export const setCronFocusOutput = (jobId: string, outputId: string, profile?: string) =>
-  $cronFocus.set({ jobId, outputId, profile })
+export const setCronFocusJobId = (id: null | string, profile?: string, connectionId?: null | string) =>
+  $cronFocus.set(id ? { connectionId, jobId: id, profile } : null)
+export const setCronFocusOutput = (jobId: string, outputId: string, profile?: string, connectionId?: null | string) =>
+  $cronFocus.set({ connectionId, jobId, outputId, profile })
 
 // Shell-owned one-shot intent for stores without router context. Do not set a
 // focus id here: the cron overlay's first fetch may not have loaded that row.

--- a/apps/desktop/src/store/cron.ts
+++ b/apps/desktop/src/store/cron.ts
@@ -87,6 +87,20 @@ export const updateCronJobs = (fn: (jobs: CronJob[]) => CronJob[]) => {
   $cronJobs.set(fn($cronJobs.get()))
 }
 
+/** Sidebar mutation projections kept pure so duplicate-id behavior stays
+ * deterministic under the aggregated all-profile list. */
+export function replaceCronJobForOwner(jobs: CronJob[], target: CronJob, replacement: CronJob): CronJob[] {
+  const targetIdentity = cronJobIdentity(target)
+
+  return jobs.map(job => (cronJobIdentity(job) === targetIdentity ? replacement : job))
+}
+
+export function removeCronJobForOwner(jobs: CronJob[], target: CronJob): CronJob[] {
+  const targetIdentity = cronJobIdentity(target)
+
+  return jobs.filter(job => cronJobIdentity(job) !== targetIdentity)
+}
+
 // One-shot focus target: clicking "Manage" on a job sets this, then opens the
 // cron overlay, which reads it once to select + scroll to that job. Cleared
 // after consumption so re-opening cron normally doesn't re-focus a stale job.

--- a/apps/desktop/src/store/cron.ts
+++ b/apps/desktop/src/store/cron.ts
@@ -7,6 +7,11 @@ import type { CronJob } from '@/types/hermes'
 // first-class entity; its durable outputs resolve under it in the cron detail.
 export const $cronJobs = atom<CronJob[]>([])
 
+/** Stable owner-qualified identity for aggregated cross-profile job lists. */
+export function cronJobIdentity(job: Pick<CronJob, 'id' | 'profile'>): string {
+  return JSON.stringify([job.profile?.trim() || 'default', job.id])
+}
+
 export interface CronJobsRequest {
   generation: number
   scope: string
@@ -92,7 +97,8 @@ export interface CronFocusTarget {
 }
 
 export const $cronFocus = atom<CronFocusTarget | null>(null)
-export const setCronFocusJobId = (id: null | string) => $cronFocus.set(id ? { jobId: id } : null)
+export const setCronFocusJobId = (id: null | string, profile?: string) =>
+  $cronFocus.set(id ? { jobId: id, profile } : null)
 export const setCronFocusOutput = (jobId: string, outputId: string, profile?: string) =>
   $cronFocus.set({ jobId, outputId, profile })
 

--- a/apps/desktop/src/store/cron.ts
+++ b/apps/desktop/src/store/cron.ts
@@ -4,7 +4,7 @@ import type { CronJob } from '@/types/hermes'
 
 // Cron *jobs* (not run sessions) power the sidebar "Cron jobs" section. Listing
 // the job — schedule, state, live next-run countdown — makes the job the
-// first-class entity; its runs (sessions) resolve under it in the cron detail.
+// first-class entity; its durable outputs resolve under it in the cron detail.
 export const $cronJobs = atom<CronJob[]>([])
 export const setCronJobs = (jobs: CronJob[]) => $cronJobs.set(jobs)
 
@@ -15,5 +15,13 @@ export const updateCronJobs = (fn: (jobs: CronJob[]) => CronJob[]) => $cronJobs.
 // One-shot focus target: clicking "Manage" on a job sets this, then opens the
 // cron overlay, which reads it once to select + scroll to that job. Cleared
 // after consumption so re-opening cron normally doesn't re-focus a stale job.
-export const $cronFocusJobId = atom<null | string>(null)
-export const setCronFocusJobId = (id: null | string) => $cronFocusJobId.set(id)
+export interface CronFocusTarget {
+  jobId: string
+  outputId?: string
+  profile?: string
+}
+
+export const $cronFocus = atom<CronFocusTarget | null>(null)
+export const setCronFocusJobId = (id: null | string) => $cronFocus.set(id ? { jobId: id } : null)
+export const setCronFocusOutput = (jobId: string, outputId: string, profile?: string) =>
+  $cronFocus.set({ jobId, outputId, profile })

--- a/apps/desktop/src/store/session-states-runtime-map.test.ts
+++ b/apps/desktop/src/store/session-states-runtime-map.test.ts
@@ -25,6 +25,7 @@ import { makeSessionInfo } from '@/test/session-info'
 describe('storedSessionIdForRuntimeId', () => {
   afterEach(() => {
     $sessionTiles.set([])
+    clearAllSessionStates()
   })
 
   it('maps a runtime id to the stored id of the tile bound to it', () => {
@@ -73,6 +74,31 @@ describe('storedSessionIdForRuntimeId', () => {
     clearAllSessionStates()
   })
 
+  it('maps a unique connection-owned MAIN-PANE runtime through its composite state key', () => {
+    publishSessionState('rt-owned', {
+      ...createClientSessionState('stored-owned'),
+      connectionId: 'source-a',
+      profile: 'default'
+    })
+
+    expect(storedSessionIdForRuntimeId('rt-owned')).toBe('stored-owned')
+  })
+
+  it('fails closed when two connection owners expose the same MAIN-PANE runtime id', () => {
+    publishSessionState('rt-shared', {
+      ...createClientSessionState('stored-a'),
+      connectionId: 'source-a',
+      profile: 'default'
+    })
+    publishSessionState('rt-shared', {
+      ...createClientSessionState('stored-b'),
+      connectionId: 'source-b',
+      profile: 'default'
+    })
+
+    expect(storedSessionIdForRuntimeId('rt-shared')).toBeNull()
+  })
+
   it('prefers the stored-id identity when one tile is stored-matched and another is runtime-matched', () => {
     // Pathological but possible after a stale rebind: some other tile's dead
     // runtimeId equals a live tile's storedSessionId. The stored-id claim is
@@ -108,6 +134,43 @@ describe('knownOwnerForSession / requestForOwnedSession', () => {
     setSessions([makeSessionInfo({ id: 'stored-main', profile: 'coder' })])
     expect(knownOwnerForSession('rt-main')).toBe('coder')
   })
+
+  it('resolves a unique connection-owned runtime to its stored owner', () => {
+    publishSessionState('rt-owned', {
+      ...createClientSessionState('stored-owned'),
+      connectionId: 'source-a',
+      profile: 'default'
+    })
+    setSessionOwnerHint('stored-owned', { connectionId: 'source-a', profile: 'default' })
+
+    expect(knownOwnerForSession('rt-owned')).toEqual({ connectionId: 'source-a', profile: 'default' })
+  })
+
+  it.each(['approval.respond', 'clarify.respond'])(
+    'fails %s closed for an ambiguous A/B runtime owner',
+    async method => {
+      $profiles.set([{ name: 'default' }, { name: 'other' }] as never)
+      publishSessionState('rt-shared', {
+        ...createClientSessionState('stored-a'),
+        connectionId: 'source-a',
+        profile: 'default'
+      })
+      publishSessionState('rt-shared', {
+        ...createClientSessionState('stored-b'),
+        connectionId: 'source-b',
+        profile: 'default'
+      })
+      setSessionOwnerHint('stored-a', { connectionId: 'source-a', profile: 'default' })
+      setSessionOwnerHint('stored-b', { connectionId: 'source-b', profile: 'default' })
+      const ambient = vi.fn(async () => ({ ok: true }))
+
+      expect(knownOwnerForSession('rt-shared')).toBeUndefined()
+      await expect(
+        requestForOwnedSession('rt-shared', ambient as never, method, { session_id: 'rt-shared' })
+      ).rejects.toSatisfy(isSessionOwnerResolutionError)
+      expect(ambient).not.toHaveBeenCalled()
+    }
+  )
 
   it('fails closed with an explicit owner-resolution error instead of the ambient socket', async () => {
     // Somewhere to misroute to: two profiles exist.

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -65,6 +65,53 @@ import { isBrowserWindow, isSecondaryWindow } from './windows'
 
 export const $sessionStates = atom<Record<string, ClientSessionState>>({})
 
+export interface RuntimeStateScope {
+  connectionId?: null | string
+  profile?: null | string
+}
+
+const RUNTIME_OWNER_KEY_PREFIX = 'owner:'
+
+/** Canonical renderer key. Runtime ids remain unchanged on RPC/event boundaries;
+ * registry-owned state is qualified only inside renderer maps. */
+export function runtimeStateKey(runtimeId: string, scope?: RuntimeStateScope): string {
+  const connectionId = scope?.connectionId?.trim()
+
+  return connectionId
+    ? `${RUNTIME_OWNER_KEY_PREFIX}${JSON.stringify([connectionId, normalizeProfileKey(scope?.profile), runtimeId])}`
+    : runtimeId
+}
+
+function runtimeIdFromStateKey(key: string): string {
+  if (!key.startsWith(RUNTIME_OWNER_KEY_PREFIX)) {
+    return key
+  }
+
+  try {
+    const parsed = JSON.parse(key.slice(RUNTIME_OWNER_KEY_PREFIX.length)) as unknown[]
+    return typeof parsed[2] === 'string' ? parsed[2] : key
+  } catch {
+    return key
+  }
+}
+
+/** Owner-aware lookup. A bare legacy lookup may resolve one unique registry
+ * owner, but fails closed once the same runtime id exists on multiple sources. */
+export function getSessionState(runtimeId: string, scope?: RuntimeStateScope): ClientSessionState | undefined {
+  const states = $sessionStates.get()
+
+  if (scope?.connectionId?.trim()) {
+    return states[runtimeStateKey(runtimeId, scope)]
+  }
+
+  if (states[runtimeId]) {
+    return states[runtimeId]
+  }
+
+  const matches = Object.entries(states).filter(([key]) => runtimeIdFromStateKey(key) === runtimeId)
+  return matches.length === 1 ? matches[0][1] : undefined
+}
+
 // ---------------------------------------------------------------------------
 // Event-source scopes: which registry connection's socket delivered a runtime
 // session's events. Working/attention membership alone is profile-blind — two
@@ -79,8 +126,26 @@ const sessionScopeByRuntimeId = new Map<string, string>()
 
 export function recordSessionEventScope(event: { connectionId?: string; profile?: string; session_id?: string }): void {
   if (event.session_id && event.connectionId) {
-    sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(event.connectionId, event.profile))
+    sessionScopeByRuntimeId.set(
+      runtimeStateKey(event.session_id, { connectionId: event.connectionId, profile: event.profile }),
+      registryBackendScopeKey(event.connectionId, event.profile)
+    )
   }
+}
+
+function recordedScopeForState(stateKey: string): string | undefined {
+  const direct = sessionScopeByRuntimeId.get(stateKey)
+
+  if (direct) {
+    return direct
+  }
+
+  // Legacy snapshots can install an unqualified entry after a tagged event.
+  // Alias only one unique owner; same-id A/B ambiguity must fail closed.
+  const runtimeId = runtimeIdFromStateKey(stateKey)
+  const matches = [...sessionScopeByRuntimeId].filter(([key]) => runtimeIdFromStateKey(key) === runtimeId)
+
+  return matches.length === 1 ? matches[0][1] : undefined
 }
 
 /** Composite scopes of registry-sourced sessions that are live (busy or
@@ -89,12 +154,12 @@ export function recordSessionEventScope(event: { connectionId?: string; profile?
 export function liveSessionScopes(): Set<string> {
   const scopes = new Set<string>()
 
-  for (const [runtimeId, state] of Object.entries($sessionStates.get())) {
+  for (const [stateKey, state] of Object.entries($sessionStates.get())) {
     if (!state || (!state.busy && !state.needsInput)) {
       continue
     }
 
-    const scope = sessionScopeByRuntimeId.get(runtimeId)
+    const scope = recordedScopeForState(stateKey)
 
     if (scope) {
       scopes.add(scope)
@@ -202,7 +267,12 @@ export function foregroundSessionScopes(): Set<string> {
   const scopes = new Set<string>()
 
   const addRuntimeScope = (runtimeId: string | undefined) => {
-    const scope = runtimeId ? sessionScopeByRuntimeId.get(runtimeId) : undefined
+    const state = runtimeId ? getSessionState(runtimeId) : undefined
+    const scope = runtimeId
+      ? recordedScopeForState(
+          state ? runtimeStateKey(runtimeId, { connectionId: state.connectionId, profile: state.profile }) : runtimeId
+        )
+      : undefined
 
     if (scope) {
       scopes.add(scope)
@@ -258,18 +328,26 @@ export function foregroundSessionScopes(): Set<string> {
 // presentation hint and never mutates the backend-derived busy state.
 export const $stalledSessionIds = atom<string[]>([])
 
-export function setSessionStalled(storedSessionId: string | null | undefined, stalled: boolean) {
+const stalledOwners = new Map<string, string>()
+
+export function setSessionStalled(
+  storedSessionId: string | null | undefined,
+  stalled: boolean,
+  scope?: RuntimeStateScope
+) {
   if (!storedSessionId) {
     return
   }
 
-  const current = $stalledSessionIds.get()
-  const present = current.includes(storedSessionId)
+  const ownerKey = runtimeStateKey(storedSessionId, scope)
+  const present = stalledOwners.has(ownerKey)
 
   if (stalled && !present) {
-    $stalledSessionIds.set([...current, storedSessionId])
+    stalledOwners.set(ownerKey, storedSessionId)
+    $stalledSessionIds.set([...stalledOwners.values()])
   } else if (!stalled && present) {
-    $stalledSessionIds.set(current.filter(id => id !== storedSessionId))
+    stalledOwners.delete(ownerKey)
+    $stalledSessionIds.set([...stalledOwners.values()])
   }
 }
 
@@ -282,32 +360,34 @@ export function setSessionStalled(storedSessionId: string | null | undefined, st
 export const SESSION_WATCHDOG_TIMEOUT_MS = 5 * 60 * 1000
 const sessionWatchdogTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
-function armWatchdog(runtimeId: string) {
-  const existing = sessionWatchdogTimers.get(runtimeId)
+function armWatchdog(runtimeId: string, scope?: RuntimeStateScope) {
+  const stateKey = runtimeStateKey(runtimeId, scope)
+  const existing = sessionWatchdogTimers.get(stateKey)
 
   if (existing) {
     clearTimeout(existing)
   }
 
   sessionWatchdogTimers.set(
-    runtimeId,
+    stateKey,
     setTimeout(() => {
-      sessionWatchdogTimers.delete(runtimeId)
-      const current = $sessionStates.get()[runtimeId]
+      sessionWatchdogTimers.delete(stateKey)
+      const current = $sessionStates.get()[stateKey]
 
       if (current?.busy) {
-        setSessionStalled(current.storedSessionId, true)
+        setSessionStalled(current.storedSessionId, true, current)
       }
     }, SESSION_WATCHDOG_TIMEOUT_MS)
   )
 }
 
-function clearWatchdog(runtimeId: string) {
-  const t = sessionWatchdogTimers.get(runtimeId)
+function clearWatchdog(runtimeId: string, scope?: RuntimeStateScope) {
+  const stateKey = runtimeStateKey(runtimeId, scope)
+  const t = sessionWatchdogTimers.get(stateKey)
 
   if (t) {
     clearTimeout(t)
-    sessionWatchdogTimers.delete(runtimeId)
+    sessionWatchdogTimers.delete(stateKey)
   }
 }
 
@@ -357,19 +437,19 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
     }
 
     clearSettled(previous.storedSessionId)
-    setSessionStalled(previous.storedSessionId, false)
+    setSessionStalled(previous.storedSessionId, false, previous)
   }
 
   // Every busy publish is stream activity: clear the quiet hint and restart
   // the silence window. A real terminal transition clears both the timer and
   // any hint, but only that authoritative transition clears working/busy.
   if (next.busy) {
-    setSessionStalled(next.storedSessionId, false)
-    armWatchdog(runtimeId)
+    setSessionStalled(next.storedSessionId, false, next)
+    armWatchdog(runtimeId, next)
   } else {
-    clearWatchdog(runtimeId)
-    setSessionStalled(next.storedSessionId, false)
-    setSessionStalled(previous?.storedSessionId, false)
+    clearWatchdog(runtimeId, next)
+    setSessionStalled(next.storedSessionId, false, next)
+    setSessionStalled(previous?.storedSessionId, false, previous ?? undefined)
   }
 
   const storedId = next.storedSessionId
@@ -453,7 +533,14 @@ function evictable(runtimeId: string, state: ClientSessionState): boolean {
  *  state a beat before `$activeSessionId` / the tile binding points at it. */
 export function publishSessionState(runtimeId: string, state: ClientSessionState) {
   const current = $sessionStates.get()
-  const prev = current[runtimeId] ?? null
+  const stateKey = runtimeStateKey(runtimeId, state)
+  const legacyPrev = stateKey !== runtimeId ? current[runtimeId] : undefined
+  const matchingLegacyPrev =
+    legacyPrev?.connectionId?.trim() === state.connectionId?.trim() &&
+    normalizeProfileKey(legacyPrev?.profile) === normalizeProfileKey(state.profile)
+      ? legacyPrev
+      : undefined
+  const prev = current[stateKey] ?? matchingLegacyPrev ?? null
 
   if (prev === state) {
     return
@@ -466,7 +553,13 @@ export function publishSessionState(runtimeId: string, state: ClientSessionState
     return
   }
 
-  $sessionStates.set({ ...current, [runtimeId]: state })
+  const nextStates = { ...current, [stateKey]: state }
+
+  if (matchingLegacyPrev) {
+    delete nextStates[runtimeId]
+  }
+
+  $sessionStates.set(nextStates)
   handleTransition(prev, state, runtimeId)
 }
 
@@ -474,12 +567,13 @@ export function publishSessionState(runtimeId: string, state: ClientSessionState
  * transcript. Unread completion is stored separately, so it survives too. */
 export function releaseSessionTranscript(runtimeId: string, state?: ClientSessionState) {
   const current = $sessionStates.get()
+  const retained = state ?? getSessionState(runtimeId)
 
-  if (!(runtimeId in current)) {
+  if (!retained) {
     return
   }
 
-  const retained = state ?? current[runtimeId]
+  const stateKey = runtimeStateKey(runtimeId, retained)
 
   // Older persisted snapshots can contain an undefined state or omit the
   // messages field. Treat either shape as already cold instead of throwing
@@ -491,26 +585,36 @@ export function releaseSessionTranscript(runtimeId: string, state?: ClientSessio
   const lightweight =
     Array.isArray(retained.messages) && retained.messages.length === 0 ? retained : { ...retained, messages: [] }
 
-  $sessionStates.set({ ...current, [runtimeId]: lightweight })
+  $sessionStates.set({ ...current, [stateKey]: lightweight })
 }
 
-export function dropSessionState(runtimeId: string) {
+export function dropSessionState(runtimeId: string, scope?: RuntimeStateScope) {
+  clearSessionProviderWait(runtimeId)
+  const current = $sessionStates.get()
+  const state = getSessionState(runtimeId, scope)
+
+  if (!state) {
+    return
+  }
+
+  const stateKey = runtimeStateKey(runtimeId, state)
   // Disarm the watchdog — a dropped runtime must not fire a stale clear later.
   // Settle-grace entries are keyed by stored id and self-expire; leave them so
   // a just-finished session's row survives merge eviction even if its tile or
   // cached runtime is dropped in the meantime.
-  clearWatchdog(runtimeId)
-  clearSessionProviderWait(runtimeId)
-  sessionScopeByRuntimeId.delete(runtimeId)
+  clearWatchdog(runtimeId, state)
+  for (const key of [...sessionScopeByRuntimeId.keys()]) {
+    if (key === stateKey || (stateKey === runtimeId && runtimeIdFromStateKey(key) === runtimeId)) {
+      sessionScopeByRuntimeId.delete(key)
+    }
+  }
+  setSessionStalled(state.storedSessionId, false, state)
 
-  const current = $sessionStates.get()
-  setSessionStalled(current[runtimeId]?.storedSessionId, false)
-
-  if (!(runtimeId in current)) {
+  if (!(stateKey in current)) {
     return
   }
 
-  const { [runtimeId]: _dropped, ...rest } = current
+  const { [stateKey]: _dropped, ...rest } = current
   $sessionStates.set(rest)
 }
 
@@ -525,6 +629,7 @@ export function clearAllSessionStates() {
   }
 
   sessionWatchdogTimers.clear()
+  stalledOwners.clear()
   settledExpiry.clear()
   clearAllProviderWaits()
   sessionScopeByRuntimeId.clear()
@@ -570,21 +675,22 @@ export function clearAllSessionStates() {
 export function reconcileBusyStatesOnReconnect(scope?: string) {
   const states = $sessionStates.get()
 
-  for (const [runtimeId, state] of Object.entries(states)) {
+  for (const [stateKey, state] of Object.entries(states)) {
     if (!state || (!state.busy && !state.awaitingResponse)) {
       continue
     }
 
-    const recorded = sessionScopeByRuntimeId.get(runtimeId)
+    const recorded = recordedScopeForState(stateKey)
 
     if (scope === undefined ? recorded !== undefined : recorded !== scope) {
       continue
     }
 
+    const runtimeId = runtimeIdFromStateKey(stateKey)
     sessionTileDelegate()?.retireBusyClaim?.(runtimeId)
 
     // Re-read — the write path may have republished (and released) this entry.
-    const published = $sessionStates.get()[runtimeId]
+    const published = $sessionStates.get()[stateKey]
 
     if (published?.busy || published?.awaitingResponse) {
       publishSessionState(runtimeId, { ...published, awaitingResponse: false, busy: false })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1173,7 +1173,18 @@ export function storedSessionIdForRuntimeId(sessionId: string): null | string {
   // approval.respond from a native notification, a queued send — finds its
   // durable identity, and through it the exact owner (hint / tagged row).
   // Without this rung such ids fell straight to the ambient socket.
-  const mirrored = $sessionStates.get()[sessionId]?.storedSessionId?.trim()
+  const mirroredStates = Object.entries($sessionStates.get()).filter(
+    ([stateKey]) => runtimeIdFromStateKey(stateKey) === sessionId
+  )
+
+  // Runtime ids are transport-local. A bare id may alias one composite owner,
+  // but once two registry sources expose it there is no safe durable identity
+  // (and therefore no safe approval/clarification socket) to choose.
+  if (mirroredStates.length !== 1) {
+    return null
+  }
+
+  const mirrored = mirroredStates[0][1]?.storedSessionId?.trim()
 
   return mirrored || null
 }

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -348,6 +348,7 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
   if (previous?.storedSessionId && next.storedSessionId && previous.storedSessionId !== next.storedSessionId) {
     if (runtimeId === $activeSessionId.get()) {
       setActiveSessionStoredIdRotation({
+        connectionId: next.connectionId,
         nextStoredSessionId: next.storedSessionId,
         previousStoredSessionId: previous.storedSessionId,
         profile: normalizeProfileKey(next.profile),

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -350,6 +350,7 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
       setActiveSessionStoredIdRotation({
         nextStoredSessionId: next.storedSessionId,
         previousStoredSessionId: previous.storedSessionId,
+        profile: normalizeProfileKey(next.profile),
         runtimeSessionId: runtimeId
       })
     }

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -699,6 +699,7 @@ export const $sessionsLoading = atom(true)
 export const $activeSessionId = atom<string | null>(null)
 export const $selectedStoredSessionId = atom<string | null>(null)
 export interface ActiveSessionStoredIdRotation {
+  connectionId: string | null
   nextStoredSessionId: string
   previousStoredSessionId: string
   profile: string

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -701,6 +701,7 @@ export const $selectedStoredSessionId = atom<string | null>(null)
 export interface ActiveSessionStoredIdRotation {
   nextStoredSessionId: string
   previousStoredSessionId: string
+  profile: string
   runtimeSessionId: string
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -855,11 +855,24 @@ export interface CronJob {
   next_run_at?: null | string
   no_agent?: boolean
   prompt?: null | string
+  profile?: string
   provider?: null | string
   schedule?: CronJobSchedule
   schedule_display?: null | string
   script?: null | string
   state?: null | string
+}
+
+export interface CronJobOutput {
+  byte_size: number
+  created_at: number
+  filename: string
+  id: string
+}
+
+export interface CronJobOutputDetail extends CronJobOutput {
+  content: string
+  profile: string
 }
 
 export interface CronJobCreatePayload {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -845,6 +845,7 @@ export interface AnalyticsTotals {
 }
 
 export interface CronJob {
+  connection_id?: null | string
   deliver?: null | string
   enabled: boolean
   id: string

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -796,11 +796,24 @@ export interface CronJob {
   next_run_at?: null | string
   no_agent?: boolean
   prompt?: null | string
+  profile?: string
   provider?: null | string
   schedule?: CronJobSchedule
   schedule_display?: null | string
   script?: null | string
   state?: null | string
+}
+
+export interface CronJobOutput {
+  byte_size: number
+  created_at: number
+  filename: string
+  id: string
+}
+
+export interface CronJobOutputDetail extends CronJobOutput {
+  content: string
+  profile: string
 }
 
 export interface CronJobCreatePayload {

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -40,6 +40,7 @@ from typing import Optional, Dict, List, Any, Set, Tuple, Union, Collection
 
 logger = logging.getLogger(__name__)
 
+from hermes_time import get_timezone as _get_hermes_timezone
 from hermes_time import now as _hermes_now
 from utils import atomic_replace, atomic_write_text
 
@@ -3899,7 +3900,15 @@ def _prune_job_output(job_output_dir: Path, keep: int) -> int:
 
 @contextlib.contextmanager
 def _open_job_output_directory(job_id: str):
-    """Pin one job output directory without following mutable child symlinks."""
+    """Open one job output directory without following child symlinks.
+
+    Platforms with ``dir_fd`` support pin every traversed directory by file
+    descriptor.  The path-only fallback (notably Windows) cannot provide that
+    guarantee: it rejects symlinks and verifies every directory's identity both
+    before and after the caller's operation, but a parent swapped and restored
+    entirely within that window remains inherently undetectable without a
+    descriptor-relative directory API.
+    """
     job_dir = _job_output_dir(job_id)
     output_root = job_dir.parent
     store_anchor = _current_cron_store().cron_dir.parent
@@ -3918,6 +3927,9 @@ def _open_job_output_directory(job_id: str):
         anchor_stat = os.lstat(store_anchor)
         if not stat_module.S_ISDIR(anchor_stat.st_mode):
             raise FileNotFoundError(store_anchor)
+        directory_identities = [
+            (store_anchor, anchor_stat.st_dev, anchor_stat.st_ino)
+        ]
         trusted_root = store_anchor.resolve(strict=True)
         current = store_anchor
         resolved_current = trusted_root
@@ -3930,7 +3942,29 @@ def _open_job_output_directory(job_id: str):
             expected = trusted_root.joinpath(*current.relative_to(store_anchor).parts)
             if resolved_current != expected or not resolved_current.is_relative_to(trusted_root):
                 raise FileNotFoundError(current)
-        yield None, job_dir
+            directory_identities.append(
+                (current, current_stat.st_dev, current_stat.st_ino)
+            )
+
+        try:
+            yield None, job_dir
+        except BaseException:
+            raise
+        else:
+            # Detect persistent parent replacement during the path-based
+            # operation. This intentionally runs only on success so a storage
+            # error from the operation is never hidden by cleanup validation.
+            for directory, expected_dev, expected_ino in directory_identities:
+                try:
+                    current_stat = os.lstat(directory)
+                except FileNotFoundError as exc:
+                    raise FileNotFoundError(directory) from exc
+                if (
+                    not stat_module.S_ISDIR(current_stat.st_mode)
+                    or current_stat.st_dev != expected_dev
+                    or current_stat.st_ino != expected_ino
+                ):
+                    raise FileNotFoundError(directory)
         return
 
     directory_flags = (
@@ -3962,6 +3996,23 @@ def _open_job_output_directory(job_id: str):
         os.close(current_fd)
 
 
+def _cron_output_created_at(output_id: str) -> float:
+    """Derive a stable epoch time from a generated cron output identifier.
+
+    Output IDs encode the wall clock used by :func:`save_job_output` without an
+    offset. Interpret that clock through the same configured IANA timezone (or
+    server-local fallback) as ``_hermes_now`` rather than exposing mutable file
+    metadata as creation time.
+    """
+    output_time = datetime.strptime(output_id, "%Y-%m-%d_%H-%M-%S")
+    configured_timezone = _get_hermes_timezone()
+    if configured_timezone is not None:
+        output_time = output_time.replace(tzinfo=configured_timezone)
+    else:
+        output_time = output_time.astimezone()
+    return output_time.timestamp()
+
+
 def list_job_outputs(job_id: str, limit: int = 20) -> List[Dict[str, Any]]:
     """Return one job's durable markdown outputs, newest first.
 
@@ -3987,22 +4038,26 @@ def list_job_outputs(job_id: str, limit: int = 20) -> List[Dict[str, Any]]:
                     ),
                     key=lambda entry: entry.name,
                     reverse=True,
-                )[:limit_n]
+                )
 
                 outputs: List[Dict[str, Any]] = []
                 for entry in output_entries:
                     try:
                         entry_stat = entry.stat(follow_symlinks=False)
-                    except FileNotFoundError:
+                        output_id = Path(entry.name).stem
+                        created_at = _cron_output_created_at(output_id)
+                    except (FileNotFoundError, ValueError):
                         continue
                     outputs.append(
                         {
-                            "id": Path(entry.name).stem,
+                            "id": output_id,
                             "filename": entry.name,
                             "byte_size": entry_stat.st_size,
-                            "created_at": entry_stat.st_mtime,
+                            "created_at": created_at,
                         }
                     )
+                    if len(outputs) >= limit_n:
+                        break
     except FileNotFoundError:
         return []
     return outputs
@@ -4013,6 +4068,10 @@ def get_job_output(job_id: str, output_id: str) -> Dict[str, Any]:
     output_id = str(output_id or "").strip()
     if not _CRON_OUTPUT_ID_RE.fullmatch(output_id):
         raise ValueError("Invalid cron output id")
+    try:
+        created_at = _cron_output_created_at(output_id)
+    except ValueError as exc:
+        raise ValueError("Invalid cron output id") from exc
 
     filename = f"{output_id}.md"
     with _open_job_output_directory(job_id) as (job_fd, job_dir):
@@ -4021,7 +4080,7 @@ def get_job_output(job_id: str, output_id: str) -> Dict[str, Any]:
             before = os.lstat(path)
             if not stat_module.S_ISREG(before.st_mode):
                 raise FileNotFoundError(path)
-            open_args = (path, os.O_RDONLY)
+            open_args = (path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
             open_kwargs = {}
         else:
             before = os.stat(filename, dir_fd=job_fd, follow_symlinks=False)
@@ -4033,7 +4092,7 @@ def get_job_output(job_id: str, output_id: str) -> Dict[str, Any]:
         try:
             fd = os.open(*open_args, **open_kwargs)
         except OSError as exc:
-            if exc.errno == errno.ELOOP:
+            if exc.errno in (errno.ELOOP, errno.ENOTDIR):
                 raise FileNotFoundError(path) from exc
             raise
 
@@ -4057,7 +4116,7 @@ def get_job_output(job_id: str, output_id: str) -> Dict[str, Any]:
         "id": output_id,
         "filename": path.name,
         "byte_size": opened.st_size,
-        "created_at": opened.st_mtime,
+        "created_at": created_at,
         "content": content,
     }
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -7,11 +7,13 @@ Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
 
 import contextlib
 import copy
+import errno
 from contextvars import ContextVar
 from dataclasses import dataclass
 import json
 import logging
 import shutil
+import stat as stat_module
 import tempfile
 import threading
 import time
@@ -3852,6 +3854,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
 # accumulated one file per run forever and could fill the disk (#52383). Keep the
 # most recent N files per job; a non-positive value disables pruning (opt-out).
 _CRON_OUTPUT_DEFAULT_KEEP = 50
+_CRON_OUTPUT_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$")
 
 
 def _cron_output_keep() -> int:
@@ -3892,6 +3895,171 @@ def _prune_job_output(job_output_dir: Path, keep: int) -> int:
         except OSError as exc:
             logger.debug("Failed to prune cron output %s: %s", stale.name, exc)
     return deleted
+
+
+@contextlib.contextmanager
+def _open_job_output_directory(job_id: str):
+    """Pin one job output directory without following mutable child symlinks."""
+    job_dir = _job_output_dir(job_id)
+    output_root = job_dir.parent
+    store_anchor = _current_cron_store().cron_dir.parent
+
+    try:
+        relative_parts = output_root.relative_to(store_anchor).parts
+    except ValueError:
+        # Tests and embedders may deliberately repoint OUTPUT_DIR. Treat that
+        # configured root as the trusted anchor, while still refusing a
+        # symlink at the root itself or at the per-job child.
+        store_anchor = output_root
+        relative_parts = ()
+
+    supports_dir_fd = os.open in os.supports_dir_fd
+    if not supports_dir_fd:
+        anchor_stat = os.lstat(store_anchor)
+        if not stat_module.S_ISDIR(anchor_stat.st_mode):
+            raise FileNotFoundError(store_anchor)
+        trusted_root = store_anchor.resolve(strict=True)
+        current = store_anchor
+        resolved_current = trusted_root
+        for part in (*relative_parts, job_dir.name):
+            current = current / part
+            current_stat = os.lstat(current)
+            if not stat_module.S_ISDIR(current_stat.st_mode):
+                raise FileNotFoundError(current)
+            resolved_current = current.resolve(strict=True)
+            expected = trusted_root.joinpath(*current.relative_to(store_anchor).parts)
+            if resolved_current != expected or not resolved_current.is_relative_to(trusted_root):
+                raise FileNotFoundError(current)
+        yield None, job_dir
+        return
+
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        current_fd = os.open(store_anchor, directory_flags)
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+            raise FileNotFoundError(store_anchor) from exc
+        raise
+    try:
+        for part in (*relative_parts, job_dir.name):
+            try:
+                next_fd = os.open(part, directory_flags, dir_fd=current_fd)
+            except OSError as exc:
+                if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                    raise FileNotFoundError(job_dir) from exc
+                raise
+            previous_fd = current_fd
+            current_fd = next_fd
+            os.close(previous_fd)
+        if not stat_module.S_ISDIR(os.fstat(current_fd).st_mode):
+            raise FileNotFoundError(job_dir)
+        yield current_fd, job_dir
+    finally:
+        os.close(current_fd)
+
+
+def list_job_outputs(job_id: str, limit: int = 20) -> List[Dict[str, Any]]:
+    """Return one job's durable markdown outputs, newest first.
+
+    Output files are the authoritative result of every cron execution (including
+    script-only and session-store-degraded runs). Desktop run history must not
+    depend on an optional chat transcript existing in ``state.db``.
+    """
+    try:
+        limit_n = max(1, min(int(limit), 100))
+    except (TypeError, ValueError):
+        limit_n = 20
+
+    try:
+        with _open_job_output_directory(job_id) as (job_fd, job_dir):
+            with os.scandir(job_fd if job_fd is not None else job_dir) as entries:
+                output_entries = sorted(
+                    (
+                        entry
+                        for entry in entries
+                        if entry.name.endswith(".md")
+                        and entry.is_file(follow_symlinks=False)
+                        and _CRON_OUTPUT_ID_RE.fullmatch(Path(entry.name).stem)
+                    ),
+                    key=lambda entry: entry.name,
+                    reverse=True,
+                )[:limit_n]
+
+                outputs: List[Dict[str, Any]] = []
+                for entry in output_entries:
+                    try:
+                        entry_stat = entry.stat(follow_symlinks=False)
+                    except FileNotFoundError:
+                        continue
+                    outputs.append(
+                        {
+                            "id": Path(entry.name).stem,
+                            "filename": entry.name,
+                            "byte_size": entry_stat.st_size,
+                            "created_at": entry_stat.st_mtime,
+                        }
+                    )
+    except FileNotFoundError:
+        return []
+    return outputs
+
+
+def get_job_output(job_id: str, output_id: str) -> Dict[str, Any]:
+    """Read one generated cron markdown document without permitting path escape."""
+    output_id = str(output_id or "").strip()
+    if not _CRON_OUTPUT_ID_RE.fullmatch(output_id):
+        raise ValueError("Invalid cron output id")
+
+    filename = f"{output_id}.md"
+    with _open_job_output_directory(job_id) as (job_fd, job_dir):
+        path = job_dir / filename
+        if job_fd is None:
+            before = os.lstat(path)
+            if not stat_module.S_ISREG(before.st_mode):
+                raise FileNotFoundError(path)
+            open_args = (path, os.O_RDONLY)
+            open_kwargs = {}
+        else:
+            before = os.stat(filename, dir_fd=job_fd, follow_symlinks=False)
+            if not stat_module.S_ISREG(before.st_mode):
+                raise FileNotFoundError(path)
+            open_args = (filename, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+            open_kwargs = {"dir_fd": job_fd}
+
+        try:
+            fd = os.open(*open_args, **open_kwargs)
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise FileNotFoundError(path) from exc
+            raise
+
+        try:
+            opened = os.fstat(fd)
+            if (
+                not stat_module.S_ISREG(opened.st_mode)
+                or opened.st_dev != before.st_dev
+                or opened.st_ino != before.st_ino
+            ):
+                raise FileNotFoundError(path)
+
+            with os.fdopen(fd, "r", encoding="utf-8") as output_file:
+                fd = -1  # ownership transferred to output_file
+                content = output_file.read()
+        finally:
+            if fd >= 0:
+                os.close(fd)
+
+    return {
+        "id": output_id,
+        "filename": path.name,
+        "byte_size": opened.st_size,
+        "created_at": opened.st_mtime,
+        "content": content,
+    }
 
 
 def save_job_output(job_id: str, output: str):

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -7,11 +7,13 @@ Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
 
 import contextlib
 import copy
+import errno
 from contextvars import ContextVar
 from dataclasses import dataclass
 import json
 import logging
 import shutil
+import stat as stat_module
 import tempfile
 import threading
 import time
@@ -3003,6 +3005,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
 # accumulated one file per run forever and could fill the disk (#52383). Keep the
 # most recent N files per job; a non-positive value disables pruning (opt-out).
 _CRON_OUTPUT_DEFAULT_KEEP = 50
+_CRON_OUTPUT_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$")
 
 
 def _cron_output_keep() -> int:
@@ -3043,6 +3046,171 @@ def _prune_job_output(job_output_dir: Path, keep: int) -> int:
         except OSError as exc:
             logger.debug("Failed to prune cron output %s: %s", stale.name, exc)
     return deleted
+
+
+@contextlib.contextmanager
+def _open_job_output_directory(job_id: str):
+    """Pin one job output directory without following mutable child symlinks."""
+    job_dir = _job_output_dir(job_id)
+    output_root = job_dir.parent
+    store_anchor = _current_cron_store().cron_dir.parent
+
+    try:
+        relative_parts = output_root.relative_to(store_anchor).parts
+    except ValueError:
+        # Tests and embedders may deliberately repoint OUTPUT_DIR. Treat that
+        # configured root as the trusted anchor, while still refusing a
+        # symlink at the root itself or at the per-job child.
+        store_anchor = output_root
+        relative_parts = ()
+
+    supports_dir_fd = os.open in os.supports_dir_fd
+    if not supports_dir_fd:
+        anchor_stat = os.lstat(store_anchor)
+        if not stat_module.S_ISDIR(anchor_stat.st_mode):
+            raise FileNotFoundError(store_anchor)
+        trusted_root = store_anchor.resolve(strict=True)
+        current = store_anchor
+        resolved_current = trusted_root
+        for part in (*relative_parts, job_dir.name):
+            current = current / part
+            current_stat = os.lstat(current)
+            if not stat_module.S_ISDIR(current_stat.st_mode):
+                raise FileNotFoundError(current)
+            resolved_current = current.resolve(strict=True)
+            expected = trusted_root.joinpath(*current.relative_to(store_anchor).parts)
+            if resolved_current != expected or not resolved_current.is_relative_to(trusted_root):
+                raise FileNotFoundError(current)
+        yield None, job_dir
+        return
+
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        current_fd = os.open(store_anchor, directory_flags)
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+            raise FileNotFoundError(store_anchor) from exc
+        raise
+    try:
+        for part in (*relative_parts, job_dir.name):
+            try:
+                next_fd = os.open(part, directory_flags, dir_fd=current_fd)
+            except OSError as exc:
+                if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                    raise FileNotFoundError(job_dir) from exc
+                raise
+            previous_fd = current_fd
+            current_fd = next_fd
+            os.close(previous_fd)
+        if not stat_module.S_ISDIR(os.fstat(current_fd).st_mode):
+            raise FileNotFoundError(job_dir)
+        yield current_fd, job_dir
+    finally:
+        os.close(current_fd)
+
+
+def list_job_outputs(job_id: str, limit: int = 20) -> List[Dict[str, Any]]:
+    """Return one job's durable markdown outputs, newest first.
+
+    Output files are the authoritative result of every cron execution (including
+    script-only and session-store-degraded runs). Desktop run history must not
+    depend on an optional chat transcript existing in ``state.db``.
+    """
+    try:
+        limit_n = max(1, min(int(limit), 100))
+    except (TypeError, ValueError):
+        limit_n = 20
+
+    try:
+        with _open_job_output_directory(job_id) as (job_fd, job_dir):
+            with os.scandir(job_fd if job_fd is not None else job_dir) as entries:
+                output_entries = sorted(
+                    (
+                        entry
+                        for entry in entries
+                        if entry.name.endswith(".md")
+                        and entry.is_file(follow_symlinks=False)
+                        and _CRON_OUTPUT_ID_RE.fullmatch(Path(entry.name).stem)
+                    ),
+                    key=lambda entry: entry.name,
+                    reverse=True,
+                )[:limit_n]
+
+                outputs: List[Dict[str, Any]] = []
+                for entry in output_entries:
+                    try:
+                        entry_stat = entry.stat(follow_symlinks=False)
+                    except FileNotFoundError:
+                        continue
+                    outputs.append(
+                        {
+                            "id": Path(entry.name).stem,
+                            "filename": entry.name,
+                            "byte_size": entry_stat.st_size,
+                            "created_at": entry_stat.st_mtime,
+                        }
+                    )
+    except FileNotFoundError:
+        return []
+    return outputs
+
+
+def get_job_output(job_id: str, output_id: str) -> Dict[str, Any]:
+    """Read one generated cron markdown document without permitting path escape."""
+    output_id = str(output_id or "").strip()
+    if not _CRON_OUTPUT_ID_RE.fullmatch(output_id):
+        raise ValueError("Invalid cron output id")
+
+    filename = f"{output_id}.md"
+    with _open_job_output_directory(job_id) as (job_fd, job_dir):
+        path = job_dir / filename
+        if job_fd is None:
+            before = os.lstat(path)
+            if not stat_module.S_ISREG(before.st_mode):
+                raise FileNotFoundError(path)
+            open_args = (path, os.O_RDONLY)
+            open_kwargs = {}
+        else:
+            before = os.stat(filename, dir_fd=job_fd, follow_symlinks=False)
+            if not stat_module.S_ISREG(before.st_mode):
+                raise FileNotFoundError(path)
+            open_args = (filename, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+            open_kwargs = {"dir_fd": job_fd}
+
+        try:
+            fd = os.open(*open_args, **open_kwargs)
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise FileNotFoundError(path) from exc
+            raise
+
+        try:
+            opened = os.fstat(fd)
+            if (
+                not stat_module.S_ISREG(opened.st_mode)
+                or opened.st_dev != before.st_dev
+                or opened.st_ino != before.st_ino
+            ):
+                raise FileNotFoundError(path)
+
+            with os.fdopen(fd, "r", encoding="utf-8") as output_file:
+                fd = -1  # ownership transferred to output_file
+                content = output_file.read()
+        finally:
+            if fd >= 0:
+                os.close(fd)
+
+    return {
+        "id": output_id,
+        "filename": path.name,
+        "byte_size": opened.st_size,
+        "created_at": opened.st_mtime,
+        "content": content,
+    }
 
 
 def save_job_output(job_id: str, output: str):

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -35,6 +35,8 @@ _run_cron_dashboard_io = late("_run_cron_dashboard_io")
 _list_cron_jobs_sync = late("_list_cron_jobs_sync")
 _get_cron_job_sync = late("_get_cron_job_sync")
 _list_cron_job_runs_sync = late("_list_cron_job_runs_sync")
+_list_cron_job_outputs_sync = late("_list_cron_job_outputs_sync")
+_get_cron_job_output_sync = late("_get_cron_job_output_sync")
 _create_cron_job_sync = late("_create_cron_job_sync")
 _update_cron_job_sync = late("_update_cron_job_sync")
 _pause_cron_job_sync = late("_pause_cron_job_sync")
@@ -73,6 +75,18 @@ async def get_cron_job(job_id: str, profile: Optional[str] = None):
 @router.get("/api/cron/jobs/{job_id}/runs")
 async def list_cron_job_runs(job_id: str, profile: Optional[str] = None, limit: int = 20):
     return await _run_cron_dashboard_io(_list_cron_job_runs_sync, job_id, profile, limit)
+
+
+@router.get("/api/cron/jobs/{job_id}/outputs")
+async def list_cron_job_outputs(job_id: str, profile: Optional[str] = None, limit: int = 20):
+    return await _run_cron_dashboard_io(_list_cron_job_outputs_sync, job_id, profile, limit)
+
+
+@router.get("/api/cron/jobs/{job_id}/outputs/{output_id}")
+async def get_cron_job_output(job_id: str, output_id: str, profile: Optional[str] = None):
+    return await _run_cron_dashboard_io(
+        _get_cron_job_output_sync, job_id, output_id, profile
+    )
 
 
 @router.post("/api/cron/jobs")

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -35,6 +35,8 @@ _run_cron_dashboard_io = late("_run_cron_dashboard_io")
 _list_cron_jobs_sync = late("_list_cron_jobs_sync")
 _get_cron_job_sync = late("_get_cron_job_sync")
 _list_cron_job_runs_sync = late("_list_cron_job_runs_sync")
+_list_cron_job_outputs_sync = late("_list_cron_job_outputs_sync")
+_get_cron_job_output_sync = late("_get_cron_job_output_sync")
 _create_cron_job_sync = late("_create_cron_job_sync")
 _update_cron_job_sync = late("_update_cron_job_sync")
 _pause_cron_job_sync = late("_pause_cron_job_sync")
@@ -62,6 +64,18 @@ async def get_cron_job(job_id: str, profile: Optional[str] = None):
 @router.get("/api/cron/jobs/{job_id}/runs")
 async def list_cron_job_runs(job_id: str, profile: Optional[str] = None, limit: int = 20):
     return await _run_cron_dashboard_io(_list_cron_job_runs_sync, job_id, profile, limit)
+
+
+@router.get("/api/cron/jobs/{job_id}/outputs")
+async def list_cron_job_outputs(job_id: str, profile: Optional[str] = None, limit: int = 20):
+    return await _run_cron_dashboard_io(_list_cron_job_outputs_sync, job_id, profile, limit)
+
+
+@router.get("/api/cron/jobs/{job_id}/outputs/{output_id}")
+async def get_cron_job_output(job_id: str, output_id: str, profile: Optional[str] = None):
+    return await _run_cron_dashboard_io(
+        _get_cron_job_output_sync, job_id, output_id, profile
+    )
 
 
 @router.post("/api/cron/jobs")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13169,6 +13169,8 @@ from hermes_cli.web_routers.cron import (  # noqa: E402,F401 — legacy re-expor
     list_cron_jobs,
     get_cron_job,
     list_cron_job_runs,
+    list_cron_job_outputs,
+    get_cron_job_output,
     create_cron_job,
     get_cron_delivery_targets,
     update_cron_job,
@@ -13239,6 +13241,70 @@ def _list_cron_job_runs_sync(job_id: str, profile: Optional[str] = None, limit: 
         db.close()
 
 
+def _list_cron_job_outputs_sync(job_id: str, profile: Optional[str] = None, limit: int = 20):
+    """Durable markdown outputs produced by a cron job, newest first."""
+    selected = profile or _find_cron_job_profile(job_id)
+    if not selected:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    job = _call_cron_for_profile(selected, "get_job", job_id)
+    if not isinstance(job, dict) or not job.get("id"):
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    raw_outputs = _call_cron_for_profile(
+        selected, "list_job_outputs", str(job["id"]), limit
+    )
+    outputs = [
+        {
+            "id": item["id"],
+            "filename": item["filename"],
+            "byte_size": item["byte_size"],
+            "created_at": item["created_at"],
+        }
+        for item in raw_outputs
+        if isinstance(item, dict)
+    ] if isinstance(raw_outputs, list) else []
+    return {"outputs": outputs, "profile": selected}
+
+
+def _get_cron_job_output_sync(
+    job_id: str,
+    output_id: str,
+    profile: Optional[str] = None,
+):
+    """Return one cron output document from its owning profile."""
+    # Reject malformed ids before profile/job discovery so path-like input is
+    # always a client error and never reaches filesystem construction.
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}", str(output_id or "")):
+        raise HTTPException(status_code=400, detail="Invalid cron output id")
+
+    selected = profile or _find_cron_job_profile(job_id)
+    if not selected:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    job = _call_cron_for_profile(selected, "get_job", job_id)
+    if not isinstance(job, dict) or not job.get("id"):
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    try:
+        raw_output = _call_cron_for_profile(
+            selected, "get_job_output", str(job["id"]), output_id
+        )
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Cron output not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    if not isinstance(raw_output, dict):
+        raise HTTPException(status_code=500, detail="Invalid cron output response")
+    return {
+        "id": raw_output["id"],
+        "filename": raw_output["filename"],
+        "byte_size": raw_output["byte_size"],
+        "created_at": raw_output["created_at"],
+        "content": raw_output["content"],
+        "profile": selected,
+    }
 
 
 def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13275,7 +13275,12 @@ def _get_cron_job_output_sync(
     """Return one cron output document from its owning profile."""
     # Reject malformed ids before profile/job discovery so path-like input is
     # always a client error and never reaches filesystem construction.
-    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}", str(output_id or "")):
+    output_id = str(output_id or "")
+    try:
+        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}", output_id):
+            raise ValueError
+        datetime.strptime(output_id, "%Y-%m-%d_%H-%M-%S")
+    except ValueError:
         raise HTTPException(status_code=400, detail="Invalid cron output id")
 
     selected = profile or _find_cron_job_profile(job_id)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11963,6 +11963,8 @@ from hermes_cli.web_routers.cron import (  # noqa: E402,F401 — legacy re-expor
     list_cron_jobs,
     get_cron_job,
     list_cron_job_runs,
+    list_cron_job_outputs,
+    get_cron_job_output,
     create_cron_job,
     get_cron_delivery_targets,
     update_cron_job,
@@ -12033,6 +12035,70 @@ def _list_cron_job_runs_sync(job_id: str, profile: Optional[str] = None, limit: 
         db.close()
 
 
+def _list_cron_job_outputs_sync(job_id: str, profile: Optional[str] = None, limit: int = 20):
+    """Durable markdown outputs produced by a cron job, newest first."""
+    selected = profile or _find_cron_job_profile(job_id)
+    if not selected:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    job = _call_cron_for_profile(selected, "get_job", job_id)
+    if not isinstance(job, dict) or not job.get("id"):
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    raw_outputs = _call_cron_for_profile(
+        selected, "list_job_outputs", str(job["id"]), limit
+    )
+    outputs = [
+        {
+            "id": item["id"],
+            "filename": item["filename"],
+            "byte_size": item["byte_size"],
+            "created_at": item["created_at"],
+        }
+        for item in raw_outputs
+        if isinstance(item, dict)
+    ] if isinstance(raw_outputs, list) else []
+    return {"outputs": outputs, "profile": selected}
+
+
+def _get_cron_job_output_sync(
+    job_id: str,
+    output_id: str,
+    profile: Optional[str] = None,
+):
+    """Return one cron output document from its owning profile."""
+    # Reject malformed ids before profile/job discovery so path-like input is
+    # always a client error and never reaches filesystem construction.
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}", str(output_id or "")):
+        raise HTTPException(status_code=400, detail="Invalid cron output id")
+
+    selected = profile or _find_cron_job_profile(job_id)
+    if not selected:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    job = _call_cron_for_profile(selected, "get_job", job_id)
+    if not isinstance(job, dict) or not job.get("id"):
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    try:
+        raw_output = _call_cron_for_profile(
+            selected, "get_job_output", str(job["id"]), output_id
+        )
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Cron output not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    if not isinstance(raw_output, dict):
+        raise HTTPException(status_code=500, detail="Invalid cron output response")
+    return {
+        "id": raw_output["id"],
+        "filename": raw_output["filename"],
+        "byte_size": raw_output["byte_size"],
+        "created_at": raw_output["created_at"],
+        "content": raw_output["content"],
+        "profile": selected,
+    }
 
 
 def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -2,6 +2,7 @@
 
 from concurrent.futures import ThreadPoolExecutor
 import json
+from pathlib import Path
 from queue import Empty, SimpleQueue
 import threading
 
@@ -125,6 +126,302 @@ def test_create_registers_scheduler_inside_target_profile(
     assert captured["runtime_home"] == worker_home
     assert captured["jobs_file"] == worker_home / "cron" / "jobs.json"
     assert job["profile"] == "worker_alpha"
+
+
+def test_cron_run_outputs_are_read_from_the_owning_profile(
+    isolated_profiles,
+):
+    """Desktop run detail must use the durable markdown output, not a chat row."""
+    from hermes_cli import web_server
+
+    worker_home = isolated_profiles["worker_alpha"]
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="produce a markdown report",
+        schedule="every 1h",
+        name="markdown-report",
+    )
+    assert isinstance(job, dict)
+    output_dir = worker_home / "cron" / "output" / job["id"]
+    output_dir.mkdir(parents=True)
+    older = output_dir / "2026-08-10_09-00-00.md"
+    newer = output_dir / "2026-08-11_09-00-00.md"
+    older.write_text("# Older\n", encoding="utf-8")
+    newer.write_text("# Report\n\n| Name | Value |\n| --- | --- |\n| ok | 1 |\n", encoding="utf-8")
+
+    listed = web_server._list_cron_job_outputs_sync(job["id"], limit=1)
+
+    assert listed["profile"] == "worker_alpha"
+    assert listed["outputs"] == [
+        {
+            "id": "2026-08-11_09-00-00",
+            "filename": newer.name,
+            "byte_size": newer.stat().st_size,
+            "created_at": newer.stat().st_mtime,
+        }
+    ]
+    detail = web_server._get_cron_job_output_sync(
+        job["id"], "2026-08-11_09-00-00"
+    )
+    assert detail["profile"] == "worker_alpha"
+    assert detail["content"].startswith("# Report")
+    assert "| ok | 1 |" in detail["content"]
+
+
+def test_cron_run_output_rejects_path_escape(isolated_profiles):
+    from hermes_cli import web_server
+
+    with pytest.raises(HTTPException) as exc_info:
+        web_server._get_cron_job_output_sync("missing", "../jobs")
+
+    assert exc_info.value.status_code == 400
+
+
+def test_cron_run_output_does_not_follow_symlinks(isolated_profiles, tmp_path):
+    """The dashboard must not turn a planted output symlink into a file reader."""
+    from hermes_cli import web_server
+
+    worker_home = isolated_profiles["worker_alpha"]
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="produce a markdown report",
+        schedule="every 1h",
+        name="symlink-report",
+    )
+    assert isinstance(job, dict)
+    output_dir = worker_home / "cron" / "output" / job["id"]
+    output_dir.mkdir(parents=True)
+    secret = tmp_path / "secret.md"
+    secret.write_text("must not leak", encoding="utf-8")
+    planted = output_dir / "2026-08-11_09-00-00.md"
+    try:
+        planted.symlink_to(secret)
+    except OSError:
+        pytest.skip("symlink creation is unavailable on this platform")
+
+    assert web_server._list_cron_job_outputs_sync(job["id"])["outputs"] == []
+    with pytest.raises(HTTPException) as exc_info:
+        web_server._get_cron_job_output_sync(job["id"], planted.stem)
+
+    assert exc_info.value.status_code == 404
+
+
+def test_cron_run_output_rejects_symlink_swap_during_open(
+    isolated_profiles,
+    monkeypatch,
+    tmp_path,
+):
+    """The descriptor read must stay pinned when the path changes after lstat."""
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    worker_home = isolated_profiles["worker_alpha"]
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="produce a markdown report",
+        schedule="every 1h",
+        name="race-report",
+    )
+    assert isinstance(job, dict)
+    output_dir = worker_home / "cron" / "output" / job["id"]
+    output_dir.mkdir(parents=True)
+    planted = output_dir / "2026-08-11_09-00-00.md"
+    planted.write_text("safe output", encoding="utf-8")
+    secret = tmp_path / "secret.md"
+    secret.write_text("must not leak", encoding="utf-8")
+
+    real_open = cron_jobs.os.open
+    swapped = False
+
+    def swap_then_open(path, flags, *args, **kwargs):
+        nonlocal swapped
+        if not swapped and Path(path).name == planted.name:
+            planted.unlink()
+            try:
+                planted.symlink_to(secret)
+            except OSError:
+                pytest.skip("symlink creation is unavailable on this platform")
+            swapped = True
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(cron_jobs.os, "open", swap_then_open)
+
+    with pytest.raises(HTTPException) as exc_info:
+        web_server._get_cron_job_output_sync(
+            job["id"], planted.stem, profile="worker_alpha"
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+def test_cron_run_output_rejects_symlinked_output_root(
+    isolated_profiles,
+    tmp_path,
+):
+    """A planted parent symlink must not move reads outside the profile store."""
+    from hermes_cli import web_server
+
+    worker_home = isolated_profiles["worker_alpha"]
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="produce a markdown report",
+        schedule="every 1h",
+        name="parent-symlink-report",
+    )
+    assert isinstance(job, dict)
+    external_root = tmp_path / "outside"
+    external_job_dir = external_root / job["id"]
+    external_job_dir.mkdir(parents=True)
+    planted = external_job_dir / "2026-08-11_09-00-00.md"
+    planted.write_text("must not leak", encoding="utf-8")
+    output_root = worker_home / "cron" / "output"
+    if output_root.exists():
+        output_root.rmdir()
+    try:
+        output_root.symlink_to(external_root, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink creation is unavailable on this platform")
+
+    assert web_server._list_cron_job_outputs_sync(
+        job["id"], profile="worker_alpha"
+    )["outputs"] == []
+    with pytest.raises(HTTPException) as exc_info:
+        web_server._get_cron_job_output_sync(
+            job["id"], planted.stem, profile="worker_alpha"
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.parametrize("force_path_fallback", [False, True])
+def test_cron_run_output_rejects_symlinked_job_directory(
+    isolated_profiles,
+    monkeypatch,
+    tmp_path,
+    force_path_fallback,
+):
+    """Descriptor and cross-platform path fallback both reject a job-dir link."""
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    if force_path_fallback:
+        monkeypatch.setattr(
+            cron_jobs.os,
+            "supports_dir_fd",
+            frozenset(cron_jobs.os.supports_dir_fd - {cron_jobs.os.open}),
+        )
+
+    worker_home = isolated_profiles["worker_alpha"]
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="produce a markdown report",
+        schedule="every 1h",
+        name="job-dir-symlink-report",
+    )
+    assert isinstance(job, dict)
+    external_job_dir = tmp_path / "outside-job"
+    external_job_dir.mkdir()
+    planted = external_job_dir / "2026-08-11_09-00-00.md"
+    planted.write_text("must not leak", encoding="utf-8")
+    output_root = worker_home / "cron" / "output"
+    output_root.mkdir(exist_ok=True)
+    job_dir = output_root / job["id"]
+    try:
+        job_dir.symlink_to(external_job_dir, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink creation is unavailable on this platform")
+
+    assert web_server._list_cron_job_outputs_sync(
+        job["id"], profile="worker_alpha"
+    )["outputs"] == []
+    with pytest.raises(HTTPException) as exc_info:
+        web_server._get_cron_job_output_sync(
+            job["id"], planted.stem, profile="worker_alpha"
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+def test_cron_run_output_listing_surfaces_storage_errors(
+    isolated_profiles,
+    monkeypatch,
+):
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    worker_home = isolated_profiles["worker_alpha"]
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="produce a markdown report",
+        schedule="every 1h",
+        name="unreadable-report",
+    )
+    assert isinstance(job, dict)
+    output_dir = worker_home / "cron" / "output" / job["id"]
+    output_dir.mkdir(parents=True)
+    real_scandir = cron_jobs.os.scandir
+
+    def fail_output_scan(path):
+        if isinstance(path, int) or Path(path) == output_dir:
+            raise PermissionError("output directory unavailable")
+        return real_scandir(path)
+
+    monkeypatch.setattr(cron_jobs.os, "scandir", fail_output_scan)
+
+    with pytest.raises(PermissionError, match="output directory unavailable"):
+        web_server._list_cron_job_outputs_sync(
+            job["id"], profile="worker_alpha"
+        )
+
+
+def test_cron_run_output_listing_surfaces_metadata_errors(
+    isolated_profiles,
+    monkeypatch,
+):
+    """A durable output metadata failure is not an empty-history response."""
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    worker_home = isolated_profiles["worker_alpha"]
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="produce a markdown report",
+        schedule="every 1h",
+        name="unreadable-output-metadata",
+    )
+    assert isinstance(job, dict)
+    output_dir = worker_home / "cron" / "output" / job["id"]
+    output_dir.mkdir(parents=True)
+
+    class UnreadableOutputEntry:
+        name = "2026-08-11_09-00-00.md"
+
+        def is_file(self, *, follow_symlinks=True):
+            return True
+
+        def stat(self, *, follow_symlinks=True):
+            raise PermissionError("output metadata unavailable")
+
+    class OutputEntries:
+        def __enter__(self):
+            return iter([UnreadableOutputEntry()])
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    monkeypatch.setattr(cron_jobs.os, "scandir", lambda _path: OutputEntries())
+
+    with pytest.raises(PermissionError, match="output metadata unavailable"):
+        web_server._list_cron_job_outputs_sync(
+            job["id"], profile="worker_alpha"
+        )
 
 
 def test_dashboard_create_reports_saved_but_unregistered(

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -1,7 +1,9 @@
 """Regression tests for dashboard cron job profile routing."""
 
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
 import json
+import os
 from pathlib import Path
 from queue import Empty, SimpleQueue
 import threading
@@ -130,8 +132,10 @@ def test_create_registers_scheduler_inside_target_profile(
 
 def test_cron_run_outputs_are_read_from_the_owning_profile(
     isolated_profiles,
+    monkeypatch,
 ):
     """Desktop run detail must use the durable markdown output, not a chat row."""
+    from cron import jobs as cron_jobs
     from hermes_cli import web_server
 
     worker_home = isolated_profiles["worker_alpha"]
@@ -147,8 +151,13 @@ def test_cron_run_outputs_are_read_from_the_owning_profile(
     output_dir.mkdir(parents=True)
     older = output_dir / "2026-08-10_09-00-00.md"
     newer = output_dir / "2026-08-11_09-00-00.md"
+    invalid = output_dir / "9999-99-99_99-99-99.md"
     older.write_text("# Older\n", encoding="utf-8")
     newer.write_text("# Report\n\n| Name | Value |\n| --- | --- |\n| ok | 1 |\n", encoding="utf-8")
+    invalid.write_text("must not shadow a valid output", encoding="utf-8")
+    os.utime(newer, (1, 1))
+    monkeypatch.setattr(cron_jobs, "_get_hermes_timezone", lambda: timezone.utc)
+    expected_created_at = datetime(2026, 8, 11, 9, tzinfo=timezone.utc).timestamp()
 
     listed = web_server._list_cron_job_outputs_sync(job["id"], limit=1)
 
@@ -158,13 +167,14 @@ def test_cron_run_outputs_are_read_from_the_owning_profile(
             "id": "2026-08-11_09-00-00",
             "filename": newer.name,
             "byte_size": newer.stat().st_size,
-            "created_at": newer.stat().st_mtime,
+            "created_at": expected_created_at,
         }
     ]
     detail = web_server._get_cron_job_output_sync(
         job["id"], "2026-08-11_09-00-00"
     )
     assert detail["profile"] == "worker_alpha"
+    assert detail["created_at"] == expected_created_at
     assert detail["content"].startswith("# Report")
     assert "| ok | 1 |" in detail["content"]
 
@@ -174,6 +184,13 @@ def test_cron_run_output_rejects_path_escape(isolated_profiles):
 
     with pytest.raises(HTTPException) as exc_info:
         web_server._get_cron_job_output_sync("missing", "../jobs")
+
+    assert exc_info.value.status_code == 400
+
+    with pytest.raises(HTTPException) as exc_info:
+        web_server._get_cron_job_output_sync(
+            "missing", "2026-99-99_99-99-99"
+        )
 
     assert exc_info.value.status_code == 400
 
@@ -345,6 +362,39 @@ def test_cron_run_output_rejects_symlinked_job_directory(
         )
 
     assert exc_info.value.status_code == 404
+
+
+def test_cron_run_output_path_fallback_detects_persistent_parent_swap(
+    isolated_profiles,
+    monkeypatch,
+):
+    """The path-only fallback rechecks directory identity after an operation."""
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(
+        cron_jobs.os,
+        "supports_dir_fd",
+        frozenset(cron_jobs.os.supports_dir_fd - {cron_jobs.os.open}),
+    )
+    worker_home = isolated_profiles["worker_alpha"]
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="produce a markdown report",
+        schedule="every 1h",
+        name="parent-swap-report",
+    )
+    assert isinstance(job, dict)
+    job_dir = worker_home / "cron" / "output" / job["id"]
+    job_dir.mkdir(parents=True)
+    displaced_job_dir = job_dir.with_name(f"{job['id']}-displaced")
+
+    with cron_jobs.use_cron_store(worker_home):
+        with pytest.raises(FileNotFoundError):
+            with cron_jobs._open_job_output_directory(job["id"]):
+                job_dir.rename(displaced_job_dir)
+                job_dir.mkdir()
 
 
 def test_cron_run_output_listing_surfaces_storage_errors(


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop cron detail view so selecting a completed run loads and renders the durable Markdown output stored under that job's profile-scoped cron output directory.

The backend now exposes narrow list/detail endpoints for cron output documents instead of leaking filesystem paths. Output identifiers are restricted to Hermes' timestamp filename format. Directory components and files are opened without following symlinks, reads stay pinned to file descriptors to prevent swap races, and the cross-platform fallback enforces strict resolved containment. The Desktop uses those endpoints in both the Scheduled Jobs view and the chat sidebar run-history path, with loading, error, and empty states.

## Related Issue

Fixes #83679

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add profile-aware cron output list/detail APIs over the existing durable Markdown files
- validate output IDs and safely reject symlinked output roots, job directories, files, and swap races
- render selected output with the existing Markdown renderer in the Scheduled Jobs pane
- retain the owning profile when routing sidebar selections and loading the exact cron output document
- prevent overlapping run-history polls from publishing stale results
- add backend profile/security regression coverage and Desktop UI/scope tests

## How to Test

1. Create a cron job and let it produce a Markdown output file.
2. Open **Scheduled Jobs**, select the job, and click its output under **Run history**.
3. Confirm the Markdown content (including headings, tables, and links) renders; repeat by opening the run from the chat sidebar.

Automated verification (commit `94aae488268954c65bcd6cd4cffd1deebb92396a`):

- `HERMES_PYTHON=... scripts/run_tests.sh tests/hermes_cli/test_web_server_cron_profiles.py tests/hermes_cli/test_cron.py tests/cron/test_cron_context_from.py tests/cron/test_cron_script.py tests/cron/test_cron_workdir.py` — 120 passed, 1 skipped
- `LANG=C.UTF-8 LC_ALL=C.UTF-8 npm run test:ui --workspace hermes` — 559 files, 5,359 tests passed
- `LANG=C.UTF-8 LC_ALL=C.UTF-8 npm run test:desktop:platforms --workspace hermes` — 112 files passed, 1 skipped; 1,574 tests passed, 3 skipped
- `npm run typecheck --workspace hermes` — passed
- `npm run lint --workspace hermes` — 0 errors (repository baseline warnings only)
- `python -m ruff check ...` and `git diff --check` — passed
- `npm run build --workspace hermes` — passed with install stamp `94aae4882689`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux + Electron/Chromium Playwright

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing command or config contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no agent tool schema changed

## Screenshots / Logs

A Playwright smoke test seeded a profile-scoped cron output, opened it in the real Desktop renderer, and verified the rendered heading, table rows, and link. The retained screenshot contains no credentials or user data.
