### PR TITLE
fix: report managed runtime updates truthfully

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -194,6 +194,7 @@ import {
 } from './ssh-connection'
 import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
+import { nativeUpdateApplyDecision } from './update-apply-boundary'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
@@ -12137,13 +12138,24 @@ ipcMain.handle('hermes:updates:check', async () =>
   }))
 )
 
-ipcMain.handle('hermes:updates:apply', async (_event, payload) =>
-  applyUpdates(payload || {}).catch(error => ({
+ipcMain.handle('hermes:updates:apply', async (_event, payload) => {
+  const status = await checkUpdates().catch(error => ({
+    supported: true,
+    error: 'check-failed',
+    message: error?.message || String(error)
+  }))
+  const decision = nativeUpdateApplyDecision(status)
+
+  if (!decision.ok) {
+    return decision
+  }
+
+  return applyUpdates(payload || {}).catch(error => ({
     ok: false,
     error: 'apply-failed',
     message: error?.message || String(error)
   }))
-)
+})
 
 ipcMain.handle('hermes:updates:branch:get', async () => readDesktopUpdateConfig())
 

--- a/apps/desktop/electron/update-apply-boundary.test.ts
+++ b/apps/desktop/electron/update-apply-boundary.test.ts
@@ -1,0 +1,25 @@
+/** Fail-closed native update-apply boundary tests. */
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { nativeUpdateApplyDecision } from './update-apply-boundary'
+
+const available = { supported: true, behind: 2 }
+
+test('permits only a successful native check with a positive count', () => {
+  assert.deepEqual(nativeUpdateApplyDecision(available), { ok: true })
+})
+
+test.each([
+  ['missing', null],
+  ['unsupported', { supported: false, behind: 2 }],
+  ['failed', { supported: true, behind: 2, error: 'check-failed' }],
+  ['current', { supported: true, behind: 0 }],
+  ['unknown count', { supported: true }],
+  ['invalid negative count', { supported: true, behind: -1 }]
+])('refuses %s update status before native transport', (_label, status) => {
+  const decision = nativeUpdateApplyDecision(status)
+  assert.equal(decision.ok, false)
+  assert.equal(decision.error, 'update-not-applyable')
+})

--- a/apps/desktop/electron/update-apply-boundary.ts
+++ b/apps/desktop/electron/update-apply-boundary.ts
@@ -1,0 +1,37 @@
+export type NativeUpdateStatus = {
+  supported?: boolean
+  behind?: number
+  error?: string
+} | null | undefined
+
+export type NativeUpdateApplyDecision =
+  | { ok: true }
+  | { ok: false; error: 'update-not-applyable'; message: string }
+
+export function nativeUpdateApplyDecision(status: NativeUpdateStatus): NativeUpdateApplyDecision {
+  if (!status || status.supported !== true) {
+    return {
+      ok: false,
+      error: 'update-not-applyable',
+      message: 'Desktop updates are unavailable for this installation.'
+    }
+  }
+
+  if (status.error) {
+    return {
+      ok: false,
+      error: 'update-not-applyable',
+      message: 'Desktop update status must be checked successfully before applying.'
+    }
+  }
+
+  if (!Number.isInteger(status.behind) || Number(status.behind) <= 0) {
+    return {
+      ok: false,
+      error: 'update-not-applyable',
+      message: status.behind === 0 ? 'Hermes Desktop is already up to date.' : 'No verified Desktop update is available.'
+    }
+  }
+
+  return { ok: true }
+}

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -553,6 +553,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
       applying: apply.applying || apply.stage === 'restart',
       behind: status?.behind ?? 0,
       copy: t.shell.statusbar,
+      error: status?.error,
       remote: backend,
       restarting: apply.stage === 'restart',
       sha: status?.currentSha?.slice(0, 7) ?? null,

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -278,6 +278,7 @@ export function useStatusbarItems({
       behind: updateStatus?.behind ?? 0,
       branch: updateStatus?.branch,
       copy,
+      error: updateStatus?.error,
       remote: connection?.mode === 'remote',
       restarting: updateApply.stage === 'restart',
       sha: updateStatus?.currentSha?.slice(0, 7) ?? null,
@@ -309,7 +310,8 @@ export function useStatusbarItems({
     updateApply.stage,
     updateStatus?.behind,
     updateStatus?.branch,
-    updateStatus?.currentSha
+    updateStatus?.currentSha,
+    updateStatus?.error
   ])
 
   const backendVersionItem = useMemo<StatusbarItem | null>(() => {
@@ -324,6 +326,7 @@ export function useStatusbarItems({
       applyMessage: backendUpdateApply.message,
       behind: backendUpdateStatus?.behind ?? 0,
       copy,
+      error: backendUpdateStatus?.error,
       remote: true,
       restarting: backendUpdateApply.stage === 'restart',
       target: 'backend',
@@ -347,6 +350,7 @@ export function useStatusbarItems({
     connection?.mode,
     statusSnapshot?.version,
     backendUpdateStatus?.behind,
+    backendUpdateStatus?.error,
     backendUpdateStatus?.updateAvailable,
     backendUpdateApply.applying,
     backendUpdateApply.message,

--- a/apps/desktop/src/app/updates-overlay.test.tsx
+++ b/apps/desktop/src/app/updates-overlay.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $backendUpdateChecking,
+  $backendUpdateStatus,
+  $updateOverlayTarget,
+  resetUpdateApplyState,
+  setUpdateOverlayOpen
+} from '@/store/updates'
+
+import { UpdatesOverlay } from './updates-overlay'
+
+beforeEach(() => {
+  resetUpdateApplyState()
+  $backendUpdateChecking.set(false)
+  $updateOverlayTarget.set('backend')
+  setUpdateOverlayOpen(true)
+})
+
+afterEach(() => {
+  setUpdateOverlayOpen(false)
+  $backendUpdateStatus.set(null)
+  cleanup()
+})
+
+describe('UpdatesOverlay', () => {
+  it('shows a retryable check failure before managed-runtime guidance', () => {
+    $backendUpdateStatus.set({
+      supported: false,
+      error: 'update-check-failed',
+      message: 'Managed outside the desktop.',
+      fetchedAt: Date.now()
+    })
+
+    render(<UpdatesOverlay />)
+
+    expect(screen.getByText('Couldn’t check for updates')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeTruthy()
+    expect(screen.queryByText('Update not available')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -186,16 +186,6 @@ function IdleView({
     )
   }
 
-  if (!status.supported) {
-    return (
-      <CenteredStatus
-        body={status.message ?? u.unsupportedMessage}
-        icon={<AlertCircle className="size-6 text-muted-foreground" />}
-        title={u.notAvailableTitle}
-      />
-    )
-  }
-
   if (status.error) {
     return (
       <CenteredStatus
@@ -207,6 +197,16 @@ function IdleView({
         body={u.connectionRetry}
         icon={<ErrorIcon />}
         title={u.checkFailedTitle}
+      />
+    )
+  }
+
+  if (!status.supported) {
+    return (
+      <CenteredStatus
+        body={status.message ?? u.unsupportedMessage}
+        icon={<AlertCircle className="size-6 text-muted-foreground" />}
+        title={u.notAvailableTitle}
       />
     )
   }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2072,6 +2072,7 @@ export const ar = defineLocale({
     },
     statusbar: {
       unknown: 'غير معروف',
+      checkFailed: 'فشل التحقق',
       restart: 'إعادة تشغيل',
       update: 'تحديث',
       updateInProgress: 'التحديث جار',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2481,6 +2481,7 @@ export const en: Translations = {
     },
     statusbar: {
       unknown: 'unknown',
+      checkFailed: 'check failed',
       restart: 'restart',
       update: 'update',
       updateInProgress: 'Update in progress',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2302,6 +2302,7 @@ export const ja = defineLocale({
     },
     statusbar: {
       unknown: '不明',
+      checkFailed: '確認失敗',
       restart: '再起動',
       update: '更新',
       updateInProgress: '更新中',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2077,6 +2077,7 @@ export interface Translations {
     }
     statusbar: {
       unknown: string
+      checkFailed: string
       restart: string
       update: string
       updateInProgress: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2225,6 +2225,7 @@ export const zhHant = defineLocale({
     },
     statusbar: {
       unknown: '未知',
+      checkFailed: '檢查失敗',
       restart: '重新啟動',
       update: '更新',
       updateInProgress: '更新中',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2660,6 +2660,7 @@ export const zh: Translations = {
     },
     statusbar: {
       unknown: '未知',
+      checkFailed: '检查失败',
       restart: '重启',
       update: '更新',
       updateInProgress: '正在更新',

--- a/apps/desktop/src/lib/version-status.test.ts
+++ b/apps/desktop/src/lib/version-status.test.ts
@@ -79,6 +79,21 @@ describe('resolveVersionStatus', () => {
     expect(backend({ behind: 4, updateAvailable: true, version: '0.4.2' }).label).toBe('backend v0.4.2 (+4)')
   })
 
+  it('shows a failed backend check instead of implying the backend is current', () => {
+    const status = backend({ error: 'update-check-failed', version: '0.4.2' })
+
+    expect(status.label).toBe('backend v0.4.2 (check failed)')
+    expect(status.hasUpdate).toBe(false)
+    expect(status.tooltip).toContain('check failed')
+  })
+
+  it('suppresses a stale client update tint when the latest check failed', () => {
+    const status = client({ behind: 3, error: 'check-failed', version: '0.4.2' })
+
+    expect(status.label).toBe('v0.4.2 (check failed)')
+    expect(status.hasUpdate).toBe(false)
+  })
+
   it('hides a backend row that has no version at all', () => {
     expect(backend().unknown).toBe(true)
   })

--- a/apps/desktop/src/lib/version-status.ts
+++ b/apps/desktop/src/lib/version-status.ts
@@ -14,6 +14,7 @@ export interface VersionStatusCopy {
   backendLabel: (version: string) => string
   backendVersion: (version: string) => string
   branch: (branch: string) => string
+  checkFailed: string
   clientLabel: (version: string) => string
   commit: (sha: string) => string
   commitsBehind: (count: number, branch: string) => string
@@ -32,6 +33,7 @@ export interface VersionStatusInput {
   behind?: number
   branch?: string
   copy: VersionStatusCopy
+  error?: string
   /** Remote mode: the client is one of two versions on screen, so it says so. */
   remote: boolean
   /** The apply reached the restart stage — labels `restart`, not `update`. */
@@ -61,6 +63,7 @@ export function resolveVersionStatus({
   behind = 0,
   branch,
   copy,
+  error,
   remote,
   restarting,
   sha = null,
@@ -83,10 +86,19 @@ export function resolveVersionStatus({
 
   // Commits behind is the precise diff; `(update)` is the fallback for a
   // backend that knows it's stale but can't count (pip, non-git checkout).
-  const hint = busy ? '' : behind > 0 ? ` (+${behind})` : available ? ` (${copy.update})` : ''
+  const hint = busy
+    ? ''
+    : error
+      ? ` (${copy.checkFailed})`
+      : behind > 0
+        ? ` (+${behind})`
+        : available
+          ? ` (${copy.update})`
+          : ''
 
   const tooltip = [
     busy && (applyMessage || copy.updateInProgress),
+    !busy && error && copy.checkFailed,
     !busy && behind > 0 && copy.commitsBehind(behind, (client ? branch : 'main') || '...'),
     !busy && behind <= 0 && available && copy.update,
     version && (client ? copy.desktopVersion(version) : copy.backendVersion(version)),
@@ -98,7 +110,7 @@ export function resolveVersionStatus({
 
   return {
     detail: client && version && sha && !busy && !remote ? sha : undefined,
-    hasUpdate: !busy && available,
+    hasUpdate: !busy && !error && available,
     label: busy ? `${base} · ${restarting ? copy.restart : copy.update}` : `${base}${hint}`,
     tooltip: tooltip || undefined,
     unknown: !version && !(client && sha)

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -240,13 +240,53 @@ describe('checkBackendUpdates', () => {
       update_available: false,
       can_apply: false,
       update_command: 'docker pull ...',
-      message: 'Docker images are immutable.'
+      message: 'Docker images are immutable.',
+      error_code: 'update-check-not-applicable'
     })
 
     const result = await checkBackendUpdates()
 
     expect(result?.supported).toBe(false)
     expect(result?.message).toBe('Docker images are immutable.')
+    expect(result?.error).toBeUndefined()
+  })
+
+  it('marks behind=null from an older backend as a failed check without error_code', async () => {
+    setRemote(true)
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'docker',
+      current_version: '0.16.0',
+      behind: null,
+      update_available: false,
+      can_apply: false,
+      update_command: 'docker pull ...',
+      message: 'Unable to check for updates.'
+    })
+
+    const result = await checkBackendUpdates()
+
+    expect(result?.error).toBe('check-failed')
+    expect(result?.behind).toBeUndefined()
+  })
+
+  it('preserves a backend update-check failure instead of mapping it to current', async () => {
+    setRemote(true)
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'managed-runtime',
+      current_version: '0.20.0',
+      behind: null,
+      update_available: false,
+      can_apply: false,
+      update_command: 'managed outside dashboard',
+      message: "Couldn't reach the update source — try again later.",
+      error_code: 'update-check-failed'
+    })
+
+    const result = await checkBackendUpdates()
+
+    expect(result?.error).toBe('update-check-failed')
+    expect(result?.behind).toBeUndefined()
+    expect(result?.updateAvailable).toBe(false)
   })
 
   it('is a no-op in local mode (backend check only runs when remote)', async () => {
@@ -348,6 +388,52 @@ describe('requestActiveUpdate', () => {
     requestActiveUpdate()
     await vi.waitFor(() => expect(updateHermesSpy).toHaveBeenCalled())
   })
+
+  it('opens managed non-applyable backend updates without calling apply', async () => {
+    setRemote(true)
+    $backendUpdateStatus.set(status({ behind: 0, updateAvailable: true, supported: false }))
+
+    requestActiveUpdate()
+    await vi.waitFor(() => expect(checkHermesUpdateSpy).toHaveBeenCalled())
+
+    expect($updateOverlayOpen.get()).toBe(true)
+    expect($updateOverlayTarget.get()).toBe('backend')
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a direct managed backend apply before transport', async () => {
+    setRemote(true)
+    $backendUpdateStatus.set(status({ behind: 3, updateAvailable: true, supported: false }))
+
+    const result = await applyBackendUpdate()
+
+    expect(result).toMatchObject({ ok: false, error: 'update-not-applyable' })
+    expect($updateOverlayOpen.get()).toBe(true)
+    expect($updateOverlayTarget.get()).toBe('backend')
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a direct backend apply before status is known', async () => {
+    setRemote(true)
+    $backendUpdateStatus.set(null)
+
+    const result = await applyBackendUpdate()
+
+    expect(result).toMatchObject({ ok: false, error: 'update-not-applyable' })
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+  })
+
+  it('opens an errored client update status without calling apply', async () => {
+    setRemote(false)
+    $updateStatus.set(status({ behind: 3, error: 'check-failed' }))
+
+    requestActiveUpdate()
+    await vi.waitFor(() => expect(checkClientMock).toHaveBeenCalled())
+
+    expect($updateOverlayOpen.get()).toBe(true)
+    expect($updateOverlayTarget.get()).toBe('client')
+    expect(applyClientMock).not.toHaveBeenCalled()
+  })
 })
 
 describe('applyUpdates terminal state', () => {
@@ -359,6 +445,7 @@ describe('applyUpdates terminal state', () => {
     dismissSpy.mockClear()
     applyMock.mockReset()
     resetUpdateApplyState()
+    $updateStatus.set(status())
     $updateOverlayOpen.set(true)
     ;(globalThis as unknown as { window: unknown }).window = {
       hermesDesktop: { updates: { apply: applyMock } }
@@ -368,6 +455,20 @@ describe('applyUpdates terminal state', () => {
 
   afterEach(() => {
     delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it.each([
+    ['missing', null],
+    ['current', status({ behind: 0, updateAvailable: false })],
+    ['unsupported', status({ supported: false })],
+    ['failed', status({ error: 'check-failed' })]
+  ])('rejects %s client status at the shared apply boundary', async (_label, invalidStatus) => {
+    $updateStatus.set(invalidStatus)
+
+    const result = await applyUpdates()
+
+    expect(result).toMatchObject({ ok: false, error: 'update-not-applyable' })
+    expect(applyMock).not.toHaveBeenCalled()
   })
 
   it('holds the restart view when a relauncher hands off (no close, no toast)', async () => {
@@ -469,7 +570,7 @@ describe('applyBackendUpdate recovery', () => {
     checkHermesUpdateSpy.mockReset()
     updateHermesSpy.mockReset()
     getActionStatusSpy.mockReset()
-    $backendUpdateStatus.set(null)
+    $backendUpdateStatus.set(status())
     $backendUpdateApply.set({
       applying: false,
       stage: 'idle',
@@ -484,6 +585,15 @@ describe('applyBackendUpdate recovery', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('refuses to apply when the backend is already current', async () => {
+    $backendUpdateStatus.set(status({ behind: 0, updateAvailable: false }))
+
+    const result = await applyBackendUpdate()
+
+    expect(result).toMatchObject({ ok: false, error: 'update-not-applyable' })
+    expect(updateHermesSpy).not.toHaveBeenCalled()
   })
 
   it('waits for the backend to return after the restart drops the connection, then clears the overlay', async () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -266,7 +266,11 @@ export function requestActiveUpdate(): void {
   const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
   const status = target === 'backend' ? $backendUpdateStatus.get() : $updateStatus.get()
 
-  if ((status?.behind ?? 0) > 0 || status?.updateAvailable) {
+  if (
+    status?.supported !== false &&
+    !status?.error &&
+    ((status?.behind ?? 0) > 0 || status?.updateAvailable)
+  ) {
     startActiveUpdate()
 
     return
@@ -308,13 +312,14 @@ function isRemoteMode(): boolean {
 }
 
 function mapBackendCheck(res: BackendUpdateCheckResponse): DesktopUpdateStatus {
-  const behind = res.behind ?? 0
+  const notApplicable = res.error_code === 'update-check-not-applicable'
 
   return {
     supported: res.can_apply,
     message: res.message ?? undefined,
+    error: notApplicable ? undefined : (res.error_code ?? (res.behind === null ? 'check-failed' : undefined)),
     updateAvailable: res.update_available,
-    behind: behind > 0 ? behind : 0,
+    behind: res.behind === null ? undefined : Math.max(0, res.behind),
     currentVersion: res.current_version,
     targetSha: res.update_available ? `backend:${res.current_version}` : undefined,
     commits: res.commits,
@@ -387,6 +392,24 @@ export async function checkUpdates(): Promise<DesktopUpdateStatus | null> {
 }
 
 export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promise<DesktopUpdateApplyResult> {
+  const status = $updateStatus.get()
+  const updateAvailable =
+    status?.updateAvailable === true || (typeof status?.behind === 'number' && status.behind > 0)
+  if (!status || status.supported === false || status.error || !updateAvailable) {
+    $updateOverlayTarget.set('client')
+    $updateOverlayOpen.set(true)
+
+    return {
+      ok: false,
+      error: 'update-not-applyable',
+      message: status?.error
+        ? 'Desktop update status must be checked successfully before applying.'
+        : !updateAvailable && status
+          ? 'Hermes Desktop is already up to date.'
+          : 'Desktop updates are unavailable for this installation.'
+    }
+  }
+
   const bridge = window.hermesDesktop?.updates
 
   if (!bridge) {
@@ -681,6 +704,24 @@ async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
 }
 
 export function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
+  const status = $backendUpdateStatus.get()
+  const updateAvailable =
+    status?.updateAvailable === true || (typeof status?.behind === 'number' && status.behind > 0)
+  if (!status || status.supported === false || status.error || !updateAvailable) {
+    $updateOverlayTarget.set('backend')
+    $updateOverlayOpen.set(true)
+
+    return Promise.resolve({
+      ok: false,
+      error: 'update-not-applyable',
+      message: status?.error
+        ? 'Backend update status must be checked successfully before applying.'
+        : !updateAvailable && status
+          ? 'The backend is already up to date.'
+          : 'Backend updates are managed outside Hermes Desktop.'
+    })
+  }
+
   if (backendUpdateInFlight) {
     return backendUpdateInFlight
   }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1193,6 +1193,7 @@ export interface BackendUpdateCheckResponse {
   can_apply: boolean
   update_command: string | null
   message: string | null
+  error_code?: string
   commits?: BackendUpdateCommit[]
 }
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import threading
 import time
+import uuid
 from pathlib import Path
 from urllib.parse import urlparse
 from hermes_constants import get_hermes_home
@@ -141,20 +142,42 @@ UPDATE_AVAILABLE_NO_COUNT = -1
 _UPSTREAM_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
 _OFFICIAL_REPO_CANONICAL = "github.com/nousresearch/hermes-agent"
 
+# Absolute (idempotent) depth used to recover exact recent counts in installer
+# clones. This stays bounded and preserves the shallow boundary; it never uses
+# relative ``--deepen`` or downloads the full repository history.
+_SHALLOW_HISTORY_TARGET = 200
+
 
 def _canonical_github_remote(url: str | None) -> str:
-    """Return ``host/owner/repo`` for common GitHub remote URL forms."""
+    """Return ``host/owner/repo`` only for explicit HTTPS/SSH GitHub URLs."""
     if not url:
         return ""
     value = url.strip()
-    if value.startswith("git@github.com:"):
+    lower_value = value.lower()
+    if lower_value.startswith("git@github.com:"):
         value = "github.com/" + value[len("git@github.com:"):]
-    elif value.startswith("ssh://git@github.com/"):
+    elif lower_value.startswith("ssh://git@github.com/"):
         value = "github.com/" + value[len("ssh://git@github.com/"):]
     else:
         parsed = urlparse(value)
-        if parsed.netloc and parsed.path:
-            value = f"{parsed.netloc}{parsed.path}"
+        try:
+            port = parsed.port
+        except ValueError:
+            return ""
+        if (
+            parsed.scheme.lower() != "https"
+            or parsed.netloc.lower() not in {"github.com", "github.com:443"}
+            or (parsed.hostname or "").lower() != "github.com"
+            or parsed.username
+            or parsed.password
+            or port not in (None, 443)
+            or parsed.params
+            or parsed.query
+            or parsed.fragment
+            or not parsed.path
+        ):
+            return ""
+        value = f"github.com{parsed.path}"
     value = value.strip().rstrip("/")
     if value.endswith(".git"):
         value = value[:-4]
@@ -172,6 +195,47 @@ def _is_official_ssh_remote(url: str | None) -> bool:
     return _is_ssh_remote(url) and _canonical_github_remote(url) == _OFFICIAL_REPO_CANONICAL
 
 
+def _is_official_remote(url: str | None) -> bool:
+    return _canonical_github_remote(url) == _OFFICIAL_REPO_CANONICAL
+
+
+_REPOSITORY_SELECTING_GIT_ENV = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_PREFIX",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_SHALLOW_FILE",
+    "GIT_GRAFT_FILE",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_QUARANTINE_PATH",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+)
+
+
+def _sanitized_git_env() -> dict[str, str]:
+    """Return the process environment without ambient repository selection."""
+    env = os.environ.copy()
+    for key in _REPOSITORY_SELECTING_GIT_ENV:
+        env.pop(key, None)
+    # Process-level config can still rewrite origins through
+    # ``url.*.insteadOf``. Remove every config carrier and ignore system/global
+    # config; update checks need only local repository config and public access.
+    for key in list(env):
+        if key == "GIT_CONFIG" or key == "GIT_CONFIG_PARAMETERS" or key.startswith("GIT_CONFIG_"):
+            env.pop(key, None)
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    return env
+
+
 def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str]:
     try:
         result = subprocess.run(
@@ -185,6 +249,7 @@ def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str
             errors="replace",
             timeout=timeout,
             cwd=str(cwd),
+            env=_sanitized_git_env(),
         )
     except Exception:
         return None
@@ -204,6 +269,7 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
             ["git", "ls-remote", _UPSTREAM_REPO_URL, "refs/heads/main"],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=10,
+            env=_sanitized_git_env(),
         )
     except Exception:
         return None
@@ -215,73 +281,102 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _fetch_main_snapshot(repo_dir: Path, *, bounded: bool) -> Optional[tuple[str, str]]:
+    """Fetch origin/main into a unique ref and return its immutable commit ID."""
+    snapshot_ref = f"refs/hermes/update-check/{uuid.uuid4().hex}"
+    fetch_args = ["git", "fetch", "--quiet"]
+    if bounded:
+        fetch_args += ["--depth", str(_SHALLOW_HISTORY_TARGET)]
+    fetch_args += ["origin", f"main:{snapshot_ref}"]
+    try:
+        result = subprocess.run(
+            fetch_args,
+            capture_output=True,
+            timeout=30 if bounded else 10,
+            cwd=str(repo_dir),
+            env=_sanitized_git_env(),
+        )
+    except Exception:
+        _delete_snapshot_ref(repo_dir, snapshot_ref)
+        return None
+    if result.returncode != 0:
+        _delete_snapshot_ref(repo_dir, snapshot_ref)
+        return None
+
+    target_rev = _git_stdout(
+        ["rev-parse", "--verify", f"{snapshot_ref}^{{commit}}"],
+        cwd=repo_dir,
+    )
+    if not target_rev:
+        _delete_snapshot_ref(repo_dir, snapshot_ref)
+        return None
+    return target_rev, snapshot_ref
+
+
+def _delete_snapshot_ref(repo_dir: Path, snapshot_ref: str) -> None:
+    """Best-effort cleanup after all graph operations have consumed a snapshot."""
+    try:
+        subprocess.run(
+            ["git", "update-ref", "-d", snapshot_ref],
+            capture_output=True,
+            timeout=5,
+            cwd=str(repo_dir),
+            env=_sanitized_git_env(),
+        )
+    except Exception:
+        pass
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
-    """Count commits behind origin/main in a local checkout."""
+    """Count commits behind the fetched origin/main snapshot."""
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
         checked = _check_via_rev(head_rev) if head_rev else None
-        if checked == UPDATE_AVAILABLE_NO_COUNT:
-            return 1
         return checked
 
-    # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
-    # clone the history stops at a single commit, so a plain `git fetch` would
-    # unshallow the repo (dragging in the whole history) and
-    # `rev-list --count HEAD..origin/main` would report a huge bogus "behind"
-    # number (e.g. "12492 commits behind"). Detect shallow up front: fetch with
-    # --depth 1 to preserve the boundary and compare tip SHAs instead of
-    # counting. Full clones (developers, Docker dev images) keep the exact
-    # count path unchanged. Mirrors the desktop fix in apps/desktop/electron/main.cjs.
+    # Installer checkouts are shallow (`git clone --depth 1`). A plain fetch can
+    # unshallow the repo and download the whole history. A failed/unsupported
+    # shallow-state probe is not evidence of a full clone, so it also takes the
+    # absolute bounded-depth path.
     shallow = _git_stdout(["rev-parse", "--is-shallow-repository"], cwd=repo_dir)
-    is_shallow = shallow == "true"
+    bounded = shallow != "false"
+    head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
+    if not head_rev:
+        return None
 
+    snapshot = _fetch_main_snapshot(repo_dir, bounded=bounded)
+    if snapshot is None:
+        # A bounded checkout may still compare its immutable local tip to the
+        # official remote tip without trusting a stale FETCH_HEAD. Never change
+        # identity to the hard-coded official repo for forks/missing origins.
+        # Full clones fail closed rather than counting against a stale ref.
+        return _check_via_rev(head_rev) if bounded and _is_official_remote(origin_url) else None
+
+    target_rev, snapshot_ref = snapshot
     try:
-        # Scope the fetch to the one branch the behind-count compares against.
-        # An unscoped ``git fetch origin`` transfers every remote head (~1,400
-        # on this repo — measured 3.0 s vs 0.55 s scoped) and can burn the full
-        # 10 s timeout on slow links. ``cmd_update`` already scopes its fetch
-        # for the same reason. Modern git updates the ``origin/main`` tracking
-        # ref on a scoped fetch, so the ``HEAD..origin/main`` count below is
-        # unaffected; the shallow path compares against FETCH_HEAD, which a
-        # scoped fetch also updates.
-        fetch_args = ["git", "fetch", "origin", "main"]
-        if is_shallow:
-            fetch_args += ["--depth", "1"]
-        fetch_args.append("--quiet")
-        subprocess.run(
-            fetch_args,
-            capture_output=True, timeout=10,
-            cwd=str(repo_dir),
-        )
-    except Exception:
-        pass  # Offline or timeout — use stale refs, that's fine
+        if head_rev == target_rev:
+            return 0
 
-    if is_shallow:
-        # No history to count across the shallow boundary. `origin/main` may not
-        # be a tracking ref in a `clone --depth 1`, so prefer FETCH_HEAD (just
-        # updated by the fetch above) and fall back to origin/main.
-        head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        target_rev = (
-            _git_stdout(["rev-parse", "FETCH_HEAD"], cwd=repo_dir)
-            or _git_stdout(["rev-parse", "origin/main"], cwd=repo_dir)
-        )
-        if not head_rev or not target_rev:
-            return None
-        return 0 if head_rev == target_rev else UPDATE_AVAILABLE_NO_COUNT
+        if bounded:
+            # Report the exact count when the bounded fetch includes the merge
+            # base; otherwise retain the truthful unknown-count sentinel.
+            if _git_stdout(["merge-base", head_rev, target_rev], cwd=repo_dir):
+                count = _git_stdout(
+                    ["rev-list", "--count", f"{head_rev}..{target_rev}"],
+                    cwd=repo_dir,
+                )
+                if count and count.isdigit():
+                    return int(count)
+            return UPDATE_AVAILABLE_NO_COUNT
 
-    try:
-        result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD..origin/main"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
-            timeout=5,
-            cwd=str(repo_dir),
+        count = _git_stdout(
+            ["rev-list", "--count", f"{head_rev}..{target_rev}"],
+            cwd=repo_dir,
         )
-        if result.returncode == 0:
-            return int(result.stdout.strip())
-    except Exception:
-        pass
-    return None
+        return int(count) if count and count.isdigit() else None
+    finally:
+        _delete_snapshot_ref(repo_dir, snapshot_ref)
 
 
 def check_for_updates() -> Optional[int]:
@@ -297,18 +392,27 @@ def check_for_updates() -> Optional[int]:
     """
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
-    embedded_rev = os.environ.get("HERMES_REVISION") or None
+    runtime_root = os.environ.get("HERMES_RUNTIME_ROOT", "").strip()
+    # An explicit managed selector is the runtime identity. It wins over a
+    # packaged HERMES_REVISION and remains fail-closed when invalid.
+    embedded_rev = None if runtime_root else (os.environ.get("HERMES_REVISION") or None)
+    repo_dir = _resolve_repo_dir() if runtime_root or not embedded_rev else None
+    repo_identity = str(repo_dir) if repo_dir is not None else None
 
-    # Docker images have no working tree to count commits against — the
-    # published image excludes `.git` (see .dockerignore) and sets no
-    # HERMES_REVISION (that's nix-only). Returning None makes both the Rich
-    # banner (build_welcome_banner) and the Ink badge (branding.tsx, guarded
-    # on `typeof === 'number' && > 0`) show nothing. The dashboard's REST
-    # `/api/hermes/update/check` endpoint short-circuits docker the same way
-    # (web_server.py); mirror that here so the banner/TUI surfaces agree.
+    # An explicit selector is authoritative. If it cannot be validated, fail
+    # before consulting caches from older releases that carried no repo key.
+    if runtime_root and repo_dir is None:
+        return None
+
+    # Docker images normally have no working tree to count commits against —
+    # the published image excludes `.git` (see .dockerignore) and sets no
+    # HERMES_REVISION (that's nix-only). A validated HERMES_RUNTIME_ROOT is an
+    # authoritative managed checkout, though, even when imports come from a
+    # package tree stamped as docker; only short-circuit when no checkout was
+    # resolved. The dashboard endpoint applies the same runtime-root policy.
     try:
         from hermes_cli.config import detect_install_method, get_project_root
-        if detect_install_method(get_project_root()) == "docker":
+        if repo_dir is None and detect_install_method(get_project_root()) == "docker":
             return None
     except Exception:
         pass
@@ -323,6 +427,7 @@ def check_for_updates() -> Optional[int]:
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
                 and cached.get("ver") == VERSION
+                and cached.get("repo") == repo_identity
             ):
                 return cached.get("behind")
     except Exception:
@@ -331,13 +436,7 @@ def check_for_updates() -> Optional[int]:
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
+        if repo_dir is None:
             # No git checkout and no embedded revision — can't determine
             # update status. This is the Docker path (already short-circuited
             # above) or an unsupported install without a source tree.
@@ -347,7 +446,15 @@ def check_for_updates() -> Optional[int]:
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+            json.dumps(
+                {
+                    "ts": now,
+                    "behind": behind,
+                    "rev": embedded_rev,
+                    "ver": VERSION,
+                    "repo": repo_identity,
+                }
+            ),
             encoding="utf-8",
         )
     except Exception:
@@ -356,18 +463,45 @@ def check_for_updates() -> Optional[int]:
     return behind
 
 
+def _validated_worktree_root(candidate: Path) -> Optional[Path]:
+    """Return candidate only when Git identifies that exact path as a worktree root."""
+    try:
+        resolved = candidate.resolve()
+    except (OSError, RuntimeError):
+        return None
+
+    top_level = _git_stdout(["rev-parse", "--show-toplevel"], cwd=resolved)
+    if not top_level:
+        return None
+    try:
+        return resolved if Path(top_level).resolve() == resolved else None
+    except (OSError, RuntimeError):
+        return None
+
+
 def _resolve_repo_dir() -> Optional[Path]:
     """Return the active Hermes git checkout, or None if this isn't a git install.
 
-    Prefers the running code's location over the profile-scoped path
-    because ``$HERMES_HOME/hermes-agent/`` may be a stale copy carried
-    over by ``--clone-all``.
+    Managed installs can import Hermes from a packaged ``site-packages`` tree
+    while ``HERMES_RUNTIME_ROOT`` selects the authoritative checkout. Treat
+    that explicit runtime identity as fail-closed; only when it is unset try
+    the running source location and then the profile-scoped fallback (which may
+    be stale after ``--clone-all``).
     """
-    repo_dir = Path(__file__).parent.parent.resolve()
-    if not (repo_dir / ".git").exists():
-        hermes_home = get_hermes_home()
-        repo_dir = hermes_home / "hermes-agent"
-    return repo_dir if (repo_dir / ".git").exists() else None
+    runtime_root = os.environ.get("HERMES_RUNTIME_ROOT", "").strip()
+    if runtime_root:
+        return _validated_worktree_root(Path(runtime_root).expanduser())
+
+    candidates = [
+        Path(__file__).parent.parent,
+        get_hermes_home() / "hermes-agent",
+    ]
+
+    for candidate in candidates:
+        resolved = _validated_worktree_root(candidate)
+        if resolved is not None:
+            return resolved
+    return None
 
 
 def _git_short_hash(repo_dir: Path, rev: str) -> Optional[str]:
@@ -381,6 +515,7 @@ def _git_short_hash(repo_dir: Path, rev: str) -> Optional[str]:
             errors="replace",
             timeout=5,
             cwd=str(repo_dir),
+            env=_sanitized_git_env(),
         )
     except Exception:
         return None
@@ -458,6 +593,7 @@ def _compute_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]
             errors="replace",
             timeout=5,
             cwd=str(repo_dir),
+            env=_sanitized_git_env(),
         )
         if result.returncode == 0:
             ahead = int((result.stdout or "0").strip() or "0")
@@ -496,6 +632,7 @@ def get_latest_release_tag(repo_dir: Optional[Path] = None) -> Optional[tuple]:
             errors="replace",
             timeout=3,
             cwd=str(repo_dir),
+            env=_sanitized_git_env(),
         )
     except Exception:
         _latest_release_cache = ()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2141,6 +2141,10 @@ def _default_hermes_root_is_opt_data() -> bool:
 def _dashboard_local_update_managed_externally() -> bool:
     """Return true when the dashboard should not offer ``hermes update``.
 
+    An explicit runtime root means an external selector owns activation. The
+    dashboard may inspect that checkout for update status, but must not mutate
+    it through the built-in updater.
+
     Containerized dashboards are updated by the outer launcher/image, not by an
     in-browser local update action. Keep this dashboard capability separate
     from install-method detection: manual git/pip installs inside containers can
@@ -2153,6 +2157,8 @@ def _dashboard_local_update_managed_externally() -> bool:
     externally managed unless their apply path is proven safe inside the
     running container filesystem.
     """
+    if os.environ.get("HERMES_RUNTIME_ROOT", "").strip():
+        return True
     if _default_hermes_root_is_opt_data():
         return True
     try:
@@ -4176,9 +4182,8 @@ async def update_hermes():
     """Kick off ``hermes update`` in the background."""
     if _dashboard_local_update_managed_externally():
         message = (
-            "Hermes updates are managed outside this dashboard in "
-            "containerized environments. The built-in local updater is "
-            "disabled here."
+            "Hermes updates are managed outside this dashboard. "
+            "The built-in local updater is disabled here."
         )
         _record_completed_action("hermes-update", message, exit_code=1)
         return {
@@ -4227,6 +4232,39 @@ async def update_hermes():
         if action_id:
             response["action_id"] = action_id
         return response
+
+    try:
+        from hermes_cli.banner import check_for_updates
+
+        try:
+            (get_hermes_home() / ".update_check").unlink()
+        except OSError:
+            pass
+        behind = await asyncio.to_thread(check_for_updates)
+    except Exception:
+        _log.exception("Pre-apply update check failed")
+        behind = None
+
+    if behind is None:
+        message = "Update status could not be checked successfully; no update was started."
+        _record_completed_action("hermes-update", message, exit_code=1)
+        return {
+            "ok": False,
+            "pid": None,
+            "name": "hermes-update",
+            "error": "dashboard_update_check_failed",
+            "message": message,
+        }
+    if behind == 0:
+        message = "Hermes is already up to date; no update was started."
+        _record_completed_action("hermes-update", message, exit_code=1)
+        return {
+            "ok": False,
+            "pid": None,
+            "name": "hermes-update",
+            "error": "dashboard_update_not_available",
+            "message": message,
+        }
 
     action_id = secrets.token_hex(16)
     try:
@@ -4320,40 +4358,41 @@ async def check_hermes_update(force: bool = False):
                    user must update out-of-band
         update_command: the recommended command for this install method
         message: human-readable guidance for non-applyable methods
-        commits: for git installs that are behind, a list of the commits
-                 the local checkout is behind upstream by — each
-                 {sha, summary, author, at}. Absent/empty otherwise. The
-                 desktop's remote update overlay renders this as "what's
-                 changed". Additive: existing consumers ignore it.
+        error_code: stable machine-readable code when the check fails; absent
+                    after a successful check
     """
-    if _dashboard_local_update_managed_externally():
-        return {
-            "install_method": "managed-runtime",
-            "current_version": __version__,
-            "behind": None,
-            "update_available": False,
-            "can_apply": False,
-            "update_command": "managed outside dashboard",
-            "message": (
-                "Hermes updates are managed outside this dashboard in "
-                "containerized environments."
-            ),
-        }
-
-    install_method = detect_install_method(PROJECT_ROOT)
-    update_command = recommended_update_command_for_method(install_method)
+    explicit_runtime_root = bool(os.environ.get("HERMES_RUNTIME_ROOT", "").strip())
+    if explicit_runtime_root:
+        managed_externally = True
+        install_method = "managed-runtime"
+        update_command = "managed outside dashboard"
+    else:
+        detected_install_method = detect_install_method(PROJECT_ROOT)
+        managed_externally = _dashboard_local_update_managed_externally()
+        # Preserve Docker's more specific out-of-band update contract even
+        # though canonical containers are also externally managed.
+        if detected_install_method == "docker":
+            install_method = "docker"
+            update_command = recommended_update_command_for_method(install_method)
+        elif managed_externally:
+            install_method = "managed-runtime"
+            update_command = "managed outside dashboard"
+        else:
+            install_method = detected_install_method
+            update_command = recommended_update_command_for_method(install_method)
 
     payload: Dict[str, Any] = {
         "install_method": install_method,
         "current_version": __version__,
         "behind": None,
         "update_available": False,
-        "can_apply": install_method == "git",
+        "can_apply": not managed_externally and install_method == "git",
         "update_command": update_command,
         "message": None,
     }
 
     if install_method == "docker":
+        payload["error_code"] = "update-check-not-applicable"
         payload["message"] = format_docker_update_message()
         return payload
 
@@ -4376,16 +4415,22 @@ async def check_hermes_update(force: bool = False):
 
     payload["behind"] = behind
     if behind is None:
+        payload["error_code"] = "update-check-failed"
         payload["message"] = "Couldn't reach the update source — try again later."
+        if managed_externally:
+            payload["message"] += " Hermes updates are managed outside this dashboard."
     elif behind == 0:
         payload["message"] = "You're on the latest version."
+        if managed_externally:
+            payload["message"] += " Hermes updates are managed outside this dashboard."
     else:
         payload["update_available"] = True
-        # Enrich with the actual commits we're behind by, so the desktop's
-        # remote update overlay can show "what's changed". git only;
-        # best-effort (empty list on any failure).
-        if install_method == "git":
-            payload["commits"] = await asyncio.to_thread(_recent_upstream_commits)
+        if managed_externally:
+            payload["message"] = "Update available; Hermes updates are managed outside this dashboard."
+        # Do not reconstruct a changelog from mutable HEAD/origin/main after the
+        # count's immutable snapshot has been released. The count remains
+        # authoritative; commit enrichment is optional and therefore omitted
+        # until the checker can return its exact endpoint SHA pair.
 
     return payload
 

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -779,6 +779,7 @@ class TestUpdateCheckEndpoint:
     def test_git_install_reports_behind_count(self, monkeypatch):
         import hermes_cli.web_server as ws
 
+        monkeypatch.setattr(ws, "_dashboard_local_update_managed_externally", lambda: False)
         monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "git")
         # Stub the shared checker so the contract is deterministic (no network).
         import hermes_cli.banner as banner
@@ -803,12 +804,29 @@ class TestUpdateCheckEndpoint:
         # git/pip installs can apply the update in place from the dashboard.
         assert body["can_apply"] is True
 
+    def test_docker_install_is_explicitly_not_applicable(self, monkeypatch):
+        import hermes_cli.web_server as ws
 
+        # Canonical containers are externally managed, but the API must retain
+        # the more specific Docker contract and guidance.
+        monkeypatch.delenv("HERMES_RUNTIME_ROOT", raising=False)
+        monkeypatch.setattr(ws, "_dashboard_local_update_managed_externally", lambda: True)
+        monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "docker")
+
+        body = self.client.get("/api/hermes/update/check").json()
+
+        assert body["install_method"] == "docker"
+        assert body["behind"] is None
+        assert body["update_available"] is False
+        assert body["can_apply"] is False
+        assert body["error_code"] == "update-check-not-applicable"
+        assert body["message"]
 
     def test_managed_runtime_dashboard_is_not_applyable(self, monkeypatch):
         import hermes_cli.web_server as ws
+        import hermes_cli.banner as banner
 
-        monkeypatch.setattr(ws, "_dashboard_local_update_managed_externally", lambda: True)
+        monkeypatch.setenv("HERMES_RUNTIME_ROOT", "/managed/hermes-runtime")
         monkeypatch.setattr(
             ws,
             "detect_install_method",
@@ -816,15 +834,109 @@ class TestUpdateCheckEndpoint:
                 "managed runtime update check should not probe install method"
             ),
         )
+        monkeypatch.setattr(banner, "check_for_updates", lambda: 7)
 
         body = self.client.get("/api/hermes/update/check").json()
         assert body["install_method"] == "managed-runtime"
         assert body["can_apply"] is False
-        assert body["update_available"] is False
-        assert body["behind"] is None
+        assert body["update_available"] is True
+        assert body["behind"] == 7
         assert "managed outside this dashboard" in body["message"]
 
+    def test_explicit_runtime_root_marks_dashboard_as_externally_managed(
+        self, monkeypatch
+    ):
+        import hermes_cli.web_server as ws
 
+        monkeypatch.setenv("HERMES_RUNTIME_ROOT", "/managed/hermes-runtime")
+
+        assert ws._dashboard_local_update_managed_externally() is True
+
+    def test_failed_update_check_has_stable_error_code(self, monkeypatch):
+        import hermes_cli.banner as banner
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "_dashboard_local_update_managed_externally", lambda: False)
+        monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "git")
+        monkeypatch.setattr(banner, "check_for_updates", lambda: None)
+
+        body = self.client.get("/api/hermes/update/check").json()
+
+        assert body["behind"] is None
+        assert body["update_available"] is False
+        assert body["error_code"] == "update-check-failed"
+
+    def test_update_check_omits_unbound_commit_enrichment(self, monkeypatch):
+        """A truthful count must not be paired with a separately resolved range."""
+        import hermes_cli.banner as banner
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "_dashboard_local_update_managed_externally", lambda: False)
+        monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "git")
+        monkeypatch.setattr(banner, "check_for_updates", lambda: 2)
+        monkeypatch.setattr(
+            ws,
+            "_recent_upstream_commits",
+            lambda *a, **k: pytest.fail("unbound changelog range must not be read"),
+        )
+
+        body = self.client.get("/api/hermes/update/check").json()
+
+        assert body["behind"] == 2
+        assert body["update_available"] is True
+        assert "commits" not in body
+
+
+
+
+    def test_post_update_refuses_current_or_failed_status(self, monkeypatch):
+        import hermes_cli.banner as banner
+        import hermes_cli.web_server as ws
+
+        monkeypatch.delenv("HERMES_RUNTIME_ROOT", raising=False)
+        monkeypatch.setattr(ws, "_dashboard_local_update_managed_externally", lambda: False)
+        monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "git")
+        ws._ACTION_PROCS.pop("hermes-update", None)
+        monkeypatch.setattr(
+            ws,
+            "_spawn_hermes_action",
+            lambda *a, **k: pytest.fail("unavailable update must not spawn"),
+        )
+
+        for behind, error in (
+            (0, "dashboard_update_not_available"),
+            (None, "dashboard_update_check_failed"),
+        ):
+            monkeypatch.setattr(banner, "check_for_updates", lambda value=behind: value)
+            response = self.client.post("/api/hermes/update")
+            assert response.status_code == 200
+            assert response.json()["ok"] is False
+            assert response.json()["error"] == error
+
+    def test_post_update_spawns_only_when_available(self, monkeypatch):
+        import hermes_cli.banner as banner
+        import hermes_cli.web_server as ws
+
+        monkeypatch.delenv("HERMES_RUNTIME_ROOT", raising=False)
+        monkeypatch.setattr(ws, "_dashboard_local_update_managed_externally", lambda: False)
+        monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "git")
+        monkeypatch.setattr(banner, "check_for_updates", lambda: 2)
+        ws._ACTION_PROCS.pop("hermes-update", None)
+        calls = []
+
+        class Proc:
+            pid = 4242
+
+        def spawn(args, name, **kwargs):
+            calls.append((args, name, kwargs))
+            return Proc()
+
+        monkeypatch.setattr(ws, "_spawn_hermes_action", spawn)
+        response = self.client.post("/api/hermes/update")
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+        assert calls and calls[0][:2] == (["update"], "hermes-update")
 
 
 class TestDebugShareEndpoint:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -10,30 +11,467 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _git(*args, cwd=None):
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
+    """When cache is fresh, check_for_updates should return it without an update check."""
     from hermes_cli.banner import check_for_updates
     from hermes_cli import __version__
 
-    # Create a fake git repo and fresh cache
     repo_dir = tmp_path / "hermes-agent"
-    repo_dir.mkdir()
-    (repo_dir / ".git").mkdir()
+    _git("init", "-b", "main", str(repo_dir))
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(
+        json.dumps(
+            {
+                "ts": time.time(),
+                "behind": 3,
+                "ver": __version__,
+                "rev": None,
+                "repo": str(repo_dir.resolve()),
+            }
+        )
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    monkeypatch.setenv("HERMES_RUNTIME_ROOT", str(repo_dir))
+    with patch("hermes_cli.banner._check_via_local_git") as mock_check:
         result = check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    mock_check.assert_not_called()
 
 
+def test_check_for_updates_prefers_managed_runtime_root_over_packaged_docker_stamp(tmp_path, monkeypatch):
+    """A packaged Docker stamp must not suppress the selected runtime checkout."""
+    import hermes_cli.banner as banner
 
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    runtime_repo = tmp_path / "candidate"
+    _git("init", "-b", "main", str(runtime_repo))
+    runtime_selector = tmp_path / "hermes-active"
+    runtime_selector.symlink_to(runtime_repo, target_is_directory=True)
+    packaged_module = tmp_path / "site-packages" / "hermes_cli" / "banner.py"
+    packaged_module.parent.mkdir(parents=True)
+    packaged_module.touch()
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_RUNTIME_ROOT", str(runtime_selector))
+    monkeypatch.setattr(banner, "__file__", str(packaged_module))
+
+    checked = []
+    monkeypatch.setattr(
+        banner,
+        "_check_via_local_git",
+        lambda repo_dir: checked.append(repo_dir) or 7,
+    )
+
+    with patch("hermes_cli.config.detect_install_method", return_value="docker"):
+        assert banner.check_for_updates() == 7
+    assert checked == [runtime_repo.resolve()]
+
+
+def test_resolve_repo_dir_fails_closed_for_invalid_managed_runtime_root(tmp_path, monkeypatch):
+    """An explicit managed runtime root must never fall back to another checkout."""
+    import hermes_cli.banner as banner
+
+    hermes_home = tmp_path / "home"
+    fallback_repo = hermes_home / "hermes-agent"
+    imported_repo = tmp_path / "imported"
+    _git("init", "-b", "main", str(fallback_repo))
+    _git("init", "-b", "main", str(imported_repo))
+    imported_module = imported_repo / "hermes_cli" / "banner.py"
+    imported_module.parent.mkdir()
+    imported_module.touch()
+
+    dangling_target = tmp_path / "missing-runtime"
+    runtime_selector = tmp_path / "hermes-active"
+    runtime_selector.symlink_to(dangling_target, target_is_directory=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_RUNTIME_ROOT", str(runtime_selector))
+    monkeypatch.setattr(banner, "__file__", str(imported_module))
+
+    assert banner._resolve_repo_dir() is None
+
+
+def test_resolve_repo_dir_rejects_git_marker_without_a_worktree(tmp_path, monkeypatch):
+    """A .git entry alone must not make an explicit runtime root trustworthy."""
+    import hermes_cli.banner as banner
+
+    runtime_root = tmp_path / "not-a-worktree"
+    runtime_root.mkdir()
+    (runtime_root / ".git").mkdir()
+    monkeypatch.setenv("HERMES_RUNTIME_ROOT", str(runtime_root))
+
+    assert banner._resolve_repo_dir() is None
+
+
+def test_check_for_updates_invalidates_cache_when_runtime_target_changes(tmp_path, monkeypatch):
+    """A selector flip must not reuse the previous candidate's cached count."""
+    import hermes_cli.banner as banner
+    from hermes_cli import __version__
+
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    old_repo = tmp_path / "old-candidate"
+    new_repo = tmp_path / "new-candidate"
+    for repo in (old_repo, new_repo):
+        _git("init", "-b", "main", str(repo))
+    runtime_selector = tmp_path / "hermes-active"
+    runtime_selector.symlink_to(new_repo, target_is_directory=True)
+    (hermes_home / ".update_check").write_text(
+        json.dumps(
+            {
+                "ts": time.time(),
+                "behind": 3,
+                "ver": __version__,
+                "rev": None,
+                "repo": str(old_repo.resolve()),
+            }
+        )
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_RUNTIME_ROOT", str(runtime_selector))
+    checked = []
+    monkeypatch.setattr(
+        banner,
+        "_check_via_local_git",
+        lambda repo_dir: checked.append(repo_dir) or 9,
+    )
+
+    assert banner.check_for_updates() == 9
+    assert checked == [new_repo.resolve()]
+
+
+def test_shallow_checkout_reports_exact_bounded_behind_count(tmp_path):
+    """Recent shallow installs recover an exact count without unshallowing."""
+    from hermes_cli.banner import _check_via_local_git
+
+    remote = tmp_path / "origin.git"
+    source = tmp_path / "source"
+    shallow = tmp_path / "shallow"
+    _git("init", "--bare", str(remote))
+    _git("init", "-b", "main", str(source))
+    _git("config", "user.email", "test@example.com", cwd=source)
+    _git("config", "user.name", "Test", cwd=source)
+    (source / "history.txt").write_text("base\n")
+    _git("add", "history.txt", cwd=source)
+    _git("commit", "-m", "base", cwd=source)
+    # Keep more history behind the installed revision than the passive fetch
+    # target, so recovering the seven recent commits cannot unshallow the repo.
+    for index in range(205):
+        _git("commit", "--allow-empty", "-m", f"old {index}", cwd=source)
+    _git("remote", "add", "origin", str(remote), cwd=source)
+    _git("push", "-u", "origin", "main", cwd=source)
+    _git("clone", "--depth", "1", "--branch", "main", f"file://{remote}", str(shallow))
+
+    for index in range(7):
+        with (source / "history.txt").open("a") as handle:
+            handle.write(f"{index}\n")
+        _git("add", "history.txt", cwd=source)
+        _git("commit", "-m", f"commit {index}", cwd=source)
+    _git("push", "origin", "main", cwd=source)
+
+    assert _check_via_local_git(shallow) == 7
+    assert _git("rev-parse", "--is-shallow-repository", cwd=shallow).stdout.strip() == "true"
+
+
+def test_unknown_shallow_state_uses_bounded_fetch(tmp_path, monkeypatch):
+    """A failed shallow-state probe must never fall through to a full fetch."""
+    import hermes_cli.banner as banner
+
+    head_rev = "a" * 40
+
+    def fake_git_stdout(args, *, cwd, timeout=5):
+        if args == ["remote", "get-url", "origin"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args == ["rev-parse", "--is-shallow-repository"]:
+            return None
+        if args in (["rev-parse", "HEAD"], ["rev-parse", "--verify", "HEAD^{commit}"]):
+            return head_rev
+        return None
+
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return MagicMock(returncode=1, stdout="")
+
+    monkeypatch.setattr(banner, "_git_stdout", fake_git_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+
+    assert banner._check_via_local_git(tmp_path) is None
+    fetch_cmd = next(cmd for cmd in commands if cmd[:2] == ["git", "fetch"])
+    assert fetch_cmd[fetch_cmd.index("--depth") + 1] == str(banner._SHALLOW_HISTORY_TARGET)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "https://example.com/acme/hermes-agent.git",
+        "file://github.com/NousResearch/hermes-agent.git",
+        "github.com/NousResearch/hermes-agent.git",
+        "https://github.com:notaport/NousResearch/hermes-agent.git",
+        "https://github.com:/NousResearch/hermes-agent.git",
+        "https://github.com/NousResearch/hermes-agent.git?redirect=evil",
+        "https://github.com/NousResearch/hermes-agent.git#fragment",
+        "https://github.com/NousResearch/hermes-agent.git;parameter",
+    ],
+)
+def test_nonofficial_origin_does_not_fallback_to_official_tip(monkeypatch, tmp_path, origin):
+    """Fetch failure must not silently change a checkout's upstream identity."""
+    import hermes_cli.banner as banner
+
+    def fake_git_stdout(args, **_kwargs):
+        if args == ["remote", "get-url", "origin"]:
+            return origin
+        if args == ["rev-parse", "--is-shallow-repository"]:
+            return "true"
+        if args == ["rev-parse", "HEAD"]:
+            return "a" * 40
+        return None
+
+    monkeypatch.setattr(banner, "_git_stdout", fake_git_stdout)
+    monkeypatch.setattr(banner, "_fetch_main_snapshot", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        banner,
+        "_check_via_rev",
+        lambda _rev: pytest.fail("nonofficial origin must not query official upstream"),
+    )
+
+    assert banner._check_via_local_git(tmp_path) is None
+
+
+def test_ambient_git_config_cannot_redirect_update_fetch(tmp_path, monkeypatch):
+    """Process-level Git config injection must not relabel origin/main."""
+    import hermes_cli.banner as banner
+
+    origin = tmp_path / "origin.git"
+    decoy = tmp_path / "decoy.git"
+    source = tmp_path / "source"
+    checkout = tmp_path / "checkout"
+    _git("init", "--bare", str(origin))
+    _git("init", "--bare", str(decoy))
+    _git("init", "-b", "main", str(source))
+    _git("config", "user.email", "test@example.com", cwd=source)
+    _git("config", "user.name", "Test", cwd=source)
+    _git("commit", "--allow-empty", "-m", "base", cwd=source)
+    _git("remote", "add", "origin", str(origin), cwd=source)
+    _git("push", "-u", "origin", "main", cwd=source)
+    _git("push", f"file://{decoy}", "main", cwd=source)
+    _git("clone", f"file://{origin}", str(checkout))
+    _git("commit", "--allow-empty", "-m", "upstream update", cwd=source)
+    _git("push", "origin", "main", cwd=source)
+
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", f"url.file://{decoy}.insteadOf")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", f"file://{origin}")
+
+    assert banner._check_via_local_git(checkout) == 1
+
+
+def test_git_graph_modifiers_are_removed_from_update_environment(monkeypatch):
+    """Ambient namespace/shallow overrides must not alter the checked graph."""
+    import hermes_cli.banner as banner
+
+    hostile = {
+        "GIT_NAMESPACE": "attacker",
+        "GIT_SHALLOW_FILE": "/tmp/attacker-shallow",
+        "GIT_GRAFT_FILE": "/tmp/attacker-grafts",
+        "GIT_REPLACE_REF_BASE": "refs/attacker/replace/",
+        "GIT_NO_REPLACE_OBJECTS": "1",
+        "GIT_QUARANTINE_PATH": "/tmp/attacker-objects",
+        "GIT_IMPLICIT_WORK_TREE": "0",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM": "1",
+    }
+    for key, value in hostile.items():
+        monkeypatch.setenv(key, value)
+
+    env = banner._sanitized_git_env()
+
+    assert hostile.keys().isdisjoint(env)
+
+
+def test_concurrent_fetch_head_overwrite_does_not_change_main_snapshot(tmp_path):
+    """A second real fetch cannot relabel the main commit captured by the check."""
+    import hermes_cli.banner as banner
+
+    remote = tmp_path / "origin.git"
+    source = tmp_path / "source"
+    shallow = tmp_path / "shallow"
+    _git("init", "--bare", str(remote))
+    _git("init", "-b", "main", str(source))
+    _git("config", "user.email", "test@example.com", cwd=source)
+    _git("config", "user.name", "Test", cwd=source)
+    (source / "history.txt").write_text("base\n")
+    _git("add", "history.txt", cwd=source)
+    _git("commit", "-m", "base", cwd=source)
+    _git("branch", "feature", cwd=source)
+    _git("remote", "add", "origin", str(remote), cwd=source)
+    _git("push", "-u", "origin", "main", "feature", cwd=source)
+    _git("clone", "--depth", "1", "--branch", "main", f"file://{remote}", str(shallow))
+
+    with (source / "history.txt").open("a") as handle:
+        handle.write("main update\n")
+    _git("add", "history.txt", cwd=source)
+    _git("commit", "-m", "main update", cwd=source)
+    _git("push", "origin", "main", cwd=source)
+
+    real_run = subprocess.run
+    overwrote_fetch_head = False
+
+    def overwrite_after_main_fetch(cmd, **kwargs):
+        nonlocal overwrote_fetch_head
+        result = real_run(cmd, **kwargs)
+        if (
+            not overwrote_fetch_head
+            and result.returncode == 0
+            and cmd[:2] == ["git", "fetch"]
+            and any(arg == "main" or arg.startswith("main:") for arg in cmd[2:])
+        ):
+            overwrite = real_run(
+                ["git", "fetch", "origin", "feature", "--quiet"],
+                capture_output=True,
+                timeout=30,
+                cwd=kwargs["cwd"],
+            )
+            assert overwrite.returncode == 0
+            overwrote_fetch_head = True
+        return result
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=overwrite_after_main_fetch):
+        assert banner._check_via_local_git(shallow) == 1
+
+    assert overwrote_fetch_head
+    assert _git("rev-parse", "FETCH_HEAD", cwd=shallow).stdout == _git("rev-parse", "HEAD", cwd=shallow).stdout
+
+
+def test_runtime_root_validation_ignores_ambient_git_repository_selection(
+    tmp_path, monkeypatch
+):
+    """GIT_DIR/GIT_WORK_TREE must not turn an arbitrary selector into a repo."""
+    import hermes_cli.banner as banner
+
+    real_repo = tmp_path / "real"
+    impostor = tmp_path / "impostor"
+    _git("init", "-b", "main", str(real_repo))
+    impostor.mkdir()
+    monkeypatch.setenv("HERMES_RUNTIME_ROOT", str(impostor))
+    monkeypatch.setenv("GIT_DIR", str(real_repo / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(impostor))
+
+    assert banner._resolve_repo_dir() is None
+
+
+def test_invalid_runtime_root_overrides_embedded_revision(tmp_path, monkeypatch):
+    """An explicit invalid selector fails closed even when HERMES_REVISION exists."""
+    import hermes_cli.banner as banner
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HERMES_RUNTIME_ROOT", str(tmp_path / "missing"))
+    monkeypatch.setenv("HERMES_REVISION", "a" * 40)
+    monkeypatch.setattr(
+        banner,
+        "_check_via_rev",
+        lambda _rev: pytest.fail("embedded revision must not bypass selector authority"),
+    )
+
+    assert banner.check_for_updates() is None
+
+
+def test_invalid_runtime_root_does_not_reuse_legacy_cache(tmp_path, monkeypatch):
+    """A legacy cache without repo identity cannot validate an explicit selector."""
+    import hermes_cli.banner as banner
+    from hermes_cli import __version__
+
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    (hermes_home / ".update_check").write_text(
+        json.dumps(
+            {
+                "ts": time.time(),
+                "behind": 9,
+                "ver": __version__,
+                "rev": None,
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_RUNTIME_ROOT", str(tmp_path / "missing"))
+
+    assert banner.check_for_updates() is None
+
+
+def test_failed_snapshot_fetch_cleans_created_temporary_ref(tmp_path, monkeypatch):
+    """A fetch that writes its ref then reports failure must not leak the ref."""
+    import hermes_cli.banner as banner
+
+    remote = tmp_path / "origin.git"
+    source = tmp_path / "source"
+    checkout = tmp_path / "checkout"
+    _git("init", "--bare", str(remote))
+    _git("init", "-b", "main", str(source))
+    _git("config", "user.email", "test@example.com", cwd=source)
+    _git("config", "user.name", "Test", cwd=source)
+    _git("commit", "--allow-empty", "-m", "base", cwd=source)
+    _git("remote", "add", "origin", str(remote), cwd=source)
+    _git("push", "-u", "origin", "main", cwd=source)
+    _git("clone", str(remote), str(checkout))
+
+    real_run = subprocess.run
+
+    def report_failure_after_fetch(cmd, **kwargs):
+        result = real_run(cmd, **kwargs)
+        if cmd[:2] == ["git", "fetch"] and result.returncode == 0:
+            return subprocess.CompletedProcess(
+                result.args, 1, stdout=result.stdout, stderr=result.stderr
+            )
+        return result
+
+    monkeypatch.setattr(banner.subprocess, "run", report_failure_after_fetch)
+    assert banner._fetch_main_snapshot(checkout, bounded=False) is None
+
+    refs = real_run(
+        ["git", "for-each-ref", "--format=%(refname)", "refs/hermes/update-check"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert refs == ""
+
+
+def test_official_ssh_remote_mismatch_has_unknown_count(monkeypatch, tmp_path):
+    """An unclassified SHA mismatch is not proof of exactly one commit behind."""
+    import hermes_cli.banner as banner
+
+    monkeypatch.setattr(
+        banner,
+        "_git_stdout",
+        lambda args, **_kwargs: (
+            "git@github.com:NousResearch/hermes-agent.git"
+            if args == ["remote", "get-url", "origin"]
+            else "a" * 40
+        ),
+    )
+    monkeypatch.setattr(
+        banner, "_check_via_rev", lambda _rev: banner.UPDATE_AVAILABLE_NO_COUNT
+    )
+
+    assert banner._check_via_local_git(tmp_path) == banner.UPDATE_AVAILABLE_NO_COUNT
 
 
 


### PR DESCRIPTION
## Summary

- treat a validated `HERMES_RUNTIME_ROOT` as the authoritative managed-runtime Git identity, including symlinked selectors, and fail closed for invalid roots before legacy cache, Docker, or embedded-revision fallbacks
- recover bounded exact counts for shallow installs using an immutable per-check ref, sanitize repository/config/graph-selecting `GIT_*` variables, strictly recognize only explicit official HTTPS/SSH origins for fallback, and clean temporary refs on every exit
- preserve failed/unknown backend checks through the API and Desktop instead of rendering them as current
- keep externally managed, errored, unknown, and already-current runtimes non-applyable at both UI entry points and the centralized Desktop apply boundary
- preserve canonical Docker not-applicable guidance even though container installs are externally managed, while explicit managed runtime roots remain authoritative
- omit optional commit enrichment rather than pairing an immutable count with a separately resolved mutable Git range

## Regression coverage

- valid, invalid, dangling, symlinked, Docker-stamped, and embedded-revision runtime-root states
- legacy cache entries without repository identity and cache invalidation after selector changes
- shallow, unknown-shallow, failed fetch, mutable `FETCH_HEAD`, temporary-ref cleanup, ambient `GIT_DIR` / `GIT_WORK_TREE`, config-injected URL rewrites, and nonofficial/malformed/query/fragment origin fallback cases
- explicit Docker not-applicable responses remain unsupported guidance rather than retryable check failures
- `behind` values `0`, `>0`, `-1`, and `null`, including older backend payloads without `error_code`
- managed/error/unknown Desktop status rendering and apply-transport denial

## Verification at exact head `08da846c937f8dc4aedabc6628244bf2851984c3`

- affected Python suites: 68 passed
- complete Desktop UI suite: 3,690 passed across 414 files
- affected Desktop suites: 63 passed
- TypeScript typecheck: passed
- ESLint: passed
- Ruff: passed
- `git diff --check`: passed
- live managed-runtime proof: exact count 49, hostile ambient Git variables ignored, zero leaked temporary refs
- independent exact-head blocking review: running; this line will be updated with the final verdict

## Notes

The full local Python suite was attempted earlier and retains unrelated optional-dependency/environment baseline failures outside these paths (for example missing `acp`). GitHub currently reports no hosted checks for this branch, so the exact-head local evidence and independent review above are the available gates.
