### PR TITLE
feat(telegram): support single external send attempts

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5482,6 +5482,11 @@ class BasePlatformAdapter(ABC):
         to a plain-text version before giving up. If all attempts fail due to
         network errors, sends the user a brief delivery-failure notice so they
         know to retry rather than waiting indefinitely.
+
+        ``metadata["single_external_attempt"] is True`` returns the first
+        result unchanged. The caller has already persisted its mutation
+        boundary and owns ambiguity reconciliation, so this wrapper must not
+        retry, fallback-send, or emit a second failure-notice mutation.
         """
 
         result = await self.send(
@@ -5496,6 +5501,13 @@ class BasePlatformAdapter(ABC):
 
         error_str = result.error or ""
         is_network = result.retryable or self._is_retryable_error(error_str)
+        single_external_attempt = (
+            isinstance(metadata, dict)
+            and metadata.get("single_external_attempt") is True
+        )
+
+        if single_external_attempt:
+            return result
 
         # Timeout errors are not safe to retry (message may have been
         # delivered) and not formatting errors — return the failure as-is.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -650,6 +650,7 @@ class TelegramAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = 4096
     supports_code_blocks = True  # Telegram MarkdownV2 renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+    supports_single_external_attempt = True
     # Bot API 10.1 Rich Messages cap the raw markdown/html text at 32,768
     # UTF-8 characters. Content above this is sent via the legacy chunking path.
     RICH_MESSAGE_MAX_CHARS = 32768
@@ -1675,6 +1676,21 @@ class TelegramAdapter(BasePlatformAdapter):
             )
 
     @staticmethod
+    def _is_single_external_attempt(
+        metadata: Optional[Dict[str, Any]],
+    ) -> bool:
+        return isinstance(metadata, dict) and metadata.get("single_external_attempt") is True
+
+    @staticmethod
+    def _single_external_attempt_failure(error: Exception) -> SendResult:
+        return SendResult(
+            success=False,
+            error=_redact_telegram_error_text(error),
+            retryable=False,
+            error_kind=classify_send_error(error),
+        )
+
+    @staticmethod
     def _is_bad_request_error(error: Exception) -> bool:
         name = error.__class__.__name__.lower()
         if name == "badrequest" or name.endswith("badrequest"):
@@ -1742,6 +1758,8 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             return await send_fn(**send_kwargs)
         except Exception as send_err:
+            if self._is_single_external_attempt(metadata):
+                raise
             if not self._should_retry_without_dm_topic_reply_anchor(
                 send_err,
                 metadata,
@@ -5124,7 +5142,13 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None
     ) -> SendResult:
-        """Send a message to a Telegram chat."""
+        """Send a message to a Telegram chat.
+
+        ``metadata["single_external_attempt"]`` disables uncertain internal
+        network and flood-control retries. Definitive format/routing rejection
+        fallbacks remain allowed because the rejected request did not mutate
+        Telegram state.
+        """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
@@ -5135,7 +5159,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
-        
+
+        single_external_attempt = (
+            (metadata or {}).get("single_external_attempt") is True
+        )
+
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls
@@ -5164,6 +5192,13 @@ class TelegramAdapter(BasePlatformAdapter):
             chunks = self.truncate_message(
                 formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
             )
+            if single_external_attempt and len(chunks) > 1:
+                return SendResult(
+                    success=False,
+                    error="message_too_long",
+                    error_kind="too_long",
+                    retryable=False,
+                )
             if len(chunks) > 1:
                 # truncate_message appends a raw " (1/2)" suffix. Escape the
                 # MarkdownV2-special parentheses so Telegram doesn't reject the
@@ -5195,6 +5230,7 @@ class TelegramAdapter(BasePlatformAdapter):
             except (ImportError, AttributeError):
                 _TimedOut = None  # type: ignore[assignment,misc]
 
+            max_send_attempts = 3
             for i, chunk in enumerate(chunks):
                 retried_thread_not_found = False
                 metadata_reply_to = self._metadata_reply_to_message_id(metadata)
@@ -5239,7 +5275,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 effective_thread_id = thread_kwargs.get("message_thread_id")
 
                 msg = None
-                for _send_attempt in range(3):
+                for _send_attempt in range(max_send_attempts):
                     try:
                         # Try Markdown first, fall back to plain text if it fails
                         try:
@@ -5363,24 +5399,37 @@ class TelegramAdapter(BasePlatformAdapter):
                             raise
                         if is_pool_timeout:
                             await self._drain_general_connections_after_pool_timeout()
-                        if _send_attempt < 2:
+                        if (
+                            not single_external_attempt
+                            and _send_attempt < max_send_attempts - 1
+                        ):
                             wait = 2 ** _send_attempt
                             safe_send_error = _redact_telegram_error_text(send_err)
-                            logger.warning("[%s] Network error on send (attempt %d/3), retrying in %ds: %s",
-                                           self.name, _send_attempt + 1, wait, safe_send_error)
+                            logger.warning(
+                                "[%s] Network error on send (attempt %d/%d), retrying in %ds: %s",
+                                self.name,
+                                _send_attempt + 1,
+                                max_send_attempts,
+                                wait,
+                                safe_send_error,
+                            )
                             await asyncio.sleep(wait)
                         else:
                             raise
                     except Exception as send_err:
                         retry_after = getattr(send_err, "retry_after", None)
                         if retry_after is not None or "retry after" in str(send_err).lower():
-                            if _send_attempt < 2:
+                            if (
+                                not single_external_attempt
+                                and _send_attempt < max_send_attempts - 1
+                            ):
                                 wait = float(retry_after) if retry_after is not None else 1.0
                                 safe_send_error = _redact_telegram_error_text(send_err)
                                 logger.warning(
-                                    "[%s] Telegram flood control on send (attempt %d/3), retrying in %.1fs: %s",
+                                    "[%s] Telegram flood control on send (attempt %d/%d), retrying in %.1fs: %s",
                                     self.name,
                                     _send_attempt + 1,
+                                    max_send_attempts,
                                     wait,
                                     safe_send_error,
                                 )
@@ -7687,6 +7736,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            if self._is_single_external_attempt(metadata):
+                logger.warning(
+                    "[%s] Failed to send Telegram voice/audio: %s",
+                    self.name,
+                    _redact_telegram_error_text(e),
+                    exc_info=True,
+                )
+                return self._single_external_attempt_failure(e)
             logger.error(
                 "[%s] Failed to send Telegram voice/audio, falling back to base adapter: %s",
                 self.name,
@@ -7815,6 +7872,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     reset_media=_reset_opened_files,
                 )
             except Exception as e:
+                if self._is_single_external_attempt(metadata):
+                    logger.warning(
+                        "[%s] send_media_group failed (chunk %d/%d): %s",
+                        self.name,
+                        chunk_idx + 1,
+                        len(chunks),
+                        _redact_telegram_error_text(e),
+                        exc_info=True,
+                    )
+                    return
                 logger.warning(
                     "[%s] send_media_group failed (chunk %d/%d), falling back to per-image: %s",
                     self.name, chunk_idx + 1, len(chunks), _redact_telegram_error_text(e),
@@ -7876,6 +7943,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            if self._is_single_external_attempt(metadata):
+                logger.warning(
+                    "[%s] Failed to send Telegram local image as photo: %s",
+                    self.name,
+                    _redact_telegram_error_text(e),
+                    exc_info=True,
+                )
+                return self._single_external_attempt_failure(e)
             error_str = str(e)
             # Dimension-related errors are the expected case for valid image
             # files that Telegram just refuses as photos (screenshots, extreme
@@ -7974,6 +8049,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            if self._is_single_external_attempt(metadata):
+                logger.warning(
+                    "[%s] Failed to send document: %s",
+                    self.name, _redact_telegram_error_text(e),
+                )
+                return self._single_external_attempt_failure(e)
             logger.warning(
                 "[%s] Failed to send document: %s",
                 self.name, _redact_telegram_error_text(e),
@@ -8025,6 +8106,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            if self._is_single_external_attempt(metadata):
+                logger.warning(
+                    "[%s] Failed to send video: %s",
+                    self.name, _redact_telegram_error_text(e),
+                )
+                return self._single_external_attempt_failure(e)
             logger.warning(
                 "[%s] Failed to send video: %s",
                 self.name, _redact_telegram_error_text(e),
@@ -8080,6 +8167,14 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            if self._is_single_external_attempt(metadata):
+                logger.warning(
+                    "[%s] URL-based send_photo failed: %s",
+                    self.name,
+                    _redact_telegram_error_text(e),
+                    exc_info=True,
+                )
+                return self._single_external_attempt_failure(e)
             logger.warning(
                 "[%s] URL-based send_photo failed, trying file upload: %s",
                 self.name,
@@ -8171,6 +8266,14 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            if self._is_single_external_attempt(metadata):
+                logger.warning(
+                    "[%s] Failed to send Telegram animation: %s",
+                    self.name,
+                    _redact_telegram_error_text(e),
+                    exc_info=True,
+                )
+                return self._single_external_attempt_failure(e)
             logger.error(
                 "[%s] Failed to send Telegram animation, falling back to photo: %s",
                 self.name,

--- a/tests/gateway/test_telegram_single_external_attempt.py
+++ b/tests/gateway/test_telegram_single_external_attempt.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.error import BadRequest, NetworkError
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+class FloodError(Exception):
+    retry_after = 30.0
+
+
+def _adapter_with_send(side_effect) -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._should_attempt_rich = lambda *_args, **_kwargs: False  # type: ignore[method-assign]
+    adapter._bot = SimpleNamespace(send_message=AsyncMock(side_effect=side_effect))
+    return adapter
+
+
+def test_adapter_advertises_single_external_attempt_capability() -> None:
+    assert TelegramAdapter.supports_single_external_attempt is True
+
+
+@pytest.mark.asyncio
+async def test_single_external_attempt_disables_internal_network_retry(monkeypatch) -> None:
+    adapter = _adapter_with_send(NetworkError("connection lost after write"))
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
+
+    result = await adapter.send(
+        "12345",
+        "hello",
+        metadata={"single_external_attempt": True, "notify": True},
+    )
+
+    assert result.success is False
+    assert adapter._bot.send_message.await_count == 1
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_default_send_keeps_existing_network_retry_behavior(monkeypatch) -> None:
+    adapter = _adapter_with_send(
+        [
+            NetworkError("first failure"),
+            NetworkError("second failure"),
+            SimpleNamespace(message_id=901),
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
+
+    result = await adapter.send("12345", "hello", metadata={"notify": True})
+
+    assert result.success is True
+    assert result.message_id == "901"
+    assert adapter._bot.send_message.await_count == 3
+    assert sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_single_external_attempt_does_not_sleep_for_flood_retry(monkeypatch) -> None:
+    adapter = _adapter_with_send(FloodError("retry after 30"))
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
+
+    result = await adapter.send(
+        "12345",
+        "hello",
+        metadata={"single_external_attempt": True, "notify": True},
+    )
+
+    assert result.success is False
+    assert adapter._bot.send_message.await_count == 1
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_single_external_attempt_preserves_safe_deleted_reply_fallback() -> None:
+    adapter = _adapter_with_send(
+        [
+            BadRequest("Message to be replied not found"),
+            SimpleNamespace(message_id=902),
+        ]
+    )
+
+    result = await adapter.send(
+        "12345",
+        "hello",
+        reply_to="999",
+        metadata={"single_external_attempt": True, "notify": True},
+    )
+
+    assert result.success is True
+    assert result.message_id == "902"
+    assert adapter._bot.send_message.await_count == 2
+    calls = adapter._bot.send_message.await_args_list
+    assert calls[0].kwargs["reply_to_message_id"] == 999
+    assert calls[1].kwargs["reply_to_message_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_single_external_attempt_preserves_safe_markdown_parse_fallback() -> None:
+    adapter = _adapter_with_send(
+        [
+            BadRequest("can't parse entities"),
+            SimpleNamespace(message_id=903),
+        ]
+    )
+
+    result = await adapter.send(
+        "12345",
+        "hello _world_",
+        metadata={"single_external_attempt": True, "notify": True},
+    )
+
+    assert result.success is True
+    assert result.message_id == "903"
+    assert adapter._bot is not None
+    calls = adapter._bot.send_message.await_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["parse_mode"] is not None
+    assert calls[1].kwargs["parse_mode"] is None
+
+
+@pytest.mark.asyncio
+async def test_shared_send_wrapper_honors_single_external_attempt(monkeypatch) -> None:
+    adapter = _adapter_with_send(NetworkError("connection lost after write"))
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.platforms.base.asyncio.sleep", sleep)
+
+    result = await adapter._send_with_retry(
+        "12345",
+        "hello",
+        metadata={"single_external_attempt": True, "notify": True},
+        max_retries=2,
+        base_delay=0,
+    )
+
+    assert result.success is False
+    assert adapter._bot.send_message.await_count == 1
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_single_external_attempt_rejects_multi_chunk_before_first_send() -> None:
+    adapter = _adapter_with_send(SimpleNamespace(message_id=903))
+    object.__setattr__(adapter, "MAX_MESSAGE_LENGTH", 12)
+
+    result = await adapter.send(
+        "12345",
+        "this response requires multiple Telegram chunks",
+        metadata={"single_external_attempt": True, "notify": True},
+    )
+
+    assert result.success is False
+    assert result.error_kind == "too_long"
+    assert adapter._bot is not None
+    adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shared_wrapper_never_fallback_sends_for_single_attempt() -> None:
+    adapter = _adapter_with_send(SimpleNamespace(message_id=904))
+    first_failure = SendResult(
+        success=False,
+        error="definitive formatting rejection",
+        error_kind="formatting",
+        retryable=False,
+    )
+    adapter.send = AsyncMock(
+        side_effect=[first_failure, SendResult(success=True, message_id="duplicate")]
+    )
+
+    result = await adapter._send_with_retry(
+        "12345",
+        "hello",
+        metadata={"single_external_attempt": True, "notify": True},
+    )
+
+    assert result is first_failure
+    assert adapter.send.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "bot_method_name", "path_kw", "filename", "payload"),
+    [
+        ("send_image_file", "send_photo", "image_path", "photo.png", b"png-data"),
+        ("send_document", "send_document", "file_path", "report.txt", b"report-data"),
+        ("send_video", "send_video", "video_path", "clip.mp4", b"video-data"),
+    ],
+)
+async def test_single_external_attempt_disables_stale_dm_topic_media_retry(
+    tmp_path,
+    method_name,
+    bot_method_name,
+    path_kw,
+    filename,
+    payload,
+) -> None:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    media_path = tmp_path / filename
+    media_path.write_bytes(payload)
+    adapter._bot = SimpleNamespace(
+        **{
+            bot_method_name: AsyncMock(
+                side_effect=BadRequest("Message to be replied not found")
+            )
+        }
+    )
+
+    result = await getattr(adapter, method_name)(
+        chat_id="12345",
+        **{path_kw: str(media_path)},
+        metadata={
+            "single_external_attempt": True,
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "telegram_reply_to_message_id": "462",
+        },
+    )
+
+    assert result.success is False
+    getattr(adapter._bot, bot_method_name).assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_single_external_attempt_disables_media_group_per_image_fallback(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    image_path = tmp_path / "photo.png"
+    image_path.write_bytes(b"png-data")
+    adapter._bot = SimpleNamespace(
+        send_media_group=AsyncMock(side_effect=RuntimeError("album rejected"))
+    )
+    fallback = AsyncMock()
+    monkeypatch.setattr(BasePlatformAdapter, "send_multiple_images", fallback)
+
+    await adapter.send_multiple_images(
+        chat_id="12345",
+        images=[(f"file://{image_path}", "caption")],
+        metadata={"single_external_attempt": True},
+    )
+
+    adapter._bot.send_media_group.assert_awaited_once()
+    fallback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_single_external_attempt_disables_image_file_document_fallback(
+    tmp_path,
+) -> None:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    image_path = tmp_path / "photo.png"
+    image_path.write_bytes(b"png-data")
+    adapter._bot = SimpleNamespace(
+        send_photo=AsyncMock(side_effect=RuntimeError("photo rejected"))
+    )
+    adapter.send_document = AsyncMock(return_value=SendResult(success=True))
+
+    result = await adapter.send_image_file(
+        chat_id="12345",
+        image_path=str(image_path),
+        metadata={"single_external_attempt": True},
+    )
+
+    assert result.success is False
+    adapter._bot.send_photo.assert_awaited_once()
+    adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "bot_method_name", "path_kw", "filename", "payload", "base_method"),
+    [
+        (
+            "send_document",
+            "send_document",
+            "file_path",
+            "report.txt",
+            b"report-data",
+            "send_document",
+        ),
+        ("send_video", "send_video", "video_path", "clip.mp4", b"video-data", "send_video"),
+    ],
+)
+async def test_single_external_attempt_disables_document_video_base_fallback(
+    monkeypatch,
+    tmp_path,
+    method_name,
+    bot_method_name,
+    path_kw,
+    filename,
+    payload,
+    base_method,
+) -> None:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    media_path = tmp_path / filename
+    media_path.write_bytes(payload)
+    adapter._bot = SimpleNamespace(
+        **{bot_method_name: AsyncMock(side_effect=RuntimeError("upload rejected"))}
+    )
+    fallback = AsyncMock(return_value=SendResult(success=True, message_id="fallback"))
+    monkeypatch.setattr(BasePlatformAdapter, base_method, fallback)
+
+    result = await getattr(adapter, method_name)(
+        chat_id="12345",
+        **{path_kw: str(media_path)},
+        metadata={"single_external_attempt": True},
+    )
+
+    assert result.success is False
+    getattr(adapter._bot, bot_method_name).assert_awaited_once()
+    fallback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_single_external_attempt_disables_url_photo_download_upload_fallback(
+    monkeypatch,
+) -> None:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = SimpleNamespace(
+        send_photo=AsyncMock(side_effect=RuntimeError("url rejected"))
+    )
+    fallback = AsyncMock(return_value=SendResult(success=True, message_id="fallback"))
+
+    def fail_client(**_kwargs):
+        raise AssertionError("single-attempt URL photo must not download fallback")
+
+    monkeypatch.setattr(BasePlatformAdapter, "send_image", fallback)
+    monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: True)
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_async_client", fail_client)
+
+    result = await adapter.send_image(
+        chat_id="12345",
+        image_url="https://example.com/photo.png",
+        metadata={"single_external_attempt": True},
+    )
+
+    assert result.success is False
+    adapter._bot.send_photo.assert_awaited_once()
+    fallback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_single_external_attempt_disables_animation_photo_fallback() -> None:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = SimpleNamespace(
+        send_animation=AsyncMock(side_effect=RuntimeError("animation rejected"))
+    )
+    adapter.send_image = AsyncMock(return_value=SendResult(success=True, message_id="photo"))
+
+    result = await adapter.send_animation(
+        chat_id="12345",
+        animation_url="https://example.com/animated.gif",
+        metadata={"single_external_attempt": True},
+    )
+
+    assert result.success is False
+    adapter._bot.send_animation.assert_awaited_once()
+    adapter.send_image.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "payload", "bot_method_name"),
+    [
+        ("clip.ogg", b"ogg-data", "send_voice"),
+        ("clip.mp3", b"mp3-data", "send_audio"),
+    ],
+)
+async def test_single_external_attempt_disables_voice_audio_base_fallback(
+    monkeypatch,
+    tmp_path,
+    filename,
+    payload,
+    bot_method_name,
+) -> None:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    audio_path = tmp_path / filename
+    audio_path.write_bytes(payload)
+    adapter._bot = SimpleNamespace(
+        **{bot_method_name: AsyncMock(side_effect=RuntimeError("audio rejected"))}
+    )
+    fallback = AsyncMock(return_value=SendResult(success=True, message_id="fallback"))
+    monkeypatch.setattr(BasePlatformAdapter, "send_voice", fallback)
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter._probe_voice_duration_seconds",
+        lambda _path: 7,
+    )
+
+    result = await adapter.send_voice(
+        chat_id="12345",
+        audio_path=str(audio_path),
+        metadata={"single_external_attempt": True},
+    )
+
+    assert result.success is False
+    getattr(adapter._bot, bot_method_name).assert_awaited_once()
+    fallback.assert_not_awaited()


### PR DESCRIPTION
## Summary

Add an opt-in `metadata["single_external_attempt"]` contract for callers that persist their own external-mutation boundary and ambiguity state.

When enabled:

- the shared send wrapper returns the first `SendResult` unchanged;
- Telegram does not retry uncertain network, pool/connect, or flood-control failures;
- Telegram rejects multi-chunk text before the first platform send;
- the wrapper does not emit a fallback response or delivery-failure notice as a second mutation;
- definitive pre-mutation corrections remain available (Markdown parse fallback and deleted reply-anchor fallback).

Default gateway behavior is unchanged when the metadata flag is absent.

## Why

A durable outbox must persist `begin_attempt` before the external request and reconcile an unknown result as ambiguous. Hidden adapter retries, chunk splitting, fallback sends, or failure notices can otherwise create duplicate remote mutations that the outbox cannot identify as one operation.

## Verification

- `scripts/run_tests.sh tests/gateway/test_telegram_single_external_attempt.py` — 8 passed
- focused Telegram send/final/overflow/stream and WeCom suites passed
- `scripts/run_tests.sh tests/gateway/` — 5,253 passed, 0 failed, 31 platform skips
- Ruff passed on all changed Python files
- `git diff --check`
- independent review found no correctness issue
