### PR TITLE
refactor(providers): make external_process provider resolution generic

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -244,6 +244,16 @@ class ProviderConfig:
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
+    # For external_process providers: how to locate and invoke the local CLI.
+    # command_env_vars are checked in priority order before default_command;
+    # args_env_var (shlex-split) overrides default_args. When base_url starts
+    # with one of remote_base_url_prefixes the provider talks to an already
+    # running process, so a missing local command is not an error.
+    command_env_vars: tuple = ()
+    default_command: str = ""
+    default_args: tuple = ()
+    args_env_var: str = ""
+    remote_base_url_prefixes: tuple = ()
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -304,6 +314,11 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+        command_env_vars=("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"),
+        default_command="copilot",
+        default_args=("--acp", "--stdio"),
+        args_env_var="HERMES_COPILOT_ACP_ARGS",
+        remote_base_url_prefixes=("acp+tcp://",),
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -7038,33 +7053,63 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+def _resolve_external_process_invocation(
+    pconfig: ProviderConfig,
+) -> Tuple[str, List[str], Optional[str], str, bool]:
+    """Resolve command/args/base_url for an external-process provider.
+
+    Every value comes from the provider's own ProviderConfig, so any plugin
+    declaring auth_type="external_process" is served by the same path.
+    Returns (command, args, resolved_command, base_url, is_remote).
+    """
+    command = ""
+    for env_var in pconfig.command_env_vars:
+        command = os.getenv(env_var, "").strip()
+        if command:
+            break
+    if not command:
+        command = pconfig.default_command
+
+    raw_args = os.getenv(pconfig.args_env_var, "").strip() if pconfig.args_env_var else ""
+    args = shlex.split(raw_args) if raw_args else list(pconfig.default_args)
+
+    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    if not base_url:
+        base_url = pconfig.inference_base_url
+
+    resolved_command = shutil.which(command) if command else None
+    is_remote = bool(
+        pconfig.remote_base_url_prefixes
+        and base_url.startswith(tuple(pconfig.remote_base_url_prefixes))
+    )
+    return command, args, resolved_command, base_url, is_remote
+
+
+def is_external_process_provider(provider_id: str) -> bool:
+    """True when the provider is backed by a local subprocess."""
+    pconfig = PROVIDER_REGISTRY.get(provider_id)
+    return bool(pconfig and pconfig.auth_type == "external_process")
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
+    command, args, resolved_command, base_url, is_remote = (
+        _resolve_external_process_invocation(pconfig)
     )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
-    if not base_url:
-        base_url = pconfig.inference_base_url
-
-    resolved_command = shutil.which(command) if command else None
+    available = bool(resolved_command or is_remote)
     return {
-        "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "configured": available,
         "provider": provider_id,
         "name": pconfig.name,
         "command": command,
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "logged_in": available,
     }
 
 
@@ -7271,29 +7316,24 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
-    if not base_url:
-        base_url = pconfig.inference_base_url
-
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
+    command, args, resolved_command, base_url, is_remote = (
+        _resolve_external_process_invocation(pconfig)
     )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    resolved_command = shutil.which(command) if command else None
-    if not resolved_command and not base_url.startswith("acp+tcp://"):
+    if not resolved_command and not is_remote:
+        hint = (
+            f" Install it or set {'/'.join(pconfig.command_env_vars)}."
+            if pconfig.command_env_vars
+            else ""
+        )
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the {pconfig.name} command '{command}'.{hint}",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code="missing_external_process_command",
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -35,6 +35,7 @@ from hermes_cli.auth import (
     resolve_xai_oauth_runtime_credentials,
     resolve_qwen_runtime_credentials,
     resolve_api_key_provider_credentials,
+    is_external_process_provider,
     resolve_external_process_provider_credentials,
     has_usable_secret,
     is_actual_local_base_url,
@@ -2025,10 +2026,10 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider == "copilot-acp":
+    if is_external_process_provider(provider):
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/tests/hermes_cli/test_external_process_providers.py
+++ b/tests/hermes_cli/test_external_process_providers.py
@@ -1,0 +1,167 @@
+"""Tests for the generic external_process provider path.
+
+copilot-acp was the only external_process provider for a while and its command
+resolution was hardcoded in auth.py. These tests pin the generic behaviour: any
+provider declaring auth_type="external_process" resolves its command, args and
+base URL from its own ProviderConfig.
+"""
+
+import pytest
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    AuthError,
+    ProviderConfig,
+    get_external_process_provider_status,
+    is_external_process_provider,
+    resolve_external_process_provider_credentials,
+)
+
+
+@pytest.fixture
+def acme_provider(monkeypatch):
+    """Register a throwaway external-process provider for the duration of a test."""
+    pconfig = ProviderConfig(
+        id="acme-cli",
+        name="Acme CLI",
+        auth_type="external_process",
+        inference_base_url="acme://local",
+        base_url_env_var="ACME_BASE_URL",
+        command_env_vars=("HERMES_ACME_COMMAND", "ACME_CLI_PATH"),
+        default_command="acme",
+        default_args=("--serve", "--stdio"),
+        args_env_var="HERMES_ACME_ARGS",
+        remote_base_url_prefixes=("acme+tcp://",),
+    )
+    monkeypatch.setitem(PROVIDER_REGISTRY, "acme-cli", pconfig)
+    for env_var in (
+        "HERMES_ACME_COMMAND",
+        "ACME_CLI_PATH",
+        "HERMES_ACME_ARGS",
+        "ACME_BASE_URL",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    return pconfig
+
+
+class TestIsExternalProcessProvider:
+    def test_copilot_acp_is_external_process(self):
+        assert is_external_process_provider("copilot-acp") is True
+
+    def test_api_key_provider_is_not(self):
+        assert is_external_process_provider("copilot") is False
+
+    def test_unknown_provider_is_not(self):
+        assert is_external_process_provider("does-not-exist") is False
+
+
+class TestGenericCommandResolution:
+    def test_defaults_come_from_provider_config(self, acme_provider, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/bin/{command}")
+
+        creds = resolve_external_process_provider_credentials("acme-cli")
+
+        assert creds["command"] == "/usr/bin/acme"
+        assert creds["args"] == ["--serve", "--stdio"]
+        assert creds["base_url"] == "acme://local"
+        assert creds["api_key"] == "acme-cli"
+        assert creds["source"] == "process"
+
+    def test_command_env_vars_win_in_priority_order(self, acme_provider, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/bin/{command}")
+        monkeypatch.setenv("ACME_CLI_PATH", "acme-fallback")
+        monkeypatch.setenv("HERMES_ACME_COMMAND", "acme-preferred")
+
+        creds = resolve_external_process_provider_credentials("acme-cli")
+
+        assert creds["command"] == "/usr/bin/acme-preferred"
+
+    def test_args_env_var_overrides_defaults(self, acme_provider, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/bin/{command}")
+        monkeypatch.setenv("HERMES_ACME_ARGS", "--rpc --port 9000")
+
+        creds = resolve_external_process_provider_credentials("acme-cli")
+
+        assert creds["args"] == ["--rpc", "--port", "9000"]
+
+    def test_missing_command_raises_with_provider_specific_hint(self, acme_provider, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: None)
+
+        with pytest.raises(AuthError) as excinfo:
+            resolve_external_process_provider_credentials("acme-cli")
+
+        message = str(excinfo.value)
+        assert "Acme CLI" in message
+        assert "HERMES_ACME_COMMAND" in message
+        assert "copilot" not in message.lower()
+
+    def test_remote_base_url_does_not_require_local_command(self, acme_provider, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: None)
+        monkeypatch.setenv("ACME_BASE_URL", "acme+tcp://127.0.0.1:9000")
+
+        creds = resolve_external_process_provider_credentials("acme-cli")
+
+        assert creds["base_url"] == "acme+tcp://127.0.0.1:9000"
+        assert creds["command"] == "acme"
+
+    def test_status_reports_configured_when_command_found(self, acme_provider, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/bin/{command}")
+
+        status = get_external_process_provider_status("acme-cli")
+
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["name"] == "Acme CLI"
+        assert status["args"] == ["--serve", "--stdio"]
+
+    def test_status_reports_unconfigured_when_command_missing(self, acme_provider, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: None)
+
+        status = get_external_process_provider_status("acme-cli")
+
+        assert status["configured"] is False
+        assert status["logged_in"] is False
+
+
+class TestCopilotAcpBehaviourUnchanged:
+    """copilot-acp must resolve exactly as it did before the generalisation."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        for env_var in (
+            "HERMES_COPILOT_ACP_COMMAND",
+            "COPILOT_CLI_PATH",
+            "HERMES_COPILOT_ACP_ARGS",
+            "COPILOT_ACP_BASE_URL",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+
+    def test_defaults(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/bin/{command}")
+
+        creds = resolve_external_process_provider_credentials("copilot-acp")
+
+        assert creds["command"] == "/usr/bin/copilot"
+        assert creds["args"] == ["--acp", "--stdio"]
+        assert creds["base_url"] == "acp://copilot"
+        assert creds["api_key"] == "copilot-acp"
+
+    def test_legacy_env_vars_still_honoured(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/bin/{command}")
+        monkeypatch.setenv("COPILOT_CLI_PATH", "copilot-nightly")
+
+        creds = resolve_external_process_provider_credentials("copilot-acp")
+
+        assert creds["command"] == "/usr/bin/copilot-nightly"
+
+    def test_acp_tcp_base_url_skips_command_lookup(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: None)
+        monkeypatch.setenv("COPILOT_ACP_BASE_URL", "acp+tcp://127.0.0.1:4000")
+
+        creds = resolve_external_process_provider_credentials("copilot-acp")
+
+        assert creds["base_url"] == "acp+tcp://127.0.0.1:4000"
+
+    def test_non_external_process_provider_rejected(self):
+        with pytest.raises(AuthError):
+            resolve_external_process_provider_credentials("copilot")


### PR DESCRIPTION
## Summary

`auth_type="external_process"` is already a documented provider auth type (`hermes_cli/providers.py:40`), and both resolver functions are already named and gated generically — `resolve_external_process_provider_credentials(provider_id)` with the docstring "Resolve runtime details for local subprocess-backed providers", rejecting anything whose `auth_type != "external_process"`.

Their bodies, though, hardcode Copilot:

```python
command = (
    os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
    or os.getenv("COPILOT_CLI_PATH", "").strip()
    or "copilot"
)
raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
```

duplicated across `get_external_process_provider_status()` and `resolve_external_process_provider_credentials()`, and `runtime_provider.py` only reaches the path through `if provider == "copilot-acp":`. The net effect is that a second provider declaring `external_process` is unreachable from `runtime_provider`, and would resolve Copilot's argv if it got there.

This PR moves that resolution onto the provider config, where `base_url_env_var` already lives.

## Changes

New `ProviderConfig` fields:

| Field | Purpose |
| --- | --- |
| `command_env_vars` | env vars checked in priority order |
| `default_command` | fallback command name |
| `default_args` | default argv |
| `args_env_var` | shlex-split argv override |
| `remote_base_url_prefixes` | base URLs that reach an already running process, where a missing local command is not an error |

- Both resolvers now share one `_resolve_external_process_invocation(pconfig)` helper, removing the duplicated block.
- `runtime_provider.py` gates on a new `is_external_process_provider(provider)` instead of the `"copilot-acp"` literal, and returns `provider` rather than the hardcoded name.
- `copilot-acp` declares its previous values in `PROVIDER_REGISTRY`.

## Behaviour

Unchanged for `copilot-acp`: same env vars (`HERMES_COPILOT_ACP_COMMAND`, `COPILOT_CLI_PATH`, `HERMES_COPILOT_ACP_ARGS`, `COPILOT_ACP_BASE_URL`), same `--acp --stdio` defaults, same `acp+tcp://` handling, same `api_key` value of `"copilot-acp"`.

Two intentional differences:

- The error code is now `missing_external_process_command` instead of `missing_copilot_cli`. The old code had no other references in the tree.
- The error message is built from the provider's own `name` and `command_env_vars` rather than naming Copilot, so a different provider gets an accurate hint.

## Why

`AGENTS.md` states the rule this cleans up: "if a plugin needs a capability the framework doesn't expose, expand the generic plugin surface (new hook, new ctx method) — never hardcode plugin-specific logic into core."

The practical payoff is that a CLI-backed inference backend becomes expressible as an out-of-tree plugin under `$HERMES_HOME/plugins/model-providers/<name>/`, matching the standing "third-party integrations ship as standalone plugin repos" policy. Today that policy has a gap for this provider shape: the HTTP path is pluggable, the subprocess path is not, so anyone wrapping a local CLI has to stand up a loopback HTTP server and register a `custom:` provider instead. This closes that gap without adding any vendor to the tree.

## Tests

New `tests/hermes_cli/test_external_process_providers.py` (17 tests):

- a synthetic `acme-cli` provider resolves its own command, args, env-var priority, and base URL — asserting the failure message does not mention Copilot
- `remote_base_url_prefixes` skips the local-command requirement
- status snapshot reports configured/unconfigured correctly
- a `TestCopilotAcpBehaviourUnchanged` class pins the existing defaults, legacy env vars, `acp+tcp://` handling, and non-external-process rejection

```
tests/hermes_cli/test_external_process_providers.py
tests/hermes_cli/test_api_key_providers.py
tests/hermes_cli/test_provider_catalog.py
→ 123 passed
```

Wider run across `test_auth*.py`, `test_*provider*.py`, `test_model_switch*.py`: **678 passed, 7 skipped, 4 failed**. All 4 failures (`test_arcee_provider`, `test_auth_nous_provider`, `test_gemini_provider`, `test_ollama_cloud_provider`) reproduce identically on a clean `main` on this machine — a `ModuleNotFoundError` from `hermes_logging.py:65` for an optional dependency, unrelated to this change.

Unrelated note while running the suite on Windows: `tests/hermes_cli/test_doctor_journal_modes.py` fails at collection because it calls `os.geteuid()` at class-definition time, which does not exist on Windows, and some session-export tests write `Usersadmin…jsonl` files into the repo root rather than a tmp dir. Both are pre-existing and left alone here.
