### PR TITLE
fix(tools): accept empty tool call arguments

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -139,7 +139,9 @@ class _BatchAbandoned(BaseException):
 
 
 def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
-    """Parse model-emitted arguments without repairing or coercing them."""
+    """Parse model-emitted arguments without repairing malformed payloads."""
+    if isinstance(raw_arguments, str) and not raw_arguments.strip():
+        return {}, None
     try:
         arguments = json.loads(raw_arguments)
     except (json.JSONDecodeError, TypeError):

--- a/tests/run_agent/test_malformed_tool_arguments.py
+++ b/tests/run_agent/test_malformed_tool_arguments.py
@@ -53,7 +53,6 @@ def _tool_call(call_id: str, arguments: str):
         pytest.param("not-json", id="malformed-json"),
         pytest.param('"scalar"', id="scalar"),
         pytest.param("[]", id="list"),
-        pytest.param("", id="empty"),
         pytest.param('{"query": "cut off', id="truncated"),
     ],
 )
@@ -95,3 +94,41 @@ def test_malformed_arguments_are_rejected_without_blocking_valid_sibling(
     assert '"error": "Invalid tool arguments"' in messages[0]["content"]
     assert "JSON object" in messages[0]["content"]
     assert json.loads(messages[1]["content"]) == {"ok": "valid"}
+
+
+@pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
+def test_empty_arguments_dispatch_as_empty_object(dispatch_mode: str):
+    agent = _make_agent()
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=[
+            _tool_call("call-empty", " \n\t"),
+            _tool_call("call-good", '{"query": "valid"}'),
+        ],
+    )
+    messages = []
+    executed = []
+
+    def fake_dispatch(name, args, task_id, *positional, **kwargs):
+        call_id = kwargs.get("tool_call_id") or (positional[0] if positional else None)
+        executed.append((name, args, call_id))
+        return json.dumps({"args": args})
+
+    with (
+        patch("run_agent.handle_function_call", side_effect=fake_dispatch),
+        patch.object(agent, "_invoke_tool", side_effect=fake_dispatch),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        execute = getattr(agent, f"_execute_tool_calls_{dispatch_mode}")
+        execute(assistant_message, messages, "task-1")
+
+    assert executed == [
+        ("web_search", {}, "call-empty"),
+        ("web_search", {"query": "valid"}, "call-good"),
+    ]
+    assert [message["tool_call_id"] for message in messages] == ["call-empty", "call-good"]
+    assert json.loads(messages[0]["content"]) == {"args": {}}
+    assert json.loads(messages[1]["content"]) == {"args": {"query": "valid"}}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1634,6 +1634,21 @@ class TestExecuteToolCalls:
         assert post_call["status"] == "error"
         assert post_call["error_type"] == "invalid_tool_arguments"
 
+    def test_empty_string_args_execute_as_empty_object(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments=" \n\t", call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with patch("run_agent.handle_function_call", return_value="ok") as mock_hfc:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        args, _kwargs = mock_hfc.call_args
+        assert args[:3] == ("web_search", {}, "task-1")
+        assert len(messages) == 1
+        assert messages[0]["role"] == "tool"
+        assert messages[0]["tool_call_id"] == "c1"
+        assert messages[0]["content"] == "ok"
+
     def test_concurrent_invalid_json_args_emit_terminal_hook(self, agent, monkeypatch):
         tc = _mock_tool_call(
             name="web_search", arguments="not valid json", call_id="c1"

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -267,6 +267,18 @@ class TestBridgeDispatch:
         # Will fail classification because unknown_xxx isn't deferrable.
         assert err is not None
 
+    def test_resolve_underlying_call_treats_empty_string_args_as_empty_object(self, monkeypatch):
+        from tools import tool_search
+
+        monkeypatch.setattr(tool_search, "is_deferrable_tool_name", lambda name: True)
+        name, args, err = tool_search.resolve_underlying_call({
+            "name": "mcp_empty_args",
+            "arguments": " \n\t",
+        })
+
+        assert name == "mcp_empty_args"
+        assert args == {}
+        assert err is None
 
     def test_resolve_underlying_call_rejects_recursion(self):
         """tool_call cannot invoke tool_call itself."""

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1035,10 +1035,13 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     if raw_args is None:
         raw_args = {}
     if isinstance(raw_args, str):
-        try:
-            raw_args = json.loads(raw_args)
-        except json.JSONDecodeError as e:
-            return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
+        if not raw_args.strip():
+            raw_args = {}
+        else:
+            try:
+                raw_args = json.loads(raw_args)
+            except json.JSONDecodeError as e:
+                return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name):


### PR DESCRIPTION
## Summary
- Treat empty or whitespace-only model-emitted tool arguments as `{}` at the direct execution parse boundary.
- Apply the same normalization when unwrapping deferred `tool_call` bridge invocations.
- Keep malformed non-empty JSON and non-object arguments on the existing rejection path.

Fixes #83937

## Tests
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py::TestExecuteToolCalls::test_empty_string_args_execute_as_empty_object tests/run_agent/test_run_agent.py::TestExecuteToolCalls::test_invalid_json_args_are_rejected_without_dispatch tests/tools/test_tool_search.py::TestToolSearchDiscovery::test_resolve_underlying_call_treats_empty_string_args_as_empty_object tests/tools/test_tool_search.py::TestToolSearchDiscovery::test_resolve_underlying_call_parses_object_args -q`
- `scripts/run_tests.sh tests/run_agent/test_malformed_tool_arguments.py -q`
- `scripts/run_tests.sh tests/tools/test_tool_search.py tests/run_agent/test_run_agent.py tests/run_agent/test_malformed_tool_arguments.py -q`
- `.venv/bin/ruff check agent/tool_executor.py tools/tool_search.py tests/run_agent/test_run_agent.py tests/run_agent/test_malformed_tool_arguments.py tests/tools/test_tool_search.py`
- `git diff --check`

Documentation-impact: none - execution parser bug fix only.