### PR TITLE
fix(doctor): honor bounded session retention

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -325,7 +325,13 @@ STATE_DB_SIZE_WARN_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB logical size
 from hermes_cli.sizefmt import format_bytes as _human_bytes
 
 
-def _render_state_db_stats(stats: dict, holders=None) -> list:
+def _render_state_db_stats(
+    stats: dict,
+    holders=None,
+    *,
+    auto_prune_enabled: bool = False,
+    retention_days: int | None = None,
+) -> list:
     """Turn a collect_state_db_stats() dict into doctor output lines.
 
     Returns a list of ``(kind, text, detail)`` tuples where kind is one of
@@ -372,30 +378,48 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
             "",
         ))
 
-    # Advisory: oversized database. Suggest auto_prune, and — when the v23
-    # FTS rebuild is pending OR the DB still carries the legacy inline
-    # trigram layout (fts_storage_version marker absent) — the offline
-    # optimize-storage pass that migrates/compacts the FTS indexes.
+    # Advisory: oversized database. Suggest auto_prune only when growth is not
+    # already bounded. When the v23 FTS rebuild is pending OR the DB still
+    # carries the legacy inline trigram layout (fts_storage_version marker
+    # absent), keep warning for the resumable optimize-storage pass.
     if logical is not None and logical > STATE_DB_SIZE_WARN_BYTES:
-        detail = (
-            "consider enabling sessions.auto_prune in config.yaml "
-            "to bound growth"
+        retention_valid = (
+            isinstance(retention_days, int)
+            and not isinstance(retention_days, bool)
+            and retention_days > 0
         )
         legacy_trigram = (
             fts is not None
             and fts.get("messages_fts_trigram")
             and stats.get("fts_storage_version") is None
         )
-        if stats.get("fts_rebuild_pending") or legacy_trigram:
-            detail += (
-                "; run 'hermes sessions optimize-storage' offline "
-                "(with the gateway stopped) to compact FTS storage"
+        optimize_needed = bool(stats.get("fts_rebuild_pending") or legacy_trigram)
+        actions = []
+        if not auto_prune_enabled:
+            actions.append(
+                "consider enabling sessions.auto_prune in config.yaml to bound growth"
             )
-        lines.append((
-            "warn",
-            f"state.db is large ({_human_bytes(logical)})",
-            f"({detail})",
-        ))
+        elif not retention_valid:
+            actions.append(
+                "set sessions.retention_days to a positive integer in config.yaml"
+            )
+        if optimize_needed:
+            actions.append(
+                "run 'hermes sessions optimize-storage' to compact FTS storage"
+            )
+
+        if actions:
+            lines.append((
+                "warn",
+                f"state.db is large ({_human_bytes(logical)})",
+                f"({'; '.join(actions)})",
+            ))
+        else:
+            lines.append((
+                "info",
+                f"state.db is large ({_human_bytes(logical)}), auto-prune enabled",
+                f"({retention_days}-day retention)",
+            ))
 
     # WAL runaway is deliberately NOT warned here: the pre-existing WAL
     # check later in the state.db section already warns above 50 MB and
@@ -1793,10 +1817,25 @@ def run_doctor(args):
         try:
             from hermes_state import collect_state_db_stats, count_db_holders
 
+            from hermes_cli.config import load_config
+
             _db_stats = collect_state_db_stats(state_db_path)
             _db_holders = count_db_holders(state_db_path)
+            _sessions_cfg = (load_config() or {}).get("sessions") or {}
+            _auto_prune_enabled = (
+                isinstance(_sessions_cfg, dict)
+                and _sessions_cfg.get("auto_prune") is True
+            )
+            _retention_days = (
+                _sessions_cfg.get("retention_days")
+                if isinstance(_sessions_cfg, dict)
+                else None
+            )
             for _kind, _text, _detail in _render_state_db_stats(
-                _db_stats, holders=_db_holders
+                _db_stats,
+                holders=_db_holders,
+                auto_prune_enabled=_auto_prune_enabled,
+                retention_days=_retention_days,
             ):
                 if _kind == "warn":
                     check_warn(_text, _detail)
@@ -1805,10 +1844,19 @@ def run_doctor(args):
                             "state.db is large — enable sessions.auto_prune "
                             "in config.yaml"
                             + (
-                                " and run 'hermes sessions optimize-storage' "
-                                "offline (gateway stopped)"
+                                " and run 'hermes sessions optimize-storage'"
                                 if "optimize-storage" in _detail else ""
                             )
+                        )
+                    elif "retention_days" in _detail:
+                        issues.append(
+                            "state.db is large — set sessions.retention_days "
+                            "to a positive integer in config.yaml"
+                        )
+                    elif "optimize-storage" in _detail:
+                        issues.append(
+                            "state.db is large — run 'hermes sessions "
+                            "optimize-storage' to compact FTS storage"
                         )
                 else:
                     check_info(_text + (f" {_detail}" if _detail else ""))

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -429,6 +429,22 @@ def _render_state_db_stats(
     return lines
 
 
+def _state_db_issue_from_detail(detail: str) -> str:
+    """Build the actionable summary without dropping combined remediations."""
+    actions: list[str] = []
+    if "auto_prune" in detail:
+        actions.append("enable sessions.auto_prune in config.yaml")
+    elif "retention_days" in detail:
+        actions.append(
+            "set sessions.retention_days to a positive integer in config.yaml"
+        )
+    if "optimize-storage" in detail:
+        actions.append("run 'hermes sessions optimize-storage' to compact FTS storage")
+    if not actions:
+        actions.append("inspect the state.db warning above")
+    return "state.db is large — " + " and ".join(actions)
+
+
 def _section(title: str) -> None:
     """Print a doctor section banner: blank line + bold cyan ◆ title."""
     print()
@@ -1839,25 +1855,7 @@ def run_doctor(args):
             ):
                 if _kind == "warn":
                     check_warn(_text, _detail)
-                    if "auto_prune" in _detail:
-                        issues.append(
-                            "state.db is large — enable sessions.auto_prune "
-                            "in config.yaml"
-                            + (
-                                " and run 'hermes sessions optimize-storage'"
-                                if "optimize-storage" in _detail else ""
-                            )
-                        )
-                    elif "retention_days" in _detail:
-                        issues.append(
-                            "state.db is large — set sessions.retention_days "
-                            "to a positive integer in config.yaml"
-                        )
-                    elif "optimize-storage" in _detail:
-                        issues.append(
-                            "state.db is large — run 'hermes sessions "
-                            "optimize-storage' to compact FTS storage"
-                        )
+                    issues.append(_state_db_issue_from_detail(_detail))
                 else:
                     check_info(_text + (f" {_detail}" if _detail else ""))
         except Exception as _stats_exc:

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -196,6 +196,58 @@ def test_render_large_db_with_pending_rebuild_suggests_optimize():
     assert "optimize-storage" in blob
 
 
+def test_render_large_db_with_auto_prune_is_informational():
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big),
+        holders=None,
+        auto_prune_enabled=True,
+        retention_days=180,
+    )
+    assert not [line for line in lines if line[0] == "warn"]
+    blob = " ".join(" ".join(str(p) for p in line) for line in lines)
+    assert "auto-prune enabled" in blob
+    assert "180-day retention" in blob
+
+
+@pytest.mark.parametrize("retention_days", [None, 0, True, "180"])
+def test_render_large_db_with_invalid_auto_prune_retention_still_warns(
+    retention_days,
+):
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big),
+        holders=None,
+        auto_prune_enabled=True,
+        retention_days=retention_days,
+    )
+    warns = [line for line in lines if line[0] == "warn"]
+    assert warns
+    blob = " ".join(" ".join(str(p) for p in line) for line in warns)
+    assert "retention_days" in blob
+
+
+def test_render_large_db_pending_rebuild_still_warns_with_auto_prune():
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big, fts_rebuild_pending=True),
+        holders=None,
+        auto_prune_enabled=True,
+        retention_days=180,
+    )
+    warns = [line for line in lines if line[0] == "warn"]
+    assert warns
+    blob = " ".join(" ".join(str(p) for p in line) for line in warns)
+    assert "optimize-storage" in blob
+    assert "auto_prune" not in blob
+
+
 def test_render_large_db_legacy_trigram_suggests_optimize():
     from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
 

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -248,6 +248,26 @@ def test_render_large_db_pending_rebuild_still_warns_with_auto_prune():
     assert "auto_prune" not in blob
 
 
+def test_state_db_issue_summary_keeps_invalid_retention_and_optimize_actions():
+    from hermes_cli.doctor import (
+        STATE_DB_SIZE_WARN_BYTES,
+        _render_state_db_stats,
+        _state_db_issue_from_detail,
+    )
+
+    big = STATE_DB_SIZE_WARN_BYTES + 1
+    lines = _render_state_db_stats(
+        _base_stats(logical_size_bytes=big, fts_rebuild_pending=True),
+        holders=None,
+        auto_prune_enabled=True,
+        retention_days=0,
+    )
+    detail = next(detail for kind, _text, detail in lines if kind == "warn")
+    issue = _state_db_issue_from_detail(detail)
+    assert "retention_days" in issue
+    assert "optimize-storage" in issue
+
+
 def test_render_large_db_legacy_trigram_suggests_optimize():
     from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
 


### PR DESCRIPTION
## Summary

- Treat an oversized `state.db` as informational when bounded session auto-pruning is already configured correctly.
- Require `sessions.auto_prune` to be exact `true` and `retention_days` to be a positive, non-boolean integer; invalid or disabled settings still fail closed with an actionable warning.
- Preserve optimization warnings for pending FTS rebuilds or legacy trigram storage, including both actions when pruning and optimization are simultaneously needed.

## Motivation

`hermes doctor` currently recommends enabling session auto-pruning based only on database size, even when bounded retention is already active. That creates a persistent advisory with no valid operator action.

This change makes the diagnostic reflect resolved configuration while keeping genuine retention and database-optimization work actionable.

## Verification

- `scripts/run_tests.sh tests/test_state_db_stats.py tests/hermes_cli/test_doctor.py -q`
  - **68 passed**
- Live candidate `hermes doctor`: **All checks passed** with bounded 180-day retention enabled.
- Ruff, `py_compile`, `git diff --check`, and fast-forward ancestry passed.
- Independent exact-SHA review: **GO**, no P0/P1/P2, at `2907ed2f3a7d3960fa2f7c853f68f968eb092fe8`.

No migration or stored-data backfill is required.
