### PR TITLE
fix(agent): omit tool_choice on max-iteration codex/xAI summary

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2460,8 +2460,15 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             summary_extra_body["tags"] = _portal_tags()
 
         if agent.api_mode == "codex_responses":
-            codex_kwargs = agent._build_api_kwargs(api_messages)
-            codex_kwargs.pop("tools", None)
+            # Summary must be text-only. Passing agent.tools (default of
+            # _build_api_kwargs) sets tools + tool_choice=auto; then popping
+            # only tools leaves tool_choice set → xAI/OpenAI Responses 400:
+            # "tool_choice was set … but no tools were specified" (rd-head
+            # 2026-08-11 session 20260811_111523_39a9eb). Build with empty
+            # tools so tool_choice is never emitted; still strip defensively.
+            codex_kwargs = agent._build_api_kwargs(api_messages, tools_for_api=[])
+            for _k in ("tools", "tool_choice", "parallel_tool_calls"):
+                codex_kwargs.pop(_k, None)
             summary_response = agent._run_codex_stream(codex_kwargs)
             _ct_sum = agent._get_transport()
             _cnr_sum = _ct_sum.normalize_response(summary_response)
@@ -2572,8 +2579,9 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         else:
             # Retry summary generation
             if agent.api_mode == "codex_responses":
-                codex_kwargs = agent._build_api_kwargs(api_messages)
-                codex_kwargs.pop("tools", None)
+                codex_kwargs = agent._build_api_kwargs(api_messages, tools_for_api=[])
+                for _k in ("tools", "tool_choice", "parallel_tool_calls"):
+                    codex_kwargs.pop(_k, None)
                 retry_response = agent._run_codex_stream(codex_kwargs)
                 _ct_retry = agent._get_transport()
                 _cnr_retry = _ct_retry.normalize_response(retry_response)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2644,6 +2644,56 @@ class TestHandleMaxIterations:
             for item in input_items
         )
 
+    def test_codex_summary_omits_tool_choice_without_tools(self, agent):
+        """Regression: xAI/codex max-iter summary must not send tool_choice alone.
+
+        Prior bug: ``_build_api_kwargs`` used agent.tools (non-empty) which
+        set ``tools`` + ``tool_choice=auto``, then only ``tools`` was popped →
+        xAI 400: "tool_choice was set … but no tools were specified."
+        """
+        agent.api_mode = "codex_responses"
+        agent.provider = "xai-oauth"
+        agent.base_url = "https://api.x.ai/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "api.x.ai"
+        agent.model = "grok-4.5"
+        agent._cached_system_prompt = "You are helpful."
+        agent.tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "search",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        captured = {}
+
+        def fake_run_codex_stream(kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                status="completed",
+                output=[
+                    SimpleNamespace(
+                        type="message",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text="Summary")],
+                    )
+                ],
+            )
+
+        with patch.object(agent, "_run_codex_stream", side_effect=fake_run_codex_stream):
+            result = agent._handle_max_iterations(
+                [{"role": "user", "content": "do stuff"}],
+                45,
+            )
+
+        assert result == "Summary"
+        assert "tools" not in captured, captured
+        assert "tool_choice" not in captured, captured
+        assert "parallel_tool_calls" not in captured, captured
+
     def test_api_sanitizer_matches_responses_call_id_when_id_differs(self, agent):
         messages = [
             {


### PR DESCRIPTION
## Summary

- Max-iteration text-only summary on `codex_responses` (xAI OAuth / OpenAI Codex) built kwargs with the agent tool registry, which sets `tool_choice: auto`, then popped only `tools`.
- Providers (notably xAI) return **400**: `tool_choice was set on the request but no tools were specified`, so users see *reached maximum iterations but couldn't summarize*.
- Build summary with `tools_for_api=[]` and strip `tools` / `tool_choice` / `parallel_tool_calls`. Add regression test for xai-oauth.

## Test plan

- [x] `pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations::test_codex_summary_omits_tool_choice_without_tools`
- [ ] After merge: force max-iter path on xai-oauth and confirm summary returns without 400