### PR TITLE
fix(voice): honor configured silence threshold on stop

### DIFF
--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -713,7 +713,7 @@ def _continuous_on_silence() -> None:
     wav_path = rec.stop()
     # Peak RMS is the critical diagnostic when stop() returns None despite
     # the VAD firing — tells us at a glance whether the mic was too quiet
-    # for SILENCE_RMS_THRESHOLD (200) or the VAD + peak checks disagree.
+    # for the configured silence threshold or another capture issue.
     peak_rms = getattr(rec, "_peak_rms", -1)
     _debug(
         f"_continuous_on_silence: rec.stop -> {wav_path!r} (peak_rms={peak_rms})"

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -473,6 +473,41 @@ class TestAudioRecorderStop:
         wav_path = recorder.stop()
         assert wav_path is None
 
+    @pytest.mark.parametrize(
+        ("silence_threshold", "peak_rms", "should_write"),
+        ((80, 160, True), (500, 300, False)),
+    )
+    def test_stop_uses_configured_silence_threshold(
+        self, mock_sd, monkeypatch, silence_threshold, peak_rms, should_write
+    ):
+        mock_sd.InputStream.return_value = MagicMock()
+
+        from tools.voice_mode import AudioRecorder, SAMPLE_RATE
+
+        recorder = AudioRecorder()
+        recorder._silence_threshold = silence_threshold
+        recorder.start()
+
+        audio_data = [peak_rms] * SAMPLE_RATE
+        fake_np = MagicMock()
+        fake_np.concatenate.return_value = audio_data
+        monkeypatch.setattr(
+            "tools.voice_mode._import_audio", lambda: (mock_sd, fake_np)
+        )
+        write_wav = MagicMock(return_value="recording.wav")
+        monkeypatch.setattr(recorder, "_write_wav", write_wav)
+        recorder._frames = [object()]
+        recorder._peak_rms = peak_rms
+
+        wav_path = recorder.stop()
+
+        if should_write:
+            assert wav_path == "recording.wav"
+            write_wav.assert_called_once_with(audio_data, sample_rate=SAMPLE_RATE)
+        else:
+            assert wav_path is None
+            write_wav.assert_not_called()
+
 
 class TestAudioRecorderCancel:
     def test_cancel_discards_frames(self, mock_sd):

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1146,9 +1146,9 @@ class AudioRecorder:
 
             # Skip silent recordings using peak RMS (not overall average, which
             # gets diluted by silence at the end of the recording).
-            if self._peak_rms < SILENCE_RMS_THRESHOLD:
+            if self._peak_rms < self._silence_threshold:
                 logger.info("Recording too quiet (peak RMS=%d < %d), discarding",
-                            self._peak_rms, SILENCE_RMS_THRESHOLD)
+                            self._peak_rms, self._silence_threshold)
                 return None
 
             return self._write_wav(audio_data, sample_rate=self._sample_rate)


### PR DESCRIPTION
## Problem

Voice activity detection honors the configurable `voice.silence_threshold`, but `AudioRecorder.stop()` performed its final peak-RMS validation against the fixed `SILENCE_RMS_THRESHOLD` default of 200.

For quieter microphones, audio could therefore trigger VAD under a lower configured threshold and still be discarded as "too quiet" when the recording stopped. A raised configured threshold had the inverse inconsistency: audio below the configured threshold could pass the final gate.

Addresses the confirmed silence-threshold mismatch reported in #84046. The separate TTS and possible recorder-lifecycle concerns remain intentionally out of scope.

## Root cause

The configurable threshold was wired into the streaming VAD comparisons, while the older hard-coded threshold remained in the final recording validation path.

## Before-fix deterministic regression

The new dependency-independent regression test drives `AudioRecorder.stop()` with a configured threshold of 80 and peak RMS of 160. Before the production change, `stop()` returned `None` instead of writing the recording:

```text
FAILED TestAudioRecorderStop.test_stop_uses_configured_silence_threshold
AssertionError: assert None == 'recording.wav'
1 failed
```

## Fix

- Compare peak RMS with `self._silence_threshold` in the final gate.
- Report the effective configured threshold in the discard log.
- Update the continuous-mode diagnostic comment to match the corrected behavior.

## Regression coverage

The parameterized regression covers both directions of the contract:

- threshold 80 / peak RMS 160: preserve the recording
- threshold 500 / peak RMS 300: discard the recording

Existing default-threshold, silent-recording, continuous-mode, CLI wrapper, TUI configuration, and integration behavior remains covered by the adjacent suites.

## Validation

Run against a clean branch based on upstream `main` at `ed5e17f4b86da0c4f09c0694757b6074ae6b9d16`:

```text
python -m pytest tests/tools/test_voice_mode.py::TestAudioRecorderStop tests/tools/test_voice_mode.py::TestConfigurableSilenceParams tests/tools/test_voice_mode.py::TestContinuousModeFlow tests/hermes_cli/test_voice_wrapper.py tests/test_voice_max_recording_seconds.py tests/integration/test_voice_channel_flow.py -q
27 passed, 5 skipped
```

```text
python -m pytest tests/tools/test_voice_cli_integration.py tests/test_tui_gateway_server.py::test_voice_record_start_handles_non_dict_voice_cfg -q
32 passed
```

```text
python -m ruff check .
All checks passed
```

```text
git diff --check upstream/main...HEAD
(no output; passed)
```

```text
python scripts/audit_pr_attribution.py
All contributor emails on this branch are mapped
```

## Compatibility / risk

The default configured threshold remains 200, so default behavior is unchanged. The change only makes explicit threshold configuration apply consistently to both speech detection and final recording validation.

No public API, configuration schema, dependency, lockfile, generated artifact, or unrelated file changes are included. Hardware microphone behavior was not exercised locally; the threshold boundary itself is covered deterministically in both directions.
