### PR TITLE
fix: reconcile state, LSP, and terminal safety guards

### DIFF
--- a/agent/lsp/__init__.py
+++ b/agent/lsp/__init__.py
@@ -93,6 +93,24 @@ def shutdown_service() -> None:
             logger.debug("LSP shutdown error: %s", e)
 
 
+def publish_service_status() -> None:
+    """Publish the current singleton state without creating a service.
+
+    Lifecycle callers such as the gateway use this hook next to their own
+    runtime-status writes. Reading ``_service`` is deliberate: calling
+    :func:`get_service` here would instantiate a disconnected service merely
+    to report status.
+    """
+    with _service_lock:
+        svc = _service
+    if svc is not None and svc.is_active():
+        svc._publish_status()
+        return
+    from agent.lsp.status import write_lsp_status
+
+    write_lsp_status({"enabled": False, "clients": [], "broken": []})
+
+
 def _atexit_shutdown() -> None:
     """atexit-registered wrapper.  Logs at debug because by the time
     atexit fires the user has already seen the agent's final output —
@@ -103,4 +121,9 @@ def _atexit_shutdown() -> None:
         logger.debug("atexit LSP shutdown failed: %s", e)
 
 
-__all__ = ["get_service", "shutdown_service", "LSPService"]
+__all__ = [
+    "get_service",
+    "shutdown_service",
+    "publish_service_status",
+    "LSPService",
+]

--- a/agent/lsp/cli.py
+++ b/agent/lsp/cli.py
@@ -89,13 +89,17 @@ def run_lsp_command(args: argparse.Namespace) -> int:
 
 
 def _cmd_status(emit_json: bool) -> int:
-    from agent.lsp import get_service
+    from agent.lsp.status import read_lsp_status
     from agent.lsp.servers import SERVERS
     from agent.lsp.install import detect_status
 
-    svc = get_service()
-    service_active = svc is not None
-    info = svc.get_status() if svc is not None else {"enabled": False}
+    # Read the cross-process snapshot rather than calling get_service():
+    # this CLI invocation is normally a separate process from whichever
+    # one is actually running the LSP service, so instantiating a local
+    # singleton here would spin up a brand-new, disconnected service with
+    # zero real clients instead of showing what's actually running.
+    info = read_lsp_status() or {"enabled": False}
+    service_active = bool(info.get("enabled"))
 
     if emit_json:
         import json

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -490,7 +491,9 @@ class LSPClient:
         self._proc = None
         if proc is None:
             return
-        if proc.returncode is None:
+        if proc.returncode is not None:
+            return
+        if sys.platform == "win32":
             try:
                 proc.terminate()
                 try:
@@ -503,6 +506,44 @@ class LSPClient:
                         pass
             except ProcessLookupError:
                 pass
+            return
+        await self._terminate_process_group(proc)
+
+    async def _terminate_process_group(self, proc: "asyncio.subprocess.Process") -> None:
+        """POSIX: SIGTERM the server's whole process group, wait, then
+        SIGKILL if it lingers.
+
+        ``_spawn`` launches the server with ``start_new_session=True`` so
+        it leads its own process group — signalling only ``proc.pid``
+        would leave behind any children a wrapper script (npx shims,
+        launcher scripts) forked under that group.  ``os.killpg`` reaches
+        all of them.
+        """
+        try:
+            pgid = os.getpgid(proc.pid)
+        except ProcessLookupError:
+            return
+
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
+            return
+        except asyncio.TimeoutError:
+            pass
+
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+        try:
+            await proc.wait()
+        except ProcessLookupError:
+            pass
 
     # ------------------------------------------------------------------
     # request / notification plumbing

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -176,6 +176,10 @@ class LSPService:
         self._broken: set = set()
         self._spawning: Dict[Tuple[str, str], asyncio.Future] = {}
         self._last_used: Dict[Tuple[str, str], float] = {}
+        # Operation refcount — a positive count means some in-flight
+        # snapshot/diagnostics call is actively using the client, so the
+        # idle reaper must not evict it regardless of _last_used.
+        self._client_refcount: Dict[Tuple[str, str], int] = {}
         self._state_lock = threading.Lock()
         self._idle_reaper_task: Optional[asyncio.Task] = None
 
@@ -187,6 +191,9 @@ class LSPService:
 
         if self._enabled and self._idle_timeout > 0:
             self._loop.run(self._start_idle_reaper(), timeout=2.0)
+
+        if self._enabled:
+            self._publish_status()
 
     @classmethod
     def create_from_config(cls) -> Optional["LSPService"]:
@@ -461,6 +468,7 @@ class LSPService:
 
         if not already_broken:
             eventlog.log_spawn_failed(srv.server_id, per_server_root, exc)
+            self._publish_status()
 
     def shutdown(self) -> None:
         """Tear down all clients and stop the background loop."""
@@ -481,19 +489,24 @@ class LSPService:
         client = await self._get_or_spawn(file_path)
         if client is None:
             return []
+        key = (client.server_id, client.workspace_root)
+        self._acquire_client(key)
         try:
-            version = await client.open_file(file_path, language_id=language_id_for(file_path))
-            fresh = await client.wait_for_diagnostics(file_path, version, mode=self._wait_mode)
-        except Exception as e:  # noqa: BLE001
-            logger.debug("snapshot open/wait failed: %s", e)
-            return []
-        self._touch(client)
-        if not fresh:
-            # No fresh data for the pre-edit content — an empty baseline
-            # is safe: worst case the delta filter removes less, never
-            # more.  Never seed the baseline from stale stores.
-            return []
-        return list(client.diagnostics_for(file_path, fresh_only=True))
+            try:
+                version = await client.open_file(file_path, language_id=language_id_for(file_path))
+                fresh = await client.wait_for_diagnostics(file_path, version, mode=self._wait_mode)
+            except Exception as e:  # noqa: BLE001
+                logger.debug("snapshot open/wait failed: %s", e)
+                return []
+            self._touch(client)
+            if not fresh:
+                # No fresh data for the pre-edit content — an empty baseline
+                # is safe: worst case the delta filter removes less, never
+                # more.  Never seed the baseline from stale stores.
+                return []
+            return list(client.diagnostics_for(file_path, fresh_only=True))
+        finally:
+            self._release_client(key)
 
     async def _open_and_wait_async(self, file_path: str) -> Optional[List[Dict[str, Any]]]:
         """Open + wait for FRESH diagnostics.
@@ -507,19 +520,24 @@ class LSPService:
         client = await self._get_or_spawn(file_path)
         if client is None:
             return None
+        key = (client.server_id, client.workspace_root)
+        self._acquire_client(key)
         try:
-            version = await client.open_file(file_path, language_id=language_id_for(file_path))
-            await client.save_file(file_path)
-            fresh = await client.wait_for_diagnostics(
-                file_path, version, mode=self._wait_mode, timeout=self._wait_timeout
-            )
-        except Exception as e:  # noqa: BLE001
-            logger.debug("open/wait failed for %s: %s", file_path, e)
-            return None
-        self._touch(client)
-        if not fresh:
-            return None
-        return list(client.diagnostics_for(file_path, fresh_only=True))
+            try:
+                version = await client.open_file(file_path, language_id=language_id_for(file_path))
+                await client.save_file(file_path)
+                fresh = await client.wait_for_diagnostics(
+                    file_path, version, mode=self._wait_mode, timeout=self._wait_timeout
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.debug("open/wait failed for %s: %s", file_path, e)
+                return None
+            self._touch(client)
+            if not fresh:
+                return None
+            return list(client.diagnostics_for(file_path, fresh_only=True))
+        finally:
+            self._release_client(key)
 
     async def _current_diags_async(self, file_path: str) -> List[Dict[str, Any]]:
         ws, gated = resolve_workspace_for_file(file_path)
@@ -556,7 +574,7 @@ class LSPService:
         with self._state_lock:
             client = self._clients.get(key)
             if client is not None and client.is_running:
-                self._last_used[key] = time.time()
+                self._last_used[key] = time.monotonic()
                 eventlog.log_active(srv.server_id, per_server_root)
                 return client
             spawning = self._spawning.get(key)
@@ -588,6 +606,7 @@ class LSPService:
                 eventlog.log_server_unavailable(srv.server_id, srv.server_id)
                 self._broken.add(key)
                 spawn_future.set_result(None)
+                self._publish_status()
                 return None
             client = LSPClient(
                 server_id=srv.server_id,
@@ -604,12 +623,14 @@ class LSPService:
                 eventlog.log_spawn_failed(srv.server_id, per_server_root, e)
                 self._broken.add(key)
                 spawn_future.set_result(None)
+                self._publish_status()
                 return None
             with self._state_lock:
                 self._clients[key] = client
-                self._last_used[key] = time.time()
+                self._last_used[key] = time.monotonic()
             eventlog.log_active(srv.server_id, per_server_root)
             spawn_future.set_result(client)
+            self._publish_status()
             return client
         finally:
             with self._state_lock:
@@ -625,11 +646,56 @@ class LSPService:
         resurrect an orphan ``_last_used`` entry after the reaper popped
         the key.  All writers and the reaper run on the background loop
         thread; the lock keeps this consistent with the reader anyway.
+
+        Uses ``time.monotonic()`` rather than the wall clock — idle
+        timing is a duration comparison, and the wall clock can jump
+        (NTP step, DST, manual change) in ways that would falsely reap a
+        fresh client or keep a truly idle one alive indefinitely.
         """
         key = (client.server_id, client.workspace_root)
         with self._state_lock:
             if key in self._clients:
-                self._last_used[key] = time.time()
+                self._last_used[key] = time.monotonic()
+
+    def _acquire_client(self, key: Tuple[str, str]) -> None:
+        """Lease a client for the duration of an in-flight operation.
+
+        A held lease blocks ``_reap_idle_once`` from evicting the client
+        out from under a slow ``open_file``/``wait_for_diagnostics`` call
+        that outlives ``idle_timeout`` — the sweep and the operation both
+        run as coroutines on the same background loop and can interleave
+        at any ``await`` point.
+        """
+        with self._state_lock:
+            self._client_refcount[key] = self._client_refcount.get(key, 0) + 1
+
+    def _release_client(self, key: Tuple[str, str]) -> None:
+        """Release a lease acquired via :meth:`_acquire_client`.
+
+        Clamped at zero so an unmatched release can never leave the
+        refcount negative, which would require multiple future acquires
+        to counteract a single lease and could block reaping forever.
+        """
+        with self._state_lock:
+            remaining = self._client_refcount.get(key, 0) - 1
+            if remaining > 0:
+                self._client_refcount[key] = remaining
+            else:
+                self._client_refcount.pop(key, None)
+
+    def _publish_status(self) -> None:
+        """Publish a cross-process snapshot to ``<HERMES_HOME>/runtime/lsp-status.json``.
+
+        ``hermes lsp status`` runs as its own process and must not spin up
+        a second, disconnected :class:`LSPService` to answer — it reads
+        this file instead.  Best-effort: a publish failure must never
+        break the service itself.
+        """
+        try:
+            from agent.lsp.status import write_lsp_status
+            write_lsp_status(self.get_status())
+        except Exception as e:  # noqa: BLE001
+            logger.debug("LSP status publish failed: %s", e)
 
     async def _idle_reaper_loop(self) -> None:
         interval = min(60.0, self._idle_timeout)
@@ -646,12 +712,13 @@ class LSPService:
                 logger.debug("LSP idle reaper sweep error: %s", e)
 
     async def _reap_idle_once(self) -> None:
-        cutoff = time.time() - self._idle_timeout
+        cutoff = time.monotonic() - self._idle_timeout
         with self._state_lock:
             idle_keys = [
                 key
                 for key in self._clients
                 if self._last_used.get(key, 0) < cutoff
+                and self._client_refcount.get(key, 0) <= 0
             ]
             clients = [self._clients.pop(key) for key in idle_keys]
             for key in idle_keys:
@@ -665,6 +732,7 @@ class LSPService:
                 *(client.shutdown() for client in clients),
                 return_exceptions=True,
             )
+            self._publish_status()
 
     async def _shutdown_async(self) -> None:
         reaper = self._idle_reaper_task
@@ -677,10 +745,12 @@ class LSPService:
             self._clients.clear()
             self._broken.clear()
             self._last_used.clear()
+            self._client_refcount.clear()
         await asyncio.gather(
             *(c.shutdown() for c in clients),
             return_exceptions=True,
         )
+        self._publish_status()
 
     # ------------------------------------------------------------------
     # status / introspection (used by ``hermes lsp status``)

--- a/agent/lsp/status.py
+++ b/agent/lsp/status.py
@@ -1,0 +1,62 @@
+"""Cross-process publication of the LSP service's live status.
+
+``LSPService`` runs inside whichever process embeds the agent (CLI,
+gateway, TUI backend, ...).  ``hermes lsp status`` is normally invoked as
+its *own*, separate process — calling :func:`agent.lsp.get_service` there
+would spin up a brand-new, disconnected service with zero real clients
+rather than showing what the actual running process is doing.  Instead,
+the owning process publishes its :meth:`agent.lsp.manager.LSPService.get_status`
+snapshot here on every meaningful lifecycle change, and the CLI just reads
+the file.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+logger = logging.getLogger("agent.lsp.status")
+
+_STATUS_FILENAME = "lsp-status.json"
+
+
+def status_path() -> Path:
+    """Return the path to the cross-process LSP status snapshot."""
+    return get_hermes_home() / "runtime" / _STATUS_FILENAME
+
+
+def write_lsp_status(payload: Dict[str, Any]) -> None:
+    """Atomically persist ``payload`` (an ``LSPService.get_status()`` snapshot).
+
+    Best-effort — a write failure (read-only HERMES_HOME, disk full) must
+    never break the LSP service itself.
+    """
+    record = dict(payload)
+    record["updated_at"] = datetime.now(timezone.utc).isoformat()
+    try:
+        atomic_json_write(status_path(), record, indent=None, separators=(",", ":"))
+    except Exception as e:  # noqa: BLE001
+        logger.debug("failed to publish LSP status snapshot: %s", e)
+
+
+def read_lsp_status() -> Optional[Dict[str, Any]]:
+    """Read the persisted cross-process LSP status snapshot, or ``None``."""
+    try:
+        raw = status_path().read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError, UnicodeDecodeError):
+        return None
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+__all__ = ["status_path", "write_lsp_status", "read_lsp_status"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8039,6 +8039,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         except Exception:
             pass
+        try:
+            # Keep the cross-process LSP snapshot aligned with gateway
+            # lifecycle transitions without instantiating an LSP singleton.
+            from agent.lsp import publish_service_status
+
+            publish_service_status()
+        except Exception:
+            pass
 
     def _persist_active_agents(self) -> None:
         """Persist the live in-flight agent count to ``gateway_state.json``.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1946,6 +1946,8 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
     # sessions.* wins over stale env; env stays the cross-process carrier).
     sessions_cfg = cfg.get("sessions", {})
     if isinstance(sessions_cfg, dict):
+        if "trigram_fts" in sessions_cfg:
+            os.environ["HERMES_TRIGRAM_FTS"] = str(sessions_cfg["trigram_fts"])
         if "cjk_fts" in sessions_cfg:
             os.environ["HERMES_CJK_FTS"] = str(sessions_cfg["cjk_fts"])
         if "search_slow_ms" in sessions_cfg:
@@ -2276,6 +2278,10 @@ if _config_path.exists():
         # bridge semantics as the agent settings above.
         _sessions_cfg = _cfg.get("sessions", {})
         if _sessions_cfg and isinstance(_sessions_cfg, dict):
+            if "trigram_fts" in _sessions_cfg:
+                os.environ["HERMES_TRIGRAM_FTS"] = str(
+                    _sessions_cfg["trigram_fts"]
+                )
             if "cjk_fts" in _sessions_cfg:
                 os.environ["HERMES_CJK_FTS"] = str(_sessions_cfg["cjk_fts"])
             if "search_slow_ms" in _sessions_cfg:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3221,6 +3221,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "degraded_mode": "TERMINAL_DEGRADED_MODE",
     "cwd": "TERMINAL_CWD",
     "timeout": "TERMINAL_TIMEOUT",
+    "max_concurrent_heavy_jobs": "TERMINAL_MAX_CONCURRENT_HEAVY_JOBS",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
     "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2815,6 +2815,11 @@ DEFAULT_CONFIG = {
         #     enforcement is a copy/gating change, not new migration code.
         #   "off": suppress the notice entirely.
         "fts_optimize_notice": "advise",
+        # Trigram substring index used for CJK and other substring queries.
+        # True preserves upstream behavior. False quarantines any existing
+        # index by removing its write triggers while preserving canonical
+        # messages and the standard FTS index. Bridged to HERMES_TRIGRAM_FTS.
+        "trigram_fts": True,
         # CJK-bigram search index (messages_fts_cjk, cjk_unicode61 loadable
         # tokenizer). When the extension is built (native/fts5_cjk/build.sh →
         # ~/.hermes/lib/libfts5_cjk.so), 1-2 char CJK terms (일본, 项目, ...)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -300,6 +300,9 @@ DEFAULT_CONFIG = {
         # it here without patching the built desktop app.
         "font_family": "",
         "timeout": 180,
+        # Optional cross-process guard for resource-heavy terminal jobs (test
+        # suites, Supabase/PGlite labs, and AI reviewer CLIs). Zero disables it.
+        "max_concurrent_heavy_jobs": 0,
         # Bounded grace period (seconds) between SIGTERM and an escalated
         # SIGKILL when terminating a host process tree (browser daemons, etc.).
         # A daemon that stalls in its SIGTERM handler is force-killed after this

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -6,6 +6,7 @@ reference them without importing hermes_state (which would be a cycle).
 hermes_state re-imports every name here for backward compatibility.
 """
 
+import os
 from typing import Any
 
 from agent.skill_commands import (
@@ -184,14 +185,26 @@ FTS_STORAGE_VERSION = 1
 MAX_FTS5_QUERY_CHARS = 2_048
 
 
-_FTS_TRIGGERS = (
+_FTS_BASE_TRIGGERS = (
     "messages_fts_insert",
     "messages_fts_delete",
     "messages_fts_update",
+)
+
+_FTS_TRIGRAM_TRIGGERS = (
     "messages_fts_trigram_insert",
     "messages_fts_trigram_delete",
     "messages_fts_trigram_update",
 )
+
+_FTS_TRIGGERS = _FTS_BASE_TRIGGERS + _FTS_TRIGRAM_TRIGGERS
+
+
+def _trigram_fts_config_enabled() -> bool:
+    """config.yaml ``sessions.trigram_fts`` (default on), via its env bridge."""
+    return os.getenv("HERMES_TRIGRAM_FTS", "1").strip().lower() not in (
+        "0", "false", "off", "no",
+    )
 
 
 SCHEMA_SQL = """
@@ -547,6 +560,11 @@ _FTS_CJK_TRIGGERS = (
 # on are missing from the cjk index, so it must not serve reads until
 # `hermes sessions optimize-storage` rebuilds it on a capable host.
 FTS_CJK_STALE_KEY = "fts_cjk_stale"
+
+# Breadcrumb set when trigram is deliberately disabled. Existing trigram
+# storage is quarantined by dropping its live triggers, not destructively
+# removed while it may be corrupt; a later enabled open can rebuild safely.
+FTS_TRIGRAM_STALE_KEY = "fts_trigram_stale"
 
 
 # Durable breadcrumb for a base/trigram FTS index that was detached from the

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -18,6 +18,7 @@ from hermes_state_common import (
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
     FTS_STALE_KEY,
+    FTS_TRIGRAM_STALE_KEY,
     FTS_SQL,
     FTS_STORAGE_VERSION,
     FTS_TRIGRAM_SQL,
@@ -25,9 +26,12 @@ from hermes_state_common import (
     LEGACY_FTS_TRIGRAM_SQL,
     SCHEMA_SQL,
     SCHEMA_VERSION,
+    _FTS_BASE_TRIGGERS,
     _FTS_CJK_TRIGGERS,
     _FTS_TRIGGERS,
+    _FTS_TRIGRAM_TRIGGERS,
     _ephemeral_child_sql,
+    _trigram_fts_config_enabled,
 )
 
 # Moved methods logged under the "hermes_state" logger before the split;
@@ -126,14 +130,67 @@ class SessionSchemaMixin:
                 pass
 
     @staticmethod
-    def _fts_trigger_count(cursor: sqlite3.Cursor) -> int:
-        placeholders = ",".join("?" for _ in _FTS_TRIGGERS)
+    def _fts_trigger_count(
+        cursor: sqlite3.Cursor,
+        triggers=_FTS_TRIGGERS,
+    ) -> int:
+        placeholders = ",".join("?" for _ in triggers)
         row = cursor.execute(
             f"SELECT COUNT(*) FROM sqlite_master "
             f"WHERE type = 'trigger' AND name IN ({placeholders})",
-            _FTS_TRIGGERS,
+            triggers,
         ).fetchone()
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
+
+    def _quarantine_trigram_schema(self, cursor: sqlite3.Cursor) -> None:
+        """Disable trigram writes without destructively touching its storage.
+
+        Persist the stale breadcrumb before dropping triggers, mirroring the
+        CJK fail-closed path. Canonical messages and the base FTS index remain
+        untouched; a later explicitly-enabled open can rebuild from messages.
+        """
+        self._trigram_available = False
+        present = cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'messages_fts_trigram'"
+        ).fetchone()
+        live = cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'trigger' "
+            f"AND name IN ({','.join('?' for _ in _FTS_TRIGRAM_TRIGGERS)}) "
+            "LIMIT 1",
+            _FTS_TRIGRAM_TRIGGERS,
+        ).fetchone()
+        if not present and not live:
+            return
+        self.set_meta(FTS_TRIGRAM_STALE_KEY, "1", cursor=cursor)
+        for trigger in _FTS_TRIGRAM_TRIGGERS:
+            cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+
+    def _reset_stale_trigram_schema(self, cursor: sqlite3.Cursor) -> bool:
+        """Remove quarantined trigram storage before a controlled rebuild."""
+        stale = cursor.execute(
+            "SELECT 1 FROM state_meta WHERE key = ?",
+            (FTS_TRIGRAM_STALE_KEY,),
+        ).fetchone()
+        if not stale:
+            return True
+        try:
+            for trigger in _FTS_TRIGRAM_TRIGGERS:
+                cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            cursor.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+            cursor.execute("DROP VIEW IF EXISTS messages_fts_trigram_src")
+            cursor.execute(
+                "DELETE FROM state_meta WHERE key = ?",
+                (FTS_TRIGRAM_STALE_KEY,),
+            )
+            return True
+        except sqlite3.Error:
+            logger.warning(
+                "Could not reset quarantined trigram FTS; keeping it disabled",
+                exc_info=True,
+            )
+            self._trigram_available = False
+            return False
 
 
     @staticmethod
@@ -167,10 +224,10 @@ class SessionSchemaMixin:
         # destructive candidates so the legacy branch never drops a trigger
         # it does not recreate.
         legacy_layout = self._db_has_legacy_inline_fts(cursor)
-        update_names = (
-            "messages_fts_update",
-            "messages_fts_trigram_update",
-        )
+        trigram_enabled = _trigram_fts_config_enabled()
+        update_names = ("messages_fts_update",)
+        if trigram_enabled:
+            update_names += ("messages_fts_trigram_update",)
         if not legacy_layout and hasattr(self, "_ensure_fts_cjk_schema"):
             update_names += ("messages_fts_cjk_update",)
         placeholders = ", ".join("?" for _ in update_names)
@@ -197,14 +254,16 @@ class SessionSchemaMixin:
         # Choose legacy vs v23 the same way _init_schema does.
         if legacy_layout:
             self._ensure_fts_schema(cursor, "messages_fts", LEGACY_FTS_SQL)
-            self._ensure_fts_schema(
-                cursor, "messages_fts_trigram", LEGACY_FTS_TRIGRAM_SQL
-            )
+            if trigram_enabled:
+                self._ensure_fts_schema(
+                    cursor, "messages_fts_trigram", LEGACY_FTS_TRIGRAM_SQL
+                )
         else:
             self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
-            self._ensure_fts_schema(
-                cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
-            )
+            if trigram_enabled:
+                self._ensure_fts_schema(
+                    cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+                )
             # CJK triggers live on the host SessionDB; only recreate one that
             # this migration actually dropped. ``_ensure_fts_cjk_schema`` is
             # documented never-raises and soft-fails OperationalError by
@@ -1198,46 +1257,65 @@ class SessionSchemaMixin:
                     self._fts_enabled = False
                     self._trigram_available = False
                     self._fts_cjk_available = False
-            elif legacy_fts:
-                triggers_need_repair = (
-                    self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
-                )
-                self._fts_enabled = self._ensure_fts_schema(
-                    cursor, "messages_fts", LEGACY_FTS_SQL
-                )
-                if self._fts_enabled:
-                    trigram_enabled = self._ensure_fts_schema(
-                        cursor, "messages_fts_trigram", LEGACY_FTS_TRIGRAM_SQL
-                    )
-                    self._trigram_available = trigram_enabled
-                    if triggers_need_repair:
-                        self._rebuild_legacy_fts_indexes(
-                            cursor, include_trigram=trigram_enabled
-                        )
             else:
-                triggers_need_repair = (
-                    self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+                trigram_requested = _trigram_fts_config_enabled()
+                trigram_enabled_for_open = (
+                    trigram_requested and self._reset_stale_trigram_schema(cursor)
                 )
-                self._fts_enabled = self._ensure_fts_schema(
-                    cursor, "messages_fts", FTS_SQL
-                )
+                expected_triggers = _FTS_BASE_TRIGGERS
+                if trigram_enabled_for_open:
+                    expected_triggers += _FTS_TRIGRAM_TRIGGERS
 
-                # Trigram FTS5 for CJK/substring search. This is optional
-                # relative to the main FTS table; if it cannot be created,
-                # CJK search falls back to LIKE.
-                if self._fts_enabled:
-                    trigram_enabled = self._ensure_fts_schema(
-                        cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+                if legacy_fts:
+                    triggers_need_repair = (
+                        self._fts_trigger_count(cursor, expected_triggers)
+                        < len(expected_triggers)
                     )
-                    self._trigram_available = trigram_enabled
-                    if triggers_need_repair:
-                        self._rebuild_fts_indexes(
-                            cursor,
-                            include_trigram=trigram_enabled,
-                        )
-                    # CJK-bigram index (cjk_unicode61). Strictly additive to
-                    # the surfaces above and gated on the loadable tokenizer:
-                    self._ensure_fts_cjk_schema(cursor)
+                    self._fts_enabled = self._ensure_fts_schema(
+                        cursor, "messages_fts", LEGACY_FTS_SQL
+                    )
+                    if self._fts_enabled:
+                        if trigram_enabled_for_open:
+                            trigram_enabled = self._ensure_fts_schema(
+                                cursor, "messages_fts_trigram", LEGACY_FTS_TRIGRAM_SQL
+                            )
+                            self._trigram_available = trigram_enabled
+                            if triggers_need_repair:
+                                self._rebuild_legacy_fts_indexes(
+                                    cursor, include_trigram=trigram_enabled
+                                )
+                        else:
+                            self._quarantine_trigram_schema(cursor)
+                else:
+                    triggers_need_repair = (
+                        self._fts_trigger_count(cursor, expected_triggers)
+                        < len(expected_triggers)
+                    )
+                    self._fts_enabled = self._ensure_fts_schema(
+                        cursor, "messages_fts", FTS_SQL
+                    )
+
+                    # Trigram FTS5 for CJK/substring search. Enabled by
+                    # default for upstream parity, but operators can
+                    # quarantine it without touching canonical messages or
+                    # the base FTS surface.
+                    if self._fts_enabled:
+                        if trigram_enabled_for_open:
+                            trigram_enabled = self._ensure_fts_schema(
+                                cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+                            )
+                            self._trigram_available = trigram_enabled
+                            if triggers_need_repair:
+                                self._rebuild_fts_indexes(
+                                    cursor,
+                                    include_trigram=trigram_enabled,
+                                )
+                        else:
+                            self._quarantine_trigram_schema(cursor)
+                        # CJK-bigram index (cjk_unicode61). Strictly additive
+                        # to the surfaces above and gated on the loadable
+                        # tokenizer:
+                        self._ensure_fts_cjk_schema(cursor)
 
             # Replace any pre-existing broad AFTER UPDATE triggers with
             # AFTER UPDATE OF variants. IF NOT EXISTS cannot rewrite them.

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -2361,7 +2361,7 @@ class SessionSearchMixin:
         index internally, then VACUUM returns the freed pages to the OS.
 
         Skips any FTS table that does not exist (e.g. the trigram index when
-        disabled via ``HERMES_DISABLE_FTS_TRIGRAM`` or not yet created), so
+        disabled via ``sessions.trigram_fts: false`` or not yet created), so
         it is safe to call unconditionally.
 
         Returns the number of FTS indexes that were optimized.

--- a/tests/agent/lsp/test_reaper.py
+++ b/tests/agent/lsp/test_reaper.py
@@ -1,0 +1,322 @@
+"""Tests for Adaptation D: client leases, monotonic idle timing, and the
+cross-process LSP status snapshot.
+
+Two bugs motivate the client lease/refcount:
+
+- A client mid-operation (``open_file`` + ``wait_for_diagnostics`` can take
+  several seconds) could be reaped out from under an in-flight
+  ``get_diagnostics_sync``/``snapshot_baseline`` call, since the idle-reaper
+  sweep and the operation coroutine both run on the same background loop
+  and can interleave at any ``await`` point.
+- ``_last_used`` was recorded with ``time.time()`` (wall clock), which can
+  jump on an NTP step or manual clock change; ``time.monotonic()`` is the
+  correct source for a duration-based cutoff.
+
+Also covers the new cross-process status snapshot: ``hermes lsp status``
+runs as a *separate* process from whichever one is actually running the
+service, so it must read a published snapshot rather than instantiate its
+own disconnected singleton.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+import sys
+import time
+from contextlib import redirect_stdout
+
+import pytest
+
+from agent.lsp.client import LSPClient
+from agent.lsp.manager import LSPService
+
+
+class _FakeClient:
+    """Stand-in for LSPClient — just enough surface for the reaper/lease paths."""
+
+    def __init__(self, server_id: str, workspace_root: str) -> None:
+        self.server_id = server_id
+        self.workspace_root = workspace_root
+        self.shutdown_calls = 0
+
+    @property
+    def is_running(self) -> bool:
+        return True
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+def _idle_service(**overrides) -> LSPService:
+    kwargs = dict(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=1.0,
+        install_strategy="manual",
+        # Long enough that the background reaper loop never sweeps on its
+        # own during the test — sweeps are triggered manually below.
+        idle_timeout=60.0,
+    )
+    kwargs.update(overrides)
+    return LSPService(**kwargs)
+
+
+def _seed_idle_client(svc: LSPService, key):
+    client = _FakeClient(*key)
+    with svc._state_lock:
+        svc._clients[key] = client
+        svc._last_used[key] = time.monotonic() - 10_000.0  # far past any cutoff
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Lease/refcount — a leased client must survive a sweep
+# ---------------------------------------------------------------------------
+
+
+def test_leased_client_survives_reap_sweep():
+    svc = _idle_service()
+    key = ("fake", "/tmp/ws-a")
+    client = _seed_idle_client(svc, key)
+    try:
+        svc._acquire_client(key)
+        svc._loop.run(svc._reap_idle_once(), timeout=5.0)
+        assert key in svc._clients, "a leased client must not be reaped mid-operation"
+        assert client.shutdown_calls == 0
+    finally:
+        svc.shutdown()
+
+
+def test_released_client_is_reaped_on_next_sweep():
+    svc = _idle_service()
+    key = ("fake", "/tmp/ws-b")
+    client = _seed_idle_client(svc, key)
+    try:
+        svc._acquire_client(key)
+        svc._loop.run(svc._reap_idle_once(), timeout=5.0)
+        assert key in svc._clients  # still leased
+
+        svc._release_client(key)
+        svc._loop.run(svc._reap_idle_once(), timeout=5.0)
+        assert key not in svc._clients, "releasing the lease must let the sweep reap it"
+        assert client.shutdown_calls == 1
+    finally:
+        svc.shutdown()
+
+
+def test_nested_acquire_requires_matching_releases():
+    """Two overlapping operations on the same client must both release
+    their lease before the client becomes reapable."""
+    svc = _idle_service()
+    key = ("fake", "/tmp/ws-c")
+    client = _seed_idle_client(svc, key)
+    try:
+        svc._acquire_client(key)
+        svc._acquire_client(key)
+        svc._release_client(key)
+
+        svc._loop.run(svc._reap_idle_once(), timeout=5.0)
+        assert key in svc._clients, "one outstanding lease must still block the sweep"
+
+        svc._release_client(key)
+        svc._loop.run(svc._reap_idle_once(), timeout=5.0)
+        assert key not in svc._clients
+        assert client.shutdown_calls == 1
+    finally:
+        svc.shutdown()
+
+
+def test_release_without_acquire_does_not_go_negative():
+    """An unmatched release must not leave the refcount negative — that
+    would require multiple future acquires to counteract a single lease."""
+    svc = _idle_service()
+    key = ("fake", "/tmp/ws-d")
+    _seed_idle_client(svc, key)
+    try:
+        svc._release_client(key)  # no matching acquire
+        svc._acquire_client(key)
+        svc._release_client(key)
+
+        svc._loop.run(svc._reap_idle_once(), timeout=5.0)
+        assert key not in svc._clients, "refcount must not go negative and block reaping forever"
+    finally:
+        svc.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Idle timing must use a monotonic clock
+# ---------------------------------------------------------------------------
+
+
+def test_last_used_is_recorded_via_monotonic_clock(monkeypatch):
+    import agent.lsp.manager as manager_mod
+
+    fake_monotonic = 12345.0
+    monkeypatch.setattr(manager_mod.time, "monotonic", lambda: fake_monotonic)
+    monkeypatch.setattr(manager_mod.time, "time", lambda: 999999999.0)
+
+    svc = _idle_service()
+    try:
+        key = ("fake", "/tmp/ws-e")
+        client = _FakeClient(*key)
+        with svc._state_lock:
+            svc._clients[key] = client
+        svc._touch(client)
+        assert svc._last_used[key] == fake_monotonic, (
+            "idle timestamps must come from time.monotonic(), not time.time()"
+        )
+    finally:
+        svc.shutdown()
+
+
+def test_reap_cutoff_uses_monotonic_clock_not_wall_clock(monkeypatch):
+    """The idle-reap cutoff must be derived from ``time.monotonic()``.
+
+    Spies on both clock functions during a sweep — the wall clock must
+    never be consulted, since it can jump (NTP step, DST, manual change)
+    and either falsely reap a fresh client or keep a truly idle one alive.
+    """
+    import agent.lsp.manager as manager_mod
+
+    real_monotonic = manager_mod.time.monotonic
+    calls = {"monotonic": 0, "time": 0}
+
+    def spy_monotonic():
+        calls["monotonic"] += 1
+        return real_monotonic()
+
+    def spy_time():
+        calls["time"] += 1
+        return 0.0
+
+    svc = _idle_service(idle_timeout=5.0)
+    try:
+        monkeypatch.setattr(manager_mod.time, "monotonic", spy_monotonic)
+        monkeypatch.setattr(manager_mod.time, "time", spy_time)
+        svc._loop.run(svc._reap_idle_once(), timeout=5.0)
+        assert calls["monotonic"] >= 1, "the idle-reap cutoff must be computed from time.monotonic()"
+        assert calls["time"] == 0, "the idle-reap cutoff must not read the wall clock"
+    finally:
+        svc.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Cross-process status snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_status_snapshot_published_on_broken_mark(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from agent.lsp.status import read_lsp_status
+
+    svc = _idle_service()
+    try:
+        key = ("fake", str(tmp_path))
+        svc._broken.add(key)
+        svc._publish_status()
+
+        snapshot = read_lsp_status()
+        assert snapshot is not None
+        assert list(key) in snapshot["broken"]
+    finally:
+        svc.shutdown()
+
+
+def test_status_cli_reads_snapshot_without_instantiating_singleton(tmp_path, monkeypatch):
+    """``hermes lsp status`` must read the published snapshot, not spin up
+    its own disconnected LSPService — which would show no clients even
+    though a different process has real ones running."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from agent.lsp import cli as lsp_cli
+    from agent.lsp.status import write_lsp_status
+
+    write_lsp_status({
+        "enabled": True,
+        "wait_mode": "document",
+        "wait_timeout": 5.0,
+        "install_strategy": "auto",
+        "clients": [
+            {
+                "server_id": "pyright",
+                "workspace_root": str(tmp_path),
+                "state": "running",
+                "running": True,
+            }
+        ],
+        "broken": [],
+        "disabled_servers": [],
+    })
+
+    called = {"n": 0}
+
+    def _boom():
+        called["n"] += 1
+        raise AssertionError("hermes lsp status must not instantiate a local LSPService singleton")
+
+    monkeypatch.setattr("agent.lsp.get_service", _boom)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = lsp_cli._cmd_status(emit_json=False)
+
+    assert rc == 0
+    assert called["n"] == 0
+    assert "active clients:  1" in buf.getvalue()
+
+
+def test_publish_service_status_does_not_create_singleton(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import agent.lsp as lsp
+    from agent.lsp.status import read_lsp_status
+
+    monkeypatch.setattr(lsp, "_service", None)
+    lsp.publish_service_status()
+
+    snapshot = read_lsp_status()
+    assert lsp._service is None
+    assert snapshot is not None
+    assert snapshot["enabled"] is False
+    assert snapshot["clients"] == []
+    assert snapshot["broken"] == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group semantics")
+@pytest.mark.asyncio
+async def test_cleanup_terminates_posix_process_group_descendant(tmp_path):
+    """Cleanup must terminate a server wrapper and the child it spawned."""
+    script = (
+        "import subprocess,sys,time; "
+        "p=subprocess.Popen([sys.executable,'-c','import time; time.sleep(60)']); "
+        "print(p.pid, flush=True); time.sleep(60)"
+    )
+    parent = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        script,
+        stdout=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+    assert parent.stdout is not None
+    child_pid = int((await parent.stdout.readline()).decode().strip())
+
+    client = LSPClient(
+        server_id="test",
+        workspace_root=str(tmp_path),
+        command=[sys.executable],
+    )
+    client._proc = parent
+    await client._cleanup_process()
+
+    assert parent.returncode is not None
+    for _ in range(50):
+        try:
+            state = open(f"/proc/{child_pid}/stat", encoding="utf-8").read().split()[2]
+        except FileNotFoundError:
+            break
+        if state == "Z":
+            break
+        await asyncio.sleep(0.02)
+    else:
+        os.kill(child_pid, 0)
+        pytest.fail("language-server descendant survived process-group cleanup")

--- a/tests/gateway/test_lsp_status_hook.py
+++ b/tests/gateway/test_lsp_status_hook.py
@@ -1,0 +1,31 @@
+"""Gateway lifecycle publication of the cross-process LSP status."""
+
+from gateway.run import GatewayRunner
+
+
+def test_runtime_status_update_publishes_lsp_snapshot(monkeypatch):
+    calls = {"runtime": [], "lsp": 0}
+
+    def fake_runtime_status(**kwargs):
+        calls["runtime"].append(kwargs)
+
+    def fake_lsp_status():
+        calls["lsp"] += 1
+
+    monkeypatch.setattr("gateway.status.write_runtime_status", fake_runtime_status)
+    monkeypatch.setattr("agent.lsp.publish_service_status", fake_lsp_status)
+    monkeypatch.setattr(GatewayRunner, "_active_work_count", lambda self: 0)
+
+    runner = object.__new__(GatewayRunner)
+    runner._restart_requested = False
+    runner._update_runtime_status("running")
+
+    assert calls["runtime"] == [
+        {
+            "gateway_state": "running",
+            "exit_reason": None,
+            "restart_requested": False,
+            "active_agents": 0,
+        }
+    ]
+    assert calls["lsp"] == 1

--- a/tests/gateway/test_trigram_fts_config_bridge.py
+++ b/tests/gateway/test_trigram_fts_config_bridge.py
@@ -1,0 +1,39 @@
+"""config.yaml sessions.trigram_fts bridge (config-authoritative).
+
+Modeled directly on test_cjk_fts_config_bridge.py — adaptation C wires the
+trigram index gate through the same config->env bridge as sessions.cjk_fts.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+import gateway.run as gateway_run
+
+
+def _write_home(tmp_path: Path, sessions_cfg: dict, env_text: str = "") -> Path:
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"sessions": sessions_cfg}), encoding="utf-8"
+    )
+    (hermes_home / ".env").write_text(env_text, encoding="utf-8")
+    return hermes_home
+
+
+def test_trigram_fts_bridged_from_config(tmp_path, monkeypatch):
+    home = _write_home(tmp_path, {"trigram_fts": False})
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "1")
+    gateway_run._reload_runtime_env_preserving_config_authority()
+    assert os.environ["HERMES_TRIGRAM_FTS"] == "False"
+
+
+def test_trigram_fts_documented_default_enabled():
+    """Enabled-by-default upstream parity, same as sessions.cjk_fts."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["sessions"]["trigram_fts"] is True

--- a/tests/test_fts_trigram_config_gate.py
+++ b/tests/test_fts_trigram_config_gate.py
@@ -1,0 +1,293 @@
+"""Adaptation C: config/env gate + stale-quarantine for messages_fts_trigram.
+
+Production evidence: recurrent messages_fts_trigram corruption after FTS
+rebuilds. Upstream v2026.8.3 already solves the same problem class for the
+CJK-bigram index (config gate + breadcrumb quarantine, see
+``_cjk_fts_config_enabled`` / ``_quarantine_cjk_after_update_of_migration``
+in hermes_state.py / hermes_state_schema.py) but has no equivalent escape
+hatch for the trigram index — ``HERMES_DISABLE_FTS_TRIGRAM`` survives only
+as a stale docstring reference with no backing code. These tests establish
+the same gate for trigram, modeled on the CJK pattern, WITHOUT a bespoke
+``_drop_trigram_schema`` that could leave triggers against a half-dismantled
+schema.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+_FTS_TRIGRAM_TRIGGERS = (
+    "messages_fts_trigram_insert",
+    "messages_fts_trigram_delete",
+    "messages_fts_trigram_update",
+)
+
+
+def _trigger_names(conn: sqlite3.Connection) -> set:
+    return {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+        ).fetchall()
+    }
+
+
+def _table_or_view_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE name = ?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def test_trigram_enabled_by_default_on_fresh_db(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("HERMES_TRIGRAM_FTS", raising=False)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        assert db._trigram_available is True
+        assert _table_or_view_exists(db._conn, "messages_fts_trigram")
+        assert _table_or_view_exists(db._conn, "messages_fts_trigram_src")
+        names = _trigger_names(db._conn)
+        for trig in _FTS_TRIGRAM_TRIGGERS:
+            assert trig in names
+    finally:
+        db.close()
+
+
+def test_trigram_disabled_prevents_schema_creation_on_fresh_db(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "0")
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        assert db._trigram_available is False
+        assert not _table_or_view_exists(db._conn, "messages_fts_trigram")
+        assert not _table_or_view_exists(db._conn, "messages_fts_trigram_src")
+        names = _trigger_names(db._conn)
+        for trig in _FTS_TRIGRAM_TRIGGERS:
+            assert trig not in names
+
+        # Canonical messages + main FTS must be completely unaffected.
+        assert db._fts_enabled is True
+        assert _table_or_view_exists(db._conn, "messages_fts")
+        assert "messages_fts_insert" in names
+        assert "messages_fts_delete" in names
+        assert "messages_fts_update" in names
+    finally:
+        db.close()
+
+
+def test_trigram_disabled_quarantines_existing_schema_on_reopen(
+    tmp_path: Path, monkeypatch
+):
+    path = tmp_path / "state.db"
+    monkeypatch.delenv("HERMES_TRIGRAM_FTS", raising=False)
+    db = SessionDB(db_path=path)
+    sid = "s1"
+    db.create_session(sid, source="test")
+    db.append_message(sid, role="user", content="hello searchable world")
+    assert db._trigram_available is True
+    db.close()
+
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "0")
+    db2 = SessionDB(db_path=path)
+    try:
+        assert db2._trigram_available is False
+        # Match the CJK quarantine pattern: preserve the existing index for a
+        # later controlled rebuild, but remove every trigger so a corrupt or
+        # stale index cannot break canonical message writes.
+        assert _table_or_view_exists(db2._conn, "messages_fts_trigram")
+        assert _table_or_view_exists(db2._conn, "messages_fts_trigram_src")
+        assert db2._conn.execute(
+            "SELECT value FROM state_meta WHERE key = 'fts_trigram_stale'"
+        ).fetchone() is not None
+        names = _trigger_names(db2._conn)
+        for trig in _FTS_TRIGRAM_TRIGGERS:
+            assert trig not in names
+
+        # Main FTS triggers must survive the quarantine untouched.
+        assert "messages_fts_insert" in names
+        assert "messages_fts_delete" in names
+        assert "messages_fts_update" in names
+
+        # Canonical messages row from before quarantine must still be there.
+        rows = db2._conn.execute(
+            "SELECT content FROM messages WHERE session_id = ?", (sid,)
+        ).fetchall()
+        assert any("hello searchable world" in (r[0] or "") for r in rows)
+
+        # Writes must keep working after quarantine (no half-dismantled
+        # trigger left referencing a dropped table/view).
+        mid = db2.append_message(sid, role="user", content="second message")
+        assert mid is not None
+    finally:
+        db2.close()
+
+
+def test_reenable_rebuilds_quarantined_trigram_from_canonical_messages(
+    tmp_path: Path, monkeypatch
+):
+    path = tmp_path / "state.db"
+    monkeypatch.delenv("HERMES_TRIGRAM_FTS", raising=False)
+    db = SessionDB(db_path=path)
+    db.create_session("s1", source="test")
+    db.append_message("s1", role="user", content="before quarantine 프로젝트")
+    db.close()
+
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "0")
+    disabled = SessionDB(db_path=path)
+    disabled.append_message("s1", role="user", content="during quarantine 관리도구")
+    disabled.close()
+
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "1")
+    rebuilt = SessionDB(db_path=path)
+    try:
+        assert rebuilt._trigram_available is True
+        assert rebuilt._conn.execute(
+            "SELECT 1 FROM state_meta WHERE key = 'fts_trigram_stale'"
+        ).fetchone() is None
+        names = _trigger_names(rebuilt._conn)
+        assert set(_FTS_TRIGRAM_TRIGGERS) <= names
+        results = rebuilt.search_messages("관리도구")
+        assert any("관리도구" in (r.get("snippet") or "") for r in results)
+    finally:
+        rebuilt.close()
+
+
+def test_trigram_disabled_reopen_does_not_repeat_rebuild(
+    tmp_path: Path, monkeypatch
+):
+    """_fts_trigger_count must be parameterized so a disabled trigram index
+    doesn't look like "needs repair" forever and re-trigger a full FTS
+    rebuild on every single open."""
+    path = tmp_path / "state.db"
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "0")
+    db = SessionDB(db_path=path)
+    db.create_session("s1", source="test")
+    db.append_message("s1", role="user", content="hello world")
+    db.close()
+
+    import hermes_state_schema
+
+    calls = []
+    orig = hermes_state_schema.SessionSchemaMixin._rebuild_fts_indexes
+
+    def _spy(cursor, *, include_trigram=True):
+        calls.append(include_trigram)
+        return orig(cursor, include_trigram=include_trigram)
+
+    monkeypatch.setattr(
+        hermes_state_schema.SessionSchemaMixin, "_rebuild_fts_indexes", staticmethod(_spy)
+    )
+
+    db2 = SessionDB(db_path=path)
+    try:
+        assert calls == [], (
+            "reopening a stable disabled-trigram DB must not trigger a "
+            f"full FTS rebuild (got calls={calls!r})"
+        )
+    finally:
+        db2.close()
+
+
+def test_migrate_broad_update_triggers_does_not_resurrect_disabled_trigram(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "0")
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        assert not _table_or_view_exists(db._conn, "messages_fts_trigram")
+
+        # Force a broad (pre-narrowing) main FTS UPDATE trigger the way an
+        # older install would have had it, so the migration has real work.
+        db._conn.execute("DROP TRIGGER IF EXISTS messages_fts_update")
+        db._conn.execute(
+            """
+            CREATE TRIGGER messages_fts_update AFTER UPDATE ON messages
+            BEGIN
+                SELECT 1;
+            END
+            """
+        )
+        db._conn.commit()
+
+        dropped = db._migrate_broad_fts_update_triggers(db._conn)
+        db._conn.commit()
+        assert dropped >= 1
+
+        # The migration's blanket DDL re-apply must not resurrect trigram.
+        # This is a fresh disabled DB, so there is no old storage to quarantine.
+        assert not _table_or_view_exists(db._conn, "messages_fts_trigram")
+        assert not _table_or_view_exists(db._conn, "messages_fts_trigram_src")
+        names = _trigger_names(db._conn)
+        for trig in _FTS_TRIGRAM_TRIGGERS:
+            assert trig not in names
+    finally:
+        db.close()
+
+
+def test_search_falls_back_safely_when_trigram_disabled(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "0")
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        sid = "s1"
+        db.create_session(sid, source="test")
+        db.append_message(sid, role="user", content="the quick brown fox jumps")
+        db.append_message(sid, role="user", content="korean term: 프로젝트 관리")
+
+        # Ordinary latin token — must still be answered via the base FTS5
+        # index (no trigram dependency at all).
+        results = db.search_messages("quick")
+        assert any("quick" in (r.get("snippet") or "") for r in results)
+
+        # Short CJK query that would normally route to trigram/LIKE — must
+        # not raise even though trigram is disabled.
+        cjk_results = db.search_messages("관리")
+        assert any("관리" in (r.get("snippet") or "") for r in cjk_results)
+    finally:
+        db.close()
+
+
+def test_trigram_fts_config_gate_documented_and_defaults_enabled():
+    """Enabled-by-default upstream parity: the gate function itself must
+    default to True with no env var set, matching _cjk_fts_config_enabled's
+    polarity."""
+    import os
+
+    from hermes_state_common import _trigram_fts_config_enabled
+
+    assert _trigram_fts_config_enabled.__doc__, (
+        "gate must be documented (config/env parity note)"
+    )
+    old = os.environ.pop("HERMES_TRIGRAM_FTS", None)
+    try:
+        assert _trigram_fts_config_enabled() is True
+        os.environ["HERMES_TRIGRAM_FTS"] = "0"
+        assert _trigram_fts_config_enabled() is False
+        os.environ["HERMES_TRIGRAM_FTS"] = "false"
+        assert _trigram_fts_config_enabled() is False
+        os.environ["HERMES_TRIGRAM_FTS"] = "1"
+        assert _trigram_fts_config_enabled() is True
+    finally:
+        if old is None:
+            os.environ.pop("HERMES_TRIGRAM_FTS", None)
+        else:
+            os.environ["HERMES_TRIGRAM_FTS"] = old
+
+
+def test_stale_trigram_docstring_is_fixed():
+    """The HERMES_DISABLE_FTS_TRIGRAM docstring reference (audit finding)
+    must be replaced by the real gate name, not left dangling."""
+    import inspect
+
+    import hermes_state_search
+
+    src = inspect.getsource(hermes_state_search.SessionSearchMixin.optimize_fts)
+    assert "HERMES_DISABLE_FTS_TRIGRAM" not in src
+    assert "sessions.trigram_fts" in src

--- a/tests/tools/test_heavy_work_guard.py
+++ b/tests/tools/test_heavy_work_guard.py
@@ -1,0 +1,676 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.heavy_work_guard import (
+    HeavyWorkConflict,
+    acquire_heavy_work_lease,
+    classify_heavy_work,
+    heavy_work_requests_detach,
+)
+
+
+class _FakeLease:
+    def __init__(self):
+        self.release_count = 0
+
+    def release(self):
+        self.release_count += 1
+
+    def child_pass_fds(self):
+        return ()
+
+
+@pytest.mark.parametrize(
+    ("command", "category"),
+    [
+        ("pytest -q", "test-suite"),
+        ("python -m pytest tests", "test-suite"),
+        ("python3.13 -m pytest tests", "test-suite"),
+        ("uv run pytest -q", "test-suite"),
+        ("poetry run python -m pytest", "test-suite"),
+        ("bash -lc 'cd /tmp && pytest -q'", "test-suite"),
+        ("if true; then pytest -q; fi", "test-suite"),
+        ("{ pytest -q; }", "test-suite"),
+        ("( pytest -q )", "test-suite"),
+        ("nohup pytest -q >/tmp/t.log 2>&1 &", "test-suite"),
+        ("setsid pytest -q >/tmp/t.log 2>&1 &", "test-suite"),
+        ("command pytest -q", "test-suite"),
+        ("python3 -c \"import subprocess; subprocess.run(['pytest','-q'])\"", "test-suite"),
+        ("sudo -u root pytest -q", "dynamic-execution"),
+        ("timeout --kill-after 3 10 pytest -q", "dynamic-execution"),
+        ("eval pytest -q", "dynamic-execution"),
+        ("sh -c 'eval pytest -q'", "dynamic-execution"),
+        ("cmd=pytest; $cmd -q", "dynamic-execution"),
+        (
+            "python -c \"import subprocess; subprocess.run(['py' + 'test','-q'])\"",
+            "dynamic-execution",
+        ),
+        (
+            "python -c \"import os; os.system('py' + 'test -q')\" --help",
+            "dynamic-execution",
+        ),
+        ("bash ./opaque-script.sh --help", "dynamic-execution"),
+        ("printf 'pytest -q' | bash", "dynamic-execution"),
+        ("xargs pytest -q", "dynamic-execution"),
+        ("node -e \"require('child_process').spawn('pytest')\"", "dynamic-execution"),
+        ("env -i pytest -q", "dynamic-execution"),
+        ("env --ignore-environment pytest -q", "dynamic-execution"),
+        ("nice -n 10 pytest -q", "dynamic-execution"),
+        ("ionice -c 3 pytest -q", "dynamic-execution"),
+        ("time -p pytest -q", "dynamic-execution"),
+        ("flock /tmp/l pytest -q", "dynamic-execution"),
+        ("chronic pytest -q", "dynamic-execution"),
+        ("npx --yes vitest run", "dynamic-execution"),
+        ("npm exec -- vitest", "dynamic-execution"),
+        ("pnpm test", "test-suite"),
+        ("npm run test:unit", "test-suite"),
+        ("cargo test --workspace", "test-suite"),
+        ("go test ./...", "test-suite"),
+        ("npx vitest run", "test-suite"),
+        ("supabase start", "database-lab"),
+        ("npx supabase db reset", "database-lab"),
+        ("pglite ./scripts/check.ts", "database-lab"),
+        ("claude -p 'review this diff'", "ai-reviewer"),
+        ("codex exec --full-auto 'review'", "ai-reviewer"),
+        ("opencode run 'review'", "ai-reviewer"),
+    ],
+)
+def test_classifies_heavy_commands(command, category):
+    assert classify_heavy_work(command) == category
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo pytest",
+        "echo 'pytest && supabase start'",
+        "pytest --help",
+        "supabase status",
+        "supabase stop",
+        "codex --version",
+        "claude --help",
+        "python --help",
+        "bash --version",
+        "node --help",
+        "command -v pytest",
+        "command -V pytest",
+        "ps aux | grep pglite",
+    ],
+)
+def test_does_not_block_inspection_cleanup_or_mentions(command):
+    assert classify_heavy_work(command) is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "nohup pytest -q >/tmp/t.log 2>&1 & exit",
+        "pytest -q & disown",
+        "python worker.py --daemon",
+        "systemd-run pytest -q",
+        "pytest -q >out.log 2>&1 &",
+    ],
+)
+def test_detects_self_detaching_heavy_commands(command):
+    assert heavy_work_requests_detach(command) is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pytest -q",
+        "nohup pytest -q",
+        "setsid pytest -q",
+        "echo harmless &",
+        "pytest -q 2>&1",
+        "pytest -q &>out.log",
+        "pytest -q >&2",
+        "pytest -q <&0",
+    ],
+)
+def test_does_not_reject_managed_or_nonheavy_commands(command):
+    assert heavy_work_requests_detach(command) is False
+
+
+def test_kernel_lease_blocks_second_process_and_recovers_after_release(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    lease, conflict = acquire_heavy_work_lease(
+        "pytest -q", limit=1, session_key="first"
+    )
+    assert lease is not None
+    assert conflict is None
+
+    script = """
+import json
+from tools.heavy_work_guard import acquire_heavy_work_lease
+lease, conflict = acquire_heavy_work_lease('codex exec review', limit=1, session_key='second')
+print(json.dumps({'acquired': lease is not None, 'owner': conflict.owner if conflict else None}))
+if lease:
+    lease.release()
+"""
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(tmp_path)
+    blocked = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(blocked.stdout)
+    assert payload["acquired"] is False
+    assert payload["owner"]["category"] == "test-suite"
+    assert payload["owner"]["session_key"] == "first"
+
+    lease.release()
+
+    acquired = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert json.loads(acquired.stdout)["acquired"] is True
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX FD inheritance semantics")
+def test_child_inherited_fd_keeps_slot_after_holder_crash(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    holder_script = r'''
+import os
+import subprocess
+from tools.heavy_work_guard import acquire_heavy_work_lease
+lease, conflict = acquire_heavy_work_lease("pytest -q", limit=1, session_key="crash-holder")
+assert lease is not None and conflict is None
+child = subprocess.Popen(
+    ["sleep", "2"],
+    stdin=subprocess.DEVNULL,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+    start_new_session=True,
+    pass_fds=lease.child_pass_fds(),
+)
+print(child.pid, flush=True)
+os._exit(0)
+'''
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(tmp_path)
+    holder = subprocess.run(
+        [sys.executable, "-c", holder_script],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=10,
+    )
+    child_pid = int(holder.stdout.strip())
+    # Signal 0 only probes liveness and is permitted by the live-system guard.
+    os.kill(child_pid, 0)
+    lease, conflict = acquire_heavy_work_lease("codex exec review", limit=1)
+    assert lease is None
+    assert conflict is not None
+
+    # Once the surviving job exits naturally, the kernel releases the inherited lock.
+    import time
+
+    deadline = time.time() + 5
+    recovered = None
+    while time.time() < deadline:
+        recovered, _ = acquire_heavy_work_lease("codex exec review", limit=1)
+        if recovered is not None:
+            break
+        time.sleep(0.05)
+    assert recovered is not None
+    recovered.release()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX FD inheritance semantics")
+def test_parent_release_does_not_unlock_inherited_child_fd(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    lease, conflict = acquire_heavy_work_lease(
+        "pytest -q", limit=1, session_key="release-parent"
+    )
+    assert lease is not None and conflict is None
+    child = subprocess.Popen(
+        ["sleep", "2"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+        pass_fds=lease.child_pass_fds(),
+    )
+
+    lease.release()
+    rival, rival_conflict = acquire_heavy_work_lease(
+        "codex exec review", limit=1, session_key="rival"
+    )
+    blocked_while_child_alive = rival is None and rival_conflict is not None
+    if rival is not None:
+        rival.release()
+    assert blocked_while_child_alive
+
+    child.wait(timeout=5)
+    recovered, recovered_conflict = acquire_heavy_work_lease(
+        "codex exec review", limit=1, session_key="recovered"
+    )
+    assert recovered is not None and recovered_conflict is None
+    recovered.release()
+
+
+def test_disabled_limit_does_not_acquire(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    lease, conflict = acquire_heavy_work_lease("pytest -q", limit=0)
+    assert lease is None
+    assert conflict is None
+
+
+def test_lock_metadata_does_not_persist_command_or_inline_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    lease, conflict = acquire_heavy_work_lease(
+        "API_TOKEN=do-not-store pytest -q", limit=1, session_key="safe-session"
+    )
+    assert lease is not None
+    assert conflict is None
+    payload = json.loads(lease.path.read_text(encoding="utf-8"))
+    assert "command" not in payload
+    assert "do-not-store" not in lease.path.read_text(encoding="utf-8")
+    lease.release()
+
+
+def test_limit_two_allows_two_then_blocks_third(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    first, _ = acquire_heavy_work_lease("pytest -q", limit=2)
+    second, _ = acquire_heavy_work_lease("supabase start", limit=2)
+    third, conflict = acquire_heavy_work_lease("codex exec review", limit=2)
+    assert first is not None
+    assert second is not None
+    assert third is None
+    assert conflict is not None
+    first.release()
+    second.release()
+
+
+def test_terminal_config_bridge_exports_heavy_limit():
+    from hermes_cli.config import apply_terminal_config_to_env
+
+    target = {}
+    apply_terminal_config_to_env(
+        env=target,
+        config={"terminal": {"max_concurrent_heavy_jobs": 1}},
+        override=True,
+    )
+    assert target["TERMINAL_MAX_CONCURRENT_HEAVY_JOBS"] == "1"
+
+
+def test_registry_releases_background_lease_once(monkeypatch):
+    from tools.process_registry import ProcessRegistry, ProcessSession
+
+    registry = ProcessRegistry()
+    monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+    lease = _FakeLease()
+    session = ProcessSession(
+        id="proc_test",
+        command="pytest -q",
+        task_id="task",
+        session_key="session",
+        cwd=".",
+        started_at=0.0,
+        _heavy_work_lease=lease,
+    )
+    registry._running[session.id] = session
+
+    registry._move_to_finished(session)
+    registry._move_to_finished(session)
+
+    assert lease.release_count == 1
+    assert session._heavy_work_lease is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX PTY pass_fds semantics")
+def test_registry_pty_spawn_inherits_kernel_lock_fd(tmp_path, monkeypatch):
+    from ptyprocess import PtyProcess
+    from tools.process_registry import ProcessRegistry
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    lease, conflict = acquire_heavy_work_lease("pytest -q", limit=1)
+    assert lease is not None and conflict is None
+    expected = lease.child_pass_fds()
+    seen = {}
+    original_spawn = PtyProcess.spawn
+
+    def _spy_spawn(*args, **kwargs):
+        seen["pass_fds"] = kwargs.get("pass_fds")
+        return original_spawn(*args, **kwargs)
+
+    monkeypatch.setattr(PtyProcess, "spawn", staticmethod(_spy_spawn))
+    registry = ProcessRegistry()
+    monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+
+    session = registry.spawn_local(
+        command="printf pty-ok",
+        cwd=str(tmp_path),
+        task_id="pty-heavy",
+        use_pty=True,
+        heavy_work_lease=lease,
+    )
+    finished = registry.wait(session.id, timeout=5)
+
+    assert finished["status"] == "exited"
+    assert seen["pass_fds"] == expected
+
+
+def _terminal_test_config():
+    return {
+        "env_type": "local",
+        "timeout": 180,
+        "cwd": "/tmp",
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+
+
+def test_terminal_foreground_releases_lease(monkeypatch):
+    from tools import heavy_work_guard
+    from tools import terminal_tool as terminal_module
+
+    lease = _FakeLease()
+    monkeypatch.setenv("TERMINAL_MAX_CONCURRENT_HEAVY_JOBS", "1")
+    monkeypatch.setattr(terminal_module, "_get_env_config", _terminal_test_config)
+    monkeypatch.setattr(terminal_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        heavy_work_guard,
+        "acquire_heavy_work_lease",
+        lambda *args, **kwargs: (lease, None),
+    )
+
+    result = json.loads(
+        terminal_module.terminal_tool(command=f"{sys.executable} -c 'print(\"ok\")'")
+    )
+
+    assert result["exit_code"] == 0
+    assert lease.release_count == 1
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX FD inheritance semantics")
+def test_terminal_foreground_child_inherits_kernel_lock_fd(tmp_path, monkeypatch):
+    from tools import heavy_work_guard
+    from tools import terminal_tool as terminal_module
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TERMINAL_MAX_CONCURRENT_HEAVY_JOBS", "1")
+    lease, conflict = acquire_heavy_work_lease("pytest -q", limit=1)
+    assert lease is not None and conflict is None
+    fd = lease.child_pass_fds()[0]
+    monkeypatch.setattr(terminal_module, "_get_env_config", _terminal_test_config)
+    monkeypatch.setattr(terminal_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        heavy_work_guard,
+        "acquire_heavy_work_lease",
+        lambda *args, **kwargs: (lease, None),
+    )
+
+    command = (
+        f"{sys.executable} -c 'import os; "
+        f"print(os.readlink(\"/proc/self/fd/{fd}\"))'"
+    )
+    result = json.loads(
+        terminal_module.terminal_tool(
+            command=command,
+            task_id="heavy-foreground-inherited-fd",
+        )
+    )
+
+    assert result["exit_code"] == 0
+    assert "heavy-work-0.lock" in result["output"]
+
+
+def test_terminal_background_holds_lease_until_process_finishes(monkeypatch):
+    from tools import heavy_work_guard
+    from tools import terminal_tool as terminal_module
+    from tools.process_registry import process_registry
+
+    lease = _FakeLease()
+    monkeypatch.setenv("TERMINAL_MAX_CONCURRENT_HEAVY_JOBS", "1")
+    monkeypatch.setattr(terminal_module, "_get_env_config", _terminal_test_config)
+    monkeypatch.setattr(terminal_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        heavy_work_guard,
+        "acquire_heavy_work_lease",
+        lambda *args, **kwargs: (lease, None),
+    )
+
+    result = json.loads(
+        terminal_module.terminal_tool(
+            command=f"{sys.executable} -c 'import time; time.sleep(0.4)'",
+            background=True,
+        )
+    )
+    assert result["exit_code"] == 0
+    assert lease.release_count == 0
+
+    finished = process_registry.wait(result["session_id"], timeout=5)
+    assert finished["status"] == "exited"
+    assert lease.release_count == 1
+
+
+def test_terminal_background_kill_releases_lease(monkeypatch):
+    from tools import heavy_work_guard
+    from tools import terminal_tool as terminal_module
+    from tools.process_registry import process_registry
+
+    lease = _FakeLease()
+    monkeypatch.setenv("TERMINAL_MAX_CONCURRENT_HEAVY_JOBS", "1")
+    monkeypatch.setattr(terminal_module, "_get_env_config", _terminal_test_config)
+    monkeypatch.setattr(terminal_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        heavy_work_guard,
+        "acquire_heavy_work_lease",
+        lambda *args, **kwargs: (lease, None),
+    )
+
+    result = json.loads(
+        terminal_module.terminal_tool(
+            command=f"{sys.executable} -c 'import time; time.sleep(30)'",
+            background=True,
+        )
+    )
+    assert lease.release_count == 0
+    killed = process_registry.kill_process(result["session_id"], source="test")
+    assert killed["status"] == "killed"
+    assert lease.release_count == 1
+
+
+def test_terminal_rejects_second_heavy_job_without_execution(monkeypatch):
+    from tools import heavy_work_guard
+    from tools import terminal_tool as terminal_module
+
+    class _NoExecuteEnv:
+        cwd = "/tmp"
+        cwd_owner = ""
+        env = {}
+
+        def execute(self, *args, **kwargs):
+            raise AssertionError("busy heavy work must not execute")
+
+    monkeypatch.setenv("TERMINAL_MAX_CONCURRENT_HEAVY_JOBS", "1")
+    monkeypatch.setattr(terminal_module, "_get_env_config", _terminal_test_config)
+    monkeypatch.setattr(terminal_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_module, "_create_environment", lambda **kwargs: _NoExecuteEnv())
+    monkeypatch.setattr(
+        heavy_work_guard,
+        "acquire_heavy_work_lease",
+        lambda *args, **kwargs: (
+            None,
+            HeavyWorkConflict(owner={"category": "test-suite", "pid": 123}),
+        ),
+    )
+
+    result = json.loads(
+        terminal_module.terminal_tool(
+            command=f"{sys.executable} -c 'print(\"never-runs\")'",
+            task_id="heavy-conflict-after-approval",
+        )
+    )
+
+    assert result["status"] == "busy"
+    assert result["exit_code"] == 75
+    assert "test-suite" in result["error"]
+
+
+def test_pending_approval_does_not_acquire_heavy_slot(monkeypatch):
+    from tools import heavy_work_guard
+    from tools import terminal_tool as terminal_module
+
+    class _ApprovalEnv:
+        cwd = "/tmp"
+        cwd_owner = ""
+        env = {}
+
+    monkeypatch.setenv("TERMINAL_MAX_CONCURRENT_HEAVY_JOBS", "1")
+    monkeypatch.setattr(terminal_module, "_get_env_config", _terminal_test_config)
+    monkeypatch.setattr(terminal_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_module, "_create_environment", lambda **kwargs: _ApprovalEnv())
+    monkeypatch.setattr(
+        terminal_module,
+        "_check_all_guards",
+        lambda *args, **kwargs: {
+            "approved": False,
+            "status": "pending_approval",
+            "command": args[0],
+            "description": "test approval",
+        },
+    )
+    monkeypatch.setattr(
+        heavy_work_guard,
+        "acquire_heavy_work_lease",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("pending approval must not acquire a heavy slot")
+        ),
+    )
+
+    result = json.loads(
+        terminal_module.terminal_tool(
+            command=f"{sys.executable} -c 'print(\"approved later\")'",
+            task_id="heavy-pending-approval",
+        )
+    )
+
+    assert result["status"] == "pending_approval"
+    assert result["approval_pending"] is True
+
+
+def test_terminal_rejects_self_detaching_heavy_work_before_execution(monkeypatch):
+    from tools import heavy_work_guard
+    from tools import terminal_tool as terminal_module
+
+    monkeypatch.setenv("TERMINAL_MAX_CONCURRENT_HEAVY_JOBS", "1")
+    monkeypatch.setattr(terminal_module, "_get_env_config", _terminal_test_config)
+    monkeypatch.setattr(terminal_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_module,
+        "_create_environment",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("self-detaching heavy work must not create an environment")
+        ),
+    )
+    monkeypatch.setattr(
+        heavy_work_guard,
+        "acquire_heavy_work_lease",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("self-detaching heavy work must be rejected before acquisition")
+        ),
+    )
+
+    result = json.loads(
+        terminal_module.terminal_tool(
+            command="nohup pytest -q >/tmp/t.log 2>&1 & exit",
+            task_id="heavy-self-detach",
+            background=True,
+        )
+    )
+
+    assert result["status"] == "unsupported"
+    assert result["exit_code"] == 78
+    assert result["heavy_work"] is True
+    assert "self-detach" in result["error"]
+
+
+def test_terminal_fails_closed_for_non_local_heavy_work(monkeypatch):
+    from tools import heavy_work_guard
+    from tools import terminal_tool as terminal_module
+
+    config = _terminal_test_config()
+    config["env_type"] = "docker"
+    config["docker_image"] = "unused"
+    monkeypatch.setenv("TERMINAL_MAX_CONCURRENT_HEAVY_JOBS", "1")
+    monkeypatch.setattr(terminal_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(
+        terminal_module,
+        "_create_environment",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("unsupported guarded backend must not be created")
+        ),
+    )
+    monkeypatch.setattr(
+        heavy_work_guard,
+        "acquire_heavy_work_lease",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("unsupported backend must be rejected before acquisition")
+        ),
+    )
+
+    result = json.loads(terminal_module.terminal_tool(command="pytest -q"))
+
+    assert result["status"] == "unsupported"
+    assert result["exit_code"] == 78
+
+
+def test_terminal_reports_remote_background_failed_start(monkeypatch):
+    from tools import heavy_work_guard
+    from tools import terminal_tool as terminal_module
+
+    class _FailedEnv:
+        cwd = "/tmp"
+        cwd_owner = ""
+
+        def execute(self, *args, **kwargs):
+            return {"output": "launcher failed", "returncode": 2}
+
+    config = _terminal_test_config()
+    config["env_type"] = "docker"
+    config["docker_image"] = "unused"
+    monkeypatch.setattr(terminal_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        heavy_work_guard,
+        "acquire_heavy_work_lease",
+        lambda *args, **kwargs: (None, None),
+    )
+    monkeypatch.setitem(terminal_module._active_environments, "default", _FailedEnv())
+
+    result = json.loads(
+        terminal_module.terminal_tool(
+            command="printf not-started",
+            background=True,
+            task_id="remote-failed-start",
+        )
+    )
+
+    assert result["status"] == "failed_start"
+    assert result["exit_code"] == 2
+    assert "launcher failed" in result["output"]

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -312,6 +312,10 @@ def _silent_bg_harness(monkeypatch, tmp_path):
             watcher_thread_id="",
             watcher_message_id="",
             watcher_interval=0,
+            # exited/completion_reason mirror ProcessSession's real defaults
+            # (terminal_tool checks these for a synchronous failed-start signal).
+            exited=False,
+            completion_reason="exited",
         )
 
     monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -130,7 +130,11 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
 
         def spawn_local(self, **kwargs):
             self.calls.append(kwargs)
-            return SimpleNamespace(id="proc_test", pid=1234)
+            # exited/completion_reason mirror ProcessSession's real defaults
+            # (terminal_tool checks these for a synchronous failed-start signal).
+            return SimpleNamespace(
+                id="proc_test", pid=1234, exited=False, completion_reason="exited",
+            )
 
     import tools.process_registry as process_registry_mod
 
@@ -170,6 +174,7 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "session_key": task_id,
         "env_vars": {},
         "use_pty": False,
+        "heavy_work_lease": None,
     }]
 
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -13,6 +13,7 @@ import tempfile
 import time
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -1527,7 +1528,16 @@ class LocalEnvironment(BaseEnvironment):
 
         _popen_cwd = self.cwd
 
-        _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+        _popen_kwargs: dict[str, Any] = (
+            {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+        )
+        if not _IS_WINDOWS:
+            # Heavy foreground jobs inherit the kernel-lock FD through a
+            # task-local context set by terminal_tool. The lock therefore stays
+            # held if Hermes crashes while the command tree is still alive.
+            from tools.heavy_work_guard import current_heavy_work_child_fds
+
+            _popen_kwargs["pass_fds"] = current_heavy_work_child_fds()
 
         proc = subprocess.Popen(
             args,
@@ -1544,7 +1554,7 @@ class LocalEnvironment(BaseEnvironment):
         )
         if not _IS_WINDOWS:
             try:
-                proc._hermes_pgid = os.getpgid(proc.pid)
+                setattr(proc, "_hermes_pgid", os.getpgid(proc.pid))
             except ProcessLookupError:
                 pass
 

--- a/tools/heavy_work_guard.py
+++ b/tools/heavy_work_guard.py
@@ -1,0 +1,476 @@
+"""Cross-process concurrency guard for resource-heavy terminal commands.
+
+The guard is opt-in via ``terminal.max_concurrent_heavy_jobs``. Ownership is
+held by a kernel file lock. On supported POSIX-local execution, spawned jobs
+inherit the lock FD so gateway death cannot release a slot while the job tree is
+still alive. The JSON stored in each slot is informational only and never
+trusted for lock ownership.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+from hermes_cli.config import get_hermes_home
+
+_INFO_FLAGS = {"--help", "-h", "--version", "-V", "version", "help"}
+_SHELL_OPERATORS = {"&", "&&", "|", "||", ";", ";;", "(", ")", "{", "}"}
+_SHELL_CONTROL_WORDS = {
+    "if", "then", "elif", "else", "fi", "for", "while", "until", "do", "done", "!",
+}
+_DYNAMIC_EXECUTABLES = {
+    ".",
+    "chronic",
+    "chrt",
+    "daemon",
+    "daemonize",
+    "doas",
+    "docker",
+    "env",
+    "eval",
+    "flock",
+    "ionice",
+    "nice",
+    "parallel",
+    "podman",
+    "runuser",
+    "source",
+    "start-stop-daemon",
+    "stdbuf",
+    "sudo",
+    "systemd-run",
+    "taskset",
+    "time",
+    "timeout",
+    "unbuffer",
+    "xargs",
+}
+_DETACHING_EXECUTABLES = {
+    "daemon",
+    "daemonize",
+    "start-stop-daemon",
+    "systemd-run",
+}
+_DYNAMIC_INTERPRETERS = {
+    "node",
+    "nodejs",
+    "perl",
+    "php",
+    "ruby",
+}
+_HEAVY_CHILD_FDS: ContextVar[tuple[int, ...]] = ContextVar(
+    "heavy_work_child_fds", default=()
+)
+
+
+def _token_segments(command: str) -> list[list[str]]:
+    """Split a shell command without treating quoted operators as separators."""
+    lexer = shlex.shlex(
+        command,
+        posix=os.name != "nt",
+        punctuation_chars="();&|{}",
+    )
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for token in lexer:
+        if token in _SHELL_OPERATORS:
+            if current:
+                segments.append(current)
+                current = []
+        else:
+            current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _strip_wrappers(tokens: list[str]) -> list[str]:
+    current = list(tokens)
+    while current:
+        executable = Path(current[0]).name.lower()
+        if executable in _SHELL_CONTROL_WORDS:
+            current = current[1:]
+            continue
+        if executable == "sudo":
+            current = current[1:]
+            while current and current[0].startswith("-"):
+                current = current[1:]
+            continue
+        if executable == "env":
+            current = current[1:]
+            while current and "=" in current[0] and not current[0].startswith("="):
+                current = current[1:]
+            continue
+        if executable == "time":
+            current = current[1:]
+            continue
+        # ``setsid`` is treated as a transparent wrapper, NOT a self-detach.
+        # Invoked from a shell, setsid is not a process-group leader, so it
+        # execs the target in place (or waits for it under ``--wait``): the
+        # shell waits for the job and the inherited kernel-lock FD stays with
+        # the job tree. A trailing ``&`` / ``disown`` / detaching launcher is
+        # what actually backgrounds it, and ``heavy_work_requests_detach``
+        # still catches those. See test_setsid_wrapper_is_not_self_detach.
+        if executable in {"nohup", "command", "exec", "setsid"}:
+            current = current[1:]
+            while current and current[0].startswith("-"):
+                current = current[1:]
+            continue
+        if executable == "timeout":
+            current = current[1:]
+            while current and current[0].startswith("-"):
+                current = current[1:]
+            if current:
+                current = current[1:]
+            continue
+        while current and "=" in current[0] and not current[0].startswith("="):
+            current = current[1:]
+        break
+    return current
+
+
+def _is_command_substitution(token: str) -> bool:
+    """Return whether *token* contains inline command substitution.
+
+    ``$(...)`` and backtick substitution both run an arbitrary command inline
+    (which may itself be heavy), so they are genuinely opaque to lexical
+    classification. A plain ``$VAR`` / ``${VAR}`` parameter expansion is NOT
+    command substitution — it only expands a value and, in argument position,
+    does not change which program runs. That distinction is handled separately.
+    """
+    return "$(" in token or "`" in token
+
+
+def _classify_tokens(tokens: list[str]) -> Optional[str]:
+    # Command substitution ``$(...)`` and backticks execute an arbitrary —
+    # possibly heavy — command inline, opaque to lexical matching, so serialize
+    # them fail-closed wherever they appear. A *simple* parameter expansion
+    # (``echo $HOME``, ``grep $foo``) used as an argument does not change which
+    # program runs, so it is not dynamic on its own; it is only treated as
+    # dynamic when it produces the executable itself (checked after wrapper
+    # stripping below).
+    if any(_is_command_substitution(token) for token in tokens):
+        return "dynamic-execution"
+    if (
+        tokens
+        and Path(tokens[0]).name.lower() == "command"
+        and len(tokens) > 1
+        and tokens[1] in {"-v", "-V"}
+    ):
+        return None
+    if tokens and Path(tokens[0]).name.lower() in _DYNAMIC_EXECUTABLES:
+        return "dynamic-execution"
+
+    tokens = _strip_wrappers(tokens)
+    if not tokens:
+        return None
+
+    # A leading token whose value comes from variable/parameter expansion
+    # (``$cmd``, ``${cmd}``) computes the executable at runtime — we cannot know
+    # which program actually runs, so fail closed. Simple expansions confined to
+    # argument positions were already allowed through above.
+    if "$" in tokens[0]:
+        return "dynamic-execution"
+
+    executable = Path(tokens[0]).name.lower()
+    args = tokens[1:]
+    informational = any(arg in _INFO_FLAGS for arg in args)
+    direct_informational = bool(args) and args[0] in _INFO_FLAGS
+
+    if re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", executable):
+        if len(args) >= 2 and args[0] == "-m" and args[1] in {"pytest", "tox", "nox"}:
+            return None if informational else "test-suite"
+        if len(args) >= 2 and args[0] == "-c":
+            indirect = args[1].lower()
+            if re.search(r"\b(pytest|py\.test|tox|nox|jest|vitest)\b", indirect):
+                return "test-suite"
+            if re.search(r"\b(supabase|pglite)\b", indirect):
+                return "database-lab"
+            if re.search(r"\b(claude|codex|opencode)\b", indirect):
+                return "ai-reviewer"
+        # Arbitrary modules, snippets, and scripts can spawn a heavy child using
+        # computed strings that lexical matching cannot recover.
+        return None if direct_informational else "dynamic-execution"
+
+    if executable in {"uv", "poetry", "pipenv"} and args[:1] == ["run"]:
+        return _classify_tokens(args[1:])
+    if executable in {"bash", "dash", "ksh", "sh", "zsh", "fish"}:
+        for index, arg in enumerate(args):
+            if arg.startswith("-") and "c" in arg[1:] and index + 1 < len(args):
+                nested = classify_heavy_work(args[index + 1])
+                return nested
+        # A script path or stdin-fed shell is opaque to this command line.
+        return None if direct_informational else "dynamic-execution"
+    if executable in _DYNAMIC_INTERPRETERS:
+        return None if direct_informational else "dynamic-execution"
+
+    if executable in {"pytest", "py.test", "tox", "nox", "jest", "vitest"}:
+        return None if informational else "test-suite"
+    if executable == "cargo" and args[:1] == ["test"]:
+        return None if informational else "test-suite"
+    if executable == "go" and args[:1] == ["test"]:
+        return None if informational else "test-suite"
+    if executable in {"npm", "pnpm", "yarn", "bun"}:
+        if executable == "npm" and args[:1] in (["exec"], ["x"]):
+            return "dynamic-execution"
+        runner_args = args[1:] if args[:1] == ["run"] else args
+        if runner_args and runner_args[0].lower().startswith("test"):
+            return None if informational else "test-suite"
+    if executable == "make" and args and args[0].lower() in {"test", "tests", "check"}:
+        return None if informational else "test-suite"
+
+    if executable == "npx" and args:
+        if args[0].startswith("-"):
+            return "dynamic-execution"
+        return _classify_tokens(args)
+
+    if executable == "supabase" and args:
+        action = args[0].lower()
+        if action == "start" or action in {"db", "test"}:
+            return None if informational else "database-lab"
+    if executable.startswith("pglite"):
+        return None if informational else "database-lab"
+
+    if executable in {"claude", "codex", "opencode"}:
+        return None if informational else "ai-reviewer"
+
+    return None
+
+
+def classify_heavy_work(command: str) -> Optional[str]:
+    """Return the heavy-work category for a shell command, if any."""
+    if not isinstance(command, str) or not command.strip():
+        return None
+    try:
+        segments = _token_segments(command)
+    except ValueError:
+        return "dynamic-execution"
+    for tokens in segments:
+        category = _classify_tokens(tokens)
+        if category:
+            return category
+    return None
+
+
+def heavy_work_requests_detach(command: str) -> bool:
+    """Return whether guarded work asks the shell/program to self-detach.
+
+    Hermes can keep a lease across its own background/PTY lifecycle, but it
+    cannot guarantee ownership after a command deliberately closes inherited
+    descriptors. Reject recognized detach forms instead of running unguarded.
+    """
+    if classify_heavy_work(command) is None:
+        return False
+    try:
+        lexer = shlex.shlex(
+            command,
+            posix=os.name != "nt",
+            punctuation_chars="();&|{}",
+        )
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return True
+
+    def _is_redirection_ampersand(index: int) -> bool:
+        previous = tokens[index - 1] if index > 0 else ""
+        following = tokens[index + 1] if index + 1 < len(tokens) else ""
+        # shlex emits fd duplication as ['2>', '&', '1'] / ['>', '&', '2']
+        # and combined output redirection as ['&', '>file']. Neither backgrounds.
+        return previous.endswith((">", "<")) or following.startswith(">")
+
+    if any(
+        token == "&" and not _is_redirection_ampersand(index)
+        for index, token in enumerate(tokens)
+    ):
+        return True
+    # ``setsid`` is deliberately absent from _DETACHING_EXECUTABLES: from a
+    # shell it execs the target in place (not a process-group leader) or waits
+    # for it under ``--wait``, so the shell waits for the job and the inherited
+    # lock FD stays with the job tree. Only a trailing ``&`` / ``disown`` (both
+    # handled here) or a genuine detaching launcher backgrounds a setsid job.
+    lowered = [Path(token).name.lower() for token in tokens]
+    if "disown" in lowered or any(
+        executable in _DETACHING_EXECUTABLES for executable in lowered
+    ):
+        return True
+    return any(
+        token.lower() in {"--background", "--daemon", "--detach", "--fork"}
+        for token in tokens
+    )
+
+
+def lease_fd_inheritable() -> bool:
+    """Return whether a spawned child inherits the heavy-work kernel-lock FD.
+
+    POSIX advisory locks (``flock``) live on the open file description shared by
+    inherited descriptors, so a descendant keeps the slot pinned even if the
+    Hermes process that opened it dies. Windows ``msvcrt`` byte-range locks are
+    bound to the opening process and are NOT inherited by children, so the
+    survive-Hermes-death guarantee is void there. Callers must fail closed on
+    platforms where this returns ``False`` rather than run guarded heavy work
+    with a slot Hermes cannot keep held. Split out as a function so tests can
+    monkeypatch the platform verdict without a real Windows host.
+    """
+    return os.name != "nt"
+
+
+def configured_heavy_work_limit() -> int:
+    """Read the internal env bridge for terminal.max_concurrent_heavy_jobs."""
+    raw = os.getenv("TERMINAL_MAX_CONCURRENT_HEAVY_JOBS", "0")
+    try:
+        return max(0, min(int(raw), 16))
+    except (TypeError, ValueError):
+        return 0
+
+
+@dataclass(frozen=True)
+class HeavyWorkConflict:
+    owner: dict[str, Any]
+
+
+class HeavyWorkLease:
+    """One held kernel-lock slot. Release is idempotent."""
+
+    def __init__(self, handle, path: Path, owner: dict[str, Any]) -> None:
+        self._handle = handle
+        self.path = path
+        self.owner = owner
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        handle = self._handle
+        self._handle = None
+        if handle is None:
+            return
+        try:
+            # Keep owner metadata intact. POSIX flock locks belong to the open
+            # file description shared by inherited FDs. Closing only this copy
+            # preserves ownership until the last descendant closes its copy;
+            # an explicit LOCK_UN here would incorrectly unlock every holder.
+            if os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        finally:
+            handle.close()
+
+    def child_pass_fds(self) -> tuple[int, ...]:
+        """Return POSIX FDs a child must inherit to keep the lease alive."""
+        if self._released or self._handle is None or os.name == "nt":
+            return ()
+        return (self._handle.fileno(),)
+
+    def __enter__(self) -> "HeavyWorkLease":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.release()
+
+
+@contextmanager
+def inherit_heavy_work_lease(lease: Optional[HeavyWorkLease]) -> Iterator[None]:
+    """Expose a lease FD to LocalEnvironment's next foreground spawn."""
+    fds = lease.child_pass_fds() if lease is not None else ()
+    token = _HEAVY_CHILD_FDS.set(fds)
+    try:
+        yield
+    finally:
+        _HEAVY_CHILD_FDS.reset(token)
+
+
+def current_heavy_work_child_fds() -> tuple[int, ...]:
+    """Return task-local lease FDs for a local subprocess spawn."""
+    return _HEAVY_CHILD_FDS.get()
+
+
+def _try_lock(handle) -> bool:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except (BlockingIOError, OSError):
+        return False
+
+
+def _read_owner(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return payload if isinstance(payload, dict) else {}
+    except (OSError, ValueError, TypeError):
+        return {}
+
+
+def acquire_heavy_work_lease(
+    command: str,
+    *,
+    limit: Optional[int] = None,
+    session_key: str = "",
+) -> tuple[Optional[HeavyWorkLease], Optional[HeavyWorkConflict]]:
+    """Try to claim a heavy-work slot without waiting.
+
+    ``(None, None)`` means the command is not classified or the guard is
+    disabled. ``(None, conflict)`` means every configured slot is held.
+    """
+    category = classify_heavy_work(command)
+    effective_limit = configured_heavy_work_limit() if limit is None else max(0, limit)
+    if category is None or effective_limit <= 0:
+        return None, None
+
+    runtime_dir = get_hermes_home() / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    owner = {
+        "pid": os.getpid(),
+        "category": category,
+        "session_key": session_key,
+        "started_at_epoch": time.time(),
+    }
+    occupied: list[dict[str, Any]] = []
+
+    for slot in range(effective_limit):
+        path = runtime_dir / f"heavy-work-{slot}.lock"
+        handle = open(path, "a+b")
+        try:
+            os.chmod(path, 0o600)
+            if not _try_lock(handle):
+                handle.close()
+                occupied.append(_read_owner(path))
+                continue
+            handle.seek(0)
+            handle.truncate(0)
+            handle.write(json.dumps(owner, sort_keys=True).encode("utf-8"))
+            handle.flush()
+            os.fsync(handle.fileno())
+            return HeavyWorkLease(handle, path, owner), None
+        except Exception:
+            handle.close()
+            raise
+
+    conflict_owner = next((item for item in occupied if item), {})
+    return None, HeavyWorkConflict(owner=conflict_owner)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -414,6 +414,7 @@ class ProcessSession:
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
+    _heavy_work_lease: Any = field(default=None, repr=False)
 
 
 class ProcessRegistry:
@@ -969,8 +970,9 @@ class ProcessRegistry:
         cwd: str = None,
         task_id: str = "",
         session_key: str = "",
-        env_vars: dict = None,
+        env_vars: Optional[dict] = None,
         use_pty: bool = False,
+        heavy_work_lease: Any = None,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -982,6 +984,15 @@ class ProcessRegistry:
                      CLI tools (Codex, Claude Code, Python REPL). Falls back to
                      subprocess.Popen if ptyprocess is not installed.
         """
+        if heavy_work_lease is not None and _IS_WINDOWS:
+            heavy_work_lease.release()
+            raise RuntimeError(
+                "Heavy-work execution is fail-closed on Windows because child lock inheritance is unavailable"
+            )
+        lease_fds = (
+            heavy_work_lease.child_pass_fds() if heavy_work_lease is not None else ()
+        )
+
         # Guard against the `A && B &` subshell-wait trap (issue #68915).
         # Bash parses ``A && B &`` as ``(A && B) &`` — a subshell that holds
         # the stdout pipe open forever when B is a long-running server.
@@ -998,6 +1009,7 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            _heavy_work_lease=heavy_work_lease,
         )
 
         pty_scope_attempted = False
@@ -1037,11 +1049,19 @@ class ProcessRegistry:
                         "worker shares the gateway cgroup."
                     )
 
+                _pty_spawn_kwargs: Dict[str, Any] = {}
+                if not _IS_WINDOWS:
+                    # pywinpty (Windows) has no POSIX fd-inheritance model, and
+                    # heavy_work_lease is always None here (Windows fail-closed
+                    # above) — only pass pass_fds to ptyprocess so the Windows
+                    # spawn call stays byte-identical to upstream.
+                    _pty_spawn_kwargs["pass_fds"] = lease_fds
                 pty_proc = _PtyProcessCls.spawn(
                     pty_argv,
                     cwd=session.cwd,
                     env=pty_env,
                     dimensions=(30, 120),
+                    **_pty_spawn_kwargs,
                 )
                 session.pid = pty_proc.pid
                 session.host_start_time = self._safe_host_start_time(session.pid)
@@ -1086,7 +1106,11 @@ class ProcessRegistry:
         # stdout is a pipe, hiding output from process(action="poll")).
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
         bg_env["PYTHONUNBUFFERED"] = "1"
-        _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+        _popen_kwargs: Dict[str, Any] = (
+            {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+        )
+        if not _IS_WINDOWS:
+            _popen_kwargs["pass_fds"] = lease_fds
 
         # Cgroup isolation (#70716): when running in the live, supervised
         # systemd gateway, wrap the worker in its own transient systemd
@@ -1209,6 +1233,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        heavy_work_lease: Any = None,
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -1220,7 +1245,16 @@ class ProcessRegistry:
 
         This is less capable than local spawn (no live stdout pipe, no stdin),
         but it ensures the command runs in the correct sandbox context.
+
+        Heavy guarded work is rejected here: a remote/container process cannot
+        inherit the host kernel-lock FD, so gateway death could otherwise free
+        the slot while the remote job remains alive.
         """
+        if heavy_work_lease is not None:
+            heavy_work_lease.release()
+            raise RuntimeError(
+                "Heavy-work execution is fail-closed for non-local backends because the job cannot inherit the host lock"
+            )
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
@@ -1230,6 +1264,7 @@ class ProcessRegistry:
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
+            _heavy_work_lease=heavy_work_lease,
         )
 
         # Run the command in the sandbox with output capture
@@ -1298,6 +1333,8 @@ class ProcessRegistry:
 
         if not session.exited:
             self._write_checkpoint()
+        else:
+            self._release_heavy_work_lease(session)
 
         return session
 
@@ -1544,6 +1581,17 @@ class ProcessRegistry:
             session.completion_reason = "exited"
         self._move_to_finished(session)
 
+    @staticmethod
+    def _release_heavy_work_lease(session: ProcessSession) -> None:
+        with session._lock:
+            lease = session._heavy_work_lease
+            session._heavy_work_lease = None
+        if lease is not None:
+            try:
+                lease.release()
+            except Exception:
+                logger.debug("Failed to release heavy-work lease", exc_info=True)
+
     def _move_to_finished(self, session: ProcessSession):
         """Move a session from running to finished.
 
@@ -1551,6 +1599,7 @@ class ProcessRegistry:
         with the reader thread), the second call is a no-op — no duplicate
         completion notification is enqueued.
         """
+        self._release_heavy_work_lease(session)
         with self._lock:
             was_running = self._running.pop(session.id, None) is not None
             self._finished[session.id] = session

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2670,6 +2670,41 @@ def terminal_tool(
         # Start cleanup thread
         _start_cleanup_thread()
 
+        # Optional cross-process guard for resource-heavy local commands.  Only
+        # classify here; the lease itself is acquired after security approvals
+        # so waiting for a human never consumes a concurrency slot.
+        from tools import heavy_work_guard
+
+        _heavy_limit = heavy_work_guard.configured_heavy_work_limit()
+        _heavy_category = (
+            heavy_work_guard.classify_heavy_work(command)
+            if _heavy_limit > 0 else None
+        )
+        if _heavy_category and heavy_work_guard.heavy_work_requests_detach(command):
+            return json.dumps({
+                "output": "",
+                "exit_code": 78,
+                "error": (
+                    "Blocked: guarded heavy work may not self-detach. Use "
+                    "background=true without shell-level '&', disown, or daemon mode."
+                ),
+                "status": "unsupported",
+                "heavy_work": True,
+            }, ensure_ascii=False)
+        if _heavy_category and (
+            env_type != "local" or not heavy_work_guard.lease_fd_inheritable()
+        ):
+            return json.dumps({
+                "output": "",
+                "exit_code": 78,
+                "error": (
+                    "Blocked: guarded heavy work requires a local POSIX backend "
+                    "that can pass the kernel-lock file descriptor to child processes."
+                ),
+                "status": "unsupported",
+                "heavy_work": True,
+            }, ensure_ascii=False)
+
         # Get or create environment.
         # Use a per-task creation lock so concurrent tool calls for the same
         # task_id wait for the first one to finish creating the sandbox,
@@ -2972,6 +3007,25 @@ def terminal_tool(
                 "EOF."
             )
 
+        # Security approval and workdir validation are complete. Acquire the
+        # non-blocking kernel lease only now, immediately before execution.
+        _heavy_lease = None
+        if _heavy_category:
+            _heavy_lease, _heavy_conflict = heavy_work_guard.acquire_heavy_work_lease(
+                command,
+                limit=_heavy_limit,
+                session_key=session_key,
+            )
+            if _heavy_conflict is not None:
+                owner_category = (_heavy_conflict.owner or {}).get("category", "heavy-work")
+                return json.dumps({
+                    "output": "",
+                    "exit_code": 75,
+                    "error": f"Busy: another {owner_category} job holds the concurrency slot.",
+                    "status": "busy",
+                    "heavy_work": True,
+                }, ensure_ascii=False)
+
         # The session key is already computed above the gateway guard.
         if background:
             # Spawn a tracked background process via the process registry.
@@ -2994,7 +3048,10 @@ def terminal_tool(
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        heavy_work_lease=_heavy_lease,
                     )
+                    # The registry owns and releases the lease from this point.
+                    _heavy_lease = None
                 else:
                     proc_session = process_registry.spawn_via_env(
                         env=env,
@@ -3003,6 +3060,17 @@ def terminal_tool(
                         task_id=effective_task_id,
                         session_key=session_key,
                     )
+
+                if (
+                    proc_session.exited
+                    and proc_session.completion_reason == "failed_start"
+                ):
+                    return json.dumps({
+                        "output": proc_session.output_buffer,
+                        "exit_code": proc_session.exit_code,
+                        "error": "Background process failed to start",
+                        "status": "failed_start",
+                    }, ensure_ascii=False)
 
                 result_data = {
                     "output": "Background process started",
@@ -3216,6 +3284,9 @@ def terminal_tool(
 
                 return json.dumps(result_data, ensure_ascii=False)
             except Exception as e:
+                if _heavy_lease is not None:
+                    _heavy_lease.release()
+                    _heavy_lease = None
                 return json.dumps({
                     "output": "",
                     "exit_code": -1,
@@ -3240,55 +3311,61 @@ def terminal_tool(
                 from tools.interrupt import clear_current_thread_interrupt
                 clear_current_thread_interrupt()
 
-            while retry_count <= max_retries:
-                try:
-                    command_cwd = _resolve_command_cwd(
-                        workdir=workdir,
-                        default_cwd=cwd,
-                        session_key=session_key,
-                        env_type=env_type,
-                    )
-                    execute_kwargs = {
-                        "timeout": effective_timeout,
-                        "cwd": command_cwd,
-                        # Foreground model-facing output: cap retention while
-                        # streaming (head/tail window) so a verbose command
-                        # can't OOM the gateway before truncation (#64435).
-                        # Internal env.execute() consumers (file ops cat
-                        # reads, RPC reads) intentionally stay unbounded.
-                        "bounded_capture": True,
-                    }
-                    result = env.execute(command, **execute_kwargs)
-                except Exception as e:
-                    error_str = str(e).lower()
-                    if "timeout" in error_str:
+            try:
+                while retry_count <= max_retries:
+                    try:
+                        command_cwd = _resolve_command_cwd(
+                            workdir=workdir,
+                            default_cwd=cwd,
+                            session_key=session_key,
+                            env_type=env_type,
+                        )
+                        execute_kwargs = {
+                            "timeout": effective_timeout,
+                            "cwd": command_cwd,
+                            # Foreground model-facing output: cap retention while
+                            # streaming (head/tail window) so a verbose command
+                            # can't OOM the gateway before truncation (#64435).
+                            # Internal env.execute() consumers (file ops cat
+                            # reads, RPC reads) intentionally stay unbounded.
+                            "bounded_capture": True,
+                        }
+                        with heavy_work_guard.inherit_heavy_work_lease(_heavy_lease):
+                            result = env.execute(command, **execute_kwargs)
+                    except Exception as e:
+                        error_str = str(e).lower()
+                        if "timeout" in error_str:
+                            return json.dumps({
+                                "output": "",
+                                "exit_code": 124,
+                                "error": f"Command timed out after {effective_timeout} seconds"
+                            }, ensure_ascii=False)
+
+                        # Retry on transient errors
+                        if retry_count < max_retries:
+                            retry_count += 1
+                            wait_time = 2 ** retry_count
+                            logger.warning("Execution error, retrying in %ds (attempt %d/%d) - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
+                                           wait_time, retry_count, max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
+                            time.sleep(wait_time)
+                            continue
+
+                        logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
+                                     max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
                         return json.dumps({
                             "output": "",
-                            "exit_code": 124,
-                            "error": f"Command timed out after {effective_timeout} seconds"
+                            "exit_code": -1,
+                            "error": _redact_terminal_error_text(
+                                f"Command execution failed: {type(e).__name__}: {e}"
+                            )
                         }, ensure_ascii=False)
-                    
-                    # Retry on transient errors
-                    if retry_count < max_retries:
-                        retry_count += 1
-                        wait_time = 2 ** retry_count
-                        logger.warning("Execution error, retrying in %ds (attempt %d/%d) - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
-                                       wait_time, retry_count, max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
-                        time.sleep(wait_time)
-                        continue
-                    
-                    logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
-                                 max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
-                    return json.dumps({
-                        "output": "",
-                        "exit_code": -1,
-                        "error": _redact_terminal_error_text(
-                            f"Command execution failed: {type(e).__name__}: {e}"
-                        )
-                    }, ensure_ascii=False)
-                
-                # Got a result
-                break
+
+                    # Got a result
+                    break
+            finally:
+                if _heavy_lease is not None:
+                    _heavy_lease.release()
+                    _heavy_lease = None
 
             # Dual-write (cwd rearch step 1): the env's post-command tracking
             # (marker parse / local sync) has just updated env.cwd with the

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -142,6 +142,7 @@ terminal:
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   font_family: ""   # Desktop terminal font; e.g. "MesloLGS NF"
   timeout: 180      # Per-command timeout in seconds
+  max_concurrent_heavy_jobs: 0  # Cross-process limit for tests/builds; 0 disables
   home_mode: auto   # auto | real | profile — subprocess HOME policy
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
   singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"  # Container image for Singularity backend
@@ -150,6 +151,8 @@ terminal:
 ```
 
 `terminal.font_family` controls the embedded terminal in Hermes Desktop. It accepts either one locally installed family name (for example, `MesloLGS NF`) or a CSS font stack. Hermes appends its bundled JetBrains Mono stack as a fallback, and an empty value keeps the default. You can edit the same profile-scoped setting in **Settings → Appearance → Terminal Font**; no Google Fonts download or system-font permission is required.
+
+`terminal.max_concurrent_heavy_jobs` limits concurrently running test suites, builds, and other resource-heavy commands across Hermes processes that share the same `HERMES_HOME`. The default `0` disables the guard. A positive value uses inherited kernel locks, so guarded heavy commands are supported only by the local backend on platforms with file-descriptor inheritance. Heavy commands that self-detach, use a remote/container backend, or run on an unsupported platform fail closed instead of losing their slot. Use `background=true` rather than shell-level `nohup`, `disown`, daemon mode, or a trailing `&`.
 
 For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2031,6 +2031,22 @@ fails open if the registry cannot be read or locked so users are not stranded.
 It is intended for a single host/profile runtime, not a shared `$HERMES_HOME`
 mounted across multiple machines.
 
+### Session search indexes
+
+The trigram substring index is enabled by default. If repeated trigram-index
+corruption affects message writes, disable only that optional index:
+
+```yaml
+sessions:
+  trigram_fts: false
+```
+
+Hermes then removes the trigram write triggers and routes affected searches to
+the standard FTS index or a safe `LIKE` fallback. Canonical messages and the
+standard FTS index are preserved. Re-enabling the setting performs a controlled
+rebuild from canonical messages. The `HERMES_TRIGRAM_FTS` environment variable
+is an internal cross-process carrier; configure the YAML key instead.
+
 Control whether shared chats keep one conversation per room or one conversation per participant:
 
 ```yaml

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -135,7 +135,11 @@ hermes lsp which <id>      # print resolved binary path
 
 `hermes lsp status` is the best starting point — it shows which
 languages will get semantic diagnostics today and which need a
-binary installed.
+binary installed. The command reads the owning process's atomically
+published snapshot at `<HERMES_HOME>/runtime/lsp-status.json`; it does
+not start a second local LSP service merely to report status. The
+snapshot is refreshed when clients spawn, fail, become idle, shut down,
+and when the gateway publishes a lifecycle transition.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Reconciles three narrowly scoped safety adaptations onto the current `main` branch:

- **Terminal/process guard (E/F):** restores the optional cross-process heavy-work admission guard, preserves default inert behavior, and distinguishes shell redirection from true detach/background execution while retaining current cgroup, process-state, and error-redaction behavior.
- **State/trigram FTS (C):** adds `sessions.trigram_fts` with a safe quarantine breadcrumb, keeps base FTS and CJK fallback operational when disabled, and performs a controlled rebuild when re-enabled. The gate is integrated beneath `main`'s newer emergency FTS corruption-recovery path rather than replacing it.
- **LSP lifecycle (D):** adds per-client operation leases, monotonic idle timing, POSIX process-group cleanup, and an atomically published cross-process status snapshot consumed by `hermes lsp status` without creating a disconnected singleton.

This intentionally does **not** reintroduce an LSP LRU/max-client cap.

## History

- Originally reconciled from tag `v2026.8.3` (`3c27eb6234`).
- Rebased and conflict-resolved onto current `main` at `f51aa6a9b5`.
- Three commits remain separated by adaptation area:
  - `0ba9403bc5` — terminal/process E/F
  - `c1b9993d59` — trigram FTS C
  - `577980c069` — LSP lifecycle D
- Supersedes the initial conflict-bearing PR #84040. A new branch was used because local policy prohibits force-push.

## Post-rebase verification

All suites were run sequentially from the isolated worktree after resolving the rebase:

- State, FTS, trigram gate/bridge, CJK, WAL and schema regressions: **432 passed, 8 skipped**
- LSP suite plus gateway publication hook: **70 passed, 1 skipped**
- Current terminal/process/heavy-work suite: **315 passed, 2 skipped**
- Available Discord/gateway/cron isolation surfaces from the original audit set: **42 passed**
- Isolated temporary-`HERMES_HOME` state + LSP status smoke: **PASS**
- `ruff`, `py_compile`, and `git diff --check`: **PASS**

The isolated state smoke correctly used the existing SQLite WAL-reset safety fallback (`journal_mode=DELETE`) because the linked SQLite is 3.50.4.

## Safety properties

- `terminal.max_concurrent_heavy_jobs=0` remains inert/default behavior.
- `sessions.trigram_fts=true` preserves existing trigram behavior by default.
- Disabling trigram removes only its write triggers and records `fts_trigram_stale`; canonical messages remain authoritative.
- `main`'s `fts_stale` corruption recovery remains higher priority than the trigram gate.
- LSP reaper skips leased clients and uses `time.monotonic()`.
- POSIX cleanup signals the full language-server process group; the Windows path remains unchanged.
- No merge, deploy, gateway restart, or production data change was performed.
