### PR TITLE
fix(hindsight): isolate banks by gateway chat

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -60,7 +60,7 @@ Config file: `~/.hermes/hindsight/config.json`
 | Key | Default | Description |
 |-----|---------|-------------|
 | `bank_id` | `hermes` | Memory bank name (static fallback used when `bank_id_template` is unset or resolves empty) |
-| `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
+| `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{chat}`, `{session}`. Example: `hermes-{profile}-{platform}-{chat}` isolates gateway chats while retaining cross-session recall inside each chat. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
 | `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Applied via Banks API. |
 | `bank_retain_mission` | — | Retain mission (steers what gets extracted). Applied via Banks API. |
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -649,6 +649,7 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
       {workspace} — Hermes workspace name (from agent_workspace)
       {platform}  — "cli", "telegram", "discord", etc.
       {user}      — platform user id (gateway sessions)
+      {chat}      — platform chat id (gateway sessions)
       {session}   — current session id
 
     Missing/empty placeholders are rendered as the empty string and then
@@ -1069,7 +1070,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
             {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
             {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
-            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
+            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {chat}, {session}. Example: hermes-{profile}", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
             {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
@@ -1539,6 +1540,7 @@ class HindsightMemoryProvider(MemoryProvider):
             workspace=self._agent_workspace,
             platform=self._platform,
             user=self._user_id,
+            chat=self._chat_id,
             session=self._session_id,
         )
         budget = self._config.get("recall_budget") or self._config.get("budget") or banks.get("budget", "mid")
@@ -1612,9 +1614,9 @@ class HindsightMemoryProvider(MemoryProvider):
         logger.info("Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, prefetch_method=%s, client=%s",
                      self._mode, self._api_url, self._bank_id, self._budget, self._memory_mode, self._prefetch_method, _client_version)
         if self._bank_id_template:
-            logger.debug("Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s -> bank=%s",
+            logger.debug("Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s chat=%s -> bank=%s",
                          self._bank_id_template, self._agent_identity, self._agent_workspace,
-                         self._platform, self._user_id, self._bank_id)
+                         self._platform, self._user_id, self._chat_id, self._bank_id)
         logger.debug("Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
                      "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
                      self._auto_retain, self._auto_recall, self._retain_every_n_turns,

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1082,9 +1082,33 @@ class TestBankIdTemplate:
         result = _resolve_bank_id_template(
             "user-{user}", fallback="hermes",
             profile="", workspace="", platform="",
-            user="josh@example.com", session="",
+            user="josh@example.com", chat="", session="",
         )
         assert result == "user-josh-example-com"
+
+    def test_provider_uses_chat_in_bank_id_template(self, tmp_path, monkeypatch):
+        config = {
+            "mode": "cloud",
+            "apiKey": "k",
+            "api_url": "http://x",
+            "bank_id": "fallback-bank",
+            "bank_id_template": "hermes-{profile}-{platform}-{chat}",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        p = HindsightMemoryProvider()
+        p.initialize(
+            session_id="s1",
+            hermes_home=str(tmp_path),
+            platform="telegram",
+            chat_id="-100123",
+            agent_identity="default",
+            agent_workspace="hermes",
+        )
+        assert p._bank_id == "hermes-default-telegram-100123"
 
 
     def test_provider_uses_bank_id_template_from_config(self, tmp_path, monkeypatch):

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -442,6 +442,7 @@ The setup wizard installs dependencies automatically and only installs what's ne
 |-----|---------|-------------|
 | `mode` | `cloud` | `cloud` or `local` |
 | `bank_id` | `hermes` | Memory bank identifier |
+| `bank_id_template` | — | Dynamic bank identifier with `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{chat}`, and `{session}` placeholders. Use `{chat}` to isolate DMs and groups handled by the same profile. |
 | `recall_budget` | `mid` | Recall thoroughness: `low` / `mid` / `high` |
 | `memory_mode` | `hybrid` | `hybrid` (context + tools), `context` (auto-inject only), `tools` (tools only) |
 | `auto_retain` | `true` | Automatically retain conversation turns |


### PR DESCRIPTION
## summary

- add a `{chat}` placeholder to Hindsight `bank_id_template`
- pass gateway `chat_id` through bank resolution so DMs and groups can use separate banks while retaining cross-session memory inside each chat
- document the privacy-safe template and cover it with a provider-level test

## verification

- `python -m pytest tests/plugins/memory/test_hindsight_provider.py -q` (58 passed)
- `git diff --check`

This closes the privacy gap where the same platform user could appear in a DM and shared group while `{user}` resolved both contexts to one bank.
