### PR TITLE
fix(kanban): reject invalid decomposed dependency graphs

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7277,6 +7277,64 @@ def specify_triage_task(
     return True
 
 
+class DecomposeGraphRejected(ValueError):
+    """Invalid graph whose rejection event committed on the triage root."""
+
+    rejection_event_committed = True
+
+
+def _validate_decomposed_children(children: list[dict]) -> None:
+    """Validate a sibling dependency graph without touching durable state."""
+    for idx, child in enumerate(children):
+        if not isinstance(child, dict):
+            raise ValueError(f"child[{idx}] is not a dict")
+        title = child.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise ValueError(f"child[{idx}].title is required")
+        parents_idx = child["parents"] if "parents" in child else []
+        if not isinstance(parents_idx, list):
+            raise ValueError(f"child[{idx}].parents must be a list")
+        seen_parents: set[int] = set()
+        for parent_pos, parent_idx in enumerate(parents_idx):
+            # bool subclasses int in Python, but JSON booleans are not graph
+            # indices and must not silently become edges 0 or 1.
+            if type(parent_idx) is not int or not 0 <= parent_idx < len(children):
+                raise ValueError(
+                    f"child[{idx}].parents[{parent_pos}] is not a valid "
+                    "index into children"
+                )
+            if parent_idx == idx:
+                raise ValueError(f"child[{idx}] cannot list itself as a parent")
+            if parent_idx in seen_parents:
+                raise ValueError(
+                    f"child[{idx}] lists parent index {parent_idx} more than once"
+                )
+            seen_parents.add(parent_idx)
+
+    # Detect cycles in the sibling parent graph (Kahn's topological sort).
+    # link_tasks() calls _would_cycle() for every new edge; here we check the
+    # entire sibling graph before touching task/link rows. A cycle silently
+    # deadlocks every involved child in 'todo' because recompute_ready() can
+    # never promote them.
+    in_degree = [0] * len(children)
+    adjacency: list[list[int]] = [[] for _ in children]
+    for child_idx, child in enumerate(children):
+        for parent_idx in (child["parents"] if "parents" in child else []):
+            adjacency[parent_idx].append(child_idx)
+            in_degree[child_idx] += 1
+    queue = [idx for idx, degree in enumerate(in_degree) if degree == 0]
+    seen = 0
+    while queue:
+        node = queue.pop()
+        seen += 1
+        for neighbour in adjacency[node]:
+            in_degree[neighbour] -= 1
+            if in_degree[neighbour] == 0:
+                queue.append(neighbour)
+    if seen != len(children):
+        raise ValueError("cyclic dependency detected in decomposed children list")
+
+
 def decompose_triage_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -7306,7 +7364,11 @@ def decompose_triage_task(
     success. Returns ``None`` when:
       - The root task does not exist
       - The root task is not in ``triage``
-      - A cycle would result (caller built a bad graph)
+
+    Raises :class:`DecomposeGraphRejected` only after the caller supplied an
+    invalid dependency graph and the corresponding rejection event committed
+    on the still-current triage root. Event persistence failures propagate as
+    their original DB exception instead.
 
     Validation of titles/assignees happens inside the same write_txn as
     the inserts so a malformed entry aborts the whole decomposition
@@ -7317,57 +7379,17 @@ def decompose_triage_task(
     if root_assignee is not None:
         root_assignee = _canonical_assignee(root_assignee)
 
-    # Pre-validate the children list shape outside the txn. Cheap checks
-    # that don't need DB access. Bad input aborts before we touch the DB.
-    for idx, child in enumerate(children):
-        if not isinstance(child, dict):
-            raise ValueError(f"child[{idx}] is not a dict")
-        title = child.get("title")
-        if not isinstance(title, str) or not title.strip():
-            raise ValueError(f"child[{idx}].title is required")
-        parents_idx = child.get("parents") or []
-        if not isinstance(parents_idx, list):
-            raise ValueError(f"child[{idx}].parents must be a list")
-        for p in parents_idx:
-            if not isinstance(p, int) or p < 0 or p >= len(children):
-                raise ValueError(
-                    f"child[{idx}].parents[{p}] is not a valid index into children"
-                )
-            if p == idx:
-                raise ValueError(f"child[{idx}] cannot list itself as a parent")
-
-    # Detect cycles in the sibling parent graph (Kahn's topological sort).
-    # link_tasks() calls _would_cycle() for every new edge; here we check
-    # the entire sibling graph before touching the DB.  A cycle silently
-    # deadlocks every involved child in 'todo' because recompute_ready()
-    # can never promote them.
-    _in_deg = [0] * len(children)
-    _adj: list[list[int]] = [[] for _ in range(len(children))]
-    for _i, _c in enumerate(children):
-        for _p in (_c.get("parents") or []):
-            _adj[_p].append(_i)
-            _in_deg[_i] += 1
-    _queue = [_i for _i in range(len(children)) if _in_deg[_i] == 0]
-    _seen = 0
-    while _queue:
-        _node = _queue.pop()
-        _seen += 1
-        for _nb in _adj[_node]:
-            _in_deg[_nb] -= 1
-            if _in_deg[_nb] == 0:
-                _queue.append(_nb)
-    if _seen != len(children):
-        raise ValueError("cyclic dependency detected in decomposed children list")
-
     # We do the full decomposition in a SINGLE write_txn so it's
-    # atomic: either every child is created AND the root flips to
-    # ``todo``, or nothing changes. We deliberately do NOT call any
+    # atomic: either every child is created AND the root flips to ``todo``,
+    # or one rejection event is recorded on the unchanged triage root. We
+    # deliberately do NOT call any
     # kb helper that opens its own write_txn (create_task, link_tasks,
     # add_comment) from inside this block — see architecture.md
     # write_txn pitfalls. Instead we inline the INSERTs and
     # _append_event calls.
     now = int(time.time())
     child_ids: list[str] = []
+    rejection_reason: Optional[str] = None
     with write_txn(conn):
         root_row = conn.execute(
             "SELECT id, status, tenant, workspace_kind, workspace_path "
@@ -7378,6 +7400,23 @@ def decompose_triage_task(
             return None
         if root_row["status"] != "triage":
             return None
+        try:
+            _validate_decomposed_children(children)
+        except ValueError as exc:
+            rejection_reason = str(exc)
+            _append_event(
+                conn,
+                task_id,
+                "decompose_rejected",
+                {
+                    "class": "invalid_dependency_graph",
+                    "reason": rejection_reason,
+                    "author": author,
+                },
+            )
+            children_to_write: list[dict] = []
+        else:
+            children_to_write = children
         tenant = root_row["tenant"]
         # Children inherit the root's workspace by default so a fan-out
         # of a code-gen task lands in the parent's project dir/worktree
@@ -7390,7 +7429,7 @@ def decompose_triage_task(
         # link them under the root AFTER creation so the dispatcher
         # sees a coherent state, and recompute_ready() at the end
         # promotes parent-free children to 'ready'.
-        for idx, child in enumerate(children):
+        for idx, child in enumerate(children_to_write):
             new_id = _new_task_id()
             title = child["title"].strip()
             body = child.get("body")
@@ -7441,8 +7480,8 @@ def decompose_triage_task(
             child_ids.append(new_id)
 
         # Link children to their sibling parents (within the decomposed graph).
-        for idx, child in enumerate(children):
-            for p_idx in child.get("parents") or []:
+        for idx, child in enumerate(children_to_write):
+            for p_idx in (child["parents"] if "parents" in child else []):
                 parent_id = child_ids[p_idx]
                 child_id = child_ids[idx]
                 conn.execute(
@@ -7466,39 +7505,43 @@ def decompose_triage_task(
                 (cid, task_id),
             )
 
-        # Flip the root: triage -> todo, set assignee to the orchestrator.
-        sets = ["status = 'todo'"]
-        params: list[Any] = []
-        if root_assignee is not None:
-            sets.append("assignee = ?")
-            params.append(root_assignee)
-        params.append(task_id)
-        conn.execute(
-            f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?",
-            tuple(params),
-        )
-
-        # Audit comment + event on the root so the timeline shows the fan-out.
-        if author and author.strip():
+        if rejection_reason is None:
+            # Flip the root: triage -> todo, set assignee to the orchestrator.
+            sets = ["status = 'todo'"]
+            params: list[Any] = []
+            if root_assignee is not None:
+                sets.append("assignee = ?")
+                params.append(root_assignee)
+            params.append(task_id)
             conn.execute(
-                "INSERT INTO task_comments (task_id, author, body, created_at) "
-                "VALUES (?, ?, ?, ?)",
-                (
-                    task_id,
-                    author.strip(),
-                    "Decomposed into "
-                    + ", ".join(child_ids)
-                    + ". Root will wake when all children complete.",
-                    now,
-                ),
+                f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?",
+                tuple(params),
             )
-        _append_event(
-            conn, task_id, "decomposed",
-            {
-                "child_ids": child_ids,
-                "root_assignee": root_assignee,
-            },
-        )
+
+            # Audit comment + event on the root so the timeline shows the fan-out.
+            if author and author.strip():
+                conn.execute(
+                    "INSERT INTO task_comments (task_id, author, body, created_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        task_id,
+                        author.strip(),
+                        "Decomposed into "
+                        + ", ".join(child_ids)
+                        + ". Root will wake when all children complete.",
+                        now,
+                    ),
+                )
+            _append_event(
+                conn, task_id, "decomposed",
+                {
+                    "child_ids": child_ids,
+                    "root_assignee": root_assignee,
+                },
+            )
+
+    if rejection_reason is not None:
+        raise DecomposeGraphRejected(rejection_reason)
 
     # Outside the write_txn: promote parent-free children to 'ready'
     # so the dispatcher picks them up on its next tick. Same pattern

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7278,9 +7278,16 @@ def specify_triage_task(
 
 
 class DecomposeGraphRejected(ValueError):
-    """Invalid graph whose rejection event committed on the triage root."""
+    """Invalid graph with instance-scoped rejection-event commit metadata."""
 
-    rejection_event_committed = True
+    def __init__(
+        self,
+        reason: str,
+        *,
+        rejection_event_committed: bool = False,
+    ) -> None:
+        super().__init__(reason)
+        self.rejection_event_committed = rejection_event_committed
 
 
 def _validate_decomposed_children(children: list[dict]) -> None:
@@ -7541,7 +7548,10 @@ def decompose_triage_task(
             )
 
     if rejection_reason is not None:
-        raise DecomposeGraphRejected(rejection_reason)
+        raise DecomposeGraphRejected(
+            rejection_reason,
+            rejection_event_committed=True,
+        )
 
     # Outside the write_txn: promote parent-free children to 'ready'
     # so the dispatcher picks them up on its next tick. Same pattern

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -417,16 +417,15 @@ def decompose_task(
                 "routing to default_assignee %r",
                 task_id, idx, assignee, default_assignee,
             )
-        parents = entry.get("parents") or []
-        if not isinstance(parents, list):
-            parents = []
-        # Clean parent indices: drop non-int and out-of-range.
-        clean_parents = [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx]
+        # Omission means no dependencies. Supplied values must reach the DB
+        # validator unchanged so malformed graphs fail atomically instead of
+        # being silently rewritten into different execution plans.
+        parents = entry["parents"] if "parents" in entry else []
         children.append({
             "title": title.strip()[:200],
             "body": body.strip(),
             "assignee": chosen,
-            "parents": clean_parents,
+            "parents": parents,
         })
 
     try:
@@ -440,7 +439,12 @@ def decompose_task(
                 auto_promote=auto_promote,
             )
     except ValueError as exc:
-        return DecomposeOutcome(task_id, False, f"DB rejected graph: {exc}")
+        if getattr(exc, "rejection_event_committed", False):
+            # The DB marks only the exception raised after its transaction
+            # durably records one rejection on the still-current triage root.
+            return DecomposeOutcome(task_id, False, f"DB rejected graph: {exc}")
+        logger.exception("decompose: DB validation error on task %s", task_id)
+        return DecomposeOutcome(task_id, False, "DB error: ValueError")
     except Exception as exc:
         logger.exception("decompose: DB error on task %s", task_id)
         return DecomposeOutcome(task_id, False, f"DB error: {type(exc).__name__}")

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -442,7 +442,12 @@ def decompose_task(
         if getattr(exc, "rejection_event_committed", False):
             # The DB marks only the exception raised after its transaction
             # durably records one rejection on the still-current triage root.
-            return DecomposeOutcome(task_id, False, f"DB rejected graph: {exc}")
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"DB rejected graph: {exc}. "
+                "Regenerate the decomposition payload and retry.",
+            )
         logger.exception("decompose: DB validation error on task %s", task_id)
         return DecomposeOutcome(task_id, False, "DB error: ValueError")
     except Exception as exc:

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -8,6 +8,7 @@ and the assignee-fallback logic.
 from __future__ import annotations
 
 import json as jsonlib
+import sqlite3
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -69,9 +70,17 @@ def _patch_list_profiles(names: list[str]):
         for i, n in enumerate(names)
     ]
     return [
-        patch("hermes_cli.profiles.list_profiles", return_value=fake_profiles),
-        patch("hermes_cli.profiles.profile_exists", side_effect=lambda x: x in names),
-        patch("hermes_cli.profiles.get_active_profile_name", return_value=names[0] if names else "default"),
+        patch.object(decomp.profiles_mod, "list_profiles", return_value=fake_profiles),
+        patch.object(
+            decomp.profiles_mod,
+            "profile_exists",
+            side_effect=lambda x: x in names,
+        ),
+        patch.object(
+            decomp.profiles_mod,
+            "get_active_profile_name",
+            return_value=names[0] if names else "default",
+        ),
     ]
 
 
@@ -83,7 +92,7 @@ def test_decompose_with_fanout_creates_children(kanban_home):
         "fanout": True,
         "rationale": "test split",
         "tasks": [
-            {"title": "research", "body": "look it up", "assignee": "researcher", "parents": []},
+            {"title": "research", "body": "look it up", "assignee": "researcher"},
             {"title": "build", "body": "code it", "assignee": "engineer", "parents": [0]},
         ],
     })
@@ -113,6 +122,195 @@ def test_decompose_with_fanout_creates_children(kanban_home):
     assert c1.assignee == "engineer"
 
 
+@pytest.mark.parametrize(
+    "parent_fields",
+    [
+        [{"parents": "not-a-list"}],
+        [{"parents": None}],
+        [{"parents": ["0"]}],
+        [{"parents": [1]}],
+        [{"parents": [0]}],
+        [{"parents": [1]}, {"parents": [0]}],
+        [{}, {"parents": [False]}],
+        [{}, {"parents": [0, 0]}],
+    ],
+    ids=[
+        "non-list",
+        "null",
+        "string-index",
+        "out-of-range",
+        "self-reference",
+        "cycle",
+        "boolean-index-non-self",
+        "duplicate-parent",
+    ],
+)
+def test_decompose_rejects_invalid_dependency_graph_without_rewriting(
+    kanban_home, parent_fields
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="preserve this root", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "invalid graph",
+        "tasks": [
+            {
+                "title": f"child {idx}",
+                "body": "work",
+                "assignee": "worker",
+                **fields,
+            }
+            for idx, fields in enumerate(parent_fields)
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "worker"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert outcome.reason.startswith("DB rejected graph:")
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        task_ids = [row["id"] for row in conn.execute("SELECT id FROM tasks")]
+        rejection_events = [
+            event for event in kb.list_events(conn, tid)
+            if event.kind == "decompose_rejected"
+        ]
+    assert root is not None
+    assert root.status == "triage"
+    assert root.title == "preserve this root"
+    assert task_ids == [tid]
+    assert len(rejection_events) == 1
+    payload = rejection_events[0].payload
+    assert payload is not None
+    assert payload["class"] == "invalid_dependency_graph"
+    assert payload["reason"] == outcome.reason.removeprefix(
+        "DB rejected graph: "
+    )
+    assert payload["author"] == "me"
+
+
+@pytest.mark.parametrize("mutation", ["transition", "delete"])
+def test_decompose_invalid_graph_does_not_reject_a_stale_root(
+    kanban_home, mutation
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="preserve this root", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "invalid graph after stale read",
+        "tasks": [
+            {"title": "first", "body": "work", "assignee": "worker"},
+            {
+                "title": "second",
+                "body": "work",
+                "assignee": "worker",
+                "parents": ["0"],
+            },
+        ],
+    })
+
+    def mutate_root_during_llm(*args, **kwargs):
+        with kb.connect() as conn:
+            if mutation == "transition":
+                with kb.write_txn(conn):
+                    conn.execute(
+                        "UPDATE tasks SET status = 'todo' WHERE id = ?",
+                        (tid,),
+                    )
+            else:
+                assert kb.delete_task(conn, tid)
+        return _fake_aux_response(llm_payload)
+
+    patches = _patch_list_profiles(["orchestrator", "worker"])
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=mutate_root_during_llm,
+        ), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert outcome.reason == "task moved out of triage before decomposition"
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        task_ids = [row["id"] for row in conn.execute("SELECT id FROM tasks")]
+        rejection_count = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE kind = 'decompose_rejected'"
+        ).fetchone()[0]
+    assert rejection_count == 0
+    if mutation == "transition":
+        assert root is not None
+        assert root.status == "todo"
+        assert root.title == "preserve this root"
+        assert task_ids == [tid]
+    else:
+        assert root is None
+        assert task_ids == []
+
+
+def test_decompose_event_write_failure_is_not_reported_as_durable_rejection(
+    kanban_home,
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="preserve this root", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "invalid graph",
+        "tasks": [
+            {
+                "title": "child",
+                "body": "work",
+                "assignee": "worker",
+                "parents": ["0"],
+            },
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "worker"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch.object(
+            decomp.kb,
+            "_append_event",
+            side_effect=sqlite3.OperationalError("event write failed"),
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert outcome.reason == "DB error: OperationalError"
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        task_ids = [row["id"] for row in conn.execute("SELECT id FROM tasks")]
+        rejection_count = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE kind = 'decompose_rejected'"
+        ).fetchone()[0]
+    assert root is not None
+    assert root.status == "triage"
+    assert root.title == "preserve this root"
+    assert task_ids == [tid]
+    assert rejection_count == 0
+
+
 def test_decompose_fanout_false_invalid_llm_assignee_uses_default(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="route me safely", triage=True)
@@ -129,8 +327,9 @@ def test_decompose_fanout_false_invalid_llm_assignee_uses_default(kanban_home):
     for p in patches:
         p.start()
     try:
-        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
-            "hermes_cli.kanban_decompose._load_config",
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch.object(
+            decomp,
+            "_load_config",
             return_value={"kanban": {"default_assignee": "fallback"}},
         ):
             outcome = decomp.decompose_task(tid, author="me")

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json as jsonlib
 import sqlite3
+from enum import IntEnum
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -122,6 +123,17 @@ def test_decompose_with_fanout_creates_children(kanban_home):
     assert c1.assignee == "engineer"
 
 
+def test_decompose_graph_rejection_commit_flag_is_instance_scoped():
+    uncommitted = kb.DecomposeGraphRejected("validation failed")
+    committed = kb.DecomposeGraphRejected(
+        "validation failed",
+        rejection_event_committed=True,
+    )
+
+    assert uncommitted.rejection_event_committed is False
+    assert committed.rejection_event_committed is True
+
+
 @pytest.mark.parametrize(
     "parent_fields",
     [
@@ -132,6 +144,7 @@ def test_decompose_with_fanout_creates_children(kanban_home):
         [{"parents": [0]}],
         [{"parents": [1]}, {"parents": [0]}],
         [{}, {"parents": [False]}],
+        [{"parents": [True]}, {}],
         [{}, {"parents": [0, 0]}],
     ],
     ids=[
@@ -141,7 +154,8 @@ def test_decompose_with_fanout_creates_children(kanban_home):
         "out-of-range",
         "self-reference",
         "cycle",
-        "boolean-index-non-self",
+        "false-index-non-self",
+        "true-index-non-self",
         "duplicate-parent",
     ],
 )
@@ -192,10 +206,43 @@ def test_decompose_rejects_invalid_dependency_graph_without_rewriting(
     payload = rejection_events[0].payload
     assert payload is not None
     assert payload["class"] == "invalid_dependency_graph"
-    assert payload["reason"] == outcome.reason.removeprefix(
-        "DB rejected graph: "
-    )
+    assert f"DB rejected graph: {payload['reason']}" in outcome.reason
+    assert "Regenerate the decomposition payload and retry." in outcome.reason
     assert payload["author"] == "me"
+
+
+def test_decompose_rejects_programmatic_integer_subclass(kanban_home):
+    class ParentIndex(IntEnum):
+        FIRST = 0
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="preserve this root", triage=True)
+
+        with pytest.raises(kb.DecomposeGraphRejected) as caught:
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orchestrator",
+                children=[
+                    {"title": "first"},
+                    {"title": "second", "parents": [ParentIndex.FIRST]},
+                ],
+                author="me",
+            )
+
+        root = kb.get_task(conn, tid)
+        task_ids = [row["id"] for row in conn.execute("SELECT id FROM tasks")]
+        rejection_events = [
+            event for event in kb.list_events(conn, tid)
+            if event.kind == "decompose_rejected"
+        ]
+
+    assert caught.value.rejection_event_committed is True
+    assert "parents[0] is not a valid index" in str(caught.value)
+    assert root is not None
+    assert root.status == "triage"
+    assert task_ids == [tid]
+    assert len(rejection_events) == 1
 
 
 @pytest.mark.parametrize("mutation", ["transition", "delete"])
@@ -308,6 +355,44 @@ def test_decompose_event_write_failure_is_not_reported_as_durable_rejection(
     assert root.status == "triage"
     assert root.title == "preserve this root"
     assert task_ids == [tid]
+    assert rejection_count == 0
+
+
+def test_decompose_uncommitted_graph_rejection_is_reported_as_db_error(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="preserve this root", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "valid graph",
+        "tasks": [
+            {"title": "child", "body": "work", "assignee": "worker"},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "worker"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch.object(
+            decomp.kb,
+            "decompose_triage_task",
+            side_effect=kb.DecomposeGraphRejected("not durable"),
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert outcome.reason == "DB error: ValueError"
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        rejection_count = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE kind = 'decompose_rejected'"
+        ).fetchone()[0]
+    assert root is not None
+    assert root.status == "triage"
     assert rejection_count == 0
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #83048.

Rejects malformed dependency graphs returned by the Kanban decomposer instead of silently normalizing them into a different graph.

Previously, invalid `parents` values could be rewritten before the database validator saw them. The root could then be decomposed using semantics the orchestrator never supplied. This change preserves supplied values for strict validation, treats only an omitted `parents` field as `[]`, and atomically commits either the complete decomposition or one truthful `decompose_rejected` event while the root is still in `triage`.

## Related Issue

Fixes #83048

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `hermes_cli/kanban_decompose.py`
  - preserves supplied parent values so the canonical validator sees the original graph;
  - reports durable rejection only when the committed marker is present.
- `hermes_cli/kanban_db.py`
  - rejects cycles, self-references, duplicate parents, booleans, `IntEnum`, non-integers, null/non-list parents, and out-of-range indices;
  - validates root state and persists the rejection event in one `BEGIN IMMEDIATE` transaction;
  - keeps `rejection_event_committed` as exception-instance state and sets it only after successful transaction completion;
  - does not write rejection events for deleted or transitioned roots.
- `tests/hermes_cli/test_kanban_decompose.py`
  - adds deterministic validation, rollback, event-write failure, stale-root, and mutation-sensitive coverage.

## How to Test

Run each affected file in a fresh pytest process, matching the repository's isolation requirements:

```bash
python -m pytest tests/hermes_cli/test_kanban_decompose.py -o 'addopts=' -q
python -m pytest tests/hermes_cli/test_kanban_decompose_db.py -o 'addopts=' -q
python -m pytest tests/gateway/test_kanban_auto_decompose_live.py -o 'addopts=' -q
python -m pytest tests/hermes_cli/test_kanban_worktree_isolation.py -o 'addopts=' -q

python -m ruff check \
  hermes_cli/kanban_decompose.py \
  hermes_cli/kanban_db.py \
  tests/hermes_cli/test_kanban_decompose.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only related changes
- [ ] I've run the complete repository suite — the canonical affected per-file suite was used because a monolithic Kanban invocation has known shared-state/order pollution
- [x] I've added tests for the change
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation N/A — no public configuration or command syntax changed
- [x] `cli-config.yaml.example` N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A
- [x] Cross-platform impact considered; one Windows-only test is correctly skipped on Linux
- [x] Tool descriptions/schemas N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Not applicable; this is backend validation and persistence logic.

Verification on exact candidate `75800331242881c8822a4906d99851939c02f758`:

- focused CI-style suite: **24 passed**;
- broader canonical per-file Kanban suite: **311 passed, 1 Windows-only skipped**;
- synthetic transaction-commit failure proof: **passed**, root remained in `triage` and no rejection event persisted;
- independent Spec Review: **PASS**;
- independent Standards Review: **PASS**;
- Ruff: **passed**;
- Python compilation: **passed**;
- `git diff --check`: **passed**.

A combined single-process Kanban glob showed known cross-file global-state/order pollution. Every affected file passed in a fresh isolated process; this candidate does not alter that unrelated test harness behavior.
