### PR TITLE
fix(gateway): preserve skill slash commands on Windows

### DIFF
--- a/contributors/emails/Cryptodombili@gmail.com
+++ b/contributors/emails/Cryptodombili@gmail.com
@@ -1,0 +1,2 @@
+CryptoDombili
+# PR #84082

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -18,6 +18,7 @@ import subprocess
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from utils import is_truthy_value
@@ -858,6 +859,15 @@ _clamp_telegram_names = _clamp_command_names
 # Shared skill/plugin collection for gateway platforms
 # ---------------------------------------------------------------------------
 
+def _path_is_within(candidate: Path, root: Path) -> bool:
+    """Return whether resolved *candidate* is inside resolved *root*."""
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
 def _collect_gateway_skill_entries(
     platform: str,
     max_slots: int,
@@ -930,17 +940,17 @@ def _collect_gateway_skill_entries(
         from agent.skill_commands import get_skill_commands
         from tools.skills_tool import SKILLS_DIR
         from agent.skill_utils import get_external_skills_dirs
-        _skills_dir = str(SKILLS_DIR.resolve())
-        _hub_dir = str((SKILLS_DIR / ".hub").resolve()).rstrip("/") + "/"
-        # Build set of allowed directory prefixes: local skills dir + any
-        # user-configured ``skills.external_dirs``. Ensure each prefix ends
-        # with ``/`` so ``/my-skills`` does not also match ``/my-skills-extra``.
+        _skills_dir = SKILLS_DIR.resolve()
+        _hub_dir = (SKILLS_DIR / ".hub").resolve()
+        # Build the allowed roots from the local skills dir plus any
+        # user-configured ``skills.external_dirs``. Path containment keeps
+        # native Windows separators working and rejects prefix-only siblings.
         # Without this widening, external skills are visible in
         # ``hermes skills list`` and the agent's ``/skill-name`` dispatch but
         # silently excluded from gateway slash menus (#8110).
-        _allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
-        _allowed_prefixes.extend(
-            str(d).rstrip("/") + "/" for d in get_external_skills_dirs()
+        _allowed_roots = [_skills_dir]
+        _allowed_roots.extend(
+            Path(d).resolve() for d in get_external_skills_dirs()
         )
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
@@ -948,9 +958,13 @@ def _collect_gateway_skill_entries(
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
-            if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):
+            resolved_skill_path = Path(skill_path).resolve()
+            if not any(
+                _path_is_within(resolved_skill_path, root)
+                for root in _allowed_roots
+            ):
                 continue
-            if skill_path.startswith(_hub_dir):
+            if _path_is_within(resolved_skill_path, _hub_dir):
                 continue
             skill_name = info.get("name", "")
             if skill_name in _platform_disabled:
@@ -1087,8 +1101,6 @@ def discord_skill_commands_by_category(
         - *hidden_count*: skills dropped due to name clamp collisions
           against already-registered command names.
     """
-    from pathlib import Path as _P
-
     _platform_disabled: set[str] = set()
     try:
         from agent.skill_utils import get_disabled_skill_names
@@ -1117,11 +1129,11 @@ def discord_skill_commands_by_category(
         # Build list of (resolved_root, is_local) tuples. Each external dir
         # becomes its own scan root for category derivation — a skill at
         # ``<external>/mlops/foo/SKILL.md`` is still categorized as "mlops".
-        _scan_roots: list[_P] = [_skills_dir]
+        _scan_roots: list[Path] = [_skills_dir]
         try:
             for ext in get_external_skills_dirs():
                 try:
-                    _scan_roots.append(_P(ext).resolve())
+                    _scan_roots.append(Path(ext).resolve())
                 except Exception:
                     continue
         except Exception:
@@ -1133,18 +1145,16 @@ def discord_skill_commands_by_category(
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
-            sp = _P(skill_path).resolve()
+            sp = Path(skill_path).resolve()
             # Hub skills are loaded via the skill hub, not surfaced as
             # slash commands.
-            if str(sp).startswith(str(_hub_dir)):
+            if _path_is_within(sp, _hub_dir):
                 continue
             # Accept skill if it lives under any scan root; record the
             # matching root so we can derive the category correctly.
-            matched_root: _P | None = None
+            matched_root: Path | None = None
             for root in _scan_roots:
-                try:
-                    sp.relative_to(root)
-                except ValueError:
+                if not _path_is_within(sp, root):
                     continue
                 matched_root = root
                 break

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -860,7 +860,7 @@ _clamp_telegram_names = _clamp_command_names
 # ---------------------------------------------------------------------------
 
 def _path_is_within(candidate: Path, root: Path) -> bool:
-    """Return whether resolved *candidate* is inside resolved *root*."""
+    """Return whether *candidate* is inside *root* by path components."""
     try:
         candidate.relative_to(root)
     except ValueError:
@@ -940,7 +940,9 @@ def _collect_gateway_skill_entries(
         from agent.skill_commands import get_skill_commands
         from tools.skills_tool import SKILLS_DIR
         from agent.skill_utils import get_external_skills_dirs
+        _lexical_skills_dir = Path(os.path.abspath(SKILLS_DIR))
         _skills_dir = SKILLS_DIR.resolve()
+        _lexical_hub_dir = _lexical_skills_dir / ".hub"
         _hub_dir = (SKILLS_DIR / ".hub").resolve()
         # Build the allowed roots from the local skills dir plus any
         # user-configured ``skills.external_dirs``. Path containment keeps
@@ -948,7 +950,14 @@ def _collect_gateway_skill_entries(
         # Without this widening, external skills are visible in
         # ``hermes skills list`` and the agent's ``/skill-name`` dispatch but
         # silently excluded from gateway slash menus (#8110).
-        _allowed_roots = [_skills_dir]
+        # Keep the lexical local root as a first-class alias: skill discovery
+        # intentionally follows symlinks under ~/.hermes/skills while yielding
+        # their trusted visible paths (agent.skill_utils.iter_skill_index_files).
+        # The resolved alias still accepts callers that already canonicalized a
+        # normal local path, including macOS /var -> /private/var.
+        _allowed_roots = [_lexical_skills_dir]
+        if _skills_dir != _lexical_skills_dir:
+            _allowed_roots.append(_skills_dir)
         _allowed_roots.extend(
             Path(d).resolve() for d in get_external_skills_dirs()
         )
@@ -958,13 +967,18 @@ def _collect_gateway_skill_entries(
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
-            resolved_skill_path = Path(skill_path).resolve()
+            lexical_skill_path = Path(os.path.abspath(skill_path))
             if not any(
-                _path_is_within(resolved_skill_path, root)
+                _path_is_within(lexical_skill_path, root)
                 for root in _allowed_roots
             ):
                 continue
-            if _path_is_within(resolved_skill_path, _hub_dir):
+            # Exclude both a visible .hub path and a symlink whose real target
+            # is inside .hub, without treating .hub-backup as a descendant.
+            if (
+                _path_is_within(lexical_skill_path, _lexical_hub_dir)
+                or _path_is_within(lexical_skill_path.resolve(), _hub_dir)
+            ):
                 continue
             skill_name = info.get("name", "")
             if skill_name in _platform_disabled:
@@ -1124,12 +1138,16 @@ def discord_skill_commands_by_category(
         from agent.skill_utils import get_external_skills_dirs
         from tools.skills_tool import SKILLS_DIR
 
+        _lexical_skills_dir = Path(os.path.abspath(SKILLS_DIR))
         _skills_dir = SKILLS_DIR.resolve()
+        _lexical_hub_dir = _lexical_skills_dir / ".hub"
         _hub_dir = (SKILLS_DIR / ".hub").resolve()
-        # Build list of (resolved_root, is_local) tuples. Each external dir
-        # becomes its own scan root for category derivation — a skill at
+        # Build lexical/resolved scan-root aliases. Each external dir becomes
+        # its own scan root for category derivation — a skill at
         # ``<external>/mlops/foo/SKILL.md`` is still categorized as "mlops".
-        _scan_roots: list[Path] = [_skills_dir]
+        _scan_roots: list[Path] = [_lexical_skills_dir]
+        if _skills_dir != _lexical_skills_dir:
+            _scan_roots.append(_skills_dir)
         try:
             for ext in get_external_skills_dirs():
                 try:
@@ -1145,10 +1163,13 @@ def discord_skill_commands_by_category(
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
-            sp = Path(skill_path).resolve()
+            sp = Path(os.path.abspath(skill_path))
             # Hub skills are loaded via the skill hub, not surfaced as
             # slash commands.
-            if _path_is_within(sp, _hub_dir):
+            if (
+                _path_is_within(sp, _lexical_hub_dir)
+                or _path_is_within(sp.resolve(), _hub_dir)
+            ):
                 continue
             # Accept skill if it lives under any scan root; record the
             # matching root so we can derive the category correctly.

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1,5 +1,7 @@
 """Tests for the central command registry and autocomplete."""
 
+import pytest
+
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 
@@ -667,20 +669,20 @@ class TestTelegramMenuCommands:
             "/local-one": {
                 "name": "local-one",
                 "description": "Local",
-                "skill_md_path": f"{local_dir}/local-one/SKILL.md",
-                "skill_dir": f"{local_dir}/local-one",
+                "skill_md_path": str(local_dir / "local-one" / "SKILL.md"),
+                "skill_dir": str(local_dir / "local-one"),
             },
             "/morning-briefing": {
                 "name": "morning-briefing",
                 "description": "External skill",
-                "skill_md_path": f"{external_dir}/morning-briefing/SKILL.md",
-                "skill_dir": f"{external_dir}/morning-briefing",
+                "skill_md_path": str(external_dir / "morning-briefing" / "SKILL.md"),
+                "skill_dir": str(external_dir / "morning-briefing"),
             },
             "/lookalike-skill": {
                 "name": "lookalike-skill",
                 "description": "Lives in a sibling dir that shares a prefix",
-                "skill_md_path": f"{lookalike_dir}/lookalike-skill/SKILL.md",
-                "skill_dir": f"{lookalike_dir}/lookalike-skill",
+                "skill_md_path": str(lookalike_dir / "lookalike-skill" / "SKILL.md"),
+                "skill_dir": str(lookalike_dir / "lookalike-skill"),
             },
         }
 
@@ -702,6 +704,43 @@ class TestTelegramMenuCommands:
         assert "lookalike_skill" not in menu_names, (
             "prefix-match sibling directories must not be admitted"
         )
+
+    def test_hub_exclusion_is_path_component_aware(self, tmp_path, monkeypatch):
+        """Exclude real .hub descendants without hiding prefix-sharing dirs."""
+        from unittest.mock import patch
+
+        local_dir = tmp_path / "skills"
+        local_dir.mkdir()
+        fake_cmds = {
+            "/hub-skill": {
+                "name": "hub-skill",
+                "description": "Installed by the hub",
+                "skill_md_path": str(local_dir / ".hub" / "hub-skill" / "SKILL.md"),
+            },
+            "/hub-backup-skill": {
+                "name": "hub-backup-skill",
+                "description": "A normal local skill",
+                "skill_md_path": str(local_dir / ".hub-backup" / "hub-backup-skill" / "SKILL.md"),
+            },
+            "/hub-other-skill": {
+                "name": "hub-other-skill",
+                "description": "Another normal local skill",
+                "skill_md_path": str(local_dir / ".hub-other" / "hub-other-skill" / "SKILL.md"),
+            },
+        }
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+        ):
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        menu_names = {name for name, _description in menu}
+        assert "hub_skill" not in menu_names
+        assert "hub_backup_skill" in menu_names
+        assert "hub_other_skill" in menu_names
 
     def test_special_chars_in_skill_names_sanitized(self, tmp_path, monkeypatch):
         """Skills with +, /, or other special chars produce valid Telegram names."""
@@ -793,6 +832,82 @@ class TestBackwardCompatAliases:
 class TestDiscordSkillCommands:
     """Tests for discord_skill_commands() — centralized skill registration."""
 
+
+    @pytest.mark.windows_only
+    def test_native_windows_paths_include_local_and_external_skills(
+        self, tmp_path, monkeypatch,
+    ):
+        """Backslash-native skill paths remain visible in the flat collector."""
+        from unittest.mock import patch
+
+        local_dir = tmp_path / "skills"
+        external_dir = tmp_path / "external-skills"
+        lookalike_dir = tmp_path / "external-skills-backup"
+        local_dir.mkdir()
+        external_dir.mkdir()
+        lookalike_dir.mkdir()
+        fake_cmds = {
+            "/local-skill": {
+                "name": "local-skill",
+                "description": "Local",
+                "skill_md_path": str(local_dir / "local-skill" / "SKILL.md"),
+            },
+            "/external-skill": {
+                "name": "external-skill",
+                "description": "External",
+                "skill_md_path": str(external_dir / "external-skill" / "SKILL.md"),
+            },
+            "/lookalike-skill": {
+                "name": "lookalike-skill",
+                "description": "Outside the configured external root",
+                "skill_md_path": str(
+                    lookalike_dir / "lookalike-skill" / "SKILL.md"
+                ),
+            },
+            "/hub-skill": {
+                "name": "hub-skill",
+                "description": "Installed by the hub",
+                "skill_md_path": str(
+                    local_dir / ".hub" / "hub-skill" / "SKILL.md"
+                ),
+            },
+            "/hub-backup-skill": {
+                "name": "hub-backup-skill",
+                "description": "A normal local skill",
+                "skill_md_path": str(
+                    local_dir / ".hub-backup" / "hub-backup-skill" / "SKILL.md"
+                ),
+            },
+            "/hub-other-skill": {
+                "name": "hub-other-skill",
+                "description": "Another normal local skill",
+                "skill_md_path": str(
+                    local_dir / ".hub-other" / "hub-other-skill" / "SKILL.md"
+                ),
+            },
+        }
+
+        assert "\\" in str(local_dir.resolve())
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[external_dir],
+            ),
+        ):
+            entries, hidden = discord_skill_commands(
+                max_slots=50, reserved_names=set(),
+            )
+
+        assert {name for name, _desc, _key in entries} == {
+            "external-skill",
+            "hub-backup-skill",
+            "hub-other-skill",
+            "local-skill",
+        }
+        assert hidden == 0
 
     def test_names_allow_hyphens(self, tmp_path, monkeypatch):
         """Discord names should keep hyphens (unlike Telegram's _ sanitization)."""
@@ -974,6 +1089,45 @@ class TestDiscordSkillCommandsByCategory:
             "prefix check was broken for by_category (completes #18741)"
         )
         assert any(n == "external-skill" for n, _d, _k in categories["mlops"])
+        assert uncategorized == []
+        assert hidden == 0
+
+    def test_hub_exclusion_is_path_component_aware(self, tmp_path, monkeypatch):
+        """Discord categories exclude .hub, not similarly named siblings."""
+        from unittest.mock import patch
+
+        local_dir = tmp_path / "skills"
+        fake_cmds = {
+            "/hub-skill": {
+                "name": "hub-skill",
+                "description": "Installed by the hub",
+                "skill_md_path": str(local_dir / ".hub" / "hub-skill" / "SKILL.md"),
+            },
+            "/hub-backup-skill": {
+                "name": "hub-backup-skill",
+                "description": "A normal local skill",
+                "skill_md_path": str(local_dir / ".hub-backup" / "hub-backup-skill" / "SKILL.md"),
+            },
+            "/hub-other-skill": {
+                "name": "hub-other-skill",
+                "description": "Another normal local skill",
+                "skill_md_path": str(local_dir / ".hub-other" / "hub-other-skill" / "SKILL.md"),
+            },
+        }
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+        ):
+            categories, uncategorized, hidden = discord_skill_commands_by_category(
+                reserved_names=set(),
+            )
+
+        assert ".hub" not in categories
+        assert any(name == "hub-backup-skill" for name, _desc, _key in categories[".hub-backup"])
+        assert any(name == "hub-other-skill" for name, _desc, _key in categories[".hub-other"])
         assert uncategorized == []
         assert hidden == 0
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -742,6 +742,67 @@ class TestTelegramMenuCommands:
         assert "hub_backup_skill" in menu_names
         assert "hub_other_skill" in menu_names
 
+    @pytest.mark.require_symlinks
+    def test_symlinked_local_skill_outside_root_stays_in_gateway_menus(
+        self, tmp_path, monkeypatch
+    ):
+        """A trusted lexical skill path may target a checkout outside the root."""
+        from unittest.mock import patch
+
+        from agent.skill_utils import iter_skill_index_files
+        from hermes_cli.commands import discord_skill_commands_by_category
+
+        local_dir = tmp_path / "skills"
+        local_dir.mkdir()
+        checkout_dir = tmp_path / "checked-out-skills" / "symlinked-skill"
+        checkout_dir.mkdir(parents=True)
+        (checkout_dir / "SKILL.md").write_text(
+            "---\nname: symlinked-skill\ndescription: Linked checkout\n---\n",
+            encoding="utf-8",
+        )
+        linked_dir = local_dir / "symlinked-skill"
+        linked_dir.symlink_to(checkout_dir, target_is_directory=True)
+
+        discovered = list(iter_skill_index_files(local_dir, "SKILL.md"))
+        assert discovered == [linked_dir / "SKILL.md"]
+        assert discovered[0].resolve() == checkout_dir / "SKILL.md"
+        assert not checkout_dir.is_relative_to(local_dir)
+
+        fake_cmds = {
+            "/symlinked-skill": {
+                "name": "symlinked-skill",
+                "description": "Linked checkout",
+                "skill_md_path": str(discovered[0]),
+                "skill_dir": str(linked_dir),
+            },
+        }
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+        ):
+            telegram_menu, _ = telegram_menu_commands(max_commands=100)
+            discord_entries, hidden = discord_skill_commands(
+                max_slots=50, reserved_names=set()
+            )
+            categories, uncategorized, category_hidden = (
+                discord_skill_commands_by_category(reserved_names=set())
+            )
+
+        assert "symlinked_skill" in {
+            name for name, _description in telegram_menu
+        }
+        assert "symlinked-skill" in {
+            name for name, _description, _key in discord_entries
+        }
+        assert categories == {}
+        assert [name for name, _description, _key in uncategorized] == [
+            "symlinked-skill"
+        ]
+        assert hidden == 0
+        assert category_hidden == 0
+
     def test_special_chars_in_skill_names_sanitized(self, tmp_path, monkeypatch):
         """Skills with +, /, or other special chars produce valid Telegram names."""
         from unittest.mock import patch


### PR DESCRIPTION
## Problem

Gateway skill-command enumeration infers filesystem containment with string-prefix checks. The flat Telegram/Discord collector appends a literal `/` to resolved roots, while native Windows paths use `\`. Valid local and configured external skills can therefore disappear from gateway slash-command menus on Windows.

The Discord category collector also checks `.hub` containment with an unbounded string prefix, so sibling directories such as `.hub-backup` and `.hub-other` can be mistaken for real `.hub` descendants.

## User impact

On native Windows, valid local and external skills may not be registered as Telegram or Discord slash commands. Discord category enumeration can also hide legitimate skills whose parent directory merely starts with `.hub`.

## Root cause

Filesystem ancestry is inferred from serialized path strings. Separator differences and prefix-sharing sibling names make string-prefix comparison unsuitable for path containment.

## Implementation

- Add a small `Path.relative_to()`-based containment helper.
- Resolve skill paths and allowed local/external roots as `Path` objects.
- Apply component-aware containment in both the flat gateway collector and Discord category collector.
- Preserve trusted lexical paths for symlinked local skills while retaining resolved-root aliases for canonicalized paths.
- Preserve local-before-external priority, platform-disabled filtering, command clamping, configured external directories, category derivation, and exclusion of actual `.hub` descendants.
- Add the contributor-email mapping required by the repository attribution workflow.

## Regression tests

Coverage verifies:

- native Windows backslash paths
- inclusion of local and configured external skills
- exclusion of prefix-sharing sibling directories outside configured roots
- exclusion of actual `.hub` descendants
- inclusion of `.hub-backup` and `.hub-other`
- Telegram, flat Discord, and Discord category enumeration
- real symlinked local skills whose targets live outside `SKILLS_DIR`
- existing platform-independent behavior

## Validation

```text
.\.venv\Scripts\python.exe -m pytest tests/hermes_cli/test_commands.py -q
56 passed in 8.96s

.\.venv\Scripts\python.exe -m pytest tests/hermes_cli/test_discord_skill_clamp_warning.py tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_slash_auth.py tests/gateway/test_reload_skills_discord_resync.py -q
33 passed in 2.82s

.\.venv\Scripts\python.exe -m pytest tests/hermes_cli/test_commands.py -m windows_only -q
1 passed, 55 deselected in 1.03s

.\.venv\Scripts\ruff.exe check .
All checks passed!

PYTHONUTF8=1 .\.venv\Scripts\python.exe scripts/audit_pr_attribution.py
All contributor emails on this branch are mapped.

git diff --check
passed
```

## Compatibility and risk

The production change is limited to path-containment decisions in existing enumeration paths. Trusted lexical paths remain first-class for symlinked local skills, matching the existing intent in `agent/skill_utils.py`. POSIX behavior remains covered by the existing suite, configured external roots remain supported, and ordering/clamping/filtering behavior is unchanged. No dependencies, lockfiles, generated artifacts, or unrelated formatting are changed. Regression risk is low.