### PR TITLE
fix(deps): constrain vulnerable pydantic-settings and Pygments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,11 @@ dependencies = [
   # cryptography<49, so [tool.uv] also holds an override. Read that comment
   # before you move this version.
   "cryptography==50.0.0",  # CVE-2026-69247, GHSA-m2h6-j472-rp4c, GHSA-jwv3-5hgf-82ww, CVE-2026-39892, CVE-2026-34073, GHSA-537c-gmf6-5ccf
+  # Security floors for transitives reached through MCP/Teams and Rich. Keep
+  # them direct so every install path rejects the vulnerable line instead of
+  # relying on the resolver to happen to select the latest release.
+  "pydantic-settings>=2.14.2,<3",  # GHSA-4xgf-cpjx-pc3j
+  "Pygments>=2.20.0,<3",  # GHSA-5239-wwwm-4pmq
   # Windows has no IANA tzdata shipped with the OS, so Python's ``zoneinfo``
   # (PEP 615) raises ``ZoneInfoNotFoundError`` for every non-UTC timezone
   # out of the box.  ``tzdata`` ships the Olson database as a data package

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -71,7 +71,14 @@ def test_transitive_security_floors_are_bounded_core_requirements(
     first_fixed: str,
     next_major: str,
 ):
-    """Known-vulnerable transitives must be bounded core requirements."""
+    """Known-vulnerable transitives must be bounded core requirements.
+
+    Membership checks alone cannot distinguish `>2.14.1` from `>=2.14.2` or
+    `<3` from `<3.0.1`, so beyond the vulnerable/fixed/next-major probes the
+    requirement must also structurally encode an explicit lower bound at or
+    above the first fixed release and an explicit upper bound below the next
+    major release.
+    """
     data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     requirements = {
         Requirement(spec).name.lower(): Requirement(spec)
@@ -86,6 +93,27 @@ def test_transitive_security_floors_are_bounded_core_requirements(
     assert Version(last_vulnerable) not in specifier
     assert Version(first_fixed) in specifier
     assert Version(next_major) not in specifier
+
+    # Bound shape: an explicit lower bound at or above the first fixed
+    # release, and an explicit upper bound below the next major release.
+    lower_bounds = [
+        Version(spec.version)
+        for spec in specifier
+        if spec.operator in (">=", "~=", "==")
+    ]
+    assert any(bound >= Version(first_fixed) for bound in lower_bounds), (
+        f"{package} requirement must encode a lower bound at or above the "
+        f"first fixed release {first_fixed} (got {requirements[package]!s})"
+    )
+    upper_bounds = [
+        Version(spec.version)
+        for spec in specifier
+        if spec.operator in ("<", "<=")
+    ]
+    assert any(bound <= Version(next_major) for bound in upper_bounds), (
+        f"{package} requirement must encode an upper bound below the next "
+        f"major release {next_major} (got {requirements[package]!s})"
+    )
 
 
 # Minimum non-vulnerable Starlette: CVE-2026-48710 ("BadHost") was fixed in

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -4,6 +4,8 @@ import tomllib
 from pathlib import Path
 
 import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -54,6 +56,36 @@ def test_faster_whisper_is_not_a_base_dependency():
 
     voice_extra = data["project"]["optional-dependencies"]["voice"]
     assert any(dep.startswith("faster-whisper") for dep in voice_extra)
+
+
+@pytest.mark.parametrize(
+    ("package", "last_vulnerable", "first_fixed", "next_major"),
+    [
+        ("pydantic-settings", "2.14.1", "2.14.2", "3"),
+        ("pygments", "2.19.2", "2.20.0", "3"),
+    ],
+)
+def test_transitive_security_floors_are_bounded_core_requirements(
+    package: str,
+    last_vulnerable: str,
+    first_fixed: str,
+    next_major: str,
+):
+    """Known-vulnerable transitives must be bounded core requirements."""
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    requirements = {
+        Requirement(spec).name.lower(): Requirement(spec)
+        for spec in data["project"]["dependencies"]
+    }
+
+    assert package in requirements, (
+        f"{package} must be constrained directly in core dependencies so all "
+        "install paths enforce its reviewed security floor"
+    )
+    specifier = requirements[package].specifier
+    assert Version(last_vulnerable) not in specifier
+    assert Version(first_fixed) in specifier
+    assert Version(next_major) not in specifier
 
 
 # Minimum non-vulnerable Starlette: CVE-2026-48710 ("BadHost") was fixed in

--- a/uv.lock
+++ b/uv.lock
@@ -1584,6 +1584,8 @@ dependencies = [
     { name = "psutil" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pygments" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -1889,6 +1891,8 @@ requires-dist = [
     { name = "pvporcupine", marker = "extra == 'wake'", specifier = "==4.0.3" },
     { name = "pyasn1", marker = "extra == 'google'", specifier = "==0.6.4" },
     { name = "pydantic", specifier = "==2.13.4" },
+    { name = "pydantic-settings", specifier = ">=2.14.2,<3" },
+    { name = "pygments", specifier = ">=2.20.0,<3" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
@@ -2535,16 +2539,16 @@ wheels = [
 
 [[package]]
 name = "msal"
-version = "1.36.0"
+version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/cb/b02b0f748ac668922364ccb3c3bff5b71628a05f5adfec2ba2a5c3031483/msal-1.36.0.tar.gz", hash = "sha256:3f6a4af2b036b476a4215111c4297b4e6e236ed186cd804faefba23e4990978b", size = 174217, upload-time = "2026-04-09T10:20:33.525Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/d3/414d1f0a5f6f4fe5313c2b002c54e78a3332970feb3f5fed14237aa17064/msal-1.36.0-py3-none-any.whl", hash = "sha256:36ecac30e2ff4322d956029aabce3c82301c29f0acb1ad89b94edcabb0e58ec4", size = 121547, upload-time = "2026-04-09T10:20:32.336Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add direct bounded security floors for `pydantic-settings>=2.14.2,<3` (GHSA-4xgf-cpjx-pc3j) and `Pygments>=2.20.0,<3` (GHSA-5239-wwwm-4pmq)
- regenerate lock metadata with CI-pinned uv 0.9.28 and update MSAL 1.36.0 -> 1.37.0, removing MSAL's stale `<49` cryptography cap while preserving the current-main cryptography 50.0.0 security floor
- add a behavioral packaging regression test that proves vulnerable versions are rejected, fixed versions are accepted, and the next major is excluded

## Why

Both packages were already resolved to fixed versions in `uv.lock`, but only transitively. A future resolver change could therefore select a vulnerable release without violating `pyproject.toml`. Direct bounded declarations make the reviewed floors part of the install contract across all extras and platforms.

Current `main` already moved cryptography to 50.0.0 in 2b618fe7e, so this PR intentionally preserves that fix rather than reintroducing the older 48.0.1 exception.

## Verification

- TDD RED: the new parameterized packaging test failed for both undeclared transitives before the dependency declarations were added
- `scripts/run_tests.sh` across 17 packaging/security/provider files: **180 passed**
- `uvx --from uv==0.9.28 uv lock --check`: passed
- clean `uv sync --locked` with dev, DingTalk, Azure Identity, Teams, MCP, messaging, and WeCom extras: passed
- `hermes security audit --json --fail-on low`: **121 components, 0 findings**
- `ruff check tests/test_packaging_metadata.py`: passed
- import smoke: cryptography 50.0.0, MSAL 1.37.0, pydantic-settings 2.14.2, Pygments 2.20.0, and DingTalk card SDK available

## Compatibility note

`uv pip check` still reports the pre-existing `alibabacloud-tea-openapi<49` metadata cap against cryptography 50.0.0. That is the documented current-main override from 2b618fe7e; the affected DingTalk suite and card-SDK import smoke are green. This PR removes the analogous MSAL incompatibility by updating to MSAL 1.37.0.
