### PR TITLE
fix(gateway): archive superseded turns on retry

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -4037,6 +4037,8 @@ class SessionStore:
         """
         if not self._db:
             return True
+        # Serialize against pending-queue drains. A failed rewrite retains the
+        # exact pending retry state; a successful rewrite clears it afterward.
         with self._get_transcript_drain_lock():
             try:
                 self._db.replace_messages(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -4048,13 +4048,23 @@ class SessionStore:
                     reject_active_turn_lease=reject_active_turn_lease,
                 )
             except Exception as e:
-                logger.debug("Failed to rewrite transcript in DB: %s", e)
+                # Snapshot-sensitive durable rewinds fail closed when the
+                # loaded transcript no longer maps to the active rows.
+                logger.warning(
+                    "Refused to rewrite transcript for session %s: %s",
+                    session_id,
+                    e,
+                )
                 return False
             self._clear_dirty_transcript(session_id)
             return True
 
     def load_transcript(
-        self, session_id: str, *, include_row_ids: bool = False
+        self,
+        session_id: str,
+        *,
+        include_row_ids: bool = False,
+        repair_alternation: bool = True,
     ) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
 
@@ -4087,13 +4097,12 @@ class SessionStore:
         except Exception:
             pass
         try:
-            # repair_alternation: this load feeds LIVE REPLAY. A durable
-            # user;user wedge (e.g. a turn that persisted no assistant row)
-            # would otherwise re-trigger the pre-request repair on every
-            # request forever — heal it once at the restore boundary.
+            # Live replay repairs durable role wedges at the restore boundary.
+            # Snapshot-sensitive rewrites such as /retry opt out: synthetic or
+            # coalesced turns cannot be mapped losslessly back to durable rows.
             return self._db.get_messages_as_conversation(
                 session_id,
-                repair_alternation=True,
+                repair_alternation=repair_alternation,
                 include_row_ids=include_row_ids,
             )
         except Exception as e:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -4003,6 +4003,8 @@ class SessionStore:
         session_id: str,
         messages: List[Dict[str, Any]],
         active_only: bool = False,
+        archive_dropped: bool = False,
+        expected_active_ids: Optional[List[int]] = None,
         reject_active_turn_lease: bool = False,
     ) -> bool:
         """Replace the entire transcript for a session with new messages.
@@ -4017,6 +4019,10 @@ class SessionStore:
         (#38763). Callers rewriting the live transcript of a session that
         may carry archived rows must pass ``active_only=True`` so only the
         live rows are replaced.
+
+        Pass ``archive_dropped=True`` for a user-initiated rewind that must
+        keep the replaced live rows recoverable. The default stays destructive
+        for callers such as compression and intentional content redaction.
 
         Returns ``True`` when the write lands (or there is no DB to write to)
         and ``False`` when the canonical write fails. Most callers can ignore
@@ -4037,6 +4043,8 @@ class SessionStore:
                     session_id,
                     messages,
                     active_only=active_only,
+                    archive_dropped=archive_dropped,
+                    expected_active_ids=expected_active_ids,
                     reject_active_turn_lease=reject_active_turn_lease,
                 )
             except Exception as e:
@@ -4045,7 +4053,9 @@ class SessionStore:
             self._clear_dirty_transcript(session_id)
             return True
 
-    def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
+    def load_transcript(
+        self, session_id: str, *, include_row_ids: bool = False
+    ) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
 
         state.db is the canonical store. The legacy JSONL fallback was removed
@@ -4082,7 +4092,9 @@ class SessionStore:
             # would otherwise re-trigger the pre-request repair on every
             # request forever — heal it once at the restore boundary.
             return self._db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                session_id,
+                repair_alternation=True,
+                include_row_ids=include_row_ids,
             )
         except Exception as e:
             # A failed read must be distinguishable from an empty transcript:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3760,6 +3760,8 @@ class SessionStore:
         session_id: str,
         messages: List[Dict[str, Any]],
         active_only: bool = False,
+        archive_dropped: bool = False,
+        expected_active_ids: Optional[List[int]] = None,
     ) -> bool:
         """Replace the entire transcript for a session with new messages.
 
@@ -3774,6 +3776,10 @@ class SessionStore:
         may carry archived rows must pass ``active_only=True`` so only the
         live rows are replaced.
 
+        Pass ``archive_dropped=True`` for a user-initiated rewind that must
+        keep the replaced live rows recoverable. The default stays destructive
+        for callers such as compression and intentional content redaction.
+
         Returns ``True`` when the write lands (or there is no DB to write to)
         and ``False`` when the canonical write fails. Most callers can ignore
         the result, but callers that would otherwise commit a destructive state
@@ -3785,13 +3791,21 @@ class SessionStore:
             return True
         self._clear_dirty_transcript(session_id)
         try:
-            self._db.replace_messages(session_id, messages, active_only=active_only)
+            self._db.replace_messages(
+                session_id,
+                messages,
+                active_only=active_only,
+                archive_dropped=archive_dropped,
+                expected_active_ids=expected_active_ids,
+            )
             return True
         except Exception as e:
             logger.debug("Failed to rewrite transcript in DB: %s", e)
             return False
 
-    def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
+    def load_transcript(
+        self, session_id: str, *, include_row_ids: bool = False
+    ) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
 
         state.db is the canonical store. The legacy JSONL fallback was removed
@@ -3828,7 +3842,9 @@ class SessionStore:
             # would otherwise re-trigger the pre-request repair on every
             # request forever — heal it once at the restore boundary.
             return self._db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                session_id,
+                repair_alternation=True,
+                include_row_ids=include_row_ids,
             )
         except Exception as e:
             # A failed read must be distinguishable from an empty transcript:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2638,7 +2638,9 @@ class GatewaySlashCommandsMixin:
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
         history = await self.async_session_store.load_transcript(
-            session_entry.session_id, include_row_ids=True
+            session_entry.session_id,
+            include_row_ids=True,
+            repair_alternation=False,
         )
         
         # Find the last *real* user message. Timeline bookkeeping rows carry

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2637,7 +2637,9 @@ class GatewaySlashCommandsMixin:
         """Handle /retry command - re-send the last user message."""
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        history = await self.async_session_store.load_transcript(
+            session_entry.session_id, include_row_ids=True
+        )
         
         # Find the last *real* user message. Timeline bookkeeping rows carry
         # role=user + display_kind (model_switch / async_delegation_complete /
@@ -2704,6 +2706,10 @@ class GatewaySlashCommandsMixin:
                 session_entry.session_id,
                 truncated,
                 active_only=True,
+                archive_dropped=True,
+                expected_active_ids=[
+                    msg["_row_id"] for msg in history if "_row_id" in msg
+                ],
                 reject_active_turn_lease=True,
             ):
                 return "Retry failed; transcript was not changed."

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2556,7 +2556,9 @@ class GatewaySlashCommandsMixin:
         """Handle /retry command - re-send the last user message."""
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        history = await self.async_session_store.load_transcript(
+            session_entry.session_id, include_row_ids=True
+        )
         
         # Find the last *real* user message. Timeline bookkeeping rows carry
         # role=user + display_kind (model_switch / async_delegation_complete /
@@ -2587,10 +2589,20 @@ class GatewaySlashCommandsMixin:
         # a bare rewrite (active_only=False) would DELETE them (same class as
         # #61145). /retry never intends to purge archived history, so avoid a
         # separate existence probe: it could fail open or race with the write.
+        # It is also a user-initiated rewind, so keep the superseded live turn
+        # recoverable instead of hard-deleting its assistant/tool trail.
         truncated = history[:last_user_idx]
-        await self.async_session_store.rewrite_transcript(
-            session_entry.session_id, truncated, active_only=True
+        persisted = await self.async_session_store.rewrite_transcript(
+            session_entry.session_id,
+            truncated,
+            active_only=True,
+            archive_dropped=True,
+            expected_active_ids=[
+                msg["_row_id"] for msg in history if "_row_id" in msg
+            ],
         )
+        if not persisted:
+            return "Retry failed: conversation history could not be persisted."
         # Reset stored token count — transcript was truncated
         session_entry.last_prompt_tokens = 0
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11114,15 +11114,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         archived. ``message_count``/``tool_call_count`` then track the live set,
         matching :meth:`archive_and_compact`.
 
-        Pass ``archive_dropped=True`` for a prefix-preserving durable rewind.
-        The retained prefix keeps its existing row ids; only the active suffix
-        absent from ``messages`` is marked ``active = 0, compacted = 0``. This
-        avoids copying retained rows into both inactive and active history.
-        ``messages`` must therefore be an exact prefix of the active transcript.
-        ``expected_active_ids`` optionally pins the complete active snapshot so
-        a concurrent append/rewrite fails closed instead of being rewound by a
-        stale request. Both validation and the suffix update happen in the same
-        write transaction.
+        Pass ``archive_dropped=True`` to keep replaced live rows recoverable as
+        ``active = 0, compacted = 0``. Without ``expected_active_ids`` this
+        archives the complete live set and inserts ``messages`` as fresh rows,
+        preserving the TUI row-id recovery contract for verified non-prefix
+        replacements.
+
+        Supplying ``expected_active_ids`` selects the stricter prefix-preserving
+        mode used by gateway ``/retry``. It pins the complete active snapshot,
+        requires ``messages`` to be its exact prefix, keeps retained row ids,
+        and archives only the omitted suffix. Validation and mutation happen in
+        the same write transaction so a stale retry fails closed.
 
         Pass ``reject_active_turn_lease=True`` for user-initiated rewrites that
         do not already own the cross-process turn lease. The lease check and
@@ -11152,14 +11154,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     and session["end_reason"] == "compression"
                 ):
                     raise CompressionSessionClosedError(session_id)
-            if archive_dropped:
+            if archive_dropped and expected_active_ids is not None:
                 rows = conn.execute(
                     f"SELECT {self._CONVERSATION_ROW_COLUMNS} "
                     "FROM messages WHERE session_id = ? AND active = 1 ORDER BY id",
                     (session_id,),
                 ).fetchall()
                 active_ids = [int(row["id"]) for row in rows]
-                if expected_active_ids is not None and active_ids != expected_active_ids:
+                if active_ids != expected_active_ids:
                     raise RuntimeError(
                         "active transcript changed during durable rewrite"
                     )
@@ -11223,6 +11225,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     (len(messages), tool_call_count, session_id),
                 )
                 return
+            elif archive_dropped:
+                # Compatibility mode for verified TUI replacements whose live
+                # ordering is not a byte-for-byte durable prefix.
+                conn.execute(
+                    "UPDATE messages SET active = 0, compacted = 0 "
+                    "WHERE session_id = ? AND active = 1",
+                    (session_id,),
+                )
             else:
                 conn.execute(
                     f"DELETE FROM messages WHERE session_id = ?{active_clause}",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11215,9 +11215,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     )
 
                 tool_call_count = sum(
-                    len(msg["tool_calls"])
+                    len(tool_calls) if isinstance(tool_calls, list) else 1
                     for msg in projected[: len(messages)]
-                    if isinstance(msg.get("tool_calls"), list)
+                    if (tool_calls := msg.get("tool_calls")) is not None
                 )
                 conn.execute(
                     "UPDATE sessions SET message_count = ?, tool_call_count = ? "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6828,13 +6828,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     )
                     total_messages += len(tail_ids)
                     for r in tail_rows:
-                        raw = r["tool_calls"]
-                        if raw:
-                            try:
-                                parsed = json.loads(raw) if isinstance(raw, str) else raw
-                                total_tool_calls += len(parsed) if isinstance(parsed, list) else 0
-                            except (TypeError, ValueError):
-                                pass
+                        total_tool_calls += self._tool_calls_json_and_count(
+                            r["tool_calls"]
+                        )[1]
             conn.execute(
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
                 (total_messages, total_tool_calls, child_session_id),
@@ -10522,6 +10518,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return value
         return json.dumps(value)
 
+    @staticmethod
+    def _tool_calls_json_and_count(value: Any) -> tuple[Optional[str], int]:
+        """Return the canonical persisted form and aggregate count.
+
+        ``tool_calls`` accepts decoded values and JSON text because live writes,
+        imports, forks, and rewrites all share the same insertion paths. Empty or
+        invalid values are normalized to SQL NULL and therefore count as zero;
+        non-empty lists count their entries, while a legacy non-list JSON value
+        is one call. Keeping both outputs together prevents counters from
+        describing data that was not actually persisted.
+        """
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                return None, 0
+        if not value:
+            return None, 0
+        return json.dumps(value), len(value) if isinstance(value, list) else 1
+
     def append_message(
         self,
         session_id: str,
@@ -10576,15 +10592,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         reasoning_details_json = self._reasoning_json_text(reasoning_details)
         codex_items_json = self._reasoning_json_text(codex_reasoning_items)
         codex_message_items_json = self._reasoning_json_text(codex_message_items)
-        # tool_calls may arrive as a Python list (from the live agent) or
-        # as a JSON string (from import/export). Parse first to avoid
-        # double-encoding.
-        if isinstance(tool_calls, str):
-            try:
-                tool_calls = json.loads(tool_calls)
-            except (json.JSONDecodeError, TypeError):
-                tool_calls = []
-        tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        tool_calls_json, num_tool_calls = self._tool_calls_json_and_count(tool_calls)
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
         stored_content = self._encode_content(content)
@@ -10598,11 +10606,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     message_timestamp = float(timestamp)
             except (TypeError, ValueError):
                 logger.debug("Ignoring invalid explicit message timestamp: %r", timestamp)
-
-        # Pre-compute tool call count
-        num_tool_calls = 0
-        if tool_calls is not None:
-            num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
 
         def _do(conn):
             self._check_transcript_write_guards(
@@ -11005,7 +11008,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         tool_calls_total = 0
         for msg in messages:
             role = msg.get("role", "unknown")
-            tool_calls = msg.get("tool_calls")
+            tool_calls_json, tool_call_count = self._tool_calls_json_and_count(
+                msg.get("tool_calls")
+            )
             message_timestamp = now_ts
             if msg.get("timestamp") is not None:
                 try:
@@ -11026,16 +11031,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             reasoning_details_json = self._reasoning_json_text(reasoning_details)
             codex_items_json = self._reasoning_json_text(codex_reasoning_items)
             codex_message_items_json = self._reasoning_json_text(codex_message_items)
-            # tool_calls may arrive as a Python list (from the live agent)
-            # or as a JSON string (from import_sessions / export_session,
-            # which store it as TEXT). json.dumps on an already-serialized
-            # string double-encodes it, so parse first.
-            if isinstance(tool_calls, str):
-                try:
-                    tool_calls = json.loads(tool_calls)
-                except (json.JSONDecodeError, TypeError):
-                    tool_calls = []
-            tool_calls_json = json.dumps(tool_calls) if tool_calls else None
             # Accept either `platform_message_id` (new explicit name) or
             # `message_id` (yuanbao's existing convention on message dicts).
             platform_msg_id = (
@@ -11078,10 +11073,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if isinstance(msg, dict) and cur.lastrowid is not None:
                 msg["_row_id"] = cur.lastrowid
             inserted += 1
-            if tool_calls is not None:
-                tool_calls_total += (
-                    len(tool_calls) if isinstance(tool_calls, list) else 1
-                )
+            tool_calls_total += tool_call_count
             now_ts = max(now_ts + 1e-6, message_timestamp + 1e-6)
         return inserted, tool_calls_total
 
@@ -11215,9 +11207,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     )
 
                 tool_call_count = sum(
-                    len(tool_calls) if isinstance(tool_calls, list) else 1
+                    self._tool_calls_json_and_count(msg.get("tool_calls"))[1]
                     for msg in projected[: len(messages)]
-                    if (tool_calls := msg.get("tool_calls")) is not None
                 )
                 conn.execute(
                     "UPDATE sessions SET message_count = ?, tool_call_count = ? "
@@ -11377,13 +11368,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     (session_id, int(watermark)),
                 ).fetchall():
                     tail_ids.append(int(row["id"]))
-                    raw = row["tool_calls"]
-                    if raw:
-                        try:
-                            parsed = json.loads(raw) if isinstance(raw, str) else raw
-                            tail_tool_calls += len(parsed) if isinstance(parsed, list) else 0
-                        except (TypeError, ValueError):
-                            pass
+                    tail_tool_calls += self._tool_calls_json_and_count(
+                        row["tool_calls"]
+                    )[1]
 
             # Soft-archive the live turns: active=0 hides them from the live
             # context load, compacted=1 marks them as "summarized away" (vs

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11091,6 +11091,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         messages: List[Dict[str, Any]],
         active_only: bool = False,
         archive_dropped: bool = False,
+        expected_active_ids: Optional[List[int]] = None,
         reject_active_turn_lease: bool = False,
     ) -> None:
         """Atomically replace the stored messages for a session.
@@ -11113,19 +11114,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         archived. ``message_count``/``tool_call_count`` then track the live set,
         matching :meth:`archive_and_compact`.
 
-        Pass ``archive_dropped=True`` to SOFT-archive the live rows instead of
-        DELETEing them: the replaced turns stay on disk with ``active = 0``,
-        ``compacted = 0`` — the same "the user took it back" marking
-        :meth:`rewind_to_message` applies — and stay readable via
-        :meth:`get_messages` with ``include_inactive=True``. This is the mode a
-        rewind/edit/regenerate must use: those flows overwrite a transcript the
-        user may not have meant to drop, and a plain DELETE also evicts the rows
-        from the FTS index, leaving nothing to recover from (#82756). It implies
-        active-only handling — already-archived rows are never touched — so
-        ``active_only`` is redundant with it. The rewritten set is inserted as
-        fresh active rows exactly as in the destructive path, so the live view
-        is identical either way; only the durability of the dropped turns
-        differs.
+        Pass ``archive_dropped=True`` for a prefix-preserving durable rewind.
+        The retained prefix keeps its existing row ids; only the active suffix
+        absent from ``messages`` is marked ``active = 0, compacted = 0``. This
+        avoids copying retained rows into both inactive and active history.
+        ``messages`` must therefore be an exact prefix of the active transcript.
+        ``expected_active_ids`` optionally pins the complete active snapshot so
+        a concurrent append/rewrite fails closed instead of being rewound by a
+        stale request. Both validation and the suffix update happen in the same
+        write transaction.
 
         Pass ``reject_active_turn_lease=True`` for user-initiated rewrites that
         do not already own the cross-process turn lease. The lease check and
@@ -11156,16 +11153,76 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ):
                     raise CompressionSessionClosedError(session_id)
             if archive_dropped:
-                # Content-preserving UPDATE: the rows keep their FTS entries
-                # (the messages_fts triggers fire on INSERT / DELETE / UPDATE
-                # of content columns, not on `active`), so the replaced turns
-                # stay readable via get_messages(include_inactive=True) and
-                # searchable with include_inactive=True after the rewrite.
-                conn.execute(
-                    "UPDATE messages SET active = 0 "
-                    "WHERE session_id = ? AND active = 1",
+                rows = conn.execute(
+                    f"SELECT {self._CONVERSATION_ROW_COLUMNS} "
+                    "FROM messages WHERE session_id = ? AND active = 1 ORDER BY id",
                     (session_id,),
+                ).fetchall()
+                active_ids = [int(row["id"]) for row in rows]
+                if expected_active_ids is not None and active_ids != expected_active_ids:
+                    raise RuntimeError(
+                        "active transcript changed during durable rewrite"
+                    )
+
+                projected = self._rows_to_conversation(
+                    rows,
+                    session_id=session_id,
+                    include_ancestors=False,
+                    repair_alternation=False,
+                    include_row_ids=True,
                 )
+                projected_ids = [msg.get("_row_id") for msg in projected]
+                if projected_ids != active_ids:
+                    raise RuntimeError(
+                        "active transcript cannot be mapped losslessly for durable rewrite"
+                    )
+                if len(messages) > len(projected):
+                    raise ValueError("durable rewrite is not an active transcript prefix")
+
+                ignored_keys = {
+                    "id",
+                    "session_id",
+                    "active",
+                    "compacted",
+                    "token_count",
+                }
+                for index, expected in enumerate(messages):
+                    actual = projected[index]
+                    row_id = expected.get("_row_id")
+                    if row_id is not None and row_id != actual.get("_row_id"):
+                        raise RuntimeError(
+                            "durable rewrite retained prefix identity changed"
+                        )
+                    for key, value in expected.items():
+                        if key == "_row_id" or key in ignored_keys:
+                            continue
+                        if actual.get(key) != value:
+                            raise ValueError(
+                                "durable rewrite is not an active transcript prefix"
+                            )
+
+                dropped_ids = active_ids[len(messages) :]
+                if dropped_ids:
+                    placeholders = ",".join("?" for _ in dropped_ids)
+                    # Preserve content/FTS entries while marking only the suffix
+                    # as user-abandoned retry history, not compacted history.
+                    conn.execute(
+                        f"UPDATE messages SET active = 0, compacted = 0 "
+                        f"WHERE id IN ({placeholders})",
+                        dropped_ids,
+                    )
+
+                tool_call_count = sum(
+                    len(msg["tool_calls"])
+                    for msg in projected[: len(messages)]
+                    if isinstance(msg.get("tool_calls"), list)
+                )
+                conn.execute(
+                    "UPDATE sessions SET message_count = ?, tool_call_count = ? "
+                    "WHERE id = ?",
+                    (len(messages), tool_call_count, session_id),
+                )
+                return
             else:
                 conn.execute(
                     f"DELETE FROM messages WHERE session_id = ?{active_clause}",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8190,6 +8190,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         messages: List[Dict[str, Any]],
         active_only: bool = False,
         archive_dropped: bool = False,
+        expected_active_ids: Optional[List[int]] = None,
     ) -> None:
         """Atomically replace the stored messages for a session.
 
@@ -8211,19 +8212,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         archived. ``message_count``/``tool_call_count`` then track the live set,
         matching :meth:`archive_and_compact`.
 
-        Pass ``archive_dropped=True`` to SOFT-archive the live rows instead of
-        DELETEing them: the replaced turns stay on disk with ``active = 0``,
-        ``compacted = 0`` — the same "the user took it back" marking
-        :meth:`rewind_to_message` applies — and stay readable via
-        :meth:`get_messages` with ``include_inactive=True``. This is the mode a
-        rewind/edit/regenerate must use: those flows overwrite a transcript the
-        user may not have meant to drop, and a plain DELETE also evicts the rows
-        from the FTS index, leaving nothing to recover from (#82756). It implies
-        active-only handling — already-archived rows are never touched — so
-        ``active_only`` is redundant with it. The rewritten set is inserted as
-        fresh active rows exactly as in the destructive path, so the live view
-        is identical either way; only the durability of the dropped turns
-        differs.
+        Pass ``archive_dropped=True`` for a prefix-preserving durable rewind.
+        The retained prefix keeps its existing row ids; only the active suffix
+        absent from ``messages`` is marked ``active = 0, compacted = 0``. This
+        avoids copying retained rows into both inactive and active history.
+        ``messages`` must therefore be an exact prefix of the active transcript.
+        ``expected_active_ids`` optionally pins the complete active snapshot so
+        a concurrent append/rewrite fails closed instead of being rewound by a
+        stale request. Both validation and the suffix update happen in the same
+        write transaction.
         """
 
         active_clause = " AND active = 1" if active_only else ""
@@ -8240,16 +8237,76 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ):
                 raise CompressionSessionClosedError(session_id)
             if archive_dropped:
-                # Content-preserving UPDATE: the rows keep their FTS entries
-                # (the messages_fts triggers fire on INSERT / DELETE / UPDATE
-                # of content columns, not on `active`), so the replaced turns
-                # stay readable via get_messages(include_inactive=True) and
-                # searchable with include_inactive=True after the rewrite.
-                conn.execute(
-                    "UPDATE messages SET active = 0 "
-                    "WHERE session_id = ? AND active = 1",
+                rows = conn.execute(
+                    f"SELECT {self._CONVERSATION_ROW_COLUMNS} "
+                    "FROM messages WHERE session_id = ? AND active = 1 ORDER BY id",
                     (session_id,),
+                ).fetchall()
+                active_ids = [int(row["id"]) for row in rows]
+                if expected_active_ids is not None and active_ids != expected_active_ids:
+                    raise RuntimeError(
+                        "active transcript changed during durable rewrite"
+                    )
+
+                projected = self._rows_to_conversation(
+                    rows,
+                    session_id=session_id,
+                    include_ancestors=False,
+                    repair_alternation=False,
+                    include_row_ids=True,
                 )
+                projected_ids = [msg.get("_row_id") for msg in projected]
+                if projected_ids != active_ids:
+                    raise RuntimeError(
+                        "active transcript cannot be mapped losslessly for durable rewrite"
+                    )
+                if len(messages) > len(projected):
+                    raise ValueError("durable rewrite is not an active transcript prefix")
+
+                ignored_keys = {
+                    "id",
+                    "session_id",
+                    "active",
+                    "compacted",
+                    "token_count",
+                }
+                for index, expected in enumerate(messages):
+                    actual = projected[index]
+                    row_id = expected.get("_row_id")
+                    if row_id is not None and row_id != actual.get("_row_id"):
+                        raise RuntimeError(
+                            "durable rewrite retained prefix identity changed"
+                        )
+                    for key, value in expected.items():
+                        if key == "_row_id" or key in ignored_keys:
+                            continue
+                        if actual.get(key) != value:
+                            raise ValueError(
+                                "durable rewrite is not an active transcript prefix"
+                            )
+
+                dropped_ids = active_ids[len(messages) :]
+                if dropped_ids:
+                    placeholders = ",".join("?" for _ in dropped_ids)
+                    # Preserve content/FTS entries while marking only the suffix
+                    # as user-abandoned retry history, not compacted history.
+                    conn.execute(
+                        f"UPDATE messages SET active = 0, compacted = 0 "
+                        f"WHERE id IN ({placeholders})",
+                        dropped_ids,
+                    )
+
+                tool_call_count = sum(
+                    len(msg["tool_calls"])
+                    for msg in projected[: len(messages)]
+                    if isinstance(msg.get("tool_calls"), list)
+                )
+                conn.execute(
+                    "UPDATE sessions SET message_count = ?, tool_call_count = ? "
+                    "WHERE id = ?",
+                    (len(messages), tool_call_count, session_id),
+                )
+                return
             else:
                 conn.execute(
                     f"DELETE FROM messages WHERE session_id = ?{active_clause}",

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -131,7 +131,7 @@ async def test_retry_preserves_channel_prompt(monkeypatch):
     runner = _make_runner()
     runner.session_store = SimpleNamespace(
         get_or_create_session=lambda source: SimpleNamespace(session_id="session-1", last_prompt_tokens=10),
-        load_transcript=lambda session_id: [
+        load_transcript=lambda session_id, **kwargs: [
             {"role": "user", "content": "original message"},
             {"role": "assistant", "content": "old reply"},
         ],

--- a/tests/gateway/test_retry_replacement.py
+++ b/tests/gateway/test_retry_replacement.py
@@ -222,7 +222,9 @@ def test_transcript_mutation_serializes_pending_queue_drain(
 
 
 @pytest.mark.asyncio
-async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path, monkeypatch):
+async def test_gateway_retry_archives_superseded_turn_and_replaces_active_transcript(
+    tmp_path, monkeypatch
+):
     # Pin DEFAULT_DB_PATH so SessionDB() doesn't write to the real ~/.hermes/state.db.
     # (Module-level constant snapshot, see test_load_transcript_db_only.)
     import hermes_state
@@ -230,14 +232,33 @@ async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path, mon
 
     config = GatewayConfig()
     store = SessionStore(sessions_dir=tmp_path, config=config)
+    db = store._db
+    assert db is not None
 
     session_id = "retry_session"
-    store._db.create_session(session_id=session_id, source="test")
+    db.create_session(session_id=session_id, source="test")
     for msg in [
         {"role": "session_meta", "tools": []},
         {"role": "user", "content": "first question"},
         {"role": "assistant", "content": "first answer"},
         {"role": "user", "content": "retry me"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "old-call",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "content": "old tool result",
+            "tool_name": "lookup",
+            "tool_call_id": "old-call",
+        },
         {"role": "assistant", "content": "old answer"},
     ]:
         store.append_to_transcript(session_id, msg)
@@ -250,23 +271,29 @@ async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path, mon
     session_entry.last_prompt_tokens = 111
     gw.session_store.get_or_create_session = MagicMock(return_value=session_entry)
 
+    retry_answers = iter(("new answer", "newer answer"))
+
     async def fake_handle_message(event):
         assert event.text == "retry me"
         transcript_before = store.load_transcript(session_id)
         assert [m.get("content") for m in transcript_before if m.get("role") == "user"] == [
             "first question"
         ]
+        answer = next(retry_answers)
         store.append_to_transcript(session_id, {"role": "user", "content": event.text})
-        store.append_to_transcript(session_id, {"role": "assistant", "content": "new answer"})
-        return "new answer"
+        store.append_to_transcript(session_id, {"role": "assistant", "content": answer})
+        return answer
 
     gw._handle_message = AsyncMock(side_effect=fake_handle_message)
 
-    result = await gw._handle_retry_command(
-        MessageEvent(text="/retry", message_type=MessageType.TEXT, source=MagicMock())
+    retry_event = MessageEvent(
+        text="/retry", message_type=MessageType.TEXT, source=MagicMock()
     )
+    first_result = await gw._handle_retry_command(retry_event)
+    result = await gw._handle_retry_command(retry_event)
 
-    assert result == "new answer"
+    assert first_result == "new answer"
+    assert result == "newer answer"
     transcript_after = store.load_transcript(session_id)
     assert [m.get("content") for m in transcript_after if m.get("role") == "user"] == [
         "first question",
@@ -274,8 +301,78 @@ async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path, mon
     ]
     assert [m.get("content") for m in transcript_after if m.get("role") == "assistant"] == [
         "first answer",
-        "new answer",
+        "newer answer",
     ]
+
+    # /retry's active transcript stays ordered exactly as before, while the
+    # complete superseded user/assistant/tool trail remains recoverable as
+    # rewind-style inactive rows. Repeating /retry archives only the newly
+    # superseded delta and never copies the retained prefix into the archive.
+    inactive = [
+        m
+        for m in db.get_messages(session_id, include_inactive=True)
+        if not m["active"]
+    ]
+    assert [(m["role"], m["content"]) for m in inactive] == [
+        ("user", "retry me"),
+        ("assistant", None),
+        ("tool", "old tool result"),
+        ("assistant", "old answer"),
+        ("user", "retry me"),
+        ("assistant", "new answer"),
+    ]
+    assert inactive[1]["tool_calls"][0]["id"] == "old-call"
+    assert inactive[2]["tool_call_id"] == "old-call"
+    assert all(m["compacted"] == 0 for m in inactive)
+    assert not any(
+        m["content"] in {"first question", "first answer"} for m in inactive
+    ), "retained prefix rows must never be copied into inactive history"
+
+
+@pytest.mark.asyncio
+async def test_gateway_retry_aborts_when_canonical_rewrite_fails(tmp_path, monkeypatch):
+    """A failed durable rewind leaves memory, disk, and model state untouched."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    config = GatewayConfig()
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+    db = store._db
+    assert db is not None
+
+    session_id = "retry_write_failure"
+    db.create_session(session_id=session_id, source="test")
+    db.append_messages_batch(
+        session_id,
+        [
+            {"role": "user", "content": "retry me"},
+            {"role": "assistant", "content": "keep this answer"},
+        ],
+    )
+    before = db.get_messages(session_id, include_inactive=True)
+
+    gw = GatewayRunner.__new__(GatewayRunner)
+    gw.config = config
+    gw.session_store = store
+    session_entry = MagicMock(session_id=session_id)
+    session_entry.last_prompt_tokens = 111
+    gw.session_store.get_or_create_session = MagicMock(return_value=session_entry)
+    gw._handle_message = AsyncMock(return_value="must not be sent")
+
+    monkeypatch.setattr(
+        db,
+        "replace_messages",
+        MagicMock(side_effect=OSError("simulated state.db write failure")),
+    )
+
+    result = await gw._handle_retry_command(
+        MessageEvent(text="/retry", message_type=MessageType.TEXT, source=MagicMock())
+    )
+
+    assert "failed" in result.lower()
+    assert session_entry.last_prompt_tokens == 111
+    gw._handle_message.assert_not_awaited()
+    assert db.get_messages(session_id, include_inactive=True) == before
 
 
 @pytest.mark.asyncio
@@ -521,14 +618,16 @@ async def test_gateway_retry_preserves_archived_compaction_rows_when_probe_fails
 
     config = GatewayConfig()
     store = SessionStore(sessions_dir=tmp_path, config=config)
+    db = store._db
+    assert db is not None
 
     session_id = "retry_archived_session"
-    store._db.create_session(session_id=session_id, source="test")
-    store._db.append_message(session_id=session_id, role="user", content="old question")
-    store._db.append_message(session_id=session_id, role="assistant", content="old answer")
+    db.create_session(session_id=session_id, source="test")
+    db.append_message(session_id=session_id, role="user", content="old question")
+    db.append_message(session_id=session_id, role="assistant", content="old answer")
     # In-place compaction: the two rows above are soft-archived and the
     # compacted transcript becomes the live set under the same id.
-    store._db.archive_and_compact(
+    db.archive_and_compact(
         session_id,
         [
             {"role": "user", "content": "first question"},
@@ -537,12 +636,12 @@ async def test_gateway_retry_preserves_archived_compaction_rows_when_probe_fails
             {"role": "assistant", "content": "old answer"},
         ],
     )
-    assert store._db.has_archived_messages(session_id) is True
+    assert db.has_archived_messages(session_id) is True
 
     # A failed preflight lookup must not turn this data-preservation path back
     # into a destructive full-history rewrite. The write itself still works.
     archived_probe = MagicMock(side_effect=OSError("transient archive lookup failure"))
-    monkeypatch.setattr(store._db, "has_archived_messages", archived_probe)
+    monkeypatch.setattr(db, "has_archived_messages", archived_probe)
 
     gw = GatewayRunner.__new__(GatewayRunner)
     gw.config = config
@@ -566,16 +665,22 @@ async def test_gateway_retry_preserves_archived_compaction_rows_when_probe_fails
 
     assert result == "new answer"
     archived_probe.assert_not_called()
-    # The archived pre-compaction rows survive the rewrite untouched.
-    archived = [
-        m for m in store._db.get_messages(session_id, include_inactive=True)
+    # The complete inactive set is stable: pre-compaction rows stay discoverable
+    # with compacted=1, while only the superseded retry suffix uses compacted=0.
+    inactive = [
+        m
+        for m in db.get_messages(session_id, include_inactive=True)
         if not m["active"]
     ]
-    assert [(m["role"], m["content"]) for m in archived] == [
-        ("user", "old question"),
-        ("assistant", "old answer"),
+    assert [(m["role"], m["content"], m["compacted"]) for m in inactive] == [
+        ("user", "old question", 1),
+        ("assistant", "old answer", 1),
+        ("user", "retry me", 0),
+        ("assistant", "old answer", 0),
     ]
-    assert all(m["compacted"] == 1 for m in archived)
+    assert not any(
+        m["content"] in {"first question", "first answer"} for m in inactive
+    )
     # The live set reflects the truncation plus the retried exchange.
     transcript_after = store.load_transcript(session_id)
     assert [m.get("content") for m in transcript_after if m.get("role") == "user"] == [

--- a/tests/gateway/test_retry_replacement.py
+++ b/tests/gateway/test_retry_replacement.py
@@ -376,6 +376,65 @@ async def test_gateway_retry_aborts_when_canonical_rewrite_fails(tmp_path, monke
 
 
 @pytest.mark.asyncio
+async def test_gateway_retry_uses_unrepaired_durable_snapshot(tmp_path, monkeypatch):
+    """A persisted role wedge must not synthesize rows before durable rewind."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    config = GatewayConfig()
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+    db = store._db
+    assert db is not None
+
+    session_id = "retry_unrepaired_snapshot"
+    db.create_session(session_id=session_id, source="test")
+    db.append_messages_batch(
+        session_id,
+        [
+            {"role": "user", "content": "first"},
+            {"role": "user", "content": "retry me"},
+            {"role": "assistant", "content": "superseded"},
+        ],
+    )
+    assert len(store.load_transcript(session_id)) == 2
+    assert len(store.load_transcript(session_id, repair_alternation=False)) == 3
+
+    gw = GatewayRunner.__new__(GatewayRunner)
+    gw.config = config
+    gw.session_store = store
+    session_entry = MagicMock(session_id=session_id, last_prompt_tokens=111)
+    gw.session_store.get_or_create_session = MagicMock(return_value=session_entry)
+
+    async def fake_handle_message(event):
+        store.append_to_transcript(
+            session_id, {"role": "user", "content": event.text}
+        )
+        store.append_to_transcript(
+            session_id, {"role": "assistant", "content": "replacement"}
+        )
+        return "replacement"
+
+    gw._handle_message = AsyncMock(side_effect=fake_handle_message)
+    result = await gw._handle_retry_command(
+        MessageEvent(text="/retry", message_type=MessageType.TEXT, source=MagicMock())
+    )
+
+    assert result == "replacement"
+    assert [(m["role"], m["content"]) for m in db.get_messages(session_id)] == [
+        ("user", "first"),
+        ("user", "retry me"),
+        ("assistant", "replacement"),
+    ]
+    inactive = [
+        m for m in db.get_messages(session_id, include_inactive=True) if not m["active"]
+    ]
+    assert [(m["role"], m["content"]) for m in inactive] == [
+        ("user", "retry me"),
+        ("assistant", "superseded"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_gateway_retry_redispatches_live_carrier_text_and_keeps_scaffold(
     tmp_path, monkeypatch
 ):

--- a/tests/gateway/test_retry_replacement.py
+++ b/tests/gateway/test_retry_replacement.py
@@ -11,7 +11,9 @@ from gateway.session import SessionStore
 
 
 @pytest.mark.asyncio
-async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path, monkeypatch):
+async def test_gateway_retry_archives_superseded_turn_and_replaces_active_transcript(
+    tmp_path, monkeypatch
+):
     # Pin DEFAULT_DB_PATH so SessionDB() doesn't write to the real ~/.hermes/state.db.
     # (Module-level constant snapshot, see test_load_transcript_db_only.)
     import hermes_state
@@ -19,14 +21,33 @@ async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path, mon
 
     config = GatewayConfig()
     store = SessionStore(sessions_dir=tmp_path, config=config)
+    db = store._db
+    assert db is not None
 
     session_id = "retry_session"
-    store._db.create_session(session_id=session_id, source="test")
+    db.create_session(session_id=session_id, source="test")
     for msg in [
         {"role": "session_meta", "tools": []},
         {"role": "user", "content": "first question"},
         {"role": "assistant", "content": "first answer"},
         {"role": "user", "content": "retry me"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "old-call",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "content": "old tool result",
+            "tool_name": "lookup",
+            "tool_call_id": "old-call",
+        },
         {"role": "assistant", "content": "old answer"},
     ]:
         store.append_to_transcript(session_id, msg)
@@ -39,23 +60,29 @@ async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path, mon
     session_entry.last_prompt_tokens = 111
     gw.session_store.get_or_create_session = MagicMock(return_value=session_entry)
 
+    retry_answers = iter(("new answer", "newer answer"))
+
     async def fake_handle_message(event):
         assert event.text == "retry me"
         transcript_before = store.load_transcript(session_id)
         assert [m.get("content") for m in transcript_before if m.get("role") == "user"] == [
             "first question"
         ]
+        answer = next(retry_answers)
         store.append_to_transcript(session_id, {"role": "user", "content": event.text})
-        store.append_to_transcript(session_id, {"role": "assistant", "content": "new answer"})
-        return "new answer"
+        store.append_to_transcript(session_id, {"role": "assistant", "content": answer})
+        return answer
 
     gw._handle_message = AsyncMock(side_effect=fake_handle_message)
 
-    result = await gw._handle_retry_command(
-        MessageEvent(text="/retry", message_type=MessageType.TEXT, source=MagicMock())
+    retry_event = MessageEvent(
+        text="/retry", message_type=MessageType.TEXT, source=MagicMock()
     )
+    first_result = await gw._handle_retry_command(retry_event)
+    result = await gw._handle_retry_command(retry_event)
 
-    assert result == "new answer"
+    assert first_result == "new answer"
+    assert result == "newer answer"
     transcript_after = store.load_transcript(session_id)
     assert [m.get("content") for m in transcript_after if m.get("role") == "user"] == [
         "first question",
@@ -63,8 +90,78 @@ async def test_gateway_retry_replaces_last_user_turn_in_transcript(tmp_path, mon
     ]
     assert [m.get("content") for m in transcript_after if m.get("role") == "assistant"] == [
         "first answer",
-        "new answer",
+        "newer answer",
     ]
+
+    # /retry's active transcript stays ordered exactly as before, while the
+    # complete superseded user/assistant/tool trail remains recoverable as
+    # rewind-style inactive rows. Repeating /retry archives only the newly
+    # superseded delta and never copies the retained prefix into the archive.
+    inactive = [
+        m
+        for m in db.get_messages(session_id, include_inactive=True)
+        if not m["active"]
+    ]
+    assert [(m["role"], m["content"]) for m in inactive] == [
+        ("user", "retry me"),
+        ("assistant", None),
+        ("tool", "old tool result"),
+        ("assistant", "old answer"),
+        ("user", "retry me"),
+        ("assistant", "new answer"),
+    ]
+    assert inactive[1]["tool_calls"][0]["id"] == "old-call"
+    assert inactive[2]["tool_call_id"] == "old-call"
+    assert all(m["compacted"] == 0 for m in inactive)
+    assert not any(
+        m["content"] in {"first question", "first answer"} for m in inactive
+    ), "retained prefix rows must never be copied into inactive history"
+
+
+@pytest.mark.asyncio
+async def test_gateway_retry_aborts_when_canonical_rewrite_fails(tmp_path, monkeypatch):
+    """A failed durable rewind leaves memory, disk, and model state untouched."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    config = GatewayConfig()
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+    db = store._db
+    assert db is not None
+
+    session_id = "retry_write_failure"
+    db.create_session(session_id=session_id, source="test")
+    db.append_messages_batch(
+        session_id,
+        [
+            {"role": "user", "content": "retry me"},
+            {"role": "assistant", "content": "keep this answer"},
+        ],
+    )
+    before = db.get_messages(session_id, include_inactive=True)
+
+    gw = GatewayRunner.__new__(GatewayRunner)
+    gw.config = config
+    gw.session_store = store
+    session_entry = MagicMock(session_id=session_id)
+    session_entry.last_prompt_tokens = 111
+    gw.session_store.get_or_create_session = MagicMock(return_value=session_entry)
+    gw._handle_message = AsyncMock(return_value="must not be sent")
+
+    monkeypatch.setattr(
+        db,
+        "replace_messages",
+        MagicMock(side_effect=OSError("simulated state.db write failure")),
+    )
+
+    result = await gw._handle_retry_command(
+        MessageEvent(text="/retry", message_type=MessageType.TEXT, source=MagicMock())
+    )
+
+    assert "failed" in result.lower()
+    assert session_entry.last_prompt_tokens == 111
+    gw._handle_message.assert_not_awaited()
+    assert db.get_messages(session_id, include_inactive=True) == before
 
 
 @pytest.mark.asyncio
@@ -88,14 +185,16 @@ async def test_gateway_retry_preserves_archived_compaction_rows_when_probe_fails
 
     config = GatewayConfig()
     store = SessionStore(sessions_dir=tmp_path, config=config)
+    db = store._db
+    assert db is not None
 
     session_id = "retry_archived_session"
-    store._db.create_session(session_id=session_id, source="test")
-    store._db.append_message(session_id=session_id, role="user", content="old question")
-    store._db.append_message(session_id=session_id, role="assistant", content="old answer")
+    db.create_session(session_id=session_id, source="test")
+    db.append_message(session_id=session_id, role="user", content="old question")
+    db.append_message(session_id=session_id, role="assistant", content="old answer")
     # In-place compaction: the two rows above are soft-archived and the
     # compacted transcript becomes the live set under the same id.
-    store._db.archive_and_compact(
+    db.archive_and_compact(
         session_id,
         [
             {"role": "user", "content": "first question"},
@@ -104,12 +203,12 @@ async def test_gateway_retry_preserves_archived_compaction_rows_when_probe_fails
             {"role": "assistant", "content": "old answer"},
         ],
     )
-    assert store._db.has_archived_messages(session_id) is True
+    assert db.has_archived_messages(session_id) is True
 
     # A failed preflight lookup must not turn this data-preservation path back
     # into a destructive full-history rewrite. The write itself still works.
     archived_probe = MagicMock(side_effect=OSError("transient archive lookup failure"))
-    monkeypatch.setattr(store._db, "has_archived_messages", archived_probe)
+    monkeypatch.setattr(db, "has_archived_messages", archived_probe)
 
     gw = GatewayRunner.__new__(GatewayRunner)
     gw.config = config
@@ -133,16 +232,22 @@ async def test_gateway_retry_preserves_archived_compaction_rows_when_probe_fails
 
     assert result == "new answer"
     archived_probe.assert_not_called()
-    # The archived pre-compaction rows survive the rewrite untouched.
-    archived = [
-        m for m in store._db.get_messages(session_id, include_inactive=True)
+    # The complete inactive set is stable: pre-compaction rows stay discoverable
+    # with compacted=1, while only the superseded retry suffix uses compacted=0.
+    inactive = [
+        m
+        for m in db.get_messages(session_id, include_inactive=True)
         if not m["active"]
     ]
-    assert [(m["role"], m["content"]) for m in archived] == [
-        ("user", "old question"),
-        ("assistant", "old answer"),
+    assert [(m["role"], m["content"], m["compacted"]) for m in inactive] == [
+        ("user", "old question", 1),
+        ("assistant", "old answer", 1),
+        ("user", "retry me", 0),
+        ("assistant", "old answer", 0),
     ]
-    assert all(m["compacted"] == 1 for m in archived)
+    assert not any(
+        m["content"] in {"first question", "first answer"} for m in inactive
+    )
     # The live set reflects the truncation plus the retried exchange.
     transcript_after = store.load_transcript(session_id)
     assert [m.get("content") for m in transcript_after if m.get("role") == "user"] == [

--- a/tests/gateway/test_retry_replacement.py
+++ b/tests/gateway/test_retry_replacement.py
@@ -351,6 +351,14 @@ async def test_gateway_retry_aborts_when_canonical_rewrite_fails(tmp_path, monke
     )
     before = db.get_messages(session_id, include_inactive=True)
 
+    queued = {session_id: [{"role": "user", "content": "pending append"}]}
+    failures = {session_id: 3}
+    store._dirty_transcripts = {
+        key: [dict(message) for message in messages]
+        for key, messages in queued.items()
+    }
+    store._transcript_append_failures = dict(failures)
+
     gw = GatewayRunner.__new__(GatewayRunner)
     gw.config = config
     gw.session_store = store
@@ -373,6 +381,8 @@ async def test_gateway_retry_aborts_when_canonical_rewrite_fails(tmp_path, monke
     assert session_entry.last_prompt_tokens == 111
     gw._handle_message.assert_not_awaited()
     assert db.get_messages(session_id, include_inactive=True) == before
+    assert store._dirty_transcripts == queued
+    assert store._transcript_append_failures == failures
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -411,7 +411,9 @@ class TestSessionStoreRewriteTranscript:
 
     def test_rewrite_replaces_transcript(self, store, tmp_path):
         session_id = "test_session_1"
-        store._db.create_session(session_id=session_id, source="test")
+        db = store._db
+        assert db is not None
+        db.create_session(session_id=session_id, source="test")
         # Write initial transcript
         for msg in [
             {"role": "user", "content": "hello"},
@@ -431,6 +433,11 @@ class TestSessionStoreRewriteTranscript:
         assert len(reloaded) == 2
         assert reloaded[0]["content"] == "hello"
         assert reloaded[1]["content"] == "hi"
+        assert not [
+            message
+            for message in db.get_messages(session_id, include_inactive=True)
+            if not message["active"]
+        ]
 
 
 class TestLoadTranscriptDBOnly:

--- a/tests/hermes_state/test_append_messages_batch.py
+++ b/tests/hermes_state/test_append_messages_batch.py
@@ -81,6 +81,54 @@ class TestAppendMessagesBatch:
         finally:
             db2.close()
 
+    @pytest.mark.parametrize(
+        "tool_calls, expected_value, expected_count",
+        [
+            pytest.param({}, None, 0, id="empty-object"),
+            pytest.param("{}", None, 0, id="json-empty-object"),
+            pytest.param(0, None, 0, id="zero"),
+            pytest.param(False, None, 0, id="false"),
+            pytest.param(None, None, 0, id="null"),
+            pytest.param("null", None, 0, id="json-null"),
+            pytest.param("{not-json", None, 0, id="malformed"),
+            pytest.param(
+                [{"id": "call-1"}, {"id": "call-2"}],
+                [{"id": "call-1"}, {"id": "call-2"}],
+                2,
+                id="list",
+            ),
+            pytest.param(
+                {"id": "call-object"},
+                {"id": "call-object"},
+                1,
+                id="object",
+            ),
+        ],
+    )
+    def test_tool_call_shapes_have_canonical_storage_and_count(
+        self, db, tool_calls, expected_value, expected_count
+    ):
+        db.create_session("sess-single", source="cli")
+        message = {"role": "assistant", "content": "shape", "tool_calls": tool_calls}
+
+        db.append_messages_batch("sess-batch", [message.copy()])
+        db.append_message(
+            "sess-single", role="assistant", content="shape", tool_calls=tool_calls
+        )
+
+        rows = db._conn.execute(
+            "SELECT session_id, tool_calls FROM messages ORDER BY session_id"
+        ).fetchall()
+        assert rows[0]["tool_calls"] == rows[1]["tool_calls"]
+        if expected_value is None:
+            assert rows[0]["tool_calls"] is None
+        else:
+            assert json.loads(rows[0]["tool_calls"]) == expected_value
+        assert db.get_messages("sess-batch")[0]["tool_calls"] == expected_value
+        assert db.get_messages("sess-single")[0]["tool_calls"] == expected_value
+        assert db.get_session("sess-batch")["tool_call_count"] == expected_count
+        assert db.get_session("sess-single")["tool_call_count"] == expected_count
+
     def test_reasoning_gated_to_assistant_rows(self, db):
         """_insert_message_rows role-gates reasoning fields; a tool row
         carrying reasoning keys must not persist them."""

--- a/tests/hermes_state/test_replace_messages_archive_siblings.py
+++ b/tests/hermes_state/test_replace_messages_archive_siblings.py
@@ -183,6 +183,7 @@ class TestArchiveDroppedIsRecoverable:
             ],
         )
         original = state_db.get_messages(sid)
+        original_ids = [m["id"] for m in original]
 
         retained = [
             {"role": "user", "content": "first"},
@@ -193,6 +194,7 @@ class TestArchiveDroppedIsRecoverable:
             retained,
             active_only=True,
             archive_dropped=True,
+            expected_active_ids=original_ids,
         )
 
         all_rows = state_db.get_messages(sid, include_inactive=True)
@@ -218,6 +220,7 @@ class TestArchiveDroppedIsRecoverable:
             retained,
             active_only=True,
             archive_dropped=True,
+            expected_active_ids=original_ids[:2],
         )
         repeated = state_db.get_messages(sid, include_inactive=True)
         assert [(m["id"], m["active"]) for m in repeated] == [
@@ -226,6 +229,54 @@ class TestArchiveDroppedIsRecoverable:
             (original[2]["id"], 0),
             (original[3]["id"], 0),
         ]
+
+    def test_replacement_mode_preserves_tui_row_id_recovery_contract(self, state_db):
+        """Archive-only replacement still accepts verified non-prefix live order.
+
+        TUI row-id recovery can resolve a durable target against live memory
+        whose assistant rows moved around that target. It then persists the
+        verified live prefix and returns fresh survivor ids. Prefix validation
+        belongs only to snapshot-pinned gateway retries; applying it here breaks
+        both role-shift recovery and consecutive rewind rebinding.
+        """
+        sid = "archive-tui-replacement"
+        state_db.create_session(sid, "test")
+        state_db.append_messages_batch(
+            sid,
+            [
+                {"role": "user", "content": "A"},
+                {"role": "assistant", "content": "reply A"},
+                {"role": "user", "content": "B"},
+                {"role": "assistant", "content": "reply B"},
+            ],
+        )
+        original = state_db.get_messages(sid)
+        replacement = [
+            {"role": "user", "content": "A"},
+            {"role": "assistant", "content": "reply A"},
+            {"role": "assistant", "content": "reply B"},
+        ]
+
+        state_db.replace_messages(
+            sid,
+            replacement,
+            active_only=True,
+            archive_dropped=True,
+        )
+
+        active = state_db.get_messages(sid)
+        inactive = [
+            message
+            for message in state_db.get_messages(sid, include_inactive=True)
+            if not message["active"]
+        ]
+        assert [(m["role"], m["content"]) for m in active] == [
+            ("user", "A"),
+            ("assistant", "reply A"),
+            ("assistant", "reply B"),
+        ]
+        assert {m["id"] for m in active}.isdisjoint({m["id"] for m in original})
+        assert [m["id"] for m in inactive] == [m["id"] for m in original]
 
     def test_stale_snapshot_fails_closed_without_partial_rewind(self, state_db):
         sid = "archive-race"

--- a/tests/hermes_state/test_replace_messages_archive_siblings.py
+++ b/tests/hermes_state/test_replace_messages_archive_siblings.py
@@ -182,32 +182,81 @@ class TestArchiveDroppedIsRecoverable:
                 {"role": "assistant", "content": "second reply"},
             ],
         )
+        original = state_db.get_messages(sid)
 
+        retained = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "first reply"},
+        ]
         state_db.replace_messages(
             sid,
-            [
-                {"role": "user", "content": "first"},
-                {"role": "assistant", "content": "first reply"},
-            ],
+            retained,
             active_only=True,
             archive_dropped=True,
         )
 
-        # The live transcript is exactly what a destructive replace would leave.
-        live = [
-            m for m in state_db.get_messages_as_conversation(sid)
-            if m.get("role") in ("user", "assistant")
-        ]
-        assert [m["content"] for m in live] == ["first", "first reply"]
+        all_rows = state_db.get_messages(sid, include_inactive=True)
+        live = [m for m in all_rows if m["active"]]
+        inactive = [m for m in all_rows if not m["active"]]
 
-        # …but the dropped turns are still readable instead of gone.
-        recovered = [
-            m["content"]
-            for m in state_db.get_messages(sid, include_inactive=True)
-            if not m["active"]
+        # Retained rows keep their durable identity; they are not archived and
+        # reinserted as duplicates. Only the actual suffix delta is inactive.
+        assert [(m["id"], m["content"]) for m in live] == [
+            (original[0]["id"], "first"),
+            (original[1]["id"], "first reply"),
         ]
-        assert "second" in recovered
-        assert "second reply" in recovered
+        assert [(m["id"], m["content"]) for m in inactive] == [
+            (original[2]["id"], "second"),
+            (original[3]["id"], "second reply"),
+        ]
+        assert all(m["compacted"] == 0 for m in inactive)
+
+        # Reapplying the same durable prefix is storage-idempotent: no retained
+        # copies and no duplicate inactive suffix appear.
+        state_db.replace_messages(
+            sid,
+            retained,
+            active_only=True,
+            archive_dropped=True,
+        )
+        repeated = state_db.get_messages(sid, include_inactive=True)
+        assert [(m["id"], m["active"]) for m in repeated] == [
+            (original[0]["id"], 1),
+            (original[1]["id"], 1),
+            (original[2]["id"], 0),
+            (original[3]["id"], 0),
+        ]
+
+    def test_stale_snapshot_fails_closed_without_partial_rewind(self, state_db):
+        sid = "archive-race"
+        state_db.create_session(sid, "test")
+        state_db.append_messages_batch(
+            sid,
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "first reply"},
+                {"role": "user", "content": "retry me"},
+                {"role": "assistant", "content": "old reply"},
+            ],
+        )
+        snapshot = state_db.get_messages_as_conversation(sid, include_row_ids=True)
+        expected_ids = [m["_row_id"] for m in snapshot]
+
+        # Simulate an append after /retry loaded history but before its write.
+        state_db.append_message(sid, role="user", content="concurrent turn")
+        before = state_db.get_messages(sid, include_inactive=True)
+
+        with pytest.raises(RuntimeError, match="active transcript changed"):
+            state_db.replace_messages(
+                sid,
+                snapshot[:2],
+                active_only=True,
+                archive_dropped=True,
+                expected_active_ids=expected_ids,
+            )
+
+        assert state_db.get_messages(sid, include_inactive=True) == before
+        assert all(m["active"] for m in before)
 
     def test_archived_rows_use_rewind_marking_not_compaction(self, state_db):
         """compacted=0 keeps abandoned turns out of session search results.

--- a/tests/hermes_state/test_replace_messages_archive_siblings.py
+++ b/tests/hermes_state/test_replace_messages_archive_siblings.py
@@ -230,65 +230,63 @@ class TestArchiveDroppedIsRecoverable:
             (original[3]["id"], 0),
         ]
 
-    def test_retained_object_tool_call_keeps_rows_data_and_counter(self, state_db):
-        """A prefix rewrite must use the same tool-call count as insertion.
-
-        Legacy/imported transcripts can contain one object instead of a list.
-        Insertion counts that non-null object as one call; malformed JSON is
-        normalized away and explicit null contributes zero. Retaining all three
-        shapes must not rewrite rows or change the canonical aggregate.
-        """
-        sid = "archive-object-tool-call"
+    def test_retained_tool_call_shapes_keep_rows_data_and_counter(self, state_db):
+        """Insertion and retained-prefix retry share one tool-call meaning."""
+        sid = "archive-tool-call-shapes"
         state_db.create_session(sid, "test")
+        retained = [
+            {"role": "assistant", "content": "empty object", "tool_calls": {}},
+            {"role": "assistant", "content": "JSON empty object", "tool_calls": "{}"},
+            {"role": "assistant", "content": "zero", "tool_calls": 0},
+            {"role": "assistant", "content": "false", "tool_calls": False},
+            {"role": "assistant", "content": "null", "tool_calls": None},
+            {"role": "assistant", "content": "JSON null", "tool_calls": "null"},
+            {"role": "assistant", "content": "malformed", "tool_calls": "{not-json"},
+            {
+                "role": "assistant",
+                "content": "list",
+                "tool_calls": [{"id": "call-1"}, {"id": "call-2"}],
+            },
+            {
+                "role": "assistant",
+                "content": "object",
+                "tool_calls": {"id": "call-object", "name": "legacy_tool"},
+            },
+        ]
         state_db.append_messages_batch(
             sid,
-            [
-                {
-                    "role": "assistant",
-                    "content": "object call",
-                    "tool_calls": {"id": "call-object", "name": "legacy_tool"},
-                },
-                {
-                    "role": "assistant",
-                    "content": "malformed call",
-                    "tool_calls": "{not-json",
-                },
-                {
-                    "role": "assistant",
-                    "content": "null call",
-                    "tool_calls": None,
-                },
-                {"role": "user", "content": "drop suffix"},
-            ],
+            [*retained, {"role": "user", "content": "drop suffix"}],
         )
         before = state_db.get_messages(sid)
         snapshot = state_db.get_messages_as_conversation(sid, include_row_ids=True)
         expected_ids = [message["id"] for message in before]
 
-        assert before[0]["tool_calls"] == {
+        assert [message["tool_calls"] for message in before[:7]] == [None] * 7
+        assert before[7]["tool_calls"] == [{"id": "call-1"}, {"id": "call-2"}]
+        assert before[8]["tool_calls"] == {
             "id": "call-object",
             "name": "legacy_tool",
         }
-        assert before[1]["tool_calls"] is None
-        assert before[2]["tool_calls"] is None
-        assert state_db.get_session(sid)["tool_call_count"] == 1
+        assert state_db.get_session(sid)["tool_call_count"] == 3
 
         state_db.replace_messages(
             sid,
-            snapshot[:3],
+            snapshot[: len(retained)],
             active_only=True,
             archive_dropped=True,
             expected_active_ids=expected_ids,
         )
 
         after = state_db.get_messages(sid, include_inactive=True)
-        assert after[:3] == before[:3]
-        assert [message["id"] for message in after[:3]] == expected_ids[:3]
-        assert after[3]["id"] == expected_ids[3]
-        assert after[3]["active"] == 0
+        assert after[: len(retained)] == before[: len(retained)]
+        assert [message["id"] for message in after[: len(retained)]] == expected_ids[
+            :-1
+        ]
+        assert after[-1]["id"] == expected_ids[-1]
+        assert after[-1]["active"] == 0
         session = state_db.get_session(sid)
-        assert session["message_count"] == 3
-        assert session["tool_call_count"] == 1
+        assert session["message_count"] == len(retained)
+        assert session["tool_call_count"] == 3
 
     def test_replacement_mode_preserves_tui_row_id_recovery_contract(self, state_db):
         """Archive-only replacement still accepts verified non-prefix live order.

--- a/tests/hermes_state/test_replace_messages_archive_siblings.py
+++ b/tests/hermes_state/test_replace_messages_archive_siblings.py
@@ -230,6 +230,66 @@ class TestArchiveDroppedIsRecoverable:
             (original[3]["id"], 0),
         ]
 
+    def test_retained_object_tool_call_keeps_rows_data_and_counter(self, state_db):
+        """A prefix rewrite must use the same tool-call count as insertion.
+
+        Legacy/imported transcripts can contain one object instead of a list.
+        Insertion counts that non-null object as one call; malformed JSON is
+        normalized away and explicit null contributes zero. Retaining all three
+        shapes must not rewrite rows or change the canonical aggregate.
+        """
+        sid = "archive-object-tool-call"
+        state_db.create_session(sid, "test")
+        state_db.append_messages_batch(
+            sid,
+            [
+                {
+                    "role": "assistant",
+                    "content": "object call",
+                    "tool_calls": {"id": "call-object", "name": "legacy_tool"},
+                },
+                {
+                    "role": "assistant",
+                    "content": "malformed call",
+                    "tool_calls": "{not-json",
+                },
+                {
+                    "role": "assistant",
+                    "content": "null call",
+                    "tool_calls": None,
+                },
+                {"role": "user", "content": "drop suffix"},
+            ],
+        )
+        before = state_db.get_messages(sid)
+        snapshot = state_db.get_messages_as_conversation(sid, include_row_ids=True)
+        expected_ids = [message["id"] for message in before]
+
+        assert before[0]["tool_calls"] == {
+            "id": "call-object",
+            "name": "legacy_tool",
+        }
+        assert before[1]["tool_calls"] is None
+        assert before[2]["tool_calls"] is None
+        assert state_db.get_session(sid)["tool_call_count"] == 1
+
+        state_db.replace_messages(
+            sid,
+            snapshot[:3],
+            active_only=True,
+            archive_dropped=True,
+            expected_active_ids=expected_ids,
+        )
+
+        after = state_db.get_messages(sid, include_inactive=True)
+        assert after[:3] == before[:3]
+        assert [message["id"] for message in after[:3]] == expected_ids[:3]
+        assert after[3]["id"] == expected_ids[3]
+        assert after[3]["active"] == 0
+        session = state_db.get_session(sid)
+        assert session["message_count"] == 3
+        assert session["tool_call_count"] == 1
+
     def test_replacement_mode_preserves_tui_row_id_recovery_contract(self, state_db):
         """Archive-only replacement still accepts verified non-prefix live order.
 

--- a/tests/test_compression_watermark_commit.py
+++ b/tests/test_compression_watermark_commit.py
@@ -141,8 +141,7 @@ class TestWatermarkCommit:
         watermark = db.get_active_message_watermark("sess1")
         db.append_message(
             "sess1", role="assistant", content="tail with tools",
-            tool_calls=[{"id": "t1", "type": "function",
-                         "function": {"name": "x", "arguments": "{}"}}],
+            tool_calls={"id": "t1", "name": "legacy_tool"},
         )
         db.archive_and_compact("sess1", SUMMARY, watermark=watermark)
         info = db.get_session("sess1")
@@ -252,6 +251,12 @@ class TestRotationPathWatermark:
         watermark = db.get_active_message_watermark("sess1")
         assert db.try_acquire_compression_lock("sess1", "rotator") is True
         db.append_message("sess1", role="user", content=tail_content)
+        db.append_message(
+            "sess1",
+            role="assistant",
+            content="mid-rotation tool call",
+            tool_calls={"id": "t1", "name": "legacy_tool"},
+        )
         # Ceiling captured AFTER the foreign append, BEFORE the rotation
         # path's own pre-publish flush (which this test has none of).
         ceiling = db.get_active_message_watermark("sess1")
@@ -272,6 +277,7 @@ class TestRotationPathWatermark:
             SUMMARY[0]["content"],
             SUMMARY[1]["content"],
             tail_content,
+            "mid-rotation tool call",
         ]
         model_history, display_history = db.get_resume_conversations("child1")
         visible_steers = [
@@ -280,13 +286,17 @@ class TestRotationPathWatermark:
             if message.get("content") == tail_content
         ]
         assert len(visible_steers) == 1
-        assert visible_steers[0]["_row_id"] == model_history[-1]["_row_id"]
+        model_steer = next(
+            message for message in model_history if message.get("content") == tail_content
+        )
+        assert visible_steers[0]["_row_id"] == model_steer["_row_id"]
         assert all(
             message.get("content") != tail_content
             for message in db.get_ancestor_display_prefix("child1")
         )
         info = db.get_session("child1")
-        assert info["message_count"] == 3
+        assert info["message_count"] == 4
+        assert info["tool_call_count"] == 1
         # Parent keeps its copy for lineage recovery; parent is closed.
         parent_info = db.get_session("sess1")
         assert parent_info["end_reason"] == "compression"


### PR DESCRIPTION
## What does this PR do?

Makes gateway `/retry` preserve the superseded active turn as inactive rewind history instead of hard-deleting its assistant/tool transcript rows.

`SessionStore.rewrite_transcript()` now exposes the existing `SessionDB.replace_messages(..., archive_dropped=...)` behavior with a destructive-by-default `False` value. Only the user-initiated `/retry` rewind opts into archival, so compression, redaction, and other rewrite callers retain their prior behavior.

## Related Issue

Fixes #82957

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added an `archive_dropped: bool = False` passthrough to `gateway/session.py`.
- Enabled archival only for `/retry` in `gateway/slash_commands.py`.
- Expanded the retry regression test to cover a complete assistant tool-call/tool-result trail, inactive rewind rows, compacted flags, and unchanged active ordering.
- Added a default-behavior assertion proving non-opted-in transcript rewrites remain destructive.
- Preserved existing compacted archive rows while distinguishing newly superseded retry rows (`compacted=0`).

## How to Test

1. Run the focused regression test:
   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_retry_replacement.py -q
   ```
2. Run the related transcript/session/gateway suites:
   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
     tests/gateway/test_retry_replacement.py \
     tests/gateway/test_retry_response.py \
     tests/gateway/test_session.py \
     tests/gateway/test_compress_command.py \
     tests/gateway/test_session_hygiene.py \
     tests/hermes_state/test_replace_messages_archive_siblings.py -q
   ```
3. Run lint and diff checks:
   ```bash
   ruff check gateway/session.py gateway/slash_commands.py tests/gateway/test_retry_replacement.py tests/gateway/test_session.py
   git diff --check HEAD^
   ```

### Verification evidence

- **Refreshed exact candidate:** `3a6ef91cb79c174d3b88592d0ae2f1be431be24c`, rebased onto upstream `main` at `fc9cbc872d8050c22f1192b16bc5ff4aed471e10` on 2026-08-21.
- **RED:** the new behavioral regression failed on unchanged production code because no inactive superseded rows remained (`archived == []`).
- **GREEN:** 107 related retry/session/storage tests passed, 0 failed.
- **TUI regression suite:** all 585 tests in `tests/test_tui_gateway_server.py` passed, including the two previously failing rewind/truncation cases.
- **Mutation check:** changing `/retry` back to `archive_dropped=False` reproduced the regression failure; restoring `True` returned the focused test to green.
- **Ruff:** changed-file lint passed.
- **ty:** the exact candidate introduced no new normalized diagnostics versus the exact base (candidate 313 existing diagnostics; base 320; 5 diagnostic shapes resolved). The repository baseline is not currently ty-clean.
- **Diff:** `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run: used the repository-required wrapper on 692 focused/related tests)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.1.6-1-cachyos, Python 3.13.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated; user docs N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — storage behavior is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is a gateway transcript-persistence fix covered by behavioral tests.

## Review follow-up

Independent review found that the first implementation archived the retained prefix as well as the removed suffix, and that `/retry` ignored a failed canonical rewrite. The candidate now:

- validates the requested rewrite against the active row-ID snapshot and fails closed on stale/non-prefix input;
- preserves retained active rows and their IDs, archiving only the removed suffix as inactive non-compacted rewind history;
- leaves existing compacted archive rows unchanged and avoids duplicate inactive copies of retained user rows;
- aborts `/retry` before reset/resend when the durable rewrite reports failure.

Verification after the follow-up:

- `tests/hermes_state`: **89 passed**;
- related gateway retry/session suite: **73 passed**;
- focused mutations for retained-prefix archival and ignored persistence failure both made their regressions fail, then returned to green after restoration;
- changed-file Ruff and `git diff --check`: passed.
