### PR TITLE
fix(tests): make Windows pytest collection portable

### DIFF
--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -10,6 +10,7 @@ read-only engine open creates -wal/-shm sidecar files next to a WAL database.
 import os
 import re
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -19,6 +20,11 @@ VULNERABLE = (3, 50, 4)
 FIXED_VERSIONS = [(3, 51, 3), (3, 52, 0), (3, 50, 7), (3, 44, 6)]
 
 EXPOSED_TEXT = "exposed to the WAL-reset bug"
+
+
+def _running_as_root() -> bool:
+    geteuid = getattr(os, "geteuid", None)
+    return geteuid is not None and geteuid() == 0
 
 
 def _make_db(path, journal_mode=None):
@@ -114,7 +120,7 @@ class TestReadJournalMode:
             holder.close()
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(_running_as_root(), reason="root ignores file permissions")
     def test_read_only_directory_is_still_readable(self, tmp_path):
         db = tmp_path / "state.db"
         _make_db(db, journal_mode="WAL")
@@ -185,7 +191,8 @@ class TestReportDatabaseJournalModes:
         assert "state.db is in WAL mode" in out
         assert "projects.db: rollback journal mode" in out
         assert "kanban.db: rollback journal mode" in out
-        assert "kanban/boards/myboard/kanban.db is in WAL mode" in out
+        nested_db = str(Path("kanban") / "boards" / "myboard" / "kanban.db")
+        assert f"{nested_db} is in WAL mode" in out
 
     def test_missing_databases_are_skipped(self, tmp_path, capsys):
         doctor._report_database_journal_modes(tmp_path, VULNERABLE)
@@ -209,7 +216,7 @@ class TestReportDatabaseJournalModes:
         assert "state.db: rollback journal mode" in out
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(_running_as_root(), reason="root ignores file permissions")
     def test_unreadable_database_does_not_crash(self, tmp_path, capsys):
         db = tmp_path / "state.db"
         _make_db(db)

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -24,6 +24,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import textwrap
 import time
 from pathlib import Path
@@ -32,9 +33,9 @@ import pytest
 
 
 # Both tests share the same handoff file: the leaker writes here, the
-# verifier reads here. We park it in $TMPDIR with a unique-per-run name
+# verifier reads here. We park it in the platform temp directory with a unique-per-run name
 # so concurrent invocations of the suite don't clobber each other.
-_HANDOFF_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "hermes-isolation-probe"
+_HANDOFF_DIR = Path(tempfile.gettempdir()) / "hermes-isolation-probe"
 _HANDOFF_DIR.mkdir(exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- avoid calling POSIX-only `os.geteuid()` while pytest is importing the doctor journal-mode tests on Windows
- use `tempfile.gettempdir()` for the parallel-runner handoff directory instead of assuming `/tmp`
- make the nested database path assertion use the platform path separator

Fixes #83935.

## Testing
- `.venv\Scripts\python.exe -m pytest --collect-only -q tests\hermes_cli\test_doctor_journal_modes.py tests\test_run_tests_parallel.py`
- `.venv\Scripts\python.exe -m pytest -q tests\hermes_cli\test_doctor_journal_modes.py`

Note: running `tests\test_run_tests_parallel.py` fully on this Windows checkout still times out inside its subprocess runner smoke test after collection succeeds; this PR targets the collection-time abort described in the issue.