### PR TITLE
fix(qqbot): preserve passive-reply anchor for media

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4355,8 +4355,41 @@ class BasePlatformAdapter(ABC):
         Override in subclasses to bundle into a single native API call
         (e.g. Signal's multi-attachment RPC)
         """
+        await self._send_multiple_images_individually(
+            chat_id=chat_id,
+            images=images,
+            metadata=metadata,
+            human_delay=human_delay,
+        )
+
+    async def _send_multiple_images_with_reply_anchor(
+        self,
+        chat_id: str,
+        images: List[Tuple[str, str]],
+        reply_to: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        human_delay: float = 0.0,
+    ) -> None:
+        """Send an image batch while anchoring each default-path upload."""
+        await self._send_multiple_images_individually(
+            chat_id=chat_id,
+            images=images,
+            reply_to=reply_to,
+            metadata=metadata,
+            human_delay=human_delay,
+        )
+
+    async def _send_multiple_images_individually(
+        self,
+        chat_id: str,
+        images: List[Tuple[str, str]],
+        metadata: Optional[Dict[str, Any]] = None,
+        human_delay: float = 0.0,
+        reply_to: Optional[str] = None,
+    ) -> None:
         from urllib.parse import unquote as _unquote
 
+        reply_kwargs = {"reply_to": reply_to} if reply_to else {}
         for image_url, alt_text in images:
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
@@ -4372,6 +4405,7 @@ class BasePlatformAdapter(ABC):
                         chat_id=chat_id,
                         image_path=_unquote(image_url[7:]),
                         caption=alt_text if alt_text else None,
+                        **reply_kwargs,
                         metadata=metadata,
                     )
                 elif self._is_animation_url(image_url):
@@ -4379,6 +4413,7 @@ class BasePlatformAdapter(ABC):
                         chat_id=chat_id,
                         animation_url=image_url,
                         caption=alt_text if alt_text else None,
+                        **reply_kwargs,
                         metadata=metadata,
                     )
                 else:
@@ -4386,6 +4421,7 @@ class BasePlatformAdapter(ABC):
                         chat_id=chat_id,
                         image_url=image_url,
                         caption=alt_text if alt_text else None,
+                        **reply_kwargs,
                         metadata=metadata,
                     )
                 if not img_result.success:
@@ -6392,6 +6428,12 @@ class BasePlatformAdapter(ABC):
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _reply_anchor = _reply_anchor_for_event(event)
+                _media_reply_kwargs = (
+                    {"reply_to": _reply_anchor}
+                    if self.platform == Platform.QQBOT and _reply_anchor
+                    else {}
+                )
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
@@ -6469,6 +6511,7 @@ class BasePlatformAdapter(ABC):
                             chat_id=event.source.chat_id,
                             audio_path=_tts_path,
                             caption=telegram_tts_caption,
+                            **_media_reply_kwargs,
                             metadata=_final_thread_metadata,
                         )
                         _record_delivery(tts_result)
@@ -6503,7 +6546,6 @@ class BasePlatformAdapter(ABC):
                         len(text_content),
                         event.source.chat_id,
                     )
-                    _reply_anchor = _reply_anchor_for_event(event)
                     # Delivery-obligation ledger: durably record the final
                     # response BEFORE the send attempt so a gateway crash
                     # between finalize and platform ACK can redeliver it on
@@ -6594,12 +6636,21 @@ class BasePlatformAdapter(ABC):
                 if images:
                     logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
                     try:
-                        await self.send_multiple_images(
-                            chat_id=event.source.chat_id,
-                            images=images,
-                            metadata=_final_thread_metadata,
-                            human_delay=human_delay,
-                        )
+                        if _media_reply_kwargs:
+                            await self._send_multiple_images_with_reply_anchor(
+                                chat_id=event.source.chat_id,
+                                images=images,
+                                **_media_reply_kwargs,
+                                metadata=_final_thread_metadata,
+                                human_delay=human_delay,
+                            )
+                        else:
+                            await self.send_multiple_images(
+                                chat_id=event.source.chat_id,
+                                images=images,
+                                metadata=_final_thread_metadata,
+                                human_delay=human_delay,
+                            )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
@@ -6636,12 +6687,21 @@ class BasePlatformAdapter(ABC):
                 if _image_paths:
                     try:
                         _batch = [(f"file://{_quote(p)}", "") for p in _image_paths]
-                        await self.send_multiple_images(
-                            chat_id=event.source.chat_id,
-                            images=_batch,
-                            metadata=_final_thread_metadata,
-                            human_delay=human_delay,
-                        )
+                        if _media_reply_kwargs:
+                            await self._send_multiple_images_with_reply_anchor(
+                                chat_id=event.source.chat_id,
+                                images=_batch,
+                                **_media_reply_kwargs,
+                                metadata=_final_thread_metadata,
+                                human_delay=human_delay,
+                            )
+                        else:
+                            await self.send_multiple_images(
+                                chat_id=event.source.chat_id,
+                                images=_batch,
+                                metadata=_final_thread_metadata,
+                                human_delay=human_delay,
+                            )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
@@ -6660,6 +6720,7 @@ class BasePlatformAdapter(ABC):
                             media_result = await self.send_voice(
                                 chat_id=event.source.chat_id,
                                 audio_path=media_path,
+                                **_media_reply_kwargs,
                                 metadata=_final_thread_metadata,
                             )
                         elif ext in _VIDEO_EXTS:
@@ -6672,12 +6733,14 @@ class BasePlatformAdapter(ABC):
                             media_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=media_path,
+                                **_media_reply_kwargs,
                                 metadata=_final_thread_metadata,
                             )
                         else:
                             media_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=media_path,
+                                **_media_reply_kwargs,
                                 metadata=_final_thread_metadata,
                             )
 
@@ -6702,12 +6765,14 @@ class BasePlatformAdapter(ABC):
                             file_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
+                                **_media_reply_kwargs,
                                 metadata=_final_thread_metadata,
                             )
                         else:
                             file_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
+                                **_media_reply_kwargs,
                                 metadata=_final_thread_metadata,
                             )
                         if not file_result.success:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21781,6 +21781,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             media_files, cleaned = adapter.extract_media(response)
             media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+            reply_anchor = self._reply_anchor_for_event(event)
+            media_reply_kwargs = (
+                {"reply_to": reply_anchor}
+                if event.source.platform == Platform.QQBOT and reply_anchor
+                else {}
+            )
             # Do NOT deduplicate explicit MEDIA tags against prior turns here
             # (#73771). This rescan is already EXPLICIT-ONLY (see docstring):
             # a MEDIA: directive in the final streamed reply is the model
@@ -21801,7 +21807,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if thread_metadata is not None
                 else self._thread_metadata_for_source(
                     event.source,
-                    self._reply_anchor_for_event(event),
+                    reply_anchor,
                 )
             )
 
@@ -21826,11 +21832,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if image_paths:
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
-                    await adapter.send_multiple_images(
-                        chat_id=event.source.chat_id,
-                        images=images,
-                        metadata=_thread_meta,
-                    )
+                    if media_reply_kwargs:
+                        await adapter._send_multiple_images_with_reply_anchor(
+                            chat_id=event.source.chat_id,
+                            images=images,
+                            **media_reply_kwargs,
+                            metadata=_thread_meta,
+                        )
+                    else:
+                        await adapter.send_multiple_images(
+                            chat_id=event.source.chat_id,
+                            images=images,
+                            metadata=_thread_meta,
+                        )
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
 
@@ -21841,18 +21855,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await adapter.send_voice(
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
+                            **media_reply_kwargs,
                             metadata=_thread_meta,
                         )
                     elif ext in _VIDEO_EXTS:
                         await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
+                            **media_reply_kwargs,
                             metadata=_thread_meta,
                         )
                     else:
                         await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
+                            **media_reply_kwargs,
                             metadata=_thread_meta,
                         )
                 except Exception as e:
@@ -22086,6 +22103,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from gateway.platforms.base import BasePlatformAdapter
                 media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
                 images, text_content = adapter.extract_images(response)
+                media_reply_kwargs = (
+                    {"reply_to": event_message_id}
+                    if source.platform == Platform.QQBOT and event_message_id
+                    else {}
+                )
 
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
                 header = f'✅ Background task complete\nPrompt: "{preview}"\n\n'
@@ -22110,6 +22132,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             chat_id=source.chat_id,
                             image_url=image_url,
                             caption=alt_text,
+                            **media_reply_kwargs,
                             metadata=_thread_metadata,
                         )
                     except Exception:
@@ -22130,24 +22153,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             await adapter.send_voice(
                                 chat_id=source.chat_id,
                                 audio_path=media_path,
+                                **media_reply_kwargs,
                                 metadata=_thread_metadata,
                             )
                         elif _ext in _VIDEO_EXTS:
                             await adapter.send_video(
                                 chat_id=source.chat_id,
                                 video_path=media_path,
+                                **media_reply_kwargs,
                                 metadata=_thread_metadata,
                             )
                         elif _ext in _IMAGE_EXTS:
                             await adapter.send_image_file(
                                 chat_id=source.chat_id,
                                 image_path=media_path,
+                                **media_reply_kwargs,
                                 metadata=_thread_metadata,
                             )
                         else:
                             await adapter.send_document(
                                 chat_id=source.chat_id,
                                 file_path=media_path,
+                                **media_reply_kwargs,
                                 metadata=_thread_metadata,
                             )
                     except Exception:

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -166,6 +166,58 @@ class TestRunBackgroundTask:
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_media_delivery_reuses_triggering_message_as_reply_anchor(
+        self, tmp_path, monkeypatch,
+    ):
+        runner = _make_runner()
+        media_root = tmp_path / "media-cache"
+        media_root.mkdir()
+        report = media_root / "report.pdf"
+        report.write_bytes(b"report")
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (media_root,),
+        )
+
+        mock_adapter = AsyncMock()
+        mock_adapter.extract_media = MagicMock(
+            return_value=([(str(report), False)], "")
+        )
+        mock_adapter.extract_images = MagicMock(return_value=([], ""))
+        mock_adapter.send_document = AsyncMock()
+        runner.adapters[Platform.QQBOT] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.QQBOT,
+            user_id="user-1",
+            chat_id="group-1",
+            chat_type="group",
+        )
+        mock_result = {"final_response": f"MEDIA:{report}", "messages": []}
+
+        with patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"api_key": "test-key"},
+        ), patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = mock_result
+            mock_agent_cls.return_value = mock_agent
+
+            await runner._run_background_task(
+                "make report",
+                source,
+                "bg_media",
+                event_message_id="inbound-42",
+            )
+
+        mock_adapter.send_document.assert_awaited_once_with(
+            chat_id="group-1",
+            file_path=str(report),
+            reply_to="inbound-42",
+            metadata=None,
+        )
+
 
 # ---------------------------------------------------------------------------
 # /background in help and known_commands

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -22,8 +22,8 @@ from gateway.session import SessionSource, build_session_key
 
 
 class _MediaRoutingAdapter(BasePlatformAdapter):
-    def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="test"), platform)
 
     async def connect(self, *, is_reconnect: bool = False):
         return True
@@ -38,9 +38,9 @@ class _MediaRoutingAdapter(BasePlatformAdapter):
         return {"id": chat_id, "type": "dm"}
 
 
-def _event(thread_id=None):
+def _event(thread_id=None, platform=Platform.TELEGRAM):
     source = SessionSource(
-        platform=Platform.TELEGRAM,
+        platform=platform,
         chat_id="chat-1",
         chat_type="dm",
         thread_id=thread_id,
@@ -86,14 +86,156 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
     adapter.send_document.assert_not_awaited()
 
 
-def _fake_runner(thread_meta):
+@pytest.mark.asyncio
+async def test_base_qqbot_image_batch_forwards_reply_anchor(tmp_path):
+    adapter = _MediaRoutingAdapter(Platform.QQBOT)
+    image = tmp_path / "chart.png"
+    image.write_bytes(b"image")
+    adapter.send_image_file = AsyncMock(
+        return_value=SendResult(success=True, message_id="image")
+    )
+
+    await adapter._send_multiple_images_with_reply_anchor(
+        chat_id="chat-1",
+        images=[(f"file://{image}", "chart")],
+        reply_to="msg-1",
+    )
+
+    adapter.send_image_file.assert_awaited_once_with(
+        chat_id="chat-1",
+        image_path=str(image),
+        caption="chart",
+        reply_to="msg-1",
+        metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_non_qq_image_batch_preserves_public_send_contract(tmp_path):
+    adapter = _MediaRoutingAdapter(Platform.TELEGRAM)
+    image = tmp_path / "chart.png"
+    image.write_bytes(b"image")
+    adapter.send_image_file = AsyncMock(
+        return_value=SendResult(success=True, message_id="image")
+    )
+
+    await adapter.send_multiple_images(
+        chat_id="chat-1",
+        images=[(f"file://{image}", "chart")],
+    )
+
+    adapter.send_image_file.assert_awaited_once_with(
+        chat_id="chat-1",
+        image_path=str(image),
+        caption="chart",
+        metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_qqbot_media_delivery_forwards_reply_anchor(tmp_path, monkeypatch):
+    adapter = _MediaRoutingAdapter(Platform.QQBOT)
+    event = _event(platform=Platform.QQBOT)
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "speech.ogg")
+    adapter._message_handler = AsyncMock(
+        return_value=f"[[audio_as_voice]]\nMEDIA:{media_file}"
+    )
+    adapter.send_voice = AsyncMock(
+        return_value=SendResult(success=True, message_id="voice")
+    )
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.send_voice.assert_awaited_once_with(
+        chat_id="chat-1",
+        audio_path=str(media_file),
+        reply_to="msg-1",
+        metadata={"notify": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_qqbot_auto_tts_forwards_reply_anchor(tmp_path, monkeypatch):
+    adapter = _MediaRoutingAdapter(Platform.QQBOT)
+    event = _event(platform=Platform.QQBOT)
+    event.message_type = MessageType.VOICE
+    tts_path = tmp_path / "speech.ogg"
+
+    adapter._message_handler = AsyncMock(return_value="Spoken reply")
+    adapter._should_auto_tts_for_chat = lambda chat_id: True
+    adapter.play_tts = AsyncMock(
+        return_value=SendResult(success=True, message_id="voice")
+    )
+    monkeypatch.setattr(
+        "gateway.platforms.base.build_auto_tts_output_path",
+        lambda platform: str(tts_path),
+    )
+    monkeypatch.setattr("tools.tts_tool.check_tts_requirements", lambda: True)
+
+    def fake_tts(**kwargs):
+        tts_path.write_bytes(b"audio")
+        return f'{{"success": true, "file_path": "{tts_path}"}}'
+
+    monkeypatch.setattr("tools.tts_tool.text_to_speech_tool", fake_tts)
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.play_tts.assert_awaited_once_with(
+        chat_id="chat-1",
+        audio_path=str(tts_path),
+        caption=None,
+        reply_to="msg-1",
+        metadata={"notify": True},
+    )
+
+
+def _fake_runner(thread_meta, reply_anchor=None):
     """Build a fake GatewayRunner-like object with the helper methods needed by
     _deliver_media_from_response."""
     runner = SimpleNamespace(
         _thread_metadata_for_source=lambda source, anchor=None: thread_meta,
-        _reply_anchor_for_event=lambda event: None,
+        _reply_anchor_for_event=lambda event: reply_anchor,
     )
     return runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "directive", "method_name", "path_kwarg"),
+    [
+        ("speech.ogg", "[[audio_as_voice]]\n", "send_voice", "audio_path"),
+        ("clip.mp4", "", "send_video", "video_path"),
+        ("report.pdf", "", "send_document", "file_path"),
+    ],
+)
+async def test_streaming_media_delivery_forwards_reply_anchor(
+    tmp_path, monkeypatch, filename, directive, method_name, path_kwarg,
+):
+    event = _event(platform=Platform.QQBOT)
+    media_file = _allowed_media_path(tmp_path, monkeypatch, filename)
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}, reply_anchor="msg-1"),
+        f"{directive}MEDIA:{media_file}",
+        event,
+        adapter,
+    )
+
+    getattr(adapter, method_name).assert_awaited_once_with(
+        chat_id="chat-1",
+        **{path_kwarg: str(media_file)},
+        reply_to="msg-1",
+        metadata={},
+    )
 
 
 @pytest.mark.asyncio
@@ -205,7 +347,7 @@ class _DiscordMediaFailureAdapter(BasePlatformAdapter):
 async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_image(
     tmp_path, monkeypatch,
 ):
-    event = _event(thread_id="topic-1")
+    event = _event(thread_id="topic-1", platform=Platform.QQBOT)
     media_file = _allowed_media_path(tmp_path, monkeypatch, "pricelist.png")
     runner = object.__new__(GatewayRunner)
     runner._thread_metadata_for_source = lambda source, anchor=None: {"thread_id": "topic-1"}
@@ -217,7 +359,7 @@ async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_ima
         extract_images=BasePlatformAdapter.extract_images,
         extract_local_files=BasePlatformAdapter.extract_local_files,
         send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
-        send_multiple_images=AsyncMock(return_value=None),
+        _send_multiple_images_with_reply_anchor=AsyncMock(return_value=None),
         send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
         send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
         send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
@@ -237,9 +379,10 @@ async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_ima
         "Quote here",
         metadata={"thread_id": "topic-1"},
     )
-    adapter.send_multiple_images.assert_awaited_once_with(
+    adapter._send_multiple_images_with_reply_anchor.assert_awaited_once_with(
         chat_id="chat-1",
         images=[(f"file://{media_file.as_posix()}", "")],
+        reply_to="msg-1",
         metadata={"thread_id": "topic-1"},
     )
 
@@ -249,7 +392,7 @@ async def test_queued_followup_delivery_reuses_routing_metadata_for_media(
     tmp_path, monkeypatch,
 ):
     """Queued text and media must stay on the same precomputed reply route."""
-    event = _event(thread_id="source-topic")
+    event = _event(thread_id="source-topic", platform=Platform.QQBOT)
     media_file = _allowed_media_path(tmp_path, monkeypatch, "threaded.png")
     runner = object.__new__(GatewayRunner)
     runner._thread_metadata_for_source = (
@@ -267,7 +410,7 @@ async def test_queued_followup_delivery_reuses_routing_metadata_for_media(
         extract_images=BasePlatformAdapter.extract_images,
         extract_local_files=BasePlatformAdapter.extract_local_files,
         send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
-        send_multiple_images=AsyncMock(return_value=None),
+        _send_multiple_images_with_reply_anchor=AsyncMock(return_value=None),
         send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
         send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
         send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
@@ -287,9 +430,10 @@ async def test_queued_followup_delivery_reuses_routing_metadata_for_media(
         "Threaded image",
         metadata=routing_metadata,
     )
-    adapter.send_multiple_images.assert_awaited_once_with(
+    adapter._send_multiple_images_with_reply_anchor.assert_awaited_once_with(
         chat_id="chat-1",
         images=[(f"file://{media_file.as_posix()}", "")],
+        reply_to="msg-1",
         metadata=routing_metadata,
     )
 
@@ -456,7 +600,7 @@ class _QueuedMediaCaptureAdapter(BasePlatformAdapter):
     """Adapter that records text + native image delivery for queued-resend tests."""
 
     def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.QQBOT)
         self.sent = []
         self.images = []
 
@@ -471,15 +615,13 @@ class _QueuedMediaCaptureAdapter(BasePlatformAdapter):
         return SendResult(success=True, message_id=f"text-{len(self.sent)}")
 
     async def send_image_file(self, chat_id, image_path, caption=None, reply_to=None, metadata=None, **kwargs):
-        self.images.append({"chat_id": chat_id, "image_path": image_path, "metadata": metadata})
+        self.images.append({
+            "chat_id": chat_id,
+            "image_path": image_path,
+            "metadata": metadata,
+            "reply_to": reply_to,
+        })
         return SendResult(success=True, message_id=f"img-{len(self.images)}")
-
-    async def send_multiple_images(self, chat_id, images, metadata=None, human_delay=0.0):
-        for image_url, _alt in images:
-            path = image_url
-            if path.startswith("file://"):
-                path = path[len("file://"):]
-            self.images.append({"chat_id": chat_id, "image_path": path, "metadata": metadata})
 
     async def get_chat_info(self, chat_id):
         return {"id": chat_id, "type": "dm"}
@@ -549,7 +691,7 @@ async def test_queued_resend_branch_delivers_media_and_preserves_protected_examp
     monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
 
     source = SessionSource(
-        platform=Platform.TELEGRAM,
+        platform=Platform.QQBOT,
         chat_id="chat-1",
         chat_type="dm",
         thread_id="topic-1",
@@ -569,6 +711,7 @@ async def test_queued_resend_branch_delivers_media_and_preserves_protected_examp
         source=source,
         session_id="sess-queued-media",
         session_key=session_key,
+        event_message_id="initial-1",
     )
 
     assert _QueuedMediaAgent.calls == 2
@@ -580,3 +723,5 @@ async def test_queued_resend_branch_delivers_media_and_preserves_protected_examp
     assert any(str(media_file) in img["image_path"] for img in adapter.images), (
         f"expected native image delivery via queued resend, got: {adapter.images!r}"
     )
+    assert any(img["reply_to"] == "initial-1" for img in adapter.images)
+    assert all(img["reply_to"] != "queued-1" for img in adapter.images)


### PR DESCRIPTION
## What does this PR do?

Fixes QQBot passive media replies being rejected as proactive group messages. QQ requires the triggering inbound message ID as `msg_id`; the QQBot adapter already maps `reply_to` to that field, but gateway media delivery dropped the anchor before reaching the adapter.

This change forwards the current inbound anchor only for QQBot media sends across completed, streamed, queued, auto-TTS, and `/background` delivery paths. Batched QQBot images use a private anchored helper so the public `send_multiple_images` signature and non-QQ adapter behavior remain unchanged.

## Related Issue

Fixes #83085

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`
  - Preserve QQBot's inbound reply anchor for normal media, local files, image batches, and auto-TTS.
  - Add a private anchored image-batch path while preserving the public batch API and ordinary non-QQ calls.
- `gateway/run.py`
  - Forward QQBot anchors through post-stream, queued-first-response, and background-task media delivery.
  - Keep queued media tied to the original triggering message rather than a later queued follow-up.
- `tests/gateway/test_tts_media_routing.py`
  - Cover QQBot voice, video, document, image, auto-TTS, streaming, queued, and cross-message routing behavior.
  - Pin unchanged non-QQ image-batch behavior.
- `tests/gateway/test_background_command.py`
  - Cover `/background` media delivery using the triggering inbound message ID.

## How to Test

1. In a QQ group, trigger replies containing image, voice/audio, video, and document attachments.
2. Confirm each final QQ API message POST includes the inbound message's `msg_id` and is accepted as a passive reply.
3. Run:

```bash
env -u PYTHONPATH -u VIRTUAL_ENV /home/jakub/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/gateway/test_tts_media_routing.py \
  tests/gateway/test_background_command.py \
  -o 'addopts=' -q

env -u PYTHONPATH -u VIRTUAL_ENV /home/jakub/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/gateway/test_qqbot.py \
  tests/gateway/test_signal.py \
  tests/gateway/test_post_stream_media_delivery.py \
  tests/gateway/test_media_metadata_contract.py \
  tests/gateway/test_platform_base.py \
  -o 'addopts=' -q

uv tool run ruff check \
  gateway/platforms/base.py gateway/run.py \
  tests/gateway/test_tts_media_routing.py \
  tests/gateway/test_background_command.py

git diff --check HEAD^
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; focused and adjacent gateway/platform suites are reported below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.1.6-1-cachyos x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture/workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform routing only; filesystem behavior is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changes

## Screenshots / Logs

- Original regression RED: `9 failed, 13 passed`.
- Final focused GREEN: `25 passed in 1.68s`.
- Fresh QQBot-only mutation: `9 failed, 16 passed`; after restoration, `25 passed`.
- Adjacent QQBot/Signal/media/platform suite: `202 passed, 1 skipped` (one existing QQBot fake-websocket coroutine warning).
- Ruff: `All checks passed!`.
- `ty==0.0.21` comparison on the two production files: candidate and current base each report the same 140 semantic diagnostics; no candidate-only diagnostic.
- Public-signature comparison: no public method signature changes in `BasePlatformAdapter`; non-QQ batch behavior is covered directly.
- `git diff --check`: clean.
