### PR TITLE
fix(desktop): spare active turns from pool reaper

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -159,6 +159,7 @@ import {
 import { runNativeLogin } from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
+import { canStopIdlePoolBackend } from './pool-backend-lifecycle'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
@@ -1077,6 +1078,15 @@ let softRehomeInProgress = false
 // with no named profiles never populates this map, so their experience is
 // byte-for-byte the single-backend behavior.
 const backendPool = new Map() // profile -> { process, port, token, connectionPromise, lastActiveAt }
+// Renderers report authoritative in-flight turn state for the quit guard. Keep
+// it beside the backend pool too: renderer timer pings are advisory and may be
+// throttled while a backend is still executing a long tool call.
+const activeWorkByWebContents = new Map<number, ActiveWork>()
+
+function currentActiveWorkCount() {
+  return mergeActiveWork(activeWorkByWebContents.values()).count
+}
+
 // Keep the pool light: cap concurrent profile backends (LRU eviction) and reap
 // idle ones. A user idles at exactly the primary backend; pool backends only
 // exist while a non-primary profile is actively being chatted through.
@@ -8196,9 +8206,16 @@ function evictLruPoolBackends(keep) {
   }
 
   const now = Date.now()
+  const activeWorkCount = currentActiveWorkCount()
 
   const evictable = [...backendPool.entries()]
-    .filter(([, entry]) => now - (entry.lastActiveAt || 0) > POOL_KEEPALIVE_FRESH_MS)
+    .filter(([, entry]) =>
+      canStopIdlePoolBackend({
+        activeWorkCount,
+        idleForMs: now - (entry.lastActiveAt || 0),
+        idleThresholdMs: POOL_KEEPALIVE_FRESH_MS
+      })
+    )
     .sort((a, b) => (a[1].lastActiveAt || 0) - (b[1].lastActiveAt || 0))
 
   let removable = backendPool.size - Math.max(0, keep)
@@ -8221,9 +8238,16 @@ function startPoolIdleReaper() {
 
   poolIdleReaper = setInterval(() => {
     const now = Date.now()
+    const activeWorkCount = currentActiveWorkCount()
 
     for (const [profile, entry] of [...backendPool.entries()]) {
-      if (now - (entry.lastActiveAt || 0) > POOL_IDLE_MS) {
+      if (
+        canStopIdlePoolBackend({
+          activeWorkCount,
+          idleForMs: now - (entry.lastActiveAt || 0),
+          idleThresholdMs: POOL_IDLE_MS
+        })
+      ) {
         rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(POOL_IDLE_MS / 1000)}s)`)
         stopPoolBackend(profile)
       }
@@ -11288,17 +11312,13 @@ ipcMain.handle('hermes:watchDirectory', (_event, dir) => watchDirectory(String(d
 
 ipcMain.handle('hermes:stopPreviewFileWatch', (_event, id) => stopPreviewFileWatch(String(id || '')))
 
-// Each renderer reports the turns it has in flight; the quit guard reads the
-// merged picture. Keyed by webContents id so a closed window stops counting.
-const activeWorkByWebContents = new Map<number, ActiveWork>()
-
 // The same merged picture drives background throttling: chat windows run
 // unthrottled while any turn is in flight (streaming must paint while hidden)
 // and fall back to Chromium's default throttling at idle. See stream-throttle.ts.
 const streamThrottle = createStreamThrottle()
 
 function updateStreamThrottleFromActiveWork() {
-  streamThrottle.update(mergeActiveWork(activeWorkByWebContents.values()).count > 0)
+  streamThrottle.update(currentActiveWorkCount() > 0)
 }
 
 ipcMain.on('hermes:active-work', (event, payload) => {

--- a/apps/desktop/electron/pool-backend-lifecycle.test.ts
+++ b/apps/desktop/electron/pool-backend-lifecycle.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { canStopIdlePoolBackend } from './pool-backend-lifecycle'
+
+test('stale pool backend may be stopped when no turn is active', () => {
+  assert.equal(
+    canStopIdlePoolBackend({
+      activeWorkCount: 0,
+      idleForMs: 600_001,
+      idleThresholdMs: 600_000
+    }),
+    true
+  )
+})
+
+test('active work vetoes stopping a stale pool backend', () => {
+  assert.equal(
+    canStopIdlePoolBackend({
+      activeWorkCount: 1,
+      idleForMs: 600_001,
+      idleThresholdMs: 600_000
+    }),
+    false
+  )
+})
+
+test('fresh pool backend is retained when no turn is active', () => {
+  assert.equal(
+    canStopIdlePoolBackend({
+      activeWorkCount: 0,
+      idleForMs: 599_999,
+      idleThresholdMs: 600_000
+    }),
+    false
+  )
+})

--- a/apps/desktop/electron/pool-backend-lifecycle.ts
+++ b/apps/desktop/electron/pool-backend-lifecycle.ts
@@ -1,0 +1,19 @@
+interface PoolBackendStopDecision {
+  activeWorkCount: number
+  idleForMs: number
+  idleThresholdMs: number
+}
+
+/**
+ * A renderer keepalive is useful evidence that a pool backend is live, but it is
+ * not authoritative: Chromium may throttle or suspend renderer timers while a
+ * long tool call continues in the backend. The main process's merged active-work
+ * report is the hard veto against terminating any pooled backend mid-turn.
+ */
+export function canStopIdlePoolBackend({
+  activeWorkCount,
+  idleForMs,
+  idleThresholdMs
+}: PoolBackendStopDecision): boolean {
+  return activeWorkCount < 1 && idleForMs > idleThresholdMs
+}


### PR DESCRIPTION
## Summary

- prevent the Desktop pool idle reaper from terminating named-profile backends while any renderer reports an active turn
- apply the same active-work veto to stale LRU eviction, which otherwise has the same mid-turn termination failure mode
- add a pure lifecycle decision and focused regression coverage

Closes #84044

## Root cause

Named-profile backends are kept fresh by a renderer `setInterval` calling `touchBackend` every 60 seconds. Chromium may throttle or suspend that renderer timer while the backend continues a long tool call.

Electron main already owns authoritative active-turn state through `hermes:active-work`, but `evictLruPoolBackends()` and `startPoolIdleReaper()` considered only `lastActiveAt`. Once that timestamp crossed the 10-minute idle threshold, Desktop issued `SIGTERM` to the active profile backend, taking its driver-owned browser and in-memory process tracking with it.

## Fix

`canStopIdlePoolBackend()` makes active work a hard veto against an idle/LRU stop. Both termination paths use the same tested rule. Normal idle cleanup is unchanged when no turn is active.

This deliberately spares all pooled backends while any Desktop turn is active because the existing `ActiveWork` IPC contract does not identify a profile. The pool is small and the alternative is terminating an in-flight tool call.

## Regression proof

The new regression was sabotage-tested by temporarily restoring the old decision (`idleForMs > idleThresholdMs`). The active-work case failed exactly as expected:

```text
active work vetoes stopping a stale pool backend
true !== false
```

Restoring the veto returned the focused suite to green.

## Verification

```text
focused lifecycle/quit/throttle tests: 16 passed
full Electron project: 1,038 passed, 2 skipped
Electron TypeScript: passed
ESLint (changed files): passed
git diff --check: passed
production Desktop build: passed
```

## Related work

- #44089 addresses the same symptom by extending the shared renderer watchdog from 8 to 12 minutes. Its current review flags that as delaying hung-turn recovery globally. This PR leaves watchdog behavior unchanged and fixes the Electron termination boundary instead.
- #75398 excludes processless remote descriptors from pool reaping and LRU eviction. This PR protects active local named-profile backends, so the scopes are complementary.

## Non-goals

This does not address the separate exact-window `0x0` capture or key-event verification defects recorded in #84044.
