### PR TITLE
fix(desktop): resolve react/react-dom from one origin to fix blank window (#84018)

### DIFF
--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -1,11 +1,35 @@
-import { accessSync } from "fs"
+import { accessSync, readFileSync } from "fs"
+import { createRequire } from "module"
 import { resolve, join } from "path"
 
-const root = resolve(import.meta.dirname, "..", "..", "..")
+const app = resolve(import.meta.dirname, "..")
+const root = resolve(app, "..", "..")
 
 try {
   accessSync(join(root, "node_modules", "vite", "package.json"))
 } catch {
   console.error(`Run from repo root: cd ${root} && npm ci`)
+  process.exit(1)
+}
+
+// `vite.config.ts` aliases react/react-dom to whatever this workspace resolves,
+// and React refuses to run when the two come from different installed copies
+// ("Minified React error #527" — it throws before the first paint, so the app
+// window stays blank). npm stays silent about the split because the hoisted
+// react still satisfies react-dom's caret peer range. Fail the build loudly
+// instead of shipping a white screen.
+const requireFromApp = createRequire(join(app, "package.json"))
+const installedVersion = (pkg) =>
+  JSON.parse(readFileSync(requireFromApp.resolve(`${pkg}/package.json`), "utf8")).version
+
+const react = installedVersion("react")
+const reactDom = installedVersion("react-dom")
+
+if (react !== reactDom) {
+  console.error(
+    `react@${react} / react-dom@${reactDom} version mismatch — React would fail ` +
+      `with error #527 and render a blank window. Pin both to the same version ` +
+      `in ${join(app, "package.json")}, then reinstall: cd ${root} && npm ci`
+  )
   process.exit(1)
 }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 import fs from 'fs'
+import { createRequire } from 'module'
 
 // `hgui` symlinks a worktree's node_modules to the main checkout. Vite realpaths
 // those before enforcing server.fs.allow, so codicon/font assets resolve outside
@@ -24,6 +25,20 @@ const fsAllow = [
     ].filter((p): p is string => p !== null)
   )
 ]
+
+// React refuses to run when `react` and `react-dom` come from two different
+// installed copies ("Minified React error #527" — a blank window, since it
+// throws before the first paint). Both packages are pinned to one version in
+// this workspace's package.json, but npm hoists whatever *it* considers
+// compatible to the monorepo root: a root dependency whose react peer is a
+// loose range (e.g. `^18 || ^19`) pulls the newest react up there, while
+// react-dom stays at the pinned one. `^19.2.7` accepts `19.2.8`, so npm never
+// warns. Resolving from this workspace instead of a hardcoded root path yields
+// the versions declared here — npm nests a copy under the workspace exactly
+// when the hoisted one differs, so the pair can only ever match.
+const requireFromApp = createRequire(path.join(__dirname, 'vite.config.ts'))
+const reactDir = path.dirname(requireFromApp.resolve('react/package.json'))
+const reactDomDir = path.dirname(requireFromApp.resolve('react-dom/package.json'))
 
 // The dev-only render/state churn counters (src/debug) must be imported
 // STATICALLY above react-dom — react-dom captures the devtools hook at module
@@ -147,10 +162,10 @@ export default defineConfig(({ command }) => ({
       '@hermes/plugin-sdk': path.resolve(__dirname, './src/sdk/index.ts'),
       '@hermes/shared/billing': path.resolve(__dirname, '../shared/src/billing-types.ts'),
       '@hermes/shared': path.resolve(__dirname, '../shared/src'),
-      react: path.resolve(__dirname, '../../node_modules/react'),
-      'react-dom': path.resolve(__dirname, '../../node_modules/react-dom'),
-      'react/jsx-dev-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-dev-runtime.js'),
-      'react/jsx-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-runtime.js')
+      react: reactDir,
+      'react-dom': reactDomDir,
+      'react/jsx-dev-runtime': path.join(reactDir, 'jsx-dev-runtime.js'),
+      'react/jsx-runtime': path.join(reactDir, 'jsx-runtime.js')
     },
     dedupe: ['react', 'react-dom', 'react-router']
   },

--- a/tests-js/react-dom-pair-compat.test.ts
+++ b/tests-js/react-dom-pair-compat.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Invariant: every workspace that renders React ships one react/react-dom pair.
+ *
+ * React validates at import time that ``react`` and ``react-dom`` come from the
+ * same installed copy. When they don't, it throws "Minified React error #527"
+ * *before* the first paint — the Electron window just stays blank white, with
+ * the only clue buried in the devtools console of a packaged build.
+ *
+ * npm never warns about this. ``apps/desktop`` pins both packages to one exact
+ * version, but a root dependency whose react peer is a loose range (e.g.
+ * ``^18.0.0 || ^19.0.0``, and with no react-dom peer to keep the two in step)
+ * makes npm hoist the newest react to the monorepo root while react-dom stays
+ * at the pinned version. react-dom's own peer range is a caret, so the newer
+ * react still "satisfies" it and the install reports success.
+ *
+ * ``apps/desktop/vite.config.ts`` used to alias both packages to a hardcoded
+ * ``../../node_modules/<pkg>`` — i.e. straight into the split — so the bundle
+ * shipped the mismatched pair. It now resolves them from the workspace itself,
+ * where npm guarantees the declared versions are reachable.
+ *
+ * This is a *contract* test: it asserts no specific version, only that the two
+ * halves of the pair can never drift apart again — neither through a loosened
+ * manifest spec, nor by re-pinning the bundler at the hoisted copy.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+const REPO_ROOT = path.resolve(__dirname, '..')
+const DESKTOP_VITE_CONFIG = path.join(REPO_ROOT, 'apps', 'desktop', 'vite.config.ts')
+
+interface Manifest {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  workspaces?: string[]
+}
+
+function readManifest(file: string): Manifest {
+  return JSON.parse(fs.readFileSync(file, 'utf-8')) as Manifest
+}
+
+/** Every workspace manifest, resolved from the root ``workspaces`` globs. */
+function workspaceManifests(): { name: string, manifest: Manifest }[] {
+  const patterns = readManifest(path.join(REPO_ROOT, 'package.json')).workspaces ?? []
+  const found: { name: string, manifest: Manifest }[] = []
+
+  for (const pattern of patterns) {
+    // The globs in use are plain paths or a single trailing ``/*``.
+    const parent = pattern.endsWith('/*') ? path.join(REPO_ROOT, pattern.slice(0, -2)) : null
+    const dirs = parent === null
+      ? [pattern]
+      : fs.existsSync(parent)
+        ? fs.readdirSync(parent).map((entry) => `${pattern.slice(0, -2)}/${entry}`)
+        : []
+
+    for (const dir of dirs) {
+      const file = path.join(REPO_ROOT, dir, 'package.json')
+
+      if (fs.existsSync(file)) {found.push({ name: dir, manifest: readManifest(file) })}
+    }
+  }
+
+  return found
+}
+
+test('workspaces declaring react and react-dom pin them to the same exact version', () => {
+  const offenders: string[] = []
+
+  for (const { name, manifest } of workspaceManifests()) {
+    const deps = { ...manifest.devDependencies, ...manifest.dependencies }
+    const react = deps['react']
+    const reactDom = deps['react-dom']
+
+    if (!react || !reactDom) {continue}
+
+    if (react !== reactDom) {
+      offenders.push(`${name} declares react"${react}" but react-dom"${reactDom}"`)
+      continue
+    }
+
+    if (!/^\d/.test(react)) {
+      offenders.push(`${name} declares a floating range react/react-dom"${react}"`)
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    'react and react-dom must be pinned to the same exact version per workspace, ' +
+      'otherwise npm can hoist a newer react next to the older react-dom and React ' +
+      `throws error #527 (blank window): ${offenders.join('; ')}`
+  )
+})
+
+test('the desktop bundler does not alias react at the hoisted root copy', () => {
+  const config = fs.readFileSync(DESKTOP_VITE_CONFIG, 'utf-8')
+
+  assert.ok(
+    !config.includes('node_modules/react'),
+    'apps/desktop/vite.config.ts hardcodes a node_modules path for react/react-dom. ' +
+      'That pins the bundle to the hoisted copies, which npm is free to resolve to a ' +
+      'different version than the pinned react-dom. Resolve both from the workspace ' +
+      "instead (see this test's module docstring)."
+  )
+})


### PR DESCRIPTION
Fixes #84018.

## Summary

The Windows desktop app opens to a blank white window on a fresh install. React throws `Minified React error #527` from `vendor-react-<hash>.js` before the first paint — nothing is ever mounted, so there is no error boundary and no visible failure, just white.

`apps/desktop/package.json` pins `react` and `react-dom` to the same exact version. The bundler did not use that pin: `vite.config.ts` aliased **both** packages to a hardcoded `../../node_modules/<pkg>` — the monorepo root, the one place npm is free to install a *different* react.

## Root cause

`@streamdown/math` is a **root** dependency whose react peer is `^18.0.0 || ^19.0.0`, and it declares **no** react-dom peer. Nothing keeps the two in step, so npm claims the root `node_modules/react` slot at the newest matching version (19.2.8), while `node_modules/react-dom` is hoisted from the workspaces at the pinned 19.2.7. react-dom's own peer is `react: ^19.2.7` — which 19.2.8 satisfies — so npm reports a clean install and prints no warning.

Reproduced from the workspace manifests alone (no lockfile), byte-for-byte matching the tree in the issue:

```
node_modules/react                    => 19.2.8   <-- hoisted by @streamdown/math
node_modules/react-dom                => 19.2.7
apps/desktop/node_modules/react       => 19.2.7   <-- what the app actually pins
web/node_modules/react                => 19.2.7
ui-tui/node_modules/react             => 19.2.7
```

Two things make it hard to catch:

- **CI is green.** `npm ci` is lock-faithful and the lockfile pins the root react to 19.2.7, so the split never appears in CI.
- **It comes back and leaves no trace.** `_run_npm_install_deterministic()` (`hermes_cli/main.py`) falls back to `npm install --no-save` when `npm ci` fails. That re-resolves the entire tree — reproducing the split — and `--no-save` guarantees the result is never written back, so the next update re-triggers it.

## Why not pin react at the npm layer

The issue's preferred fix (a root pin / `overrides`) does not work in this repo. Every manifest-level variant was tried in an isolated sandbox — root dependency, root `overrides` literal, `overrides` with `$react`, a scoped override on `@streamdown/math`, moving the pin into `overrides` — and **all five** break a fresh install with:

```
ERESOLVE ... peer ink-text-input@"6.0.0" from @hermes/ink@0.0.1
```

A control run pinning an unrelated root dependency installs cleanly, so the failure is specific to constraining react. This repo's fresh-install topology structurally depends on the root react being free to differ from the workspaces' pin.

## The fix

Repair the **resolution**, not the hoist.

The aliases now resolve `react` and `react-dom` from the desktop workspace itself. npm guarantees a workspace's declared dependencies are reachable from that workspace — it nests a private copy exactly when the hoisted one differs — so the bundle can only ever ship the pair `apps/desktop` pins. `resolve.dedupe` alone would have been inert here, because `resolve.alias` is applied first.

Two guards keep the failure from ever being silent again:

- **`assert-root-install.mjs`** — the *existing* preflight of `build`, `dev:renderer` and `preview` — now also fails when the resolved react and react-dom versions differ. No new script, no new wiring.
- **One `tests-js` contract test**, sibling to `assistant-ui-tap-compat.test.ts`: every workspace must pin the two packages to the same exact version, and the desktop bundler must not point at a hardcoded `node_modules` path again.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A["🩸 Root Dependency<br/>loose react peer, no react-dom peer"] -->|"npm hoists newest"| B["🔥 Root node_modules<br/>react 19.2.8 / react-dom 19.2.7"]
    B -->|"caret peer satisfied — install silent"| C{"⚔️ Bundler Alias Origin"}

    C -->|"BEFORE: hardcoded root path"| D["💀 Mismatched Pair Bundled"]
    D --> E["🕯️ React Error #527<br/>Blank White Window"]

    C -->|"AFTER: resolved from workspace"| F["🛡️ Pinned Pair<br/>react 19.2.7 / react-dom 19.2.7"]
    F --> G["✅ Renderer Boots"]

    F -.->|"preflight guard"| H["🔎 assert-root-install<br/>fails build on version drift"]
    F -.->|"contract test"| I["📜 tests-js<br/>exact-pin + no hardcoded path"]
```
## Infographic:
<img width="1024" height="1024" alt="infographic_cyber_renaissance" src="https://github.com/user-attachments/assets/e0d2cbef-410a-440c-aa43-ade4a4414b0c" />


## Test plan

- [x] Split tree simulated (root react 19.2.8 / react-dom 19.2.7, workspace react 19.2.7): old aliases resolve `19.2.8 + 19.2.7`, new aliases resolve `19.2.7 + 19.2.7`.
- [x] Preflight guard exits `0` on the matched tree and exits `1` with an actionable message on the split tree.
- [x] `tests-js` suite green — 11 passed, 0 failed (including the 2 new contract assertions).
- [x] Vite loads the patched config and resolves the aliases in this checkout (`react` and `react-dom` both 19.2.7).
- [ ] Full `vite build` / desktop component tests could not be completed locally: this checkout's `node_modules` is missing unrelated declared packages (`tw-shimmer`, `@testing-library/react`, `plist`), which fail before and after this change. CI covers both.

## Risk

Behaviour is unchanged on a healthy tree — the aliases resolve to the same root paths they were hardcoded to. The change only matters when the root copy differs from the workspace pin, which is exactly the broken case. The aliases date back to the original desktop-app commit and no later fix depends on the hardcoded path; the intent (a single react copy in the bundle) is preserved and now enforced.
