### PR TITLE
fix(gateway): strip thinking from queued first responses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3107,6 +3107,17 @@ def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
     return cleaned.strip()
 
 
+def _prepare_queued_response_text_for_direct_send(response: str, adapter) -> str:
+    """Return queued fallback text safe for direct platform delivery."""
+    cleaned = _strip_response_attachments_for_direct_send(response, adapter)
+    if not cleaned:
+        return ""
+
+    from agent.agent_runtime_helpers import strip_think_blocks
+
+    return strip_think_blocks(None, cleaned).strip()
+
+
 def _skill_slug_from_frontmatter(skill_md: Path) -> tuple[str | None, str | None]:
     """Derive the /command slug and declared frontmatter name from a SKILL.md.
 
@@ -20189,7 +20200,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> None:
         """Deliver a queued response using the normal text+attachment split."""
         if not text_already_delivered:
-            text_content = _strip_response_attachments_for_direct_send(response, adapter)
+            text_content = _prepare_queued_response_text_for_direct_send(
+                response,
+                adapter,
+            )
             if text_content:
                 await adapter.send(
                     source.chat_id,

--- a/tests/gateway/test_queued_first_response.py
+++ b/tests/gateway/test_queued_first_response.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _Adapter:
+    name = "fake"
+
+    def __init__(self) -> None:
+        self.send = AsyncMock(return_value=SimpleNamespace(success=True))
+
+    def extract_media(self, response: str):
+        lines = response.splitlines()
+        cleaned = "\n".join(line for line in lines if not line.startswith("MEDIA:"))
+        return [], cleaned
+
+
+@pytest.mark.asyncio
+async def test_queued_first_response_strips_think_blocks_before_direct_send():
+    adapter = _Adapter()
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1")
+
+    await GatewayRunner._deliver_queued_first_response(
+        object(),
+        "<think>private reasoning</think>\nVisible answer.\nMEDIA:/tmp/result.png",
+        source,
+        adapter,
+        deliver_media=False,
+    )
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.args[:2] == ("chat-1", "Visible answer.")


### PR DESCRIPTION
Fixes #84086.

## Summary
- strip inline reasoning/thinking blocks from queued first-response fallback text before adapter.send()
- keep existing attachment cleanup and media redelivery behavior unchanged
- add a focused regression test for the direct-send fallback path

## Reproduction
- verified current upstream/main sends `'<think>private reasoning</think>\nVisible answer.'` through `_deliver_queued_first_response` before this fix

## Tests
- `/Users/yuanangyang/hermes-agent/.venv/bin/python -m pytest -q tests/gateway/test_queued_first_response.py tests/gateway/test_stream_consumer.py`
- `/Users/yuanangyang/hermes-agent/.venv/bin/ruff check gateway/run.py tests/gateway/test_queued_first_response.py`
- `git diff --check`

Documentation-impact: none - gateway delivery sanitization fix only