### PR TITLE
fix(tools): preserve schema literal values

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import copy
 
+import pytest
+
 from tools.schema_sanitizer import (
+    collapse_const_unions,
     sanitize_tool_schemas,
     strip_pattern_and_format,
     strip_slash_enum,
@@ -329,6 +332,24 @@ def test_dependent_required_does_not_mutate_original_input():
     assert schema["dependentRequired"] == original_dep
 
 
+def test_dependent_required_tracks_sanitized_property_names():
+    """Both dependency sources and targets must follow property-key renames."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "owner~id": {"type": "string"},
+            "repo[id]": {"type": "string"},
+        },
+        "dependentRequired": {"owner~id": ["repo[id]"]},
+    }
+
+    out = sanitize_tool_schemas([_tool("t", schema)])
+    params = out[0]["function"]["parameters"]
+
+    assert set(params["properties"]) == {"owner_id", "repo_id_"}
+    assert params["dependentRequired"] == {"owner_id": ["repo_id_"]}
+
+
 def test_dependent_schemas_still_recursively_sanitized():
     """dependentSchemas (real schemas, not literal lists) must still be sanitized."""
     schema = {
@@ -348,13 +369,44 @@ def test_dependent_schemas_still_recursively_sanitized():
     )
 
 
+def test_legacy_property_dependencies_stay_literal_and_follow_property_renames():
+    """Draft-07 dependency arrays contain property names, not nested schemas."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "card~id": {"type": "string"},
+            "billing[id]": {"type": "string"},
+        },
+        "dependencies": {"card~id": ["billing[id]"]},
+    }
+
+    out = sanitize_tool_schemas([_tool("t", schema)])
+    params = out[0]["function"]["parameters"]
+
+    assert set(params["properties"]) == {"card_id", "billing_id_"}
+    assert params["dependencies"] == {"card_id": ["billing_id_"]}
+
+
+def test_legacy_schema_dependencies_are_sanitized_and_follow_property_renames():
+    """Draft-07 also permits a real schema as each dependency-map value."""
+    schema = {
+        "type": "object",
+        "properties": {"owner~id": {"type": "string"}},
+        "dependencies": {"owner~id": {"type": "object"}},
+    }
+
+    out = sanitize_tool_schemas([_tool("t", schema)])
+    params = out[0]["function"]["parameters"]
+
+    assert params["dependencies"] == {
+        "owner_id": {"type": "object", "properties": {}},
+    }
+
+
 # ---------------------------------------------------------------------------
 # collapse_const_unions — anyOf/oneOf of same-typed const branches -> enum
 # Ported from: block/goose tool_schema_normalize.rs (Apache-2.0)
 # ---------------------------------------------------------------------------
-
-from tools.schema_sanitizer import collapse_const_unions
-
 
 def test_pure_const_union_collapses_to_enum():
     schema = {
@@ -517,3 +569,193 @@ def test_collapse_is_deterministic():
     first = collapse_const_unions(copy.deepcopy(schema))
     second = collapse_const_unions(copy.deepcopy(schema))
     assert first == second == {"type": "string", "enum": ["b", "a"]}
+
+
+_OPAQUE_LITERAL_CASES = (
+    ("const", False),
+    ("default", False),
+    ("enum", True),
+    ("examples", True),
+    ("x-provider-metadata", False),
+)
+
+
+@pytest.mark.parametrize(("keyword", "wrap_in_list"), _OPAQUE_LITERAL_CASES)
+def test_literal_keywords_are_opaque_to_sanitizer_passes(keyword, wrap_in_list):
+    """Schema-looking data in annotation/literal positions stays byte-for-byte data."""
+    literal = {
+        "$ref": "#/literal-data",
+        "default": 7,
+        "nested": {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+        },
+    }
+    value = [literal] if wrap_in_list else literal
+    schema = {
+        "type": "object",
+        "properties": {
+            "payload": {"type": "string", keyword: value},
+        },
+    }
+
+    out = sanitize_tool_schemas([_tool("t", schema)])
+    actual = out[0]["function"]["parameters"]["properties"]["payload"][keyword]
+
+    assert actual == value
+
+
+@pytest.mark.parametrize(("keyword", "wrap_in_list"), _OPAQUE_LITERAL_CASES)
+def test_literal_keywords_are_opaque_to_const_union_collapse(keyword, wrap_in_list):
+    """MCP const-union normalization must not enter literal values either."""
+    literal = {"anyOf": [{"const": "red"}, {"const": "green"}]}
+    value = [literal] if wrap_in_list else literal
+    schema = {"type": "string", keyword: value}
+
+    assert collapse_const_unions(schema)[keyword] == value
+
+
+def test_reactive_schema_strippers_do_not_enter_literal_values():
+    """Recovery-only passes obey the same literal boundary as normal sanitization."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "pattern_data": {
+                "type": "object",
+                "const": {"type": "string", "pattern": "^literal$"},
+            },
+            "enum_data": {
+                "type": "object",
+                "default": {"enum": ["owner/model"]},
+            },
+        },
+    }
+
+    pattern_tools, pattern_count = strip_pattern_and_format(
+        [_tool("t", copy.deepcopy(schema))]
+    )
+    slash_tools, slash_count = strip_slash_enum([_tool("t", copy.deepcopy(schema))])
+
+    pattern_props = pattern_tools[0]["function"]["parameters"]["properties"]
+    slash_props = slash_tools[0]["function"]["parameters"]["properties"]
+    assert pattern_count == 0
+    assert pattern_props["pattern_data"]["const"] == {
+        "type": "string",
+        "pattern": "^literal$",
+    }
+    assert slash_count == 0
+    assert slash_props["enum_data"]["default"] == {"enum": ["owner/model"]}
+
+
+def test_property_names_that_match_literal_keywords_still_hold_schemas():
+    """Opaque keyword rules apply to schema keys, not names in a properties map."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "const": {
+                "anyOf": [{"const": "red"}, {"const": "green"}],
+            },
+            "x-metadata": {
+                "anyOf": [{"const": 1}, {"const": 2}],
+            },
+        },
+    }
+
+    out = collapse_const_unions(schema)
+
+    assert out["properties"]["const"] == {
+        "type": "string",
+        "enum": ["red", "green"],
+    }
+    assert out["properties"]["x-metadata"] == {
+        "type": "integer",
+        "enum": [1, 2],
+    }
+
+
+def test_unknown_object_annotation_is_opaque_across_all_walkers():
+    """Unknown JSON-Schema keywords are annotations, not schema positions."""
+    annotation = {
+        "$ref": "#/annotation",
+        "default": 7,
+        "anyOf": [{"const": "red"}, {"const": "green"}],
+        "pattern": "^literal$",
+        "enum": ["owner/model"],
+        "child": {"type": "object"},
+    }
+    schema = {
+        "type": "object",
+        "properties": {
+            "payload": {"type": "string", "vendorMetadata": annotation},
+        },
+    }
+
+    sanitized = sanitize_tool_schemas([_tool("t", copy.deepcopy(schema))])
+    params = sanitized[0]["function"]["parameters"]
+    assert params["properties"]["payload"]["vendorMetadata"] == annotation
+
+    collapsed = collapse_const_unions(copy.deepcopy(schema))
+    assert collapsed["properties"]["payload"]["vendorMetadata"] == annotation
+
+    pattern_tools, pattern_count = strip_pattern_and_format(
+        [_tool("t", copy.deepcopy(schema))]
+    )
+    slash_tools, slash_count = strip_slash_enum(
+        [_tool("t", copy.deepcopy(schema))]
+    )
+    assert pattern_count == 0
+    assert slash_count == 0
+    assert (
+        pattern_tools[0]["function"]["parameters"]["properties"]["payload"]
+        ["vendorMetadata"]
+        == annotation
+    )
+    assert (
+        slash_tools[0]["function"]["parameters"]["properties"]["payload"]
+        ["vendorMetadata"]
+        == annotation
+    )
+
+
+@pytest.mark.parametrize(
+    "keyword",
+    [
+        "additionalItems",
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    ],
+)
+def test_single_schema_keywords_are_still_recursively_sanitized(keyword):
+    collapsed = collapse_const_unions(
+        {
+            "type": "object",
+            keyword: {"anyOf": [{"const": "a"}, {"const": "b"}]},
+        }
+    )
+    assert collapsed[keyword] == {"type": "string", "enum": ["a", "b"]}
+
+    schema = {"type": "array", keyword: {"type": "object"}}
+    sanitized = sanitize_tool_schemas(
+        [_tool("t", {"type": "object", "properties": {"value": schema}})]
+    )
+    nested = sanitized[0]["function"]["parameters"]["properties"]["value"]
+    assert nested[keyword] == {"type": "object", "properties": {}}
+
+
+@pytest.mark.parametrize("keyword", ["allOf", "anyOf", "oneOf", "prefixItems"])
+def test_schema_array_keywords_are_still_recursively_sanitized(keyword):
+    schema = {"type": "array", keyword: [{"type": "object"}]}
+
+    sanitized = sanitize_tool_schemas(
+        [_tool("t", {"type": "object", "properties": {"value": schema}})]
+    )
+    nested = sanitized[0]["function"]["parameters"]["properties"]["value"]
+    assert nested[keyword] == [{"type": "object", "properties": {}}]

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -39,9 +39,106 @@ from __future__ import annotations
 import copy
 import logging
 import re
+from collections.abc import Callable, Iterator
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+# Values under these keywords are instance data or property-name references,
+# never nested schemas.  Every recursive pass must stop at this boundary even
+# when the literal happens to contain schema-looking keys.
+_OPAQUE_SCHEMA_VALUE_KEYS = frozenset({
+    "const",
+    "default",
+    "dependentRequired",
+    "enum",
+    "examples",
+    "required",
+})
+
+# These keywords contain name -> schema maps.  Their names are not schema
+# keywords, so a property or definition literally named ``const`` / ``x-*``
+# must still have its schema visited.
+_SCHEMA_MAP_KEYS = frozenset({
+    "$defs",
+    "definitions",
+    "dependentSchemas",
+    "patternProperties",
+    "properties",
+})
+
+# Keywords whose value is one schema (or, for legacy ``items``, an array of
+# schemas). Unknown object-valued keywords are annotations and must remain
+# opaque: JSON Schema explicitly permits vocabulary extensions that do not use
+# an ``x-`` prefix.
+_SINGLE_SCHEMA_KEYS = frozenset({
+    "additionalItems",
+    "additionalProperties",
+    "contains",
+    "contentSchema",
+    "else",
+    "if",
+    "items",
+    "not",
+    "propertyNames",
+    "then",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+})
+
+_SCHEMA_ARRAY_KEYS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+
+
+def _is_opaque_schema_value(key: str) -> bool:
+    return key in _OPAQUE_SCHEMA_VALUE_KEYS or key.startswith("x-")
+
+
+def _map_schema_children(
+    node: dict[str, Any], transform: Callable[[Any], Any]
+) -> dict[str, Any]:
+    """Apply ``transform`` only where a dict/list can contain schemas."""
+    out = {}
+    for key, value in node.items():
+        if _is_opaque_schema_value(key):
+            out[key] = copy.deepcopy(value)
+        elif key in _SCHEMA_MAP_KEYS and isinstance(value, dict):
+            out[key] = {name: transform(schema) for name, schema in value.items()}
+        elif key == "dependencies" and isinstance(value, dict):
+            # Draft-07 dependencies is a mixed map: each value is either a
+            # schema or a literal list of property-name strings.
+            out[key] = {
+                name: transform(dependency)
+                if isinstance(dependency, (dict, bool))
+                else copy.deepcopy(dependency)
+                for name, dependency in value.items()
+            }
+        elif key in _SINGLE_SCHEMA_KEYS:
+            out[key] = transform(value)
+        elif key in _SCHEMA_ARRAY_KEYS and isinstance(value, list):
+            out[key] = transform(value)
+        else:
+            out[key] = copy.deepcopy(value)
+    return out
+
+
+def _iter_schema_children(node: dict[str, Any]) -> Iterator[Any]:
+    """Yield nested schema positions while skipping literal-value keywords."""
+    for key, value in node.items():
+        if _is_opaque_schema_value(key):
+            continue
+        if key in _SCHEMA_MAP_KEYS and isinstance(value, dict):
+            yield from value.values()
+        elif key == "dependencies" and isinstance(value, dict):
+            yield from (
+                dependency
+                for dependency in value.values()
+                if isinstance(dependency, (dict, bool))
+            )
+        elif key in _SINGLE_SCHEMA_KEYS:
+            yield value
+        elif key in _SCHEMA_ARRAY_KEYS and isinstance(value, list):
+            yield from value
 
 
 # Anthropic (and Bedrock/Vertex/Azure fronting it) reject tool input schemas
@@ -194,7 +291,7 @@ def _strip_ref_siblings(node: Any) -> Any:
     if not isinstance(node, dict):
         return node
 
-    out = {key: _strip_ref_siblings(value) for key, value in node.items()}
+    out = _map_schema_children(node, _strip_ref_siblings)
     if "$ref" in out:
         for key in _REF_FORBIDDEN_SIBLINGS:
             if key in out:
@@ -273,10 +370,12 @@ def strip_nullable_unions(
     if not isinstance(schema, dict):
         return schema
 
-    stripped = {
-        k: strip_nullable_unions(v, keep_nullable_hint=keep_nullable_hint)
-        for k, v in schema.items()
-    }
+    stripped = _map_schema_children(
+        schema,
+        lambda value: strip_nullable_unions(
+            value, keep_nullable_hint=keep_nullable_hint
+        ),
+    )
     for key in ("anyOf", "oneOf"):
         variants = stripped.get(key)
         if not isinstance(variants, list):
@@ -370,7 +469,7 @@ def collapse_const_unions(schema: Any) -> Any:
     if not isinstance(schema, dict):
         return schema
 
-    out = {k: collapse_const_unions(v) for k, v in schema.items()}
+    out = _map_schema_children(schema, collapse_const_unions)
     for key in ("anyOf", "oneOf"):
         variants = out.get(key)
         if not isinstance(variants, list) or not variants:
@@ -482,33 +581,54 @@ def _sanitize_node(node: Any, path: str) -> Any:
             out["type"] = "null" if has_null else "object"
             continue
 
-        if key in {"properties", "$defs", "definitions"} and isinstance(value, dict):
+        if key in _SCHEMA_MAP_KEYS and isinstance(value, dict):
             renames = prop_renames if key == "properties" else {}
             new_props = {}
             for sub_k, sub_v in value.items():
                 out_k = renames.get(sub_k, sub_k)
                 new_props[out_k] = _sanitize_node(sub_v, f"{path}.{key}.{out_k}")
             out[key] = new_props
-        elif key in {"items", "additionalProperties"}:
+        elif key == "dependencies" and isinstance(value, dict):
+            # Draft-07 dependencies mixes schema dependencies with literal
+            # property-name arrays. Both the source key and names in an array
+            # refer to sibling properties and must track any provider-safe
+            # renames, while only real schema values recurse.
+            dependencies = {}
+            for source, dependency in value.items():
+                out_source = prop_renames.get(source, source)
+                if isinstance(dependency, list):
+                    dependencies[out_source] = [
+                        prop_renames.get(target, target)
+                        if isinstance(target, str) else copy.deepcopy(target)
+                        for target in dependency
+                    ]
+                elif isinstance(dependency, (dict, bool)):
+                    dependencies[out_source] = _sanitize_node(
+                        dependency, f"{path}.dependencies.{out_source}"
+                    )
+                else:
+                    dependencies[out_source] = copy.deepcopy(dependency)
+            out[key] = dependencies
+        elif key in _SINGLE_SCHEMA_KEYS:
             if isinstance(value, bool):
-                # Keep bool ``additionalProperties`` as-is — it's a valid form
-                # and widely accepted. ``items: true/false`` is non-standard
-                # but we preserve rather than drop.
+                # Boolean schemas are valid in every schema position.
                 out[key] = value
             else:
                 out[key] = _sanitize_node(value, f"{path}.{key}")
-        elif key in {"anyOf", "oneOf", "allOf"} and isinstance(value, list):
+        elif key in _SCHEMA_ARRAY_KEYS and isinstance(value, list):
             out[key] = [
                 _sanitize_node(item, f"{path}.{key}[{i}]")
                 for i, item in enumerate(value)
             ]
-        elif key in {"required", "enum", "examples", "dependentRequired"}:
+        elif _is_opaque_schema_value(key):
             # Schema "sibling" keywords whose values are NOT schemas:
             #  - ``required``: list of property-name strings
             #  - ``enum``: list of literal values (any JSON type)
             #  - ``examples``: list of example values (any JSON type)
             #  - ``dependentRequired``: mapping of property names to lists of
             #    required property-name strings (JSON Schema 2020-12)
+            #  - ``const`` / ``default``: a single literal value (any JSON type)
+            #  - ``x-*``: extension data, not a portable schema position
             # Recursing into these with _sanitize_node() would mis-interpret
             # literal strings like "path" as bare-string schemas and replace
             # them with {"type": "object"} dicts. Pass through unchanged
@@ -516,10 +636,23 @@ def _sanitize_node(node: Any, path: str) -> Any:
             if key == "required" and prop_renames and isinstance(value, list):
                 out[key] = [prop_renames.get(r, r) if isinstance(r, str) else r
                             for r in value]
+            elif key == "dependentRequired" and prop_renames and isinstance(value, dict):
+                out[key] = {
+                    prop_renames.get(source, source): [
+                        prop_renames.get(target, target)
+                        if isinstance(target, str) else target
+                        for target in targets
+                    ]
+                    if isinstance(targets, list) else copy.deepcopy(targets)
+                    for source, targets in value.items()
+                }
             else:
                 out[key] = copy.deepcopy(value) if isinstance(value, (list, dict)) else value
         else:
-            out[key] = _sanitize_node(value, f"{path}.{key}") if isinstance(value, (dict, list)) else value
+            # Unknown keywords are annotations. JSON Schema permits custom
+            # vocabularies without an ``x-`` prefix, so object/list values in
+            # unknown positions must never be interpreted as schemas.
+            out[key] = copy.deepcopy(value) if isinstance(value, (dict, list)) else value
 
     # Object nodes without properties: inject empty properties dict.
     # llama.cpp's grammar generator can't constrain a free-form object.
@@ -591,7 +724,8 @@ def strip_pattern_and_format(tools: list[dict]) -> tuple[list[dict], int]:
                     node.pop(key, None)
                     stripped += 1
                     continue
-                _walk(node[key])
+            for child in _iter_schema_children(node):
+                _walk(child)
         elif isinstance(node, list):
             for item in node:
                 _walk(item)
@@ -659,8 +793,8 @@ def strip_slash_enum(tools: list[dict]) -> tuple[list[dict], int]:
             ):
                 node.pop("enum", None)
                 stripped += 1
-            for v in node.values():
-                _walk(v)
+            for child in _iter_schema_children(node):
+                _walk(child)
         elif isinstance(node, list):
             for item in node:
                 _walk(item)


### PR DESCRIPTION
## What does this PR do?

Fixes recursive JSON Schema sanitization that could interpret annotation and literal payloads as nested schemas. Literal values under `const`, `default`, `enum`, `examples`, and `x-*` are now copied verbatim across the normal sanitizer, MCP const-union collapse, and reactive recovery passes.

The change also keeps `dependentRequired` consistent when provider-illegal property names are sanitized by remapping both dependency source names and their target property names.

## Related Issue

Fixes #84038

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/schema_sanitizer.py`
  - distinguish schema-bearing positions from opaque literal/annotation values during recursive passes
  - preserve schemas for properties literally named `const` or `x-*`
  - remap `dependentRequired` source and target property names after property sanitization
- `tests/tools/test_schema_sanitizer.py`
  - cover literal opacity in public, MCP, and reactive sanitizer paths
  - cover schema-map property-name counterexamples and `dependentRequired` remapping

## How to Test

1. Run the focused and adjacent sanitizer/tool tests:
   ```bash
   scripts/run_tests.sh tests/tools/test_schema_sanitizer.py tests/tools/test_mcp_tool.py tests/test_model_tools.py -q
   ```
2. Run lint, type, portability, and whitespace checks:
   ```bash
   uvx --from ruff==0.15.10 ruff check tools/schema_sanitizer.py tests/tools/test_schema_sanitizer.py
   uvx ty==0.0.21 check tools/schema_sanitizer.py
   python scripts/check-windows-footguns.py tools/schema_sanitizer.py tests/tools/test_schema_sanitizer.py
   git diff --check HEAD^..HEAD
   ```
3. Exercise a schema containing nested objects in literal values plus a renamed property referenced by `dependentRequired`; verify literal payloads remain byte-for-byte equivalent as Python values and dependency names match the sanitized property names.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the relevant 165 tests pass; the broader `tests/tools/` run has 46 optional-dependency failures that reproduce unchanged on the exact base commit (details below)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux 7.1.6, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and covered by regression tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no configuration changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); changed code is platform-independent and the footgun check passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; this corrects transport sanitization without changing public tool contracts

## Screenshots / Logs

Strict TDD and mutation evidence:

- Untouched base plus regression tests: **11 failed**; the additional reactive-pass regression failed independently.
- Mutation proof (`_is_opaque_schema_value` temporarily disabled): **12 failed**; restored implementation: **12 passed**.
- Focused sanitizer file: **45 passed**.
- Focused plus adjacent tool suites: **165 passed**.
- Ruff, `ty` (production file), Windows footgun check, compile check, and `git diff --check`: **passed**.
- Broader `tests/tools/` run: **6200 passed, 46 failed, 71 skipped**. The same 46 failures reproduce on exact base `f51aa6a9b5ce514e15f8e337777f522fd5cc6fa2` in the same five optional integration files (managed media, Daytona, image generation, web-tools config, and video matrix) with lazy installs disabled/missing optional packages.


## Review follow-up

An independent review identified two additional JSON-Schema position boundaries, now covered in the updated commit:

- Draft-07 `dependencies` is handled as a mixed map: schema-valued entries recurse, property-dependency arrays remain literal, and source/target names follow provider-safe property renames.
- Recursive walkers now use an explicit schema-position allowlist, so arbitrary object-valued custom annotations remain opaque even without an `x-` prefix. Known single-schema, schema-array, and schema-map keywords retain recursive sanitization.

Follow-up verification: focused sanitizer suite **64 passed**; dedicated RED and mutation probes failed before restoration; Ruff and `git diff --check` passed.
