### PR TITLE
fix(logging): classify recovered transport retries

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -198,10 +198,8 @@ _TELEGRAM_UPDATER_SHUTDOWN_MESSAGE = (
 )
 
 
-def _is_nonnegative_finite_number(value: object) -> bool:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return False
-    return math.isfinite(value) and value >= 0
+def _is_nonnegative_finite_float(value: object) -> bool:
+    return type(value) is float and math.isfinite(value) and value >= 0
 
 
 def _normalize_recovered_transport_retry_severity(record: logging.LogRecord) -> None:
@@ -217,17 +215,22 @@ def _normalize_recovered_transport_retry_severity(record: logging.LogRecord) -> 
         return
     args = record.args
     discord_retry = (
-        record.name == "discord.client"
+        type(record.name) is str
+        and record.name == "discord.client"
+        and type(record.msg) is str
         and record.msg == _DISCORD_RECONNECT_TEMPLATE
-        and isinstance(args, tuple)
+        and type(args) is tuple
         and len(args) == 1
-        and _is_nonnegative_finite_number(args[0])
+        and _is_nonnegative_finite_float(args[0])
     )
     telegram_retry = (
-        record.name == "telegram.ext"
+        type(record.name) is str
+        and record.name == "telegram.ext"
+        and type(record.msg) is str
         and record.msg == _TELEGRAM_RETRY_ABORT_TEMPLATE
-        and isinstance(args, tuple)
+        and type(args) is tuple
         and len(args) == 3
+        and type(args[0]) is str
         and args[0] in _TELEGRAM_DELETE_WEBHOOK_PREFIXES
         and type(args[1]) is int
         and args[1] == 0
@@ -235,9 +238,12 @@ def _normalize_recovered_transport_retry_severity(record: logging.LogRecord) -> 
         and args[2] == 0
     )
     telegram_shutdown = (
-        record.name == "telegram.ext.Updater"
+        type(record.name) is str
+        and record.name == "telegram.ext.Updater"
+        and type(record.msg) is str
         and record.msg == _TELEGRAM_UPDATER_SHUTDOWN_MESSAGE
-        and not args
+        and type(args) is tuple
+        and len(args) == 0
     )
     recovered_retry = (
         discord_retry

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -211,7 +211,7 @@ def _normalize_recovered_transport_retry_severity(record: logging.LogRecord) -> 
     as WARNINGs; adapter exhaustion, authentication failures, and every unknown
     SDK error remain ERROR.
     """
-    if record.levelno != logging.ERROR:
+    if type(record.levelno) is not int or record.levelno != logging.ERROR:
         return
     args = record.args
     discord_retry = (

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -31,6 +31,7 @@ import atexit
 import copy
 import io
 import logging
+import math
 import os
 import queue
 import sys
@@ -181,6 +182,28 @@ def clear_session_context() -> None:
 # ---------------------------------------------------------------------------
 
 
+_DISCORD_RECONNECT_TEMPLATE = "Attempting a reconnect in %.2fs"
+_TELEGRAM_RETRY_ABORT_TEMPLATE = "%s Failed run number %s of %s. Aborting."
+_TELEGRAM_DELETE_WEBHOOK_PREFIXES = frozenset(
+    {
+        "Network Retry Loop (Bootstrap delete Webhook):",
+        "Network Retry Loop (Bootstrap delete Webhook): Timed out: Timed out.",
+    }
+)
+_TELEGRAM_UPDATER_SHUTDOWN_MESSAGE = (
+    "Error while calling `get_updates` one more time to mark all fetched updates. "
+    "Suppressing error to ensure graceful shutdown. When polling for "
+    "updates is restarted, updates may be fetched again. Please adjust timeouts "
+    "via `ApplicationBuilder` or the parameter `get_updates_request` of `Bot`."
+)
+
+
+def _is_nonnegative_finite_number(value: object) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return math.isfinite(value) and value >= 0
+
+
 def _normalize_recovered_transport_retry_severity(record: logging.LogRecord) -> None:
     """Demote SDK-internal retry records whose failure is owned by an adapter.
 
@@ -192,20 +215,34 @@ def _normalize_recovered_transport_retry_severity(record: logging.LogRecord) -> 
     """
     if record.levelno != logging.ERROR:
         return
-    message = record.getMessage()
-    recovered_retry = (
+    args = record.args
+    discord_retry = (
         record.name == "discord.client"
-        and message.startswith("Attempting a reconnect in ")
-    ) or (
+        and record.msg == _DISCORD_RECONNECT_TEMPLATE
+        and isinstance(args, tuple)
+        and len(args) == 1
+        and _is_nonnegative_finite_number(args[0])
+    )
+    telegram_retry = (
         record.name == "telegram.ext"
-        and message.startswith("Network Retry Loop (Bootstrap delete Webhook):")
-        and message.endswith("Failed run number 0 of 0. Aborting.")
-    ) or (
+        and record.msg == _TELEGRAM_RETRY_ABORT_TEMPLATE
+        and isinstance(args, tuple)
+        and len(args) == 3
+        and args[0] in _TELEGRAM_DELETE_WEBHOOK_PREFIXES
+        and type(args[1]) is int
+        and args[1] == 0
+        and type(args[2]) is int
+        and args[2] == 0
+    )
+    telegram_shutdown = (
         record.name == "telegram.ext.Updater"
-        and message.startswith(
-            "Error while calling `get_updates` one more time to mark all fetched updates."
-        )
-        and "Suppressing error to ensure graceful shutdown." in message
+        and record.msg == _TELEGRAM_UPDATER_SHUTDOWN_MESSAGE
+        and not args
+    )
+    recovered_retry = (
+        discord_retry
+        or telegram_retry
+        or telegram_shutdown
     )
     if recovered_retry:
         record.levelno = logging.WARNING

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -177,8 +177,40 @@ def clear_session_context() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Record factory — injects session_tag into every LogRecord at creation
+# Record factory — injects session_tag and normalizes owned retry severity
 # ---------------------------------------------------------------------------
+
+
+def _normalize_recovered_transport_retry_severity(record: logging.LogRecord) -> None:
+    """Demote SDK-internal retry records whose failure is owned by an adapter.
+
+    discord.py and python-telegram-bot emit selected, self-recovering transport
+    retries at ERROR even though Hermes keeps the adapter alive and independently
+    detects unrecovered/stale connections.  Preserve those records and tracebacks
+    as WARNINGs; adapter exhaustion, authentication failures, and every unknown
+    SDK error remain ERROR.
+    """
+    if record.levelno != logging.ERROR:
+        return
+    message = record.getMessage()
+    recovered_retry = (
+        record.name == "discord.client"
+        and message.startswith("Attempting a reconnect in ")
+    ) or (
+        record.name == "telegram.ext"
+        and message.startswith("Network Retry Loop (Bootstrap delete Webhook):")
+        and message.endswith("Failed run number 0 of 0. Aborting.")
+    ) or (
+        record.name == "telegram.ext.Updater"
+        and message.startswith(
+            "Error while calling `get_updates` one more time to mark all fetched updates."
+        )
+        and "Suppressing error to ensure graceful shutdown." in message
+    )
+    if recovered_retry:
+        record.levelno = logging.WARNING
+        record.levelname = "WARNING"
+
 
 def _install_session_record_factory() -> None:
     """Replace the global LogRecord factory with one that adds ``session_tag``.
@@ -199,6 +231,7 @@ def _install_session_record_factory() -> None:
 
     def _session_record_factory(*args, **kwargs):
         record = current_factory(*args, **kwargs)
+        _normalize_recovered_transport_retry_severity(record)
         sid = getattr(_session_context, "session_id", None)
         record.session_tag = f" [{sid}]" if sid else ""  # type: ignore[attr-defined]
         return record

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -257,33 +257,50 @@ class TestRecoveredTransportRetrySeverity:
     """SDK retry noise is warning-level; adapter-owned failures stay errors."""
 
     @pytest.mark.parametrize(
-        ("logger_name", "message"),
+        ("logger_name", "message", "args"),
         [
-            ("discord.client", "Attempting a reconnect in 1.44s"),
+            ("discord.client", "Attempting a reconnect in %.2fs", (1.44,)),
             (
                 "telegram.ext",
-                "Network Retry Loop (Bootstrap delete Webhook): Failed run number 0 of 0. Aborting.",
+                "%s Failed run number %s of %s. Aborting.",
+                ("Network Retry Loop (Bootstrap delete Webhook):", 0, 0),
             ),
             (
                 "telegram.ext.Updater",
                 "Error while calling `get_updates` one more time to mark all fetched updates. "
-                "Suppressing error to ensure graceful shutdown.",
+                "Suppressing error to ensure graceful shutdown. When polling for "
+                "updates is restarted, updates may be fetched again. Please adjust timeouts "
+                "via `ApplicationBuilder` or the parameter `get_updates_request` of `Bot`.",
+                (),
             ),
         ],
     )
-    def test_exact_sdk_recovery_records_are_downgraded(self, caplog, logger_name, message):
+    def test_exact_sdk_recovery_records_are_downgraded(
+        self, caplog, logger_name, message, args
+    ):
         caplog.set_level(logging.WARNING)
-        logging.getLogger(logger_name).error(message)
+        logging.getLogger(logger_name).error(message, *args)
         record = caplog.records[-1]
         assert record.levelno == logging.WARNING
         assert record.levelname == "WARNING"
-        assert record.getMessage() == message
+        assert record.msg == message
+        assert record.args == args
 
     @pytest.mark.parametrize(
         ("logger_name", "message"),
         [
             ("discord.client", "Authentication failed while connecting"),
+            (
+                "discord.client",
+                "Attempting a reconnect in 1.00s; authentication failed permanently",
+            ),
             ("telegram.ext", "Network Retry Loop for outbound delivery aborted"),
+            (
+                "telegram.ext.Updater",
+                "Error while calling `get_updates` one more time to mark all fetched updates. "
+                "Suppressing error to ensure graceful shutdown. Authentication failed and "
+                "shutdown is incomplete",
+            ),
             (
                 "hermes_plugins.discord_platform.adapter",
                 "[Discord] Discord Gateway WebSocket remained unhealthy; forcing reconnect",
@@ -296,6 +313,53 @@ class TestRecoveredTransportRetrySeverity:
         record = caplog.records[-1]
         assert record.levelno == logging.ERROR
         assert record.levelname == "ERROR"
+
+    @pytest.mark.parametrize(
+        ("logger_name", "message", "args"),
+        [
+            ("discord.client", "Attempting a reconnect in %.2fs", (-1.0,)),
+            ("discord.client", "Attempting a reconnect in %.2fs", (float("nan"),)),
+            ("discord.client", "Attempting a reconnect in %.2fs", (True,)),
+            (
+                "telegram.ext",
+                "%s Failed run number %s of %s. Aborting.",
+                (
+                    "Network Retry Loop (Bootstrap delete Webhook): "
+                    "Authentication failed permanently.",
+                    0,
+                    0,
+                ),
+            ),
+            (
+                "telegram.ext",
+                "%s Failed run number %s of %s. Aborting.",
+                ("Network Retry Loop (Bootstrap delete Webhook):", True, 0),
+            ),
+        ],
+    )
+    def test_sdk_templates_with_unapproved_arguments_remain_errors(
+        self, caplog, logger_name, message, args
+    ):
+        caplog.set_level(logging.WARNING)
+        logging.getLogger(logger_name).error(message, *args)
+        record = caplog.records[-1]
+        assert record.levelno == logging.ERROR
+        assert record.levelname == "ERROR"
+
+    def test_unrelated_malformed_error_formatting_is_not_evaluated(self):
+        factory = logging.getLogRecordFactory()
+        record = factory(
+            "unrelated.library",
+            logging.ERROR,
+            __file__,
+            1,
+            "broken %s",
+            (1, 2),
+            None,
+        )
+        assert record.levelno == logging.ERROR
+        assert record.msg == "broken %s"
+        assert record.args == (1, 2)
 
 
 class TestComponentFilter:

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -320,6 +320,7 @@ class TestRecoveredTransportRetrySeverity:
             ("discord.client", "Attempting a reconnect in %.2fs", (-1.0,)),
             ("discord.client", "Attempting a reconnect in %.2fs", (float("nan"),)),
             ("discord.client", "Attempting a reconnect in %.2fs", (True,)),
+            ("discord.client", "Attempting a reconnect in %.2fs", (10**10000,)),
             (
                 "telegram.ext",
                 "%s Failed run number %s of %s. Aborting.",
@@ -335,16 +336,30 @@ class TestRecoveredTransportRetrySeverity:
                 "%s Failed run number %s of %s. Aborting.",
                 ("Network Retry Loop (Bootstrap delete Webhook):", True, 0),
             ),
+            (
+                "telegram.ext",
+                "%s Failed run number %s of %s. Aborting.",
+                ([], 0, 0),
+            ),
         ],
     )
     def test_sdk_templates_with_unapproved_arguments_remain_errors(
-        self, caplog, logger_name, message, args
+        self, logger_name, message, args
     ):
-        caplog.set_level(logging.WARNING)
-        logging.getLogger(logger_name).error(message, *args)
-        record = caplog.records[-1]
+        factory = logging.getLogRecordFactory()
+        record = factory(
+            logger_name,
+            logging.ERROR,
+            __file__,
+            1,
+            message,
+            args,
+            None,
+        )
         assert record.levelno == logging.ERROR
         assert record.levelname == "ERROR"
+        assert record.msg == message
+        assert record.args == args
 
     def test_unrelated_malformed_error_formatting_is_not_evaluated(self):
         factory = logging.getLogRecordFactory()
@@ -360,6 +375,47 @@ class TestRecoveredTransportRetrySeverity:
         assert record.levelno == logging.ERROR
         assert record.msg == "broken %s"
         assert record.args == (1, 2)
+
+    @pytest.mark.parametrize("field", ["msg", "discord_arg", "telegram_prefix"])
+    def test_hostile_objects_are_not_evaluated(self, field):
+        class Hostile:
+            def __eq__(self, other):
+                raise AssertionError("equality must not run")
+
+            def __hash__(self):
+                raise AssertionError("hashing must not run")
+
+            def __float__(self):
+                raise AssertionError("float conversion must not run")
+
+            def __bool__(self):
+                raise AssertionError("truth testing must not run")
+
+        cases = {
+            "msg": ("discord.client", Hostile(), (1.0,)),
+            "discord_arg": (
+                "discord.client",
+                "Attempting a reconnect in %.2fs",
+                (Hostile(),),
+            ),
+            "telegram_prefix": (
+                "telegram.ext",
+                "%s Failed run number %s of %s. Aborting.",
+                (Hostile(), 0, 0),
+            ),
+        }
+        logger_name, message, args = cases[field]
+        factory = logging.getLogRecordFactory()
+        record = factory(
+            logger_name,
+            logging.ERROR,
+            __file__,
+            1,
+            message,
+            args,
+            None,
+        )
+        assert record.levelno == logging.ERROR
 
 
 class TestComponentFilter:

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -253,6 +253,51 @@ class TestSessionContext:
 
 
 
+class TestRecoveredTransportRetrySeverity:
+    """SDK retry noise is warning-level; adapter-owned failures stay errors."""
+
+    @pytest.mark.parametrize(
+        ("logger_name", "message"),
+        [
+            ("discord.client", "Attempting a reconnect in 1.44s"),
+            (
+                "telegram.ext",
+                "Network Retry Loop (Bootstrap delete Webhook): Failed run number 0 of 0. Aborting.",
+            ),
+            (
+                "telegram.ext.Updater",
+                "Error while calling `get_updates` one more time to mark all fetched updates. "
+                "Suppressing error to ensure graceful shutdown.",
+            ),
+        ],
+    )
+    def test_exact_sdk_recovery_records_are_downgraded(self, caplog, logger_name, message):
+        caplog.set_level(logging.WARNING)
+        logging.getLogger(logger_name).error(message)
+        record = caplog.records[-1]
+        assert record.levelno == logging.WARNING
+        assert record.levelname == "WARNING"
+        assert record.getMessage() == message
+
+    @pytest.mark.parametrize(
+        ("logger_name", "message"),
+        [
+            ("discord.client", "Authentication failed while connecting"),
+            ("telegram.ext", "Network Retry Loop for outbound delivery aborted"),
+            (
+                "hermes_plugins.discord_platform.adapter",
+                "[Discord] Discord Gateway WebSocket remained unhealthy; forcing reconnect",
+            ),
+        ],
+    )
+    def test_other_transport_errors_remain_errors(self, caplog, logger_name, message):
+        caplog.set_level(logging.WARNING)
+        logging.getLogger(logger_name).error(message)
+        record = caplog.records[-1]
+        assert record.levelno == logging.ERROR
+        assert record.levelname == "ERROR"
+
+
 class TestComponentFilter:
     """Unit tests for _ComponentFilter."""
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -417,6 +417,30 @@ class TestRecoveredTransportRetrySeverity:
         )
         assert record.levelno == logging.ERROR
 
+    def test_hostile_level_equality_is_not_evaluated(self):
+        class HostileLevel(int):
+            __hash__ = int.__hash__
+
+            def __eq__(self, other):
+                raise AssertionError("level equality must not run")
+
+            def __ne__(self, other):
+                raise AssertionError("level inequality must not run")
+
+        factory = logging.getLogRecordFactory()
+        record = factory(
+            "discord.client",
+            logging.ERROR,
+            __file__,
+            1,
+            "Attempting a reconnect in %.2fs",
+            (1.0,),
+            None,
+        )
+        record.levelno = HostileLevel(logging.ERROR)
+        hermes_logging._normalize_recovered_transport_retry_severity(record)
+        assert type(record.levelno) is HostileLevel
+
 
 class TestComponentFilter:
     """Unit tests for _ComponentFilter."""


### PR DESCRIPTION
## Summary

- Reclassify only exact Discord and Telegram SDK transport-retry records that represent automatic recovery from `ERROR` to `WARNING`.
- Keep authentication failures, unknown or extended messages, retry exhaustion, stale sockets, adapter-owned errors, malformed records, and `CRITICAL` events actionable.
- Make the process-global matcher total and side-effect-free: no eager `LogRecord.getMessage()`, custom equality, hashing, float conversion, truthiness, or formatting.

## Motivation

A transient host DNS/network interruption can make both SDKs emit internal retry records at `ERROR` even though they reconnect automatically. Those recovered retries should remain visible without being indistinguishable from failures that need operator action.

The normalization is deliberately bound to exact logger names, raw pinned-SDK message templates, built-in tuple argument shapes, and exact `ERROR` level.

## Verification

- `scripts/run_tests.sh tests/test_hermes_logging.py tests/gateway/test_discord_liveness.py tests/gateway/test_telegram_network_reconnect.py -q`
  - **70 passed, 2 Windows-only skips**
- Focused recovered-retry regression subset: **20 passed**
- Ruff, `py_compile`, `git diff --check`, and fast-forward ancestry passed.
- Independent exact-SHA review: **GO**, no P0/P1/P2, at `9bb17493978a789fa653fee1bfd10a627290b529`.

No migration or stored-data backfill is required.
