### PR TITLE
refactor(mcp_tool): extract connect-cooldown slice R3-2 into tools/mcp_connect_cooldown.py

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/tests/tools/test_mcp_connect_cooldown_seam.py
+++ b/tests/tools/test_mcp_connect_cooldown_seam.py
@@ -1,0 +1,59 @@
+"""Compatibility and shared-state seams for the MCP connect cooldown extraction."""
+
+from __future__ import annotations
+
+from tools import mcp_connect_cooldown as cooldown
+from tools import mcp_tool
+
+
+_MOVED_NAMES = (
+    "_server_connect_retry_after",
+    "_server_connect_failures",
+    "_CONNECT_RETRY_BASE_BACKOFF_SEC",
+    "_CONNECT_RETRY_MAX_BACKOFF_SEC",
+    "_record_connect_failure",
+    "_clear_connect_failure",
+    "_connect_cooldown_active",
+)
+
+
+def _clear_state() -> None:
+    cooldown._server_connect_retry_after.clear()
+    cooldown._server_connect_failures.clear()
+
+
+def test_original_namespace_reexports_preserve_identity() -> None:
+    for name in _MOVED_NAMES:
+        assert getattr(mcp_tool, name) is getattr(cooldown, name)
+
+
+def test_cooldown_behavior_and_cross_module_clear_mutation(monkeypatch) -> None:
+    _clear_state()
+    now = [100.0]
+    monkeypatch.setattr(cooldown.time, "monotonic", lambda: now[0])
+
+    mcp_tool._record_connect_failure("broken-server")
+    assert cooldown._server_connect_failures == {"broken-server": 1}
+    assert mcp_tool._server_connect_failures is cooldown._server_connect_failures
+    assert mcp_tool._server_connect_retry_after is cooldown._server_connect_retry_after
+    assert cooldown._connect_cooldown_active("broken-server") is True
+
+    now[0] = 130.0
+    assert mcp_tool._connect_cooldown_active("broken-server") is False
+
+    # The legacy namespace is the mutation authority used by shutdown paths.
+    mcp_tool._server_connect_retry_after["broken-server"] = 999.0
+    mcp_tool._server_connect_failures["broken-server"] = 7
+    cooldown._server_connect_retry_after.clear()
+    assert mcp_tool._server_connect_retry_after == {}
+    assert mcp_tool._server_connect_failures == {"broken-server": 7}
+
+    # The reverse direction is also the same live object, not a copied dict.
+    mcp_tool._server_connect_failures.clear()
+    assert cooldown._server_connect_failures == {}
+
+    mcp_tool._record_connect_failure("broken-server")
+    assert cooldown._server_connect_failures["broken-server"] == 1
+    cooldown._clear_connect_failure("broken-server")
+    assert mcp_tool._server_connect_failures == {}
+    assert mcp_tool._server_connect_retry_after == {}

--- a/tools/mcp_connect_cooldown.py
+++ b/tools/mcp_connect_cooldown.py
@@ -1,0 +1,60 @@
+import logging
+import time
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+# Connection-retry cooldown (per-server isolation against restart storms).
+#
+# A single stdio MCP server that fails to spawn (bad PATH, ``exec: not
+# found``, crash-on-start) is never recorded in ``_servers`` -- ``start()``
+# raises and ``_discover_and_register_server`` aborts before the
+# ``_servers[name] = server`` line. Without a cooldown, EVERY subsequent
+# ``discover_mcp_tools()`` (one per agent worker session, i.e. every few
+# seconds) sees the server as "not connected" and re-spawns it from
+# scratch. That is the restart storm in #50394: the failing server is
+# re-attempted on the shared MCP event loop on every worker session, the
+# subprocesses pile up unreaped, and the churn destabilises the healthy
+# co-located servers (their tools intermittently surface as
+# "Unknown tool").
+#
+# Fix: after a failed connection attempt, stamp a monotonic
+# ``retry_after`` deadline with exponential backoff. ``register_mcp_servers``
+# skips a server whose cooldown has not elapsed, so a chronically failing
+# server is retried on a backoff schedule instead of on every worker
+# session -- isolating it from the rest of the bridge. A successful
+# connection clears the state.
+_server_connect_retry_after: Dict[str, float] = {}   # name -> monotonic deadline
+_server_connect_failures: Dict[str, int] = {}        # name -> consecutive failures
+_CONNECT_RETRY_BASE_BACKOFF_SEC = 30.0
+_CONNECT_RETRY_MAX_BACKOFF_SEC = 600.0
+
+
+def _record_connect_failure(server_name: str) -> None:
+    """Stamp an exponential-backoff cooldown after a failed connect.
+
+    Called (under ``_lock``) when a server fails its discovery/connect
+    attempt. The cooldown grows geometrically with the consecutive
+    failure count and is capped at :data:`_CONNECT_RETRY_MAX_BACKOFF_SEC`,
+    so a permanently-broken server settles into infrequent retries
+    rather than a tight respawn loop.
+    """
+    n = _server_connect_failures.get(server_name, 0) + 1
+    _server_connect_failures[server_name] = n
+    backoff = min(
+        _CONNECT_RETRY_BASE_BACKOFF_SEC * (2 ** (n - 1)),
+        _CONNECT_RETRY_MAX_BACKOFF_SEC,
+    )
+    _server_connect_retry_after[server_name] = time.monotonic() + backoff
+
+
+def _clear_connect_failure(server_name: str) -> None:
+    """Clear the connect-cooldown state after a successful connection."""
+    _server_connect_failures.pop(server_name, None)
+    _server_connect_retry_after.pop(server_name, None)
+
+
+def _connect_cooldown_active(server_name: str) -> bool:
+    """Return True if ``server_name`` is still within its retry cooldown."""
+    deadline = _server_connect_retry_after.get(server_name)
+    return deadline is not None and time.monotonic() < deadline

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -119,6 +119,15 @@ from urllib.parse import urlparse
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
+from tools.mcp_connect_cooldown import (
+    _server_connect_retry_after,
+    _server_connect_failures,
+    _CONNECT_RETRY_BASE_BACKOFF_SEC,
+    _CONNECT_RETRY_MAX_BACKOFF_SEC,
+    _record_connect_failure,
+    _clear_connect_failure,
+    _connect_cooldown_active,
+)
 
 # Upper bound for the OSV malware preflight during stdio MCP startup. The
 # check makes a blocking urllib HTTPS call whose own timeout can fail to
@@ -3828,60 +3837,6 @@ _connect_server_claim: contextvars.ContextVar[
     Optional[Callable[[MCPServerTask], None]]
 ] = contextvars.ContextVar("mcp_connect_server_claim", default=None)
 
-# Connection-retry cooldown (per-server isolation against restart storms).
-#
-# A single stdio MCP server that fails to spawn (bad PATH, ``exec: not
-# found``, crash-on-start) is never recorded in ``_servers`` -- ``start()``
-# raises and ``_discover_and_register_server`` aborts before the
-# ``_servers[name] = server`` line. Without a cooldown, EVERY subsequent
-# ``discover_mcp_tools()`` (one per agent worker session, i.e. every few
-# seconds) sees the server as "not connected" and re-spawns it from
-# scratch. That is the restart storm in #50394: the failing server is
-# re-attempted on the shared MCP event loop on every worker session, the
-# subprocesses pile up unreaped, and the churn destabilises the healthy
-# co-located servers (their tools intermittently surface as
-# "Unknown tool").
-#
-# Fix: after a failed connection attempt, stamp a monotonic
-# ``retry_after`` deadline with exponential backoff. ``register_mcp_servers``
-# skips a server whose cooldown has not elapsed, so a chronically failing
-# server is retried on a backoff schedule instead of on every worker
-# session -- isolating it from the rest of the bridge. A successful
-# connection clears the state.
-_server_connect_retry_after: Dict[str, float] = {}   # name -> monotonic deadline
-_server_connect_failures: Dict[str, int] = {}        # name -> consecutive failures
-_CONNECT_RETRY_BASE_BACKOFF_SEC = 30.0
-_CONNECT_RETRY_MAX_BACKOFF_SEC = 600.0
-
-
-def _record_connect_failure(server_name: str) -> None:
-    """Stamp an exponential-backoff cooldown after a failed connect.
-
-    Called (under ``_lock``) when a server fails its discovery/connect
-    attempt. The cooldown grows geometrically with the consecutive
-    failure count and is capped at :data:`_CONNECT_RETRY_MAX_BACKOFF_SEC`,
-    so a permanently-broken server settles into infrequent retries
-    rather than a tight respawn loop.
-    """
-    n = _server_connect_failures.get(server_name, 0) + 1
-    _server_connect_failures[server_name] = n
-    backoff = min(
-        _CONNECT_RETRY_BASE_BACKOFF_SEC * (2 ** (n - 1)),
-        _CONNECT_RETRY_MAX_BACKOFF_SEC,
-    )
-    _server_connect_retry_after[server_name] = time.monotonic() + backoff
-
-
-def _clear_connect_failure(server_name: str) -> None:
-    """Clear the connect-cooldown state after a successful connection."""
-    _server_connect_failures.pop(server_name, None)
-    _server_connect_retry_after.pop(server_name, None)
-
-
-def _connect_cooldown_active(server_name: str) -> bool:
-    """Return True if ``server_name`` is still within its retry cooldown."""
-    deadline = _server_connect_retry_after.get(server_name)
-    return deadline is not None and time.monotonic() < deadline
 
 # Circuit breaker: consecutive error counts per server.  After
 # _CIRCUIT_BREAKER_THRESHOLD consecutive failures, the handler returns


### PR DESCRIPTION
## Summary

Byte-verbatim extraction of slice R3-2 from `tools/mcp_tool.py` (7,731 lines at pin `ee4bb75b532e932a1055d9a710802a7435163b6a`) into a new module, per the repo-wide god-file sharding policy — the R3 consensus's adjudicated second slice.

- **Moved (7 names):** `_server_connect_retry_after`, `_server_connect_failures`, `_CONNECT_RETRY_BASE_BACKOFF_SEC`, `_CONNECT_RETRY_MAX_BACKOFF_SEC`, `_record_connect_failure`, `_clear_connect_failure`, `_connect_cooldown_active` (lines 3851–3884, 34 lines, connect-cooldown state + helpers; #50394 rationale comment travelled per contract option) → `tools/mcp_connect_cooldown.py`
- **Golden sha (window at pin):** `2cef3e307a2cb2a789b937521a59f03adb7aecd049b95f6f4c7d94523120d47c` — byte-verbatim, re-verified from the committed blob
- **Seam:** identity-preserving re-export of all 7 names in `tools/mcp_tool.py` (plain binding) — no public rename, no stale duplicate, external `.clear()` mutations (7430–7474) and all 3 test patch targets resolve through the original namespace, monkeypatch authority intact. New module: `import time` + `Dict` typing + logging/logger; no circular import (both import orders verified); startup-latency contract preserved.
- **Seam tests:** `tests/tools/test_mcp_connect_cooldown_seam.py` — object identity all 7 names + cross-module mutation path
- **Zero behavior change.** Diff: `tools/mcp_tool.py` 9 insertions / 54 deletions; new module 60 lines; seam test 59 lines.

## Method

5×2×3 double-blind decomposition (per the All Gods Must Die mandate): 5 blind region analysts → 5 blind adversarial witnesses → 5 consensus adjudicators → blind implementer → 2 blind re-reviewers, both **APPROVED**:

- Review 1: `C:/tmp/tg-Feature Package/mcp-tool/review/R32-review-1.md` (10,434 B) — all 7 battery gates PASS
- Review 2: `C:/tmp/tg-Feature Package/mcp-tool/review/R32-review-2.md` (10,383 B) — APPROVED, all gates

Suite evidence: pristine-pin baseline 2 failed / 486 passed / 5 skipped (both Windows-env-dependent); post-extraction identical 2-failure set + seam tests. No new failures.

## Coordination table

| Item | Value |
|---|---|
| Pin | `ee4bb75b532e932a1055d9a710802a7435163b6a` (origin/main) |
| Slice | R3-2 (region 3, second slice) |
| Window | 3851–3884 (34 lines) |
| Module | `tools/mcp_connect_cooldown.py` |
| Golden sha | `2cef3e307a2cb2a789b937521a59f03adb7aecd049b95f6f4c7d94523120d47c` |
| Colliders | NONE — #83354, #83393, #83559, #83575, #83641, #83760, #83860, #83917, #84023 hunks all outside window (re-verified at extraction) |
| Dependencies | none |
| Conflicts | none |
| Merge position | standalone; no stacking |

## Dedup statement

No prior extraction of this window exists. Open-PR census for `tools/mcp_tool.py` (live-verified via GraphQL): #83354, #83393 (external) + Feature Package siblings — none touch 3851–3884. No duplicate work.

## Credit

- Author: Axl Ibiza, MBA (DCO-signed commit `67eb5ffa288`)
- Method: All Gods Must Die 5×2×3 (blind lanes, consensus contracts, blind re-review)

## 

This slice is governed by the mcp_tool : `C:/tmp/tg-Feature Package/locks/LOCK-mcp_tool.md` (posted on #78642). Former whole: 7,731 lines. Mess issues: #5467, #5468. Fixer roster: #83354, #83393.

Part of #78642
Part of #78647