### PR TITLE
fix(kanban): make retry notifications conditional

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -469,17 +469,27 @@ class GatewayKanbanWatchersMixin:
                                 f"after repeated spawn failures{err}"
                             )
                         elif kind == "crashed":
+                            retry = (
+                                "; dispatcher will retry"
+                                if ev.payload and ev.payload.get("will_retry") is True
+                                else ""
+                            )
                             msg = (
                                 f"✖ {board_tag}{tag}Kanban {sub['task_id']} worker crashed "
-                                f"(pid gone); dispatcher will retry"
+                                f"(pid gone){retry}"
                             )
                         elif kind == "timed_out":
                             limit = 0
                             if ev.payload and ev.payload.get("limit_seconds"):
                                 limit = int(ev.payload["limit_seconds"])
+                            retry = (
+                                "; will retry"
+                                if ev.payload and ev.payload.get("will_retry") is True
+                                else ""
+                            )
                             msg = (
                                 f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                f"(max_runtime={limit}s); will retry"
+                                f"(max_runtime={limit}s){retry}"
                             )
                         elif kind == "status":
                             new_status = ""

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8169,29 +8169,25 @@ def enforce_max_runtime(
                 event_id = _append_event(
                     conn, tid, "timed_out", payload, run_id=run_id,
                 )
-                timed_out.append(tid)
-        # Increment the unified failure counter. Outside the write_txn
-        # above because ``_record_task_failure`` opens its own. If the
-        # breaker trips, this flips the retried task to ``blocked`` and
-        # emits a ``gave_up`` event on top of the ``timed_out`` we
-        # already emitted.
-        if cur.rowcount == 1:
-            tripped = _record_task_failure(
-                conn, tid,
-                error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
-                outcome="timed_out",
-                release_claim=False,
-                end_run=False,
-                event_payload_extra={
-                    "pid": pid,
-                    "sigkill": killed,
-                    "retry_status": retry_status,
-                },
-            )
-            payload["will_retry"] = not tripped
-            with write_txn(conn):
+                tripped = _record_task_failure_in_txn(
+                    conn, tid,
+                    error=(
+                        f"elapsed {int(elapsed)}s > "
+                        f"limit {int(row['max_runtime_seconds'])}s"
+                    ),
+                    outcome="timed_out",
+                    release_claim=False,
+                    end_run=False,
+                    event_payload_extra={
+                        "pid": pid,
+                        "sigkill": killed,
+                        "retry_status": retry_status,
+                    },
+                )
+                payload["will_retry"] = not tripped
                 _update_event_payload(conn, event_id, payload)
                 _update_run_metadata(conn, run_id, payload)
+                timed_out.append(tid)
     return timed_out
 
 
@@ -8839,124 +8835,147 @@ def _record_task_failure(
     ``max_retries`` override against the violation streak itself. The
     failure is still counted into ``consecutive_failures``.
     """
+    with write_txn(conn):
+        return _record_task_failure_in_txn(
+            conn,
+            task_id,
+            error,
+            outcome=outcome,
+            failure_limit=failure_limit,
+            force_trip=force_trip,
+            release_claim=release_claim,
+            end_run=end_run,
+            event_payload_extra=event_payload_extra,
+        )
+
+
+def _record_task_failure_in_txn(
+    conn: sqlite3.Connection,
+    task_id: str,
+    error: str,
+    *,
+    outcome: str,
+    failure_limit: int = None,
+    force_trip: bool = False,
+    release_claim: bool = False,
+    end_run: bool = False,
+    event_payload_extra: Optional[dict] = None,
+) -> bool:
+    """Inner implementation of _record_task_failure for existing write_txn scopes."""
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     blocked = False
-    with write_txn(conn):
-        row = conn.execute(
-            "SELECT consecutive_failures, status, max_retries, current_run_id "
-            "FROM tasks WHERE id = ?", (task_id,),
-        ).fetchone()
-        if row is None:
-            return False
-        retry_status = (
-            _retry_status_for_run(conn, task_id, row["current_run_id"])
-            if release_claim
-            else ("review" if row["status"] == "review" else "ready")
-        )
-        failures = int(row["consecutive_failures"]) + 1
+    row = conn.execute(
+        "SELECT consecutive_failures, status, max_retries, current_run_id "
+        "FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    retry_status = (
+        _retry_status_for_run(conn, task_id, row["current_run_id"])
+        if release_claim
+        else ("review" if row["status"] == "review" else "ready")
+    )
+    failures = int(row["consecutive_failures"]) + 1
 
-        # Per-task override wins over both caller-supplied and default
-        # thresholds. None (the common case) falls through.
-        task_override = (
-            row["max_retries"] if "max_retries" in row.keys() else None
-        )
-        if task_override is not None:
-            effective_limit = int(task_override)
-            limit_source = "task"
-        else:
-            effective_limit = int(failure_limit)
-            limit_source = "dispatcher"
+    # Per-task override wins over both caller-supplied and default
+    # thresholds. None (the common case) falls through.
+    task_override = (
+        row["max_retries"] if "max_retries" in row.keys() else None
+    )
+    if task_override is not None:
+        effective_limit = int(task_override)
+        limit_source = "task"
+    else:
+        effective_limit = int(failure_limit)
+        limit_source = "dispatcher"
 
-        if force_trip or failures >= effective_limit:
-            # Trip the breaker.
-            if release_claim:
-                # Spawn path: still running, also clear claim state.
-                conn.execute(
-                    "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
-                    "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status IN ('running', 'ready', 'review')",
-                    (failures, error[:500], task_id),
-                )
-            else:
-                # Timeout/crash path: source phase already restored with claim
-                # cleared; just flip to blocked + update
-                # counter fields.
-                conn.execute(
-                    "UPDATE tasks SET status = 'blocked', "
-                    "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status IN ('ready', 'review', 'running')",
-                    (failures, error[:500], task_id),
-                )
-            run_id = None
-            if end_run:
-                # Only the spawn path has an open run to close.
-                run_id = _end_run(
-                    conn, task_id,
-                    outcome="gave_up", status="gave_up",
-                    error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "trigger_outcome": outcome,
-                        "effective_limit": effective_limit,
-                        "limit_source": limit_source,
-                        "retry_status": retry_status,
-                    },
-                )
-            payload = {
-                "failures": failures,
-                "effective_limit": effective_limit,
-                "limit_source": limit_source,
-                "error": error[:500],
-                "trigger_outcome": outcome,
-                "retry_status": retry_status,
-            }
-            if event_payload_extra:
-                payload.update(event_payload_extra)
-            _append_event(
-                conn, task_id, "gave_up", payload, run_id=run_id,
+    if force_trip or failures >= effective_limit:
+        # Trip the breaker.
+        if release_claim:
+            # Spawn path: still running, also clear claim state.
+            conn.execute(
+                "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, "
+                "consecutive_failures = ?, last_failure_error = ? "
+                "WHERE id = ? AND status IN ('running', 'ready', 'review')",
+                (failures, error[:500], task_id),
             )
-            blocked = True
         else:
-            # Below threshold.
-            if release_claim:
-                # Spawn path: restore the claimed source phase + clear claim.
-                conn.execute(
-                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
-                    "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status = 'running'",
-                    (retry_status, failures, error[:500], task_id),
-                )
-            else:
-                # Timeout/crash path: caller already restored the source phase.
-                conn.execute(
-                    "UPDATE tasks SET consecutive_failures = ?, "
-                    "last_failure_error = ? WHERE id = ?",
-                    (failures, error[:500], task_id),
-                )
-            if end_run:
-                # Spawn path: close the open run with outcome.
-                run_id = _end_run(
-                    conn, task_id,
-                    outcome=outcome, status=outcome,
-                    error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
-                )
-                _append_event(
-                    conn, task_id, outcome,
-                    {
-                        "error": error[:500],
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
-                    run_id=run_id,
-                )
-            # Timeout/crash path's caller already emitted its own event.
+            # Timeout/crash path: source phase already restored with claim
+            # cleared; just flip to blocked + update counter fields.
+            conn.execute(
+                "UPDATE tasks SET status = 'blocked', "
+                "consecutive_failures = ?, last_failure_error = ? "
+                "WHERE id = ? AND status IN ('ready', 'review', 'running')",
+                (failures, error[:500], task_id),
+            )
+        run_id = None
+        if end_run:
+            # Only the spawn path has an open run to close.
+            run_id = _end_run(
+                conn, task_id,
+                outcome="gave_up", status="gave_up",
+                error=error[:500],
+                metadata={
+                    "failures": failures,
+                    "trigger_outcome": outcome,
+                    "effective_limit": effective_limit,
+                    "limit_source": limit_source,
+                    "retry_status": retry_status,
+                },
+            )
+        payload = {
+            "failures": failures,
+            "effective_limit": effective_limit,
+            "limit_source": limit_source,
+            "error": error[:500],
+            "trigger_outcome": outcome,
+            "retry_status": retry_status,
+        }
+        if event_payload_extra:
+            payload.update(event_payload_extra)
+        _append_event(conn, task_id, "gave_up", payload, run_id=run_id)
+        blocked = True
+    else:
+        # Below threshold.
+        if release_claim:
+            # Spawn path: restore the claimed source phase + clear claim.
+            conn.execute(
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, "
+                "consecutive_failures = ?, last_failure_error = ? "
+                "WHERE id = ? AND status = 'running'",
+                (retry_status, failures, error[:500], task_id),
+            )
+        else:
+            # Timeout/crash path: caller already restored the source phase.
+            conn.execute(
+                "UPDATE tasks SET consecutive_failures = ?, "
+                "last_failure_error = ? WHERE id = ?",
+                (failures, error[:500], task_id),
+            )
+        if end_run:
+            # Spawn path: close the open run with outcome.
+            run_id = _end_run(
+                conn, task_id,
+                outcome=outcome, status=outcome,
+                error=error[:500],
+                metadata={
+                    "failures": failures,
+                    "retry_status": retry_status,
+                },
+            )
+            _append_event(
+                conn, task_id, outcome,
+                {
+                    "error": error[:500],
+                    "failures": failures,
+                    "retry_status": retry_status,
+                },
+                run_id=run_id,
+            )
+        # Timeout/crash path's caller already emitted its own event.
     return blocked
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4040,7 +4040,7 @@ def _append_event(
     payload: Optional[dict] = None,
     *,
     run_id: Optional[int] = None,
-) -> None:
+) -> int:
     """Record an event row.  Called from within an already-open txn.
 
     ``run_id`` is optional: pass the current run id so UIs can group
@@ -4050,10 +4050,35 @@ def _append_event(
     """
     now = int(time.time())
     pl = json.dumps(payload, ensure_ascii=False) if payload else None
-    conn.execute(
+    cur = conn.execute(
         "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
+    )
+    return int(cur.lastrowid or 0)
+
+
+def _update_event_payload(
+    conn: sqlite3.Connection,
+    event_id: int,
+    payload: dict,
+) -> None:
+    conn.execute(
+        "UPDATE task_events SET payload = ? WHERE id = ?",
+        (json.dumps(payload, ensure_ascii=False), event_id),
+    )
+
+
+def _update_run_metadata(
+    conn: sqlite3.Connection,
+    run_id: Optional[int],
+    metadata: dict,
+) -> None:
+    if run_id is None:
+        return
+    conn.execute(
+        "UPDATE task_runs SET metadata = ? WHERE id = ?",
+        (json.dumps(metadata, ensure_ascii=False), run_id),
     )
 
 
@@ -8141,7 +8166,7 @@ def enforce_max_runtime(
                     error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
                     metadata=payload,
                 )
-                _append_event(
+                event_id = _append_event(
                     conn, tid, "timed_out", payload, run_id=run_id,
                 )
                 timed_out.append(tid)
@@ -8151,7 +8176,7 @@ def enforce_max_runtime(
         # emits a ``gave_up`` event on top of the ``timed_out`` we
         # already emitted.
         if cur.rowcount == 1:
-            _record_task_failure(
+            tripped = _record_task_failure(
                 conn, tid,
                 error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
                 outcome="timed_out",
@@ -8163,6 +8188,10 @@ def enforce_max_runtime(
                     "retry_status": retry_status,
                 },
             )
+            payload["will_retry"] = not tripped
+            with write_txn(conn):
+                _update_event_payload(conn, event_id, payload)
+                _update_run_metadata(conn, run_id, payload)
     return timed_out
 
 
@@ -8511,8 +8540,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # clean-exit-but-still-running case, which is accounted against its
     # own bounded violation streak instead of the unified failure
     # counter (see the post-txn loop below).
-    crash_details: list[tuple[str, int, str, bool, str]] = []
-    # (task_id, pid, claimer, protocol_violation, error_text)
+    crash_details: list[tuple[str, int, str, bool, str, int, Optional[int], dict]] = []
+    # (task_id, pid, claimer, protocol_violation, error_text, event_id, run_id, payload)
     with write_txn(conn):
         rows = conn.execute(
             "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
@@ -8619,7 +8648,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     error=error_text,
                     metadata=dict(event_payload),
                 )
-                _append_event(
+                event_id = _append_event(
                     conn, row["id"], event_kind,
                     event_payload,
                     run_id=run_id,
@@ -8651,7 +8680,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     crashed.append(row["id"])
                     crash_details.append(
                         (row["id"], pid, row["claim_lock"],
-                         protocol_violation, error_text)
+                         protocol_violation, error_text, event_id, run_id,
+                         dict(event_payload))
                     )
     # Outside the main txn: account each crashed task and maybe trip the
     # breaker (the retried task transitions to blocked with a ``gave_up`` event
@@ -8673,10 +8703,13 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     if crash_details:
         # Fingerprint errors to detect systemic failures.
         _fp_counts: dict[str, int] = {}
-        for _, _, _, _, err_text in crash_details:
+        for _, _, _, _, err_text, _, _, _ in crash_details:
             fp = _error_fingerprint(err_text)
             _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
-        for tid, pid, claimer, protocol_violation, error_text in crash_details:
+        for (
+            tid, pid, claimer, protocol_violation, error_text, event_id,
+            run_id, event_payload,
+        ) in crash_details:
             if protocol_violation:
                 streak = _protocol_violation_streak(conn, tid)
                 trow = conn.execute(
@@ -8734,6 +8767,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 end_run=False,
                 event_payload_extra={"pid": pid, "claimer": claimer},
             )
+            event_payload["will_retry"] = not tripped
+            with write_txn(conn):
+                _update_event_payload(conn, event_id, event_payload)
+                _update_run_metadata(conn, run_id, event_payload)
             if tripped:
                 auto_blocked.append(tid)
     # Stash auto-blocked ids on the function for the dispatch loop to pick up.

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -353,6 +353,46 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     assert "crashed" in adapter.sent[1]["text"].lower()
 
 
+def test_notifier_retry_copy_requires_affirmative_payload(tmp_path, monkeypatch):
+    db_path = tmp_path / "retry-copy.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="retry copy", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb._append_event(conn, tid, kind="crashed", payload={"will_retry": False})
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert "crashed" in adapter.sent[0]["text"].lower()
+    assert "will retry" not in adapter.sent[0]["text"].lower()
+
+    conn = kb.connect()
+    try:
+        kb._append_event(
+            conn,
+            tid,
+            kind="timed_out",
+            payload={"limit_seconds": 5, "will_retry": True},
+        )
+    finally:
+        conn.close()
+
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 2
+    assert "timed out" in adapter.sent[1]["text"].lower()
+    assert "will retry" in adapter.sent[1]["text"].lower()
+
+
 def test_notifier_wakeup_uses_subscription_chat_type(tmp_path, monkeypatch):
     db_path = tmp_path / "chat-type-wakeup.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -308,6 +308,58 @@ def test_max_runtime_terminates_overrun_worker(kanban_home):
             to_event = next(e for e in events if e.kind == "timed_out")
             assert to_event.payload["limit_seconds"] == 1
             assert to_event.payload["elapsed_seconds"] >= 30
+            assert to_event.payload["will_retry"] is True
+        finally:
+            conn.close()
+    finally:
+        _kb._pid_alive = original_alive
+
+
+def test_max_runtime_marks_no_retry_when_breaker_trips(kanban_home):
+    killed = []
+
+    def _signal_fn(pid, sig):
+        killed.append((pid, sig))
+
+    import hermes_cli.kanban_db as _kb
+    original_alive = _kb._pid_alive
+    _kb._pid_alive = lambda pid: False
+
+    try:
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(
+                conn,
+                title="one shot timeout",
+                assignee="worker",
+                max_runtime_seconds=1,
+                max_retries=1,
+            )
+            kb.claim_task(conn, tid)
+            kb._set_worker_pid(conn, tid, os.getpid())
+            old_started = int(time.time()) - 30
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET started_at = ? WHERE id = ?",
+                    (old_started, tid),
+                )
+                conn.execute(
+                    "UPDATE task_runs SET started_at = ? "
+                    "WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
+                    (old_started, tid),
+                )
+
+            timed_out = kb.enforce_max_runtime(conn, signal_fn=_signal_fn)
+            assert tid in timed_out
+            assert killed and killed[0][0] == os.getpid()
+
+            task = kb.get_task(conn, tid)
+            assert task.status == "blocked"
+            events = kb.list_events(conn, tid)
+            timed_out_event = next(e for e in events if e.kind == "timed_out")
+            gave_up_event = next(e for e in events if e.kind == "gave_up")
+            assert timed_out_event.payload["will_retry"] is False
+            assert gave_up_event.payload["trigger_outcome"] == "timed_out"
         finally:
             conn.close()
     finally:
@@ -1368,6 +1420,29 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
         conn.close()
 
 
+def test_crashed_event_marks_no_retry_when_breaker_trips(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="one shot crash",
+            assignee="worker",
+            max_retries=1,
+        )
+
+        assert tid in _drive_nonzero_crash(conn, tid, 992000)
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        events = kb.list_events(conn, tid)
+        crashed = next(e for e in events if e.kind == "crashed")
+        gave_up = next(e for e in events if e.kind == "gave_up")
+        assert crashed.payload["will_retry"] is False
+        assert gave_up.payload["trigger_outcome"] == "crashed"
+    finally:
+        conn.close()
+
+
 
 
 
@@ -1406,5 +1481,4 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
 

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -222,6 +222,29 @@ class TestFormatKanbanEventText:
         text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
         assert "timed out" in text
 
+    def test_timed_out_retry_copy_requires_affirmative_payload(self):
+        for payload in ({}, {"will_retry": False}, {"will_retry": "true"}):
+            ev = SimpleNamespace(kind="timed_out", payload=payload)
+            text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+            assert "will retry" not in text
+
+        ev = SimpleNamespace(
+            kind="timed_out",
+            payload={"limit_seconds": 5, "will_retry": True},
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "will retry" in text
+
+    def test_crashed_retry_copy_requires_affirmative_payload(self):
+        for payload in ({}, {"will_retry": False}, {"will_retry": "true"}):
+            ev = SimpleNamespace(kind="crashed", payload=payload)
+            text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+            assert "dispatcher will retry" not in text
+
+        ev = SimpleNamespace(kind="crashed", payload={"will_retry": True})
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "dispatcher will retry" in text
+
 
 class TestNotificationPollerLoopKanbanWiring:
     """Drive a real TUI subscription through ``_notification_poller_loop``.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9108,14 +9108,16 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
         err = f"\n{str(payload.get('error'))[:200]}" if payload.get("error") else ""
         return f"✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}"
     if kind == "crashed":
-        return f"✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry"
+        retry = "; dispatcher will retry" if payload.get("will_retry") is True else ""
+        return f"✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone){retry}"
     if kind == "timed_out":
         limit = 0
         try:
             limit = int(payload.get("limit_seconds") or 0)
         except (TypeError, ValueError):
             pass
-        return f"⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry"
+        retry = "; will retry" if payload.get("will_retry") is True else ""
+        return f"⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s){retry}"
     if kind == "status":
         return f"🔄 {board_tag}{tag}Kanban {task_id} → {payload.get('status') or ''}"
     return None


### PR DESCRIPTION
## Summary

Fixes #84059.

- record `will_retry` on timed-out and crashed Kanban events after `_record_task_failure()` decides whether the breaker tripped
- make gateway and TUI notification copy append retry text only for `will_retry: true`
- keep legacy/missing payloads conservative by omitting retry promises instead of asserting them

## Tests

- `.venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py::test_max_runtime_terminates_overrun_worker tests/hermes_cli/test_kanban_core_functionality.py::test_max_runtime_marks_no_retry_when_breaker_trips tests/hermes_cli/test_kanban_core_functionality.py::test_crashed_event_marks_no_retry_when_breaker_trips`
- `.venv/bin/python -m pytest tests/tui_gateway/test_kanban_notify_poller.py::TestFormatKanbanEventText tests/gateway/test_kanban_notifier.py::test_notifier_retry_copy_requires_affirmative_payload`
- `.venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py tests/tui_gateway/test_kanban_notify_poller.py tests/gateway/test_kanban_notifier.py`
- `.venv/bin/python -m ruff check hermes_cli/kanban_db.py gateway/kanban_watchers.py tui_gateway/server.py tests/hermes_cli/test_kanban_core_functionality.py tests/tui_gateway/test_kanban_notify_poller.py tests/gateway/test_kanban_notifier.py`
- `git diff --check`