### PR TITLE
fix(auth): add profile-global inheritance boundary

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3126,10 +3126,11 @@ def load_pool(provider: str) -> CredentialPool:
         for payload in raw_entries
     )
     entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
-    if not auth_mod.profile_auth_materialization_enabled():
-        # Credentialless profiles must remain read-only and empty when they
-        # start without local auth state. In particular, inspection commands
-        # must not seed ambient env/singleton credentials into auth.json.
+    if not auth_mod.profile_global_auth_inheritance_enabled():
+        # Global-auth-isolated profiles must remain empty when they start
+        # without local auth state. In particular, inspection commands must
+        # not seed ambient env/singleton credentials into auth.json. Explicit
+        # profile-local auth operations remain permitted.
         return CredentialPool(provider, entries)
     raw_needs_auth_normalization = any(
         isinstance(payload, dict)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3112,7 +3112,11 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
     return changed, active_sources
 
 
-def load_pool(provider: str) -> CredentialPool:
+def load_pool(
+    provider: str,
+    *,
+    _allow_local_nous_sync: bool = False,
+) -> CredentialPool:
     provider = (provider or "").strip().lower()
     raw_entries = read_credential_pool(provider)
     disk_ids = {
@@ -3131,6 +3135,28 @@ def load_pool(provider: str) -> CredentialPool:
         # without local auth state. In particular, inspection commands must
         # not seed ambient env/singleton credentials into auth.json. Explicit
         # profile-local auth operations remain permitted.
+        if not (_allow_local_nous_sync and provider == "nous"):
+            return CredentialPool(provider, entries)
+        singleton_changed, singleton_sources = _seed_from_singletons(
+            provider,
+            entries,
+        )
+        changed = raw_needs_sanitization or singleton_changed
+        changed |= _prune_stale_seeded_entries(entries, singleton_sources)
+        if changed:
+            new_ids = {entry.id for entry in entries}
+            write_credential_pool(
+                provider,
+                [
+                    entry.to_dict()
+                    for entry in sorted(entries, key=lambda item: item.priority)
+                ],
+                removed_ids={
+                    str(entry_id)
+                    for entry_id in disk_ids - new_ids
+                    if entry_id
+                },
+            )
         return CredentialPool(provider, entries)
     raw_needs_auth_normalization = any(
         isinstance(payload, dict)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3126,6 +3126,11 @@ def load_pool(provider: str) -> CredentialPool:
         for payload in raw_entries
     )
     entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
+    if not auth_mod.profile_auth_materialization_enabled():
+        # Credentialless profiles must remain read-only and empty when they
+        # start without local auth state. In particular, inspection commands
+        # must not seed ambient env/singleton credentials into auth.json.
+        return CredentialPool(provider, entries)
     raw_needs_auth_normalization = any(
         isinstance(payload, dict)
         and _normalize_pool_auth_type(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1058,14 +1058,16 @@ def _auth_file_path() -> Path:
     return path
 
 
-def profile_auth_materialization_enabled() -> bool:
-    """Return whether the active profile may inherit or persist auth state.
+def profile_global_auth_inheritance_enabled() -> bool:
+    """Return whether the active profile may use global/shared auth sources.
 
     ``auth.inherit_global`` is intentionally a fail-closed profile boundary.
     The setting is backward-compatible when absent, but once present only the
-    boolean value ``true`` permits global-root fallback, ambient credential
-    seeding, or auth.json writes. Invalid values and unreadable configuration
-    deny those paths rather than silently restoring credential authority.
+    boolean value ``true`` permits global-root fallback, shared auth state,
+    cross-profile token caches, or ambient credential seeding. Invalid values
+    and unreadable configuration deny those paths rather than silently
+    restoring credential authority. Explicit profile-local reads and writes
+    remain permitted.
     """
     try:
         config = read_raw_config_strict()
@@ -1093,7 +1095,7 @@ def _global_auth_file_path() -> Optional[Path]:
 
     See issue #18594 follow-up (credential_pool shadowing).
     """
-    if not profile_auth_materialization_enabled():
+    if not profile_global_auth_inheritance_enabled():
         return None
     try:
         from hermes_constants import get_default_hermes_root
@@ -1353,11 +1355,16 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     # specific store — e.g. the global-root write-through for rotating xAI
     # OAuth grants (#43589) — reusing this function's atomic O_EXCL + 0o600
     # write so the root auth.json gets the same TOCTOU-safe treatment.
-    if not profile_auth_materialization_enabled():
+    active_auth_file = _auth_file_path()
+    auth_file = target_path if target_path is not None else active_auth_file
+    if (
+        target_path is not None
+        and not _same_path(auth_file, active_auth_file)
+        and not profile_global_auth_inheritance_enabled()
+    ):
         raise AuthError(
-            "Profile auth materialization is disabled by auth.inherit_global"
+            "Global auth persistence is disabled by auth.inherit_global"
         )
-    auth_file = target_path if target_path is not None else _auth_file_path()
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.
@@ -1741,10 +1748,6 @@ def write_credential_pool(
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
     merge does not resurrect them from the on-disk copy.
     """
-    if not profile_auth_materialization_enabled():
-        raise AuthError(
-            "Profile auth materialization is disabled by auth.inherit_global"
-        )
     removed = {rid for rid in (removed_ids or ()) if rid}
     with _auth_store_lock():
         auth_store = _load_auth_store()
@@ -5383,7 +5386,7 @@ def _nous_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
     can't race on the single-use shared refresh token; that helper must
     NOT be called with ``_auth_store_lock`` already held.
     """
-    if not profile_auth_materialization_enabled():
+    if not profile_global_auth_inheritance_enabled():
         yield
         return
     try:
@@ -5447,7 +5450,7 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
     We deliberately omit the runtime ``agent_key`` compatibility field;
     the OAuth tokens are the cross-profile source of truth.
     """
-    if not profile_auth_materialization_enabled():
+    if not profile_global_auth_inheritance_enabled():
         return
     refresh_token = state.get("refresh_token")
     access_token = state.get("access_token")
@@ -5513,7 +5516,7 @@ def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
     lacks required fields. Callers should treat ``None`` as "no shared
     credentials available — fall through to device-code".
     """
-    if not profile_auth_materialization_enabled():
+    if not profile_global_auth_inheritance_enabled():
         return None
     try:
         path = _nous_shared_store_path()
@@ -5540,7 +5543,7 @@ def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
 
 def _clear_shared_nous_state(reason: str) -> None:
     """Remove the shared Nous OAuth store after a terminal token failure."""
-    if not profile_auth_materialization_enabled():
+    if not profile_global_auth_inheritance_enabled():
         return
     try:
         with _nous_shared_store_lock():
@@ -5738,7 +5741,7 @@ def _try_import_shared_nous_state(
     etc.) — caller should then fall through to the normal device-code
     flow.
     """
-    if not profile_auth_materialization_enabled():
+    if not profile_global_auth_inheritance_enabled():
         return None
     try:
         with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
@@ -5953,7 +5956,7 @@ def resolve_nous_access_token(
     """Resolve a refresh-aware Nous Portal access token for managed tool gateways."""
     global _RESOLVE_TOKEN_CACHE
     cache_home = _resolve_token_cache_home()
-    cache_allowed = profile_auth_materialization_enabled()
+    cache_allowed = profile_global_auth_inheritance_enabled()
     # Memo: collapse the startup burst of managed-tool check_fns into one
     # network refresh. Only cache a successful, non-forced resolution for a
     # short window; force_fresh / error paths bypass and don't populate it.
@@ -6710,25 +6713,61 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
 # ~350ms even on the failure path, and read-only UI surfaces (`hermes tools`, status panels,
 # subscription-feature checks) call it many times per render — `hermes tools` → "All Platforms"
 # was firing the refresh ~31× during one menu paint, racking up >13s of HTTP and burning
-# single-use refresh tokens. Cache the snapshot for a few seconds, keyed on the auth.json
-# path + mtime so that profile switches do not share a process memo and
-# `hermes auth login/logout/add/remove` invalidate naturally on the next call.
+# single-use refresh tokens. Cache the snapshot for a few seconds, keyed on the
+# local and inherited auth stores plus the strict inheritance verdict so profile
+# switches and policy changes do not share a process memo. Auth writes invalidate
+# naturally through the high-resolution mtime components.
 _NOUS_AUTH_STATUS_CACHE_TTL = 15.0  # seconds
-_nous_auth_status_cache: Optional[Tuple[float, str, Optional[float], Dict[str, Any]]] = None
+_NousAuthStatusCacheIdentity = Tuple[
+    str,
+    Optional[int],
+    bool,
+    Optional[str],
+    Optional[int],
+]
+_nous_auth_status_cache: Optional[
+    Tuple[float, _NousAuthStatusCacheIdentity, Dict[str, Any]]
+] = None
 
 
-def _auth_file_cache_key() -> Tuple[str, Optional[float]]:
+def _auth_file_cache_key() -> Tuple[str, Optional[int]]:
     auth_file = _auth_file_path()
     try:
         auth_file_key = str(auth_file.resolve(strict=False))
     except Exception:
         auth_file_key = str(auth_file)
     try:
-        return auth_file_key, auth_file.stat().st_mtime
+        return auth_file_key, auth_file.stat().st_mtime_ns
     except FileNotFoundError:
         return auth_file_key, None
     except Exception:
         return auth_file_key, None
+
+
+def _nous_auth_status_cache_identity() -> _NousAuthStatusCacheIdentity:
+    """Bind a status memo to local/global stores and strict policy state."""
+    auth_file_key, mtime_ns = _auth_file_cache_key()
+    inherit_global = profile_global_auth_inheritance_enabled()
+    global_key: Optional[str] = None
+    global_mtime_ns: Optional[int] = None
+    if inherit_global:
+        global_path = _global_auth_file_path()
+        if global_path is not None:
+            try:
+                global_key = str(global_path.resolve(strict=False))
+            except Exception:
+                global_key = str(global_path)
+            try:
+                global_mtime_ns = global_path.stat().st_mtime_ns
+            except (FileNotFoundError, OSError):
+                global_mtime_ns = None
+    return (
+        auth_file_key,
+        mtime_ns,
+        inherit_global,
+        global_key,
+        global_mtime_ns,
+    )
 
 
 def invalidate_nous_auth_status_cache() -> None:
@@ -6752,27 +6791,26 @@ def get_nous_auth_status() -> Dict[str, Any]:
     as a healthy login. If provider state is absent, fall back to the credential
     pool for the just-logged-in / not-yet-promoted case.
 
-    The returned snapshot is memoised for ~15s keyed on the auth.json mtime,
-    so menu/status surfaces that ask repeatedly don't trigger one refresh POST
-    per call. Login/logout flows write to auth.json and therefore invalidate
-    the cache automatically; tests can also call
+    The returned snapshot is memoised for ~15s keyed on local/global auth-store
+    identity and the strict inheritance verdict, so policy/profile changes do
+    not reuse another authority context. Login/logout flows write to auth.json
+    and therefore invalidate the cache automatically; tests can also call
     ``invalidate_nous_auth_status_cache()`` explicitly.
     """
     global _nous_auth_status_cache
     now = time.monotonic()
-    auth_file_key, mtime = _auth_file_cache_key()
+    cache_identity = _nous_auth_status_cache_identity()
     cached = _nous_auth_status_cache
     if cached is not None:
-        cached_at, cached_auth_file_key, cached_mtime, cached_status = cached
+        cached_at, cached_identity, cached_status = cached
         if (
-            cached_auth_file_key == auth_file_key
-            and cached_mtime == mtime
+            cached_identity == cache_identity
             and (now - cached_at) < _NOUS_AUTH_STATUS_CACHE_TTL
         ):
             return dict(cached_status)
 
     status = _compute_nous_auth_status()
-    _nous_auth_status_cache = (now, auth_file_key, mtime, dict(status))
+    _nous_auth_status_cache = (now, cache_identity, dict(status))
     return status
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5942,17 +5942,29 @@ def _agent_key_is_usable(state: Dict[str, Any], min_ttl_seconds: int) -> bool:
 # burst into a single network round-trip; callers that need freshness use
 # separate flows (force_fresh / refresh_nous_oauth_pure) and are unaffected.
 _RESOLVE_TOKEN_CACHE_LOCK = threading.Lock()
-_RESOLVE_TOKEN_CACHE: "tuple[str, float, str] | None" = None
+_RESOLVE_TOKEN_CACHE: "tuple[_NousAuthStoreIdentity, float, str] | None" = None
 _RESOLVE_TOKEN_CACHE_TTL_S = 5.0
 
 
-def _resolve_token_cache_home() -> str:
-    """Return the canonical profile home that owns a memoized Nous token."""
-    home = get_hermes_home()
-    try:
-        return str(home.resolve(strict=False))
-    except Exception:
-        return str(home)
+def _memoize_nous_access_token(
+    token: str,
+    *,
+    insecure: Optional[bool],
+    ca_bundle: Optional[str],
+) -> None:
+    """Cache a resolved token under the post-persistence auth-store identity."""
+    global _RESOLVE_TOKEN_CACHE
+    if insecure or ca_bundle is not None:
+        return
+    if not profile_global_auth_inheritance_enabled():
+        return
+    cache_identity = _nous_auth_store_identity()
+    with _RESOLVE_TOKEN_CACHE_LOCK:
+        _RESOLVE_TOKEN_CACHE = (
+            cache_identity,
+            time.monotonic(),
+            token,
+        )
 
 
 def resolve_nous_access_token(
@@ -5964,7 +5976,7 @@ def resolve_nous_access_token(
 ) -> str:
     """Resolve a refresh-aware Nous Portal access token for managed tool gateways."""
     global _RESOLVE_TOKEN_CACHE
-    cache_home = _resolve_token_cache_home()
+    cache_identity = _nous_auth_store_identity()
     cache_allowed = profile_global_auth_inheritance_enabled()
     # Memo: collapse the startup burst of managed-tool check_fns into one
     # network refresh. Only cache a successful, non-forced resolution for a
@@ -5972,9 +5984,9 @@ def resolve_nous_access_token(
     if cache_allowed and not insecure and ca_bundle is None:
         with _RESOLVE_TOKEN_CACHE_LOCK:
             if _RESOLVE_TOKEN_CACHE is not None:
-                cached_home, cached_at, cached_token = _RESOLVE_TOKEN_CACHE
+                cached_identity, cached_at, cached_token = _RESOLVE_TOKEN_CACHE
                 if (
-                    cached_home == cache_home
+                    cached_identity == cache_identity
                     and (time.monotonic() - cached_at) < _RESOLVE_TOKEN_CACHE_TTL_S
                 ):
                     return cached_token
@@ -6038,13 +6050,12 @@ def resolve_nous_access_token(
                 # state reads to reach this return. The token has at least
                 # refresh_skew_seconds (>= 120s) of life here, so a 5s memo
                 # can never serve an expired token.
-                if cache_allowed and not insecure and ca_bundle is None:
-                    with _RESOLVE_TOKEN_CACHE_LOCK:
-                        _RESOLVE_TOKEN_CACHE = (
-                            cache_home,
-                            time.monotonic(),
-                            access_token,
-                        )
+                if cache_allowed:
+                    _memoize_nous_access_token(
+                        access_token,
+                        insecure=insecure,
+                        ca_bundle=ca_bundle,
+                    )
                 return access_token
 
             if not isinstance(refresh_token, str) or not refresh_token:
@@ -6103,13 +6114,12 @@ def resolve_nous_access_token(
             _save_provider_state_to_source(auth_store, "nous", state, state_source_path)
             _write_shared_nous_state(state)
             resolved = state["access_token"]
-            if cache_allowed and not insecure and ca_bundle is None:
-                with _RESOLVE_TOKEN_CACHE_LOCK:
-                    _RESOLVE_TOKEN_CACHE = (
-                        cache_home,
-                        time.monotonic(),
-                        resolved,
-                    )
+            if cache_allowed:
+                _memoize_nous_access_token(
+                    resolved,
+                    insecure=insecure,
+                    ca_bundle=ca_bundle,
+                )
             return resolved
 
 
@@ -6736,7 +6746,7 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
 # switches and policy changes do not share a process memo. Auth writes invalidate
 # naturally through the high-resolution mtime components.
 _NOUS_AUTH_STATUS_CACHE_TTL = 15.0  # seconds
-_NousAuthStatusCacheIdentity = Tuple[
+_NousAuthStoreIdentity = Tuple[
     str,
     Optional[int],
     bool,
@@ -6744,7 +6754,7 @@ _NousAuthStatusCacheIdentity = Tuple[
     Optional[int],
 ]
 _nous_auth_status_cache: Optional[
-    Tuple[float, _NousAuthStatusCacheIdentity, Dict[str, Any]]
+    Tuple[float, _NousAuthStoreIdentity, Dict[str, Any]]
 ] = None
 
 
@@ -6762,8 +6772,8 @@ def _auth_file_cache_key() -> Tuple[str, Optional[int]]:
         return auth_file_key, None
 
 
-def _nous_auth_status_cache_identity() -> _NousAuthStatusCacheIdentity:
-    """Bind a status memo to local/global stores and strict policy state."""
+def _nous_auth_store_identity() -> _NousAuthStoreIdentity:
+    """Bind an auth memo to local/global stores and strict policy state."""
     auth_file_key, mtime_ns = _auth_file_cache_key()
     inherit_global = profile_global_auth_inheritance_enabled()
     global_key: Optional[str] = None
@@ -6817,7 +6827,7 @@ def get_nous_auth_status() -> Dict[str, Any]:
     """
     global _nous_auth_status_cache
     now = time.monotonic()
-    cache_identity = _nous_auth_status_cache_identity()
+    cache_identity = _nous_auth_store_identity()
     cached = _nous_auth_status_cache
     if cached is not None:
         cached_at, cached_identity, cached_status = cached

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5383,6 +5383,9 @@ def _nous_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
     can't race on the single-use shared refresh token; that helper must
     NOT be called with ``_auth_store_lock`` already held.
     """
+    if not profile_auth_materialization_enabled():
+        yield
+        return
     try:
         lock_path = _nous_shared_store_path().with_suffix(".lock")
     except RuntimeError:
@@ -5444,6 +5447,8 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
     We deliberately omit the runtime ``agent_key`` compatibility field;
     the OAuth tokens are the cross-profile source of truth.
     """
+    if not profile_auth_materialization_enabled():
+        return
     refresh_token = state.get("refresh_token")
     access_token = state.get("access_token")
     if not (isinstance(refresh_token, str) and refresh_token.strip()):
@@ -5508,6 +5513,8 @@ def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
     lacks required fields. Callers should treat ``None`` as "no shared
     credentials available — fall through to device-code".
     """
+    if not profile_auth_materialization_enabled():
+        return None
     try:
         path = _nous_shared_store_path()
     except RuntimeError:
@@ -5533,6 +5540,8 @@ def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
 
 def _clear_shared_nous_state(reason: str) -> None:
     """Remove the shared Nous OAuth store after a terminal token failure."""
+    if not profile_auth_materialization_enabled():
+        return
     try:
         with _nous_shared_store_lock():
             path = _nous_shared_store_path()
@@ -5729,6 +5738,8 @@ def _try_import_shared_nous_state(
     etc.) — caller should then fall through to the normal device-code
     flow.
     """
+    if not profile_auth_materialization_enabled():
+        return None
     try:
         with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
             shared = _read_shared_nous_state()
@@ -5919,8 +5930,17 @@ def _agent_key_is_usable(state: Dict[str, Any], min_ttl_seconds: int) -> bool:
 # burst into a single network round-trip; callers that need freshness use
 # separate flows (force_fresh / refresh_nous_oauth_pure) and are unaffected.
 _RESOLVE_TOKEN_CACHE_LOCK = threading.Lock()
-_RESOLVE_TOKEN_CACHE: "tuple[float, str] | None" = None
+_RESOLVE_TOKEN_CACHE: "tuple[str, float, str] | None" = None
 _RESOLVE_TOKEN_CACHE_TTL_S = 5.0
+
+
+def _resolve_token_cache_home() -> str:
+    """Return the canonical profile home that owns a memoized Nous token."""
+    home = get_hermes_home()
+    try:
+        return str(home.resolve(strict=False))
+    except Exception:
+        return str(home)
 
 
 def resolve_nous_access_token(
@@ -5932,14 +5952,19 @@ def resolve_nous_access_token(
 ) -> str:
     """Resolve a refresh-aware Nous Portal access token for managed tool gateways."""
     global _RESOLVE_TOKEN_CACHE
+    cache_home = _resolve_token_cache_home()
+    cache_allowed = profile_auth_materialization_enabled()
     # Memo: collapse the startup burst of managed-tool check_fns into one
     # network refresh. Only cache a successful, non-forced resolution for a
     # short window; force_fresh / error paths bypass and don't populate it.
-    if not insecure and ca_bundle is None:
+    if cache_allowed and not insecure and ca_bundle is None:
         with _RESOLVE_TOKEN_CACHE_LOCK:
             if _RESOLVE_TOKEN_CACHE is not None:
-                cached_at, cached_token = _RESOLVE_TOKEN_CACHE
-                if (time.monotonic() - cached_at) < _RESOLVE_TOKEN_CACHE_TTL_S:
+                cached_home, cached_at, cached_token = _RESOLVE_TOKEN_CACHE
+                if (
+                    cached_home == cache_home
+                    and (time.monotonic() - cached_at) < _RESOLVE_TOKEN_CACHE_TTL_S
+                ):
                     return cached_token
     with _provider_state_transaction("nous") as (
         auth_store,
@@ -6001,9 +6026,13 @@ def resolve_nous_access_token(
                 # state reads to reach this return. The token has at least
                 # refresh_skew_seconds (>= 120s) of life here, so a 5s memo
                 # can never serve an expired token.
-                if not insecure and ca_bundle is None:
+                if cache_allowed and not insecure and ca_bundle is None:
                     with _RESOLVE_TOKEN_CACHE_LOCK:
-                        _RESOLVE_TOKEN_CACHE = (time.monotonic(), access_token)
+                        _RESOLVE_TOKEN_CACHE = (
+                            cache_home,
+                            time.monotonic(),
+                            access_token,
+                        )
                 return access_token
 
             if not isinstance(refresh_token, str) or not refresh_token:
@@ -6062,9 +6091,13 @@ def resolve_nous_access_token(
             _save_provider_state_to_source(auth_store, "nous", state, state_source_path)
             _write_shared_nous_state(state)
             resolved = state["access_token"]
-            if not insecure and ca_bundle is None:
+            if cache_allowed and not insecure and ca_bundle is None:
                 with _RESOLVE_TOKEN_CACHE_LOCK:
-                    _RESOLVE_TOKEN_CACHE = (time.monotonic(), resolved)
+                    _RESOLVE_TOKEN_CACHE = (
+                        cache_home,
+                        time.monotonic(),
+                        resolved,
+                    )
             return resolved
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -85,6 +85,7 @@ from hermes_cli.config import (
     get_hermes_home,
     get_config_path,
     read_raw_config,
+    read_raw_config_strict,
     require_readable_config_before_write,
 )
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
@@ -1057,6 +1058,31 @@ def _auth_file_path() -> Path:
     return path
 
 
+def profile_auth_materialization_enabled() -> bool:
+    """Return whether the active profile may inherit or persist auth state.
+
+    ``auth.inherit_global`` is intentionally a fail-closed profile boundary.
+    The setting is backward-compatible when absent, but once present only the
+    boolean value ``true`` permits global-root fallback, ambient credential
+    seeding, or auth.json writes. Invalid values and unreadable configuration
+    deny those paths rather than silently restoring credential authority.
+    """
+    try:
+        config = read_raw_config_strict()
+    except Exception:
+        return False
+    if config is None:
+        return True
+    auth_config = config.get("auth")
+    if "auth" not in config:
+        return True
+    if not isinstance(auth_config, dict):
+        return False
+    if "inherit_global" not in auth_config:
+        return True
+    return auth_config.get("inherit_global") is True
+
+
 def _global_auth_file_path() -> Optional[Path]:
     """Return the global-root auth.json when the process is in profile mode.
 
@@ -1067,6 +1093,8 @@ def _global_auth_file_path() -> Optional[Path]:
 
     See issue #18594 follow-up (credential_pool shadowing).
     """
+    if not profile_auth_materialization_enabled():
+        return None
     try:
         from hermes_constants import get_default_hermes_root
         global_root = get_default_hermes_root()
@@ -1325,6 +1353,10 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     # specific store — e.g. the global-root write-through for rotating xAI
     # OAuth grants (#43589) — reusing this function's atomic O_EXCL + 0o600
     # write so the root auth.json gets the same TOCTOU-safe treatment.
+    if not profile_auth_materialization_enabled():
+        raise AuthError(
+            "Profile auth materialization is disabled by auth.inherit_global"
+        )
     auth_file = target_path if target_path is not None else _auth_file_path()
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
@@ -1709,6 +1741,10 @@ def write_credential_pool(
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
     merge does not resurrect them from the on-disk copy.
     """
+    if not profile_auth_materialization_enabled():
+        raise AuthError(
+            "Profile auth materialization is disabled by auth.inherit_global"
+        )
     removed = {rid for rid in (removed_ids or ()) if rid}
     with _auth_store_lock():
         auth_store = _load_auth_store()

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1269,7 +1269,16 @@ def _auth_store_lock(
     refresh paths follow this order; violating it risks deadlock
     against a concurrent import on the shared store.
     """
-    auth_path = target_path if target_path is not None else _auth_file_path()
+    active_auth_path = _auth_file_path()
+    auth_path = target_path if target_path is not None else active_auth_path
+    if (
+        target_path is not None
+        and not _same_path(auth_path, active_auth_path)
+        and not profile_global_auth_inheritance_enabled()
+    ):
+        raise AuthError(
+            "Global auth persistence is disabled by auth.inherit_global"
+        )
     lock_path = auth_path.with_suffix(".lock") if target_path is not None else _auth_lock_path()
     with _file_lock(
         lock_path,
@@ -6280,6 +6289,15 @@ def persist_nous_credentials(
     with _auth_store_lock():
         auth_store = _load_auth_store()
         _save_provider_state(auth_store, "nous", state)
+        suppressed = auth_store.get("suppressed_sources")
+        if isinstance(suppressed, dict):
+            sources = suppressed.get("nous")
+            if isinstance(sources, list) and "device_code" in sources:
+                remaining = [source for source in sources if source != "device_code"]
+                if remaining:
+                    suppressed["nous"] = remaining
+                else:
+                    suppressed.pop("nous", None)
         _save_auth_store(auth_store)
 
     # Mirror to the shared store so a new profile can one-tap import
@@ -6288,7 +6306,7 @@ def persist_nous_credentials(
     # auth.json is still the source of truth).
     _write_shared_nous_state(state)
 
-    pool = load_pool("nous")
+    pool = load_pool("nous", _allow_local_nous_sync=True)
     return next(
         (e for e in pool.entries() if e.source == NOUS_DEVICE_CODE_SOURCE),
         None,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1064,17 +1064,20 @@ def profile_global_auth_inheritance_enabled() -> bool:
     ``auth.inherit_global`` is intentionally a fail-closed profile boundary.
     The setting is backward-compatible when absent, but once present only the
     boolean value ``true`` permits global-root fallback, shared auth state,
-    cross-profile token caches, or ambient credential seeding. Invalid values
-    and unreadable configuration deny those paths rather than silently
-    restoring credential authority. Explicit profile-local reads and writes
-    remain permitted.
+    cross-profile token caches, or ambient credential seeding. Administrator-
+    managed config is applied after the strict profile read, so its leaf value
+    wins exactly as it does for other effective Hermes configuration. Invalid
+    values and unreadable profile configuration deny those paths rather than
+    silently restoring credential authority. Explicit profile-local reads and
+    writes remain permitted.
     """
     try:
-        config = read_raw_config_strict()
+        config = read_raw_config_strict() or {}
+        from hermes_cli.managed_scope import apply_managed_overlay
+
+        config = apply_managed_overlay(config)
     except Exception:
         return False
-    if config is None:
-        return True
     auth_config = config.get("auth")
     if "auth" not in config:
         return True

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -695,7 +695,7 @@ def get_container_exec_info() -> Optional[dict]:
 
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home, get_process_hermes_home  # noqa: F811,E402
-from utils import atomic_replace, fast_safe_load
+from utils import atomic_replace, fast_safe_load, strict_safe_load
 
 def get_config_path() -> Path:
     """Get the main config file path."""
@@ -3031,7 +3031,7 @@ def read_raw_config_strict() -> Optional[Dict[str, Any]]:
             return copy.deepcopy(cached[1])
 
         with open(config_path, encoding="utf-8") as handle:
-            data = fast_safe_load(handle)
+            data = strict_safe_load(handle)
         if data is None:
             data = {}
         if not isinstance(data, dict):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -250,6 +250,12 @@ _LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
 _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+# Security-policy reads must distinguish a missing file from parse/I/O/type
+# failures and must notice permission-only changes. Keep their stronger cache
+# separate from read_raw_config()'s backward-compatible fail-open cache.
+_STRICT_RAW_CONFIG_CACHE: Dict[
+    str, Tuple[Tuple[int, int, int, int], Dict[str, Any]]
+] = {}
 # Serializes all config read/write paths. libyaml's C extension is not
 # thread-safe for concurrent safe_load() on the same file, and multiple
 # tool threads (approval.py, browser_tool.py, setup flows) hit
@@ -3003,6 +3009,37 @@ def read_raw_config() -> Dict[str, Any]:
         return data
 
 
+def read_raw_config_strict() -> Optional[Dict[str, Any]]:
+    """Read raw config without collapsing security-relevant failures.
+
+    Returns ``None`` only when the active config file is absent. Valid empty
+    configuration returns ``{}``. Parse errors, I/O errors, and non-mapping
+    YAML roots raise so fail-closed policy callers cannot mistake them for an
+    absent policy. The cache includes ctime and mode to invalidate on
+    permission-only changes.
+    """
+    with _CONFIG_LOCK:
+        config_path = get_config_path()
+        try:
+            st = config_path.stat()
+        except FileNotFoundError:
+            return None
+        cache_key = (st.st_mtime_ns, st.st_ctime_ns, st.st_size, st.st_mode)
+        path_key = str(config_path)
+        cached = _STRICT_RAW_CONFIG_CACHE.get(path_key)
+        if cached is not None and cached[0] == cache_key:
+            return copy.deepcopy(cached[1])
+
+        with open(config_path, encoding="utf-8") as handle:
+            data = fast_safe_load(handle)
+        if data is None:
+            data = {}
+        if not isinstance(data, dict):
+            raise ValueError("Hermes config root must be a mapping")
+        _STRICT_RAW_CONFIG_CACHE[path_key] = (cache_key, copy.deepcopy(data))
+        return data
+
+
 def read_user_config_raw(config_path: Optional[Path] = None) -> Dict[str, Any]:
     """Read a user ``config.yaml`` EXACTLY as written on disk.
 
@@ -3674,6 +3711,7 @@ def save_config(
         )
         _secure_file(config_path)
         _RAW_CONFIG_CACHE.pop(str(config_path), None)
+        _STRICT_RAW_CONFIG_CACHE.pop(str(config_path), None)
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
 
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -6,6 +6,7 @@ import base64
 import json
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -165,6 +166,110 @@ def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert singleton["agent_key"] == token
     assert singleton["portal_base_url"] == "https://portal.example.com"
     assert singleton["inference_base_url"] == "https://inference.example.com/v1"
+
+
+def test_isolated_profile_nous_public_lifecycle_stays_local(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    global_root = tmp_path / ".hermes"
+    profile = global_root / "profiles" / "argus"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    (profile / "config.yaml").write_text(
+        "auth:\n  inherit_global: false\n",
+        encoding="utf-8",
+    )
+    global_store = {
+        "version": 1,
+        "providers": {"nous": {"access_token": "synthetic-global"}},
+    }
+    (global_root / "auth.json").write_text(
+        json.dumps(global_store, indent=2),
+        encoding="utf-8",
+    )
+
+    first_token = _jwt_with_email("first-nous@example.com")
+    second_token = _jwt_with_email("second-nous@example.com")
+    future = datetime.fromtimestamp(time.time() + 3600, tz=timezone.utc).isoformat()
+    logins = iter([
+        {
+            "access_token": first_token,
+            "refresh_token": "synthetic-local-refresh-1",
+            "agent_key": first_token,
+            "expires_at": future,
+            "agent_key_expires_at": future,
+            "portal_base_url": "https://portal.example.com",
+            "inference_base_url": "https://inference.example.com/v1",
+        },
+        {
+            "access_token": second_token,
+            "refresh_token": "synthetic-local-refresh-2",
+            "agent_key": second_token,
+            "expires_at": future,
+            "agent_key_expires_at": future,
+            "portal_base_url": "https://portal.example.com",
+            "inference_base_url": "https://inference.example.com/v1",
+        },
+    ])
+    monkeypatch.setattr(
+        "hermes_cli.auth._nous_device_code_login",
+        lambda **kwargs: next(logins),
+    )
+
+    from hermes_cli.auth_commands import (
+        auth_add_command,
+        auth_list_command,
+        auth_remove_command,
+    )
+
+    class _AddArgs:
+        provider = "nous"
+        auth_type = "oauth"
+        api_key = None
+        label = "local-nous"
+        portal_url = None
+        inference_url = None
+        client_id = None
+        scope = None
+        no_browser = False
+        timeout = None
+        insecure = False
+        ca_bundle = None
+
+    class _ListArgs:
+        provider = "nous"
+
+    class _RemoveArgs:
+        provider = "nous"
+        target = "1"
+
+    auth_add_command(_AddArgs())
+    capsys.readouterr()
+    auth_list_command(_ListArgs())
+    assert "local-nous" in capsys.readouterr().out
+
+    payload = json.loads((profile / "auth.json").read_text())
+    assert payload["providers"]["nous"]["access_token"] == first_token
+    assert len(payload["credential_pool"]["nous"]) == 1
+    assert payload["credential_pool"]["nous"][0]["access_token"] == first_token
+
+    auth_add_command(_AddArgs())
+    payload = json.loads((profile / "auth.json").read_text())
+    assert payload["providers"]["nous"]["access_token"] == second_token
+    assert len(payload["credential_pool"]["nous"]) == 1
+    assert payload["credential_pool"]["nous"][0]["access_token"] == second_token
+
+    auth_remove_command(_RemoveArgs())
+    payload = json.loads((profile / "auth.json").read_text())
+    assert "nous" not in payload.get("providers", {})
+    assert payload["credential_pool"]["nous"] == []
+    capsys.readouterr()
+    auth_list_command(_ListArgs())
+    assert capsys.readouterr().out == ""
+    assert json.loads((global_root / "auth.json").read_text()) == global_store
 
 
 def test_auth_add_nous_oauth_honors_custom_label(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -269,28 +269,50 @@ def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):
 # ---------------------------------------------------------------------------
 
 
-def test_inheritance_disabled_refuses_profile_auth_materialization(profile_env):
-    from hermes_cli.auth import AuthError, write_credential_pool
+def test_inheritance_disabled_allows_profile_local_pool_persistence(profile_env):
+    from hermes_cli.auth import write_credential_pool
 
     _disable_global_auth_inheritance(profile_env["profile"])
 
-    with pytest.raises(AuthError, match="auth materialization is disabled"):
-        write_credential_pool("openrouter", [_pool_entry(access_token="synthetic-local")])
+    write_credential_pool("openrouter", [_pool_entry(access_token="synthetic-local")])
 
-    assert not (profile_env["profile"] / "auth.json").exists()
+    profile_store = json.loads((profile_env["profile"] / "auth.json").read_text())
+    assert profile_store["credential_pool"]["openrouter"][0]["access_token"] == "synthetic-local"
 
 
-def test_inheritance_disabled_refuses_singleton_auth_materialization(profile_env):
+def test_inheritance_disabled_allows_profile_local_singleton_persistence(profile_env):
+    from hermes_cli.auth import _save_auth_store
+
+    _disable_global_auth_inheritance(profile_env["profile"])
+
+    _save_auth_store({
+        "version": 1,
+        "providers": {"nous": {"access_token": "synthetic-local"}},
+    })
+
+    profile_store = json.loads((profile_env["profile"] / "auth.json").read_text())
+    assert profile_store["providers"]["nous"]["access_token"] == "synthetic-local"
+
+
+def test_inheritance_disabled_refuses_explicit_global_store_write(profile_env):
     from hermes_cli.auth import AuthError, _save_auth_store
 
+    global_path = profile_env["global"] / "auth.json"
+    original = _make_auth_store(providers={
+        "nous": {"access_token": "synthetic-global-original"},
+    })
+    _write(global_path, original)
     _disable_global_auth_inheritance(profile_env["profile"])
 
-    with pytest.raises(AuthError, match="auth materialization is disabled"):
-        _save_auth_store({
-            "version": 1,
-            "providers": {"nous": {"access_token": "synthetic-local"}},
-        })
+    with pytest.raises(AuthError, match="Global auth persistence is disabled"):
+        _save_auth_store(
+            _make_auth_store(providers={
+                "nous": {"access_token": "synthetic-global-replacement"},
+            }),
+            target_path=global_path,
+        )
 
+    assert json.loads(global_path.read_text()) == original
     assert not (profile_env["profile"] / "auth.json").exists()
 
 
@@ -368,6 +390,41 @@ def test_nous_token_memo_cannot_cross_into_isolated_profile(profile_env):
     with pytest.raises(AuthError, match="not logged into Nous Portal"):
         auth.resolve_nous_access_token()
 
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+def test_nous_status_memo_invalidates_when_inheritance_is_disabled(
+    profile_env,
+    monkeypatch,
+):
+    import hermes_cli.auth as auth
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
+        "nous": {"access_token": "synthetic-global-status"},
+    }))
+    auth.invalidate_nous_auth_status_cache()
+    calls = 0
+
+    def _compute_without_network():
+        nonlocal calls
+        calls += 1
+        state = auth.get_provider_auth_state("nous") or {}
+        return {
+            "logged_in": bool(state.get("access_token")),
+            "access_token": state.get("access_token"),
+        }
+
+    monkeypatch.setattr(auth, "_compute_nous_auth_status", _compute_without_network)
+
+    first = auth.get_nous_auth_status()
+    assert first["access_token"] == "synthetic-global-status"
+
+    _disable_global_auth_inheritance(profile_env["profile"])
+    second = auth.get_nous_auth_status()
+
+    assert second["logged_in"] is False
+    assert second["access_token"] is None
+    assert calls == 2
     assert not (profile_env["profile"] / "auth.json").exists()
 
 

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -316,6 +316,28 @@ def test_inheritance_disabled_refuses_explicit_global_store_write(profile_env):
     assert not (profile_env["profile"] / "auth.json").exists()
 
 
+def test_inheritance_disabled_denies_global_persist_before_lock(profile_env):
+    import hermes_cli.auth as auth
+
+    global_path = profile_env["global"] / "auth.json"
+    original = _make_auth_store(providers={
+        "nous": {"access_token": "synthetic-global-original"},
+    })
+    _write(global_path, original)
+    _disable_global_auth_inheritance(profile_env["profile"])
+
+    with pytest.raises(auth.AuthError, match="Global auth persistence is disabled"):
+        auth._persist_provider_state_to_store(
+            "nous",
+            {"access_token": "synthetic-global-replacement"},
+            global_path,
+        )
+
+    assert json.loads(global_path.read_text()) == original
+    assert not global_path.with_suffix(".lock").exists()
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
 def test_inheritance_disabled_skips_ambient_pool_seeding(profile_env, monkeypatch):
     from agent.credential_pool import load_pool
 

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import time
 from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -120,6 +121,25 @@ def test_non_mapping_auth_policy_fails_closed(profile_env):
     from hermes_cli.auth import read_credential_pool
 
     _write(profile_env["profile"] / "config.yaml", {"auth": "invalid"})
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [_pool_entry(id="global-openrouter", access_token="synthetic-global")],
+    }))
+
+    assert read_credential_pool("openrouter") == []
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    (
+        "auth:\n  inherit_global: false\n  inherit_global: true\n",
+        "auth:\n  inherit_global: false\nauth:\n  inherit_global: true\n",
+    ),
+)
+def test_duplicate_auth_policy_keys_fail_closed(profile_env, config_text):
+    from hermes_cli.auth import read_credential_pool
+
+    (profile_env["profile"] / "config.yaml").write_text(config_text)
     _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
         "openrouter": [_pool_entry(id="global-openrouter", access_token="synthetic-global")],
     }))
@@ -283,6 +303,71 @@ def test_inheritance_disabled_skips_ambient_pool_seeding(profile_env, monkeypatc
     pool = load_pool("openrouter")
 
     assert pool.entries() == []
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+def test_inheritance_disabled_blocks_shared_nous_store(profile_env, monkeypatch):
+    import hermes_cli.auth as auth
+
+    _disable_global_auth_inheritance(profile_env["profile"])
+    shared_dir = profile_env["global"].parent / "synthetic-shared"
+    shared_dir.mkdir()
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    shared_path = shared_dir / auth.NOUS_SHARED_STORE_FILENAME
+    original = {
+        "access_token": "synthetic-shared-access",
+        "refresh_token": "synthetic-shared-refresh",
+    }
+    _write(shared_path, original)
+
+    refresh_called = False
+
+    def _unexpected_refresh(*args, **kwargs):
+        nonlocal refresh_called
+        refresh_called = True
+        raise AssertionError("shared credentials must not be refreshed")
+
+    monkeypatch.setattr(auth, "refresh_nous_oauth_from_state", _unexpected_refresh)
+
+    assert auth._read_shared_nous_state() is None
+    assert auth._try_import_shared_nous_state() is None
+    auth._write_shared_nous_state({
+        "access_token": "synthetic-replacement-access",
+        "refresh_token": "synthetic-replacement-refresh",
+    })
+    auth._clear_shared_nous_state("synthetic-test")
+
+    assert json.loads(shared_path.read_text()) == original
+    assert refresh_called is False
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+def test_nous_token_memo_cannot_cross_into_isolated_profile(profile_env):
+    import hermes_cli.auth as auth
+    from hermes_cli.auth import AuthError
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    source_profile = profile_env["global"] / "profiles" / "source"
+    source_profile.mkdir()
+    _write(source_profile / "auth.json", _make_auth_store(providers={
+        "nous": {
+            "access_token": "synthetic-source-access",
+            "refresh_token": "synthetic-source-refresh",
+            "expires_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        },
+    }))
+    _disable_global_auth_inheritance(profile_env["profile"])
+    auth._RESOLVE_TOKEN_CACHE = None
+
+    token = set_hermes_home_override(source_profile)
+    try:
+        assert auth.resolve_nous_access_token() == "synthetic-source-access"
+    finally:
+        reset_hermes_home_override(token)
+
+    with pytest.raises(AuthError, match="not logged into Nous Portal"):
+        auth.resolve_nous_access_token()
+
     assert not (profile_env["profile"] / "auth.json").exists()
 
 

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -148,6 +148,86 @@ def test_duplicate_auth_policy_keys_fail_closed(profile_env, config_text):
     assert not (profile_env["profile"] / "auth.json").exists()
 
 
+def test_managed_false_overrides_user_true_and_blocks_global_fallback(
+    profile_env, tmp_path, monkeypatch
+):
+    from hermes_cli import managed_scope
+    from hermes_cli.auth import (
+        get_provider_auth_state,
+        profile_global_auth_inheritance_enabled,
+        read_credential_pool,
+    )
+
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    (managed / "config.yaml").write_text(
+        "auth:\n  inherit_global: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    managed_scope.invalidate_managed_cache()
+
+    _disable_global_auth_inheritance(profile_env["profile"], value=True)
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    _pool_entry(
+                        id="global-openrouter",
+                        access_token="synthetic-global",
+                    )
+                ],
+            },
+            providers={
+                "openrouter": {"api_key": "synthetic-global"},
+            },
+        ),
+    )
+
+    assert profile_global_auth_inheritance_enabled() is False
+    assert read_credential_pool("openrouter") == []
+    assert get_provider_auth_state("openrouter") is None
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+@pytest.mark.parametrize(
+    ("user_value", "managed_value", "expected"),
+    (
+        (None, False, False),
+        (False, True, True),
+        (True, "false", False),
+    ),
+)
+def test_managed_auth_policy_has_leaf_precedence(
+    profile_env,
+    tmp_path,
+    monkeypatch,
+    user_value,
+    managed_value,
+    expected,
+):
+    from hermes_cli import managed_scope
+    from hermes_cli.auth import profile_global_auth_inheritance_enabled
+
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    _write(
+        managed / "config.yaml",
+        {"auth": {"inherit_global": managed_value}},
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    managed_scope.invalidate_managed_cache()
+
+    if user_value is not None:
+        _disable_global_auth_inheritance(
+            profile_env["profile"],
+            value=user_value,
+        )
+
+    assert profile_global_auth_inheritance_enabled() is expected
+
+
 
 
 

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -52,10 +52,80 @@ def _write(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2))
 
 
+def _disable_global_auth_inheritance(profile: Path, value: object = False) -> None:
+    _write(profile / "config.yaml", {"auth": {"inherit_global": value}})
+
+
 # ---------------------------------------------------------------------------
 # read_credential_pool — provider-slice reads
 # ---------------------------------------------------------------------------
 
+
+def test_profile_can_fail_closed_against_all_global_pool_fallback(profile_env):
+    from hermes_cli.auth import read_credential_pool
+
+    _disable_global_auth_inheritance(profile_env["profile"])
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [_pool_entry(id="global-codex", access_token="synthetic-global")],
+        "xai-oauth": [_pool_entry(id="global-xai", access_token="synthetic-global")],
+    }))
+
+    assert read_credential_pool("openai-codex") == []
+    assert read_credential_pool("xai-oauth") == []
+    assert read_credential_pool() == {}
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+def test_invalid_inherit_global_value_fails_closed(profile_env):
+    from hermes_cli.auth import read_credential_pool
+
+    _disable_global_auth_inheritance(profile_env["profile"], value="false")
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [_pool_entry(id="global-openrouter", access_token="synthetic-global")],
+    }))
+
+    assert read_credential_pool("openrouter") == []
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+def test_malformed_profile_config_fails_closed(profile_env):
+    from hermes_cli.auth import read_credential_pool
+
+    (profile_env["profile"] / "config.yaml").write_text("auth: [\n")
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [_pool_entry(id="global-openrouter", access_token="synthetic-global")],
+    }))
+
+    assert read_credential_pool("openrouter") == []
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+def test_unreadable_profile_config_fails_closed(profile_env):
+    from hermes_cli.auth import read_credential_pool
+
+    config_path = profile_env["profile"] / "config.yaml"
+    _disable_global_auth_inheritance(profile_env["profile"])
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [_pool_entry(id="global-openrouter", access_token="synthetic-global")],
+    }))
+    config_path.chmod(0)
+    try:
+        assert read_credential_pool("openrouter") == []
+    finally:
+        config_path.chmod(0o600)
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+def test_non_mapping_auth_policy_fails_closed(profile_env):
+    from hermes_cli.auth import read_credential_pool
+
+    _write(profile_env["profile"] / "config.yaml", {"auth": "invalid"})
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [_pool_entry(id="global-openrouter", access_token="synthetic-global")],
+    }))
+
+    assert read_credential_pool("openrouter") == []
+    assert not (profile_env["profile"] / "auth.json").exists()
 
 
 
@@ -114,6 +184,20 @@ def test_malformed_global_auth_file_does_not_break_profile_read(profile_env):
 # ---------------------------------------------------------------------------
 
 
+def test_profile_can_fail_closed_against_global_singleton_fallback(profile_env):
+    from hermes_cli.auth import get_provider_auth_state
+
+    _disable_global_auth_inheritance(profile_env["profile"])
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
+        "nous": {"access_token": "synthetic-global", "refresh_token": "synthetic-refresh"},
+        "xai-oauth": {"access_token": "synthetic-global"},
+    }))
+
+    assert get_provider_auth_state("nous") is None
+    assert get_provider_auth_state("xai-oauth") is None
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
 def test_provider_auth_state_falls_back_to_global_when_profile_has_none(profile_env):
     from hermes_cli.auth import get_provider_auth_state
 
@@ -163,6 +247,43 @@ def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):
 # ---------------------------------------------------------------------------
 # Writes stay scoped to the profile
 # ---------------------------------------------------------------------------
+
+
+def test_inheritance_disabled_refuses_profile_auth_materialization(profile_env):
+    from hermes_cli.auth import AuthError, write_credential_pool
+
+    _disable_global_auth_inheritance(profile_env["profile"])
+
+    with pytest.raises(AuthError, match="auth materialization is disabled"):
+        write_credential_pool("openrouter", [_pool_entry(access_token="synthetic-local")])
+
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+def test_inheritance_disabled_refuses_singleton_auth_materialization(profile_env):
+    from hermes_cli.auth import AuthError, _save_auth_store
+
+    _disable_global_auth_inheritance(profile_env["profile"])
+
+    with pytest.raises(AuthError, match="auth materialization is disabled"):
+        _save_auth_store({
+            "version": 1,
+            "providers": {"nous": {"access_token": "synthetic-local"}},
+        })
+
+    assert not (profile_env["profile"] / "auth.json").exists()
+
+
+def test_inheritance_disabled_skips_ambient_pool_seeding(profile_env, monkeypatch):
+    from agent.credential_pool import load_pool
+
+    _disable_global_auth_inheritance(profile_env["profile"])
+    monkeypatch.setenv("OPENROUTER_API_KEY", "synthetic-ambient")
+
+    pool = load_pool("openrouter")
+
+    assert pool.entries() == []
+    assert not (profile_env["profile"] / "auth.json").exists()
 
 
 def test_write_credential_pool_targets_profile_not_global(profile_env):

--- a/tests/hermes_cli/test_nous_auth_status_cache.py
+++ b/tests/hermes_cli/test_nous_auth_status_cache.py
@@ -3,9 +3,10 @@
 The cache avoids re-validating Nous credentials on every menu paint —
 `hermes tools` → "All Platforms" used to fire ~31 OAuth refresh POSTs
 against portal.nousresearch.com during one render. The cache is keyed
-on auth.json path + mtime so profile switches stay isolated while
-login/logout flows invalidate naturally; tests and other writers can
-also call invalidate_nous_auth_status_cache().
+on local/global auth-store identity plus strict inheritance policy so
+profile or policy transitions stay isolated while auth writes invalidate
+naturally; tests and other writers can also call
+invalidate_nous_auth_status_cache().
 """
 
 from __future__ import annotations
@@ -86,4 +87,36 @@ def test_get_nous_auth_status_caches_failure_path(tmp_path, monkeypatch):
         f"Logged-out snapshots must cache; got {call_count['n']} computes for 10 calls."
     )
 
+    auth_mod.invalidate_nous_auth_status_cache()
+
+
+def test_get_nous_auth_status_invalidates_when_global_source_changes(
+    tmp_path,
+    monkeypatch,
+):
+    """An inherited source write invalidates even if local auth is unchanged."""
+    local_home = tmp_path / "profile"
+    local_home.mkdir()
+    global_auth = tmp_path / "global-auth.json"
+    global_auth.write_text('{"version": 1}\n', encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(local_home))
+
+    from hermes_cli import auth as auth_mod
+
+    auth_mod.invalidate_nous_auth_status_cache()
+    monkeypatch.setattr(auth_mod, "_global_auth_file_path", lambda: global_auth)
+    calls = 0
+
+    def fake_compute():
+        nonlocal calls
+        calls += 1
+        return {"logged_in": True, "call": calls}
+
+    with patch.object(auth_mod, "_compute_nous_auth_status", side_effect=fake_compute):
+        assert auth_mod.get_nous_auth_status()["call"] == 1
+        assert auth_mod.get_nous_auth_status()["call"] == 1
+        global_auth.write_text('{"version": 2}\n', encoding="utf-8")
+        assert auth_mod.get_nous_auth_status()["call"] == 2
+
+    assert calls == 2
     auth_mod.invalidate_nous_auth_status_cache()

--- a/tests/hermes_cli/test_resolve_token_memo.py
+++ b/tests/hermes_cli/test_resolve_token_memo.py
@@ -8,6 +8,7 @@ cross-process file locks + state reads) or triggering a network refresh.
 
 import json
 import time
+from pathlib import Path
 
 import pytest
 
@@ -76,12 +77,12 @@ def test_memo_expires_after_ttl(monkeypatch, tmp_path):
 
     auth.resolve_nous_access_token()
     assert auth._RESOLVE_TOKEN_CACHE is not None
-    cached_home, cached_at, tok = auth._RESOLVE_TOKEN_CACHE
+    cached_identity, cached_at, tok = auth._RESOLVE_TOKEN_CACHE
     monkeypatch.setattr(
         auth,
         "_RESOLVE_TOKEN_CACHE",
         (
-            cached_home,
+            cached_identity,
             cached_at - auth._RESOLVE_TOKEN_CACHE_TTL_S - 1.0,
             tok,
         ),
@@ -99,3 +100,45 @@ def test_insecure_callers_bypass_memo(monkeypatch, tmp_path):
     auth.resolve_nous_access_token(insecure=True)
 
     assert calls["n"] == 2, "insecure callers must bypass the memo entirely"
+
+
+def test_memo_invalidates_when_profile_shadows_inherited_global_source(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    global_root = tmp_path / ".hermes"
+    profile = global_root / "profiles" / "coder"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    auth._RESOLVE_TOKEN_CACHE = None
+
+    expires_at = time.strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00",
+        time.gmtime(time.time() + 3600),
+    )
+    (global_root / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            "nous": {
+                "access_token": "synthetic-global-token",
+                "refresh_token": "synthetic-global-refresh",
+                "expires_at": expires_at,
+            },
+        },
+    }))
+
+    assert auth.resolve_nous_access_token() == "synthetic-global-token"
+
+    (profile / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            "nous": {
+                "access_token": "synthetic-local-token",
+                "refresh_token": "synthetic-local-refresh",
+                "expires_at": expires_at,
+            },
+        },
+    }))
+
+    assert auth.resolve_nous_access_token() == "synthetic-local-token"

--- a/tests/hermes_cli/test_resolve_token_memo.py
+++ b/tests/hermes_cli/test_resolve_token_memo.py
@@ -75,11 +75,16 @@ def test_memo_expires_after_ttl(monkeypatch, tmp_path):
     calls = _count_transactions(monkeypatch)
 
     auth.resolve_nous_access_token()
-    cached_at, tok = auth._RESOLVE_TOKEN_CACHE
+    assert auth._RESOLVE_TOKEN_CACHE is not None
+    cached_home, cached_at, tok = auth._RESOLVE_TOKEN_CACHE
     monkeypatch.setattr(
         auth,
         "_RESOLVE_TOKEN_CACHE",
-        (cached_at - auth._RESOLVE_TOKEN_CACHE_TTL_S - 1.0, tok),
+        (
+            cached_home,
+            cached_at - auth._RESOLVE_TOKEN_CACHE_TTL_S - 1.0,
+            tok,
+        ),
     )
     auth.resolve_nous_access_token()
 

--- a/utils.py
+++ b/utils.py
@@ -622,6 +622,7 @@ def safe_json_loads(text: str, default: Any = None) -> Any:
 # is a true drop-in for ``safe_load`` (same restricted tag set), so prefer it
 # and fall back to the pure-Python loader only when libyaml isn't compiled in.
 _fast_yaml_loader = None
+_strict_yaml_loader = None
 
 
 def _get_fast_yaml_loader():
@@ -640,6 +641,62 @@ def fast_safe_load(stream: Any) -> Any:
     available, so behavior is identical everywhere — only the speed differs.
     """
     return yaml.load(stream, Loader=_get_fast_yaml_loader())
+
+
+def _get_strict_yaml_loader():
+    """Return a safe YAML loader that rejects duplicate mapping keys."""
+    global _strict_yaml_loader
+    if _strict_yaml_loader is not None:
+        return _strict_yaml_loader
+
+    StrictSafeLoader = type(
+        "StrictSafeLoader",
+        (_get_fast_yaml_loader(),),
+        {},
+    )
+
+    def _construct_unique_mapping(loader, node, deep=False):
+        if not isinstance(node, yaml.MappingNode):
+            raise yaml.constructor.ConstructorError(
+                None,
+                None,
+                f"expected a mapping node, but found {node.id}",
+                node.start_mark,
+            )
+        loader.flatten_mapping(node)
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            try:
+                duplicate = key in mapping
+            except TypeError as exc:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found an unhashable key",
+                    key_node.start_mark,
+                ) from exc
+            if duplicate:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r}",
+                    key_node.start_mark,
+                )
+            mapping[key] = loader.construct_object(value_node, deep=deep)
+        return mapping
+
+    StrictSafeLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        _construct_unique_mapping,
+    )
+    _strict_yaml_loader = StrictSafeLoader
+    return _strict_yaml_loader
+
+
+def strict_safe_load(stream: Any) -> Any:
+    """Safely parse YAML while rejecting duplicate keys at every depth."""
+    return yaml.load(stream, Loader=_get_strict_yaml_loader())  # type: ignore[arg-type]
 
 
 # ─── Environment Variable Helpers ─────────────────────────────────────────────

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -209,6 +209,29 @@ If you want this profile to work in a specific project by default, also set its 
 coder config set terminal.cwd /absolute/path/to/project
 ```
 
+### Credentialless profiles
+
+Named profiles normally inherit provider credentials from the global Hermes
+auth store when they have no profile-local entry. To create a fail-closed
+profile that must not inherit or materialize authentication state, add:
+
+```yaml
+auth:
+  inherit_global: false
+```
+
+With this setting, Hermes does not read global-root credential pools or
+provider/OAuth singletons, does not seed ambient credentials into the profile,
+and refuses writes that would create or update the profile's `auth.json`.
+Inspection commands such as `hermes -p <name> auth list` remain read-only. The
+setting is deliberately fail-closed: if `inherit_global` is present, only the
+boolean value `true` enables inheritance and auth materialization. Omitting the
+setting preserves the standard profile behavior.
+
+This protects Hermes provider auth state only. External tools can still use the
+OS user's `HOME`; combine it with `terminal.home_mode: profile` and an explicit
+tool allowlist when external CLI credential isolation is also required.
+
 ### From the dashboard
 
 The [web dashboard](features/web-dashboard.md#managing-multiple-profiles)

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -209,24 +209,38 @@ If you want this profile to work in a specific project by default, also set its 
 coder config set terminal.cwd /absolute/path/to/project
 ```
 
-### Credentialless profiles
+### Global-auth-isolated profiles
 
-Named profiles normally inherit provider credentials from the global Hermes
-auth store when they have no profile-local entry. To create a fail-closed
-profile that must not inherit or materialize authentication state, add:
+Named profiles normally inherit provider credentials from global Hermes auth
+stores when they have no profile-local entry. To create a fail-closed profile
+that must not inherit or materialize Hermes authentication state, add:
 
 ```yaml
 auth:
   inherit_global: false
 ```
 
-With this setting, Hermes does not read global-root credential pools or
-provider/OAuth singletons, does not seed ambient credentials into the profile,
-and refuses writes that would create or update the profile's `auth.json`.
-Inspection commands such as `hermes -p <name> auth list` remain read-only. The
-setting is deliberately fail-closed: if `inherit_global` is present, only the
-boolean value `true` enables inheritance and auth materialization. Omitting the
-setting preserves the standard profile behavior.
+With this setting, Hermes does not read global-root credential pools,
+provider/OAuth singletons, or the cross-profile shared Nous OAuth store. Nous
+token memos are also scoped to one canonical profile home. Hermes does not seed
+ambient credentials into the profile auth pool and refuses writes that would
+create or update the profile's `auth.json` or shared Nous state. Inspection
+commands such as `hermes -p <name> auth list` remain read-only.
+
+The setting is deliberately fail-closed: if `inherit_global` is present, only
+the boolean value `true` enables inheritance and auth materialization. Invalid,
+unreadable, malformed, or duplicate-key policy YAML denies those paths.
+Omitting the setting preserves the standard profile behavior.
+
+This setting is an **auth-store boundary**, not by itself a promise that the
+process has zero effective credentials. Existing profile-local auth entries and
+profile-local `.env` values remain local inputs. A directly exported provider
+key in the process environment can also remain available to provider runtime
+resolution without being seeded into `auth.json`. For a credentialless
+bootstrap check, additionally start Hermes with a constructed minimal
+environment, an empty profile with no `.env` or `auth.json`, and a disabled
+managed/external secret-source configuration; then verify the effective
+resolved state after startup.
 
 This protects Hermes provider auth state only. External tools can still use the
 OS user's `HOME`; combine it with `terminal.home_mode: profile` and an explicit

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -213,7 +213,7 @@ coder config set terminal.cwd /absolute/path/to/project
 
 Named profiles normally inherit provider credentials from global Hermes auth
 stores when they have no profile-local entry. To create a fail-closed profile
-that must not inherit or materialize Hermes authentication state, add:
+that must not inherit global or shared Hermes authentication state, add:
 
 ```yaml
 auth:
@@ -222,14 +222,16 @@ auth:
 
 With this setting, Hermes does not read global-root credential pools,
 provider/OAuth singletons, or the cross-profile shared Nous OAuth store. Nous
-token memos are also scoped to one canonical profile home. Hermes does not seed
-ambient credentials into the profile auth pool and refuses writes that would
-create or update the profile's `auth.json` or shared Nous state. Inspection
-commands such as `hermes -p <name> auth list` remain read-only.
+token and status memos are bound to the active profile and policy context.
+Hermes does not seed ambient credentials into the profile auth pool and refuses
+writes to shared Nous state. Inspection commands such as
+`hermes -p <name> auth list` remain read-only and do not create `auth.json`.
+Intentional profile-local login, add, rotation, and removal operations may
+create or update the profile's own `auth.json`.
 
 The setting is deliberately fail-closed: if `inherit_global` is present, only
-the boolean value `true` enables inheritance and auth materialization. Invalid,
-unreadable, malformed, or duplicate-key policy YAML denies those paths.
+the boolean value `true` enables global/shared inheritance. Invalid, unreadable,
+malformed, or duplicate-key policy YAML denies those inheritance paths.
 Omitting the setting preserves the standard profile behavior.
 
 This setting is an **auth-store boundary**, not by itself a promise that the


### PR DESCRIPTION
## What does this PR do?

Adds an explicit, backward-compatible boundary for named profiles that must not inherit global/shared credentials:

```yaml
auth:
  inherit_global: false
```

Missing policy, a missing key, or `true` preserves Hermes' current root-auth fallback. Exact `false` blocks global/shared inheritance while preserving credentials intentionally written to the active profile's own `auth.json` and keeping `active_provider` profile-scoped.

The boundary is applied to the current source-aware auth paths rather than merging root/profile stores. It covers root `auth.json` fallback, credential-pool global and ambient seeding, shared Nous OAuth state, xAI/OAuth write-through, process token/status memos, explicit non-active targets, and policy/profile/source transitions. Invalid, ambiguous, malformed, or unreadable policy fails closed.

This follows the salvage direction requested on #19250: implement an opt-out on current fallback paths and preserve profile-scoped selection. It does not implement the separate shared-auth-residence proposal in #29530 / #74639.

## Related Issue

Related: #19250

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`: enforce the strict inheritance verdict across provider state, shared Nous state, write-through, and authority-aware token/status caches.
- `agent/credential_pool.py`: prevent global/ambient pool seeding under isolation while preserving explicit active-profile local Nous lifecycle behavior.
- `hermes_cli/config.py` and `utils.py`: load the profile policy strictly and reject duplicate YAML keys.
- `tests/hermes_cli/` and `tests/agent/`: cover malformed policy, profile/policy/source transitions, global-to-local shadowing, local add/list/rotate/remove, pre-lock write denial, and cache isolation.
- `website/docs/user-guide/profiles.md`: document the global/shared inheritance boundary and clarify that process-environment isolation remains the launcher's responsibility.

## How to Test

1. Run the targeted auth/config/runtime matrix:
   ```bash
   python -m pytest \
     tests/hermes_cli/test_auth_profile_fallback.py \
     tests/hermes_cli/test_resolve_token_memo.py \
     tests/hermes_cli/test_nous_auth_status_cache.py \
     tests/hermes_cli/test_auth_nous_provider.py \
     tests/hermes_cli/test_auth_xai_oauth_provider.py \
     tests/hermes_cli/test_xai_oauth_refresh.py \
     tests/hermes_cli/test_xai_oauth_profile_auth.py \
     tests/hermes_cli/test_xai_oauth_writethrough.py \
     tests/hermes_cli/test_auth_commands.py \
     tests/agent/test_credential_pool.py \
     tests/tools/test_credential_pool_env_fallback.py \
     tests/tools/test_xai_http_credentials.py \
     tests/hermes_cli/test_config.py \
     tests/hermes_cli/test_config_validation.py \
     tests/hermes_cli/test_config_read_guard.py -q
   ```
2. Confirm compile/static checks on the changed Python files.
3. Against a temporary named `HERMES_HOME`, populate hostile synthetic global/shared/env state and verify exact `false` resolves no inherited credentials, creates no local `auth.json`, and still supports an explicitly added active-profile local credential.

Local result: **268 targeted tests passed**, compileall passed, Ruff passed, and network-denied synthetic profile proofs passed. The complete repository test suite has not been run locally; this draft leaves that to CI/current-main reconciliation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. The regression is covered by deterministic synthetic auth/profile tests; no real credentials are included.
