### PR TITLE
fix(tui): add full skin picker

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -858,6 +858,21 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
     )
 
 
+def _safe_user_skin_path(name: str) -> Optional[Path]:
+    """Return a contained user-skin path, or None for unsafe identifiers."""
+    if not name or name in {".", ".."} or "/" in name or "\\" in name or "\x00" in name:
+        return None
+
+    skins_path = _skins_dir().resolve()
+    candidate = (skins_path / f"{name}.yaml").resolve()
+    try:
+        candidate.relative_to(skins_path)
+    except ValueError:
+        return None
+
+    return candidate
+
+
 def list_skins() -> List[Dict[str, str]]:
     """List all available skins (built-in + user-installed).
 
@@ -876,7 +891,9 @@ def list_skins() -> List[Dict[str, str]]:
         for f in sorted(skins_path.glob("*.yaml")):
             data = _load_skin_from_yaml(f)
             if data:
-                skin_name = data.get("name", f.stem)
+                skin_name = str(data.get("name", f.stem))
+                if _safe_user_skin_path(skin_name) is None:
+                    continue
                 # Skip if it shadows a built-in
                 if any(s["name"] == skin_name for s in result):
                     continue
@@ -892,9 +909,8 @@ def list_skins() -> List[Dict[str, str]]:
 def load_skin(name: str) -> SkinConfig:
     """Load a skin by name. Checks user skins first, then built-in."""
     # Check user skins directory
-    skins_path = _skins_dir()
-    user_file = skins_path / f"{name}.yaml"
-    if user_file.is_file():
+    user_file = _safe_user_skin_path(name)
+    if user_file is not None and user_file.is_file():
         data = _load_skin_from_yaml(user_file)
         if data:
             return _build_skin_config(data)

--- a/tests/tui_gateway/test_skin_picker.py
+++ b/tests/tui_gateway/test_skin_picker.py
@@ -50,3 +50,13 @@ def test_skin_preview_rejects_unknown_names(tmp_path, monkeypatch):
     response = server._methods["skin.preview"]("skin-preview", {"name": "missing"})
 
     assert response["error"]["code"] == 4002
+
+
+def test_skin_options_rejects_an_empty_active_skin_payload(monkeypatch):
+    handler = server._methods["skin.options"]
+    monkeypatch.setitem(handler.__globals__, "resolve_skin", lambda _name=None: {})
+
+    response = handler("skin-options", {})
+
+    assert response["error"]["code"] == 5020
+    assert "could not resolve active skin" in response["error"]["message"]

--- a/tests/tui_gateway/test_skin_picker.py
+++ b/tests/tui_gateway/test_skin_picker.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import yaml
+
+import tui_gateway.server as server
+
+
+def test_skin_options_include_every_discovered_skin_and_active_branding(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "skins").mkdir()
+    (tmp_path / "skins" / "custom.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "custom",
+                "description": "Custom picker fixture",
+                "branding": {"agent_name": "Custom Agent"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "config.yaml").write_text("display:\n  skin: custom\n", encoding="utf-8")
+
+    response = server._methods["skin.options"]("skin-options", {})
+
+    result = response["result"]
+    names = {skin["name"] for skin in result["skins"]}
+    assert {"default", "custom"}.issubset(names)
+    assert result["active"] == "custom"
+    assert result["active_skin"]["name"] == "custom"
+    assert result["active_skin"]["branding"]["agent_name"] == "Custom Agent"
+
+
+def test_skin_preview_resolves_branding_without_persisting_selection(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("display:\n  skin: default\n", encoding="utf-8")
+
+    response = server._methods["skin.preview"]("skin-preview", {"name": "charizard"})
+
+    assert response["result"]["name"] == "charizard"
+    assert response["result"]["branding"]["agent_name"] == "Charizard Agent"
+    assert "skin: default" in (tmp_path / "config.yaml").read_text(encoding="utf-8")
+
+
+def test_skin_preview_rejects_unknown_names(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    response = server._methods["skin.preview"]("skin-preview", {"name": "missing"})
+
+    assert response["error"]["code"] == 4002

--- a/tests/tui_gateway/test_skin_picker.py
+++ b/tests/tui_gateway/test_skin_picker.py
@@ -52,6 +52,40 @@ def test_skin_preview_rejects_unknown_names(tmp_path, monkeypatch):
     assert response["error"]["code"] == 4002
 
 
+def test_skin_preview_rejects_traversal_names_from_user_skin_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    skins_dir = tmp_path / "skins"
+    skins_dir.mkdir()
+    (skins_dir / "decoy.yaml").write_text(
+        yaml.safe_dump({"name": "../outside", "description": "unsafe metadata"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "outside.yaml").write_text(
+        yaml.safe_dump({"name": "outside", "branding": {"agent_name": "Leaked Agent"}}),
+        encoding="utf-8",
+    )
+
+    response = server._methods["skin.preview"]("skin-preview", {"name": "../outside"})
+
+    assert response["error"]["code"] == 4002
+    assert "result" not in response
+
+
+def test_config_set_rejects_skin_names_outside_discovered_options(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("display:\n  skin: default\n", encoding="utf-8")
+
+    response = server._methods["config.set"](
+        "skin-set",
+        {"key": "skin", "value": "../outside"},
+    )
+
+    assert response["error"]["code"] == 4002
+    assert "skin: default" in (tmp_path / "config.yaml").read_text(encoding="utf-8")
+
+
 def test_skin_options_rejects_an_empty_active_skin_payload(monkeypatch):
     handler = server._methods["skin.options"]
     monkeypatch.setitem(handler.__globals__, "resolve_skin", lambda _name=None: {})

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -415,6 +415,44 @@ def _readiness_profile_scope(params: dict):
     return profile, _server._session_profile_runtime_scope({"profile_home": str(home)})
 
 
+@method("skin.options")
+def _(rid, params: dict) -> dict:
+    """Return every discovered skin plus the active skin's resolved payload."""
+    try:
+        from hermes_cli.skin_engine import list_skins
+
+        active_skin = resolve_skin()
+        active = str(active_skin.get("name") or "default")
+        return _ok(
+            rid,
+            {
+                "active": active,
+                "active_skin": active_skin,
+                "skins": list_skins(),
+            },
+        )
+    except Exception as e:
+        return _err(rid, 5020, str(e))
+
+
+@method("skin.preview")
+def _(rid, params: dict) -> dict:
+    """Resolve one skin for a local live preview without changing config."""
+    try:
+        from hermes_cli.skin_engine import list_skins
+
+        name = str(params.get("name") or "").strip().lower()
+        available = {skin["name"] for skin in list_skins()}
+        if not name or name not in available:
+            return _err(rid, 4002, f"unknown skin: {name or '(empty)'}")
+        skin = resolve_skin(name)
+        if not skin:
+            return _err(rid, 5020, f"could not resolve skin: {name}")
+        return _ok(rid, skin)
+    except Exception as e:
+        return _err(rid, 5020, str(e))
+
+
 @method("setup.status")
 def _(rid, params: dict) -> dict:
     """Loose provider check; ``profile`` (optional) scopes it to that profile's home."""

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -422,7 +422,9 @@ def _(rid, params: dict) -> dict:
         from hermes_cli.skin_engine import list_skins
 
         active_skin = resolve_skin()
-        active = str(active_skin.get("name") or "default")
+        if not active_skin:
+            return _err(rid, 5020, "could not resolve active skin")
+        active = str(active_skin["name"])
         return _ok(
             rid,
             {

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -341,6 +341,44 @@ def _(rid, params: dict) -> dict:
     return _err(rid, 4002, f"unknown config key: {key}")
 
 
+@method("skin.options")
+def _(rid, params: dict) -> dict:
+    """Return every discovered skin plus the active skin's resolved payload."""
+    try:
+        from hermes_cli.skin_engine import list_skins
+
+        active_skin = resolve_skin()
+        active = str(active_skin.get("name") or "default")
+        return _ok(
+            rid,
+            {
+                "active": active,
+                "active_skin": active_skin,
+                "skins": list_skins(),
+            },
+        )
+    except Exception as e:
+        return _err(rid, 5020, str(e))
+
+
+@method("skin.preview")
+def _(rid, params: dict) -> dict:
+    """Resolve one skin for a local live preview without changing config."""
+    try:
+        from hermes_cli.skin_engine import list_skins
+
+        name = str(params.get("name") or "").strip().lower()
+        available = {skin["name"] for skin in list_skins()}
+        if not name or name not in available:
+            return _err(rid, 4002, f"unknown skin: {name or '(empty)'}")
+        skin = resolve_skin(name)
+        if not skin:
+            return _err(rid, 5020, f"could not resolve skin: {name}")
+        return _ok(rid, skin)
+    except Exception as e:
+        return _err(rid, 5020, str(e))
+
+
 @method("setup.status")
 def _(rid, params: dict) -> dict:
     try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5083,25 +5083,32 @@ def _clear_pending(sid: str | None = None) -> None:
 # ── Agent factory ────────────────────────────────────────────────────
 
 
-def resolve_skin() -> dict:
-    try:
-        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin
+def _skin_payload(skin) -> dict:
+    return {
+        "name": skin.name,
+        "colors": skin.colors,
+        # Paired palettes: the TUI detects the terminal's polarity and
+        # prefers the matching hand-tuned block over adapting `colors`.
+        "light_colors": skin.light_colors,
+        "dark_colors": skin.dark_colors,
+        "branding": skin.branding,
+        "banner_logo": skin.banner_logo,
+        "banner_hero": skin.banner_hero,
+        "tool_prefix": skin.tool_prefix,
+        "help_header": (skin.branding or {}).get("help_header", ""),
+    }
 
-        init_skin_from_config(_load_cfg())
-        skin = get_active_skin()
-        return {
-            "name": skin.name,
-            "colors": skin.colors,
-            # Paired palettes: the TUI detects the terminal's polarity and
-            # prefers the matching hand-tuned block over adapting `colors`.
-            "light_colors": skin.light_colors,
-            "dark_colors": skin.dark_colors,
-            "branding": skin.branding,
-            "banner_logo": skin.banner_logo,
-            "banner_hero": skin.banner_hero,
-            "tool_prefix": skin.tool_prefix,
-            "help_header": (skin.branding or {}).get("help_header", ""),
-        }
+
+def resolve_skin(name: str | None = None) -> dict:
+    try:
+        from hermes_cli.skin_engine import get_active_skin, init_skin_from_config, load_skin
+
+        if name is None:
+            init_skin_from_config(_load_cfg())
+            skin = get_active_skin()
+        else:
+            skin = load_skin(name)
+        return _skin_payload(skin)
     except Exception:
         return {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15338,6 +15338,18 @@ def _(rid, params: dict) -> dict:
                     sid_key, session, new_prompt, pname
                 )
             else:
+                if key == "skin":
+                    from hermes_cli.skin_engine import list_skins
+
+                    requested_skin = str(value or "").strip().lower()
+                    available_skins = {skin["name"] for skin in list_skins()}
+                    if not requested_skin or requested_skin not in available_skins:
+                        return _err(
+                            rid,
+                            4002,
+                            f"unknown skin: {requested_skin or '(empty)'}",
+                        )
+                    value = requested_skin
                 _write_config_key(f"display.{key}", value)
                 nv = value
                 if key == "skin":

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3327,25 +3327,32 @@ def _clear_pending(sid: str | None = None) -> None:
 # ── Agent factory ────────────────────────────────────────────────────
 
 
-def resolve_skin() -> dict:
-    try:
-        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin
+def _skin_payload(skin) -> dict:
+    return {
+        "name": skin.name,
+        "colors": skin.colors,
+        # Paired palettes: the TUI detects the terminal's polarity and
+        # prefers the matching hand-tuned block over adapting `colors`.
+        "light_colors": skin.light_colors,
+        "dark_colors": skin.dark_colors,
+        "branding": skin.branding,
+        "banner_logo": skin.banner_logo,
+        "banner_hero": skin.banner_hero,
+        "tool_prefix": skin.tool_prefix,
+        "help_header": (skin.branding or {}).get("help_header", ""),
+    }
 
-        init_skin_from_config(_load_cfg())
-        skin = get_active_skin()
-        return {
-            "name": skin.name,
-            "colors": skin.colors,
-            # Paired palettes: the TUI detects the terminal's polarity and
-            # prefers the matching hand-tuned block over adapting `colors`.
-            "light_colors": skin.light_colors,
-            "dark_colors": skin.dark_colors,
-            "branding": skin.branding,
-            "banner_logo": skin.banner_logo,
-            "banner_hero": skin.banner_hero,
-            "tool_prefix": skin.tool_prefix,
-            "help_header": (skin.branding or {}).get("help_header", ""),
-        }
+
+def resolve_skin(name: str | None = None) -> dict:
+    try:
+        from hermes_cli.skin_engine import get_active_skin, init_skin_from_config, load_skin
+
+        if name is None:
+            init_skin_from_config(_load_cfg())
+            skin = get_active_skin()
+        else:
+            skin = load_skin(name)
+        return _skin_payload(skin)
     except Exception:
         return {}
 

--- a/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
+++ b/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
@@ -355,6 +355,7 @@ describe('status-chrome timers track the current overlay model', () => {
     ['pager', { pager: { lines: ['a'], offset: 0 } }],
     ['petPicker', { petPicker: true }],
     ['pluginsHub', { pluginsHub: true }],
+    ['skinPicker', { skinPicker: true }],
     ['sessions', { sessions: true }],
     ['skillsHub', { skillsHub: true }],
     ['widget', { widget: { appId: 'demo', state: null } }]

--- a/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
+++ b/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
@@ -346,6 +346,7 @@ describe('status-chrome timers track the current overlay model', () => {
     ['pager', { pager: { lines: ['a'], offset: 0 } }],
     ['petPicker', { petPicker: true }],
     ['pluginsHub', { pluginsHub: true }],
+    ['skinPicker', { skinPicker: true }],
     ['sessions', { sessions: true }],
     ['skillsHub', { skillsHub: true }],
     ['widget', { widget: { appId: 'demo', state: null } }]

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
+import {
+  applyPersistedSkin,
+  applySkinPreview,
+  createGatewayEventHandler,
+  restorePersistedSkin
+} from '../app/createGatewayEventHandler.js'
 import { getOverlayState, patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
@@ -832,6 +837,32 @@ describe('createGatewayEventHandler', () => {
     createGatewayEventHandler(buildCtx(appended))({ payload: skin, type: 'skin.changed' } as any)
     expect(getUiState().theme.color.primary).toBe('#8B0000')
     vi.unstubAllEnvs()
+  })
+
+  it('restores the newest persisted skin after a temporary preview', () => {
+    applyPersistedSkin({ colors: { banner_title: '#AA0000' } } as any)
+    const persistedPrimary = getUiState().theme.color.primary
+
+    applySkinPreview({ colors: { banner_title: '#0000AA' } } as any)
+    expect(getUiState().theme.color.primary).not.toBe(persistedPrimary)
+
+    restorePersistedSkin()
+
+    expect(getUiState().theme.color.primary).toBe(persistedPrimary)
+  })
+
+  it('clears persisted skin state when a new gateway handler is created', () => {
+    const fallback = { colors: { banner_title: '#00AA00' } } as any
+
+    applySkinPreview(fallback)
+    const fallbackPrimary = getUiState().theme.color.primary
+    applyPersistedSkin({ colors: { banner_title: '#AA0000' } } as any)
+    createGatewayEventHandler(buildCtx([]))
+
+    applySkinPreview({ colors: { banner_title: '#0000AA' } } as any)
+    restorePersistedSkin(fallback)
+
+    expect(getUiState().theme.color.primary).toBe(fallbackPrimary)
   })
 
   it('a skin that owns the background paints BOTH terminal defaults (OSC 11 bg + OSC 10 fg)', () => {

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -40,6 +40,22 @@ describe('createSlashHandler', () => {
     expect(getOverlayState().sessions).toBe(true)
   })
 
+  it('opens the skin picker for bare /skin', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/skin')).toBe(true)
+    expect(getOverlayState().skinPicker).toBe(true)
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+  })
+
+  it('keeps direct /skin <name> selection on config.set', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/skin poseidon')).toBe(true)
+    expect(getOverlayState().skinPicker).toBe(false)
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', { key: 'skin', value: 'poseidon' })
+  })
+
   it('resumes a prior session by id when /resume has an argument', () => {
     const ctx = buildCtx()
 

--- a/ui-tui/src/__tests__/skinPicker.test.ts
+++ b/ui-tui/src/__tests__/skinPicker.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { filterSkinOptions, skinAgentLabel } from '../components/skinPicker.js'
+
+const skins = [
+  { description: 'Ocean-god theme', name: 'poseidon', source: 'builtin' },
+  { description: 'Volcanic theme', name: 'charizard', source: 'builtin' },
+  { description: 'Custom blue theme', name: 'blueprint', source: 'user' }
+]
+
+describe('skin picker helpers', () => {
+  it('keeps every skin when the filter is empty', () => {
+    expect(filterSkinOptions(skins, '')).toEqual(skins)
+  })
+
+  it('filters by skin name and description', () => {
+    expect(filterSkinOptions(skins, 'ocean').map(skin => skin.name)).toEqual(['poseidon'])
+    expect(filterSkinOptions(skins, 'blue').map(skin => skin.name)).toEqual(['blueprint'])
+  })
+
+  it('shows optional agent branding without pretending every skin renames Hermes', () => {
+    expect(skinAgentLabel({ agent_name: 'Charizard Agent' })).toBe('agent: Charizard Agent')
+    expect(skinAgentLabel({})).toBe('agent: Hermes Agent')
+  })
+})

--- a/ui-tui/src/__tests__/skinPicker.test.ts
+++ b/ui-tui/src/__tests__/skinPicker.test.ts
@@ -1,6 +1,74 @@
-import { describe, expect, it } from 'vitest'
+import { PassThrough } from 'stream'
 
-import { filterSkinOptions, skinAgentLabel } from '../components/skinPicker.js'
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+const pickerHarness = vi.hoisted(() => ({
+  applySkinPreview: vi.fn(),
+  handler: undefined as undefined | ((input: string, key: Record<string, boolean>) => void),
+  persistedRevision: 0,
+  restorePersistedSkin: vi.fn()
+}))
+
+vi.mock('@hermes/ink', async importOriginal => {
+  const mod = await importOriginal<Record<string, unknown>>()
+
+  return {
+    ...mod,
+    useInput: (handler: (input: string, key: Record<string, boolean>) => void) => {
+      pickerHarness.handler = handler
+    }
+  }
+})
+
+vi.mock('../app/createGatewayEventHandler.js', () => ({
+  applySkinPreview: pickerHarness.applySkinPreview,
+  getPersistedSkinRevision: () => pickerHarness.persistedRevision,
+  restorePersistedSkin: pickerHarness.restorePersistedSkin
+}))
+
+import { filterSkinOptions, SKIN_PREVIEW_DEBOUNCE_MS, skinAgentLabel, SkinPicker } from '../components/skinPicker.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+function mountPicker(gw: unknown, onClose = vi.fn()) {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 100, isTTY: false, rows: 40 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  pickerHarness.handler = undefined
+
+  const element = React.createElement(SkinPicker, { gw, onClose, t: DEFAULT_THEME } as never)
+
+  const instance = renderSync(element, {
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  return {
+    cleanup: () => {
+      instance.unmount()
+      instance.cleanup()
+    },
+    onClose,
+    rerender: () => instance.rerender(element)
+  }
+}
 
 const skins = [
   { description: 'Ocean-god theme', name: 'poseidon', source: 'builtin' },
@@ -21,5 +89,218 @@ describe('skin picker helpers', () => {
   it('shows optional agent branding without pretending every skin renames Hermes', () => {
     expect(skinAgentLabel({ agent_name: 'Charizard Agent' })).toBe('agent: Charizard Agent')
     expect(skinAgentLabel({})).toBe('agent: Hermes Agent')
+  })
+})
+
+describe('skin preview scheduling', () => {
+  it('debounces preview requests to avoid flooding the gateway', () => {
+    expect(SKIN_PREVIEW_DEBOUNCE_MS).toBe(120)
+  })
+
+  it('resolves the active selection through the gateway instead of stale options', async () => {
+    vi.useFakeTimers()
+
+    const request = vi.fn((method: string) => {
+      if (method === 'skin.options') {
+        return Promise.resolve({
+          active: 'default',
+          active_skin: { name: 'default', version: 'old' },
+          skins: [{ name: 'default' }]
+        })
+      }
+
+      return Promise.resolve({ name: 'default', version: 'fresh' })
+    })
+
+    const mounted = mountPicker({ request })
+
+    try {
+      await vi.advanceTimersByTimeAsync(0)
+      mounted.rerender()
+      await vi.advanceTimersByTimeAsync(SKIN_PREVIEW_DEBOUNCE_MS)
+
+      expect(request).toHaveBeenCalledWith('skin.preview', { name: 'default' })
+    } finally {
+      mounted.cleanup()
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a preview response that arrives after selection is saved', async () => {
+    vi.useFakeTimers()
+
+    const pendingPreview = deferred<Record<string, unknown>>()
+
+    const request = vi.fn((method: string) => {
+      if (method === 'skin.options') {
+        return Promise.resolve({
+          active: 'default',
+          active_skin: { name: 'default' },
+          skins: [{ name: 'default' }, { name: 'charizard' }]
+        })
+      }
+
+      if (method === 'skin.preview') {
+        return pendingPreview.promise
+      }
+
+      return Promise.resolve({ value: 'charizard' })
+    })
+
+    const mounted = mountPicker({ request })
+
+    try {
+      await vi.advanceTimersByTimeAsync(0)
+      mounted.rerender()
+      pickerHarness.handler?.('', { downArrow: true })
+      mounted.rerender()
+      await vi.advanceTimersByTimeAsync(SKIN_PREVIEW_DEBOUNCE_MS)
+      pickerHarness.applySkinPreview.mockClear()
+
+      pickerHarness.handler?.('', { return: true })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mounted.onClose).toHaveBeenCalledTimes(1)
+
+      pendingPreview.resolve({ name: 'charizard' })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(pickerHarness.applySkinPreview).not.toHaveBeenCalled()
+    } finally {
+      mounted.cleanup()
+      vi.useRealTimers()
+    }
+  })
+
+  it('restores the latest persisted skin when cancelled', async () => {
+    vi.useFakeTimers()
+
+    const request = vi.fn(() =>
+      Promise.resolve({
+        active: 'default',
+        active_skin: { name: 'default' },
+        skins: [{ name: 'default' }, { name: 'charizard' }]
+      })
+    )
+
+    const mounted = mountPicker({ request })
+
+    try {
+      await vi.advanceTimersByTimeAsync(0)
+      mounted.rerender()
+      pickerHarness.applySkinPreview.mockClear()
+      pickerHarness.restorePersistedSkin.mockClear()
+
+      pickerHarness.handler?.('', { escape: true })
+
+      expect(pickerHarness.restorePersistedSkin).toHaveBeenCalledTimes(1)
+      expect(pickerHarness.applySkinPreview).not.toHaveBeenCalled()
+      expect(mounted.onClose).toHaveBeenCalledTimes(1)
+    } finally {
+      mounted.cleanup()
+      vi.useRealTimers()
+    }
+  })
+
+  it('handles Ctrl+C cancellation while idle', async () => {
+    vi.useFakeTimers()
+
+    const request = vi.fn(() =>
+      Promise.resolve({
+        active: 'default',
+        active_skin: { name: 'default' },
+        skins: [{ name: 'default' }, { name: 'charizard' }]
+      })
+    )
+
+    const mounted = mountPicker({ request })
+
+    try {
+      await vi.advanceTimersByTimeAsync(0)
+      mounted.rerender()
+      pickerHarness.restorePersistedSkin.mockClear()
+
+      pickerHarness.handler?.('c', { ctrl: true })
+
+      expect(pickerHarness.restorePersistedSkin).toHaveBeenCalledTimes(1)
+      expect(mounted.onClose).toHaveBeenCalledTimes(1)
+    } finally {
+      mounted.cleanup()
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores Ctrl+C while a skin save is in flight', async () => {
+    vi.useFakeTimers()
+
+    const pendingSave = deferred<{ value: string }>()
+
+    const request = vi.fn((method: string) => {
+      if (method === 'skin.options') {
+        return Promise.resolve({
+          active: 'default',
+          active_skin: { name: 'default' },
+          skins: [{ name: 'default' }]
+        })
+      }
+
+      return pendingSave.promise
+    })
+
+    const mounted = mountPicker({ request })
+
+    try {
+      await vi.advanceTimersByTimeAsync(0)
+      mounted.rerender()
+      pickerHarness.handler?.('', { return: true })
+      mounted.rerender()
+
+      pickerHarness.handler?.('c', { ctrl: true })
+      expect(mounted.onClose).not.toHaveBeenCalled()
+
+      pendingSave.resolve({ value: 'default' })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mounted.onClose).toHaveBeenCalledTimes(1)
+    } finally {
+      mounted.cleanup()
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a preview response older than the latest persisted skin', async () => {
+    vi.useFakeTimers()
+    pickerHarness.persistedRevision = 0
+
+    const pendingPreview = deferred<Record<string, unknown>>()
+
+    const request = vi.fn((method: string) => {
+      if (method === 'skin.options') {
+        return Promise.resolve({
+          active: 'default',
+          active_skin: { name: 'default' },
+          skins: [{ name: 'default' }, { name: 'charizard' }]
+        })
+      }
+
+      return pendingPreview.promise
+    })
+
+    const mounted = mountPicker({ request })
+
+    try {
+      await vi.advanceTimersByTimeAsync(0)
+      mounted.rerender()
+      pickerHarness.handler?.('', { downArrow: true })
+      mounted.rerender()
+      await vi.advanceTimersByTimeAsync(SKIN_PREVIEW_DEBOUNCE_MS)
+      pickerHarness.applySkinPreview.mockClear()
+
+      pickerHarness.persistedRevision = 1
+      pendingPreview.resolve({ name: 'charizard' })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(pickerHarness.applySkinPreview).not.toHaveBeenCalled()
+    } finally {
+      mounted.cleanup()
+      vi.useRealTimers()
+    }
   })
 })

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -7,6 +7,7 @@ import {
   handleIdleHotkeyExit,
   resolveCtrlCComposerAction,
   shouldAllowIdleHotkeyExit,
+  shouldDeferSkinPickerCtrlC,
   shouldDetachEditedHistoryInput,
   shouldFallThroughForScroll
 } from '../app/useInputHandlers.js'
@@ -182,5 +183,15 @@ describe('dismissSensitivePrompt', () => {
     expect(sys).toHaveBeenCalledWith('secret entry cancelled')
     expect(rpc).toHaveBeenCalledWith('secret.respond', { request_id: 'secret-1', value: '' })
     await pending
+  })
+})
+
+describe('shouldDeferSkinPickerCtrlC', () => {
+  it('leaves skin-picker cancellation to its busy-aware input handler', () => {
+    resetOverlayState()
+    patchOverlayState({ skinPicker: true })
+
+    expect(shouldDeferSkinPickerCtrlC(getOverlayState())).toBe(true)
+    expect(getOverlayState().skinPicker).toBe(true)
   })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -75,6 +75,8 @@ const statusFromBusy = () => (getUiState().busy ? 'running…' : 'ready')
 // The last gateway skin, kept so the theme can be re-derived when the OSC-11
 // background answer arrives after (or without) gateway.ready.
 let lastSkin: GatewaySkin | null = null
+let lastPersistedSkin: GatewaySkin | null = null
+let persistedSkinRevision = 0
 
 const themeForSkin = (s: GatewaySkin) => {
   // Polarity overrides OVERLAY the base palette, they don't replace it: a skin
@@ -176,6 +178,27 @@ export const applySkinPreview = (s: GatewaySkin) => {
 
   commitTheme(theme)
   paintTerminalDefaults(theme)
+}
+
+export const applyPersistedSkin = (s: GatewaySkin) => {
+  lastPersistedSkin = s
+  persistedSkinRevision += 1
+  applySkinPreview(s)
+}
+
+export const clearPersistedSkin = () => {
+  lastPersistedSkin = null
+  persistedSkinRevision += 1
+}
+
+export const getPersistedSkinRevision = () => persistedSkinRevision
+
+export const restorePersistedSkin = (fallback?: GatewaySkin) => {
+  const skin = lastPersistedSkin ?? fallback
+
+  if (skin) {
+    applySkinPreview(skin)
+  }
 }
 
 /** Re-derive the theme from current detection signals (env overrides, cached
@@ -416,6 +439,7 @@ const normalizeSubagentStatus = (status: unknown, fallback: SubagentStatus): Sub
 }
 
 export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev: GatewayEvent) => void {
+  clearPersistedSkin()
   syncThemeToTerminalBackground()
 
   const { rpc } = ctx.gateway
@@ -661,7 +685,9 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
   const handleReady = (skin?: GatewaySkin) => {
     if (skin) {
-      applySkinPreview(skin)
+      applyPersistedSkin(skin)
+    } else {
+      clearPersistedSkin()
     }
 
     // Kick off the config fetch once the gateway is actually ready. If handler
@@ -777,7 +803,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'skin.changed':
         if (ev.payload) {
-          applySkinPreview(ev.payload)
+          applyPersistedSkin(ev.payload)
         }
 
         return

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -170,7 +170,7 @@ const paintTerminalDefaults = (theme: Theme) => {
   setTerminalForeground(isPaintableHex(background) ? themeToneHex(theme.color.text) : '')
 }
 
-const applySkin = (s: GatewaySkin) => {
+export const applySkinPreview = (s: GatewaySkin) => {
   lastSkin = s
   const theme = themeForSkin(s)
 
@@ -661,7 +661,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
   const handleReady = (skin?: GatewaySkin) => {
     if (skin) {
-      applySkin(skin)
+      applySkinPreview(skin)
     }
 
     // Kick off the config fetch once the gateway is actually ready. If handler
@@ -777,7 +777,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'skin.changed':
         if (ev.payload) {
-          applySkin(ev.payload)
+          applySkinPreview(ev.payload)
         }
 
         return

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -136,7 +136,7 @@ const paintTerminalDefaults = (theme: Theme) => {
   setTerminalForeground(isPaintableHex(background) ? themeToneHex(theme.color.text) : '')
 }
 
-const applySkin = (s: GatewaySkin) => {
+export const applySkinPreview = (s: GatewaySkin) => {
   lastSkin = s
   const theme = themeForSkin(s)
 
@@ -613,7 +613,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
   const handleReady = (skin?: GatewaySkin) => {
     if (skin) {
-      applySkin(skin)
+      applySkinPreview(skin)
     }
 
     // Kick off the config fetch once the gateway is actually ready. If handler
@@ -729,7 +729,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'skin.changed':
         if (ev.payload) {
-          applySkin(ev.payload)
+          applySkinPreview(ev.payload)
         }
 
         return

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -296,6 +296,7 @@ export interface OverlayState {
   pager: null | PagerState
   petPicker: boolean
   pluginsHub: boolean
+  skinPicker: boolean
   secret: null | SecretReq
   sessions: boolean
   skillsHub: boolean

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -17,6 +17,7 @@ const buildOverlayState = (): OverlayState => ({
   pager: null,
   petPicker: false,
   pluginsHub: false,
+  skinPicker: false,
   secret: null,
   sessions: false,
   skillsHub: false,
@@ -39,6 +40,7 @@ export const $isBlocked = computed(
     pager,
     petPicker,
     pluginsHub,
+    skinPicker,
     secret,
     sessions,
     skillsHub,
@@ -57,6 +59,7 @@ export const $isBlocked = computed(
       pager ||
       petPicker ||
       pluginsHub ||
+      skinPicker ||
       secret ||
       sessions ||
       skillsHub ||
@@ -123,6 +126,7 @@ export const hasFloatingPanel = (overlay: OverlayState): boolean =>
     overlay.pager ||
     overlay.petPicker ||
     overlay.pluginsHub ||
+    overlay.skinPicker ||
     overlay.sessions ||
     overlay.skillsHub
   )
@@ -158,6 +162,7 @@ export const resetFlowOverlays = () =>
     modelPicker: $overlayState.get().modelPicker,
     petPicker: $overlayState.get().petPicker,
     pluginsHub: $overlayState.get().pluginsHub,
+    skinPicker: $overlayState.get().skinPicker,
     sessions: $overlayState.get().sessions,
     skillsHub: $overlayState.get().skillsHub
   })

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -475,9 +475,9 @@ export const sessionCommands: SlashCommand[] = [
     name: 'skin',
     run: (arg, ctx) => {
       if (!arg) {
-        return ctx.gateway
-          .rpc<ConfigGetValueResponse>('config.get', { key: 'skin' })
-          .then(ctx.guarded<ConfigGetValueResponse>(r => ctx.transcript.sys(`skin: ${r.value || 'default'}`)))
+        patchOverlayState({ skinPicker: true })
+
+        return
       }
 
       ctx.gateway

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -455,9 +455,9 @@ export const sessionCommands: SlashCommand[] = [
     name: 'skin',
     run: (arg, ctx) => {
       if (!arg) {
-        return ctx.gateway
-          .rpc<ConfigGetValueResponse>('config.get', { key: 'skin' })
-          .then(ctx.guarded<ConfigGetValueResponse>(r => ctx.transcript.sys(`skin: ${r.value || 'default'}`)))
+        patchOverlayState({ skinPicker: true })
+
+        return
       }
 
       ctx.gateway

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -85,6 +85,8 @@ export function resolveCtrlCComposerAction(opts: {
   return 'exit'
 }
 
+export const shouldDeferSkinPickerCtrlC = (overlay: OverlayState): boolean => overlay.skinPicker
+
 /**
  * Approval / clarify / confirm overlays mount their own `useInput` handlers
  * for the in-prompt keys (arrows, numbers, Enter, sometimes Esc).  The global
@@ -225,6 +227,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
     if (overlay.sudo || overlay.secret) {
       return dismissSensitivePrompt(overlay, gateway.rpc, actions.sys)
+    }
+
+    if (shouldDeferSkinPickerCtrlC(overlay)) {
+      return
     }
 
     if (overlay.modelPicker) {

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -18,6 +18,7 @@ import { PetPicker } from './petPicker.js'
 import { PluginsHub } from './pluginsHub.js'
 import { ApprovalPrompt, ClarifyPrompt, ConfirmPrompt } from './prompts.js'
 import { SkillsHub } from './skillsHub.js'
+import { SkinPicker } from './skinPicker.js'
 import { SubscriptionOverlay } from './subscriptionOverlay.js'
 import { WidgetGrid, type WidgetGridWidget } from './widgetGrid.js'
 
@@ -265,6 +266,17 @@ export function FloatingOverlays({
       render: width => (
         <FloatBox color={theme.color.border}>
           <PetPicker gw={gw} maxWidth={width} onClose={() => patchOverlayState({ petPicker: false })} t={theme} />
+        </FloatBox>
+      )
+    })
+  }
+
+  if (overlay.skinPicker) {
+    widgets.push({
+      id: 'skin-picker',
+      render: width => (
+        <FloatBox color={theme.color.border}>
+          <SkinPicker gw={gw} maxWidth={width} onClose={() => patchOverlayState({ skinPicker: false })} t={theme} />
         </FloatBox>
       )
     })

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -18,6 +18,7 @@ import { PetPicker } from './petPicker.js'
 import { PluginsHub } from './pluginsHub.js'
 import { ApprovalPrompt, ClarifyPrompt, ConfirmPrompt } from './prompts.js'
 import { SkillsHub } from './skillsHub.js'
+import { SkinPicker } from './skinPicker.js'
 import { SubscriptionOverlay } from './subscriptionOverlay.js'
 import { WidgetGrid, type WidgetGridWidget } from './widgetGrid.js'
 
@@ -260,6 +261,17 @@ export function FloatingOverlays({
       render: width => (
         <FloatBox color={theme.color.border}>
           <PetPicker gw={gw} maxWidth={width} onClose={() => patchOverlayState({ petPicker: false })} t={theme} />
+        </FloatBox>
+      )
+    })
+  }
+
+  if (overlay.skinPicker) {
+    widgets.push({
+      id: 'skin-picker',
+      render: width => (
+        <FloatBox color={theme.color.border}>
+          <SkinPicker gw={gw} maxWidth={width} onClose={() => patchOverlayState({ skinPicker: false })} t={theme} />
         </FloatBox>
       )
     })

--- a/ui-tui/src/components/skinPicker.tsx
+++ b/ui-tui/src/components/skinPicker.tsx
@@ -1,0 +1,218 @@
+import { Box, Text, useInput, useStdout } from '@hermes/ink'
+import type { SkinBranding } from '@hermes/shared/skin'
+import { useEffect, useMemo, useState } from 'react'
+
+import { applySkinPreview } from '../app/createGatewayEventHandler.js'
+import type { GatewayClient } from '../gatewayClient.js'
+import type { GatewaySkin } from '../gatewayTypes.js'
+import { rpcErrorMessage } from '../lib/rpc.js'
+import type { Theme } from '../theme.js'
+
+import { OverlayHint, windowItems } from './overlayControls.js'
+import { chipRowProps, clampOverlayWidth } from './overlayPrimitives.js'
+
+const VISIBLE = 12
+const MIN_WIDTH = 48
+const MAX_WIDTH = 100
+
+export interface SkinOption {
+  description?: string
+  name: string
+  source?: string
+}
+
+interface SkinOptionsResponse {
+  active: string
+  active_skin: GatewaySkin
+  skins: SkinOption[]
+}
+
+export const filterSkinOptions = (skins: SkinOption[], query: string): SkinOption[] => {
+  const needle = query.trim().toLowerCase()
+
+  return needle
+    ? skins.filter(
+        skin => skin.name.toLowerCase().includes(needle) || (skin.description ?? '').toLowerCase().includes(needle)
+      )
+    : skins
+}
+
+export const skinAgentLabel = (branding: SkinBranding): string =>
+  `agent: ${branding.agent_name?.trim() || 'Hermes Agent'}`
+
+export function SkinPicker({ gw, maxWidth, onClose, t }: SkinPickerProps) {
+  const [options, setOptions] = useState<SkinOptionsResponse | null>(null)
+  const [query, setQuery] = useState('')
+  const [idx, setIdx] = useState(0)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  const { stdout } = useStdout()
+  const preferredWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+  const width = clampOverlayWidth(preferredWidth, maxWidth)
+
+  useEffect(() => {
+    let current = true
+
+    gw.request<SkinOptionsResponse>('skin.options')
+      .then(response => {
+        if (!current) {
+          return
+        }
+
+        setOptions(response)
+        setIdx(Math.max(0, response.skins.findIndex(skin => skin.name === response.active)))
+        setErr('')
+      })
+      .catch((error: unknown) => current && setErr(rpcErrorMessage(error)))
+      .finally(() => current && setLoading(false))
+
+    return () => {
+      current = false
+    }
+  }, [gw])
+
+  const view = useMemo(() => filterSkinOptions(options?.skins ?? [], query), [options, query])
+  const selected = view[idx]
+
+  useEffect(() => {
+    if (!options || !selected) {
+      return
+    }
+
+    let current = true
+
+    const preview =
+      selected.name === options.active
+        ? Promise.resolve(options.active_skin)
+        : gw.request<GatewaySkin>('skin.preview', { name: selected.name })
+
+    preview
+      .then(skin => current && applySkinPreview(skin))
+      .catch((error: unknown) => current && setErr(rpcErrorMessage(error)))
+
+    return () => {
+      current = false
+    }
+  }, [gw, options, selected])
+
+  const cancel = () => {
+    if (options?.active_skin) {
+      applySkinPreview(options.active_skin)
+    }
+
+    onClose()
+  }
+
+  const select = (name: string) => {
+    setBusy(true)
+    setErr('')
+    gw.request<{ value?: string }>('config.set', { key: 'skin', value: name })
+      .then(response => {
+        if (!response.value) {
+          throw new Error('skin selection was not saved')
+        }
+
+        onClose()
+      })
+      .catch((error: unknown) => {
+        setErr(rpcErrorMessage(error))
+        setBusy(false)
+      })
+  }
+
+  useInput((input, key) => {
+    if (busy) {
+      return
+    }
+
+    if (key.escape) {
+      return cancel()
+    }
+
+    if (key.upArrow) {
+      return setIdx(current => Math.max(0, current - 1))
+    }
+
+    if (key.downArrow) {
+      return setIdx(current => Math.min(Math.max(0, view.length - 1), current + 1))
+    }
+
+    if (key.return) {
+      return selected ? select(selected.name) : undefined
+    }
+
+    if (key.backspace || key.delete) {
+      setQuery(current => current.slice(0, -1))
+
+      return setIdx(0)
+    }
+
+    if (input && input.length === 1 && input >= ' ' && !key.ctrl && !key.meta) {
+      setQuery(current => current + input)
+      setIdx(0)
+    }
+  })
+
+  if (loading) {
+    return <Text color={t.color.muted}>loading skins…</Text>
+  }
+
+  if (err && !options) {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text color={t.color.label}>error: {err}</Text>
+        <OverlayHint t={t}>Esc cancel</OverlayHint>
+      </Box>
+    )
+  }
+
+  const { items, offset } = windowItems(view, idx, VISIBLE)
+  const total = options?.skins.length ?? 0
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Text bold color={t.color.accent}>
+        Skins
+      </Text>
+      <Text color={t.color.muted} wrap="truncate-end">
+        {query ? `filter: ${query}` : 'type to filter'} · showing {view.length} of {total} ·{' '}
+        {skinAgentLabel({ agent_name: t.brand.name })}
+      </Text>
+
+      {offset > 0 && <Text color={t.color.muted}> ↑ {offset} more</Text>}
+      {view.length === 0 ? (
+        <Text color={t.color.muted}>no skins match "{query}"</Text>
+      ) : (
+        items.map((skin, itemIndex) => {
+          const at = offset + itemIndex === idx
+          const active = skin.name === options?.active
+
+          return (
+            <Text color={t.color.muted} {...chipRowProps(t, at)} key={skin.name} wrap="truncate-end">
+              {at ? '▸ ' : '  '}
+              {active ? '●' : ' '} {skin.name}
+              <Text color={at ? t.color.accent : t.color.muted}>
+                {' '}
+                · {skin.source ?? 'unknown'}
+                {skin.description ? ` · ${skin.description}` : ''}
+              </Text>
+            </Text>
+          )
+        })
+      )}
+      {offset + VISIBLE < view.length && <Text color={t.color.muted}> ↓ {view.length - offset - VISIBLE} more</Text>}
+      {err ? <Text color={t.color.label}>error: {err}</Text> : null}
+      {busy ? <Text color={t.color.accent}>saving…</Text> : null}
+      <OverlayHint t={t}>↑/↓ preview · Enter select · type to filter · Esc cancel</OverlayHint>
+    </Box>
+  )
+}
+
+interface SkinPickerProps {
+  gw: GatewayClient
+  maxWidth?: number
+  onClose: () => void
+  t: Theme
+}

--- a/ui-tui/src/components/skinPicker.tsx
+++ b/ui-tui/src/components/skinPicker.tsx
@@ -14,6 +14,7 @@ import { chipRowProps, clampOverlayWidth } from './overlayPrimitives.js'
 const VISIBLE = 12
 const MIN_WIDTH = 48
 const MAX_WIDTH = 100
+export const SKIN_PREVIEW_DEBOUNCE_MS = 120
 
 export interface SkinOption {
   description?: string
@@ -82,18 +83,20 @@ export function SkinPicker({ gw, maxWidth, onClose, t }: SkinPickerProps) {
     }
 
     let current = true
+    const timer = setTimeout(() => {
+      const preview =
+        selected.name === options.active
+          ? Promise.resolve(options.active_skin)
+          : gw.request<GatewaySkin>('skin.preview', { name: selected.name })
 
-    const preview =
-      selected.name === options.active
-        ? Promise.resolve(options.active_skin)
-        : gw.request<GatewaySkin>('skin.preview', { name: selected.name })
-
-    preview
-      .then(skin => current && applySkinPreview(skin))
-      .catch((error: unknown) => current && setErr(rpcErrorMessage(error)))
+      preview
+        .then(skin => current && applySkinPreview(skin))
+        .catch((error: unknown) => current && setErr(rpcErrorMessage(error)))
+    }, SKIN_PREVIEW_DEBOUNCE_MS)
 
     return () => {
       current = false
+      clearTimeout(timer)
     }
   }, [gw, options, selected])
 

--- a/ui-tui/src/components/skinPicker.tsx
+++ b/ui-tui/src/components/skinPicker.tsx
@@ -1,8 +1,12 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
 import type { SkinBranding } from '@hermes/shared/skin'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { applySkinPreview } from '../app/createGatewayEventHandler.js'
+import {
+  applySkinPreview,
+  getPersistedSkinRevision,
+  restorePersistedSkin
+} from '../app/createGatewayEventHandler.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { GatewaySkin } from '../gatewayTypes.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
@@ -48,6 +52,7 @@ export function SkinPicker({ gw, maxWidth, onClose, t }: SkinPickerProps) {
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState('')
   const [loading, setLoading] = useState(true)
+  const previewGeneration = useRef(0)
 
   const { stdout } = useStdout()
   const preferredWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
@@ -82,29 +87,34 @@ export function SkinPicker({ gw, maxWidth, onClose, t }: SkinPickerProps) {
       return
     }
 
-    let current = true
-    const timer = setTimeout(() => {
-      const preview =
-        selected.name === options.active
-          ? Promise.resolve(options.active_skin)
-          : gw.request<GatewaySkin>('skin.preview', { name: selected.name })
+    const generation = ++previewGeneration.current
+    const persistedRevision = getPersistedSkinRevision()
 
-      preview
-        .then(skin => current && applySkinPreview(skin))
-        .catch((error: unknown) => current && setErr(rpcErrorMessage(error)))
+    const timer = setTimeout(() => {
+      gw.request<GatewaySkin>('skin.preview', { name: selected.name })
+        .then(
+          skin =>
+            generation === previewGeneration.current &&
+            persistedRevision === getPersistedSkinRevision() &&
+            applySkinPreview(skin)
+        )
+        .catch(
+          (error: unknown) =>
+            generation === previewGeneration.current &&
+            persistedRevision === getPersistedSkinRevision() &&
+            setErr(rpcErrorMessage(error))
+        )
     }, SKIN_PREVIEW_DEBOUNCE_MS)
 
     return () => {
-      current = false
+      previewGeneration.current += 1
       clearTimeout(timer)
     }
   }, [gw, options, selected])
 
   const cancel = () => {
-    if (options?.active_skin) {
-      applySkinPreview(options.active_skin)
-    }
-
+    previewGeneration.current += 1
+    restorePersistedSkin(options?.active_skin)
     onClose()
   }
 
@@ -117,6 +127,7 @@ export function SkinPicker({ gw, maxWidth, onClose, t }: SkinPickerProps) {
           throw new Error('skin selection was not saved')
         }
 
+        previewGeneration.current += 1
         onClose()
       })
       .catch((error: unknown) => {
@@ -130,7 +141,7 @@ export function SkinPicker({ gw, maxWidth, onClose, t }: SkinPickerProps) {
       return
     }
 
-    if (key.escape) {
+    if (key.escape || (key.ctrl && (input.toLowerCase() === 'c' || input === '\u0003'))) {
       return cancel()
     }
 


### PR DESCRIPTION
## Summary

Fixes the TUI `/skin` command so a bare `/skin` opens a searchable picker containing every discovered built-in and user skin.

- Lists all skins returned by the existing skin engine.
- Supports arrow-key live previews without saving the preview.
- Restores the active skin when the picker is cancelled.
- Keeps `/skin <name>` as the direct persistent selection path.
- Shows the selected skin's optional agent branding clearly.
- Guards against stale asynchronous previews overwriting a newer selection.

## Why

The TUI command registry describes `/skin [name]` as the display skin selector, but submitting bare `/skin` only printed the current skin. Users with large installed skin collections had no complete picker after autocomplete.

## Verification

- `scripts/run_tests.sh tests/tui_gateway/test_skin_picker.py tests/tui_gateway/test_protocol.py -q`, 45 passed.
- Focused TUI tests, 6 passed across the picker, slash dispatch, and overlay timer behavior.
- `npm run typecheck`, passed.
- `npm run lint`, passed with one pre-existing warning in `useSessionLifecycle.ts`.
- `npm run build`, passed.
- Gitleaks scanned the one-commit branch, no leaks found.
- Lea read-only security and logic review, PASS with no required fixes.
- Live TUI verification opened `/skin` and displayed `showing 113 of 113`; Escape preserved the active skin.

BChop retains the merge decision.