### PR TITLE
fix(web/ddgs): enable web_extract via the ddgs Python package

### DIFF
--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -25,7 +25,7 @@ import os
 import subprocess
 import sys
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from agent.web_search_provider import WebSearchProvider
 
@@ -298,7 +298,7 @@ class DDGSWebSearchProvider(WebSearchProvider):
         return True
 
     def supports_extract(self) -> bool:
-        return False
+        return True
 
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
         """Execute a DuckDuckGo search and return normalized results.
@@ -349,6 +349,62 @@ class DDGSWebSearchProvider(WebSearchProvider):
             "DDGS search '%s': %d results (limit %d)", query, len(web_results), limit
         )
         return {"success": True, "data": {"web": web_results}}
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract content from one or more URLs via the ``ddgs`` package.
+
+        Returns the hermes web_extract shape: a list of dicts with ``url``,
+        ``title``, ``content``, ``raw_content`` (best-effort duplicates of
+        ``content`` — ddgs doesn't separate the two), and ``metadata``.
+
+        The upstream ``ddgs`` ``DDGS().extract()`` returns ``{url, content}``
+        per URL. We normalize to the registry contract; per-URL failures
+        surface as ``{"error": ...}`` entries so the caller can decide
+        whether to retry or skip.
+        """
+        try:
+            from ddgs import DDGS  # type: ignore
+        except ImportError:
+            return [
+                {
+                    "url": u,
+                    "error": "ddgs package is not installed — run `pip install ddgs`",
+                }
+                for u in urls
+            ]
+
+        results: List[Dict[str, Any]] = []
+        fmt = (kwargs.get("format") or "text_markdown").strip()
+        with DDGS() as client:
+            for url in urls:
+                try:
+                    raw = client.extract(url, fmt=fmt)
+                except Exception as exc:  # noqa: BLE001 — ddgs raises its own exceptions
+                    logger.warning("DDGS extract error for %s: %s", url, exc)
+                    results.append({"url": url, "error": f"DuckDuckGo extract failed: {exc}"})
+                    continue
+                if not isinstance(raw, dict):
+                    results.append(
+                        {"url": url, "error": f"DuckDuckGo extract returned non-dict: {type(raw).__name__}"}
+                    )
+                    continue
+                content = str(raw.get("content", "") or "")
+                title = str(raw.get("title", "") or "")
+                results.append(
+                    {
+                        "url": url,
+                        "title": title,
+                        "content": content,
+                        "raw_content": content,  # ddgs doesn't separate
+                        "metadata": {
+                            "source": "ddgs",
+                            "format": fmt,
+                            "length": len(content),
+                        },
+                    }
+                )
+        logger.info("DDGS extract: %d/%d URLs succeeded", sum(1 for r in results if "error" not in r), len(urls))
+        return results
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return {

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -3,30 +3,38 @@
 Covers:
 - DDGSWebSearchProvider.is_available() — reflects package importability
 - DDGSWebSearchProvider.search() — happy path, missing package, runtime error
+- DDGSWebSearchProvider.extract() — happy path, per-URL error, missing package
 - Result normalization (title, url, description, position)
 - Process-isolated timeout / interrupt / GIL-hold / reap (#68096)
 - _is_backend_available("ddgs") / _get_backend() integration
-- web_extract returns a search-only error when ddgs is active
+- web_extract with ddgs backend (no longer search-only)
 """
 from __future__ import annotations
 
-import json
 import sys
 import time
 import types
 
 import pytest
 
-from tests.tools.conftest import register_all_web_providers
 
-
-def _install_fake_ddgs(monkeypatch, *, text_results=None, text_raises=None, text_sleep=None):
+def _install_fake_ddgs(
+    monkeypatch,
+    *,
+    text_results=None,
+    text_raises=None,
+    text_sleep=None,
+    extract_results=None,
+    extract_raises=None,
+):
     """Install a stub ``ddgs`` module in sys.modules for the duration of a test.
 
     ``text_results``: iterable of dicts to yield from DDGS().text(...).
     ``text_raises``: if set, DDGS().text raises this exception instead.
     ``text_sleep``: if set, DDGS().text blocks for this many seconds before
         yielding — simulates a hung/slow search for the timeout test.
+    ``extract_results``: dict mapping URL -> dict returned from DDGS().extract().
+    ``extract_raises``: if set, DDGS().extract raises this exception instead.
     """
     import time as _time
 
@@ -48,6 +56,13 @@ def _install_fake_ddgs(monkeypatch, *, text_results=None, text_raises=None, text
                 raise text_raises
             for hit in (text_results or []):
                 yield hit
+        def extract(self, url, fmt=None):
+            if extract_raises is not None:
+                raise extract_raises
+            if extract_results and url in extract_results:
+                return extract_results[url]
+            # Match real ddgs behavior: empty dict on miss
+            return {}
 
     fake.DDGS = _FakeDDGS
     monkeypatch.setitem(sys.modules, "ddgs", fake)
@@ -257,37 +272,72 @@ class TestDDGSBackendWiring:
 
 
 # ---------------------------------------------------------------------------
-# ddgs is search-only: web_extract returns a clear error
+# ddgs extract() — happy path, per-URL error, missing package
 # ---------------------------------------------------------------------------
 
 
-class TestDDGSSearchOnlyErrors:
-    _register_providers = staticmethod(register_all_web_providers)
+class TestDDGSExtract:
+    """DDGS now exposes extract() — verify the plugin wires it correctly."""
 
-    @pytest.fixture(autouse=True)
-    def _populate_web_registry(self):
-        self._register_providers()
-        yield
-        from agent.web_search_registry import _reset_for_tests
-        _reset_for_tests()
+    def test_extract_happy_path_returns_normalized_results(self, monkeypatch):
+        from plugins.web.ddgs import provider as ddgs_provider
 
-    def test_web_extract_returns_search_only_error(self, monkeypatch):
-        import asyncio
-        from tools import web_tools
-
-        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "ddgs"})
-        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
-        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
-        async def _allow_ssrf(_url: str) -> bool:
-            return True
-
-        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
-        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
-
-        result_str = asyncio.get_event_loop().run_until_complete(
-            web_tools.web_extract_tool(["https://example.com"])
+        _install_fake_ddgs(
+            monkeypatch,
+            extract_results={
+                "https://example.com/a": {"title": "A", "content": "AAA body"},
+                "https://example.com/b": {"title": "B", "content": "BBB body"},
+            },
         )
-        result = json.loads(result_str)
-        assert result["success"] is False
-        assert "search-only" in result["error"].lower()
-        assert "duckduckgo" in result["error"].lower() or "ddgs" in result["error"].lower()
+        prov = ddgs_provider.DDGSWebSearchProvider()
+        results = prov.extract(["https://example.com/a", "https://example.com/b"])
+
+        assert len(results) == 2
+        assert results[0]["url"] == "https://example.com/a"
+        assert results[0]["title"] == "A"
+        assert results[0]["content"] == "AAA body"
+        assert results[0]["raw_content"] == "AAA body"
+        assert results[0]["metadata"]["source"] == "ddgs"
+        assert results[1]["title"] == "B"
+        assert results[1]["content"] == "BBB body"
+
+    def test_extract_miss_returns_empty_content_not_error(self, monkeypatch):
+        """Real ddgs returns ``{}`` on URL miss; provider should record empty content."""
+        from plugins.web.ddgs import provider as ddgs_provider
+
+        _install_fake_ddgs(monkeypatch, extract_results={})
+        prov = ddgs_provider.DDGSWebSearchProvider()
+        results = prov.extract(["https://example.com/missing"])
+
+        assert len(results) == 1
+        assert results[0]["url"] == "https://example.com/missing"
+        assert results[0]["content"] == ""
+        assert "error" not in results[0]
+
+    def test_extract_per_url_exception_surfaces_as_error_entry(self, monkeypatch):
+        from plugins.web.ddgs import provider as ddgs_provider
+
+        _install_fake_ddgs(
+            monkeypatch,
+            extract_raises=RuntimeError("upstream ddgs error"),
+        )
+        prov = ddgs_provider.DDGSWebSearchProvider()
+        results = prov.extract(["https://example.com/x"])
+
+        assert len(results) == 1
+        assert "error" in results[0]
+        assert "DuckDuckGo extract failed" in results[0]["error"]
+        assert "upstream ddgs error" in results[0]["error"]
+
+    def test_extract_missing_package_returns_error_per_url(self, monkeypatch):
+        """If ``ddgs`` isn't installed, each URL gets an explicit error entry."""
+        from plugins.web.ddgs import provider as ddgs_provider
+
+        # Ensure ddgs isn't importable — fake it as missing by NOT installing it.
+        monkeypatch.setitem(sys.modules, "ddgs", None)
+        prov = ddgs_provider.DDGSWebSearchProvider()
+        results = prov.extract(["https://example.com/a", "https://example.com/b"])
+
+        assert len(results) == 2
+        assert results[0]["error"] == "ddgs package is not installed — run `pip install ddgs`"
+        assert results[1]["error"] == "ddgs package is not installed — run `pip install ddgs`"

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -33,7 +33,7 @@ The `web_search` and `web_extract` tools support eight backend providers, config
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | ✔ |
 | **SearXNG** | `SEARXNG_URL` | ✔ | — | — |
 | **Brave** (free tier) | `BRAVE_SEARCH_API_KEY` | ✔ | — | — |
-| **DuckDuckGo** (ddgs) | _(none)_ | ✔ | — | — |
+| **DuckDuckGo** (ddgs) | _(none)_ | ✔ | ✔ | — |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -21,13 +21,13 @@ Both are configured through a single backend selection. Providers are chosen via
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | 500 credits/mo |
 | **SearXNG** | `SEARXNG_URL` | ✔ | — | ✔ Free (self-hosted) |
 | **Brave Search (free tier)** | `BRAVE_SEARCH_API_KEY` | ✔ | — | 2 000 queries/mo |
-| **DDGS (DuckDuckGo)** | — (no key) | ✔ | — | ✔ Free |
+| **DDGS (DuckDuckGo)** | — (no key) | ✔ | ✔ | ✔ Free |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | 1 000 searches/mo |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | 1 000 searches/mo |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | Paid |
 | **xAI (Grok)** | `XAI_API_KEY` or `hermes auth add xai-oauth` | ✔ | — | Paid (SuperGrok or per-token) |
 
-Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
+DDGS supports both search and extract (via the `ddgs.extract()` per-URL path). Brave Search and xAI are **search-only** — pair either with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
 
 **Per-capability split:** you can use different providers for search and extract independently — for example SearXNG (free) for search and Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
 


### PR DESCRIPTION
Resubmission of #47001 — applied surgically on top of current main.

The ddgs Python package gained an `extract()` method in 8.0, but the
hermes ddgs provider still hardcodes `supports_extract() → False`.
This makes `web_extract` reject the ddgs backend with a 'search-only'
error even though extraction is natively supported now.

**Changes (4 files, +143/-37):**
- `plugins/web/ddgs/provider.py`: flip `supports_extract()` to `True`, add an `extract()` method that normalizes ddgs's `{url, content}` per-URL return into the hermes web_extract shape (`url`, `title`, `content`, `raw_content`, `metadata`). Per-URL failures surface as `{"error": ...}` entries.
- `tests/tools/test_web_providers_ddgs.py`: replace the old 'ddgs is search-only' test with 4 new tests (happy path, miss → empty content, per-URL exception, missing package). Update fake-ddg helper to expose `extract()`.
- `website/docs/integrations/index.md` + `website/docs/user-guide/features/web-search.md`: flip the ddgs row from search-only to search+extract, update prose.

**Why a new PR instead of just rebasing #47001:**
#47001's branch was 80 commits ahead of upstream main. A standard
`git rebase` hit ~6,000 file conflicts, most of which were
unrelated infrastructure churn that this PR doesn't touch. This commit
is the **functional delta only** (4 files, ~143 lines) so it's small
and reviewable.

Closes #47001.