### PR TITLE
fix(relay): strip empty tool_calls arrays to prevent HTTP 400 on session-resume

### DIFF
--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -24,6 +24,43 @@ _RELAY_INTERNAL_PROVIDER_HEADERS = frozenset(
 )
 
 
+def _strip_empty_tool_calls(request: dict[str, Any]) -> int:
+    """Remove empty/invalid tool_calls arrays on assistant messages.
+
+    Strict OpenAI-compatible providers (DeepSeek v4, Console Go) reject
+    ``tool_calls: []`` with HTTP 400 "Invalid 'messages[N].tool_calls':
+    empty array. Expected an array with minimum length 1". Empty arrays
+    reach this final relay chokepoint from session-resume / compression
+    rebuild paths that re-materialize assistant turns with a vacuous
+    tool_calls key. Stripping the key in place preserves object identity
+    so aliased copies (e.g. ``_moa_prepared_request.messages``) stay in
+    sync; non-empty lists are never touched.
+    """
+    stripped = 0
+    if not isinstance(request, dict):
+        return stripped
+    seen: set[int] = set()
+    prep = request.get("_moa_prepared_request")
+    for msgs in (
+        request.get("messages"),
+        (prep.get("messages") if isinstance(prep, dict) else None),
+    ):
+        if not isinstance(msgs, list) or id(msgs) in seen:
+            continue
+        seen.add(id(msgs))
+        for msg in msgs:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            if "tool_calls" not in msg:
+                continue
+            tcs = msg["tool_calls"]
+            if isinstance(tcs, list) and tcs:
+                continue
+            msg.pop("tool_calls", None)
+            stripped += 1
+    return stripped
+
+
 def execute(
     request: dict[str, Any],
     callback: Callable[[dict[str, Any]], Any],
@@ -35,6 +72,7 @@ def execute(
     defer_logical_completion: bool = False,
 ) -> Any:
     """Run one non-streaming physical provider attempt through Relay."""
+    _strip_empty_tool_calls(request)
     runtime, session, parent = relay_runtime.resolve_execution_context(session_id)
     if runtime is None or session is None or not runtime.managed_execution_enabled():
         return callback(request)
@@ -340,6 +378,12 @@ def stream(
     defer_logical_completion: bool = False,
 ) -> "ManagedLlmStream":
     """Return a synchronous view of one Relay-managed provider stream."""
+    _stripped = _strip_empty_tool_calls(request)
+    if _stripped:
+        logger.debug(
+            "relay_llm.stream: stripped %d empty tool_calls array(s) from request",
+            _stripped,
+        )
     return ManagedLlmStream(
         request,
         stream_factory,

--- a/contributors/emails/15006017098@163.com
+++ b/contributors/emails/15006017098@163.com
@@ -1,0 +1,2 @@
+12312ewqdq
+# PR #84098 (relay: strip empty tool_calls arrays)

--- a/tests/agent/test_relay_strip_empty_tool_calls.py
+++ b/tests/agent/test_relay_strip_empty_tool_calls.py
@@ -1,0 +1,105 @@
+"""Unit tests for relay-level empty tool_calls stripping.
+
+Strict OpenAI-compatible providers (DeepSeek v4, Console Go) reject
+``tool_calls: []`` with HTTP 400 "Invalid 'messages[N].tool_calls': empty
+array". Empty arrays reach the final relay chokepoint from session-resume /
+compression rebuild paths that re-materialize assistant turns with a
+vacuous tool_calls key. ``_strip_empty_tool_calls`` removes the key in
+place; non-empty lists are never touched.
+
+Self-contained on purpose: tests only the relay helper, no other layer.
+"""
+
+from agent.relay_llm import _strip_empty_tool_calls
+
+
+def _assistant(content="hi", tool_calls=None, **extra):
+    msg = {"role": "assistant", "content": content}
+    if tool_calls is not None:
+        msg["tool_calls"] = tool_calls
+    msg.update(extra)
+    return msg
+
+
+def test_non_dict_returns_zero():
+    assert _strip_empty_tool_calls(None) == 0
+    assert _strip_empty_tool_calls("nope") == 0
+    assert _strip_empty_tool_calls(42) == 0
+
+
+def test_empty_request_returns_zero():
+    assert _strip_empty_tool_calls({}) == 0
+
+
+def test_empty_tool_calls_is_stripped():
+    msg = _assistant(tool_calls=[])
+    req = {"messages": [msg]}
+    assert _strip_empty_tool_calls(req) == 1
+    assert "tool_calls" not in msg
+
+
+def test_non_empty_tool_calls_preserved():
+    tc = [{"id": "x", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
+    msg = _assistant(tool_calls=tc)
+    req = {"messages": [msg]}
+    assert _strip_empty_tool_calls(req) == 0
+    assert req["messages"][0]["tool_calls"] == tc
+
+
+def test_moa_prepared_request_messages_stripped():
+    msgs = [_assistant(tool_calls=[])]
+    req = {"messages": [], "_moa_prepared_request": {"messages": msgs}}
+    assert _strip_empty_tool_calls(req) == 1
+    assert "tool_calls" not in msgs[0]
+
+
+def test_aliased_list_stripped_once():
+    msgs = [_assistant(tool_calls=[])]
+    req = {"messages": msgs, "_moa_prepared_request": {"messages": msgs}}
+    assert _strip_empty_tool_calls(req) == 1  # id-dedup: only once
+    assert "tool_calls" not in msgs[0]
+
+
+def test_non_list_tool_calls_are_stripped():
+    """Strings / None tool_calls are stripped too (they'd also 400).
+
+    Implementation semantics: only a non-empty list is preserved;
+    ``[]``, strings, and ``None`` are all popped.
+    """
+    msgs = [
+        _assistant(tool_calls="not-a-list"),
+        {"role": "assistant", "content": "hi", "tool_calls": None},  # 显式建键
+    ]
+    req = {"messages": msgs}
+    assert _strip_empty_tool_calls(req) == 2
+    assert "tool_calls" not in msgs[0]
+    assert "tool_calls" not in msgs[1]
+
+
+def test_non_assistant_and_plain_messages_untouched():
+    """User-role messages keep their tool_calls; plain strings don't crash."""
+    req = {"messages": [
+        {"role": "user", "content": "hi", "tool_calls": []},
+        "plain-string-message",
+    ]}
+    assert _strip_empty_tool_calls(req) == 0
+    assert "tool_calls" in req["messages"][0]  # user role untouched
+
+
+if __name__ == "__main__":
+    # Local runner (venv has no pytest): python tests/agent/test_relay_strip_empty_tool_calls.py
+    import sys
+    import traceback
+
+    failed = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except Exception:
+                failed += 1
+                print(f"FAIL {name}")
+                traceback.print_exc()
+    print(f"\n{sum(1 for n in globals() if n.startswith('test_')) - failed}/{sum(1 for n in globals() if n.startswith('test_'))} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Strict OpenAI-compatible providers (DeepSeek v4, Console Go) reject tool_calls: [] with HTTP 400 'Invalid messages[N].tool_calls: empty array'. Empty arrays reach the final relay chokepoint from session-resume / compression rebuild paths that re-materialize assistant turns with a vacuous tool_calls key.

This strips the vacuous key in place, preserving object identity so aliased copies (e.g. _moa_prepared_request.messages) stay in sync; non-empty lists are never touched.

Production-verified: fault-injection round-trip (simulated reset -> auto-recovery -> grep 3 markers + py_compile OK).