### PR TITLE
fix(tools): repair stringified-array tool args via shared helper

### DIFF
--- a/tests/tools/test_tool_input_repair.py
+++ b/tests/tools/test_tool_input_repair.py
@@ -1,0 +1,115 @@
+"""Tests for the shared tool-input repair helper (tools/tool_input_repair.py).
+
+Models occasionally emit an array-typed tool parameter as a string instead
+of a real list: either a JSON string ("[\\"a\\", \\"b\\"]") or a bare string
+("a") where the schema asked for ["a"]. This helper centralizes the
+stringified-array repair that was previously duplicated ad hoc across tools.
+
+The core invariant: valid non-string inputs (real lists, dicts, None) are
+never touched, so no legitimate payload is transformed or corrupted.
+"""
+
+import json
+
+from tools.tool_input_repair import recover_list_from_json_string
+
+
+class TestStringifiedArrayRepair:
+    def test_json_array_string_is_parsed_to_list(self):
+        repaired, error = recover_list_from_json_string(
+            '["a", "b"]', param_name="urls"
+        )
+        assert error is None
+        assert repaired == ["a", "b"]
+
+    def test_whitespace_surrounding_stringified_array(self):
+        repaired, error = recover_list_from_json_string(
+            '  ["a"]  ', param_name="urls"
+        )
+        assert error is None
+        assert repaired == ["a"]
+
+    def test_stringified_array_of_objects(self):
+        raw = json.dumps([{"action": "add", "content": "x"}])
+        repaired, error = recover_list_from_json_string(
+            raw, param_name="operations"
+        )
+        assert error is None
+        assert repaired == [{"action": "add", "content": "x"}]
+
+
+class TestUnparseableStringWithWrap:
+    def test_bare_string_not_wrapped_by_default(self):
+        repaired, error = recover_list_from_json_string(
+            "https://example.com", param_name="urls"
+        )
+        assert error is not None
+        assert "JSON array" in error
+        assert repaired is None
+
+    def test_bare_string_wrapped_when_requested(self):
+        repaired, error = recover_list_from_json_string(
+            "https://example.com", param_name="urls", wrap_bare_string=True
+        )
+        assert error is None
+        assert repaired == ["https://example.com"]
+
+    def test_bare_short_string_wrapped(self):
+        repaired, error = recover_list_from_json_string(
+            "foo", param_name="urls", wrap_bare_string=True
+        )
+        assert error is None
+        assert repaired == ["foo"]
+
+    def test_empty_string_still_rejected_with_wrap(self):
+        # An empty string is not a recoverable URL, even with wrapping.
+        repaired, error = recover_list_from_json_string(
+            "", param_name="urls", wrap_bare_string=True
+        )
+        assert error is not None
+        assert repaired is None
+
+
+class TestParsedToNonList:
+    def test_string_parsing_to_dict_is_rejected(self):
+        repaired, error = recover_list_from_json_string(
+            '{"a": 1}', param_name="operations"
+        )
+        assert error is not None
+        assert "dict" in error
+        assert repaired is None
+
+    def test_string_parsing_to_scalar_is_rejected(self):
+        repaired, error = recover_list_from_json_string(
+            "42", param_name="operations"
+        )
+        assert error is not None
+        assert repaired is None
+
+
+class TestValidInputsUntouched:
+    """The critical invariant: real lists / dicts / None pass through unchanged."""
+
+    def test_real_list_untouched(self):
+        items = [{"id": "a"}]
+        repaired, error = recover_list_from_json_string(items, param_name="todos")
+        assert error is None
+        assert repaired is None  # sentinel: caller keeps the original
+
+    def test_empty_list_untouched(self):
+        repaired, error = recover_list_from_json_string([], param_name="todos")
+        assert error is None
+        assert repaired is None
+
+    def test_none_untouched(self):
+        repaired, error = recover_list_from_json_string(None, param_name="todos")
+        assert error is None
+        assert repaired is None
+
+    def test_dict_untouched(self):
+        # A dict placeholder must never be coerced into a list.
+        repaired, error = recover_list_from_json_string(
+            {"todo": "x"}, param_name="todos"
+        )
+        assert error is None
+        assert repaired is None

--- a/tests/tools/test_web_tools_dict_urls.py
+++ b/tests/tools/test_web_tools_dict_urls.py
@@ -75,6 +75,40 @@ async def test_web_extract_dispatches_urls_from_search_result_objects(extract_pr
     assert [entry["url"] for entry in result["results"]] == extract_provider.received_urls
 
 
+@pytest.mark.asyncio
+async def test_web_extract_repairs_bare_string_url(extract_provider):
+    """A bare string url must be wrapped, not iterated char-by-char.
+
+    Regression for the silent-corruption case: without the repair,
+    ``for index, item in enumerate(urls)`` over a bare string iterates each
+    character, every char fails URL validation, and the tool returns
+    "Content was inaccessible" for a perfectly valid URL.
+    """
+    result = json.loads(await web_tools.web_extract_tool("https://example.com"))
+
+    assert extract_provider.received_urls == ["https://example.com"]
+    assert [entry["url"] for entry in result["results"]] == ["https://example.com"]
+    assert "inaccessible" not in json.dumps(result).lower()
+
+
+@pytest.mark.asyncio
+async def test_web_extract_repairs_stringified_array_urls(extract_provider):
+    """A JSON-stringified array of urls must be parsed into a real list."""
+    result = json.loads(await web_tools.web_extract_tool('["https://example.com/a"]'))
+
+    assert extract_provider.received_urls == ["https://example.com/a"]
+    assert [entry["url"] for entry in result["results"]] == ["https://example.com/a"]
+
+
+@pytest.mark.asyncio
+async def test_web_extract_valid_list_untouched(extract_provider):
+    """A real list of urls must pass through unchanged (no corruption)."""
+    result = json.loads(await web_tools.web_extract_tool(["https://example.com/a"]))
+
+    assert extract_provider.received_urls == ["https://example.com/a"]
+    assert [entry["url"] for entry in result["results"]] == ["https://example.com/a"]
+
+
 def test_web_extract_registry_dispatch_accepts_search_result_objects(
     extract_provider,
 ):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -41,6 +41,7 @@ from agent.interrupt_compat import request_hard_interrupt
 # Must match hermes_cli.runtime_provider.RUNTIME_PROVIDER_TYPE_CUSTOM.
 _RUNTIME_PROVIDER_CUSTOM = "custom"
 from tools import file_state
+from tools.tool_input_repair import recover_list_from_json_string
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
 from utils import base_url_hostname, is_truthy_value
 
@@ -3045,24 +3046,20 @@ def _run_child_lifecycle(
 def _recover_tasks_from_json_string(
     tasks: Any,
 ) -> tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
-    if not isinstance(tasks, str):
-        return None, None
-    raw = tasks.strip()
-    if not raw:
+    """Recover a ``tasks`` array emitted as a JSON string.
+
+    Thin wrapper over the shared repair helper so delegate_task gets the same
+    stringified-array repair as every other array-taking tool. The empty-string
+    case keeps its tool-specific message (a single-``goal`` fallback is valid).
+    """
+    if isinstance(tasks, str) and not tasks.strip():
         return None, "Provide either 'goal' (single task) or 'tasks' (batch)."
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        return None, (
-            "tasks must be a JSON array of task objects; received a string "
-            f"that could not be parsed as JSON ({exc.msg})."
-        )
-    if not isinstance(parsed, list):
-        return None, (
-            f"tasks must be a JSON array of task objects; parsed "
-            f"{type(parsed).__name__} instead."
-        )
-    return parsed, None
+    recovered, error = recover_list_from_json_string(
+        tasks, param_name="tasks"
+    )
+    if error is not None:
+        return None, error
+    return recovered, None
 
 
 # Placeholder shapes for batch goal validation: bare 'TODO', bare 'task N'

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1084,6 +1084,15 @@ def memory_tool(
 
     # --- Batch path -------------------------------------------------------
     if operations:
+        # Repair: LLM sometimes sends operations as a JSON string instead of a
+        # list. Share the stringified-array repair with every other array tool.
+        repaired_ops, repair_err = recover_list_from_json_string(
+            operations, param_name="operations"
+        )
+        if repair_err is not None:
+            return tool_error(repair_err, success=False)
+        if repaired_ops is not None:
+            operations = repaired_ops
         if not isinstance(operations, list):
             return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
         gate_result = _apply_batch_write_gate(target, operations)
@@ -1227,6 +1236,7 @@ MEMORY_SCHEMA = {
 
 # --- Registry ---
 from tools.registry import registry, tool_error
+from tools.tool_input_repair import recover_list_from_json_string
 
 registry.register(
     name="memory",

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -221,12 +221,16 @@ def todo_tool(
         return tool_error("TodoStore not initialized")
 
     if todos is not None:
-        # Guard: LLM sometimes sends todos as a JSON string instead of a list
-        if isinstance(todos, str):
-            try:
-                todos = json.loads(todos)
-            except (json.JSONDecodeError, TypeError):
-                return tool_error("todos must be a list of objects, got unparseable string")
+        # Guard: LLM sometimes sends todos as a JSON string instead of a list.
+        # Use the shared repair so the stringified-array case is converted to a
+        # real list consistently with every other array-taking tool.
+        repaired, repair_err = recover_list_from_json_string(
+            todos, param_name="todos"
+        )
+        if repair_err is not None:
+            return tool_error(repair_err)
+        if repaired is not None:
+            todos = repaired
         if not isinstance(todos, list):
             return tool_error(
                 f"todos must be a list, got {type(todos).__name__}"
@@ -323,6 +327,7 @@ TODO_SCHEMA = {
 
 # --- Registry ---
 from tools.registry import registry, tool_error
+from tools.tool_input_repair import recover_list_from_json_string
 
 registry.register(
     name="todo",

--- a/tools/tool_input_repair.py
+++ b/tools/tool_input_repair.py
@@ -1,0 +1,73 @@
+"""Shared repair helpers for model-emitted tool arguments.
+
+LLMs occasionally emit an array-typed tool parameter as a *string* instead
+of a real list: either a JSON string ("[\"a\", \"b\"]") or a bare string
+("a") when the schema asked for ["a"]. Without a repair, each tool handler
+either rejects the input (a wasted round-trip the model must recover from)
+or, worse, silently misbehaves: a ``for x in urls`` loop over a bare string
+iterates character-by-character and returns a misleading "content not found"
+error instead of the real type mismatch.
+
+Historically this repair was duplicated ad hoc across individual tools
+(e.g. ``todo_tool`` and ``delegate_tool``). This module centralizes the
+common case so every array-taking tool gets the same, consistent repair.
+
+The repair is deliberately *narrow*: it only fires when the value is a
+string, and it only ever upgrades a string into a list. Valid inputs (real
+lists, dicts, None) are returned untouched, so no legitimate payload is ever
+transformed or corrupted.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional, Tuple
+
+
+def recover_list_from_json_string(
+    value: Any,
+    *,
+    param_name: str = "value",
+    wrap_bare_string: bool = False,
+) -> Tuple[Optional[list], Optional[str]]:
+    """Repair a stringified-JSON array parameter into a real list.
+
+    Returns ``(repaired, error)``:
+
+    * ``value`` is not a string -> ``(None, None)``. The input is left for
+      the caller's normal validation; nothing is transformed.
+    * ``value`` is a string that parses to a JSON array -> ``(list, None)``.
+    * ``value`` is a bare string that does not parse to JSON and
+      ``wrap_bare_string`` is True -> ``([value], None)``. This is the
+      ``"foo"`` -> ``["foo"]`` case, valid for params whose items are
+      strings (e.g. ``urls``).
+    * ``value`` is a string that does *not* parse to an array (unparseable,
+      or parsed to a non-list) -> ``(None, error_message)``.
+
+    Valid non-string inputs are never touched, so this is safe to call on any
+    parameter without risking corruption of well-formed payloads.
+    """
+    if not isinstance(value, str):
+        return None, None
+
+    raw = value.strip()
+    if not raw:
+        return None, f"{param_name} must be a list; received an empty string."
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        if wrap_bare_string:
+            return [value], None
+        return None, (
+            f"{param_name} must be a JSON array; received a string that could "
+            f"not be parsed as JSON ({exc.msg})."
+        )
+
+    if not isinstance(parsed, list):
+        return None, (
+            f"{param_name} must be a JSON array; parsed {type(parsed).__name__} "
+            f"instead."
+        )
+
+    return parsed, None

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -98,6 +98,7 @@ from tools.tool_backend_helpers import (  # noqa: F401
     prefers_gateway,
 )
 from tools.url_safety import async_is_safe_url, normalize_url_for_request, sensitive_query_param_name
+from tools.tool_input_repair import recover_list_from_json_string
 import sys
 
 logger = logging.getLogger(__name__)
@@ -772,6 +773,21 @@ async def web_extract_tool(
     Raises:
         Exception: If extraction fails or API key is not set
     """
+    # Repair the model-emitted ``urls`` param before touching it. Without this,
+    # a bare string ("https://example.com") or a stringified array
+    # ('["a","b"]') would flow into the ``for index, item in enumerate(urls)``
+    # loop below: a bare string iterates character-by-character and every char
+    # fails URL validation, silently returning "Content was inaccessible"
+    # instead of the real string-vs-array type mismatch. Share the same repair
+    # used by every other array-taking tool.
+    repaired_urls, repair_err = recover_list_from_json_string(
+        urls, param_name="urls", wrap_bare_string=True
+    )
+    if repair_err is not None:
+        return json.dumps({"error": repair_err}, ensure_ascii=False)
+    if repaired_urls is not None:
+        urls = repaired_urls
+
     # Block URLs containing embedded secrets (exfiltration prevention).
     # URL-decode first so percent-encoded secrets (%73k- = sk-) are caught.
     from agent.redact import _PREFIX_RE


### PR DESCRIPTION
## What

LLMs sometimes emit an array-typed tool parameter as a **string** instead of a real list: either a JSON string (`'["a", "b"]'`) or a bare string (`'a'`) where the schema asked for `['a']`. Without a repair, each tool handler either rejects the input (a wasted model round-trip) or **silently misbehaves**.

The worst case is `web_extract`: a bare-string `urls` flows into `for index, item in enumerate(urls)` and iterates **character-by-character**. Every char fails URL validation and the tool returns `"Content was inaccessible"` for a perfectly valid URL, hiding the real type mismatch from the model.

## What changed

`todo` and `delegate_task` already had ad-hoc string-repair guards. This centralizes that repair into `tools/tool_input_repair.py` and applies it to all four array-taking tools:

- **`todo.todos`**, **`delegate_task.tasks`**: refactored onto the shared helper (behavior preserved)
- **`memory.operations`**: added repair (was reject-only)
- **`web_extract.urls`**: added repair (was silent corruption), wrapping bare strings since url items are strings

The repair is deliberately **narrow**: it only fires on string values and only ever upgrades a string into a list. Valid inputs (real lists, dicts, `None`) pass through untouched, so no legitimate payload is transformed or corrupted.

## Tests

- New `tests/tools/test_tool_input_repair.py` covers the helper, including the critical "valid inputs untouched" invariant.
- `web_extract` repair cases added to `tests/tools/test_web_tools_dict_urls.py` (bare-string wrap, stringified-array parse, valid-list untouched).
- Full affected suite passes: 151 passed (todo, memory, delegate, helper, web_extract).

## Motivation (context)

This is the same failure class described in the "open model tool-calling is a harness problem" discussions: models like DeepSeek/GLM/Qwen emit the small finite set of shape mistakes, and a strict or naive harness turns recoverable noise into an apparent capability gap. The fix is to make the contract forgiving at exactly the paths that matter, without a global preprocess pass (which risks corrupting payloads that happen to be JSON-shaped).

Note: I did not touch the core argument-parsing path (`_parse_tool_arguments`); per the project's narrow-waist guidance, the fix lives at the tool edges where the schemas are known.