### PR TITLE
fix(dashboard-auth): url-encode pkce cookie value to survive rfc 6265 split

### DIFF
--- a/hermes_cli/dashboard_auth/cookies.py
+++ b/hermes_cli/dashboard_auth/cookies.py
@@ -57,6 +57,7 @@ Refresh-token handling:
 from __future__ import annotations
 
 from typing import Optional, Tuple
+from urllib.parse import quote, unquote
 
 from fastapi import Request
 from fastapi.responses import Response
@@ -240,9 +241,23 @@ def clear_session_cookies(response: Response, *, prefix: str = "") -> None:
 def set_pkce_cookie(
     response: Response, *, payload: str, use_https: bool, prefix: str = "",
 ) -> None:
+    # The PKCE payload is a flat ``key=value;key=value`` string
+    # (``provider=…;state=…;verifier=…;next=…``). RFC 6265 treats the
+    # unquoted ``;`` as a cookie-value terminator, so without quoting the
+    # browser truncates at the first ``;`` and only ``provider=…`` survives
+    # the round trip — the OIDC callback then sees a partial payload and
+    # fails with "Missing PKCE state cookie" / wrong provider. Storing the
+    # payload quoted works for parsers that follow Python's http.cookies
+    # convention but trips cross-browser discrepancies on the backslash-
+    # octal escape (\073) we use to encode the embedded ``;``. The
+    # portable fix is to URL-encode the whole payload before it reaches
+    # the wire — ``;`` becomes ``%3B`` and there is nothing left for the
+    # browser's cookie-value parser to misinterpret. The callback
+    # reader (routes.py) decodes the URL-encoded value before the
+    # ``;`` split so the parsed segments match the original payload.
     response.set_cookie(
         _resolved_name(PKCE_COOKIE, use_https=use_https, prefix=prefix),
-        payload,
+        quote(payload, safe=""),
         max_age=_PKCE_MAX_AGE,
         **_common_attrs(use_https=use_https, prefix=prefix),
     )

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -20,6 +20,7 @@ import threading
 import time
 from collections import defaultdict, deque
 from typing import Any, Deque, Dict
+from urllib.parse import unquote
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -396,12 +397,19 @@ async def auth_callback(
             detail="Missing PKCE state cookie",
         )
 
+    # The setter (cookies.set_pkce_cookie) URL-encodes the payload before
+    # it hits the wire so the browser's RFC 6265 cookie-value parser can't
+    # chop it at the first ``;``. Decode back to the original
+    # ``provider=...;state=...;verifier=...;next=...`` shape before the
+    # ``;`` split. The decode is a no-op for any pre-existing cookie value
+    # that pre-dates this change (no ``%`` means nothing to decode).
+    pkce_decoded = unquote(pkce_raw)
     # Parse ``provider=...;state=...;verifier=...;next=...`` — the
     # ``next`` segment is optional (only present when /auth/login was
     # given a next= query). All keys live in the same flat namespace;
     # ``next`` carries a URL-encoded path so it never contains ``;``.
     parts = dict(
-        seg.split("=", 1) for seg in pkce_raw.split(";") if "=" in seg
+        seg.split("=", 1) for seg in pkce_decoded.split(";") if "=" in seg
     )
     provider_name = parts.get("provider", "")
     expected_state = parts.get("state", "")

--- a/tests/hermes_cli/test_dashboard_auth_cookies.py
+++ b/tests/hermes_cli/test_dashboard_auth_cookies.py
@@ -133,5 +133,194 @@ def test_read_session_cookies_from_request_secure_prefix():
     assert rt == "rt_value"
 
 
+# ---------------------------------------------------------------------------
+# PKCE cookie: regression for #83832
+# ---------------------------------------------------------------------------
+#
+# The PKCE payload is a flat ``key=value;key=value`` string. Without
+# URL-encoding, RFC 6265's unquoted ``;`` terminates the cookie-value
+# on the wire and the browser only stores the first segment. The
+# OIDC callback then sees a partial payload and fails with
+# "Missing PKCE state cookie". The fix URL-encodes the payload
+# in the setter and decodes it in routes.py before the ``;`` split.
+# These tests pin both the wire shape and the round-trip.
+
+
+def test_set_pkce_cookie_url_encodes_payload_to_avoid_rfc6265_split():
+    """The wire-level Set-Cookie value must not contain a literal,
+    unquoted ``;`` (the RFC 6265 cookie-value terminator). The
+    embedded ``;`` separators in the payload become ``%3B`` so
+    every segment of the PKCE payload survives the browser round
+    trip intact.
+
+    Regression for #83832 — the OIDC callback was failing with
+    "Missing PKCE state cookie" because the browser truncated
+    the cookie at the first ``;``.
+    """
+    from urllib.parse import unquote
+    client = TestClient(_build_app(use_https=True, prefix=""))
+    r = client.get("/set-pkce")
+    pkce_set = next(
+        c for c in r.headers.get_list("set-cookie")
+        if c.startswith(f"__Host-{PKCE_COOKIE}=")
+    )
+    # Take just the cookie name=value pair, ignore the attributes.
+    pkce_value = pkce_set.split(";", 1)[0]
+    # No unquoted literal ``;`` left in the value (i.e. before any
+    # attribute separator). The payload is
+    # ``provider=stub;state=s;verifier=v`` — encoded as
+    # ``provider%3Dstub%3Bstate%3Ds%3Bverifier%3Dv``.
+    assert ";" not in pkce_value.split("=", 1)[1], (
+        f"unquoted ; leaked into the cookie value: {pkce_value!r}"
+    )
+    # Round-trip the URL-encoding back to the original payload.
+    decoded = unquote(pkce_value.split("=", 1)[1])
+    assert decoded == "provider=stub;state=s;verifier=v", (
+        f"URL-encoded payload didn't round-trip to the original: "
+        f"got {decoded!r}"
+    )
+
+
+def test_pkce_cookie_round_trip_preserves_all_segments():
+    """End-to-end: the browser stores the Set-Cookie, the server
+    reads it back via ``read_pkce_cookie``, the OAuth callback
+    in routes.py decodes the URL-encoded value and parses every
+    segment. Pre-fix this would lose ``state`` and ``verifier``
+    because the browser truncated at the first ``;``.
+    """
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from conftest_dashboard_auth import StubAuthProvider  # type: ignore
+    from hermes_cli import web_server
+    from hermes_cli.dashboard_auth import clear_providers, register_provider
+    from urllib.parse import unquote
+
+    clear_providers()
+    register_provider(StubAuthProvider())
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    try:
+        client = TestClient(
+            web_server.app, base_url="https://fly-app.fly.dev",
+        )
+        # /auth/login sets the PKCE cookie with provider / state / verifier
+        # packed by the login handler. Capture both the PKCE value and
+        # the state that the IDP saw.
+        r1 = client.get(
+            "/auth/login?provider=stub", follow_redirects=False,
+        )
+        assert r1.status_code == 302
+        pkce_set = next(
+            c for c in r1.headers.get_list("set-cookie")
+            if "hermes_session_pkce" in c
+        )
+        # Pull just the name=value portion so we can echo it back as
+        # a Cookie header.
+        pkce_kv = pkce_set.split(";", 1)[0]
+        # Confirm the setter URL-encoded the value.
+        encoded_value = pkce_kv.split("=", 1)[1]
+        decoded_value = unquote(encoded_value)
+        # The login handler packs provider, state, and verifier
+        # into the payload. All three must survive intact.
+        assert "provider=stub" in decoded_value
+        assert "state=" in decoded_value
+        assert "verifier=" in decoded_value
+        # And the encoded wire value must NOT have a literal, unquoted ``;``
+        # between segments.
+        assert ";" not in encoded_value, (
+            f"literal ; in wire cookie value: {encoded_value!r}"
+        )
+
+        # Round-trip via /auth/callback — the success path confirms
+        # the callback decoded the URL-encoded value and matched
+        # the state. (302 to the post-login page = success.)
+        state = r1.headers["location"].split("state=")[1]
+        r2 = client.get(
+            f"/auth/callback?code=stub_code&state={state}",
+            headers={"cookie": pkce_kv},
+            follow_redirects=False,
+        )
+        assert r2.status_code == 302, (
+            f"OIDC callback failed — the PKCE cookie round trip is broken. "
+            f"Body: {r2.text!r}"
+        )
+    finally:
+        clear_providers()
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required
+
+
+def test_pkce_callback_works_when_next_query_includes_encoded_path():
+    """The ``next=`` segment carries a URL-encoded path (e.g. a
+    relative URL containing ``;`` from a query parameter on the
+    post-login target). The setter URL-encodes the whole payload
+    (so the ``;`` in the next= value doesn't trip RFC 6265), and
+    the reader decodes the next= value back to its original form
+    for the redirect."""
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from conftest_dashboard_auth import StubAuthProvider  # type: ignore
+    from hermes_cli import web_server
+    from hermes_cli.dashboard_auth import clear_providers, register_provider
+    from urllib.parse import quote, unquote
+
+    clear_providers()
+    register_provider(StubAuthProvider())
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    try:
+        client = TestClient(
+            web_server.app, base_url="https://fly-app.fly.dev",
+        )
+        # next= with a /sessions?view=recent&project=foo target.
+        # The login handler URL-encodes the next= value once, then
+        # the setter URL-encodes the whole payload. The reader
+        # decodes the payload back, and the routes callback then
+        # passes the next= through.
+        next_target = "/sessions?view=recent&project=foo"
+        r1 = client.get(
+            f"/auth/login?provider=stub&next={quote(next_target, safe='')}",
+            follow_redirects=False,
+        )
+        assert r1.status_code == 302
+        pkce_kv = next(
+            c for c in r1.headers.get_list("set-cookie")
+            if "hermes_session_pkce" in c
+        ).split(";", 1)[0]
+        # Drive the callback — must succeed (302 to the post-login
+        # target, NOT a 400 "Missing PKCE state cookie").
+        state = r1.headers["location"].split("state=")[1]
+        r2 = client.get(
+            f"/auth/callback?code=stub_code&state={state}",
+            headers={"cookie": pkce_kv},
+            follow_redirects=False,
+        )
+        assert r2.status_code == 302, (
+            f"callback failed with next= present: {r2.text!r}"
+        )
+        # The post-login redirect carries the next= target.
+        assert next_target in r2.headers.get("location", "") or \
+            unquote(next_target) in unquote(r2.headers.get("location", "")), (
+            f"post-login redirect didn't carry the next= target: "
+            f"{r2.headers.get('location')!r}"
+        )
+    finally:
+        clear_providers()
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required
+
+
 
 


### PR DESCRIPTION
## Problem

The PKCE cookie value is a flat `provider=...;state=...;verifier=...;next=...` string. RFC 6265 treats the unquoted `;` as a cookie-value terminator, so the browser stores only the first segment (`provider=...`) and the OIDC callback sees a partial payload — failing with **"Missing PKCE state cookie"** or **"Unknown provider in cookie"**.

The previous behavior wrapped the value in double quotes and used the Python http.cookies backslash-octal escape `\073` to encode the embedded `;`. That works for Python's parser but breaks for browsers that follow RFC 6265 strictly (per section 4.1.1, the unescape rule consumes a backslash only when followed by a terminator — `\0` is not one, so the backslash itself is preserved in the value). The portable fix is to URL-encode the whole payload before it hits the wire.

## Fix

- `cookies.set_pkce_cookie`: wrap the payload in `urllib.parse.quote(safe="")` — `;` becomes `%3B`, `=` becomes `%3D`, and there is nothing left in the cookie value for the browser's cookie-value parser to misinterpret.
- `routes.callback`: URL-decode via `urllib.parse.unquote` before the `;` split, so the parsed segments match the original payload byte-for-byte. The decode is a no-op for any pre-existing cookie value that pre-dates this change (no `%` means nothing to decode).

## Regression coverage

Three new tests in `test_dashboard_auth_cookies.py`:

1. `test_set_pkce_cookie_url_encodes_payload_to_avoid_rfc6265_split` — pins the wire-level shape: no unquoted `;` in the Set-Cookie value, and the URL-encoding round-trips back to the original payload.
2. `test_pkce_cookie_round_trip_preserves_all_segments` — drives the existing end-to-end callback path through the prefix test app and verifies that the callback returns 302 (success), not 400 "Missing PKCE state cookie".
3. `test_pkce_callback_works_when_next_query_includes_encoded_path` — exercises the `next=` round-trip path with a real relative URL (`/sessions?view=recent&project=foo`) to make sure the post-login redirect carries the target.

## Proof gate

`test_set_pkce_cookie_url_encodes_payload_to_avoid_rfc6265_split` was verified to fail against the pre-fix source (the Set-Cookie value comes back as `"provider=stub\073state=s\073verifier=v"` — the broken RFC 6265 quoted-string form) and pass post-fix. The other two tests verify the full callback path is intact.

## Risk / blast radius

Low. The setter change is a pure transformation of the cookie value (URL-encoding); the reader change is a pure inverse transformation. No new dependencies, no API change, no new helper functions. The pre-existing 4 PKCE-related tests in `test_dashboard_auth_cookies.py` and the 13 prefix-cookie tests in `test_dashboard_auth_prefix.py` continue to pass (20 / 20 in the suite).

## Closes

Closes #83832