### PR TITLE
fix(config): support quoted dotted key segments

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -989,6 +989,51 @@ def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     return missing
 
 
+def _split_config_key_path(dotted_key: str) -> list[str]:
+    """Split a config key path, honoring quoted segments with literal dots.
+
+    Examples:
+      ``providers."qwen3.5".extra_headers`` →
+      ``["providers", "qwen3.5", "extra_headers"]``
+    """
+    parts: list[str] = []
+    current: list[str] = []
+    quote: Optional[str] = None
+    escaped = False
+
+    for char in dotted_key:
+        if escaped:
+            current.append(char)
+            escaped = False
+            continue
+        if char == "\\" and quote is not None:
+            escaped = True
+            continue
+        if quote is not None:
+            if char == quote:
+                quote = None
+            else:
+                current.append(char)
+            continue
+        if char in {'"', "'"}:
+            quote = char
+            continue
+        if char == ".":
+            parts.append("".join(current))
+            current = []
+            continue
+        current.append(char)
+
+    if escaped:
+        current.append("\\")
+    if quote is not None:
+        parts.append(dotted_key)
+        return parts
+
+    parts.append("".join(current))
+    return parts
+
+
 def _set_nested(config, dotted_key: str, value):
     """Set a value at an arbitrarily nested dotted key path.
 
@@ -1011,7 +1056,7 @@ def _set_nested(config, dotted_key: str, value):
     destroying list-typed config like ``custom_providers`` whenever a
     caller used an indexed path.
     """
-    parts = dotted_key.split(".")
+    parts = _split_config_key_path(dotted_key)
     current = config
     for part in parts[:-1]:
         if isinstance(current, list):
@@ -1073,7 +1118,7 @@ _MISSING = object()
 def _get_nested(config, dotted_key: str):
     """Return a dotted-path value from nested dict/list config data."""
     current = config
-    for part in dotted_key.split("."):
+    for part in _split_config_key_path(dotted_key):
         if isinstance(current, list):
             try:
                 current = current[int(part)]
@@ -1090,7 +1135,7 @@ def _get_nested(config, dotted_key: str):
 
 def _unset_nested(config, dotted_key: str) -> bool:
     """Remove a dotted-path value from nested dict/list config data."""
-    parts = dotted_key.split(".")
+    parts = _split_config_key_path(dotted_key)
     if not parts:
         return False
 
@@ -4704,7 +4749,7 @@ def _default_value_for_key(dotted_key: str):
     best-effort coercion used by ``config set``.
     """
     node = DEFAULT_CONFIG
-    for part in dotted_key.split("."):
+    for part in _split_config_key_path(dotted_key):
         if not isinstance(node, dict) or part not in node:
             return None
         node = node[part]
@@ -4810,7 +4855,7 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     if not key:
         return False, None
 
-    segments = key.split(".")
+    segments = _split_config_key_path(key)
     top = segments[0]
 
     # ── Underscore-prefixed keys are internal/test markers ───────────

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -114,6 +114,25 @@ class TestConfigYamlRouting:
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
 
+    def test_quoted_provider_key_with_literal_dot_is_one_path_segment(self, _isolated_hermes_home):
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "providers:\n"
+            "  qwen3.5-397b-wafer-non-zdr:\n"
+            "    api: https://pass.wafer.ai/v1\n"
+        )
+
+        set_config_value(
+            'providers."qwen3.5-397b-wafer-non-zdr".extra_headers.Wafer-ZDR',
+            "required",
+        )
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        provider = reloaded["providers"]["qwen3.5-397b-wafer-non-zdr"]
+        assert provider["api"] == "https://pass.wafer.ai/v1"
+        assert provider["extra_headers"] == {"Wafer-ZDR": "required"}
+        assert "qwen3" not in reloaded["providers"]
+
     def test_terminal_vercel_runtime_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.vercel_runtime", "python3.13")
         config = _read_config(_isolated_hermes_home)
@@ -189,6 +208,28 @@ class TestConfigGetUnset:
         assert "access_token" not in reloaded["platforms"]["teams"]["extra"]
         assert reloaded["platforms"]["teams"]["extra"]["tenant_id"] == "tenant"
         assert "Unset platforms.teams.extra.access_token" in capsys.readouterr().out
+
+    def test_config_get_unset_quoted_provider_key_with_literal_dot(self, _isolated_hermes_home, capsys):
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "providers:\n"
+            "  qwen3.5-397b-wafer-non-zdr:\n"
+            "    extra_headers:\n"
+            "      Wafer-ZDR: required\n"
+            "    api: https://pass.wafer.ai/v1\n"
+        )
+
+        key = 'providers."qwen3.5-397b-wafer-non-zdr".extra_headers.Wafer-ZDR'
+        config_command(argparse.Namespace(config_command="get", key=key, json=False))
+        assert capsys.readouterr().out.strip() == "required"
+
+        config_command(argparse.Namespace(config_command="unset", key=key))
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        provider = reloaded["providers"]["qwen3.5-397b-wafer-non-zdr"]
+        assert "extra_headers" not in provider
+        assert provider["api"] == "https://pass.wafer.ai/v1"
+        assert "Unset providers." in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add config key-path parsing for quoted segments, so literal dots inside provider keys are preserved
- reuse the parser for config set/get/unset plus key validation/default lookup
- add regressions for `providers."qwen3.5-397b-wafer-non-zdr"...` set/get/unset without creating a bogus `providers.qwen3` branch

Refs #84064. This fixes the dotted-key path bug; JSON-shaped string coercion for dict values is intentionally left out of scope.

## Tests
- `.venv/bin/python -m pytest tests/hermes_cli/test_set_config_value.py`
- `.venv/bin/python -m pytest tests/hermes_cli/test_config.py`
- `.venv/bin/python -m ruff check hermes_cli/config.py tests/hermes_cli/test_set_config_value.py`
- `git diff --check`