### PR TITLE
fix(dashboard-auth): ignore password providers in native authorize auto-select

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -315,14 +315,22 @@ async def auth_native_authorize(
         raise HTTPException(status_code=400, detail="code_challenge required")
     _validate_loopback_redirect_uri(redirect_uri)
 
-    # Resolve the provider. With exactly one session provider registered
-    # (the common hosted case) an empty ``provider`` selects it, mirroring
-    # the auto-SSO convenience so the desktop needn't hardcode the name.
+    # Resolve the provider. When ``provider`` is empty, select the only
+    # native-capable candidate, so the desktop does not hardcode the name.
+    # Password providers cannot broker a native flow (see the check below),
+    # so they do not count against uniqueness. Before this filter, a basic
+    # + OAuth pair made the empty-provider path fail with 404, although
+    # only one valid candidate existed.
     p = get_provider(provider) if provider else None
     if p is None and not provider:
-        sess_providers = list_session_providers()
-        if len(sess_providers) == 1:
-            p = sess_providers[0]
+        native_candidates = [
+            sp
+            for sp in list_session_providers()
+            if getattr(sp, "supports_session", True)
+            and not getattr(sp, "supports_password", False)
+        ]
+        if len(native_candidates) == 1:
+            p = native_candidates[0]
     if p is None:
         raise HTTPException(
             status_code=404, detail=f"Unknown provider: {provider!r}"

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -182,6 +182,67 @@ def test_native_authorize_rejects_non_loopback_redirect(gated_client):
 
 
 # ---------------------------------------------------------------------------
+# Empty-provider auto-select on /auth/native/authorize
+# ---------------------------------------------------------------------------
+
+
+class _PasswordStubProvider(StubAuthProvider):
+    """Password-form provider. It cannot broker a native OAuth flow."""
+
+    name = "pwstub"
+    display_name = "Password Stub (test only)"
+    supports_password = True
+
+
+class _SecondOAuthStubProvider(StubAuthProvider):
+    """Second OAuth provider, to make the empty-provider hint ambiguous."""
+
+    name = "stub2"
+    display_name = "Stub IdP 2 (test only)"
+
+
+def _native_authorize(client, *, provider=""):
+    _verifier, challenge = _make_pkce()
+    return client.get(
+        "/auth/native/authorize",
+        params={
+            "provider": provider,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": "http://127.0.0.1:53999/cb",
+            "state": "s",
+        },
+    )
+
+
+def test_native_authorize_empty_provider_selects_sole_provider(gated_client):
+    r = _native_authorize(gated_client, provider="")
+    assert r.status_code == 302, r.text
+
+
+def test_native_authorize_empty_provider_ignores_password_provider(
+    gated_client,
+):
+    """A registered password provider must not block the auto-select.
+
+    The password provider is rejected for native brokering below the
+    resolve step, so it must not count against uniqueness either. Before
+    the filter, basic + OAuth together made this request fail with 404.
+    """
+    register_provider(_PasswordStubProvider())
+    r = _native_authorize(gated_client, provider="")
+    assert r.status_code == 302, r.text
+
+
+def test_native_authorize_empty_provider_ambiguous_is_404(gated_client):
+    """Two native-capable providers stay ambiguous — the 404 remains."""
+    register_provider(_SecondOAuthStubProvider())
+    r = _native_authorize(gated_client, provider="")
+    assert r.status_code == 404
+    assert "Unknown provider" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
 # Cookieless bearer auth of a gated route — the core deliverable
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The desktop app calls `GET /auth/native/authorize` with an empty `provider` parameter. The route selects a provider automatically only when exactly one session provider is registered. A password provider counted against this limit. As a result, a gateway with both basic auth and Nous Portal OAuth returned `404 Unknown provider: ''` to the desktop, although only one valid candidate existed. The route rejects password providers for native brokering directly below the resolve step, so the count included providers that could never win.

This change filters the candidates before the count. The auto-select now counts only providers that support sessions and do not use a password form. Two OAuth providers stay ambiguous, and the 404 remains for that case.

## Reproduction

1. Register a basic-auth provider and the Nous OAuth provider on one gateway.
2. Sign in from the desktop app with the remote gateway.
3. The gateway returns `404 Unknown provider: ''` before this change. It returns the 302 redirect to the IDP after this change.

## Test Plan

- `tests/hermes_cli/test_dashboard_auth_native_flow.py` — 3 new tests:
  - empty `provider` with one OAuth provider → 302
  - empty `provider` with one OAuth provider plus one password provider → 302 (the bug case)
  - empty `provider` with two OAuth providers → 404 (ambiguity stays fail-closed)
- All 7 tests in the file pass.