### PR TITLE
fix(relay): make owner-bound stops crash-safe

### DIFF
--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -1,9 +1,10 @@
-# Relay ↔ Connector Contract (v2, EXPERIMENTAL)
+# Relay ↔ Connector Contract (v3, EXPERIMENTAL)
 
 > **Status:** EXPERIMENTAL. This contract MAY CHANGE without a deprecation
 > cycle until at least two real Class-1 platforms (Discord + Telegram) have
-> validated it. Evolution during the experimental phase is **additive-only**,
-> gated by `contract_version`. A breaking change updates both repos in lockstep.
+> validated it. Additions within one version are additive; any breaking or
+> reinterpreted control semantics require a version bump and update both repos
+> in lockstep. v3 is such a coordinated, fail-closed break from v2.
 
 This document is the formal interface between the **Hermes gateway** (Python,
 `gateway/relay/`) and the **connector** (Node/TypeScript,
@@ -21,22 +22,28 @@ connector owns all platform-specific socket/identity logic.
 ## 1. Handshake
 
 1. Gateway opens the transport (`connect`) and sends `hello` with
-   `contract_version: 2`, capability `owner-bound-interrupt-ack`, and an opaque
-   process-lifetime `runtime_epoch` (stable across reconnects, renewed after a
-   gateway restart).
-2. Connector fails the handshake closed unless both values are present, then
-   returns a v2 `CapabilityDescriptor` advertising the same capability.
-   (section 2) describing the platform this adapter instance fronts.
-3. Gateway likewise rejects and closes a v1/capability-less descriptor;
+   `contract_version: 3`, capabilities `owner-bound-interrupt-ack`,
+   `owner-bound-turn-completion`, and `owner-bound-turn-reconciliation`, an
+   opaque process-lifetime `runtime_epoch` (stable across reconnects, renewed
+   after a gateway restart), and bounded `turn_states`. Snapshot scope is an
+   HMAC fingerprint of the room/session pair, not the raw identifiers, so a
+   multiplexed transport does not disclose one connector's session keys to
+   another connector.
+2. Connector fails the handshake closed unless all values are present, then
+   returns a v3 `CapabilityDescriptor` (section 2) advertising all three
+   capabilities atomically and describing the platform this adapter instance
+   fronts.
+3. Gateway likewise rejects and closes a v1/v2 or partially capable descriptor;
    otherwise it configures the adapter from the descriptor (char limit, length
    unit, draft/edit/thread/markdown capabilities) and registers an inbound
    handler.
 4. Connector then streams inbound events and accepts outbound actions.
 
-`contract_version` (currently `2`) is carried in both directions. The gateway
+`contract_version` (currently `3`) is carried in both directions. The gateway
 ignores unknown descriptor fields (forward-compat) and fills missing optional
-fields from defaults. v1 peers MUST NOT enable the Stop UI: v2 changes Stop
-completion from write-accepted to correlated runtime acknowledgement.
+fields from defaults. Older peers MUST NOT enable the Stop UI: v3 makes inbound
+owner disposition and reconnect reconciliation part of the same atomic control
+capability as owner-bound Stop and completion.
 
 ---
 
@@ -60,7 +67,7 @@ JSON object. Source of truth: `gateway/relay/descriptor.py`.
 | `pii_safe` | bool | no | Redact PII in session descriptions. |
 | `supports_context` | bool | no | Whether the connector can supply surrounding channel/group **context** for an addressed turn on this platform (Model A on-demand history fetch — Discord/Slack/Matrix; Model B passive buffer — Telegram/Signal/WhatsApp). Default false ⇒ no `context` is attached to inbound events. See §3. |
 | `supported_ops` | string[] | no | Op-level capability discovery: the outbound op names the connector's sender for this platform actually implements (e.g. `["send", "edit", "typing", "follow_up", "get_chat_info"]`). Absent/empty ⇒ the connector predates the field and the gateway assumes the legacy op set (`send`/`edit`/`typing`/`follow_up`); a NEW op is used only when explicitly advertised. |
-| `capabilities` | string[] | no | Control-plane capabilities. v2 Stop requires `owner-bound-interrupt-ack`; absence is fail-closed and has no optimistic fallback. |
+| `capabilities` | string[] | no | Control-plane capabilities. v3 requires `owner-bound-interrupt-ack`, `owner-bound-turn-completion`, and `owner-bound-turn-reconciliation` atomically; absence of any member is fail-closed and has no optimistic fallback. |
 
 Most fields are a projection of the gateway's existing `PlatformEntry`; the
 runtime-only fields (`len_unit`, `supports_*`, `markdown_dialect`) come from the
@@ -101,7 +108,7 @@ HTTP call.
 
 Frames (connector → gateway, over the WS):
 
-- `{"type":"inbound", "event": <MessageEvent>, "bufferId"?}`
+- `{"type":"inbound", "delivery_id", "event": <MessageEvent>, "bufferId"?}`
 - `{"type":"interrupt_inbound", "session_key", "chat_id", "owner_id", "action_id"}` (§5)
 - `{"type":"passthrough_forward", "forward": <PassthroughForward>, "bufferId"?}` (§5.1)
 
@@ -109,6 +116,110 @@ The correlated response travels in the opposite direction (gateway →
 connector):
 
 - `{"type":"interrupt_result", "action_id", "accepted", "reason"}` (§5)
+- `{"type":"inbound_ack", "delivery_id", "session_key", "chat_id", "owner_id", "runtime_epoch", "disposition", "canonical_turn_owner_id", "owner_state_seq", "bufferId"?}` (§3.1)
+- `{"type":"turn_completed", "session_key", "chat_id", "owner_id", "runtime_epoch", "outcome", "owner_state_seq", "status", "next_owner_id", "next_delivery_id"}` (§3.2)
+
+### 3.1 Owner-bound inbound admission and disposition
+
+Every inbound event carries a required bounded `delivery_id` and a required
+bounded opaque string `event.owner_id`. Neither peer assigns semantics to the
+owner's spelling; in particular, the gateway MUST NOT require a connector-
+specific prefix. Control characters, leading/trailing whitespace, empty values,
+and values over the documented bounds are rejected.
+
+The gateway emits an authoritative `inbound_ack` only after the actual adapter
+and runner admission path has classified the event. `disposition` is one of:
+
+- `started`: this delivery is now the canonical turn owner. Its
+  `canonical_turn_owner_id` equals `owner_id`.
+- `queued`: this delivery may become a later independent owner, but is not yet
+  stoppable. A second `started` ack for the same `delivery_id` announces the
+  authoritative handoff after its guard binds.
+- `absorbed`: redirect, steer, prompt resolution, or another path consumed the
+  event inside the current canonical turn.
+- `merged`: debounce/media merge incorporated it into another queued/current
+  event; it never becomes an independently stoppable owner.
+- `rejected`: authorization, capacity, invalid routing, or another terminal
+  admission failure dropped it.
+
+For every non-`started` disposition,
+`canonical_turn_owner_id` names the already-running owner or is null when no
+owner exists. The connector MUST NOT rebind Stop merely because it wrote an
+`inbound` frame: it binds only from `started`. Thus an absorbed B cannot replace
+guard A, and completion A clears the UI. A queued B transitions A→handoff→B
+only through authoritative sequence-bearing frames, never a timer.
+
+`delivery_id` is the dedupe key. The gateway retains a bounded cache of exact
+ack frames; replay of a duplicate delivery returns the cached ack without
+dispatching the event twice. Durable `bufferId` acknowledgement is carried on
+this same `inbound_ack` after owner disposition—there is no parallel ack
+protocol or unbounded retry queue. The connector validates the complete v3
+owner disposition before committing the durable receipt; a buffer-only,
+foreign, stale, or conflicting ack cannot retire the ledger row.
+
+An exception escaping the admitted inbound handler is not an authoritative
+rejection. The transport emits and caches no `inbound_ack` in that case and
+reconnects; a durable connector retains/reclaims its lease and may redeliver
+the same `delivery_id`. Authorization and bounded-capacity failures remain
+explicit terminal `rejected` dispositions. Consequently this delivery leg is
+at-least-once across a transient handler failure, not exactly-once execution of
+arbitrary handler side effects.
+
+### 3.2 Owner-bound completion, handoff, and reconciliation
+
+The gateway preserves the exact accepted owner and records one logical terminal
+transition only after the final response/media projection, any generation-owned
+post-delivery callback required by that turn, and conversation/tool/child-agent
+unwind:
+
+```json
+{"type":"turn_completed","session_key":"...","chat_id":"...","owner_id":"opaque-owner","runtime_epoch":"...","outcome":"completed","owner_state_seq":2,"status":"idle","next_owner_id":null,"next_delivery_id":null}
+```
+
+`outcome` is one of `completed`, `failed`, or `cancelled`. The processing hook
+is cancellation-shielded and bounded. If outer cancellation arrives during the
+bounded terminal attempt, propagation is deferred until the barrier, debounce,
+late drain, and guard cleanup have run. Error projection remains best-effort
+and precedes completion; a failed projection or cancellation cannot skip the
+terminal state record, and a wedged send cannot block handoff without limit.
+Wire delivery itself remains best-effort and may be recovered by the hello
+snapshot after reconnect.
+
+If an independent queued successor exists, completion uses `status:"handoff"`
+and carries its exact `next_owner_id` plus `next_delivery_id`. The connector
+then reports the successor's actual guard binding with `inbound_ack started`.
+This two-step barrier prevents both a false idle gap and premature Stop on B.
+Completion for owner N is recorded before owner N+1 can bind. Missing,
+malformed, duplicate, stale, foreign, old-epoch, or old-owner frames are inert.
+
+Assistant `send`, `edit`, `typing`, progress, prompt/approval, and media frames
+are non-terminal. No text, label, quiet timer, or outbound-frame heuristic may
+stand in for `turn_completed`.
+
+An accepted `interrupt_result` remains the authoritative Stop terminal event.
+A later `turn_completed` for that stopped owner is idempotently inert; a
+rejected/timed-out Stop or transport disconnect retains the owner. A replacement
+`runtime_epoch` reconciles an owner left behind by a dead gateway process.
+
+The gateway records every owner transition in a bounded room/session-scoped
+ledger before attempting the socket write. On each `hello`, `turn_states`
+contains at most one snapshot for an opaque HMAC scope fingerprint: `running`
+with `active_owner_id`, `handoff` with terminal and next-owner fields, or `idle`
+with terminal owner and outcome. `owner_state_seq` is monotonic within one
+`runtime_epoch`; the initial idle state has the canonical fingerprint
+`idle:0:null:null`.
+
+Fresh reconciliation is the first authenticated hello accepted by a connector
+process, before that process has established any gateway epoch or owner state.
+Because connector-local issued-owner memory cannot survive that process death,
+the matching HMAC-scoped snapshot is authoritative at this one boundary and may
+bootstrap `running`, `handoff`, or `idle` even for a same-epoch gateway. Once an
+epoch is established, an equal sequence must have an identical fingerprint and
+a higher sequence must pass the normal owner transition checks; decreasing or
+conflicting snapshots fail closed and cannot clear newer state. Repeated
+reconnects are therefore idempotent. A new gateway epoch cannot retain an old
+process guard. This reconciles a connector restart or a completion lost at
+socket failure without accepting a later stale-clear replay.
 
 **Channel context on inbound (design relay-channel-context).** When the source
 platform's descriptor advertised `supports_context` (§2) and the chat is
@@ -293,6 +404,13 @@ read off the stored secret record at the WS upgrade, never asserted in a frame):
   reconnect. The connector acks the buffer entry only after this, giving
   drain-without-dup on the **delivery leg**: an instance that dies mid-drain
   redelivers exactly the unacked tail; an acked entry never redelivers.
+
+`going_idle` is exclusively an instance drain/scale-to-zero primitive and is
+never a turn-completion signal. A connector that has not implemented the real
+durable buffered-only flip MUST NOT send `going_idle_ack`; the gateway's
+bounded `go_idle()` timeout is the deliberate compatibility path before socket
+close. It is safer to time out than to acknowledge a durability guarantee the
+connector does not provide.
 
 **Buffer + drain.** While flipped, the connector appends inbound to a durable
 per-instance delivery-leg buffer (`delivery:<instanceId>`) instead of pushing it
@@ -622,13 +740,15 @@ after that discard while Stop/cancellation is still in progress remains queued,
 is rebound to its own owner/generation, and starts only after the reaper and old
 task complete.
 
-**Rollout / legacy ledger gate.** Disable Relay admission, deploy both v2 peers,
+**Rollout / legacy ledger gate.** Disable Relay admission, deploy both v3 peers,
 then start the connector before the gateway and re-enable admission only after
-the v2 handshake. Never serve traffic with a mixed v1/v2 pair. Before enabling
+the v3 handshake advertises all three owner-bound capabilities. Never serve
+traffic with a partial v3 capability set or a mixed-version pair. Before enabling
 Relay, inspect durable
-`pending`/`inflight` user-message rows. Rows written by v1 have no `owner_id`
+`pending`/`inflight` user-message and prompt-response rows. Rows written before
+v3 may have no `owner_id`
 and MUST be drained by the old pair or explicitly handled by an operator.
-The v2 connector performs a read-only health/handshake check and refuses Relay
+The v3 connector performs a read-only health/handshake check and refuses Relay
 activation while any such row remains; it never dead-letters it merely for
 being legacy and never fabricates an owner. Health reports
 `legacy_owner_drain_required` plus the blocking count.
@@ -836,8 +956,8 @@ Changes take effect on gateway restart; no connector involvement.
 
 ## 9. Versioning policy
 
-- `contract_version` is an int; bump **only** for additive changes during the
-  experimental phase (new optional fields, new `op`s).
+- `contract_version` is an int. Optional additive fields and new `op`s may be
+  introduced compatibly only when their absence has unchanged semantics.
 - A breaking change (renamed/removed field, changed semantics) requires a
   coordinated update of both repos and a version bump.
 - The connector's first PR references the commit SHA of this file it implements

--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -1,4 +1,4 @@
-# Relay ↔ Connector Contract (v1, EXPERIMENTAL)
+# Relay ↔ Connector Contract (v2, EXPERIMENTAL)
 
 > **Status:** EXPERIMENTAL. This contract MAY CHANGE without a deprecation
 > cycle until at least two real Class-1 platforms (Discord + Telegram) have
@@ -20,16 +20,23 @@ connector owns all platform-specific socket/identity logic.
 
 ## 1. Handshake
 
-1. Gateway opens the transport (`connect`).
-2. Gateway calls `handshake()`; connector returns a `CapabilityDescriptor`
+1. Gateway opens the transport (`connect`) and sends `hello` with
+   `contract_version: 2`, capability `owner-bound-interrupt-ack`, and an opaque
+   process-lifetime `runtime_epoch` (stable across reconnects, renewed after a
+   gateway restart).
+2. Connector fails the handshake closed unless both values are present, then
+   returns a v2 `CapabilityDescriptor` advertising the same capability.
    (section 2) describing the platform this adapter instance fronts.
-3. Gateway configures the adapter from the descriptor (char limit, length unit,
-   draft/edit/thread/markdown capabilities) and registers an inbound handler.
+3. Gateway likewise rejects and closes a v1/capability-less descriptor;
+   otherwise it configures the adapter from the descriptor (char limit, length
+   unit, draft/edit/thread/markdown capabilities) and registers an inbound
+   handler.
 4. Connector then streams inbound events and accepts outbound actions.
 
-`contract_version` (currently `1`) is carried in the descriptor. The gateway
+`contract_version` (currently `2`) is carried in both directions. The gateway
 ignores unknown descriptor fields (forward-compat) and fills missing optional
-fields from defaults.
+fields from defaults. v1 peers MUST NOT enable the Stop UI: v2 changes Stop
+completion from write-accepted to correlated runtime acknowledgement.
 
 ---
 
@@ -53,6 +60,7 @@ JSON object. Source of truth: `gateway/relay/descriptor.py`.
 | `pii_safe` | bool | no | Redact PII in session descriptions. |
 | `supports_context` | bool | no | Whether the connector can supply surrounding channel/group **context** for an addressed turn on this platform (Model A on-demand history fetch — Discord/Slack/Matrix; Model B passive buffer — Telegram/Signal/WhatsApp). Default false ⇒ no `context` is attached to inbound events. See §3. |
 | `supported_ops` | string[] | no | Op-level capability discovery: the outbound op names the connector's sender for this platform actually implements (e.g. `["send", "edit", "typing", "follow_up", "get_chat_info"]`). Absent/empty ⇒ the connector predates the field and the gateway assumes the legacy op set (`send`/`edit`/`typing`/`follow_up`); a NEW op is used only when explicitly advertised. |
+| `capabilities` | string[] | no | Control-plane capabilities. v2 Stop requires `owner-bound-interrupt-ack`; absence is fail-closed and has no optimistic fallback. |
 
 Most fields are a projection of the gateway's existing `PlatformEntry`; the
 runtime-only fields (`len_unit`, `supports_*`, `markdown_dialect`) come from the
@@ -94,8 +102,13 @@ HTTP call.
 Frames (connector → gateway, over the WS):
 
 - `{"type":"inbound", "event": <MessageEvent>, "bufferId"?}`
-- `{"type":"interrupt_inbound", "session_key", "chat_id"}` (§5)
+- `{"type":"interrupt_inbound", "session_key", "chat_id", "owner_id", "action_id"}` (§5)
 - `{"type":"passthrough_forward", "forward": <PassthroughForward>, "bufferId"?}` (§5.1)
+
+The correlated response travels in the opposite direction (gateway →
+connector):
+
+- `{"type":"interrupt_result", "action_id", "accepted", "reason"}` (§5)
 
 **Channel context on inbound (design relay-channel-context).** When the source
 platform's descriptor advertised `supports_context` (§2) and the chat is
@@ -452,7 +465,9 @@ from a sibling's. `style` maps per-platform
 (primary/success/danger/secondary). `timeout_s` is advisory on the wire —
 expiry is enforced GATEWAY-side (the pending-prompt registry drops expired
 entries; the owning gateway then replies with a short "no longer waiting"
-notice).
+notice; a stale structured press is consumed without becoming command text,
+while a genuinely typed command with no `prompt_response` field keeps the
+ordinary command path).
 
 **`prompt_response` (Phase 3 inbound).** The user's press crosses back as a
 normal inbound MessageEvent carrying
@@ -477,6 +492,13 @@ ack is `DEFERRED_UPDATE` so no visible "thinking…" reply). Foreign
 callback payloads (another integration's buttons) never become prompt
 events: Telegram/Slack/WhatsApp drop them at the connector; Discord type-3
 forwards keep the legacy custom_id-as-text shape.
+
+Field presence is the control boundary. If `prompt_response` is present but
+has the wrong wire type (`string`, `list`, number, or `null`), or lacks required
+ids, the gateway consumes it terminally and never dispatches its command-shaped
+`text`. If the field is absent, a typed `/c1` remains an ordinary command.
+Durable redelivery of the same `bufferId` repeats the post-consumption
+`inbound_ack`; it does not resurrect the prompt or execute the text lane.
 
 **`react` (Phase 3 ack lifecycle).** Adds/removes the bot's own `emoji`
 reaction on `message_id` — restoring the native adapters' 👀→✅/❌
@@ -561,12 +583,55 @@ gateway holds zero capability material). Source of truth:
 - **Gateway → connector:** `send_interrupt(session_key, reason?)` egresses a
   mid-turn `/stop` over the outbound WS. The connector MUST forward it to the
   gateway instance running that `session_key` (the routing invariant).
-- **Connector → gateway:** an inbound interrupt for a `session_key` is delivered
-  as an `interrupt_inbound` frame down the gateway's outbound WS (§3 transport
-  note) — routed cross-instance via the relay bus to whichever instance holds
-  the socket — and bridged by the adapter's `on_interrupt(session_key, chat_id)`
-  into the existing per-session interrupt mechanism, cancelling exactly that turn
-  (siblings untouched).
+- **Connector → gateway:** a Stop is
+  `interrupt_inbound {session_key, chat_id, owner_id, action_id}`. `owner_id`
+  is minted once with the original inbound turn and remains byte-identical
+  across durable retry/reconnect. `action_id` correlates exactly one attempt.
+- **Gateway → connector result:** after the generation-bound canonical hard
+  stop finishes, the gateway sends
+  `interrupt_result {action_id, accepted:true, reason:"accepted"}`. Validation
+  failures before owner/generation admission return `accepted:false` with a
+  bounded reason. Once that exact Stop has synchronously applied hard interrupt
+  and generation invalidation, it remains terminally accepted even if the
+  caller's timeout/cancellation lands during bounded reaping or task unwind;
+  this prevents a half-applied Stop from being rendered as safely retryable.
+  Raw exception text and frame content never appear in the result or reason log.
+
+The connector MUST clear `activeTurnId`/render Stop success only for the exact
+matching `action_id` with `accepted:true`. A NACK, local timeout, or disconnect
+keeps the same `owner_id` retryable; a late/duplicate result is inert. Repeated
+delivery of the same `action_id` is idempotent: at most one hard stop and one
+result frame. If an accepted result is lost with a transient socket close, the
+same live gateway runtime keeps a bounded terminal-owner cache: a fresh action
+for that exact owner is accepted idempotently without running hard-stop twice.
+A gateway restart clears that cache and changes `runtime_epoch`, causing the
+connector to reconcile the phantom owner instead. Distinct actions for one
+`session_key` are serialized, while the reader continues consuming
+`outbound_result` and durable inbound traffic.
+
+The gateway binds owner plus run generation before slow turn preparation and
+maps the adapter key to the exact multiplexed profile runner key. Stop is
+accepted only when session key, chat id, owner, and generation all match;
+siblings and replacement generations are untouched. The canonical hard-stop
+waits for its existing child-process reaper before releasing a queued handoff,
+so a replacement generation cannot cause an abandoned child to escape reaping.
+
+**Pending-before-Stop semantics.** A follow-up already pending when canonical
+Stop begins is consumed and discarded, matching `/stop`. A message arriving
+after that discard while Stop/cancellation is still in progress remains queued,
+is rebound to its own owner/generation, and starts only after the reaper and old
+task complete.
+
+**Rollout / legacy ledger gate.** Disable Relay admission, deploy both v2 peers,
+then start the connector before the gateway and re-enable admission only after
+the v2 handshake. Never serve traffic with a mixed v1/v2 pair. Before enabling
+Relay, inspect durable
+`pending`/`inflight` user-message rows. Rows written by v1 have no `owner_id`
+and MUST be drained by the old pair or explicitly handled by an operator.
+The v2 connector performs a read-only health/handshake check and refuses Relay
+activation while any such row remains; it never dead-letters it merely for
+being legacy and never fabricates an owner. Health reports
+`legacy_owner_drain_required` plus the blocking count.
 
 Both directions ride the gateway's outbound WS: the gateway→connector `/stop`
 egresses over it, and the connector→gateway interrupt rides the same `inbound`

--- a/gateway/interrupt_budget.py
+++ b/gateway/interrupt_budget.py
@@ -1,0 +1,28 @@
+"""Shared bounded budgets for one owner-bound Relay hard-stop.
+
+The transport timeout is intentionally derived from every bounded inner phase.
+Keeping the arithmetic here prevents a future local timeout change from making
+the outer acknowledgement cap cancel a normally progressing terminal Stop.
+"""
+
+HARD_STOP_REAP_TIMEOUT_SECONDS = 4.0
+INTERRUPT_ACTIVITY_TIMEOUT_SECONDS = 1.0
+SESSION_PROCESSING_CANCEL_TIMEOUT_SECONDS = 5.0
+
+# Scheduler/logging/queue overhead after the three sequential inner phases.
+INTERRUPT_HANDLER_SAFETY_MARGIN_SECONDS = 1.0
+# Strictly greater than inner phases plus the documented safety margin.
+INTERRUPT_HANDLER_TIMEOUT_SECONDS = (
+    HARD_STOP_REAP_TIMEOUT_SECONDS
+    + INTERRUPT_ACTIVITY_TIMEOUT_SECONDS
+    + SESSION_PROCESSING_CANCEL_TIMEOUT_SECONDS
+    + INTERRUPT_HANDLER_SAFETY_MARGIN_SECONDS
+    + 0.5
+)
+
+# Independent last-resort guard for a lost barrier signal. It exceeds the
+# transport cap so the ordinary canonical Stop remains authoritative; only a
+# broken/cancelled signal reaches this fail-safe.
+SESSION_HANDOFF_BARRIER_TIMEOUT_SECONDS = (
+    INTERRUPT_HANDLER_TIMEOUT_SECONDS + 0.5
+)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6076,7 +6076,14 @@ class BasePlatformAdapter(ABC):
         command-scoped guard, then — if a follow-up message landed while the
         command was running — spawns a fresh processing task for it.
         """
+        if self._active_sessions.get(session_key) is not command_guard:
+            return
         await self._flush_text_debounce_now(session_key)
+        # Flushing can yield, so a newer command may have claimed this session
+        # while the old cleanup waited.  That cleanup must not consume the new
+        # command's pending successor or overwrite its guard.
+        if self._active_sessions.get(session_key) is not command_guard:
+            return
         pending_event = self._pending_messages.pop(session_key, None)
         self._release_session_guard(session_key, guard=command_guard)
         if pending_event is None:
@@ -6110,6 +6117,14 @@ class BasePlatformAdapter(ABC):
 
         current_guard = self._active_sessions.get(session_key)
         command_guard = asyncio.Event()
+        # A reset-like command does not become a turn owner, but while it
+        # serializes cancellation it still represents the live owner it
+        # replaced.  Preserve that owner only when it came from the existing
+        # guard; this keeps command-on-command acknowledgements absorbed by A
+        # instead of falsely rejecting B with a null/phantom owner.
+        prior_owner = getattr(current_guard, "_hermes_owner_id", None)
+        if isinstance(prior_owner, str) and prior_owner:
+            setattr(command_guard, "_hermes_owner_id", prior_owner)
         self._active_sessions[session_key] = command_guard
         thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
 
@@ -6145,7 +6160,6 @@ class BasePlatformAdapter(ABC):
             # absorbed by the guard it is about to stop, so the connector can
             # retire B without ever inventing a short-lived owner for it.
             if getattr(event, "owner_id", None) and current_guard is not None:
-                prior_owner = getattr(current_guard, "_hermes_owner_id", None)
                 if isinstance(prior_owner, str) and prior_owner:
                     event.metadata["relay_owner_disposition"] = "absorbed"
                     event.metadata["relay_owner_canonical_id"] = prior_owner

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -67,6 +67,7 @@ _AUDIO_EXTS = frozenset(_AUDIO_MIME_TYPES)
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
+_TERMINAL_HOOK_TIMEOUT_SECONDS = 1.5
 # Delivery-time history is best-effort dedup metadata, not canonical state.
 # Keep this comfortably below the Discord heartbeat watchdog window and fail
 # open rather than withholding a legitimate attachment.
@@ -2720,6 +2721,8 @@ def merge_pending_message_event(
     """
     existing = pending_messages.get(session_key)
     if existing:
+        if getattr(event, "owner_id", None):
+            event.metadata["relay_owner_disposition"] = "merged"
         existing_is_photo = getattr(existing, "message_type", None) == MessageType.PHOTO
         incoming_is_photo = event.message_type == MessageType.PHOTO
         existing_has_media = bool(existing.media_urls)
@@ -2762,6 +2765,8 @@ def merge_pending_message_event(
             return
 
     pending_messages[session_key] = event
+    if getattr(event, "owner_id", None):
+        event.metadata["relay_owner_disposition"] = "queued"
 
 
 # Error substrings that indicate a transient *connection* failure worth retrying.
@@ -5375,6 +5380,131 @@ class BasePlatformAdapter(ABC):
         except Exception as e:
             logger.warning("[%s] %s hook failed: %s", self.name, hook_name, e)
 
+    async def _run_terminal_hook_bounded(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> bool:
+        """Run terminal lifecycle publication despite caller cancellation.
+
+        The hook owns network I/O for Relay, so it is shielded from the parent
+        task's cancellation but strictly bounded. A second cancellation waits
+        once more for the same shielded task; a timeout cancels the hook and
+        lets handoff continue honestly instead of blocking without limit.
+        Returns whether cancellation arrived while awaiting the hook; callers
+        propagate it only after their handoff/cleanup boundary is complete.
+        """
+        task = asyncio.create_task(
+            self._run_processing_hook("on_processing_complete", event, outcome)
+        )
+        cancelled = False
+        cancel_hook = False
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(task), timeout=_TERMINAL_HOOK_TIMEOUT_SECONDS
+            )
+        except asyncio.CancelledError:
+            # A hook that cancels itself is a failed best-effort terminal send,
+            # not cancellation of the owning processing task. Distinguish it
+            # before deferring an actual outer cancellation.
+            if task.cancelled():
+                logger.warning("[%s] terminal processing hook was cancelled", self.name)
+                return False
+            cancelled = True
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(task), timeout=_TERMINAL_HOOK_TIMEOUT_SECONDS
+                )
+            except asyncio.TimeoutError:
+                cancel_hook = True
+            except asyncio.CancelledError:
+                # Either the hook cancelled internally while outer cancellation
+                # was deferred, or another outer cancel arrived. In both cases
+                # cleanup must continue; reap the hook if it is still running.
+                cancel_hook = not task.done()
+        except asyncio.TimeoutError:
+            cancel_hook = True
+            logger.warning("[%s] terminal processing hook timed out", self.name)
+        finally:
+            if cancel_hook and not task.done():
+                task.cancel()
+                try:
+                    await asyncio.wait_for(asyncio.shield(task), timeout=0.25)
+                except asyncio.CancelledError:
+                    # Expected from the child cancellation. A repeated outer
+                    # cancellation is also deferred to the safe propagation
+                    # point below.
+                    if not task.done():
+                        cancelled = True
+                        task.cancel()
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "[%s] terminal processing hook did not reap after cancellation",
+                        self.name,
+                    )
+            if task.done() and not task.cancelled():
+                try:
+                    task.exception()
+                except Exception:
+                    pass
+        return cancelled
+
+    async def _run_post_delivery_callback_bounded(self, callback: Any) -> bool:
+        """Run and reap one post-delivery callback without leaking cancellation.
+
+        Relay terminal publication and session handoff happen after this
+        callback.  An outer cancellation therefore stops the callback, but is
+        deferred until those owner-state and cleanup boundaries have run.
+        Returns whether such an outer cancellation was observed.
+        """
+        try:
+            result = callback()
+        except asyncio.CancelledError:
+            logger.warning("[%s] post-delivery callback cancelled itself", self.name)
+            return False
+        except Exception as exc:
+            logger.warning("[%s] post-delivery callback failed: %s", self.name, exc)
+            return False
+        if not inspect.isawaitable(result):
+            return False
+
+        task = asyncio.ensure_future(result)
+        cancelled = False
+        cancel_callback = False
+        try:
+            done, _pending = await asyncio.wait(
+                {task}, timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS
+            )
+            cancel_callback = not done
+            if cancel_callback:
+                logger.warning("[%s] post-delivery callback timed out", self.name)
+        except asyncio.CancelledError:
+            cancelled = True
+            cancel_callback = not task.done()
+        finally:
+            if cancel_callback and not task.done():
+                task.cancel()
+                deadline = asyncio.get_running_loop().time() + 0.25
+                while not task.done():
+                    remaining = deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        logger.warning(
+                            "[%s] post-delivery callback did not reap after cancellation",
+                            self.name,
+                        )
+                        break
+                    try:
+                        await asyncio.wait({task}, timeout=remaining)
+                    except asyncio.CancelledError:
+                        # Repeated outer cancellation is remembered but cannot
+                        # skip terminal publication or owner/session cleanup.
+                        cancelled = True
+                        task.cancel()
+            if task.done() and not task.cancelled():
+                try:
+                    task.exception()
+                except Exception:
+                    pass
+        return cancelled
+
     @staticmethod
     def _is_retryable_error(error: Optional[str]) -> bool:
         """Return True if the error string looks like a transient network failure."""
@@ -5637,7 +5767,11 @@ class BasePlatformAdapter(ABC):
                 last_ts=now,
             )
             store[session_key] = state
+            if getattr(event, "owner_id", None):
+                event.metadata["relay_owner_disposition"] = "queued"
         else:
+            if getattr(event, "owner_id", None):
+                event.metadata["relay_owner_disposition"] = "merged"
             if event.text:
                 state.event.text = (
                     f"{state.event.text}\n{event.text}"
@@ -5866,6 +6000,9 @@ class BasePlatformAdapter(ABC):
             # hashable and do not support lifecycle callbacks.
             self._session_tasks.pop(session_key, None)
             self._release_session_guard(session_key, guard=guard)
+            if getattr(event, "owner_id", None):
+                event.metadata["relay_owner_disposition"] = "rejected"
+                event.metadata["relay_owner_disposition_reason"] = "task_capacity"
             return False
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
@@ -6256,6 +6393,9 @@ class BasePlatformAdapter(ABC):
         # Track delivery outcomes for the processing-complete hook
         delivery_attempted = False
         delivery_succeeded = False
+        terminal_outcome = ProcessingOutcome.FAILURE
+        terminal_hook_finished = False
+        terminal_hook_cancelled = False
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
@@ -6778,71 +6918,62 @@ class BasePlatformAdapter(ABC):
                 )
                 or ""
             )
-            await self._run_processing_hook(
-                "on_processing_complete",
-                event,
-                ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE,
+            terminal_outcome = (
+                ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE
             )
-
-            # The active drain owns debounce state. If a queue-mode timer has
-            # not fired yet, force-flush into _pending_messages here and let
-            # this task hand off the follow-up.
-            _handoff_guard = self._active_sessions.get(session_key)
-            if _handoff_guard is not None:
-                await self._wait_session_handoff_barrier(_handoff_guard)
-            await self._flush_text_debounce_now(session_key)
-
-            # Check if there's a pending message that was queued during our processing
-            if session_key in self._pending_messages:
-                pending_event = self._pending_messages.pop(session_key)
-                logger.debug("[%s] Processing queued follow-up message", self.name)
-                # Keep the _active_sessions entry live across the turn chain
-                # and only CLEAR the interrupt Event — do NOT delete the entry.
-                # If we deleted here, a concurrent inbound message arriving
-                # during the awaits below would pass the Level-1 guard, spawn
-                # its own _process_message_background, and run simultaneously
-                # with the recursive drain below.  Two agents on one
-                # session_key = duplicate responses, duplicate tool calls.
-                # Clearing the Event keeps the guard live so follow-ups take
-                # the busy-handler path as intended.
-                _active = self._active_sessions.get(session_key)
-                if _active is not None:
-                    _active.clear()
-                    self._bind_session_guard_event(_active, pending_event)
-                await _stop_typing_task()
-                if _active is not None:
-                    await self._wait_session_handoff_barrier(_active)
-                # Spawn a fresh task for the pending message instead of
-                # recursing.  Issue #17758: `await
-                # self._process_message_background(...)` here grew the
-                # call stack one frame per chained follow-up, and under
-                # sustained pending-queue activity the C stack would
-                # exhaust at ~2000 frames and SIGSEGV the process.
-                # Mirror the late-arrival drain pattern below: hand off
-                # to a new task and return so this frame can unwind.
-                drain_task = asyncio.create_task(
-                    self._process_message_background(pending_event, session_key)
+            if self.platform != Platform.RELAY:
+                # Preserve the established generic-platform ordering: reactions
+                # and the queued successor start before a potentially slow
+                # generation-owned post-delivery callback. Relay alone defers
+                # terminal publication because its completion frame must include
+                # the frozen successor owner and follow visible callback unwind.
+                await self._run_processing_hook(
+                    "on_processing_complete", event, terminal_outcome
                 )
-                # Hand ownership of the session to the drain task so
-                # stale-lock detection keeps working while it runs.
-                self._session_tasks[session_key] = drain_task
-                try:
-                    self._background_tasks.add(drain_task)
-                    drain_task.add_done_callback(self._background_tasks.discard)
-                except TypeError:
-                    # Tests stub create_task() with non-hashable sentinels; tolerate.
-                    pass
-                return  # Drain task owns the session now.
+                terminal_hook_finished = True
+                _handoff_guard = self._active_sessions.get(session_key)
+                if _handoff_guard is not None:
+                    await self._wait_session_handoff_barrier(_handoff_guard)
+                await self._flush_text_debounce_now(session_key)
+                pending_event = self._pending_messages.pop(session_key, None)
+                if pending_event is not None:
+                    logger.debug("[%s] Processing queued follow-up message", self.name)
+                    _active = self._active_sessions.get(session_key)
+                    if _active is not None:
+                        _active.clear()
+                        self._bind_session_guard_event(_active, pending_event)
+                    await _stop_typing_task()
+                    if _active is not None:
+                        await self._wait_session_handoff_barrier(_active)
+                    drain_task = asyncio.create_task(
+                        self._process_message_background(pending_event, session_key)
+                    )
+                    self._session_tasks[session_key] = drain_task
+                    try:
+                        self._background_tasks.add(drain_task)
+                        drain_task.add_done_callback(self._background_tasks.discard)
+                    except TypeError:
+                        pass
+                    return
                 
         except asyncio.CancelledError:
             current_task = asyncio.current_task()
-            outcome = ProcessingOutcome.CANCELLED
+            terminal_outcome = ProcessingOutcome.CANCELLED
             if current_task is None or current_task not in self._expected_cancelled_tasks:
-                outcome = ProcessingOutcome.FAILURE
-            await self._run_processing_hook("on_processing_complete", event, outcome)
+                terminal_outcome = ProcessingOutcome.FAILURE
+            if self.platform != Platform.RELAY:
+                await self._run_processing_hook(
+                    "on_processing_complete", event, terminal_outcome
+                )
+                terminal_hook_finished = True
             raise
         except Exception as e:
-            await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
+            terminal_outcome = ProcessingOutcome.FAILURE
+            if self.platform != Platform.RELAY:
+                await self._run_processing_hook(
+                    "on_processing_complete", event, terminal_outcome
+                )
+                terminal_hook_finished = True
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
             try:
@@ -6892,15 +7023,18 @@ class BasePlatformAdapter(ABC):
             else:
                 _post_cb = getattr(self, "_post_delivery_callbacks", {}).pop(session_key, None)
             if callable(_post_cb):
-                try:
-                    _post_result = _post_cb()
-                    if inspect.isawaitable(_post_result):
-                        await asyncio.wait_for(
-                            _post_result,
-                            timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
-                        )
-                except (asyncio.TimeoutError, Exception):
-                    pass
+                post_delivery_cancelled = (
+                    await self._run_post_delivery_callback_bounded(_post_cb)
+                )
+                if post_delivery_cancelled:
+                    current_task = asyncio.current_task()
+                    terminal_outcome = ProcessingOutcome.CANCELLED
+                    if (
+                        current_task is None
+                        or current_task not in self._expected_cancelled_tasks
+                    ):
+                        terminal_outcome = ProcessingOutcome.FAILURE
+                    terminal_hook_cancelled = True
             # Some adapters keep platform-level typing tasks.  If callback
             # work or a late refresh recreated one, make one final bounded stop
             # before releasing the session guard.
@@ -6910,6 +7044,18 @@ class BasePlatformAdapter(ABC):
                 metadata=_thread_metadata,
                 stop_attempts=1,
             )
+            # Freeze the already-admitted queued head before terminal
+            # publication. Relay's owner-transition lock then snapshots this
+            # exact event into turn_completed before the successor guard binds.
+            await self._flush_text_debounce_now(session_key)
+            # Content projection and generation-owned post-delivery callbacks
+            # are part of this turn's visible unwind. Publish terminal state
+            # after both, but before any queued successor binds its guard.
+            if not terminal_hook_finished:
+                terminal_hook_cancelled = (
+                    await self._run_terminal_hook_bounded(event, terminal_outcome)
+                    or terminal_hook_cancelled
+                )
             # Final drain/release boundary: force-flush any timer that missed
             # the in-band drain before deciding whether the guard can clear.
             _handoff_guard = self._active_sessions.get(session_key)
@@ -6985,6 +7131,8 @@ class BasePlatformAdapter(ABC):
                 current_task = asyncio.current_task()
                 if current_task is not None and self._session_tasks.get(session_key) is current_task:
                     self._cleanup_finished_session_task(session_key, interrupt_event)
+            if terminal_hook_cancelled:
+                raise asyncio.CancelledError
     
     def _cleanup_finished_session_task(
         self, session_key: str, interrupt_event: Optional[asyncio.Event]

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6141,13 +6141,20 @@ class BasePlatformAdapter(ABC):
                         message_id=_r.message_id,
                         ttl_seconds=_eph_ttl,
                     )
-            # Old adapter task (if any) is cancelled AFTER the response has
-            # been sent — keeps ordering deterministic and avoids the race.
-            await self.cancel_session_processing(
-                session_key,
-                release_guard=False,
-                discard_pending=False,
-            )
+            # The control delivery is not a new model turn.  On relay it is
+            # absorbed by the guard it is about to stop, so the connector can
+            # retire B without ever inventing a short-lived owner for it.
+            if getattr(event, "owner_id", None) and current_guard is not None:
+                prior_owner = getattr(current_guard, "_hermes_owner_id", None)
+                if isinstance(prior_owner, str) and prior_owner:
+                    event.metadata["relay_owner_disposition"] = "absorbed"
+                    event.metadata["relay_owner_canonical_id"] = prior_owner
+
+            # The response is already visible.  Do not make every platform's
+            # /stop,/new,/reset latency inherit the bounded cancellation timeout
+            # of a wedged previous task; the command guard remains installed
+            # until this detached cleanup drains it and any queued successor.
+            self._schedule_active_session_command_cleanup(session_key, command_guard)
         except Exception:
             # On failure, restore the original guard if one still exists so
             # we don't leave the session in a half-reset state.
@@ -6158,7 +6165,35 @@ class BasePlatformAdapter(ABC):
                     self._release_session_guard(session_key, guard=command_guard)
             raise
 
-        await self._drain_pending_after_session_command(session_key, command_guard)
+    def _schedule_active_session_command_cleanup(
+        self, session_key: str, command_guard: asyncio.Event
+    ) -> None:
+        """Finish a reset-like command without holding its response hostage."""
+
+        async def _cleanup() -> None:
+            try:
+                await self.cancel_session_processing(
+                    session_key,
+                    release_guard=False,
+                    discard_pending=False,
+                )
+            except asyncio.CancelledError:
+                # Shutdown may cancel detached cleanup.  The guarded drain in
+                # finally still releases the adapter state deterministically.
+                logger.debug("[%s] Command cleanup cancelled for %s", self.name, session_key)
+            except Exception:
+                logger.debug("[%s] Command cleanup failed for %s", self.name, session_key, exc_info=True)
+            finally:
+                try:
+                    await self._drain_pending_after_session_command(
+                        session_key, command_guard
+                    )
+                except Exception:
+                    logger.debug("[%s] Command pending drain failed for %s", self.name, session_key, exc_info=True)
+
+        cleanup_task = asyncio.create_task(_cleanup())
+        self._background_tasks.add(cleanup_task)
+        cleanup_task.add_done_callback(self._background_tasks.discard)
 
     async def handle_message(self, event: MessageEvent) -> None:
         """

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -23,6 +23,10 @@ import weakref
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
+from gateway.interrupt_budget import (
+    SESSION_HANDOFF_BARRIER_TIMEOUT_SECONDS,
+    SESSION_PROCESSING_CANCEL_TIMEOUT_SECONDS,
+)
 from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
@@ -2347,7 +2351,7 @@ class MessageEvent:
     # clarify resolvers) BEFORE normal dispatch; native adapters never set it
     # (their button callbacks resolve in-process).
     prompt_response: Optional[Dict[str, Any]] = None
-    
+
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.
     auto_skill: Optional[str | list[str]] = None
@@ -2375,6 +2379,18 @@ class MessageEvent:
 
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
+
+    # Opaque relay turn-owner identity. Appended after the established event
+    # fields to preserve MessageEvent's legacy positional-call compatibility.
+    # The authenticated relay connector puts the same value on the original
+    # inbound event and a later ``interrupt_inbound`` frame. RelayAdapter binds
+    # it to the active session guard so a delayed stop cannot target a
+    # replacement turn that happens to reuse the same session key. Native
+    # adapters leave it unset.
+    owner_id: Optional[str] = None
+    # Presence is distinct from parsed shape: malformed structured prompt
+    # controls remain terminal and must never become command text.
+    prompt_response_present: bool = False
     
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
@@ -3064,6 +3080,12 @@ class BasePlatformAdapter(ABC):
         self._post_delivery_callbacks: Dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
+        # Optional runtime-owner hard-stop seam. Relay uses this to route a
+        # generation-validated connector interrupt through GatewayRunner's
+        # canonical hard-stop lifecycle before cancelling the adapter monitor.
+        self._session_interrupt_handler: Optional[
+            Callable[[str, SessionSource, str, int], Awaitable[bool]]
+        ] = None
         # Optional authorization check, registered by GatewayRunner. Used by
         # adapters that fetch external context (e.g. Slack thread history) to
         # mark senders not on the allowlist as unverified in LLM context,
@@ -3629,6 +3651,13 @@ class BasePlatformAdapter(ABC):
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
+
+    def set_session_interrupt_handler(
+        self,
+        handler: Optional[Callable[[str, SessionSource, str, int], Awaitable[bool]]],
+    ) -> None:
+        """Install the runtime-owner hard-stop seam used by control transports."""
+        self._session_interrupt_handler = handler
 
     def set_reaction_handler(
         self, handler: Optional[Callable[[Dict[str, Any]], Awaitable[None]]]
@@ -5750,6 +5779,62 @@ class BasePlatformAdapter(ABC):
         self._discard_text_debounce(session_key)
         return True
 
+    def session_key_for_source(self, source: SessionSource) -> str:
+        """Return this adapter's authoritative active-session key."""
+        return build_session_key(
+            source,
+            group_sessions_per_user=self.config.extra.get(
+                "group_sessions_per_user", True
+            ),
+            thread_sessions_per_user=self.config.extra.get(
+                "thread_sessions_per_user", False
+            ),
+        )
+
+    @staticmethod
+    def _bind_session_guard_event(guard: asyncio.Event, event: MessageEvent) -> None:
+        """Rebind a reused handoff guard to exactly one inbound turn owner."""
+        for attribute in (
+            "_hermes_owner_id",
+            "_hermes_run_generation",
+            "_hermes_runner_session_key",
+        ):
+            if hasattr(guard, attribute):
+                delattr(guard, attribute)
+        owner_id = getattr(event, "owner_id", None)
+        if isinstance(owner_id, str) and owner_id:
+            setattr(guard, "_hermes_owner_id", owner_id)
+        source = getattr(event, "source", None)
+        if source is not None:
+            setattr(guard, "_hermes_session_source", source)
+
+    @staticmethod
+    async def _wait_session_handoff_barrier(guard: asyncio.Event) -> None:
+        """Hold queued handoff for a bounded canonical hard-stop interval."""
+        barrier = getattr(guard, "_hermes_hard_stop_reap_barrier", None)
+        if barrier is not None and not barrier.is_set():
+            try:
+                completed = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        barrier.wait,
+                        SESSION_HANDOFF_BARRIER_TIMEOUT_SECONDS,
+                    ),
+                    timeout=SESSION_HANDOFF_BARRIER_TIMEOUT_SECONDS + 0.1,
+                )
+            except asyncio.TimeoutError:
+                completed = False
+            if not completed:
+                logger.warning(
+                    "[%s] Hard-stop handoff barrier exceeded %.1fs; "
+                    "discarding the stale barrier so the session can recover",
+                    getattr(guard, "_hermes_adapter_name", "platform"),
+                    SESSION_HANDOFF_BARRIER_TIMEOUT_SECONDS,
+                )
+        if barrier is not None and getattr(
+            guard, "_hermes_hard_stop_reap_barrier", None
+        ) is barrier:
+            delattr(guard, "_hermes_hard_stop_reap_barrier")
+
     def _start_session_processing(
         self,
         event: MessageEvent,
@@ -5765,6 +5850,11 @@ class BasePlatformAdapter(ABC):
         session lock.
         """
         guard = interrupt_event or asyncio.Event()
+        # Bind relay wire ownership before the task starts. The runner later
+        # adds its monotonically increasing run generation to this same guard;
+        # an interrupt must match both values before either lifecycle layer is
+        # allowed to stop the turn.
+        self._bind_session_guard_event(guard, event)
         self._active_sessions[session_key] = guard
 
         task = asyncio.create_task(self._process_message_background(event, session_key))
@@ -5811,14 +5901,19 @@ class BasePlatformAdapter(ABC):
             self._expected_cancelled_tasks.add(task)
             task.cancel()
             try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
+                await asyncio.wait_for(
+                    asyncio.shield(task),
+                    timeout=SESSION_PROCESSING_CANCEL_TIMEOUT_SECONDS,
+                )
             except asyncio.CancelledError:
                 pass
             except asyncio.TimeoutError:
                 logger.warning(
-                    "[%s] Cancelled task for %s did not exit within 5s; "
+                    "[%s] Cancelled task for %s did not exit within %.1fs; "
                     "unblocking dispatch and letting the task unwind in the background",
-                    self.name, session_key,
+                    self.name,
+                    session_key,
+                    SESSION_PROCESSING_CANCEL_TIMEOUT_SECONDS,
                 )
             except Exception:
                 logger.debug(
@@ -5952,11 +6047,7 @@ class BasePlatformAdapter(ABC):
         if needs_topic_recovery:
             await asyncio.to_thread(self._apply_topic_recovery, event)
 
-        session_key = build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-        )
+        session_key = self.session_key_for_source(event.source)
 
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or
@@ -6696,6 +6787,9 @@ class BasePlatformAdapter(ABC):
             # The active drain owns debounce state. If a queue-mode timer has
             # not fired yet, force-flush into _pending_messages here and let
             # this task hand off the follow-up.
+            _handoff_guard = self._active_sessions.get(session_key)
+            if _handoff_guard is not None:
+                await self._wait_session_handoff_barrier(_handoff_guard)
             await self._flush_text_debounce_now(session_key)
 
             # Check if there's a pending message that was queued during our processing
@@ -6714,7 +6808,10 @@ class BasePlatformAdapter(ABC):
                 _active = self._active_sessions.get(session_key)
                 if _active is not None:
                     _active.clear()
+                    self._bind_session_guard_event(_active, pending_event)
                 await _stop_typing_task()
+                if _active is not None:
+                    await self._wait_session_handoff_barrier(_active)
                 # Spawn a fresh task for the pending message instead of
                 # recursing.  Issue #17758: `await
                 # self._process_message_background(...)` here grew the
@@ -6815,6 +6912,9 @@ class BasePlatformAdapter(ABC):
             )
             # Final drain/release boundary: force-flush any timer that missed
             # the in-band drain before deciding whether the guard can clear.
+            _handoff_guard = self._active_sessions.get(session_key)
+            if _handoff_guard is not None:
+                await self._wait_session_handoff_barrier(_handoff_guard)
             await self._flush_text_debounce_now(session_key)
             # Late-arrival drain: a message may have arrived during the
             # cleanup awaits above (typing_task cancel, stop_typing).  Such
@@ -6848,6 +6948,8 @@ class BasePlatformAdapter(ABC):
                     _active = self._active_sessions.get(session_key)
                     if _active is not None:
                         _active.clear()
+                        self._bind_session_guard_event(_active, late_pending)
+                        await self._wait_session_handoff_barrier(_active)
                     drain_task = asyncio.create_task(
                         self._process_message_background(late_pending, session_key)
                     )

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -27,7 +27,12 @@ from typing import Any, Callable, Dict, Optional, Tuple, cast
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
-from gateway.relay.descriptor import CapabilityDescriptor
+from gateway.relay.descriptor import (
+    OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+    OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+    OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
+    CapabilityDescriptor,
+)
 from gateway.relay.media import RelayMediaClient
 from gateway.relay.transport import RelayTransport, normalize_owner_id
 from gateway.session import SessionSource
@@ -77,6 +82,11 @@ class RelayAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.RELAY)
         self.descriptor = descriptor
         self._transport = transport
+        # The transport reader already serializes inbound frames. This lock
+        # additionally serializes that reader against terminal owner snapshots,
+        # so no event can be half-admitted while completion chooses idle vs.
+        # queued handoff.
+        self._owner_transition_lock = asyncio.Lock()
         # Recently accepted owner-bound Stops survive a transient transport
         # reconnect on this adapter instance. If the correlated result was
         # lost with the socket, a retry for that exact owner is acknowledged
@@ -369,17 +379,54 @@ class RelayAdapter(BasePlatformAdapter):
         self.MAX_MESSAGE_LENGTH = descriptor.max_message_length
         self.supports_code_blocks = descriptor.markdown_dialect not in ("", "plain")
 
-    async def _on_inbound(self, event) -> None:
+    async def _on_inbound(self, event) -> Dict[str, Any]:
+        async with self._owner_transition_lock:
+            return await self._on_inbound_locked(event)
+
+    async def _on_inbound_locked(self, event) -> Dict[str, Any]:
         """Bridge a connector-delivered MessageEvent into the normal adapter path."""
         self._capture_scope(event)
         self._stamp_slack_session_thread(event)
+        session_key = self.session_key_for_source(event.source)
+        event.metadata["relay_session_key"] = session_key
+        event.metadata["relay_chat_id"] = str(event.source.chat_id)
+
+        def guarded_owner() -> Optional[str]:
+            guard = self._active_sessions.get(session_key)
+            return normalize_owner_id(getattr(guard, "_hermes_owner_id", None))
+
+        owner_before = guarded_owner()
         # Phase 3: a structured prompt answer resolves its waiting primitive
         # (approval/confirm/clarify) and is always CONSUMED — duplicate,
         # unknown, or expired control frames must never dispatch as chat text.
         if await self._consume_prompt_response(event):
-            return
+            return {
+                "disposition": "absorbed" if owner_before else "rejected",
+                "canonical_turn_owner_id": owner_before,
+                "session_key": session_key,
+                "chat_id": str(event.source.chat_id),
+                "reason": None if owner_before else "no_active_turn",
+            }
         await self._localize_inbound_media(event)
         await self.handle_message(event)
+        owner_after = guarded_owner()
+        requested_owner = normalize_owner_id(getattr(event, "owner_id", None))
+        marked = event.metadata.get("relay_owner_disposition")
+        if owner_after is not None and owner_after == requested_owner:
+            disposition = "started"
+        elif marked in {"queued", "absorbed", "merged", "rejected"}:
+            disposition = marked
+        elif owner_after is not None:
+            disposition = "absorbed"
+        else:
+            disposition = "rejected"
+        return {
+            "disposition": disposition,
+            "canonical_turn_owner_id": owner_after,
+            "session_key": session_key,
+            "chat_id": str(event.source.chat_id),
+            "reason": event.metadata.get("relay_owner_disposition_reason"),
+        }
 
     def _relay_slack_extra(self) -> Dict[str, Any]:
         """The Slack-behavior subset of the RELAY platform config.
@@ -2333,6 +2380,12 @@ class RelayAdapter(BasePlatformAdapter):
 
     async def on_processing_start(self, event) -> None:
         """Add the 👀 in-progress reaction (op-gated; silent no-op otherwise)."""
+        publish_started = getattr(self._transport, "send_turn_started", None)
+        if callable(publish_started):
+            try:
+                await publish_started(event)
+            except Exception:
+                logger.debug("relay owner-start publication failed", exc_info=True)
         message_id = getattr(event, "message_id", None) or getattr(
             event.source, "message_id", None
         )
@@ -2341,20 +2394,76 @@ class RelayAdapter(BasePlatformAdapter):
             await self._react(str(chat_id), str(message_id), "👀")
 
     async def on_processing_complete(self, event, outcome) -> None:
-        """Swap 👀 for ✅/❌ per outcome (op-gated; silent no-op otherwise)."""
+        """Project the terminal reaction, then emit owner-bound completion.
+
+        BasePlatformAdapter invokes this hook after the message handler has
+        returned (the runner has flushed transcript/tool/child state) and after
+        the final response/media projection, but before it binds or starts a
+        queued follow-up. That ordering is the relay handoff barrier.
+        """
         from gateway.platforms.base import ProcessingOutcome
 
+        transport = self._transport
+        owner_id = normalize_owner_id(getattr(event, "owner_id", None))
+        source = getattr(event, "source", None)
+        chat_id = str(getattr(source, "chat_id", "") or "")
+        if (
+            transport is None
+            or owner_id is None
+            or not chat_id
+            or not self.descriptor.supports_capability(
+                OWNER_BOUND_INTERRUPT_ACK_CAPABILITY
+            )
+            or not self.descriptor.supports_capability(
+                OWNER_BOUND_TURN_COMPLETION_CAPABILITY
+            )
+            or not self.descriptor.supports_capability(
+                OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY
+            )
+        ):
+            return
+        send_completion = getattr(transport, "send_turn_completed", None)
+        if not callable(send_completion):
+            return
+        outcomes = {
+            ProcessingOutcome.SUCCESS: "completed",
+            ProcessingOutcome.FAILURE: "failed",
+            ProcessingOutcome.CANCELLED: "cancelled",
+        }
+        wire_outcome = outcomes.get(outcome)
+        if wire_outcome is None:
+            return
+        session_key = self.session_key_for_source(source)
+        async with self._owner_transition_lock:
+            next_event = self._pending_messages.get(session_key)
+            next_owner_id = normalize_owner_id(
+                getattr(next_event, "owner_id", None)
+            )
+            next_metadata = getattr(next_event, "metadata", {}) or {}
+            next_delivery_id = next_metadata.get("relay_delivery_id")
+            if not isinstance(next_delivery_id, str):
+                next_owner_id = None
+                next_delivery_id = None
+            await send_completion(
+                session_key,
+                chat_id,
+                owner_id,
+                wire_outcome,
+                next_owner_id,
+                next_delivery_id,
+            )
+
+        # Reactions are cosmetic and follow the authoritative terminal record;
+        # a slow connector can no longer delay completion or queued handoff.
         message_id = getattr(event, "message_id", None) or getattr(
             event.source, "message_id", None
         )
-        chat_id = getattr(event.source, "chat_id", None)
-        if not (message_id and chat_id):
-            return
-        await self._react(str(chat_id), str(message_id), "👀", remove=True)
-        if outcome == ProcessingOutcome.SUCCESS:
-            await self._react(str(chat_id), str(message_id), "✅")
-        elif outcome == ProcessingOutcome.FAILURE:
-            await self._react(str(chat_id), str(message_id), "❌")
+        if message_id:
+            await self._react(chat_id, str(message_id), "👀", remove=True)
+            if outcome == ProcessingOutcome.SUCCESS:
+                await self._react(chat_id, str(message_id), "✅")
+            elif outcome == ProcessingOutcome.FAILURE:
+                await self._react(chat_id, str(message_id), "❌")
 
     # ── Phase 4 thread lifecycle ──────────────────────────────────────────
 

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -420,9 +420,20 @@ class RelayAdapter(BasePlatformAdapter):
             disposition = "absorbed"
         else:
             disposition = "rejected"
+        canonical_owner = owner_after
+        if disposition == "absorbed":
+            # Reset-like bypass commands are control traffic for the already
+            # running owner. Their temporary command guard intentionally has
+            # no owner, so preserve the pre-dispatch guard identity rather than
+            # reporting a phantom B or a false terminal rejection.
+            marked_owner = normalize_owner_id(
+                event.metadata.get("relay_owner_canonical_id")
+            )
+            if marked_owner is not None:
+                canonical_owner = marked_owner
         return {
             "disposition": disposition,
-            "canonical_turn_owner_id": owner_after,
+            "canonical_turn_owner_id": canonical_owner,
             "session_key": session_key,
             "chat_id": str(event.source.chat_id),
             "reason": event.metadata.get("relay_owner_disposition_reason"),
@@ -2407,10 +2418,25 @@ class RelayAdapter(BasePlatformAdapter):
         owner_id = normalize_owner_id(getattr(event, "owner_id", None))
         source = getattr(event, "source", None)
         chat_id = str(getattr(source, "chat_id", "") or "")
+        if not chat_id:
+            return
+
+        # Reactions reflect a visible message, not an owner lifecycle. In
+        # particular passthrough work has no relay owner and may be connected
+        # to a pre-v3 peer, but its 👀 still needs a terminal projection.
+        message_id = getattr(event, "message_id", None) or getattr(
+            event.source, "message_id", None
+        )
+        if message_id:
+            await self._react(chat_id, str(message_id), "👀", remove=True)
+            if outcome == ProcessingOutcome.SUCCESS:
+                await self._react(chat_id, str(message_id), "✅")
+            elif outcome == ProcessingOutcome.FAILURE:
+                await self._react(chat_id, str(message_id), "❌")
+
         if (
             transport is None
             or owner_id is None
-            or not chat_id
             or not self.descriptor.supports_capability(
                 OWNER_BOUND_INTERRUPT_ACK_CAPABILITY
             )
@@ -2452,18 +2478,6 @@ class RelayAdapter(BasePlatformAdapter):
                 next_owner_id,
                 next_delivery_id,
             )
-
-        # Reactions are cosmetic and follow the authoritative terminal record;
-        # a slow connector can no longer delay completion or queued handoff.
-        message_id = getattr(event, "message_id", None) or getattr(
-            event.source, "message_id", None
-        )
-        if message_id:
-            await self._react(chat_id, str(message_id), "👀", remove=True)
-            if outcome == ProcessingOutcome.SUCCESS:
-                await self._react(chat_id, str(message_id), "✅")
-            elif outcome == ProcessingOutcome.FAILURE:
-                await self._react(chat_id, str(message_id), "❌")
 
     # ── Phase 4 thread lifecycle ──────────────────────────────────────────
 

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -423,9 +423,9 @@ class RelayAdapter(BasePlatformAdapter):
         canonical_owner = owner_after
         if disposition == "absorbed":
             # Reset-like bypass commands are control traffic for the already
-            # running owner. Their temporary command guard intentionally has
-            # no owner, so preserve the pre-dispatch guard identity rather than
-            # reporting a phantom B or a false terminal rejection.
+            # running owner. Their temporary command guard carries forward
+            # only the authoritative owner from the guard it replaced, so
+            # preserve that identity rather than reporting a phantom B.
             marked_owner = normalize_owner_id(
                 event.metadata.get("relay_owner_canonical_id")
             )
@@ -2405,7 +2405,7 @@ class RelayAdapter(BasePlatformAdapter):
             await self._react(str(chat_id), str(message_id), "👀")
 
     async def on_processing_complete(self, event, outcome) -> None:
-        """Project the terminal reaction, then emit owner-bound completion.
+        """Emit owner-bound completion, then project the terminal reaction.
 
         BasePlatformAdapter invokes this hook after the message handler has
         returned (the runner has flushed transcript/tool/child state) and after
@@ -2421,6 +2421,48 @@ class RelayAdapter(BasePlatformAdapter):
         if not chat_id:
             return
 
+        outcomes = {
+            ProcessingOutcome.SUCCESS: "completed",
+            ProcessingOutcome.FAILURE: "failed",
+            ProcessingOutcome.CANCELLED: "cancelled",
+        }
+        wire_outcome = outcomes.get(outcome)
+        send_completion = getattr(transport, "send_turn_completed", None)
+        if (
+            chat_id
+            and owner_id is not None
+            and wire_outcome is not None
+            and callable(send_completion)
+            and self.descriptor.supports_capability(
+                OWNER_BOUND_INTERRUPT_ACK_CAPABILITY
+            )
+            and self.descriptor.supports_capability(
+                OWNER_BOUND_TURN_COMPLETION_CAPABILITY
+            )
+            and self.descriptor.supports_capability(
+                OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY
+            )
+        ):
+            session_key = self.session_key_for_source(source)
+            async with self._owner_transition_lock:
+                next_event = self._pending_messages.get(session_key)
+                next_owner_id = normalize_owner_id(
+                    getattr(next_event, "owner_id", None)
+                )
+                next_metadata = getattr(next_event, "metadata", {}) or {}
+                next_delivery_id = next_metadata.get("relay_delivery_id")
+                if not isinstance(next_delivery_id, str):
+                    next_owner_id = None
+                    next_delivery_id = None
+                await send_completion(
+                    session_key,
+                    chat_id,
+                    owner_id,
+                    wire_outcome,
+                    next_owner_id,
+                    next_delivery_id,
+                )
+
         # Reactions reflect a visible message, not an owner lifecycle. In
         # particular passthrough work has no relay owner and may be connected
         # to a pre-v3 peer, but its 👀 still needs a terminal projection.
@@ -2433,51 +2475,6 @@ class RelayAdapter(BasePlatformAdapter):
                 await self._react(chat_id, str(message_id), "✅")
             elif outcome == ProcessingOutcome.FAILURE:
                 await self._react(chat_id, str(message_id), "❌")
-
-        if (
-            transport is None
-            or owner_id is None
-            or not self.descriptor.supports_capability(
-                OWNER_BOUND_INTERRUPT_ACK_CAPABILITY
-            )
-            or not self.descriptor.supports_capability(
-                OWNER_BOUND_TURN_COMPLETION_CAPABILITY
-            )
-            or not self.descriptor.supports_capability(
-                OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY
-            )
-        ):
-            return
-        send_completion = getattr(transport, "send_turn_completed", None)
-        if not callable(send_completion):
-            return
-        outcomes = {
-            ProcessingOutcome.SUCCESS: "completed",
-            ProcessingOutcome.FAILURE: "failed",
-            ProcessingOutcome.CANCELLED: "cancelled",
-        }
-        wire_outcome = outcomes.get(outcome)
-        if wire_outcome is None:
-            return
-        session_key = self.session_key_for_source(source)
-        async with self._owner_transition_lock:
-            next_event = self._pending_messages.get(session_key)
-            next_owner_id = normalize_owner_id(
-                getattr(next_event, "owner_id", None)
-            )
-            next_metadata = getattr(next_event, "metadata", {}) or {}
-            next_delivery_id = next_metadata.get("relay_delivery_id")
-            if not isinstance(next_delivery_id, str):
-                next_owner_id = None
-                next_delivery_id = None
-            await send_completion(
-                session_key,
-                chat_id,
-                owner_id,
-                wire_outcome,
-                next_owner_id,
-                next_delivery_id,
-            )
 
     # ── Phase 4 thread lifecycle ──────────────────────────────────────────
 

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -29,7 +29,7 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
 from gateway.relay.descriptor import CapabilityDescriptor
 from gateway.relay.media import RelayMediaClient
-from gateway.relay.transport import RelayTransport
+from gateway.relay.transport import RelayTransport, normalize_owner_id
 from gateway.session import SessionSource
 
 logger = logging.getLogger(__name__)
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 # reader, and ws.close (~3s), the full drain path stays inside 5s.
 _RELAY_GO_IDLE_ON_DISCONNECT_TIMEOUT_S = 2.0
 _RELAY_REVOCATION_MONITOR_TEARDOWN_TIMEOUT_S = 1.0
+_RELAY_TERMINAL_STOP_OWNER_CACHE = 512
 
 # How many already-answered prompt ids to remember, so a duplicate answer for
 # one of them (a double tap, or a connector redelivery of the same forward) is
@@ -76,6 +77,15 @@ class RelayAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.RELAY)
         self.descriptor = descriptor
         self._transport = transport
+        # Recently accepted owner-bound Stops survive a transient transport
+        # reconnect on this adapter instance. If the correlated result was
+        # lost with the socket, a retry for that exact owner is acknowledged
+        # idempotently without running canonical hard-stop twice. A gateway
+        # process restart creates a new adapter/cache and advertises a new
+        # runtime_epoch, which lets the connector clear any phantom owner.
+        self._terminal_stop_owners: OrderedDict[Tuple[str, str, str], None] = (
+            OrderedDict()
+        )
         # Capability surface read by stream_consumer (getattr(..., 4096)).
         self.MAX_MESSAGE_LENGTH = descriptor.max_message_length
         # chat_id -> scope_id (server/workspace scope), learned from inbound
@@ -364,9 +374,8 @@ class RelayAdapter(BasePlatformAdapter):
         self._capture_scope(event)
         self._stamp_slack_session_thread(event)
         # Phase 3: a structured prompt answer resolves its waiting primitive
-        # (approval/confirm/clarify) and is CONSUMED — it must not also
-        # dispatch as a chat message. Unknown/expired prompt ids fall through
-        # (the command-shaped text then behaves like a typed reply).
+        # (approval/confirm/clarify) and is always CONSUMED — duplicate,
+        # unknown, or expired control frames must never dispatch as chat text.
         if await self._consume_prompt_response(event):
             return
         await self._localize_inbound_media(event)
@@ -667,16 +676,117 @@ class RelayAdapter(BasePlatformAdapter):
         """Backward-compatible internal alias for follow-up routing."""
         return self.fronts_platform(platform)
 
-    async def on_interrupt(self, session_key: str, chat_id: str) -> None:
-        """Bridge a connector-delivered /stop into the adapter's interrupt path.
+    async def on_interrupt(
+        self,
+        session_key: str,
+        chat_id: str,
+        owner_id: Any = None,
+    ) -> bool:
+        """Hard-stop exactly the relay-owned active turn, fail-closed.
 
-        The connector forwards a mid-turn interrupt down the socket owned by
-        the gateway instance running ``session_key``; this routes it to the
-        existing per-session interrupt mechanism (sets the
-        ``_active_sessions[session_key]`` Event and clears typing), cancelling
-        the right turn without touching sibling sessions.
+        The runner callback is authoritative: it performs agent hard interrupt,
+        run-generation invalidation, terminal-child reaping, running-state
+        release, and cache eviction. Only after that callback returns do we
+        cancel the adapter-owned monitor and drain a queued handoff.
         """
-        await self.interrupt_session_activity(session_key, chat_id)
+        owner_id = normalize_owner_id(owner_id)
+        if not session_key or not chat_id or owner_id is None:
+            return False
+
+        terminal_owner_key = (session_key, chat_id, owner_id)
+        guard = self._active_sessions.get(session_key)
+        owner_task = self._session_tasks.get(session_key)
+        if (
+            guard is not None
+            and getattr(guard, "_hermes_owner_id", None) != owner_id
+        ):
+            return False
+        if guard is None or owner_task is None or owner_task.done():
+            if terminal_owner_key not in self._terminal_stop_owners:
+                return False
+            self._terminal_stop_owners.move_to_end(terminal_owner_key)
+            return True
+
+        source = getattr(guard, "_hermes_session_source", None)
+        run_generation = getattr(guard, "_hermes_run_generation", None)
+        if (
+            source is None
+            or str(getattr(source, "chat_id", "")) != chat_id
+            or not isinstance(run_generation, int)
+            or isinstance(run_generation, bool)
+            or run_generation < 1
+        ):
+            return False
+
+        hard_stop = self._session_interrupt_handler
+        if hard_stop is None:
+            return False
+        # Re-check both adapter owners immediately before the first await.
+        if (
+            self._active_sessions.get(session_key) is not guard
+            or self._session_tasks.get(session_key) is not owner_task
+        ):
+            return False
+        stop_was_cancelled = False
+        try:
+            stopped = await hard_stop(
+                session_key,
+                source,
+                owner_id,
+                run_generation,
+            )
+        except asyncio.CancelledError:
+            # Once this exact owner/generation has crossed the first await into
+            # GatewayRunner, hard interrupt + generation invalidation have
+            # already been applied synchronously. Finish the bounded adapter
+            # cleanup and report terminal acceptance instead of turning a
+            # half-applied Stop into a retryable NACK. Socket teardown may still
+            # make the result frame undeliverable; task cleanup remains bounded.
+            stop_was_cancelled = True
+            stopped = True
+        except Exception as exc:
+            logger.error(
+                "relay hard-stop callback failed reason=internal_error type=%s",
+                type(exc).__name__,
+            )
+            return False
+        if not stopped:
+            return False
+
+        self._terminal_stop_owners[terminal_owner_key] = None
+        self._terminal_stop_owners.move_to_end(terminal_owner_key)
+        while len(self._terminal_stop_owners) > _RELAY_TERMINAL_STOP_OWNER_CACHE:
+            self._terminal_stop_owners.popitem(last=False)
+
+        # Drop only this stopped generation's deferred callback before adapter
+        # cancellation enters the task's finally block. A fresher generation's
+        # callback (if already registered during a handoff) remains untouched.
+        self.pop_post_delivery_callback(
+            session_key,
+            generation=run_generation,
+        )
+
+        # Authoritative runner stop has completed. Cancel only the exact adapter
+        # task/guard snapshot; a replacement installed meanwhile must survive.
+        if (
+            self._active_sessions.get(session_key) is guard
+            and self._session_tasks.get(session_key) is owner_task
+        ):
+            await self.cancel_session_processing(
+                session_key,
+                release_guard=False,
+                discard_pending=False,
+            )
+        if (
+            self._active_sessions.get(session_key) is guard
+            and self._session_tasks.get(session_key) is None
+        ):
+            await self._drain_pending_after_session_command(session_key, guard)
+        if stop_was_cancelled:
+            logger.info(
+                "relay hard-stop caller cancelled after terminal Stop admission"
+            )
+        return True
 
     async def _on_passthrough(self, forward, buffer_id: Optional[str] = None) -> None:
         """Handle a connector-forwarded passthrough request (Phase 5 §5.1).
@@ -1999,13 +2109,18 @@ class RelayAdapter(BasePlatformAdapter):
     async def _consume_prompt_response(self, event) -> bool:
         """Route an inbound prompt_response to its waiting primitive.
 
-        Returns True when the event was a prompt answer (consumed — do NOT
-        dispatch it as a chat message), False otherwise.
+        Returns True for every structured prompt_response frame (consumed —
+        do NOT dispatch it as a chat message), even when its prompt id is
+        duplicate, expired, unknown, malformed, or belongs to a sibling
+        gateway instance. Only ordinary inbound text without a
+        prompt_response falls through to normal dispatch.
 
-        A prompt answer is ALWAYS consumed, whoever it belongs to. The three
-        non-resolving cases each stay silent rather than falling through to
-        chat dispatch:
+        The non-resolving cases each stay silent (or reply with a short
+        notice) rather than falling through to chat dispatch:
 
+        * **Malformed frame** (non-dict prompt_response payload, or missing/
+          blank prompt_id/option_id). Logged and dropped — nothing in a
+          prompt frame is ever valid command text.
         * **A sibling's prompt** (``_minted_here`` false). The connector fans a
           passthrough forward out to every live session of the tenant, so one
           button press reaches every gateway of that tenant while only the
@@ -2021,12 +2136,17 @@ class RelayAdapter(BasePlatformAdapter):
           anything useful with them.
         """
         pr = getattr(event, "prompt_response", None)
-        if not isinstance(pr, dict):
+        present = bool(getattr(event, "prompt_response_present", False))
+        if not present and not isinstance(pr, dict):
             return False
+        if not isinstance(pr, dict):
+            logger.info("relay consumed malformed structured prompt_response")
+            return True
         prompt_id = str(pr.get("prompt_id") or "")
         option_id = str(pr.get("option_id") or "")
         if not prompt_id or not option_id:
-            return False
+            logger.info("relay consumed malformed structured prompt_response")
+            return True
         if not self._minted_here(prompt_id):
             # A sibling gateway of this tenant owns this prompt and is
             # resolving it right now. Consume silently — two gateways must

--- a/gateway/relay/auth.py
+++ b/gateway/relay/auth.py
@@ -3,7 +3,7 @@
 The connector⇄gateway channel is authenticated because a gateway may be
 customer-managed and internet-exposed (see the connector repo
 ``docs/connector-gateway-auth-design.md``). This module is the **gateway half**
-of two HMAC schemes whose wire bytes must match the connector's TypeScript
+of three HMAC schemes whose wire bytes must match the connector's TypeScript
 exactly:
 
 1. **WS upgrade auth** (gateway → connector): the gateway presents
@@ -21,7 +21,12 @@ exactly:
    ``sig = HMAC_SHA256(f"{ts}.{body_json}", key).hexdigest()`` over the EXACT
    request body bytes, with a replay-window skew check.
 
-Both schemes use a **multi-secret verify list** (primary first, then a secondary
+3. **Turn-state scope fingerprint** (gateway → connector hello): raw retained
+   session/chat keys stay off a multiplexed hello. Both peers derive
+   ``HMAC_SHA256("relay-turn-state-v3\\0{session_key}\\0{chat_id}", secret)``
+   and the connector selects only its configured scope.
+
+The verification schemes use a **multi-secret verify list** (primary first, then a secondary
 during a rotation window), exactly like ``api/src/handlers/stats_oauth.ts`` — so
 a secret rotation doesn't invalidate outstanding tokens.
 
@@ -56,6 +61,11 @@ def _hmac_hex(payload: str, secret: str) -> str:
 def sign(payload: str, secret: str) -> str:
     """HMAC-SHA256 hex digest — the connector's ``sign`` (relayAuthToken.ts)."""
     return _hmac_hex(payload, secret)
+
+
+def turn_state_scope_fingerprint(secret: str, session_key: str, chat_id: str) -> str:
+    """Opaque authenticated scope selector for a v3 hello turn-state entry."""
+    return _hmac_hex(f"relay-turn-state-v3\0{session_key}\0{chat_id}", secret)
 
 
 def verify_signature(payload: str, sig_hex: str, secrets: Sequence[str]) -> bool:

--- a/gateway/relay/descriptor.py
+++ b/gateway/relay/descriptor.py
@@ -9,8 +9,9 @@ Telegram, Matrix, Signal, ... without per-platform branching.
 
 EXPERIMENTAL: this schema MAY CHANGE without a deprecation cycle until at least
 two real Class-1 platforms have validated it. Evolution during the experimental
-phase is additive-only, gated by ``contract_version`` (see
-docs/relay-connector-contract.md).
+phase keeps additions backward-compatible within a version; breaking or
+reinterpreted control semantics require a coordinated ``contract_version`` bump
+(see docs/relay-connector-contract.md).
 
 Field origins (most are a wire-serializable projection of ``PlatformEntry`` plus
 the per-instance capability methods on ``BasePlatformAdapter``):
@@ -33,10 +34,12 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass
 
-# Bump additively (never reinterpret an existing field) during the experimental
-# phase; a breaking change requires updating both repos in lockstep.
-CONTRACT_VERSION = 2
+# Never reinterpret an existing version. Breaking control semantics require a
+# version bump and coordinated updates in both repos.
+CONTRACT_VERSION = 3
 OWNER_BOUND_INTERRUPT_ACK_CAPABILITY = "owner-bound-interrupt-ack"
+OWNER_BOUND_TURN_COMPLETION_CAPABILITY = "owner-bound-turn-completion"
+OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY = "owner-bound-turn-reconciliation"
 
 
 @dataclass(frozen=True)

--- a/gateway/relay/descriptor.py
+++ b/gateway/relay/descriptor.py
@@ -35,7 +35,8 @@ from dataclasses import asdict, dataclass
 
 # Bump additively (never reinterpret an existing field) during the experimental
 # phase; a breaking change requires updating both repos in lockstep.
-CONTRACT_VERSION = 1
+CONTRACT_VERSION = 2
+OWNER_BOUND_INTERRUPT_ACK_CAPABILITY = "owner-bound-interrupt-ack"
 
 
 @dataclass(frozen=True)
@@ -68,10 +69,14 @@ class CapabilityDescriptor:
     # connector's sender for this platform actually implements (e.g.
     # ["send", "edit", "typing", "follow_up", "get_chat_info"]). Empty tuple =
     # the connector predates the field; callers MUST treat that as "legacy op
-    # set" (send/edit/typing/follow_up) rather than "nothing supported", so an
-    # old connector keeps working unchanged. Additive within contract_version 1.
+    # set" (send/edit/typing/follow_up) rather than "nothing supported".
+    # Legacy operation discovery predates v2 Stop acknowledgements and remains
+    # additive within contract version 1.
     # Stored as a tuple so the frozen dataclass stays hashable/immutable.
     supported_ops: tuple = ()
+    # Fail-closed control-plane negotiation. There is intentionally no legacy
+    # fallback: a Stop is safe only when both peers support correlated results.
+    capabilities: tuple = ()
 
     # The op set every connector supported before ``supported_ops`` existed.
     # Used as the assumed capability set when a legacy connector sends no list.
@@ -90,6 +95,9 @@ class CapabilityDescriptor:
         if not self.supported_ops:
             return op in self.LEGACY_OPS
         return op in self.supported_ops
+
+    def supports_capability(self, capability: str) -> bool:
+        return capability in self.capabilities
 
     def to_json(self) -> str:
         """Serialize to a compact, stable JSON string for the handshake frame."""
@@ -132,6 +140,16 @@ class CapabilityDescriptor:
                 )
             else:
                 filtered["supported_ops"] = ()
+        if "capabilities" in filtered:
+            raw_capabilities = filtered["capabilities"]
+            if isinstance(raw_capabilities, (list, tuple)):
+                filtered["capabilities"] = tuple(
+                    capability
+                    for capability in raw_capabilities
+                    if isinstance(capability, str) and capability
+                )
+            else:
+                filtered["capabilities"] = ()
         return cls(**filtered)
 
     @classmethod

--- a/gateway/relay/transport.py
+++ b/gateway/relay/transport.py
@@ -28,7 +28,7 @@ from gateway.platforms.base import MessageEvent
 from gateway.relay.descriptor import CapabilityDescriptor
 
 # Callback the transport invokes for each inbound normalized event.
-InboundHandler = Callable[[MessageEvent], Awaitable[None]]
+InboundHandler = Callable[[MessageEvent], Awaitable[Dict[str, Any]]]
 
 
 def normalize_owner_id(value: Any) -> Optional[str]:
@@ -114,6 +114,27 @@ class RelayTransport(Protocol):
         cancellation happens when the connector echoes an interrupt inbound
         (handled in Task 1.4).
         """
+        ...
+
+    async def send_turn_completed(
+        self,
+        session_key: str,
+        chat_id: str,
+        owner_id: str,
+        outcome: str,
+        next_owner_id: Optional[str] = None,
+        next_delivery_id: Optional[str] = None,
+    ) -> bool:
+        """Emit one owner-bound terminal-turn control frame.
+
+        Implementations must preserve the exact owner supplied by the inbound
+        event and bind it to their current runtime epoch. Returns ``False`` for
+        malformed/unnegotiated/duplicate completions.
+        """
+        ...
+
+    async def send_turn_started(self, event: MessageEvent) -> bool:
+        """Publish a queued inbound's authoritative transition to owner."""
         ...
 
     async def go_idle(self, timeout_s: float = 10.0) -> bool:

--- a/gateway/relay/transport.py
+++ b/gateway/relay/transport.py
@@ -30,6 +30,21 @@ from gateway.relay.descriptor import CapabilityDescriptor
 # Callback the transport invokes for each inbound normalized event.
 InboundHandler = Callable[[MessageEvent], Awaitable[None]]
 
+
+def normalize_owner_id(value: Any) -> Optional[str]:
+    """Return a bounded opaque relay owner id, or ``None`` for invalid input.
+
+    Owner ids are compared byte-for-byte; trimming or stringifying malformed
+    wire values would create aliases and weaken stale-generation protection.
+    """
+    if not isinstance(value, str):
+        return None
+    if not value or value != value.strip() or len(value) > 256:
+        return None
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in value):
+        return None
+    return value
+
 # Callback the transport invokes for each forwarded passthrough request (§5.1).
 # The first arg is a PassthroughForward (gateway/relay/ws_transport.py) — typed
 # as Any here to keep this protocol module free of a concrete-transport import

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -5,17 +5,20 @@ speaks the newline-delimited JSON frame protocol defined in the connector repo
 (``gateway-gateway`` ``src/relay/protocol.ts``) and mirrored in
 ``docs/relay-connector-contract.md``:
 
-  gateway -> connector : hello, outbound, interrupt
+  gateway -> connector : hello, outbound, interrupt, interrupt_result
   connector -> gateway : descriptor, inbound, outbound_result, interrupt_inbound
 
 Frames:
-  hello            {type, platform, botId}
+  hello            {type, platform, botId, contract_version, capabilities,
+                    runtime_epoch}
   descriptor       {type, descriptor}                       (handshake reply)
   inbound          {type, event, bufferId?}                 (a normalized MessageEvent)
   outbound         {type, requestId, action}                (send/edit/typing/follow_up)
   outbound_result  {type, requestId, result}
   interrupt        {type, session_key, reason?}             (gateway egresses /stop)
-  interrupt_inbound{type, session_key, chat_id}             (connector -> owning gateway)
+  interrupt_inbound{type, session_key, chat_id, owner_id,
+                    action_id}                              (connector -> owning gateway)
+  interrupt_result {type, action_id, accepted, reason}      (gateway -> connector)
 
 This is the concrete transport behind the ``RelayTransport`` Protocol; the
 ``RelayAdapter`` delegates all wire I/O to it. Outbound calls block on a
@@ -34,13 +37,19 @@ import json
 import logging
 import os
 import uuid
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from gateway.platforms.base import MessageEvent, MessageType
+from gateway.interrupt_budget import INTERRUPT_HANDLER_TIMEOUT_SECONDS
 from gateway.session import SessionSource
-from gateway.relay.descriptor import CapabilityDescriptor
-from gateway.relay.transport import InboundHandler
+from gateway.relay.descriptor import (
+    CONTRACT_VERSION,
+    OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+    CapabilityDescriptor,
+)
+from gateway.relay.transport import InboundHandler, normalize_owner_id
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +75,22 @@ _TEARDOWN_AWAIT_TIMEOUT_S = 1.0
 # asyncio.wait_for; blowing that budget cancels teardown mid-drain, skips the
 # fail-pending loop, and leaves callers blocked on _OUTBOUND_TIMEOUT_S).
 _DISCONNECT_DRAIN_GRACE_S = 5.0
+_INTERRUPT_HANDLER_TIMEOUT_S = INTERRUPT_HANDLER_TIMEOUT_SECONDS
+_INTERRUPT_QUEUE_PER_SESSION = 8
+_INTERRUPT_ACTION_CACHE = 512
+_INTERRUPT_MAX_SESSION_WORKERS = 64
+_INTERRUPT_MAX_TRACKED_TASKS = 128
+
+
+def _normalize_control_identifier(value: Any, *, max_length: int) -> Optional[str]:
+    """Validate opaque frame-boundary identifiers without coercion/aliasing."""
+    if not isinstance(value, str):
+        return None
+    if not value or value != value.strip() or len(value) > max_length:
+        return None
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in value):
+        return None
+    return value
 
 
 def _disconnect_drain_grace_s(budget_s: Optional[float] = None) -> float:
@@ -325,6 +350,8 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
             if isinstance(raw.get("prompt_response"), dict)
             else None
         ),
+        owner_id=normalize_owner_id(raw.get("owner_id")),
+        prompt_response_present="prompt_response" in raw,
     )
 
 
@@ -419,6 +446,11 @@ class WebSocketRelayTransport:
         # (dev/test, or a connector that doesn't enforce auth).
         self._gateway_id = gateway_id
         self._upgrade_secret = upgrade_secret
+        # Process-lifetime transport identity. Reconnects reuse this epoch;
+        # a gateway restart constructs a new transport and therefore a new
+        # value, allowing the connector to reconcile a phantom active owner
+        # without treating a transient socket break as terminal.
+        self._runtime_epoch = uuid.uuid4().hex
 
         # Phase 5 §5.3: a NET-NEW reconnect supervisor. The base transport's
         # _read_loop just ends on socket close ("reconnection is caller policy");
@@ -462,6 +494,10 @@ class WebSocketRelayTransport:
         self._descriptor_ready: asyncio.Future[CapabilityDescriptor] | None = None
         # requestId -> future awaiting the matching outbound_result.
         self._pending: Dict[str, asyncio.Future[Dict[str, Any]]] = {}
+        self._interrupt_queues: Dict[str, asyncio.Queue] = {}
+        self._interrupt_tasks: set[asyncio.Task] = set()
+        self._interrupt_workers: Dict[str, asyncio.Task] = {}
+        self._interrupt_actions: OrderedDict[str, None] = OrderedDict()
         # Phase 5 §5.3: future awaiting the connector's going_idle_ack.
         self._going_idle_ack: asyncio.Future[None] | None = None
         self._closing = False
@@ -508,7 +544,14 @@ class WebSocketRelayTransport:
         # sends exactly one hello — byte-identical to before. The descriptor for
         # the FIRST identity resolves handshake(); later descriptors are absorbed.
         for platform, bot_id in self._identities:
-            hello: Dict[str, Any] = {"type": "hello", "platform": platform, "botId": bot_id}
+            hello: Dict[str, Any] = {
+                "type": "hello",
+                "platform": platform,
+                "botId": bot_id,
+                "contract_version": CONTRACT_VERSION,
+                "capabilities": [OWNER_BOUND_INTERRUPT_ACK_CAPABILITY],
+                "runtime_epoch": self._runtime_epoch,
+            }
             # Phase 4: declare the gateway's slash-command set on the Discord
             # hello. The connector (which holds the bot token) reconciles
             # Discord's global registration against it — idempotent, detached,
@@ -582,6 +625,7 @@ class WebSocketRelayTransport:
                 except (asyncio.TimeoutError, asyncio.CancelledError, Exception):  # noqa: BLE001 - best-effort teardown
                     pass
                 self._reader = None
+            await self._cancel_interrupt_tasks()
             if self._ws is not None:
                 try:
                     await asyncio.wait_for(self._ws.close(), timeout=_TEARDOWN_AWAIT_TIMEOUT_S)
@@ -833,6 +877,7 @@ class WebSocketRelayTransport:
                     )
             elif not self._closing:
                 logger.warning("relay ws read loop ended: %s", exc)
+        await self._cancel_interrupt_tasks()
         # Phase 5 §5.3: the socket closed. If reconnect is enabled and this was
         # NOT a deliberate disconnect(), kick the reconnect supervisor so the
         # gateway re-dials + re-handshakes (which triggers the connector's
@@ -906,6 +951,30 @@ class WebSocketRelayTransport:
         ftype = frame.get("type")
         if ftype == "descriptor":
             descriptor = CapabilityDescriptor.from_json(json.dumps(frame.get("descriptor", {})))
+            if (
+                descriptor.contract_version != CONTRACT_VERSION
+                or not descriptor.supports_capability(
+                    OWNER_BOUND_INTERRUPT_ACK_CAPABILITY
+                )
+            ):
+                logger.warning(
+                    "relay descriptor rejected reason=owner_bound_interrupt_ack_required"
+                )
+                error = RuntimeError("relay connector contract v2 required")
+                if (
+                    self._descriptor_ready is not None
+                    and not self._descriptor_ready.done()
+                ):
+                    self._descriptor_ready.set_exception(error)
+                if self._ws is not None:
+                    try:
+                        await self._ws.close(
+                            code=4406,
+                            reason="relay contract v2 required",
+                        )
+                    except Exception:  # noqa: BLE001 - fail-closed best-effort close
+                        logger.debug("relay incompatible descriptor close failed")
+                return
             # Phase 1.5 multi-platform: one descriptor frame arrives per hello'd
             # identity. Accumulate them keyed by the descriptor's own platform so
             # the adapter can resolve PER-CHAT capabilities (e.g. Discord's 2000
@@ -947,10 +1016,7 @@ class WebSocketRelayTransport:
             if fut is not None and not fut.done():
                 fut.set_result(frame.get("result", {}))
         elif ftype == "interrupt_inbound":
-            # Bridged into the adapter's interrupt path by the runner wiring.
-            handler = getattr(self, "_interrupt_inbound_handler", None)
-            if handler is not None:
-                await handler(frame.get("session_key", ""), frame.get("chat_id", ""))
+            self._queue_interrupt(frame)
         elif ftype == "passthrough_forward":
             # Phase 5 §5.1: a forwarded passthrough-plane request (Discord
             # interaction, Twilio, …) the connector already edge-ACKed. It rides
@@ -964,6 +1030,187 @@ class WebSocketRelayTransport:
         else:
             # hello/outbound/interrupt are gateway->connector; ignore if echoed.
             pass
+
+    def _ensure_interrupt_state(self) -> None:
+        """Initialize control state for normal and object.__new__ test instances."""
+        if not hasattr(self, "_interrupt_queues"):
+            self._interrupt_queues = {}
+        if not hasattr(self, "_interrupt_tasks"):
+            self._interrupt_tasks = set()
+        if not hasattr(self, "_interrupt_workers"):
+            self._interrupt_workers = {}
+        if not hasattr(self, "_interrupt_actions"):
+            self._interrupt_actions = OrderedDict()
+
+    def _track_interrupt_task(self, task: asyncio.Task) -> None:
+        self._interrupt_tasks.add(task)
+        task.add_done_callback(self._interrupt_task_done)
+
+    def _interrupt_task_done(self, task: asyncio.Task) -> None:
+        """Consume detached task failures and retire their bookkeeping."""
+        self._interrupt_tasks.discard(task)
+        if task.cancelled():
+            return
+        try:
+            error = task.exception()
+        except asyncio.CancelledError:
+            return
+        if error is not None:
+            logger.warning(
+                "relay interrupt task failed type=%s",
+                type(error).__name__,
+            )
+
+    async def _send_interrupt_result(
+        self, action_id: str, accepted: bool, reason: str
+    ) -> None:
+        await self._send({
+            "type": "interrupt_result",
+            "action_id": action_id,
+            "accepted": accepted,
+            "reason": reason,
+        })
+
+    def _spawn_interrupt_result(
+        self, action_id: str, accepted: bool, reason: str
+    ) -> None:
+        self._ensure_interrupt_state()
+        active_tasks = sum(not task.done() for task in self._interrupt_tasks)
+        if active_tasks >= _INTERRUPT_MAX_TRACKED_TASKS:
+            logger.warning("relay interrupt result dropped reason=task_capacity")
+            return
+        task = asyncio.create_task(
+            self._send_interrupt_result(action_id, accepted, reason)
+        )
+        self._track_interrupt_task(task)
+
+    def _queue_interrupt(self, frame: Dict[str, Any]) -> None:
+        """Validate and enqueue an owner-bound Stop without blocking the reader."""
+        self._ensure_interrupt_state()
+        action_id = _normalize_control_identifier(
+            frame.get("action_id"), max_length=128
+        )
+        if action_id is None:
+            logger.info("relay interrupt dropped reason=invalid_action_id")
+            return
+        if action_id in self._interrupt_actions:
+            logger.info("relay interrupt duplicate action")
+            return
+        self._interrupt_actions[action_id] = None
+        while len(self._interrupt_actions) > _INTERRUPT_ACTION_CACHE:
+            self._interrupt_actions.popitem(last=False)
+
+        session_key = _normalize_control_identifier(
+            frame.get("session_key"), max_length=512
+        )
+        chat_id = _normalize_control_identifier(frame.get("chat_id"), max_length=256)
+        owner_id = normalize_owner_id(frame.get("owner_id"))
+        descriptor = getattr(self, "_descriptor", None)
+        reason = None
+        if (
+            descriptor is None
+            or not descriptor.supports_capability(
+                OWNER_BOUND_INTERRUPT_ACK_CAPABILITY
+            )
+        ):
+            reason = "capability_not_negotiated"
+        elif session_key is None or chat_id is None:
+            reason = "invalid_binding"
+        elif owner_id is None:
+            reason = "invalid_owner"
+
+        if reason is not None:
+            logger.info(
+                "relay interrupt rejected reason=%s session_bound=%s owner_bound=%s",
+                reason,
+                "yes" if session_key else "no",
+                "yes" if owner_id else "no",
+            )
+            self._spawn_interrupt_result(action_id, False, reason)
+            return
+
+        assert session_key is not None
+        assert chat_id is not None
+        assert owner_id is not None
+        queue = self._interrupt_queues.get(session_key)
+        if queue is None:
+            if len(self._interrupt_queues) >= _INTERRUPT_MAX_SESSION_WORKERS:
+                self._spawn_interrupt_result(action_id, False, "interrupt_busy")
+                return
+            queue = asyncio.Queue(maxsize=_INTERRUPT_QUEUE_PER_SESSION)
+            self._interrupt_queues[session_key] = queue
+        try:
+            queue.put_nowait((action_id, session_key, chat_id, owner_id))
+        except asyncio.QueueFull:
+            self._spawn_interrupt_result(action_id, False, "interrupt_busy")
+            return
+        worker = self._interrupt_workers.get(session_key)
+        if worker is None or worker.done():
+            worker = asyncio.create_task(
+                self._run_interrupt_queue(session_key, queue)
+            )
+            self._interrupt_workers[session_key] = worker
+            self._track_interrupt_task(worker)
+
+    async def _run_interrupt_queue(
+        self, session_key: str, queue: asyncio.Queue
+    ) -> None:
+        try:
+            while not queue.empty():
+                action_id, bound_session_key, chat_id, owner_id = queue.get_nowait()
+                accepted = False
+                reason = "rejected"
+                handler = getattr(self, "_interrupt_inbound_handler", None)
+                if handler is None:
+                    reason = "handler_unavailable"
+                else:
+                    try:
+                        accepted = bool(
+                            await asyncio.wait_for(
+                                handler(bound_session_key, chat_id, owner_id),
+                                timeout=_INTERRUPT_HANDLER_TIMEOUT_S,
+                            )
+                        )
+                        reason = "accepted" if accepted else "rejected"
+                    except asyncio.TimeoutError:
+                        reason = "handler_timeout"
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        logger.error(
+                            "relay interrupt handler failed reason=internal_error type=%s",
+                            type(exc).__name__,
+                        )
+                        reason = "internal_error"
+                try:
+                    await self._send_interrupt_result(action_id, accepted, reason)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "relay interrupt result send failed type=%s",
+                        type(exc).__name__,
+                    )
+                finally:
+                    queue.task_done()
+        finally:
+            if self._interrupt_queues.get(session_key) is queue:
+                self._interrupt_queues.pop(session_key, None)
+            current = asyncio.current_task()
+            if self._interrupt_workers.get(session_key) is current:
+                self._interrupt_workers.pop(session_key, None)
+
+    async def _cancel_interrupt_tasks(self) -> None:
+        self._ensure_interrupt_state()
+        tasks = [task for task in self._interrupt_tasks if not task.done()]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._interrupt_tasks.clear()
+        self._interrupt_workers.clear()
+        self._interrupt_queues.clear()
+        self._interrupt_actions.clear()
 
     def set_interrupt_inbound_handler(self, handler: Any) -> None:
         """Register the callback for connector->gateway interrupt_inbound frames."""

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -5,20 +5,27 @@ speaks the newline-delimited JSON frame protocol defined in the connector repo
 (``gateway-gateway`` ``src/relay/protocol.ts``) and mirrored in
 ``docs/relay-connector-contract.md``:
 
-  gateway -> connector : hello, outbound, interrupt, interrupt_result
+  gateway -> connector : hello, outbound, interrupt, interrupt_result,
+                         inbound_ack, turn_completed
   connector -> gateway : descriptor, inbound, outbound_result, interrupt_inbound
 
 Frames:
   hello            {type, platform, botId, contract_version, capabilities,
-                    runtime_epoch}
+                    runtime_epoch, turn_states}
   descriptor       {type, descriptor}                       (handshake reply)
-  inbound          {type, event, bufferId?}                 (a normalized MessageEvent)
+  inbound          {type, delivery_id, event, bufferId?}    (a normalized MessageEvent)
+  inbound_ack      {type, delivery_id, session_key, chat_id, owner_id,
+                    runtime_epoch, disposition, canonical_turn_owner_id,
+                    owner_state_seq, bufferId?}
   outbound         {type, requestId, action}                (send/edit/typing/follow_up)
   outbound_result  {type, requestId, result}
   interrupt        {type, session_key, reason?}             (gateway egresses /stop)
   interrupt_inbound{type, session_key, chat_id, owner_id,
                     action_id}                              (connector -> owning gateway)
   interrupt_result {type, action_id, accepted, reason}      (gateway -> connector)
+  turn_completed   {type, session_key, chat_id, owner_id, runtime_epoch,
+                    outcome, owner_state_seq, status,
+                    next_owner_id, next_delivery_id}        (gateway -> connector)
 
 This is the concrete transport behind the ``RelayTransport`` Protocol; the
 ``RelayAdapter`` delegates all wire I/O to it. Outbound calls block on a
@@ -43,13 +50,16 @@ from typing import Any, Dict, List, Optional
 
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.interrupt_budget import INTERRUPT_HANDLER_TIMEOUT_SECONDS
-from gateway.session import SessionSource
+from gateway.session import SessionSource, build_session_key
 from gateway.relay.descriptor import (
     CONTRACT_VERSION,
     OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+    OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+    OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
     CapabilityDescriptor,
 )
 from gateway.relay.transport import InboundHandler, normalize_owner_id
+from gateway.relay.auth import turn_state_scope_fingerprint
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +90,9 @@ _INTERRUPT_QUEUE_PER_SESSION = 8
 _INTERRUPT_ACTION_CACHE = 512
 _INTERRUPT_MAX_SESSION_WORKERS = 64
 _INTERRUPT_MAX_TRACKED_TASKS = 128
+_TURN_STATE_CACHE = 256
+_INBOUND_ACK_CACHE = 1024
+_TERMINAL_SEND_TIMEOUT_S = 1.0
 
 
 def _normalize_control_identifier(value: Any, *, max_length: int) -> Optional[str]:
@@ -498,6 +511,21 @@ class WebSocketRelayTransport:
         self._interrupt_tasks: set[asyncio.Task] = set()
         self._interrupt_workers: Dict[str, asyncio.Task] = {}
         self._interrupt_actions: OrderedDict[str, None] = OrderedDict()
+        # Owner-bound terminal frames are emitted at most once for this
+        # process-lifetime runtime epoch, even if a defensive lifecycle hook is
+        # invoked twice. A reconnect keeps the epoch and this cache; a process
+        # restart creates both anew.
+        self._turn_completion_owners: OrderedDict[
+            tuple[str, str, str], None
+        ] = OrderedDict()
+        # Runtime-epoch-scoped authoritative owner snapshots. They survive a
+        # socket reconnect and make a lost terminal write reconcilable in the
+        # next hello without an unbounded replay queue.
+        self._turn_states: OrderedDict[tuple[str, str], Dict[str, Any]] = OrderedDict()
+        # Latest acknowledgement per connector-issued delivery id. Replaying a
+        # durable inbound after an ack loss replays this exact disposition and
+        # never dispatches the user event twice.
+        self._inbound_ack_frames: OrderedDict[str, Dict[str, Any]] = OrderedDict()
         # Phase 5 §5.3: future awaiting the connector's going_idle_ack.
         self._going_idle_ack: asyncio.Future[None] | None = None
         self._closing = False
@@ -549,8 +577,13 @@ class WebSocketRelayTransport:
                 "platform": platform,
                 "botId": bot_id,
                 "contract_version": CONTRACT_VERSION,
-                "capabilities": [OWNER_BOUND_INTERRUPT_ACK_CAPABILITY],
+                "capabilities": [
+                    OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+                    OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+                    OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
+                ],
                 "runtime_epoch": self._runtime_epoch,
+                "turn_states": self._hello_turn_state_snapshots(),
             }
             # Phase 4: declare the gateway's slash-command set on the Discord
             # hello. The connector (which holds the bot token) reconciles
@@ -792,17 +825,192 @@ class WebSocketRelayTransport:
             logger.debug("relay go_dormant: ws.close() raised or timed out", exc_info=True)
         return acked
 
-    async def _send_inbound_ack(self, buffer_id: str) -> None:
-        """Acknowledge durable receipt of a buffered inbound delivery (§5.3).
+    def _ensure_turn_state(self) -> None:
+        if not hasattr(self, "_turn_states"):
+            self._turn_states = OrderedDict()
+        if not hasattr(self, "_inbound_ack_frames"):
+            self._inbound_ack_frames = OrderedDict()
 
-        Sent after the adapter has durably taken a buffered inbound event the
-        connector replayed on reconnect; the connector acks the buffer entry only
-        after this, giving drain-without-dup on the delivery leg.
+    def _turn_state_snapshots(self) -> list[Dict[str, Any]]:
+        self._ensure_turn_state()
+        return [dict(state) for state in self._turn_states.values()]
+
+    def _hello_turn_state_snapshots(self) -> list[Dict[str, Any]]:
+        """Return authenticated scope projections without leaking session keys.
+
+        One transport may retain owner states for several connector scopes.
+        The shared upgrade secret lets each connector match only its own
+        session/chat pair while unrelated raw identifiers stay off the wire.
+        An unauthenticated transport gets no reconciliation ledger at all.
         """
+        secret = str(getattr(self, "_upgrade_secret", "") or "")
+        if not secret:
+            return []
+        snapshots = []
+        for state in self._turn_state_snapshots():
+            session_key = str(state.pop("session_key"))
+            chat_id = str(state.pop("chat_id"))
+            state["scope_fingerprint"] = turn_state_scope_fingerprint(
+                secret, session_key, chat_id
+            )
+            snapshots.append(state)
+        return snapshots
+
+    def _remember_turn_state(self, key: tuple[str, str], state: Dict[str, Any]) -> None:
+        self._turn_states[key] = state
+        self._turn_states.move_to_end(key)
+        while len(self._turn_states) > _TURN_STATE_CACHE:
+            self._turn_states.popitem(last=False)
+
+    def _state_for_scope(self, session_key: str, chat_id: str) -> Dict[str, Any]:
+        self._ensure_turn_state()
+        key = (session_key, chat_id)
+        state = self._turn_states.get(key)
+        if state is None:
+            state = {
+                "session_key": session_key,
+                "chat_id": chat_id,
+                "owner_state_seq": 0,
+                "status": "idle",
+                "active_owner_id": None,
+                "terminal_owner_id": None,
+                "terminal_outcome": None,
+                "next_owner_id": None,
+                "next_delivery_id": None,
+            }
+            self._remember_turn_state(key, state)
+        return state
+
+    async def _publish_inbound_ack(
+        self,
+        event: MessageEvent,
+        result: Dict[str, Any],
+        *,
+        delivery_id: str,
+        buffer_id: Optional[str] = None,
+    ) -> bool:
+        """Record and send one authoritative inbound owner disposition."""
+        self._ensure_turn_state()
+        owner_id = normalize_owner_id(getattr(event, "owner_id", None))
+        session_key = _normalize_control_identifier(
+            result.get("session_key"), max_length=512
+        )
+        chat_id = _normalize_control_identifier(result.get("chat_id"), max_length=256)
+        disposition = result.get("disposition")
+        canonical_owner = normalize_owner_id(result.get("canonical_turn_owner_id"))
+        if (
+            owner_id is None
+            or session_key is None
+            or chat_id is None
+            or disposition not in {"started", "queued", "absorbed", "merged", "rejected"}
+        ):
+            return False
+
+        state = self._state_for_scope(session_key, chat_id)
+        if disposition == "started":
+            if canonical_owner != owner_id:
+                return False
+            if state["status"] != "running" or state["active_owner_id"] != owner_id:
+                state = {
+                    "session_key": session_key,
+                    "chat_id": chat_id,
+                    "owner_state_seq": int(state["owner_state_seq"]) + 1,
+                    "status": "running",
+                    "active_owner_id": owner_id,
+                    "terminal_owner_id": None,
+                    "terminal_outcome": None,
+                    "next_owner_id": None,
+                    "next_delivery_id": None,
+                }
+                self._remember_turn_state((session_key, chat_id), state)
+        else:
+            # The adapter guard is intentionally still A for the few awaits
+            # between terminal publication A->B and B's actual guard bind. It
+            # must never leak that already-terminal guard (or speculative B)
+            # as stoppable in an ack for a concurrently arriving C.
+            if state["status"] == "handoff":
+                canonical_owner = None
+            elif state["status"] == "idle" and int(state["owner_state_seq"]) > 0:
+                canonical_owner = None
+            if canonical_owner is not None and state["status"] == "idle" and int(state["owner_state_seq"]) == 0:
+                state = {
+                    **state,
+                    "owner_state_seq": 1,
+                    "status": "running",
+                    "active_owner_id": canonical_owner,
+                }
+                self._remember_turn_state((session_key, chat_id), state)
+            elif canonical_owner is not None and (
+                state["status"] != "running"
+                or state["active_owner_id"] != canonical_owner
+            ):
+                return False
+
+        frame: Dict[str, Any] = {
+            "type": "inbound_ack",
+            "delivery_id": delivery_id,
+            "session_key": session_key,
+            "chat_id": chat_id,
+            "owner_id": owner_id,
+            "runtime_epoch": self._runtime_epoch,
+            "disposition": disposition,
+            "canonical_turn_owner_id": canonical_owner,
+            "owner_state_seq": state["owner_state_seq"],
+        }
+        if buffer_id:
+            frame["bufferId"] = buffer_id
+        reason = _normalize_control_identifier(result.get("reason"), max_length=128)
+        if reason is not None:
+            frame["reason"] = reason
+        # ``on_processing_start`` can publish ``started`` while the original
+        # inbound handler is still unwinding.  The enclosing inbound frame
+        # then observes the same guard and derives the identical disposition.
+        # Emit that exact event-local acknowledgement only once.  A failed
+        # send deliberately leaves no marker so the enclosing path retries;
+        # reconnect/redelivery still uses the durable delivery-id cache below.
+        published = getattr(event, "metadata", {}).get(
+            "_relay_published_inbound_ack"
+        )
+        if published == frame:
+            return True
+        self._inbound_ack_frames[delivery_id] = dict(frame)
+        self._inbound_ack_frames.move_to_end(delivery_id)
+        while len(self._inbound_ack_frames) > _INBOUND_ACK_CACHE:
+            self._inbound_ack_frames.popitem(last=False)
         try:
-            await self._send({"type": "inbound_ack", "bufferId": buffer_id})
-        except Exception:  # noqa: BLE001 - a failed ack just redelivers the entry next time
-            logger.debug("relay: inbound_ack send failed for %s", buffer_id)
+            await self._send(frame)
+        except Exception:  # reconciliation/replay is authoritative after reconnect
+            logger.debug("relay: owner disposition send failed for %s", delivery_id)
+            return False
+        event.metadata["_relay_published_inbound_ack"] = dict(frame)
+        return True
+
+    async def send_turn_started(self, event: MessageEvent) -> bool:
+        """Promote a previously queued delivery after its guard is bound."""
+        metadata = getattr(event, "metadata", {}) or {}
+        delivery_id = _normalize_control_identifier(
+            metadata.get("relay_delivery_id"), max_length=128
+        )
+        session_key = _normalize_control_identifier(
+            metadata.get("relay_session_key"), max_length=512
+        )
+        chat_id = _normalize_control_identifier(
+            metadata.get("relay_chat_id"), max_length=256
+        )
+        owner_id = normalize_owner_id(getattr(event, "owner_id", None))
+        if not all((delivery_id, session_key, chat_id, owner_id)):
+            return False
+        return await self._publish_inbound_ack(
+            event,
+            {
+                "disposition": "started",
+                "canonical_turn_owner_id": owner_id,
+                "session_key": session_key,
+                "chat_id": chat_id,
+            },
+            delivery_id=delivery_id,
+            buffer_id=metadata.get("relay_buffer_id"),
+        )
 
     async def _request_response(
         self,
@@ -877,6 +1085,21 @@ class WebSocketRelayTransport:
                     )
             elif not self._closing:
                 logger.warning("relay ws read loop ended: %s", exc)
+        # An exception raised by an inbound handler ends this reader without a
+        # peer close. Release that still-open connector slot before the
+        # supervisor dials again; otherwise a single-slot connector rejects the
+        # replacement forever while the abandoned socket remains established.
+        ended_ws = self._ws
+        if ended_ws is not None and not self._closing:
+            try:
+                await asyncio.wait_for(
+                    ended_ws.close(), timeout=_TEARDOWN_AWAIT_TIMEOUT_S
+                )
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            finally:
+                if self._ws is ended_ws:
+                    self._ws = None
         await self._cancel_interrupt_tasks()
         # Phase 5 §5.3: the socket closed. If reconnect is enabled and this was
         # NOT a deliberate disconnect(), kick the reconnect supervisor so the
@@ -956,11 +1179,17 @@ class WebSocketRelayTransport:
                 or not descriptor.supports_capability(
                     OWNER_BOUND_INTERRUPT_ACK_CAPABILITY
                 )
+                or not descriptor.supports_capability(
+                    OWNER_BOUND_TURN_COMPLETION_CAPABILITY
+                )
+                or not descriptor.supports_capability(
+                    OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY
+                )
             ):
                 logger.warning(
-                    "relay descriptor rejected reason=owner_bound_interrupt_ack_required"
+                    "relay descriptor rejected reason=owner_bound_control_capabilities_required"
                 )
-                error = RuntimeError("relay connector contract v2 required")
+                error = RuntimeError("relay connector contract v3 required")
                 if (
                     self._descriptor_ready is not None
                     and not self._descriptor_ready.done()
@@ -970,7 +1199,7 @@ class WebSocketRelayTransport:
                     try:
                         await self._ws.close(
                             code=4406,
-                            reason="relay contract v2 required",
+                            reason="relay contract v3 required",
                         )
                     except Exception:  # noqa: BLE001 - fail-closed best-effort close
                         logger.debug("relay incompatible descriptor close failed")
@@ -998,14 +1227,44 @@ class WebSocketRelayTransport:
         elif ftype == "inbound":
             if self._inbound is not None:
                 event = _event_from_wire(frame.get("event", {}))
-                await self._inbound(event)
-                # Phase 5 §5.3: a buffered delivery (replayed on reconnect) carries
-                # a bufferId; ack it after the handler has durably taken it so the
-                # connector advances its delivery-leg buffer cursor (no dup). A live
-                # delivery has no bufferId — nothing to ack.
-                buffer_id = frame.get("bufferId")
-                if buffer_id:
-                    await self._send_inbound_ack(str(buffer_id))
+                delivery_id = _normalize_control_identifier(
+                    frame.get("delivery_id"), max_length=128
+                )
+                if delivery_id is None or normalize_owner_id(event.owner_id) is None:
+                    logger.info("relay inbound dropped reason=invalid_owner_delivery_identity")
+                    return
+                buffer_id = _normalize_control_identifier(
+                    frame.get("bufferId"), max_length=256
+                )
+                self._ensure_turn_state()
+                cached = self._inbound_ack_frames.get(delivery_id)
+                if cached is not None:
+                    replay = dict(cached)
+                    if buffer_id is not None:
+                        replay["bufferId"] = buffer_id
+                    try:
+                        await self._send(replay)
+                    except Exception:
+                        logger.debug("relay: cached inbound_ack replay failed")
+                    return
+                session_key = build_session_key(event.source)
+                chat_id = str(getattr(event.source, "chat_id", "") or "")
+                event.metadata["relay_delivery_id"] = delivery_id
+                event.metadata["relay_session_key"] = session_key
+                event.metadata["relay_chat_id"] = chat_id
+                if buffer_id is not None:
+                    event.metadata["relay_buffer_id"] = buffer_id
+                # A handler exception is transient delivery failure, not an
+                # authoritative negative admission. Let the reader fail/re-dial
+                # without publishing or caching an ack so a durable connector
+                # lease can redeliver this same delivery at least once.
+                result = await self._inbound(event)
+                await self._publish_inbound_ack(
+                    event,
+                    result if isinstance(result, dict) else {},
+                    delivery_id=delivery_id,
+                    buffer_id=buffer_id,
+                )
         elif ftype == "going_idle_ack":
             # Phase 5 §5.3: the connector confirmed our destination is now
             # buffered-only; resolve the waiter go_idle() is blocked on.
@@ -1070,6 +1329,123 @@ class WebSocketRelayTransport:
             "accepted": accepted,
             "reason": reason,
         })
+
+    async def send_turn_completed(
+        self,
+        session_key: str,
+        chat_id: str,
+        owner_id: str,
+        outcome: str,
+        next_owner_id: Optional[str] = None,
+        next_delivery_id: Optional[str] = None,
+    ) -> bool:
+        """Send one correlated terminal-turn frame for the current epoch."""
+        descriptor = getattr(self, "_descriptor", None)
+        if (
+            descriptor is None
+            or not descriptor.supports_capability(
+                OWNER_BOUND_INTERRUPT_ACK_CAPABILITY
+            )
+            or not descriptor.supports_capability(
+                OWNER_BOUND_TURN_COMPLETION_CAPABILITY
+            )
+            or not descriptor.supports_capability(
+                OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY
+            )
+        ):
+            return False
+        normalized_session = _normalize_control_identifier(
+            session_key, max_length=512
+        )
+        normalized_chat = _normalize_control_identifier(chat_id, max_length=256)
+        normalized_owner = normalize_owner_id(owner_id)
+        normalized_next_owner = (
+            normalize_owner_id(next_owner_id) if next_owner_id is not None else None
+        )
+        normalized_next_delivery = (
+            _normalize_control_identifier(next_delivery_id, max_length=128)
+            if next_delivery_id is not None else None
+        )
+        if (
+            normalized_session is None
+            or normalized_chat is None
+            or normalized_owner is None
+            or outcome not in {"completed", "failed", "cancelled"}
+            or ((normalized_next_owner is None) != (normalized_next_delivery is None))
+        ):
+            return False
+        self._ensure_turn_completion_state()
+        owner_key = (normalized_session, normalized_chat, normalized_owner)
+        if owner_key in self._turn_completion_owners:
+            return False
+        state = self._state_for_scope(normalized_session, normalized_chat)
+        if (
+            state["status"] == "running"
+            and state["active_owner_id"] != normalized_owner
+        ):
+            return False
+        if state["status"] == "idle" and int(state["owner_state_seq"]) > 0:
+            return False
+        state = {
+            "session_key": normalized_session,
+            "chat_id": normalized_chat,
+            "owner_state_seq": int(state["owner_state_seq"]) + 1,
+            "status": "handoff" if normalized_next_owner else "idle",
+            "active_owner_id": None,
+            "terminal_owner_id": normalized_owner,
+            "terminal_outcome": outcome,
+            "next_owner_id": normalized_next_owner,
+            "next_delivery_id": normalized_next_delivery,
+        }
+        self._remember_turn_state((normalized_session, normalized_chat), state)
+        frame = {
+            "type": "turn_completed",
+            "session_key": normalized_session,
+            "chat_id": normalized_chat,
+            "owner_id": normalized_owner,
+            "runtime_epoch": self._runtime_epoch,
+            "outcome": outcome,
+            "owner_state_seq": state["owner_state_seq"],
+            "status": state["status"],
+            "next_owner_id": normalized_next_owner,
+            "next_delivery_id": normalized_next_delivery,
+        }
+        self._turn_completion_owners[owner_key] = None
+        while len(self._turn_completion_owners) > 1024:
+            self._turn_completion_owners.popitem(last=False)
+        send_task = asyncio.create_task(self._send(frame))
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(send_task), timeout=_TERMINAL_SEND_TIMEOUT_S
+            )
+        except asyncio.CancelledError:
+            send_task.cancel()
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(asyncio.gather(send_task, return_exceptions=True)),
+                    timeout=_TEARDOWN_AWAIT_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                pass
+            logger.debug("relay turn completion task cancelled after bounded send cleanup")
+            raise
+        except (asyncio.TimeoutError, Exception):
+            send_task.cancel()
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(asyncio.gather(send_task, return_exceptions=True)),
+                    timeout=_TEARDOWN_AWAIT_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                pass
+            logger.debug("relay turn completion deferred to hello reconciliation")
+            return False
+        return True
+
+    def _ensure_turn_completion_state(self) -> None:
+        """Initialize completion state for normal and object.__new__ tests."""
+        if not hasattr(self, "_turn_completion_owners"):
+            self._turn_completion_owners = OrderedDict()
 
     def _spawn_interrupt_result(
         self, action_id: str, accepted: bool, reason: str

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2462,6 +2462,10 @@ from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
+from gateway.interrupt_budget import (
+    HARD_STOP_REAP_TIMEOUT_SECONDS,
+    INTERRUPT_ACTIVITY_TIMEOUT_SECONDS,
+)
 from gateway.platforms.base import (
     BasePlatformAdapter,
     EphemeralReply,
@@ -2916,6 +2920,8 @@ def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
 
 
 _INTERRUPT_REASON_STOP = "Stop requested"
+_INTERRUPT_REAP_TIMEOUT_SECONDS = HARD_STOP_REAP_TIMEOUT_SECONDS
+_INTERRUPT_ACTIVITY_TIMEOUT_SECONDS = INTERRUPT_ACTIVITY_TIMEOUT_SECONDS
 _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
 _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
@@ -11505,6 +11511,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+            _set_session_interrupt = getattr(
+                adapter, "set_session_interrupt_handler", None
+            )
+            if callable(_set_session_interrupt):
+                _set_session_interrupt(self._handle_adapter_session_interrupt)
             _set_reaction = getattr(adapter, "set_reaction_handler", None)
             if callable(_set_reaction):
                 _set_reaction(self._handle_reaction_event)
@@ -12890,6 +12901,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+                    _set_session_interrupt = getattr(
+                        adapter, "set_session_interrupt_handler", None
+                    )
+                    if callable(_set_session_interrupt):
+                        _set_session_interrupt(self._handle_adapter_session_interrupt)
                     _set_reaction = getattr(adapter, "set_reaction_handler", None)
                     if callable(_set_reaction):
                         _set_reaction(self._handle_reaction_event)
@@ -13869,6 +13885,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter.set_busy_session_handler(
             self._make_profile_busy_session_handler(profile_name)
         )
+        _set_session_interrupt = getattr(
+            adapter, "set_session_interrupt_handler", None
+        )
+        if callable(_set_session_interrupt):
+            _set_session_interrupt(self._handle_adapter_session_interrupt)
         _set_reaction = getattr(adapter, "set_reaction_handler", None)
         if callable(_set_reaction):
             _set_reaction(self._handle_reaction_event)
@@ -16322,6 +16343,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _claim_state.turn.started_ts = time.time()
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
+        # The adapter guard already exists before this handler starts. Bind the
+        # runner generation immediately, before the slow session/media/hook
+        # preparation awaits inside _handle_message_with_agent.
+        self._bind_adapter_run_generation_for_source(
+            source, _quick_key, _run_generation
+        )
 
         try:
             try:
@@ -18261,10 +18288,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Bind this gateway run generation to the adapter's active-session
         # event so deferred post-delivery callbacks can be released by the
         # same run that registered them.
-        self._bind_adapter_run_generation(
-            self._adapter_for_source(source),
-            session_key,
-            run_generation,
+        self._bind_adapter_run_generation_for_source(
+            source, _quick_key, run_generation
         )
 
         try:
@@ -19604,7 +19629,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.warning("goal continuation: status send failed: %s", exc, exc_info=True)
 
         try:
-            session_key = self._session_key_for_source(source)
+            adapter_key_for_source = getattr(adapter, "session_key_for_source", None)
+            session_key = (
+                adapter_key_for_source(source)
+                if callable(adapter_key_for_source)
+                else self._session_key_for_source(source)
+            )
         except Exception:
             session_key = None
 
@@ -23957,18 +23987,102 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _bind_adapter_run_generation(
         self,
         adapter: Any,
-        session_key: str,
+        adapter_session_key: str,
         generation: int | None,
+        *,
+        runner_session_key: str | None = None,
     ) -> None:
         """Bind a gateway run generation to the adapter's active-session event."""
-        if not adapter or not session_key or generation is None:
+        if not adapter or not adapter_session_key or generation is None:
             return
         try:
-            interrupt_event = getattr(adapter, "_active_sessions", {}).get(session_key)
+            interrupt_event = getattr(adapter, "_active_sessions", {}).get(
+                adapter_session_key
+            )
             if interrupt_event is not None:
                 setattr(interrupt_event, "_hermes_run_generation", int(generation))
+                setattr(
+                    interrupt_event,
+                    "_hermes_runner_session_key",
+                    runner_session_key or adapter_session_key,
+                )
         except Exception:
             pass
+
+    def _bind_adapter_run_generation_for_source(
+        self,
+        source: SessionSource,
+        runner_session_key: str,
+        generation: int | None,
+    ) -> None:
+        """Bind Store generation through the adapter's authoritative key map."""
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return
+        try:
+            adapter_session_key = adapter.session_key_for_source(source)
+        except Exception:
+            logger.info(
+                "Could not resolve adapter session key for runner session %s",
+                runner_session_key,
+            )
+            return
+        self._bind_adapter_run_generation(
+            adapter,
+            adapter_session_key,
+            generation,
+            runner_session_key=runner_session_key,
+        )
+
+    async def _handle_adapter_session_interrupt(
+        self,
+        session_key: str,
+        source: SessionSource,
+        owner_id: str,
+        run_generation: int,
+    ) -> bool:
+        """Route a generation-bound adapter stop through the canonical hard stop."""
+        if (
+            not session_key
+            or source is None
+            or not owner_id
+            or not isinstance(run_generation, int)
+            or isinstance(run_generation, bool)
+            or run_generation < 1
+        ):
+            return False
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return False
+        try:
+            expected_session_key = adapter.session_key_for_source(source)
+        except Exception:
+            return False
+        if expected_session_key != session_key:
+            return False
+
+        guard = getattr(adapter, "_active_sessions", {}).get(session_key)
+        runner_session_key = getattr(
+            guard, "_hermes_runner_session_key", None
+        ) if guard is not None else None
+        if (
+            guard is None
+            or getattr(guard, "_hermes_owner_id", None) != owner_id
+            or getattr(guard, "_hermes_run_generation", None) != run_generation
+            or not isinstance(runner_session_key, str)
+            or not runner_session_key
+            or not self._is_session_run_current(runner_session_key, run_generation)
+        ):
+            return False
+
+        await self._interrupt_and_clear_session(
+            runner_session_key,
+            source,
+            interrupt_reason=_INTERRUPT_REASON_STOP,
+            invalidation_reason="relay_owner_interrupt",
+            adapter_session_key=session_key,
+        )
+        return True
 
     async def _interrupt_and_clear_session(
         self,
@@ -23978,6 +24092,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         interrupt_reason: str,
         invalidation_reason: str,
         release_running_state: bool = True,
+        adapter_session_key: str | None = None,
     ) -> None:
         """Interrupt the current run and clear queued session state consistently."""
         if not session_key:
@@ -23994,65 +24109,152 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _process_baseline = getattr(
                 running_agent, "_gateway_turn_process_baseline", None
             )
-        # Bump the generation *before* scheduling the reap thread and capture
-        # the post-bump value: task_id is session-scoped (task_id ==
-        # session_id), so if a replacement turn claims this session and
-        # spawns its own process before the reap thread actually runs, that
-        # claim bumps the generation again. The closure below then sees a
-        # stale generation and skips — the replacement turn's own baseline
-        # covers its own cleanup, so nothing is left permanently unreaped.
+        adapter = self._adapter_for_source(source)
+        # Invalidate before reaping, then hold the canonical hard-stop at a
+        # completion barrier. task_id is session-scoped, so allowing a fresh
+        # turn to claim a generation before this reaper snapshots/kills would
+        # force an unsafe choice between skipping the abandoned child and
+        # killing the replacement turn's child. The adapter handoff happens
+        # only after this one existing reaper finishes; kill policy remains
+        # centralized in _reap_gateway_turn_processes.
         _generation_at_interrupt = self._invalidate_session_run_generation(
             session_key, reason=invalidation_reason
         )
-        if _process_task_id and _process_baseline is not None:
-            threading.Thread(
-                target=_reap_gateway_turn_processes,
-                args=(_process_task_id, _process_baseline),
-                kwargs={
-                    "source": "gateway_turn_interrupt",
-                    "is_still_current": lambda: self._is_session_run_current(
-                        session_key, _generation_at_interrupt
-                    ),
-                },
-                name=f"gateway-turn-reaper-{_process_task_id[:12]}",
-                daemon=True,
-            ).start()
-        adapter = self._adapter_for_source(source)
-        interrupt_session_activity = getattr(
-            type(adapter), "interrupt_session_activity", None
-        )
-        if adapter and callable(interrupt_session_activity):
-            metadata = self._thread_metadata_for_source(source)
-            try:
-                params = inspect.signature(interrupt_session_activity).parameters
-                accepts_metadata = "metadata" in params or any(
-                    param.kind is inspect.Parameter.VAR_KEYWORD
-                    for param in params.values()
+        _handoff_ready = None
+        try:
+            if _process_task_id and _process_baseline is not None:
+                _reap_done = threading.Event()
+                _handoff_ready = threading.Event()
+                _adapter_key = adapter_session_key or session_key
+                _adapter_guard = (
+                    getattr(adapter, "_active_sessions", {}).get(_adapter_key)
+                    if adapter is not None
+                    else None
                 )
-            except (TypeError, ValueError):
-                accepts_metadata = False
-            if accepts_metadata:
-                await adapter.interrupt_session_activity(
-                    session_key, source.chat_id, metadata=metadata
-                )
-            else:
-                await adapter.interrupt_session_activity(session_key, source.chat_id)
-        if adapter and hasattr(adapter, "get_pending_message"):
-            adapter.get_pending_message(session_key)  # consume and discard
-        if _iac_state is not None:
-            _iac_state.persistent.pending_command_text = None
-        if release_running_state:
-            self._release_running_agent_state(session_key)
-            # Evict the cached agent: ``_interrupt_requested`` is only
-            # cleared by the turn finalizer, so on a hung or still-draining
-            # run the flag survives the lock release and kills the session's
-            # NEXT message at the top of the tool loop (interrupted=True,
-            # api_calls=0, empty response — silently swallowed, #44212).
-            # Evicting mirrors the /new and /model paths: the next message
-            # rebuilds the agent from session history, while the old agent
-            # object keeps its interrupt flag so a hung drain still dies
-            # when it unblocks.
-            self._evict_cached_agent(session_key)
+                if _adapter_guard is not None:
+                    setattr(
+                        _adapter_guard,
+                        "_hermes_hard_stop_reap_barrier",
+                        _handoff_ready,
+                    )
+
+                def _reap_interrupted_turn() -> None:
+                    try:
+                        _reap_gateway_turn_processes(
+                            _process_task_id,
+                            _process_baseline,
+                            source="gateway_turn_interrupt",
+                            # Adapter handoff is held by the barrier. This
+                            # generation guard additionally protects a
+                            # non-adapter parallel turn that can claim the
+                            # same runner key while the reaper thread is queued.
+                            is_still_current=lambda: self._is_session_run_current(
+                                session_key, _generation_at_interrupt
+                            ),
+                        )
+                    finally:
+                        _reap_done.set()
+
+                threading.Thread(
+                    target=_reap_interrupted_turn,
+                    name=f"gateway-turn-reaper-{_process_task_id[:12]}",
+                    daemon=True,
+                ).start()
+                try:
+                    reaped = await asyncio.wait_for(
+                        asyncio.to_thread(
+                            _reap_done.wait,
+                            _INTERRUPT_REAP_TIMEOUT_SECONDS,
+                        ),
+                        timeout=_INTERRUPT_REAP_TIMEOUT_SECONDS + 0.1,
+                    )
+                except asyncio.TimeoutError:
+                    reaped = False
+                if not reaped:
+                    logger.warning(
+                        "Hard-stop process reap exceeded %.1fs; continuing "
+                        "terminal Stop cleanup under the generation guard",
+                        _INTERRUPT_REAP_TIMEOUT_SECONDS,
+                    )
+            interrupt_session_activity = getattr(
+                type(adapter), "interrupt_session_activity", None
+            )
+            if adapter and callable(interrupt_session_activity):
+                metadata = self._thread_metadata_for_source(source)
+                try:
+                    params = inspect.signature(interrupt_session_activity).parameters
+                    accepts_metadata = "metadata" in params or any(
+                        param.kind is inspect.Parameter.VAR_KEYWORD
+                        for param in params.values()
+                    )
+                except (TypeError, ValueError):
+                    accepts_metadata = False
+                if accepts_metadata:
+                    _interrupt_activity = adapter.interrupt_session_activity(
+                        adapter_session_key or session_key,
+                        source.chat_id,
+                        metadata=metadata,
+                    )
+                else:
+                    _interrupt_activity = adapter.interrupt_session_activity(
+                        adapter_session_key or session_key, source.chat_id
+                    )
+                try:
+                    await asyncio.wait_for(
+                        _interrupt_activity,
+                        timeout=_INTERRUPT_ACTIVITY_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Timed out stopping adapter session activity; continuing hard-stop cleanup"
+                    )
+        finally:
+            # From the instant the barrier is installed, every exit path —
+            # success, timeout, CancelledError, or unexpected exception — must
+            # make the guard recoverable. The individual cleanup steps are
+            # isolated so one best-effort failure cannot skip the terminal
+            # running-state release or the barrier signal.
+            if adapter and hasattr(adapter, "get_pending_message"):
+                try:
+                    adapter.get_pending_message(
+                        adapter_session_key or session_key
+                    )  # consume and discard
+                except Exception:
+                    logger.warning(
+                        "Failed to discard pending message during hard-stop cleanup",
+                        exc_info=True,
+                    )
+            if adapter and hasattr(adapter, "_discard_text_debounce"):
+                try:
+                    adapter._discard_text_debounce(adapter_session_key or session_key)
+                except Exception:
+                    logger.warning(
+                        "Failed to discard text debounce during hard-stop cleanup",
+                        exc_info=True,
+                    )
+            if _iac_state is not None:
+                _iac_state.persistent.pending_command_text = None
+            if release_running_state:
+                try:
+                    self._release_running_agent_state(session_key)
+                except Exception:
+                    logger.warning(
+                        "Failed to release running agent state during hard-stop cleanup",
+                        exc_info=True,
+                    )
+                # Evict the cached agent: ``_interrupt_requested`` is only
+                # cleared by the turn finalizer, so on a hung or still-draining
+                # run the flag survives the lock release and kills the session's
+                # NEXT message at the top of the tool loop.
+                try:
+                    self._evict_cached_agent(session_key)
+                except Exception:
+                    logger.warning(
+                        "Failed to evict cached agent during hard-stop cleanup",
+                        exc_info=True,
+                    )
+            if _handoff_ready is not None:
+                _handoff_ready.set()
 
     async def _refresh_agent_cache_message_count(
         self, session_key: str, session_id: Optional[str]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9027,6 +9027,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
         adapter = self._adapter_for_source(event.source)
         if not adapter:
+            if getattr(event, "owner_id", None):
+                event.metadata["relay_owner_disposition"] = "rejected"
+                event.metadata["relay_owner_disposition_reason"] = "adapter_unavailable"
             return
         # #28503 — Previously this called ``merge_pending_message_event``
         # with the default ``merge_text=False``, which silently OVERWROTE
@@ -9059,9 +9062,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key,
                 self._BUSY_QUEUE_MAX_PENDING,
             )
+            if getattr(event, "owner_id", None):
+                event.metadata["relay_owner_disposition"] = "rejected"
+                event.metadata["relay_owner_disposition_reason"] = "queue_capacity"
             return
 
         self._enqueue_fifo(session_key, event, adapter)
+        # Both the empty head slot and overflow entries are later rebound to
+        # their own adapter guard and emit their own processing-start/completion
+        # lifecycle. Keep this delivery pending connector-side until that later
+        # ``started`` acknowledgement. Only an actual merge into the existing
+        # head may retire a distinct delivery as ``merged`` above.
+        if getattr(event, "owner_id", None):
+            event.metadata["relay_owner_disposition"] = "queued"
 
     async def _prepare_busy_steer_text(self, event: MessageEvent) -> str:
         """Return steerable text for a busy follow-up, transcribing voice first.
@@ -9115,6 +9128,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 event.source.platform.value if event.source.platform else "unknown",
                 session_key,
             )
+            if getattr(event, "owner_id", None):
+                event.metadata["relay_owner_disposition"] = "rejected"
+                event.metadata["relay_owner_disposition_reason"] = "unauthorized"
             return True  # handled (silently dropped); do not fall through
 
         effective_mode = self._effective_busy_input_mode(event.source)
@@ -9354,6 +9370,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # merge semantics for media.
         if not steered and not redirected:
             self._queue_or_replace_pending_event(session_key, event)
+        elif getattr(event, "owner_id", None):
+            event.metadata["relay_owner_disposition"] = "absorbed"
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"

--- a/tests/gateway/relay/stub_connector.py
+++ b/tests/gateway/relay/stub_connector.py
@@ -35,6 +35,8 @@ class StubConnector:
         self.interrupts: List[Dict[str, Any]] = []
         self.follow_ups: List[Dict[str, Any]] = []
         self.follow_up_platforms: List[Optional[str]] = []
+        self.turn_completions: List[Dict[str, Any]] = []
+        self.turn_starts: List[str] = []
         # The fronted (platform, bot_id) identity set (Phase 1.5). Mirrors the real
         # transport's _identities so RelayAdapter._platform_is_fronted resolves; a
         # single-identity default keeps existing tests' behaviour unchanged.
@@ -98,6 +100,29 @@ class StubConnector:
 
     async def send_interrupt(self, session_key: str, reason: Optional[str] = None) -> None:
         self.interrupts.append({"session_key": session_key, "reason": reason})
+
+    async def send_turn_completed(
+        self, session_key: str, chat_id: str, owner_id: str, outcome: str,
+        next_owner_id: Optional[str] = None,
+        next_delivery_id: Optional[str] = None,
+    ) -> bool:
+        completion = {
+            "session_key": session_key,
+            "chat_id": chat_id,
+            "owner_id": owner_id,
+            "outcome": outcome,
+        }
+        if next_owner_id is not None:
+            completion["next_owner_id"] = next_owner_id
+            completion["next_delivery_id"] = next_delivery_id
+        self.turn_completions.append(completion)
+        return True
+
+    async def send_turn_started(self, event: MessageEvent) -> bool:
+        if not event.owner_id:
+            return False
+        self.turn_starts.append(event.owner_id)
+        return True
 
     async def send_follow_up(
         self, action: Dict[str, Any], *, platform: Optional[str] = None

--- a/tests/gateway/relay/stub_connector.py
+++ b/tests/gateway/relay/stub_connector.py
@@ -113,11 +113,16 @@ class StubConnector:
             raise RuntimeError("no inbound handler registered (call adapter.connect first)")
         await self._inbound(event)
 
-    async def push_interrupt(self, session_key: str, chat_id: str) -> None:
+    async def push_interrupt(
+        self,
+        session_key: str,
+        chat_id: str,
+        owner_id: Optional[str] = None,
+    ) -> None:
         """Simulate the connector delivering an interrupt_inbound over the WS."""
         if self._interrupt_inbound is None:
             raise RuntimeError("no interrupt_inbound handler registered (call adapter.connect first)")
-        await self._interrupt_inbound(session_key, chat_id)
+        await self._interrupt_inbound(session_key, chat_id, owner_id)
 
     async def push_passthrough(self, forward: Any, buffer_id: Optional[str] = None) -> None:
         """Simulate the connector forwarding a passthrough request over the WS (§5.1)."""

--- a/tests/gateway/relay/test_auth.py
+++ b/tests/gateway/relay/test_auth.py
@@ -26,6 +26,7 @@ from gateway.relay.auth import (
     make_token,
     make_upgrade_token,
     sign,
+    turn_state_scope_fingerprint,
     verify_delivery_signature,
     verify_signature,
     verify_token,
@@ -103,3 +104,7 @@ def test_python_make_token_matches_connector_byte_for_byte():
     assert make_token("gw-instance-1", _SECRET, 0) == _CONN_TOKEN
 
 
+def test_turn_state_scope_fingerprint_has_stable_domain_separated_bytes():
+    assert turn_state_scope_fingerprint(_SECRET, "session-A", "chat-B") == (
+        "05ffa08147a945c499415039aa92c1380b5a72abab18d320d91194fc6b5d7004"
+    )

--- a/tests/gateway/relay/test_relay_going_idle.py
+++ b/tests/gateway/relay/test_relay_going_idle.py
@@ -18,6 +18,8 @@ import pytest_asyncio
 from gateway.relay.descriptor import (
     CONTRACT_VERSION,
     OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+    OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+    OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
 )
 from gateway.relay.ws_transport import WebSocketRelayTransport, WEBSOCKETS_AVAILABLE
 
@@ -37,7 +39,11 @@ DESCRIPTOR = {
     "supports_threads": True,
     "markdown_dialect": "discord",
     "len_unit": "chars",
-    "capabilities": [OWNER_BOUND_INTERRUPT_ACK_CAPABILITY],
+    "capabilities": [
+        OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+        OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+        OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
+    ],
 }
 
 
@@ -106,18 +112,22 @@ async def test_buffered_inbound_is_acked_after_handler(server):
     server._to_push = [
         {
             "type": "inbound",
+            "delivery_id": "delivery-buffered",
             "event": {
                 "text": "buffered",
                 "message_type": "text",
+                "owner_id": "opaque-owner-buffered",
                 "source": {"platform": "discord", "chat_id": "c1", "chat_type": "dm"},
             },
             "bufferId": "buf-42",
         },
         {
             "type": "inbound",
+            "delivery_id": "delivery-live",
             "event": {
                 "text": "live",
                 "message_type": "text",
+                "owner_id": "opaque-owner-live",
                 "source": {"platform": "discord", "chat_id": "c1", "chat_type": "dm"},
             },
         },
@@ -126,6 +136,12 @@ async def test_buffered_inbound_is_acked_after_handler(server):
 
     async def handler(ev):
         seen.append(ev.text)
+        return {
+            "disposition": "started",
+            "canonical_turn_owner_id": ev.owner_id,
+            "session_key": "agent:main:relay:dm:c1",
+            "chat_id": "c1",
+        }
 
     t = WebSocketRelayTransport(server.url, "discord", "appShared")
     t.set_inbound_handler(handler)
@@ -134,8 +150,9 @@ async def test_buffered_inbound_is_acked_after_handler(server):
         await t.handshake()
         await asyncio.sleep(0.1)
         assert "buffered" in seen and "live" in seen
-        # Only the buffered (bufferId) delivery was acked.
-        assert server.inbound_acks == ["buf-42"]
+        # v3 acknowledges every owner disposition; only the durable delivery
+        # carries the existing bufferId ledger cursor.
+        assert server.inbound_acks == ["buf-42", None]
     finally:
         await t.disconnect()
 
@@ -189,9 +206,11 @@ async def test_go_dormant_redials_on_wake_and_drains(server):
     server._to_push = [
         {
             "type": "inbound",
+            "delivery_id": "delivery-wake-1",
             "event": {
                 "text": "while-asleep",
                 "message_type": "text",
+                "owner_id": "opaque-owner-wake-1",
                 "source": {"platform": "discord", "chat_id": "c1", "chat_type": "dm"},
             },
             "bufferId": "buf-wake-1",
@@ -201,6 +220,12 @@ async def test_go_dormant_redials_on_wake_and_drains(server):
 
     async def handler(ev):
         seen.append(ev.text)
+        return {
+            "disposition": "started",
+            "canonical_turn_owner_id": ev.owner_id,
+            "session_key": "agent:main:relay:dm:c1",
+            "chat_id": "c1",
+        }
 
     t = WebSocketRelayTransport(
         server.url, "discord", "appShared", reconnect=True, reconnect_backoff_s=5.0
@@ -265,4 +290,3 @@ async def test_adapter_go_dormant_delegates_to_transport(server):
         assert transport._dormant is True
     finally:
         await adapter.disconnect()
-

--- a/tests/gateway/relay/test_relay_going_idle.py
+++ b/tests/gateway/relay/test_relay_going_idle.py
@@ -15,6 +15,10 @@ import json
 import pytest
 import pytest_asyncio
 
+from gateway.relay.descriptor import (
+    CONTRACT_VERSION,
+    OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+)
 from gateway.relay.ws_transport import WebSocketRelayTransport, WEBSOCKETS_AVAILABLE
 
 pytestmark = pytest.mark.skipif(not WEBSOCKETS_AVAILABLE, reason="websockets not installed")
@@ -24,7 +28,7 @@ if WEBSOCKETS_AVAILABLE:
 
 
 DESCRIPTOR = {
-    "contract_version": 1,
+    "contract_version": CONTRACT_VERSION,
     "platform": "discord",
     "label": "Discord",
     "max_message_length": 2000,
@@ -33,6 +37,7 @@ DESCRIPTOR = {
     "supports_threads": True,
     "markdown_dialect": "discord",
     "len_unit": "chars",
+    "capabilities": [OWNER_BOUND_INTERRUPT_ACK_CAPABILITY],
 }
 
 
@@ -260,5 +265,4 @@ async def test_adapter_go_dormant_delegates_to_transport(server):
         assert transport._dormant is True
     finally:
         await adapter.disconnect()
-
 

--- a/tests/gateway/relay/test_relay_interactive.py
+++ b/tests/gateway/relay/test_relay_interactive.py
@@ -24,10 +24,16 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
 from gateway.relay.adapter import RelayAdapter
-from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+from gateway.relay.descriptor import (
+    CONTRACT_VERSION,
+    OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+    OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+    OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
+    CapabilityDescriptor,
+)
 from gateway.relay.ws_transport import WebSocketRelayTransport
 from gateway.session import SessionSource
 
@@ -56,6 +62,11 @@ def make_desc(**kw) -> CapabilityDescriptor:
         markdown_dialect="markdown_v2",
         len_unit="utf16",
         supported_ops=FULL_OPS,
+        capabilities=(
+            OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+            OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+            OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
+        ),
     )
     base.update(kw)
     return CapabilityDescriptor(**base)
@@ -76,9 +87,13 @@ def _event(
         text=text,
         message_type=MessageType.COMMAND,
         source=SessionSource(
-            platform="telegram", chat_id=chat_id, chat_type="dm", user_id="u1"
+            platform=Platform.TELEGRAM,
+            chat_id=chat_id,
+            chat_type="dm",
+            user_id="u1",
         ),
         prompt_response=prompt_response,
+        owner_id="opaque-owner:interactive",
     )
 
 
@@ -269,19 +284,24 @@ async def test_ws_prompt_redelivery_with_same_buffer_id_is_consumed_once_and_rea
     ack_attempts: list[str] = []
     committed_acks: list[str] = []
 
-    async def lose_first_ack(buffer_id: str) -> None:
+    async def lose_first_ack(frame: dict) -> None:
+        buffer_id = frame.get("bufferId")
         ack_attempts.append(buffer_id)
-        if len(ack_attempts) > 1:
-            committed_acks.append(buffer_id)
+        if len(ack_attempts) == 1:
+            raise RuntimeError("lose first ack")
+        committed_acks.append(buffer_id)
 
-    transport._send_inbound_ack = lose_first_ack
+    transport._runtime_epoch = "interactive-runtime"
+    transport._send = lose_first_ack
     frame = json.dumps(
         {
             "type": "inbound",
+            "delivery_id": "delivery-prompt-1",
             "bufferId": "buf-prompt-1",
             "event": {
                 "text": "/c0",
                 "message_type": "command",
+                "owner_id": "opaque-owner:interactive",
                 "source": {
                     "platform": "telegram",
                     "chat_id": "c1",
@@ -315,19 +335,22 @@ async def test_ws_malformed_prompt_dict_is_terminally_consumed(monkeypatch):
     transport._inbound = adapter._on_inbound
     acked: list[str] = []
 
-    async def capture_ack(buffer_id: str) -> None:
-        acked.append(buffer_id)
+    async def capture_ack(frame: dict) -> None:
+        acked.append(frame.get("bufferId"))
 
-    transport._send_inbound_ack = capture_ack
+    transport._runtime_epoch = "interactive-runtime"
+    transport._send = capture_ack
 
     await transport._handle_frame(
         json.dumps(
             {
                 "type": "inbound",
+                "delivery_id": "delivery-malformed-prompt",
                 "bufferId": "buf-malformed-prompt",
                 "event": {
                     "text": "/c0",
                     "message_type": "command",
+                    "owner_id": "opaque-owner:interactive",
                     "source": {
                         "platform": "telegram",
                         "chat_id": "c1",
@@ -396,13 +419,14 @@ def _reactable_event() -> MessageEvent:
         text="do something",
         message_type=MessageType.TEXT,
         source=SessionSource(
-            platform="discord",
+            platform=Platform.DISCORD,
             chat_id="ch1",
             chat_type="channel",
             user_id="u1",
             message_id="m42",
         ),
         message_id="m42",
+        owner_id="opaque-owner:reactable",
     )
 
 
@@ -536,16 +560,19 @@ async def test_ws_non_object_prompt_field_is_terminally_consumed_and_acked(
     transport._inbound = adapter._on_inbound
     acked: list[str] = []
 
-    async def capture_ack(buffer_id: str) -> None:
-        acked.append(buffer_id)
+    async def capture_ack(frame: dict) -> None:
+        acked.append(frame.get("bufferId"))
 
-    transport._send_inbound_ack = capture_ack
+    transport._runtime_epoch = "interactive-runtime"
+    transport._send = capture_ack
     await transport._handle_frame(json.dumps({
         "type": "inbound",
+        "delivery_id": "delivery-malformed-prompt-shape",
         "bufferId": "buf-malformed-prompt-shape",
         "event": {
             "text": "/c1",
             "message_type": "command",
+            "owner_id": "opaque-owner:interactive",
             "source": {
                 "platform": "telegram",
                 "chat_id": "c1",

--- a/tests/gateway/relay/test_relay_interactive.py
+++ b/tests/gateway/relay/test_relay_interactive.py
@@ -445,6 +445,23 @@ async def test_processing_lifecycle_reacts_eyes_then_check():
     assert all(r["message_id"] == "m42" and r["chat_id"] == "ch1" for r in reacts)
 
 
+@pytest.mark.asyncio
+async def test_ownerless_passthrough_completion_still_projects_terminal_reactions():
+    """Passthrough work has no relay owner, but its visible 👀 must still settle."""
+    adapter, stub = _adapter()
+    event = _reactable_event()
+    event.owner_id = None
+    adapter.descriptor = make_desc(capabilities=())
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    reacts = [action for action in stub.sent if action["op"] == "react"]
+    assert [(reaction["emoji"], reaction.get("remove", False)) for reaction in reacts] == [
+        ("👀", True),
+        ("✅", False),
+    ]
+
+
 # ── fanned-out prompt answers (one press, many gateways) ─────────────────
 #
 # The connector delivers a passthrough forward (a Discord button press) to

--- a/tests/gateway/relay/test_relay_interactive.py
+++ b/tests/gateway/relay/test_relay_interactive.py
@@ -8,8 +8,8 @@ Covers:
     triggers run.py's text fallback);
   - the pending-prompt registry: mint → consume-once → expiry;
   - _consume_prompt_response routes answers to the approval / slash-confirm /
-    clarify resolvers and CONSUMES the event; unknown/expired ids fall
-    through to normal dispatch;
+    clarify resolvers and CONSUMES every structured frame; duplicate, expired,
+    and unknown ids never fall through as command-shaped text;
   - the Discord type-3 hp1 decode (structured prompt_response replacing the
     bare-custom_id stub; foreign custom_ids keep the legacy text shape);
   - on_processing_start/complete drive react ops (👀 → ✅/❌), op-gated and
@@ -18,6 +18,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 import time
 from typing import Any, Dict, Optional
 
@@ -27,6 +28,7 @@ from gateway.config import PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
 from gateway.relay.adapter import RelayAdapter
 from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+from gateway.relay.ws_transport import WebSocketRelayTransport
 from gateway.session import SessionSource
 
 from tests.gateway.relay.stub_connector import StubConnector
@@ -196,6 +198,168 @@ async def test_prompt_response_resolves_clarify_choice_and_other(monkeypatch):
     assert marked == ["cl-10"]
 
 
+@pytest.mark.asyncio
+async def test_structured_prompt_duplicates_expired_and_unknown_never_dispatch(monkeypatch):
+    adapter, stub = _adapter()
+    await adapter.send_clarify("c1", "Which?", ["alpha"], "cl-11", "s")
+    prompt_id = stub.sent[-1]["prompt_id"]
+
+    resolved: list[tuple[str, str]] = []
+    dispatched: list[MessageEvent] = []
+
+    monkeypatch.setattr(
+        "tools.clarify_gateway.resolve_gateway_clarify",
+        lambda cid, resp: resolved.append((cid, resp)) or True,
+    )
+
+    async def capture_dispatch(event):
+        dispatched.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", capture_dispatch)
+
+    # First delivery resolves the prompt; a durable redelivery before ACK is a
+    # duplicate and must remain a structured control frame, never a /c0 command.
+    duplicate = _event({"prompt_id": prompt_id, "option_id": "c0"}, text="/c0")
+    await adapter._on_inbound(duplicate)
+    await adapter._on_inbound(duplicate)
+
+    expired_id = adapter._mint_prompt(
+        "clarify",
+        {
+            "session_key": "s",
+            "clarify_id": "cl-expired",
+            "choices": ["alpha"],
+            "chat_id": "c1",
+        },
+        timeout_s=-1,
+    )
+    await adapter._on_inbound(
+        _event({"prompt_id": expired_id, "option_id": "c0"}, text="/c0")
+    )
+    await adapter._on_inbound(
+        _event({"prompt_id": "unknown", "option_id": "c0"}, text="/c0")
+    )
+
+    assert resolved == [("cl-11", "alpha")]
+    assert dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_ws_prompt_redelivery_with_same_buffer_id_is_consumed_once_and_reacked(
+    monkeypatch,
+):
+    adapter, stub = _adapter()
+    await adapter.send_clarify("c1", "Which?", ["alpha"], "cl-ws", "s")
+    prompt_id = stub.sent[-1]["prompt_id"]
+    resolved: list[tuple[str, str]] = []
+    dispatched: list[MessageEvent] = []
+
+    monkeypatch.setattr(
+        "tools.clarify_gateway.resolve_gateway_clarify",
+        lambda cid, resp: resolved.append((cid, resp)) or True,
+    )
+
+    async def capture_dispatch(event):
+        dispatched.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", capture_dispatch)
+
+    transport = object.__new__(WebSocketRelayTransport)
+    transport._inbound = adapter._on_inbound
+    ack_attempts: list[str] = []
+    committed_acks: list[str] = []
+
+    async def lose_first_ack(buffer_id: str) -> None:
+        ack_attempts.append(buffer_id)
+        if len(ack_attempts) > 1:
+            committed_acks.append(buffer_id)
+
+    transport._send_inbound_ack = lose_first_ack
+    frame = json.dumps(
+        {
+            "type": "inbound",
+            "bufferId": "buf-prompt-1",
+            "event": {
+                "text": "/c0",
+                "message_type": "command",
+                "source": {
+                    "platform": "telegram",
+                    "chat_id": "c1",
+                    "chat_type": "dm",
+                    "user_id": "u1",
+                },
+                "prompt_response": {"prompt_id": prompt_id, "option_id": "c0"},
+            },
+        }
+    )
+
+    await transport._handle_frame(frame)
+    await transport._handle_frame(frame)
+
+    assert resolved == [("cl-ws", "alpha")]
+    assert dispatched == []
+    assert ack_attempts == ["buf-prompt-1", "buf-prompt-1"]
+    assert committed_acks == ["buf-prompt-1"]
+
+
+@pytest.mark.asyncio
+async def test_ws_malformed_prompt_dict_is_terminally_consumed(monkeypatch):
+    adapter, _stub = _adapter()
+    dispatched: list[MessageEvent] = []
+
+    async def capture_dispatch(event):
+        dispatched.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", capture_dispatch)
+    transport = object.__new__(WebSocketRelayTransport)
+    transport._inbound = adapter._on_inbound
+    acked: list[str] = []
+
+    async def capture_ack(buffer_id: str) -> None:
+        acked.append(buffer_id)
+
+    transport._send_inbound_ack = capture_ack
+
+    await transport._handle_frame(
+        json.dumps(
+            {
+                "type": "inbound",
+                "bufferId": "buf-malformed-prompt",
+                "event": {
+                    "text": "/c0",
+                    "message_type": "command",
+                    "source": {
+                        "platform": "telegram",
+                        "chat_id": "c1",
+                        "chat_type": "dm",
+                        "user_id": "u1",
+                    },
+                    "prompt_response": {},
+                },
+            }
+        )
+    )
+
+    assert dispatched == []
+    assert acked == ["buf-malformed-prompt"]
+
+
+@pytest.mark.asyncio
+async def test_typed_command_without_prompt_response_still_dispatches(monkeypatch):
+    adapter, _stub = _adapter()
+    dispatched: list[MessageEvent] = []
+
+    async def capture_dispatch(event):
+        dispatched.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", capture_dispatch)
+    typed = _event(prompt_response=None, text="/c0")
+
+    await adapter._on_inbound(typed)
+
+    assert dispatched == [typed]
+
+
 # ── Discord type-3 hp1 decode ────────────────────────────────────────────
 
 
@@ -354,3 +518,43 @@ def test_minted_prompt_ids_are_instance_scoped_and_callback_safe():
     # A legacy id minted before the nonce existed (no "." segment) is still
     # treated as ours, so a prompt in flight across an upgrade resolves.
     assert a._minted_here("a1b2c3d4") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("malformed", ["bad", [], 7, None])
+async def test_ws_non_object_prompt_field_is_terminally_consumed_and_acked(
+    monkeypatch, malformed
+):
+    adapter, _stub = _adapter()
+    dispatched: list[MessageEvent] = []
+
+    async def capture_dispatch(event):
+        dispatched.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", capture_dispatch)
+    transport = object.__new__(WebSocketRelayTransport)
+    transport._inbound = adapter._on_inbound
+    acked: list[str] = []
+
+    async def capture_ack(buffer_id: str) -> None:
+        acked.append(buffer_id)
+
+    transport._send_inbound_ack = capture_ack
+    await transport._handle_frame(json.dumps({
+        "type": "inbound",
+        "bufferId": "buf-malformed-prompt-shape",
+        "event": {
+            "text": "/c1",
+            "message_type": "command",
+            "source": {
+                "platform": "telegram",
+                "chat_id": "c1",
+                "chat_type": "dm",
+                "user_id": "u1",
+            },
+            "prompt_response": malformed,
+        },
+    }))
+
+    assert dispatched == []
+    assert acked == ["buf-malformed-prompt-shape"]

--- a/tests/gateway/relay/test_relay_interrupt.py
+++ b/tests/gateway/relay/test_relay_interrupt.py
@@ -671,13 +671,20 @@ async def test_interrupt_reader_stays_live_until_correlated_result_is_ready():
     async def send(frame: dict) -> None:
         sent.append(frame)
 
-    async def handle_inbound(event: MessageEvent) -> None:
+    async def handle_inbound(event: MessageEvent) -> dict:
         inbound.append(event.text)
+        return {
+            "disposition": "rejected",
+            "canonical_turn_owner_id": None,
+            "session_key": "agent:main:relay:dm:chanA",
+            "chat_id": "chanA",
+        }
 
     transport._descriptor = _desc()
     transport._interrupt_inbound_handler = handler
     transport._send = send
     transport._inbound = handle_inbound
+    transport._runtime_epoch = "interrupt-reader-runtime"
     loop = asyncio.get_running_loop()
     outbound = loop.create_future()
     transport._pending = {"outbound-1": outbound}
@@ -698,10 +705,12 @@ async def test_interrupt_reader_stays_live_until_correlated_result_is_ready():
     assert await asyncio.wait_for(outbound, timeout=0.1) == {"success": True}
     await transport._handle_frame(json.dumps({
         "type": "inbound",
+        "delivery_id": "delivery-during-stop",
         "bufferId": "buffer-during-stop",
         "event": {
             "text": "delivered while stop waits",
             "message_type": "text",
+            "owner_id": "opaque-owner:during-stop",
             "source": {
                 "platform": "relay", "chat_id": "chanA", "chat_type": "dm",
                 "user_id": "owner",
@@ -709,7 +718,18 @@ async def test_interrupt_reader_stays_live_until_correlated_result_is_ready():
         },
     }))
     assert inbound == ["delivered while stop waits"]
-    assert sent == [{"type": "inbound_ack", "bufferId": "buffer-during-stop"}]
+    assert sent == [{
+        "type": "inbound_ack",
+        "delivery_id": "delivery-during-stop",
+        "session_key": "agent:main:relay:dm:chanA",
+        "chat_id": "chanA",
+        "owner_id": "opaque-owner:during-stop",
+        "runtime_epoch": "interrupt-reader-runtime",
+        "disposition": "rejected",
+        "canonical_turn_owner_id": None,
+        "owner_state_seq": 0,
+        "bufferId": "buffer-during-stop",
+    }]
 
     release.set()
     for _ in range(50):
@@ -1192,11 +1212,11 @@ async def test_transport_handshake_rejects_legacy_descriptor_fail_closed():
         "descriptor": legacy.__dict__,
     }))
 
-    with pytest.raises(RuntimeError, match="contract v2 required"):
+    with pytest.raises(RuntimeError, match="contract v3 required"):
         await transport._descriptor_ready
     assert transport._descriptor is None
     assert transport._handshake_succeeded is False
-    assert closed == [(4406, "relay contract v2 required")]
+    assert closed == [(4406, "relay contract v3 required")]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/relay/test_relay_interrupt.py
+++ b/tests/gateway/relay/test_relay_interrupt.py
@@ -1,19 +1,38 @@
-"""Relay /stop interrupt routing (relay Phase 1, Task 1.4).
-
-Proves a connector-delivered mid-turn interrupt reaches the existing per-session
-interrupt mechanism and cancels exactly the targeted session_key's turn — never
-a sibling's. Mirrors the isolation discipline of test_stop_thread_sibling.py.
-"""
+"""Generation-bound Relay Stop routed through GatewayRunner's hard-stop seam."""
 
 from __future__ import annotations
 
 import asyncio
+import json
+import shlex
+import sys
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+import gateway.relay.ws_transport as ws_transport_module
+import gateway.run as gateway_run_module
+from gateway.interrupt_budget import (
+    HARD_STOP_REAP_TIMEOUT_SECONDS,
+    INTERRUPT_ACTIVITY_TIMEOUT_SECONDS,
+    INTERRUPT_HANDLER_SAFETY_MARGIN_SECONDS,
+    SESSION_PROCESSING_CANCEL_TIMEOUT_SECONDS,
+)
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.relay.adapter import RelayAdapter
-from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+from gateway.relay.descriptor import (
+    CONTRACT_VERSION,
+    OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+    CapabilityDescriptor,
+)
+from gateway.relay.ws_transport import WebSocketRelayTransport, _event_from_wire
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+from tools.process_registry import process_registry
 
 from tests.gateway.relay.stub_connector import StubConnector
 
@@ -29,26 +48,1397 @@ def _desc() -> CapabilityDescriptor:
         supports_threads=True,
         markdown_dialect="discord",
         len_unit="chars",
+        capabilities=(OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,),
     )
 
 
 @pytest.fixture
 def adapter():
-    return RelayAdapter(PlatformConfig(), _desc(), transport=StubConnector(_desc()))
+    return RelayAdapter(PlatformConfig(typing_indicator=False), _desc(), transport=StubConnector(_desc()))
+
+
+def _event(owner_id: str, text: str = "run a long tool") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        owner_id=owner_id,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chanA",
+            chat_type="dm",
+            user_id="userX",
+            delivered_via_upstream_relay=True,
+        ),
+    )
+
+
+def _runner(adapter: RelayAdapter) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.RELAY: adapter.config})
+    runner.adapters = {Platform.RELAY: adapter}
+    runner._profile_adapters = {}
+    runner._sessions = {}
+    runner._persist_active_agents = MagicMock()
+    runner._evict_cached_agent = MagicMock()
+    adapter.gateway_runner = runner
+    adapter.set_session_interrupt_handler(runner._handle_adapter_session_interrupt)
+    return runner
+
+
+class _ControlledAgent:
+    def __init__(self) -> None:
+        self.hard_interrupts: list[str | None] = []
+        self._gateway_turn_process_task_id = ""
+        self._gateway_turn_process_baseline = frozenset()
+
+    def hard_interrupt(self, message: str | None = None) -> None:
+        self.hard_interrupts.append(message)
+
+
+def test_inbound_wire_owner_id_is_parsed_fail_closed():
+    raw = {
+        "text": "hello",
+        "source": {"platform": "discord", "chat_id": "chanA", "chat_type": "dm"},
+    }
+
+    assert _event_from_wire({**raw, "owner_id": "relay-turn-wire"}).owner_id == "relay-turn-wire"
+    assert _event_from_wire(raw).owner_id is None
+    assert _event_from_wire({**raw, "owner_id": {"bad": "shape"}}).owner_id is None
 
 
 @pytest.mark.asyncio
-async def test_interrupt_sets_only_target_session_event(adapter):
-    key_a = "agent:main:discord:group:chanA:userX"
-    key_b = "agent:main:discord:group:chanB:userY"
-    ev_a = asyncio.Event()
-    ev_b = asyncio.Event()
-    adapter._active_sessions[key_a] = ev_a
-    adapter._active_sessions[key_b] = ev_b
+async def test_interrupt_wire_transports_owner_id_fail_closed():
+    transport = object.__new__(WebSocketRelayTransport)
+    calls: list[tuple[str, str, str | None]] = []
+    sent: list[dict] = []
 
-    await adapter.on_interrupt(key_a, chat_id="chanA")
+    async def handler(session_key: str, chat_id: str, owner_id: str | None) -> bool:
+        calls.append((session_key, chat_id, owner_id))
+        return True
 
-    assert ev_a.is_set() is True, "target session's interrupt Event must be set"
-    assert ev_b.is_set() is False, "sibling session must be untouched"
+    async def capture_send(frame: dict) -> None:
+        sent.append(frame)
+
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = handler
+    transport._send = capture_send
+    await transport._handle_frame(
+        json.dumps(
+            {
+                "type": "interrupt_inbound",
+                "session_key": "agent:main:discord:dm:chanA:userX",
+                "chat_id": "chanA",
+                "owner_id": "relay-turn-wire",
+                "action_id": "stop-action-wire-valid",
+            }
+        )
+    )
+    await transport._handle_frame(
+        json.dumps(
+            {
+                "type": "interrupt_inbound",
+                "session_key": "agent:main:discord:dm:chanA:userX",
+                "chat_id": "chanA",
+                "owner_id": {"bad": "shape"},
+                "action_id": "stop-action-wire-invalid",
+            }
+        )
+    )
+
+    for _ in range(50):
+        if len(sent) == 2:
+            break
+        await asyncio.sleep(0)
+    assert calls == [
+        ("agent:main:discord:dm:chanA:userX", "chanA", "relay-turn-wire"),
+    ]
+    assert {frame["action_id"]: frame["reason"] for frame in sent} == {
+        "stop-action-wire-valid": "accepted",
+        "stop-action-wire-invalid": "invalid_owner",
+    }
+    await transport._cancel_interrupt_tasks()
 
 
+@pytest.mark.asyncio
+async def test_missing_malformed_and_stale_owner_fail_closed(adapter):
+    current = _event("relay-turn-current")
+    started = asyncio.Event()
+    block = asyncio.Event()
+
+    async def handler(_event):
+        started.set()
+        await block.wait()
+
+    calls: list[tuple] = []
+
+    async def hard_stop(*args):
+        calls.append(args)
+        return True
+
+    adapter.set_message_handler(handler)
+    adapter.set_session_interrupt_handler(hard_stop)
+    await adapter.connect()
+    await adapter.handle_message(current)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    session_key = build_session_key(current.source)
+    owner_task = adapter._session_tasks[session_key]
+
+    try:
+        for owner_id in (None, "", "stale-owner", {"bad": "shape"}):
+            stopped = await adapter.on_interrupt(session_key, "chanA", owner_id)
+            assert stopped is False
+        assert calls == []
+        assert owner_task.done() is False
+    finally:
+        owner_task.cancel()
+        await asyncio.gather(owner_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_stale_owner_does_not_stop_replacement_generation(adapter):
+    replacement = _event("relay-turn-replacement")
+    started = asyncio.Event()
+    block = asyncio.Event()
+
+    async def handler(_event):
+        started.set()
+        await block.wait()
+
+    hard_stop = MagicMock()
+    adapter.set_message_handler(handler)
+    adapter.set_session_interrupt_handler(hard_stop)
+    await adapter.connect()
+    await adapter.handle_message(replacement)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    session_key = build_session_key(replacement.source)
+    owner_task = adapter._session_tasks[session_key]
+
+    try:
+        assert await adapter.on_interrupt(session_key, "chanA", "relay-turn-prior") is False
+        hard_stop.assert_not_called()
+        assert owner_task.done() is False
+        assert adapter._active_sessions[session_key]._hermes_owner_id == "relay-turn-replacement"
+    finally:
+        owner_task.cancel()
+        await asyncio.gather(owner_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_interrupt_sets_only_target_session_event_and_preserves_sibling(adapter):
+    target = _event("relay-turn-target")
+    sibling = MessageEvent(
+        text="sibling run",
+        message_type=MessageType.TEXT,
+        owner_id="relay-turn-sibling",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chanB",
+            chat_type="dm",
+            user_id="userY",
+            delivered_via_upstream_relay=True,
+        ),
+    )
+    started = {"chanA": asyncio.Event(), "chanB": asyncio.Event()}
+
+    async def handler(event):
+        started[event.source.chat_id].set()
+        await asyncio.Event().wait()
+
+    async def hard_stop(session_key, source, _owner_id, _generation):
+        await adapter.interrupt_session_activity(session_key, source.chat_id)
+        return True
+
+    adapter.set_message_handler(handler)
+    adapter.set_session_interrupt_handler(hard_stop)
+    await adapter.connect()
+    await adapter.handle_message(target)
+    await adapter.handle_message(sibling)
+    await asyncio.wait_for(started["chanA"].wait(), timeout=1.0)
+    await asyncio.wait_for(started["chanB"].wait(), timeout=1.0)
+    target_key = adapter.session_key_for_source(target.source)
+    sibling_key = adapter.session_key_for_source(sibling.source)
+    target_guard = adapter._active_sessions[target_key]
+    sibling_guard = adapter._active_sessions[sibling_key]
+    target_guard._hermes_run_generation = 1
+
+    assert await adapter.on_interrupt(target_key, "chanA", target.owner_id) is True
+
+    assert target_guard.is_set() is True
+    assert sibling_guard.is_set() is False
+    assert sibling_key in adapter._active_sessions
+    assert adapter._session_tasks[sibling_key].done() is False
+    sibling_task = adapter._session_tasks[sibling_key]
+    sibling_task.cancel()
+    await asyncio.gather(sibling_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_matching_owner_uses_canonical_runner_stop_reaps_real_child_and_hands_off_fresh_turn(
+    adapter, tmp_path: Path, monkeypatch
+):
+    runner = _runner(adapter)
+    first = _event("relay-turn-first")
+    doomed = _event("relay-turn-doomed", "queued before stop")
+    fresh = _event("relay-turn-fresh", "fresh next turn")
+    session_key = build_session_key(first.source)
+    sentinel = tmp_path / "late-child-sentinel"
+    first_started = asyncio.Event()
+    fresh_started = asyncio.Event()
+    child_holder = []
+    agent = _ControlledAgent()
+    late_callbacks: list[str] = []
+    owner_generations: list[tuple[str, int, str | None]] = []
+    scheduled_reapers: list[tuple] = []
+    real_thread = threading.Thread
+
+    class DelayedReaperThread:
+        def __init__(self, *, target, args=(), kwargs=None, **_options):
+            self.target = target
+            self.args = args
+            self.kwargs = kwargs or {}
+
+        def start(self):
+            scheduled_reapers.append((self.target, self.args, self.kwargs))
+
+    async def handler(event):
+        generation = runner._begin_session_run_generation(session_key)
+        runner._running_agents[session_key] = agent
+        runner._bind_adapter_run_generation(adapter, session_key, generation)
+        guard = adapter._active_sessions[session_key]
+        owner_generations.append(
+            (
+                getattr(guard, "_hermes_owner_id", ""),
+                getattr(guard, "_hermes_run_generation", 0),
+                getattr(guard, "_hermes_runner_session_key", None),
+            )
+        )
+        if event.owner_id == first.owner_id:
+            adapter.register_post_delivery_callback(
+                session_key,
+                lambda: late_callbacks.append("stale"),
+                generation=generation,
+            )
+            baseline = process_registry.snapshot_running_ids(session_key)
+            command = (
+                f"{shlex.quote(sys.executable)} -c "
+                f"{shlex.quote(f'import time; from pathlib import Path; time.sleep(30); Path({str(sentinel)!r}).write_text(chr(120))')}"
+            )
+            child = process_registry.spawn_local(command, task_id=session_key)
+            child_holder.append(child)
+            agent._gateway_turn_process_task_id = session_key
+            agent._gateway_turn_process_baseline = baseline
+            first_started.set()
+            # Model the real agent call naturally returning after hard_interrupt;
+            # no test-only allow_unwind gate keeps the adapter task open.
+            while not agent.hard_interrupts:
+                await asyncio.sleep(0)
+            return "stale response"
+        fresh_started.set()
+        return "fresh response"
+
+    adapter.set_message_handler(handler)
+    await adapter.connect()
+    await adapter.handle_message(first)
+    await asyncio.wait_for(first_started.wait(), timeout=2.0)
+    # Patch only after spawn_local created its real reader threads: run.py and
+    # process_registry share Python's threading module object.
+    monkeypatch.setattr("gateway.run.threading.Thread", DelayedReaperThread)
+    first_task = adapter._session_tasks[session_key]
+    child = child_holder[0]
+    canonical_stop = runner._interrupt_and_clear_session
+    adapter._pending_messages[session_key] = doomed
+
+    async def stop_then_receive_pending(*args, **kwargs):
+        await canonical_stop(*args, **kwargs)
+        # Model a message landing after canonical Stop discarded anything
+        # pending-before-Stop, but before adapter cancellation/drain. The old
+        # task is not held open by a test-only unwind gate.
+        adapter._pending_messages[session_key] = fresh
+
+    runner._interrupt_and_clear_session = stop_then_receive_pending
+    stop_task = asyncio.create_task(
+        adapter._transport.push_interrupt(session_key, "chanA", first.owner_id)
+    )
+    for _ in range(100):
+        if scheduled_reapers:
+            break
+        await asyncio.sleep(0)
+    assert scheduled_reapers, "hard-stop must schedule the canonical reaper"
+    assert fresh_started.is_set() is False
+
+    # Adversarial scheduler: release the reaper only after Stop reached its
+    # barrier. A replacement generation must not start before this finishes.
+    monkeypatch.setattr("gateway.run.threading.Thread", real_thread)
+    target, args, kwargs = scheduled_reapers.pop(0)
+    target(*args, **kwargs)
+    await asyncio.wait_for(stop_task, timeout=3.0)
+    await asyncio.wait_for(fresh_started.wait(), timeout=2.0)
+    assert owner_generations[0][0] == first.owner_id
+    assert owner_generations[1][0] == fresh.owner_id
+    assert [owner for owner, _generation, _runner_key in owner_generations] == [
+        first.owner_id,
+        fresh.owner_id,
+    ]
+    assert owner_generations[1][1] > owner_generations[0][1]
+    deadline = time.monotonic() + 5.0
+    while child.process.poll() is None and time.monotonic() < deadline:
+        await asyncio.sleep(0.05)
+
+    try:
+        assert child.process.poll() is not None, (
+            "a fresh handoff generation must not exempt the abandoned turn's child"
+        )
+        assert child.id not in process_registry.snapshot_running_ids(session_key)
+        assert agent.hard_interrupts
+        runner._evict_cached_agent.assert_called_once_with(session_key)
+    finally:
+        if child.process.poll() is None:
+            process_registry.kill_process(child.id, source="relay_interrupt_test_cleanup")
+    deadline = time.monotonic() + 2.0
+    while not any(
+        action.get("op") == "send" and action.get("content") == "fresh response"
+        for action in adapter._transport.sent
+    ) and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    fresh_task = adapter._session_tasks.get(session_key)
+    if fresh_task is not None:
+        await asyncio.wait_for(asyncio.shield(fresh_task), timeout=2.0)
+
+    assert first_task.cancelled() is True
+    assert not sentinel.exists()
+    assert late_callbacks == []
+    assert not any(
+        action.get("op") == "send" and action.get("content") not in {"fresh response"}
+        for action in adapter._transport.sent
+    )
+    assert any(
+        action.get("op") == "send" and action.get("content") == "fresh response"
+        for action in adapter._transport.sent
+    )
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+
+
+@pytest.mark.asyncio
+async def test_cancelling_real_canonical_stop_mid_reap_releases_barrier_and_allows_fresh_turn(
+    adapter, tmp_path: Path, monkeypatch
+):
+    """Cancellation after barrier installation must not strand the session."""
+    runner = _runner(adapter)
+    first = _event("relay-turn-cancelled")
+    fresh = _event("relay-turn-after-cancel", "fresh after cancelled stop")
+    session_key = adapter.session_key_for_source(first.source)
+    first_started = asyncio.Event()
+    fresh_started = asyncio.Event()
+    agent = _ControlledAgent()
+    child_holder = []
+    reap_entered = threading.Event()
+    release_reap = threading.Event()
+    real_reap = gateway_run_module._reap_gateway_turn_processes
+
+    def held_real_reap(*args, **kwargs):
+        reap_entered.set()
+        release_reap.wait(timeout=2.0)
+        return real_reap(*args, **kwargs)
+
+    async def handler(event):
+        generation = runner._begin_session_run_generation(session_key)
+        runner._running_agents[session_key] = agent
+        runner._bind_adapter_run_generation(
+            adapter,
+            session_key,
+            generation,
+            runner_session_key=session_key,
+        )
+        if event.owner_id == first.owner_id:
+            baseline = process_registry.snapshot_running_ids(session_key)
+            child = process_registry.spawn_local(
+                f"{shlex.quote(sys.executable)} -c "
+                f"{shlex.quote('import time; time.sleep(30)')}",
+                task_id=session_key,
+            )
+            child_holder.append(child)
+            agent._gateway_turn_process_task_id = session_key
+            agent._gateway_turn_process_baseline = baseline
+            first_started.set()
+            while not agent.hard_interrupts:
+                await asyncio.sleep(0)
+            return "stale response"
+        fresh_started.set()
+        return "fresh response"
+
+    monkeypatch.setattr(gateway_run_module, "_reap_gateway_turn_processes", held_real_reap)
+    adapter.set_message_handler(handler)
+    await adapter.connect()
+    await adapter.handle_message(first)
+    await asyncio.wait_for(first_started.wait(), timeout=2.0)
+    owner_task = adapter._session_tasks[session_key]
+    stop_task = asyncio.create_task(
+        adapter.on_interrupt(session_key, "chanA", first.owner_id)
+    )
+    await asyncio.wait_for(asyncio.to_thread(reap_entered.wait, 1.0), timeout=1.5)
+    guard = adapter._active_sessions[session_key]
+    barrier = guard._hermes_hard_stop_reap_barrier
+
+    try:
+        stop_task.cancel()
+        await asyncio.gather(stop_task, return_exceptions=True)
+        assert barrier.is_set(), "canonical Stop cancellation must release the handoff"
+
+        release_reap.set()
+        await asyncio.wait_for(
+            asyncio.gather(owner_task, return_exceptions=True), timeout=2.0
+        )
+        assert owner_task.cancelled()
+        child = child_holder[0]
+        deadline = time.monotonic() + 3.0
+        while child.process.poll() is None and time.monotonic() < deadline:
+            await asyncio.sleep(0.02)
+        assert child.process.poll() is not None
+        assert session_key not in adapter._active_sessions
+        assert session_key not in adapter._session_tasks
+
+        await adapter.handle_message(fresh)
+        await asyncio.wait_for(fresh_started.wait(), timeout=1.0)
+        fresh_task = adapter._session_tasks.get(session_key)
+        if fresh_task is not None:
+            await asyncio.wait_for(asyncio.shield(fresh_task), timeout=1.0)
+    finally:
+        release_reap.set()
+        barrier.set()
+        await asyncio.gather(stop_task, owner_task, return_exceptions=True)
+        for child in child_holder:
+            if child.process.poll() is None:
+                process_registry.kill_process(
+                    child.id, source="relay_cancel_barrier_test_cleanup"
+                )
+
+
+@pytest.mark.asyncio
+async def test_socket_close_cancellation_releases_real_canonical_reap_barrier(
+    adapter, monkeypatch
+):
+    """Transport teardown cancels the real adapter -> runner Stop call chain."""
+    runner = _runner(adapter)
+    event = _event("relay-turn-socket-close")
+    session_key = adapter.session_key_for_source(event.source)
+    started = asyncio.Event()
+    agent = _ControlledAgent()
+    agent._gateway_turn_process_task_id = session_key
+    agent._gateway_turn_process_baseline = frozenset()
+    reap_entered = threading.Event()
+    release_reap = threading.Event()
+    real_reap = gateway_run_module._reap_gateway_turn_processes
+
+    def held_real_reap(*args, **kwargs):
+        reap_entered.set()
+        release_reap.wait(timeout=2.0)
+        return real_reap(*args, **kwargs)
+
+    async def handler(_event):
+        generation = runner._begin_session_run_generation(session_key)
+        runner._running_agents[session_key] = agent
+        runner._bind_adapter_run_generation(
+            adapter, session_key, generation, runner_session_key=session_key
+        )
+        started.set()
+        while not agent.hard_interrupts:
+            await asyncio.sleep(0)
+        return "stopped"
+
+    monkeypatch.setattr(gateway_run_module, "_reap_gateway_turn_processes", held_real_reap)
+    adapter.set_message_handler(handler)
+    await adapter.connect()
+    await adapter.handle_message(event)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    interrupt_frame = {
+        "type": "interrupt_inbound",
+        "session_key": session_key,
+        "chat_id": "chanA",
+        "owner_id": event.owner_id,
+        "action_id": "stop-socket-close-real-path",
+    }
+
+    class ClosingSocket:
+        """Yield one real frame, then model the peer closing the socket."""
+
+        def __init__(self) -> None:
+            self._delivered = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._delivered:
+                self._delivered = True
+                return json.dumps(interrupt_frame) + "\n"
+            await asyncio.to_thread(reap_entered.wait, 1.0)
+            raise StopAsyncIteration
+
+        async def send(self, _frame: str) -> None:
+            raise ConnectionError("closed")
+
+    transport = object.__new__(WebSocketRelayTransport)
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = adapter.on_interrupt
+    transport._ws = ClosingSocket()
+    transport._reconnect = False
+    transport._closing = False
+    transport._auth_revoked = False
+    transport._supervisor = None
+    transport._handshake_succeeded = True
+    read_task = asyncio.create_task(transport._read_loop())
+    await asyncio.wait_for(asyncio.to_thread(reap_entered.wait, 1.0), timeout=1.5)
+    guard = adapter._active_sessions[session_key]
+    barrier = guard._hermes_hard_stop_reap_barrier
+
+    try:
+        await asyncio.wait_for(read_task, timeout=2.0)
+        assert barrier.is_set()
+        release_reap.set()
+        owner_task = adapter._session_tasks.get(session_key)
+        if owner_task is not None:
+            await asyncio.wait_for(asyncio.shield(owner_task), timeout=2.0)
+        assert transport._interrupt_tasks == set()
+        assert transport._interrupt_workers == {}
+        assert transport._interrupt_queues == {}
+        assert session_key not in adapter._active_sessions
+        assert session_key not in adapter._session_tasks
+        hard_interrupt_count = len(agent.hard_interrupts)
+        assert await adapter.on_interrupt(
+            session_key, "chanA", event.owner_id
+        ) is True
+        assert len(agent.hard_interrupts) == hard_interrupt_count
+    finally:
+        release_reap.set()
+        barrier.set()
+        await asyncio.gather(read_task, return_exceptions=True)
+        await transport._cancel_interrupt_tasks()
+        owner_task = adapter._session_tasks.get(session_key)
+        if owner_task is not None:
+            owner_task.cancel()
+            await asyncio.gather(owner_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_handoff_barrier_fail_safe_is_bounded_discarded_and_does_not_spin(
+    monkeypatch, caplog
+):
+    import gateway.platforms.base as base_module
+
+    class NeverReadyBarrier:
+        def __init__(self) -> None:
+            self.wait_calls: list[float] = []
+
+        def is_set(self) -> bool:
+            return False
+
+        def wait(self, timeout: float) -> bool:
+            self.wait_calls.append(timeout)
+            return False
+
+    guard = asyncio.Event()
+    barrier = NeverReadyBarrier()
+    guard._hermes_hard_stop_reap_barrier = barrier
+    monkeypatch.setattr(
+        base_module, "SESSION_HANDOFF_BARRIER_TIMEOUT_SECONDS", 0.01
+    )
+
+    await asyncio.wait_for(
+        base_module.BasePlatformAdapter._wait_session_handoff_barrier(guard),
+        timeout=0.2,
+    )
+
+    assert barrier.wait_calls == [0.01]
+    assert not hasattr(guard, "_hermes_hard_stop_reap_barrier")
+    assert "discarding the stale barrier" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_interrupt_reader_stays_live_until_correlated_result_is_ready():
+    transport = object.__new__(WebSocketRelayTransport)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    sent: list[dict] = []
+    inbound: list[str] = []
+
+    async def handler(_session_key: str, _chat_id: str, _owner_id: str | None) -> bool:
+        entered.set()
+        await release.wait()
+        return True
+
+    async def send(frame: dict) -> None:
+        sent.append(frame)
+
+    async def handle_inbound(event: MessageEvent) -> None:
+        inbound.append(event.text)
+
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = handler
+    transport._send = send
+    transport._inbound = handle_inbound
+    loop = asyncio.get_running_loop()
+    outbound = loop.create_future()
+    transport._pending = {"outbound-1": outbound}
+
+    await transport._handle_frame(json.dumps({
+        "type": "interrupt_inbound",
+        "session_key": "agent:main:discord:dm:chanA:userX",
+        "chat_id": "chanA",
+        "owner_id": "relay-turn-reader",
+        "action_id": "stop-action-reader",
+    }))
+    await asyncio.wait_for(entered.wait(), timeout=1.0)
+    await transport._handle_frame(json.dumps({
+        "type": "outbound_result",
+        "requestId": "outbound-1",
+        "result": {"success": True},
+    }))
+    assert await asyncio.wait_for(outbound, timeout=0.1) == {"success": True}
+    await transport._handle_frame(json.dumps({
+        "type": "inbound",
+        "bufferId": "buffer-during-stop",
+        "event": {
+            "text": "delivered while stop waits",
+            "message_type": "text",
+            "source": {
+                "platform": "relay", "chat_id": "chanA", "chat_type": "dm",
+                "user_id": "owner",
+            },
+        },
+    }))
+    assert inbound == ["delivered while stop waits"]
+    assert sent == [{"type": "inbound_ack", "bufferId": "buffer-during-stop"}]
+
+    release.set()
+    for _ in range(50):
+        if len(sent) == 2:
+            break
+        await asyncio.sleep(0)
+    assert sent[-1] == {
+        "type": "interrupt_result",
+        "action_id": "stop-action-reader",
+        "accepted": True,
+        "reason": "accepted",
+    }
+    await transport._cancel_interrupt_tasks()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_interrupt_action_id_has_one_hard_stop_and_one_result():
+    transport = object.__new__(WebSocketRelayTransport)
+    release = asyncio.Event()
+    calls = 0
+    sent: list[dict] = []
+
+    async def handler(*_args) -> bool:
+        nonlocal calls
+        calls += 1
+        await release.wait()
+        return True
+
+    async def send(frame: dict) -> None:
+        sent.append(frame)
+
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = handler
+    transport._send = send
+    frame = json.dumps({
+        "type": "interrupt_inbound",
+        "session_key": "agent:main:discord:dm:chanA:userX",
+        "chat_id": "chanA",
+        "owner_id": "relay-turn-duplicate",
+        "action_id": "stop-action-duplicate",
+    })
+    await transport._handle_frame(frame)
+    await transport._handle_frame(frame)
+    for _ in range(50):
+        if calls:
+            break
+        await asyncio.sleep(0)
+    assert calls == 1
+    release.set()
+    for _ in range(50):
+        if sent:
+            break
+        await asyncio.sleep(0)
+    assert len(sent) == 1
+    assert sent[0]["action_id"] == "stop-action-duplicate"
+    await transport._cancel_interrupt_tasks()
+
+
+@pytest.mark.asyncio
+async def test_distinct_interrupt_actions_are_serialized_per_session():
+    transport = object.__new__(WebSocketRelayTransport)
+    first_release = asyncio.Event()
+    second_release = asyncio.Event()
+    entered: list[str] = []
+    active_handlers = 0
+    max_active_handlers = 0
+    sent: list[dict] = []
+
+    async def handler(_session_key, _chat_id, owner_id) -> bool:
+        nonlocal active_handlers, max_active_handlers
+        active_handlers += 1
+        max_active_handlers = max(max_active_handlers, active_handlers)
+        entered.append(owner_id)
+        try:
+            await (first_release if len(entered) == 1 else second_release).wait()
+            return True
+        finally:
+            active_handlers -= 1
+
+    async def send(frame: dict) -> None:
+        sent.append(frame)
+
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = handler
+    transport._send = send
+    base = {
+        "type": "interrupt_inbound",
+        "session_key": "agent:main:discord:dm:chanA:userX",
+        "chat_id": "chanA",
+    }
+    await transport._handle_frame(json.dumps({
+        **base, "owner_id": "relay-turn-serial-1", "action_id": "stop-serial-1",
+    }))
+    await transport._handle_frame(json.dumps({
+        **base, "owner_id": "relay-turn-serial-2", "action_id": "stop-serial-2",
+    }))
+    for _ in range(50):
+        if entered:
+            break
+        await asyncio.sleep(0)
+    assert entered == ["relay-turn-serial-1"]
+    assert max_active_handlers == 1
+    first_release.set()
+    for _ in range(50):
+        if len(entered) == 2:
+            break
+        await asyncio.sleep(0)
+    assert entered == ["relay-turn-serial-1", "relay-turn-serial-2"]
+    assert max_active_handlers == 1
+    second_release.set()
+    for _ in range(50):
+        if len(sent) == 2:
+            break
+        await asyncio.sleep(0)
+    assert [frame["action_id"] for frame in sent] == ["stop-serial-1", "stop-serial-2"]
+    await transport._cancel_interrupt_tasks()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_worker_timeout_is_bounded_and_close_awaits_cancellation(monkeypatch):
+    """A wedged canonical stop/Slack typing cleanup cannot deadlock the reader."""
+    monkeypatch.setattr("gateway.relay.ws_transport._INTERRUPT_HANDLER_TIMEOUT_S", 0.01)
+    transport = object.__new__(WebSocketRelayTransport)
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+    sent: list[dict] = []
+
+    async def handler(*_args) -> bool:
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async def send(frame: dict) -> None:
+        sent.append(frame)
+
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = handler
+    transport._send = send
+    await transport._handle_frame(json.dumps({
+        "type": "interrupt_inbound",
+        "session_key": "agent:main:discord:dm:chanA:userX",
+        "chat_id": "chanA",
+        "owner_id": "relay-turn-timeout",
+        "action_id": "stop-timeout",
+    }))
+    await asyncio.wait_for(entered.wait(), timeout=1.0)
+    for _ in range(100):
+        if sent:
+            break
+        await asyncio.sleep(0.002)
+    assert cancelled.is_set()
+    assert sent == [{
+        "type": "interrupt_result", "action_id": "stop-timeout",
+        "accepted": False, "reason": "handler_timeout",
+    }]
+    await transport._cancel_interrupt_tasks()
+    assert transport._interrupt_tasks == set()
+    assert transport._interrupt_workers == {}
+    assert transport._interrupt_queues == {}
+
+
+def test_interrupt_handler_budget_exceeds_all_inner_bounds_with_margin():
+    """The outer ack cap must never cancel a normally bounded canonical Stop."""
+    inner_budget = (
+        HARD_STOP_REAP_TIMEOUT_SECONDS
+        + INTERRUPT_ACTIVITY_TIMEOUT_SECONDS
+        + SESSION_PROCESSING_CANCEL_TIMEOUT_SECONDS
+        + INTERRUPT_HANDLER_SAFETY_MARGIN_SECONDS
+    )
+    assert ws_transport_module._INTERRUPT_HANDLER_TIMEOUT_S > inner_budget
+    assert (
+        gateway_run_module._INTERRUPT_REAP_TIMEOUT_SECONDS
+        == HARD_STOP_REAP_TIMEOUT_SECONDS
+    )
+    assert (
+        gateway_run_module._INTERRUPT_ACTIVITY_TIMEOUT_SECONDS
+        == INTERRUPT_ACTIVITY_TIMEOUT_SECONDS
+    )
+
+
+@pytest.mark.asyncio
+async def test_outer_timeout_during_slow_reap_and_unwind_acks_admitted_terminal_stop(
+    adapter, monkeypatch
+):
+    """A half-applied exact-owner Stop must not become a retryable timeout NACK."""
+    import gateway.platforms.base as base_module
+
+    runner = _runner(adapter)
+    event = _event("relay-turn-budget-boundary")
+    session_key = adapter.session_key_for_source(event.source)
+    started = asyncio.Event()
+    unwind_entered = asyncio.Event()
+    release_unwind = asyncio.Event()
+    release_reap = threading.Event()
+    agent = _ControlledAgent()
+    agent._gateway_turn_process_task_id = session_key
+    agent._gateway_turn_process_baseline = frozenset()
+    real_reap = gateway_run_module._reap_gateway_turn_processes
+
+    def slow_reap(*args, **kwargs):
+        release_reap.wait(timeout=0.2)
+        return real_reap(*args, **kwargs)
+
+    async def handler(_event):
+        generation = runner._begin_session_run_generation(session_key)
+        runner._running_agents[session_key] = agent
+        runner._bind_adapter_run_generation(
+            adapter, session_key, generation, runner_session_key=session_key
+        )
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            unwind_entered.set()
+            await release_unwind.wait()
+            raise
+
+    monkeypatch.setattr(gateway_run_module, "_reap_gateway_turn_processes", slow_reap)
+    monkeypatch.setattr(gateway_run_module, "_INTERRUPT_REAP_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(
+        base_module, "SESSION_PROCESSING_CANCEL_TIMEOUT_SECONDS", 0.01
+    )
+    # Force the transport cap to cancel the real adapter -> runner chain while
+    # the reaper is still held. Adapter cancellation then performs its bounded
+    # slow-unwind cleanup and returns terminal acceptance.
+    monkeypatch.setattr(ws_transport_module, "_INTERRUPT_HANDLER_TIMEOUT_S", 0.005)
+    adapter.set_message_handler(handler)
+    await adapter.connect()
+    await adapter.handle_message(event)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    transport = object.__new__(WebSocketRelayTransport)
+    sent: list[dict] = []
+    result_sent = asyncio.Event()
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = adapter.on_interrupt
+
+    async def capture(frame):
+        sent.append(frame)
+        result_sent.set()
+
+    transport._send = capture
+    transport._queue_interrupt({
+        "session_key": session_key,
+        "chat_id": "chanA",
+        "owner_id": event.owner_id,
+        "action_id": "stop-budget-boundary",
+    })
+    try:
+        await asyncio.wait_for(unwind_entered.wait(), timeout=0.2)
+        await asyncio.wait_for(result_sent.wait(), timeout=0.2)
+        assert sent == [{
+            "type": "interrupt_result",
+            "action_id": "stop-budget-boundary",
+            "accepted": True,
+            "reason": "accepted",
+        }]
+        assert session_key not in adapter._active_sessions
+        assert session_key not in adapter._session_tasks
+    finally:
+        release_reap.set()
+        release_unwind.set()
+        await transport._cancel_interrupt_tasks()
+
+
+@pytest.mark.asyncio
+async def test_canonical_stop_bounds_wedged_slack_typing_cleanup(adapter, monkeypatch):
+    """A platform typing call cannot consume the WS interrupt timeout budget."""
+    runner = _runner(adapter)
+    source = _event("relay-turn-typing").source
+    session_key = adapter.session_key_for_source(source)
+    cancelled = asyncio.Event()
+    adapter._pending_messages[session_key] = _event("relay-turn-pending")
+    runner._peek_session_state = MagicMock(return_value=None)
+    runner._invalidate_session_run_generation = MagicMock()
+    runner._thread_metadata_for_source = MagicMock(return_value={})
+
+    async def wedged_typing(*_args, **_kwargs) -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    monkeypatch.setattr(adapter, "interrupt_session_activity", wedged_typing)
+    monkeypatch.setattr("gateway.run._INTERRUPT_ACTIVITY_TIMEOUT_SECONDS", 0.01)
+
+    await asyncio.wait_for(
+        runner._interrupt_and_clear_session(
+            session_key,
+            source,
+            interrupt_reason="test stop",
+            invalidation_reason="test",
+            release_running_state=False,
+        ),
+        timeout=0.5,
+    )
+
+    assert cancelled.is_set()
+    assert adapter.get_pending_message(session_key) is None
+
+
+@pytest.mark.asyncio
+async def test_interrupt_close_cancels_and_awaits_live_worker():
+    transport = object.__new__(WebSocketRelayTransport)
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+    sent: list[dict] = []
+
+    async def handler(*_args) -> bool:
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async def send(frame: dict) -> None:
+        sent.append(frame)
+
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = handler
+    transport._send = send
+    await transport._handle_frame(json.dumps({
+        "type": "interrupt_inbound",
+        "session_key": "agent:main:discord:dm:chanA:userX",
+        "chat_id": "chanA",
+        "owner_id": "relay-turn-close",
+        "action_id": "stop-close",
+    }))
+    await asyncio.wait_for(entered.wait(), timeout=1.0)
+    await transport._cancel_interrupt_tasks()
+    assert cancelled.is_set()
+    assert sent == []
+    assert transport._interrupt_tasks == set()
+    assert transport._interrupt_workers == {}
+    assert transport._interrupt_queues == {}
+
+
+@pytest.mark.asyncio
+async def test_interrupt_frame_identifiers_fail_closed_without_secret_logs(caplog):
+    transport = object.__new__(WebSocketRelayTransport)
+    calls = 0
+    sent: list[dict] = []
+
+    async def handler(*_args) -> bool:
+        nonlocal calls
+        calls += 1
+        return True
+
+    async def send(frame: dict) -> None:
+        sent.append(frame)
+
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = handler
+    transport._send = send
+    base = {
+        "type": "interrupt_inbound",
+        "session_key": "agent:main:discord:dm:chanA:userX",
+        "chat_id": "chanA",
+        "owner_id": "relay-turn-boundary",
+    }
+    await transport._handle_frame(json.dumps({
+        **base, "session_key": {"secret": "raw-session-secret"},
+        "action_id": "stop-bad-session",
+    }))
+    await transport._handle_frame(json.dumps({
+        **base, "chat_id": "raw-chat-secret\n", "action_id": "stop-bad-chat",
+    }))
+    await transport._handle_frame(json.dumps({
+        **base, "owner_id": ["raw-owner-secret"], "action_id": "stop-bad-owner",
+    }))
+    await transport._handle_frame(json.dumps({
+        **base, "action_id": {"secret": "raw-action-secret"},
+    }))
+    for _ in range(50):
+        if len(sent) == 3:
+            break
+        await asyncio.sleep(0)
+    assert calls == 0
+    assert {frame["action_id"]: frame["reason"] for frame in sent} == {
+        "stop-bad-session": "invalid_binding",
+        "stop-bad-chat": "invalid_binding",
+        "stop-bad-owner": "invalid_owner",
+    }
+    logs = caplog.text
+    for secret in (
+        "raw-session-secret", "raw-chat-secret", "raw-owner-secret", "raw-action-secret"
+    ):
+        assert secret not in logs
+    await transport._cancel_interrupt_tasks()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_requires_negotiated_ack_capability_and_never_leaks_exception():
+    transport = object.__new__(WebSocketRelayTransport)
+    sent: list[dict] = []
+    calls = 0
+
+    async def handler(*_args) -> bool:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("secret raw backend detail")
+
+    async def send(frame: dict) -> None:
+        sent.append(frame)
+
+    transport._descriptor = CapabilityDescriptor(
+        contract_version=1,
+        platform="discord",
+        label="legacy",
+        max_message_length=2000,
+        supports_draft_streaming=False,
+        supports_edit=True,
+        supports_threads=False,
+        markdown_dialect="discord",
+        len_unit="chars",
+    )
+    transport._interrupt_inbound_handler = handler
+    transport._send = send
+    base = {
+        "type": "interrupt_inbound",
+        "session_key": "agent:main:discord:dm:chanA:userX",
+        "chat_id": "chanA",
+        "owner_id": "relay-turn-capability",
+    }
+    await transport._handle_frame(json.dumps({**base, "action_id": "stop-action-legacy"}))
+    for _ in range(50):
+        if sent:
+            break
+        await asyncio.sleep(0)
+    assert calls == 0
+    assert sent[-1]["reason"] == "capability_not_negotiated"
+
+    transport._descriptor = _desc()
+    await transport._handle_frame(json.dumps({**base, "action_id": "stop-action-error"}))
+    for _ in range(50):
+        if len(sent) == 2:
+            break
+        await asyncio.sleep(0)
+    assert calls == 1
+    assert sent[-1]["accepted"] is False
+    assert sent[-1]["reason"] == "internal_error"
+    assert "secret raw backend detail" not in json.dumps(sent[-1])
+    await transport._cancel_interrupt_tasks()
+
+
+@pytest.mark.asyncio
+async def test_transport_handshake_rejects_legacy_descriptor_fail_closed():
+    transport = object.__new__(WebSocketRelayTransport)
+    loop = asyncio.get_running_loop()
+    transport._descriptor = None
+    transport._descriptors_by_platform = {}
+    transport._descriptor_ready = loop.create_future()
+    transport._handshake_succeeded = False
+    closed: list[tuple[int, str]] = []
+
+    class Socket:
+        async def close(self, *, code: int, reason: str) -> None:
+            closed.append((code, reason))
+
+    transport._ws = Socket()
+    legacy = CapabilityDescriptor(
+        contract_version=1,
+        platform="relay",
+        label="legacy",
+        max_message_length=4096,
+        supports_draft_streaming=False,
+        supports_edit=True,
+        supports_threads=False,
+        markdown_dialect="plain",
+        len_unit="chars",
+    )
+
+    await transport._handle_frame(json.dumps({
+        "type": "descriptor",
+        "descriptor": legacy.__dict__,
+    }))
+
+    with pytest.raises(RuntimeError, match="contract v2 required"):
+        await transport._descriptor_ready
+    assert transport._descriptor is None
+    assert transport._handshake_succeeded is False
+    assert closed == [(4406, "relay contract v2 required")]
+
+
+@pytest.mark.asyncio
+async def test_runner_binds_generation_before_slow_preparation_can_be_stopped(adapter):
+    runner = _runner(adapter)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._voice_mode = {}
+    runner._background_tasks = set()
+    runner._draining = False
+    runner._restart_requested = False
+    runner._restart_task_started = False
+    runner._restart_detached = False
+    runner._restart_via_service = False
+    runner._restart_drain_timeout = 0.0
+    runner._stop_task = None
+    runner._exit_code = None
+    runner._external_drain_active = False
+    runner._update_runtime_status = MagicMock()
+    runner._is_user_authorized = lambda _source: True
+    runner.hooks = MagicMock()
+    runner.session_store = None
+
+    event = _event("relay-turn-early")
+    entered_slow_preparation = asyncio.Event()
+    release_preparation = asyncio.Event()
+    canonical_stop: list[tuple] = []
+
+    async def slow_inner(_event, _source, _key, _generation):
+        entered_slow_preparation.set()
+        await release_preparation.wait()
+        return "late response"
+
+    async def capture_stop(*args, **kwargs):
+        canonical_stop.append((args, kwargs))
+
+    runner._handle_message_with_agent = slow_inner
+    runner._interrupt_and_clear_session = capture_stop
+    adapter.set_message_handler(runner._handle_message)
+    await adapter.connect()
+    await adapter.handle_message(event)
+    await asyncio.wait_for(entered_slow_preparation.wait(), timeout=1.0)
+    adapter_key = adapter.session_key_for_source(event.source)
+    guard = adapter._active_sessions[adapter_key]
+
+    assert isinstance(guard._hermes_run_generation, int)
+    assert guard._hermes_runner_session_key == runner._session_key_for_source(event.source)
+    assert await adapter.on_interrupt(adapter_key, "chanA", event.owner_id) is True
+    assert canonical_stop
+    assert canonical_stop[0][0][0] == runner._session_key_for_source(event.source)
+    release_preparation.set()
+
+
+@pytest.mark.asyncio
+async def test_multiplexed_profile_stop_maps_adapter_key_to_exact_runner_session(adapter):
+    runner = _runner(adapter)
+    runner.config.multiplex_profiles = True
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chanA",
+        chat_type="dm",
+        user_id="userX",
+        profile="research",
+        delivered_via_upstream_relay=True,
+    )
+    event = MessageEvent(
+        text="profile turn",
+        message_type=MessageType.TEXT,
+        owner_id="relay-turn-research",
+        source=source,
+    )
+    sibling = MessageEvent(
+        text="sibling turn",
+        message_type=MessageType.TEXT,
+        owner_id="relay-turn-sibling",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chanB",
+            chat_type="dm",
+            user_id="userY",
+            delivered_via_upstream_relay=True,
+        ),
+    )
+    adapter_key = adapter.session_key_for_source(source)
+    sibling_key = adapter.session_key_for_source(sibling.source)
+    research_guard = asyncio.Event()
+    sibling_guard = asyncio.Event()
+    adapter._bind_session_guard_event(research_guard, event)
+    adapter._bind_session_guard_event(sibling_guard, sibling)
+    adapter._active_sessions = {adapter_key: research_guard, sibling_key: sibling_guard}
+    loop = asyncio.get_running_loop()
+    research_task = loop.create_future()
+    sibling_task = loop.create_future()
+    adapter._session_tasks = {adapter_key: research_task, sibling_key: sibling_task}
+    runner_key = runner._session_key_for_source(source)
+    generation = runner._begin_session_run_generation(runner_key)
+    runner._bind_adapter_run_generation_for_source(source, runner_key, generation)
+    stopped: list[tuple] = []
+
+    async def capture_stop(*args, **kwargs):
+        stopped.append((args, kwargs))
+
+    runner._interrupt_and_clear_session = capture_stop
+    assert adapter_key.startswith("agent:main:")
+    assert runner_key.startswith("agent:research:")
+    assert await adapter.on_interrupt(adapter_key, "chanA", event.owner_id) is True
+    assert stopped[0][0][0] == runner_key
+    assert stopped[0][1]["adapter_session_key"] == adapter_key
+    assert sibling_guard.is_set() is False
+    assert sibling_task.done() is False
+
+
+@pytest.mark.asyncio
+async def test_multiplexed_post_delivery_callback_uses_authoritative_adapter_key_and_generation(
+    adapter,
+):
+    runner = _runner(adapter)
+    runner.config.multiplex_profiles = True
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chanA",
+        chat_type="dm",
+        user_id="userX",
+        profile="research",
+        delivered_via_upstream_relay=True,
+    )
+    event = MessageEvent(
+        text="profile callback",
+        message_type=MessageType.TEXT,
+        owner_id="relay-turn-profile-callback",
+        source=source,
+    )
+    adapter_key = adapter.session_key_for_source(source)
+    runner_key = runner._session_key_for_source(source)
+    guard = asyncio.Event()
+    adapter._bind_session_guard_event(guard, event)
+    adapter._active_sessions[adapter_key] = guard
+    generation = runner._begin_session_run_generation(runner_key)
+    runner._bind_adapter_run_generation_for_source(source, runner_key, generation)
+    delivered: list[str] = []
+
+    async def capture(_source, message):
+        delivered.append(message)
+
+    runner._send_goal_status_notice = capture
+    await runner._defer_goal_status_notice_after_delivery(source, "after")
+
+    assert runner_key != adapter_key
+    assert runner_key not in adapter._post_delivery_callbacks
+    callback = adapter.pop_post_delivery_callback(
+        adapter_key, generation=generation
+    )
+    assert callback is not None
+    await callback()
+    assert delivered == ["after"]
+
+
+@pytest.mark.asyncio
+async def test_interrupt_send_result_failure_is_consumed_and_next_action_cleans_up(caplog):
+    transport = object.__new__(WebSocketRelayTransport)
+    calls: list[str] = []
+
+    async def handler(_session_key, _chat_id, owner_id):
+        calls.append(owner_id)
+        return True
+
+    async def failed_send(_frame):
+        raise ConnectionError("raw socket detail")
+
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = handler
+    transport._send = failed_send
+    base = {
+        "session_key": "agent:main:discord:dm:chanA:userX",
+        "chat_id": "chanA",
+    }
+    transport._queue_interrupt({
+        **base,
+        "owner_id": "relay-turn-send-fail-1",
+        "action_id": "stop-send-fail-1",
+    })
+    transport._queue_interrupt({
+        **base,
+        "owner_id": "relay-turn-send-fail-2",
+        "action_id": "stop-send-fail-2",
+    })
+
+    for _ in range(100):
+        if not getattr(transport, "_interrupt_tasks", set()):
+            break
+        await asyncio.sleep(0)
+
+    assert calls == ["relay-turn-send-fail-1", "relay-turn-send-fail-2"]
+    assert transport._interrupt_tasks == set()
+    assert transport._interrupt_workers == {}
+    assert transport._interrupt_queues == {}
+    assert "raw socket detail" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_interrupt_session_worker_count_has_global_capacity(monkeypatch):
+    transport = object.__new__(WebSocketRelayTransport)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    sent: list[dict] = []
+
+    async def handler(*_args):
+        entered.set()
+        await release.wait()
+        return True
+
+    async def capture(frame):
+        sent.append(frame)
+
+    monkeypatch.setattr(ws_transport_module, "_INTERRUPT_MAX_SESSION_WORKERS", 1)
+    transport._descriptor = _desc()
+    transport._interrupt_inbound_handler = handler
+    transport._send = capture
+    transport._queue_interrupt({
+        "session_key": "agent:main:discord:dm:chanA:userX",
+        "chat_id": "chanA",
+        "owner_id": "relay-turn-capacity-a",
+        "action_id": "stop-capacity-a",
+    })
+    await asyncio.wait_for(entered.wait(), timeout=1.0)
+    transport._queue_interrupt({
+        "session_key": "agent:main:discord:dm:chanB:userY",
+        "chat_id": "chanB",
+        "owner_id": "relay-turn-capacity-b",
+        "action_id": "stop-capacity-b",
+    })
+    for _ in range(100):
+        if sent:
+            break
+        await asyncio.sleep(0)
+    assert sent == [{
+        "type": "interrupt_result",
+        "action_id": "stop-capacity-b",
+        "accepted": False,
+        "reason": "interrupt_busy",
+    }]
+    release.set()
+    await transport._cancel_interrupt_tasks()

--- a/tests/gateway/relay/test_relay_per_platform_caps.py
+++ b/tests/gateway/relay/test_relay_per_platform_caps.py
@@ -32,6 +32,8 @@ from gateway.relay.adapter import RelayAdapter
 from gateway.relay.descriptor import (
     CONTRACT_VERSION,
     OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+    OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+    OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
     CapabilityDescriptor,
 )
 from gateway.session import SessionSource
@@ -50,7 +52,11 @@ def _descriptor(platform: str, max_len: int, len_unit: str = "chars") -> Capabil
         supports_threads=False,
         markdown_dialect="plain",
         len_unit=len_unit,
-        capabilities=(OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,),
+        capabilities=(
+            OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+            OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+            OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
+        ),
     )
 
 
@@ -158,4 +164,3 @@ async def test_adapter_resolves_per_chat_limits_from_inbound_platform():
 
 
 # ───────────────────── stream consumer integration ─────────────────────
-

--- a/tests/gateway/relay/test_relay_per_platform_caps.py
+++ b/tests/gateway/relay/test_relay_per_platform_caps.py
@@ -29,7 +29,11 @@ import pytest
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.relay.adapter import RelayAdapter
-from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+from gateway.relay.descriptor import (
+    CONTRACT_VERSION,
+    OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+    CapabilityDescriptor,
+)
 from gateway.session import SessionSource
 
 from tests.gateway.relay.stub_connector import StubConnector
@@ -46,6 +50,7 @@ def _descriptor(platform: str, max_len: int, len_unit: str = "chars") -> Capabil
         supports_threads=False,
         markdown_dialect="plain",
         len_unit=len_unit,
+        capabilities=(OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,),
     )
 
 
@@ -153,5 +158,4 @@ async def test_adapter_resolves_per_chat_limits_from_inbound_platform():
 
 
 # ───────────────────── stream consumer integration ─────────────────────
-
 

--- a/tests/gateway/relay/test_relay_turn_completed.py
+++ b/tests/gateway/relay/test_relay_turn_completed.py
@@ -571,3 +571,43 @@ async def test_queued_handoff_completes_owner_n_before_owner_n_plus_one_binds() 
     assert [item["owner_id"] for item in stub.turn_completions] == [OWNER_1, OWNER_2]
     assert stub.turn_completions[0]["next_owner_id"] == OWNER_2
     assert stub.turn_completions[0]["next_delivery_id"] == "delivery-owner-2"
+
+
+@pytest.mark.asyncio
+async def test_active_turn_bypass_command_is_absorbed_by_the_real_owner_without_phantom_owner() -> None:
+    """A relay /reset is control traffic for A, never a short-lived owner B."""
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    first_started = asyncio.Event()
+
+    async def handler(event):
+        if event.owner_id == OWNER_1:
+            first_started.set()
+            await asyncio.Event().wait()
+        return "Reset confirmed"
+
+    adapter.set_message_handler(handler)
+    first = _event(OWNER_1, "long-running turn")
+    session_key = build_session_key(first.source)
+    await adapter.handle_message(first)
+    await asyncio.wait_for(first_started.wait(), timeout=0.5)
+
+    command = _event(OWNER_2, "/reset")
+    result = await asyncio.wait_for(adapter._on_inbound(command), timeout=0.5)
+
+    assert result == {
+        "disposition": "absorbed",
+        "canonical_turn_owner_id": OWNER_1,
+        "session_key": session_key,
+        "chat_id": "mission-control",
+        "reason": None,
+    }
+    assert stub.turn_starts == [OWNER_1]
+    for _ in range(50):
+        if stub.turn_completions:
+            break
+        await asyncio.sleep(0)
+    assert [completion["owner_id"] for completion in stub.turn_completions] == [OWNER_1]

--- a/tests/gateway/relay/test_relay_turn_completed.py
+++ b/tests/gateway/relay/test_relay_turn_completed.py
@@ -1,0 +1,573 @@
+"""Owner-bound Relay turn completion lifecycle contract."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import gateway.platforms.base as platform_base
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+from gateway.relay.adapter import RelayAdapter
+from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+from gateway.session import SessionSource, build_session_key
+from tests.gateway.relay.stub_connector import StubConnector
+
+
+OWNER_CAPABILITY = "owner-bound-interrupt-ack"
+COMPLETION_CAPABILITY = "owner-bound-turn-completion"
+RECONCILIATION_CAPABILITY = "owner-bound-turn-reconciliation"
+OWNER_1 = "relay-turn-00000000-0000-4000-8000-000000000001"
+OWNER_2 = "relay-turn-00000000-0000-4000-8000-000000000002"
+
+
+def _descriptor() -> CapabilityDescriptor:
+    return CapabilityDescriptor(
+        contract_version=CONTRACT_VERSION,
+        platform="relay",
+        label="Mission Control",
+        max_message_length=4096,
+        supports_draft_streaming=False,
+        supports_edit=True,
+        supports_threads=False,
+        markdown_dialect="plain",
+        len_unit="chars",
+        supported_ops=("send", "edit", "typing", "prompt"),
+        capabilities=(
+            OWNER_CAPABILITY,
+            COMPLETION_CAPABILITY,
+            RECONCILIATION_CAPABILITY,
+        ),
+    )
+
+
+def _event(owner_id: str, text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        message_id=f"message-{owner_id[-1]}",
+        owner_id=owner_id,
+        source=SessionSource(
+            platform=Platform.RELAY,
+            chat_id="mission-control",
+            chat_type="dm",
+            user_id="mission-control-owner",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_completion_is_after_final_projection_and_full_handler_unwind() -> None:
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    progress_projected = asyncio.Event()
+    release_turn = asyncio.Event()
+    order: list[str] = []
+
+    original_send_outbound = stub.send_outbound
+    original_completion = stub.send_turn_completed
+
+    async def record_outbound(action, *, platform=None):
+        order.append(f"outbound:{action.get('op')}:{action.get('content')}")
+        return await original_send_outbound(action, platform=platform)
+
+    stub.send_outbound = record_outbound  # type: ignore[method-assign]
+
+    async def record_completion(session_key, chat_id, owner_id, outcome, *handoff):
+        order.append(f"completed:{owner_id}")
+        await original_completion(session_key, chat_id, owner_id, outcome, *handoff)
+
+    stub.send_turn_completed = record_completion  # type: ignore[method-assign]
+
+    async def handler(event):
+        order.append("handler:start")
+        await adapter.send(event.source.chat_id, "tool progress")
+        await adapter._send_prompt(
+            event.source.chat_id,
+            prompt_kind="clarify",
+            text="approval still pending",
+            prompt_id="prompt-1",
+            options=[{"id": "yes", "label": "Yes"}],
+        )
+        progress_projected.set()
+        await release_turn.wait()
+        order.append("handler:unwound")
+        return "final answer"
+
+    adapter.set_message_handler(handler)
+    event = _event(OWNER_1, "run tools")
+    session_key = build_session_key(event.source)
+    task = asyncio.create_task(adapter._process_message_background(event, session_key))
+    adapter._session_tasks[session_key] = task
+
+    await progress_projected.wait()
+    assert stub.turn_completions == []
+    release_turn.set()
+    await task
+
+    assert stub.turn_completions == [
+        {
+            "session_key": session_key,
+            "chat_id": "mission-control",
+            "owner_id": OWNER_1,
+            "outcome": "completed",
+        }
+    ]
+    assert order.index("handler:unwound") < order.index("outbound:send:final answer")
+    assert order.index("outbound:send:final answer") < order.index(
+        f"completed:{OWNER_1}"
+    )
+    assert stub.sent[-1]["content"] == "final answer"
+
+
+@pytest.mark.asyncio
+async def test_completion_follows_generation_owned_post_delivery_callback() -> None:
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    order: list[str] = []
+    original_send_outbound = stub.send_outbound
+    original_completion = stub.send_turn_completed
+
+    async def record_outbound(action, *, platform=None):
+        if action.get("op") == "send":
+            order.append(f"send:{action.get('content')}")
+        return await original_send_outbound(action, platform=platform)
+
+    async def record_completion(*args, **kwargs):
+        order.append("completion")
+        return await original_completion(*args, **kwargs)
+
+    stub.send_outbound = record_outbound  # type: ignore[method-assign]
+    stub.send_turn_completed = record_completion  # type: ignore[method-assign]
+    event = _event(OWNER_1, "callback ordering")
+    session_key = build_session_key(event.source)
+
+    async def handler(_event):
+        return "final answer"
+
+    async def post_delivery():
+        await adapter.send("mission-control", "post-delivery notice")
+
+    adapter.set_message_handler(handler)
+    adapter.register_post_delivery_callback(session_key, post_delivery)
+    task = asyncio.create_task(adapter._process_message_background(event, session_key))
+    adapter._session_tasks[session_key] = task
+    await task
+
+    assert order.index("send:final answer") < order.index("send:post-delivery notice")
+    assert order.index("send:post-delivery notice") < order.index("completion")
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_post_delivery_callback_still_completes_and_drains_handoff() -> (
+    None
+):
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    callback_started = asyncio.Event()
+    callback_cancelled = asyncio.Event()
+    release_callback_cleanup = asyncio.Event()
+    callback_cleaned = asyncio.Event()
+    second_started = asyncio.Event()
+    callback_task: asyncio.Task | None = None
+
+    async def handler(event):
+        if event.owner_id == OWNER_2:
+            second_started.set()
+        return None
+
+    async def slow_post_delivery():
+        nonlocal callback_task
+        callback_task = asyncio.current_task()
+        callback_started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            callback_cancelled.set()
+            await release_callback_cleanup.wait()
+            raise
+        finally:
+            callback_cleaned.set()
+
+    adapter.set_message_handler(handler)
+    first = _event(OWNER_1, "cancel during callback")
+    second = _event(OWNER_2, "queued handoff survives")
+    session_key = build_session_key(first.source)
+    second.metadata.update(
+        {
+            "relay_delivery_id": "delivery-owner-2",
+            "relay_session_key": session_key,
+            "relay_chat_id": "mission-control",
+        }
+    )
+    adapter._post_delivery_callbacks[session_key] = slow_post_delivery
+    task = asyncio.create_task(adapter._process_message_background(first, session_key))
+    adapter._session_tasks[session_key] = task
+
+    await asyncio.wait_for(callback_started.wait(), timeout=0.5)
+    adapter._pending_messages[session_key] = second
+    started_at = asyncio.get_running_loop().time()
+    task.cancel()
+    await asyncio.wait_for(callback_cancelled.wait(), timeout=0.5)
+    task.cancel()  # A repeated outer cancel must still stop at the safe boundary.
+    release_callback_cleanup.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1.0)
+    await asyncio.wait_for(second_started.wait(), timeout=0.5)
+    while session_key in adapter._session_tasks:
+        await asyncio.sleep(0)
+
+    assert asyncio.get_running_loop().time() - started_at < 1.0
+    assert callback_cleaned.is_set()
+    assert callback_task is not None and callback_task.done()
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+    assert [item["owner_id"] for item in stub.turn_completions] == [OWNER_1, OWNER_2]
+    assert stub.turn_completions[0] == {
+        "session_key": session_key,
+        "chat_id": "mission-control",
+        "owner_id": OWNER_1,
+        "outcome": "failed",
+        "next_owner_id": OWNER_2,
+        "next_delivery_id": "delivery-owner-2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_post_delivery_callback_timeout_reaps_task_before_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform_base, "_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS", 0.01)
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    callback_cleaned = asyncio.Event()
+    callback_task: asyncio.Task | None = None
+
+    async def handler(_event):
+        return None
+
+    async def timed_out_post_delivery():
+        nonlocal callback_task
+        callback_task = asyncio.current_task()
+        try:
+            await asyncio.Future()
+        finally:
+            callback_cleaned.set()
+
+    adapter.set_message_handler(handler)
+    event = _event(OWNER_1, "callback timeout")
+    session_key = build_session_key(event.source)
+    adapter._post_delivery_callbacks[session_key] = timed_out_post_delivery
+    task = asyncio.create_task(adapter._process_message_background(event, session_key))
+    adapter._session_tasks[session_key] = task
+
+    await asyncio.wait_for(task, timeout=0.5)
+
+    assert callback_cleaned.is_set()
+    assert callback_task is not None and callback_task.done()
+    assert stub.turn_completions[0]["outcome"] == "completed"
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+
+
+@pytest.mark.asyncio
+async def test_expected_cancel_during_post_delivery_callback_projects_cancelled() -> (
+    None
+):
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    callback_started = asyncio.Event()
+    callback_cleaned = asyncio.Event()
+
+    async def handler(_event):
+        return None
+
+    async def slow_post_delivery():
+        callback_started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            callback_cleaned.set()
+
+    adapter.set_message_handler(handler)
+    event = _event(OWNER_1, "expected callback cancel")
+    session_key = build_session_key(event.source)
+    adapter._post_delivery_callbacks[session_key] = slow_post_delivery
+    task = asyncio.create_task(adapter._process_message_background(event, session_key))
+    adapter._session_tasks[session_key] = task
+    adapter._expected_cancelled_tasks.add(task)
+
+    await asyncio.wait_for(callback_started.wait(), timeout=0.5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=0.5)
+
+    assert callback_cleaned.is_set()
+    assert stub.turn_completions[0]["outcome"] == "cancelled"
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("processing_outcome", "wire_outcome"),
+    [
+        (ProcessingOutcome.FAILURE, "failed"),
+        (ProcessingOutcome.CANCELLED, "cancelled"),
+    ],
+)
+async def test_terminal_outcome_is_projected_as_safe_enum(
+    processing_outcome: ProcessingOutcome,
+    wire_outcome: str,
+) -> None:
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+
+    await adapter.on_processing_complete(
+        _event(OWNER_1, "terminal"), processing_outcome
+    )
+
+    assert stub.turn_completions == [
+        {
+            "session_key": "agent:main:relay:dm:mission-control",
+            "chat_id": "mission-control",
+            "owner_id": OWNER_1,
+            "outcome": wire_outcome,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_turn_completion_follows_final_error_projection() -> None:
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    order: list[str] = []
+    original_send_outbound = stub.send_outbound
+    original_completion = stub.send_turn_completed
+
+    async def record_outbound(action, *, platform=None):
+        order.append(f"outbound:{action.get('content')}")
+        return await original_send_outbound(action, platform=platform)
+
+    async def record_completion(session_key, chat_id, owner_id, outcome, *handoff):
+        order.append(f"completed:{outcome}")
+        await original_completion(session_key, chat_id, owner_id, outcome, *handoff)
+
+    stub.send_outbound = record_outbound  # type: ignore[method-assign]
+    stub.send_turn_completed = record_completion  # type: ignore[method-assign]
+
+    async def failing_handler(_event):
+        raise RuntimeError("expected terminal failure")
+
+    adapter.set_message_handler(failing_handler)
+    event = _event(OWNER_1, "fail")
+    session_key = build_session_key(event.source)
+    task = asyncio.create_task(adapter._process_message_background(event, session_key))
+    adapter._session_tasks[session_key] = task
+    await task
+
+    assert "expected terminal failure" in order[0]
+    assert order[-1] == "completed:failed"
+    assert stub.turn_completions[0]["outcome"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_failure_projection_cannot_skip_terminal_completion() -> (
+    None
+):
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    failure_projection_started = asyncio.Event()
+
+    async def failing_handler(_event):
+        raise RuntimeError("expected terminal failure")
+
+    async def blocked_failure_projection(*_args, **_kwargs):
+        failure_projection_started.set()
+        await asyncio.Future()
+
+    adapter.set_message_handler(failing_handler)
+    adapter.send = blocked_failure_projection  # type: ignore[method-assign]
+    event = _event("opaque-owner/cancel-1", "fail then cancel")
+    session_key = build_session_key(event.source)
+    task = asyncio.create_task(adapter._process_message_background(event, session_key))
+    adapter._session_tasks[session_key] = task
+
+    await failure_projection_started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert stub.turn_completions == [
+        {
+            "session_key": session_key,
+            "chat_id": "mission-control",
+            "owner_id": "opaque-owner/cancel-1",
+            "outcome": "failed",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_second_cancel_during_terminal_hook_still_drains_handoff_before_propagating() -> (
+    None
+):
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    failure_projection_started = asyncio.Event()
+    terminal_hook_started = asyncio.Event()
+    release_terminal_hook = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def handler(event):
+        if event.owner_id == OWNER_1:
+            raise RuntimeError("fail before cancellation")
+        second_started.set()
+        return None
+
+    async def blocked_failure_projection(*_args, **_kwargs):
+        failure_projection_started.set()
+        await asyncio.Future()
+
+    original_complete = adapter.on_processing_complete
+
+    async def blocked_complete(event, outcome):
+        if event.owner_id == OWNER_1:
+            terminal_hook_started.set()
+            await release_terminal_hook.wait()
+        await original_complete(event, outcome)
+
+    adapter.set_message_handler(handler)
+    adapter.send = blocked_failure_projection  # type: ignore[method-assign]
+    adapter.on_processing_complete = blocked_complete  # type: ignore[method-assign]
+    first = _event(OWNER_1, "fail then cancel twice")
+    second = _event(OWNER_2, "must still drain")
+    session_key = build_session_key(first.source)
+    second.metadata.update({
+        "relay_delivery_id": "delivery-owner-2",
+        "relay_session_key": session_key,
+        "relay_chat_id": "mission-control",
+    })
+    task = asyncio.create_task(adapter._process_message_background(first, session_key))
+    adapter._session_tasks[session_key] = task
+
+    await failure_projection_started.wait()
+    task.cancel()
+    await terminal_hook_started.wait()
+    adapter._pending_messages[session_key] = second
+    task.cancel()
+    release_terminal_hook.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.wait_for(second_started.wait(), timeout=0.5)
+    assert adapter._session_tasks[session_key] is not task
+
+
+@pytest.mark.asyncio
+async def test_internally_cancelled_terminal_hook_cannot_skip_guard_cleanup() -> None:
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+
+    async def handler(_event):
+        return "done"
+
+    async def internally_cancelled(_event, _outcome):
+        raise asyncio.CancelledError
+
+    adapter.set_message_handler(handler)
+    adapter.on_processing_complete = internally_cancelled  # type: ignore[method-assign]
+    event = _event(OWNER_1, "internal hook cancel")
+    session_key = build_session_key(event.source)
+    task = asyncio.create_task(adapter._process_message_background(event, session_key))
+    adapter._session_tasks[session_key] = task
+
+    await task
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+
+
+@pytest.mark.asyncio
+async def test_queued_handoff_completes_owner_n_before_owner_n_plus_one_binds() -> None:
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+    order: list[str] = []
+
+    original_completion = stub.send_turn_completed
+
+    async def record_completion(session_key, chat_id, owner_id, outcome, *handoff):
+        order.append(f"completed:{owner_id}")
+        await original_completion(session_key, chat_id, owner_id, outcome, *handoff)
+
+    stub.send_turn_completed = record_completion  # type: ignore[method-assign]
+
+    async def handler(event):
+        order.append(f"started:{event.owner_id}")
+        if event.owner_id == OWNER_1:
+            first_started.set()
+            await release_first.wait()
+        else:
+            second_started.set()
+        return f"final:{event.owner_id}"
+
+    adapter.set_message_handler(handler)
+    first = _event(OWNER_1, "first")
+    second = _event(OWNER_2, "second")
+    second.metadata.update({
+        "relay_delivery_id": "delivery-owner-2",
+        "relay_session_key": build_session_key(second.source),
+        "relay_chat_id": "mission-control",
+    })
+    session_key = build_session_key(first.source)
+    task = asyncio.create_task(adapter._process_message_background(first, session_key))
+    adapter._session_tasks[session_key] = task
+    await first_started.wait()
+    adapter._pending_messages[session_key] = second
+    release_first.set()
+    await task
+    await asyncio.wait_for(second_started.wait(), timeout=1.0)
+    while len(stub.turn_completions) < 2:
+        await asyncio.sleep(0)
+
+    assert order.index(f"completed:{OWNER_1}") < order.index(f"started:{OWNER_2}")
+    assert [item["owner_id"] for item in stub.turn_completions] == [OWNER_1, OWNER_2]
+    assert stub.turn_completions[0]["next_owner_id"] == OWNER_2
+    assert stub.turn_completions[0]["next_delivery_id"] == "delivery-owner-2"

--- a/tests/gateway/relay/test_relay_turn_completed.py
+++ b/tests/gateway/relay/test_relay_turn_completed.py
@@ -22,7 +22,7 @@ OWNER_1 = "relay-turn-00000000-0000-4000-8000-000000000001"
 OWNER_2 = "relay-turn-00000000-0000-4000-8000-000000000002"
 
 
-def _descriptor() -> CapabilityDescriptor:
+def _descriptor(*, supported_ops: tuple[str, ...] = ("send", "edit", "typing", "prompt")) -> CapabilityDescriptor:
     return CapabilityDescriptor(
         contract_version=CONTRACT_VERSION,
         platform="relay",
@@ -33,7 +33,7 @@ def _descriptor() -> CapabilityDescriptor:
         supports_threads=False,
         markdown_dialect="plain",
         len_unit="chars",
-        supported_ops=("send", "edit", "typing", "prompt"),
+        supported_ops=supported_ops,
         capabilities=(
             OWNER_CAPABILITY,
             COMPLETION_CAPABILITY,
@@ -358,6 +358,53 @@ async def test_terminal_outcome_is_projected_as_safe_enum(
 
 
 @pytest.mark.asyncio
+async def test_terminal_completion_precedes_a_blocked_terminal_reaction() -> None:
+    """Cosmetic reaction RPCs must not hold the owner handoff barrier open."""
+    descriptor = _descriptor(
+        supported_ops=("send", "edit", "typing", "prompt", "react")
+    )
+    stub = StubConnector(descriptor)
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), descriptor, transport=stub
+    )
+    await adapter.connect()
+    reaction_started = asyncio.Event()
+    release_reaction = asyncio.Event()
+    completion_sent = asyncio.Event()
+    original_send_outbound = stub.send_outbound
+    original_completion = stub.send_turn_completed
+
+    async def blocked_reaction(action, *, platform=None):
+        if action.get("op") == "react" and not reaction_started.is_set():
+            reaction_started.set()
+            await release_reaction.wait()
+        return await original_send_outbound(action, platform=platform)
+
+    async def record_completion(*args, **kwargs):
+        completion_sent.set()
+        return await original_completion(*args, **kwargs)
+
+    stub.send_outbound = blocked_reaction  # type: ignore[method-assign]
+    stub.send_turn_completed = record_completion  # type: ignore[method-assign]
+
+    task = asyncio.create_task(
+        adapter.on_processing_complete(
+            _event(OWNER_1, "completion must not wait for react"),
+            ProcessingOutcome.SUCCESS,
+        )
+    )
+
+    try:
+        await asyncio.wait_for(completion_sent.wait(), timeout=0.2)
+        await asyncio.wait_for(reaction_started.wait(), timeout=0.2)
+        assert not task.done(), "the terminal reaction should still be blocked"
+        assert stub.turn_completions[0]["owner_id"] == OWNER_1
+    finally:
+        release_reaction.set()
+        await asyncio.wait_for(task, timeout=0.2)
+
+
+@pytest.mark.asyncio
 async def test_failed_turn_completion_follows_final_error_projection() -> None:
     stub = StubConnector(_descriptor())
     adapter = RelayAdapter(
@@ -611,3 +658,54 @@ async def test_active_turn_bypass_command_is_absorbed_by_the_real_owner_without_
             break
         await asyncio.sleep(0)
     assert [completion["owner_id"] for completion in stub.turn_completions] == [OWNER_1]
+
+
+@pytest.mark.asyncio
+async def test_second_executed_control_command_keeps_the_authoritative_owner() -> None:
+    """Command-on-command is admitted control work, never a rejected phantom turn."""
+    stub = StubConnector(_descriptor())
+    adapter = RelayAdapter(
+        PlatformConfig(typing_indicator=False), _descriptor(), transport=stub
+    )
+    await adapter.connect()
+    first_started = asyncio.Event()
+    commands: list[str] = []
+
+    async def handler(event):
+        if event.owner_id == OWNER_1:
+            first_started.set()
+            await asyncio.Event().wait()
+        commands.append(event.text)
+        return "Control command executed"
+
+    # Keep both command guards installed long enough to exercise the exact
+    # command-on-command acknowledgement path without racing detached cleanup.
+    scheduled_guards: list[asyncio.Event] = []
+    adapter._schedule_active_session_command_cleanup = (  # type: ignore[method-assign]
+        lambda _session_key, guard: scheduled_guards.append(guard)
+    )
+    adapter.set_message_handler(handler)
+    first = _event(OWNER_1, "long-running turn")
+    session_key = build_session_key(first.source)
+    await adapter.handle_message(first)
+    await asyncio.wait_for(first_started.wait(), timeout=0.5)
+
+    try:
+        first_command = await adapter._on_inbound(_event(OWNER_2, "/reset"))
+        second_command = await adapter._on_inbound(
+            _event("relay-turn-00000000-0000-4000-8000-000000000003", "/stop")
+        )
+
+        assert first_command["disposition"] == "absorbed"
+        assert second_command == {
+            "disposition": "absorbed",
+            "canonical_turn_owner_id": OWNER_1,
+            "session_key": session_key,
+            "chat_id": "mission-control",
+            "reason": None,
+        }
+        assert commands == ["/reset", "/stop"]
+        assert len(scheduled_guards) == 2
+    finally:
+        await adapter.cancel_background_tasks()
+        adapter._active_sessions.pop(session_key, None)

--- a/tests/gateway/relay/test_ws_transport.py
+++ b/tests/gateway/relay/test_ws_transport.py
@@ -17,6 +17,10 @@ import json
 import pytest
 import pytest_asyncio
 
+from gateway.relay.descriptor import (
+    CONTRACT_VERSION,
+    OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+)
 from gateway.relay.ws_transport import WebSocketRelayTransport, WEBSOCKETS_AVAILABLE
 
 pytestmark = pytest.mark.skipif(not WEBSOCKETS_AVAILABLE, reason="websockets not installed")
@@ -26,7 +30,7 @@ if WEBSOCKETS_AVAILABLE:
 
 
 DESCRIPTOR = {
-    "contract_version": 1,
+    "contract_version": CONTRACT_VERSION,
     "platform": "discord",
     "label": "Discord",
     "max_message_length": 2000,
@@ -35,6 +39,7 @@ DESCRIPTOR = {
     "supports_threads": True,
     "markdown_dialect": "discord",
     "len_unit": "chars",
+    "capabilities": [OWNER_BOUND_INTERRUPT_ACK_CAPABILITY],
 }
 
 
@@ -105,8 +110,18 @@ async def test_handshake_negotiates_descriptor(server):
         hello = next(f for f in server.received if f["type"] == "hello")
         assert hello["platform"] == "discord"
         assert hello["botId"] == "appShared"
+        assert isinstance(hello["runtime_epoch"], str)
+        assert len(hello["runtime_epoch"]) == 32
+        assert hello["runtime_epoch"] == t._runtime_epoch
     finally:
         await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_runtime_epoch_is_unique_after_transport_restart(server):
+    first = WebSocketRelayTransport(server.url, "discord", "appShared")
+    replacement = WebSocketRelayTransport(server.url, "discord", "appShared")
+    assert first._runtime_epoch != replacement._runtime_epoch
 
 
 @pytest.mark.asyncio
@@ -206,5 +221,3 @@ async def test_4401_after_handshake_is_terminal_no_reconnect():
     finally:
         await t.disconnect()
         await srv.stop()
-
-

--- a/tests/gateway/relay/test_ws_transport.py
+++ b/tests/gateway/relay/test_ws_transport.py
@@ -20,7 +20,13 @@ import pytest_asyncio
 from gateway.relay.descriptor import (
     CONTRACT_VERSION,
     OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+    OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+    OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
+    CapabilityDescriptor,
 )
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
 from gateway.relay.ws_transport import WebSocketRelayTransport, WEBSOCKETS_AVAILABLE
 
 pytestmark = pytest.mark.skipif(not WEBSOCKETS_AVAILABLE, reason="websockets not installed")
@@ -39,7 +45,11 @@ DESCRIPTOR = {
     "supports_threads": True,
     "markdown_dialect": "discord",
     "len_unit": "chars",
-    "capabilities": [OWNER_BOUND_INTERRUPT_ACK_CAPABILITY],
+    "capabilities": [
+        OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+        OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+        OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
+    ],
 }
 
 
@@ -48,6 +58,7 @@ class _StubConnectorServer:
 
     def __init__(self):
         self.received: list[dict] = []
+        self.descriptor = dict(DESCRIPTOR)
         self._server = None
         self.url = ""
         # Push channel: tests set this to a frame dict to deliver inbound.
@@ -76,7 +87,10 @@ class _StubConnectorServer:
     async def _on_frame(self, ws, frame):
         ftype = frame.get("type")
         if ftype == "hello":
-            await ws.send(json.dumps({"type": "descriptor", "descriptor": DESCRIPTOR}) + "\n")
+            await ws.send(
+                json.dumps({"type": "descriptor", "descriptor": self.descriptor})
+                + "\n"
+            )
             # Deliver any queued inbound frames right after handshake.
             for f in self._to_push:
                 await ws.send(json.dumps(f) + "\n")
@@ -113,6 +127,26 @@ async def test_handshake_negotiates_descriptor(server):
         assert isinstance(hello["runtime_epoch"], str)
         assert len(hello["runtime_epoch"]) == 32
         assert hello["runtime_epoch"] == t._runtime_epoch
+        assert hello["capabilities"] == [
+            OWNER_BOUND_INTERRUPT_ACK_CAPABILITY,
+            OWNER_BOUND_TURN_COMPLETION_CAPABILITY,
+            OWNER_BOUND_TURN_RECONCILIATION_CAPABILITY,
+        ]
+    finally:
+        await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_handshake_rejects_mixed_v3_without_turn_reconciliation(server):
+    server.descriptor = {
+        **DESCRIPTOR,
+        "capabilities": [OWNER_BOUND_INTERRUPT_ACK_CAPABILITY],
+    }
+    t = WebSocketRelayTransport(server.url, "discord", "appShared")
+    await t.connect()
+    try:
+        with pytest.raises(RuntimeError, match="contract v3 required"):
+            await t.handshake()
     finally:
         await t.disconnect()
 
@@ -125,13 +159,361 @@ async def test_runtime_epoch_is_unique_after_transport_restart(server):
 
 
 @pytest.mark.asyncio
+async def test_turn_completed_frame_carries_exact_owner_session_chat_and_runtime_epoch(server):
+    t = WebSocketRelayTransport(server.url, "discord", "appShared")
+    await t.connect()
+    try:
+        await t.handshake()
+        owner_id = "opaque-owner:00000001"
+        assert await t.send_turn_completed(
+            "agent:main:relay:dm:mission-control",
+            "mission-control",
+            owner_id,
+            "completed",
+        )
+        assert not await t.send_turn_completed(
+            "agent:main:relay:dm:mission-control",
+            "mission-control",
+            owner_id,
+            "completed",
+        )
+        assert not await t.send_turn_completed(
+            "agent:main:relay:dm:mission-control",
+            "mission-control",
+            "opaque-owner:00000002",
+            "completed",
+        )
+        assert not await t.send_turn_completed(
+            "agent:main:relay:dm:mission-control",
+            "mission-control",
+            "opaque-owner:00000002",
+            "unknown",
+        )
+        await asyncio.sleep(0.05)
+        assert [f for f in server.received if f.get("type") == "turn_completed"] == [
+            {
+                "type": "turn_completed",
+                "session_key": "agent:main:relay:dm:mission-control",
+                "chat_id": "mission-control",
+                "owner_id": owner_id,
+                "runtime_epoch": t._runtime_epoch,
+                "outcome": "completed",
+                "owner_state_seq": 1,
+                "status": "idle",
+                "next_owner_id": None,
+                "next_delivery_id": None,
+            }
+        ]
+    finally:
+        await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_completion_write_failure_is_retained_for_same_epoch_hello_reconciliation():
+    t = WebSocketRelayTransport("ws://127.0.0.1:1", "discord", "appShared")
+    t._descriptor = CapabilityDescriptor.from_json(json.dumps(DESCRIPTOR))
+
+    async def disconnected_send(_frame):
+        raise RuntimeError("socket closed exactly at completion")
+
+    t._send = disconnected_send  # type: ignore[method-assign]
+    owner_id = "opaque-owner:completion-loss"
+    assert not await t.send_turn_completed(
+        "agent:main:relay:dm:mission-control",
+        "mission-control",
+        owner_id,
+        "completed",
+    )
+    assert t._turn_state_snapshots() == [
+        {
+            "session_key": "agent:main:relay:dm:mission-control",
+            "chat_id": "mission-control",
+            "owner_state_seq": 1,
+            "status": "idle",
+            "active_owner_id": None,
+            "terminal_owner_id": owner_id,
+            "terminal_outcome": "completed",
+            "next_owner_id": None,
+            "next_delivery_id": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_terminal_send_propagates_after_child_send_task_is_reaped():
+    t = WebSocketRelayTransport("ws://127.0.0.1:1", "relay", "")
+    t._descriptor = CapabilityDescriptor.from_json(json.dumps(DESCRIPTOR))
+    send_started = asyncio.Event()
+    send_reaped = asyncio.Event()
+
+    async def blocked_send(_frame):
+        send_started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            send_reaped.set()
+
+    t._send = blocked_send  # type: ignore[method-assign]
+    completion = asyncio.create_task(t.send_turn_completed(
+        "agent:main:relay:dm:mission-control",
+        "mission-control",
+        "opaque-owner:cancelled-send",
+        "completed",
+    ))
+    await send_started.wait()
+    completion.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(completion, timeout=0.5)
+    assert send_reaped.is_set()
+
+
+def test_hello_turn_states_hide_foreign_session_and_chat_keys_behind_authenticated_scope():
+    t = WebSocketRelayTransport(
+        "ws://127.0.0.1:1", "relay", "",
+        gateway_id="gw-scope", upgrade_secret="scope-secret",
+    )
+    t._state_for_scope("agent:main:relay:dm:room-a", "room-a")
+    t._state_for_scope("agent:main:relay:dm:room-b", "room-b")
+
+    snapshots = t._hello_turn_state_snapshots()
+
+    assert len(snapshots) == 2
+    assert all("session_key" not in item and "chat_id" not in item for item in snapshots)
+    assert all(len(item["scope_fingerprint"]) == 64 for item in snapshots)
+    assert snapshots[0]["scope_fingerprint"] != snapshots[1]["scope_fingerprint"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_delivery_replays_bounded_ack_without_dispatching_twice(server):
+    frame = {
+        "type": "inbound",
+        "delivery_id": "delivery-replay-1",
+        "bufferId": "buffer-replay-1",
+        "event": {
+            "text": "deliver once",
+            "message_type": "text",
+            "owner_id": "opaque-owner:replay-1",
+            "source": {"platform": "discord", "chat_id": "chan1", "chat_type": "dm"},
+        },
+    }
+    server._to_push = [frame, frame]
+    received = []
+    t = WebSocketRelayTransport(server.url, "discord", "appShared")
+
+    async def accept(ev):
+        received.append(ev.text)
+        return {
+            "disposition": "started",
+            "canonical_turn_owner_id": ev.owner_id,
+            "session_key": "agent:main:relay:dm:chan1",
+            "chat_id": "chan1",
+        }
+
+    t.set_inbound_handler(accept)
+    await t.connect()
+    try:
+        await t.handshake()
+        await asyncio.sleep(0.1)
+        assert received == ["deliver once"]
+        acks = [f for f in server.received if f.get("type") == "inbound_ack"]
+        assert len(acks) == 2
+        assert acks[0] == acks[1]
+        assert len(t._inbound_ack_frames) <= 1024
+    finally:
+        await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_transient_inbound_handler_failure_is_not_acked_or_cached_and_can_retry():
+    t = WebSocketRelayTransport("ws://127.0.0.1:1", "relay", "")
+    sent: list[dict] = []
+    attempts = 0
+
+    async def record(frame):
+        sent.append(dict(frame))
+
+    async def flaky(event):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient handler failure")
+        return {
+            "disposition": "started",
+            "canonical_turn_owner_id": event.owner_id,
+            "session_key": "agent:main:relay:dm:mission-control",
+            "chat_id": "mission-control",
+        }
+
+    t._send = record  # type: ignore[method-assign]
+    t.set_inbound_handler(flaky)
+    frame = json.dumps({
+        "type": "inbound",
+        "delivery_id": "delivery-handler-retry",
+        "bufferId": "delivery-handler-retry",
+        "event": {
+            "text": "must survive",
+            "message_type": "text",
+            "owner_id": "opaque-owner:handler-retry",
+            "source": {
+                "platform": "relay", "chat_id": "mission-control", "chat_type": "dm",
+            },
+        },
+    })
+
+    with pytest.raises(RuntimeError, match="transient handler failure"):
+        await t._handle_frame(frame)
+    assert sent == []
+    assert "delivery-handler-retry" not in t._inbound_ack_frames
+
+    await t._handle_frame(frame)
+    assert attempts == 2
+    assert sent[-1]["type"] == "inbound_ack"
+    assert sent[-1]["disposition"] == "started"
+
+
+@pytest.mark.asyncio
+async def test_identical_event_local_started_ack_is_emitted_once_but_failed_send_retries():
+    t = WebSocketRelayTransport("ws://127.0.0.1:1", "relay", "")
+    attempts: list[dict] = []
+    fail_first = True
+
+    async def record(frame):
+        nonlocal fail_first
+        attempts.append(dict(frame))
+        if fail_first:
+            fail_first = False
+            raise OSError("fixture send failure")
+
+    event = MessageEvent(
+        text="start once",
+        message_type=MessageType.TEXT,
+        owner_id="opaque-owner:start-once",
+        source=SessionSource(
+            platform=Platform.RELAY,
+            chat_id="mission-control",
+            chat_type="dm",
+        ),
+    )
+    result = {
+        "disposition": "started",
+        "canonical_turn_owner_id": event.owner_id,
+        "session_key": "agent:main:relay:dm:mission-control",
+        "chat_id": "mission-control",
+    }
+    t._send = record  # type: ignore[method-assign]
+
+    assert not await t._publish_inbound_ack(
+        event, result, delivery_id="delivery-start-once"
+    )
+    assert await t._publish_inbound_ack(
+        event, result, delivery_id="delivery-start-once"
+    )
+    assert await t._publish_inbound_ack(
+        event, result, delivery_id="delivery-start-once"
+    )
+    assert len(attempts) == 2
+    assert attempts[0] == attempts[1]
+
+
+@pytest.mark.asyncio
+async def test_inbound_during_handoff_exposes_neither_terminal_a_nor_unbound_b():
+    t = WebSocketRelayTransport("ws://127.0.0.1:1", "discord", "appShared")
+    t._descriptor = CapabilityDescriptor.from_json(json.dumps(DESCRIPTOR))
+    frames: list[dict] = []
+
+    async def record(frame):
+        frames.append(dict(frame))
+
+    t._send = record  # type: ignore[method-assign]
+
+    def event(owner: str) -> MessageEvent:
+        return MessageEvent(
+            text=owner,
+            message_type=MessageType.TEXT,
+            owner_id=owner,
+            source=SessionSource(
+                platform=Platform.RELAY,
+                chat_id="mission-control",
+                chat_type="dm",
+            ),
+        )
+
+    scope = "agent:main:relay:dm:mission-control"
+    owner_a = "opaque-owner:A"
+    owner_b = "opaque-owner:B"
+    owner_c = "opaque-owner:C"
+    assert await t._publish_inbound_ack(
+        event(owner_a),
+        {
+            "disposition": "started",
+            "canonical_turn_owner_id": owner_a,
+            "session_key": scope,
+            "chat_id": "mission-control",
+        },
+        delivery_id="delivery-A",
+    )
+    assert await t.send_turn_completed(
+        scope,
+        "mission-control",
+        owner_a,
+        "completed",
+        owner_b,
+        "delivery-B",
+    )
+    assert await t._publish_inbound_ack(
+        event(owner_c),
+        {
+            "disposition": "absorbed",
+            # The adapter guard has not rebound yet and can still report A.
+            "canonical_turn_owner_id": owner_a,
+            "session_key": scope,
+            "chat_id": "mission-control",
+        },
+        delivery_id="delivery-C",
+    )
+
+    ack = frames[-1]
+    assert ack["type"] == "inbound_ack"
+    assert ack["delivery_id"] == "delivery-C"
+    assert ack["canonical_turn_owner_id"] is None
+    assert ack["owner_state_seq"] == 2
+    assert t._turn_state_snapshots()[0]["status"] == "handoff"
+
+    successor = event(owner_b)
+    successor.metadata.update(
+        {
+            "relay_delivery_id": "delivery-B",
+            "relay_session_key": scope,
+            "relay_chat_id": "mission-control",
+        }
+    )
+    assert await t.send_turn_started(successor)
+    assert t._turn_state_snapshots() == [
+        {
+            "session_key": scope,
+            "chat_id": "mission-control",
+            "owner_state_seq": 3,
+            "status": "running",
+            "active_owner_id": owner_b,
+            "terminal_owner_id": None,
+            "terminal_outcome": None,
+            "next_owner_id": None,
+            "next_delivery_id": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_inbound_frame_reaches_handler(server):
+    opaque_owner = "owner:mc/7f6c2a8d"
     server._to_push = [
         {
             "type": "inbound",
+            "delivery_id": "delivery-1",
             "event": {
                 "text": "hello from connector",
                 "message_type": "text",
+                "owner_id": opaque_owner,
                 "source": {"platform": "discord", "chat_id": "chan1", "chat_type": "group", "scope_id": "guildA"},
             },
             "bufferId": "buf-1",
@@ -139,7 +521,17 @@ async def test_inbound_frame_reaches_handler(server):
     ]
     received = []
     t = WebSocketRelayTransport(server.url, "discord", "appShared")
-    t.set_inbound_handler(lambda ev: received.append(ev) or asyncio.sleep(0))
+
+    async def accept(ev):
+        received.append(ev)
+        return {
+            "disposition": "started",
+            "canonical_turn_owner_id": ev.owner_id,
+            "session_key": "agent:main:relay:dm:chan1",
+            "chat_id": "chan1",
+        }
+
+    t.set_inbound_handler(accept)
     await t.connect()
     try:
         await t.handshake()
@@ -148,6 +540,21 @@ async def test_inbound_frame_reaches_handler(server):
         assert len(received) == 1
         assert received[0].text == "hello from connector"
         assert received[0].source.scope_id == "guildA"
+        await asyncio.sleep(0.05)
+        assert [f for f in server.received if f.get("type") == "inbound_ack"] == [
+            {
+                "type": "inbound_ack",
+                "bufferId": "buf-1",
+                "delivery_id": "delivery-1",
+                "session_key": "agent:main:relay:dm:chan1",
+                "chat_id": "chan1",
+                "owner_id": opaque_owner,
+                "runtime_epoch": t._runtime_epoch,
+                "disposition": "started",
+                "canonical_turn_owner_id": opaque_owner,
+                "owner_state_seq": 1,
+            }
+        ]
     finally:
         await t.disconnect()
 

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -195,6 +195,7 @@ async def test_debounce_resets_timer_on_new_arrival():
     adapter._busy_text_debounce_seconds = 0.1
 
     first = _make_event("one")
+    first.owner_id = "opaque-owner-debounce-1"
     session_key = build_session_key(first.source)
     adapter._active_sessions[session_key] = asyncio.Event()
 
@@ -203,13 +204,17 @@ async def test_debounce_resets_timer_on_new_arrival():
     assert task1 is not None
     assert not task1.done()
 
-    await adapter.handle_message(_make_event("two"))
+    second = _make_event("two")
+    second.owner_id = "opaque-owner-debounce-2"
+    await adapter.handle_message(second)
     task2 = adapter._text_debounce[session_key].task
     assert task2 is not None
     assert task2 is not task1
     await asyncio.sleep(0)
     assert task1.cancelled() or task1.done()
     assert adapter._text_debounce[session_key].task is task2
+    assert first.metadata["relay_owner_disposition"] == "queued"
+    assert second.metadata["relay_owner_disposition"] == "merged"
 
     await adapter.handle_message(_make_event("three"))
     task3 = adapter._text_debounce[session_key].task
@@ -260,5 +265,4 @@ def test_command_messages_bypass_debounce_even_in_queue_mode():
     adapter = _make_adapter()
     assert not adapter._is_queue_text_debounce_candidate(_make_event(""))
     assert not adapter._is_queue_text_debounce_candidate(_make_event("/stop"))
-
 

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -254,6 +254,36 @@ async def test_control_and_clarify_messages_bypass_text_debounce():
     assert session_key not in adapter._pending_messages
 
 
+@pytest.mark.asyncio
+async def test_reset_command_response_does_not_wait_for_slow_cancel_cleanup():
+    """A platform command must reply while its cancelled turn unwinds in the background."""
+    adapter = _make_adapter()
+    active = _make_event("long-running")
+    session_key = build_session_key(active.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    active_task = asyncio.create_task(asyncio.Event().wait())
+    adapter._session_tasks[session_key] = active_task
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def slow_cancel(*_args, **_kwargs):
+        cleanup_started.set()
+        await release_cleanup.wait()
+
+    adapter.cancel_session_processing = slow_cancel  # type: ignore[method-assign]
+    adapter._message_handler = AsyncMock(return_value="Reset confirmed")
+    command = _make_event("/reset")
+
+    await asyncio.wait_for(adapter.handle_message(command), timeout=0.1)
+    await asyncio.wait_for(cleanup_started.wait(), timeout=0.1)
+    assert adapter._message_handler.await_count == 1
+
+    release_cleanup.set()
+    await asyncio.sleep(0)
+    active_task.cancel()
+    await asyncio.gather(active_task, return_exceptions=True)
+
+
 def test_adapter_defaults_to_interrupt_mode(monkeypatch):
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)
     adapter = _make_initialized_adapter()
@@ -265,4 +295,3 @@ def test_command_messages_bypass_debounce_even_in_queue_mode():
     adapter = _make_adapter()
     assert not adapter._is_queue_text_debounce_candidate(_make_event(""))
     assert not adapter._is_queue_text_debounce_candidate(_make_event("/stop"))
-

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -201,6 +201,7 @@ class TestBusySessionAck:
         adapter = _make_adapter()
 
         event = _make_event(text="also check the tests")
+        event.owner_id = "opaque-owner-steer"
         sk = build_session_key(event.source)
         runner.adapters[event.source.platform] = adapter
 
@@ -224,6 +225,7 @@ class TestBusySessionAck:
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
         assert "Steered" in content or "steer" in content.lower()
         assert "Interrupting" not in content
+        assert event.metadata["relay_owner_disposition"] == "absorbed"
 
     @pytest.mark.asyncio
     async def test_steer_mode_transcribes_voice_before_injection(self, monkeypatch):
@@ -272,6 +274,7 @@ class TestBusySessionAck:
         adapter = _make_adapter()
 
         event = _make_event(text="empty or rejected")
+        event.owner_id = "opaque-owner-queued"
         sk = build_session_key(event.source)
         runner.adapters[event.source.platform] = adapter
 
@@ -293,6 +296,7 @@ class TestBusySessionAck:
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
         assert "Queued for the next turn" in content
         assert "Steered" not in content
+        assert event.metadata["relay_owner_disposition"] == "queued"
 
     @pytest.mark.asyncio
     async def test_steer_mode_falls_back_to_queue_when_agent_pending(self):
@@ -344,6 +348,8 @@ class TestBusySessionAck:
 
         first = _evt("first message")
         second = _evt("second message")
+        first.owner_id = "opaque-owner-first"
+        second.owner_id = "opaque-owner-second"
         sk = build_session_key(first.source)
         runner.adapters[shared_platform] = adapter
 
@@ -362,6 +368,54 @@ class TestBusySessionAck:
         assert head.text == "first message"  # not "first message\nsecond message"
         overflow = runner._queued_events.get(sk, [])
         assert [e.text for e in overflow] == ["second message"]
+        assert first.metadata["relay_owner_disposition"] == "queued"
+        assert second.metadata["relay_owner_disposition"] == "queued"
+
+    @pytest.mark.asyncio
+    async def test_busy_media_head_is_queued_but_later_media_is_merged(self):
+        """The empty head becomes its own owner; an album addition does not."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner._queued_events = {}
+        adapter = _make_adapter()
+        first = _make_event(text="first image")
+        first.message_type = MessageType.PHOTO
+        first.media_urls = ["/tmp/first.png"]
+        first.media_types = ["image/png"]
+        first.owner_id = "opaque-owner-media-head"
+        second = _make_event(text="second image")
+        second.message_type = MessageType.PHOTO
+        second.media_urls = ["/tmp/second.png"]
+        second.media_types = ["image/png"]
+        second.owner_id = "opaque-owner-media-merged"
+        second.source = first.source
+        sk = build_session_key(first.source)
+        runner.adapters[first.source.platform] = adapter
+
+        runner._queue_or_replace_pending_event(sk, first)
+        runner._queue_or_replace_pending_event(sk, second)
+
+        assert adapter._pending_messages[sk] is first
+        assert first.metadata["relay_owner_disposition"] == "queued"
+        assert second.metadata["relay_owner_disposition"] == "merged"
+        assert first.media_urls == ["/tmp/first.png", "/tmp/second.png"]
+
+    @pytest.mark.asyncio
+    async def test_queue_capacity_drop_is_an_explicit_negative_owner_disposition(self):
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+        event = _make_event(text="one too many")
+        event.owner_id = "opaque-owner-over-cap"
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        runner._queue_depth = MagicMock(return_value=runner._BUSY_QUEUE_MAX_PENDING)
+
+        runner._queue_or_replace_pending_event(sk, event)
+
+        assert event.metadata["relay_owner_disposition"] == "rejected"
+        assert event.metadata["relay_owner_disposition_reason"] == "queue_capacity"
+        assert sk not in adapter._pending_messages
 
 
     @pytest.mark.asyncio
@@ -469,5 +523,3 @@ class TestLongRunningNotificationOwnership:
         assert runner._should_emit_long_running_notification(
             "sess", original_agent, executor_task=None
         ) is False
-
-

--- a/tests/gateway/test_busy_session_auth_bypass.py
+++ b/tests/gateway/test_busy_session_auth_bypass.py
@@ -123,6 +123,7 @@ class TestBusySessionAuthBypass:
             chat_id="123",
             thread_id="thread-abc",  # same thread → same session_key
         )
+        intruder_event.owner_id = "opaque-owner-unauthorized"
 
         result = await GatewayRunner._handle_active_session_busy_message(
             runner, intruder_event, sk
@@ -136,6 +137,8 @@ class TestBusySessionAuthBypass:
         runner._running_agents[sk].interrupt.assert_not_called()
         # Must NOT send any acknowledgment to the channel
         adapter._send_with_retry.assert_not_called()
+        assert intruder_event.metadata["relay_owner_disposition"] == "rejected"
+        assert intruder_event.metadata["relay_owner_disposition_reason"] == "unauthorized"
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_pending_drain_no_recursion.py
+++ b/tests/gateway/test_pending_drain_no_recursion.py
@@ -260,10 +260,14 @@ async def test_late_arrival_drain_still_fires_when_no_in_band_drain():
 
     results: list[str] = []
     original_stop_typing = getattr(adapter, "stop_typing", None)
+    injected_late_arrival = False
 
     async def injecting_stop_typing(chat_id):
+        nonlocal injected_late_arrival
         # Simulate a message landing during the cleanup awaits.
-        adapter._pending_messages[sk] = _make_event(text="late")
+        if not injected_late_arrival:
+            injected_late_arrival = True
+            adapter._pending_messages[sk] = _make_event(text="late")
         if original_stop_typing:
             await original_stop_typing(chat_id)
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1285,6 +1285,51 @@ async def test_base_processing_releases_post_delivery_callback_after_main_send()
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("platform", [Platform.TELEGRAM, Platform.DISCORD])
+async def test_generic_platform_handoff_starts_before_slow_post_delivery_callback(platform):
+    adapter = ProgressCaptureAdapter(platform=platform)
+    callback_started = asyncio.Event()
+    release_callback = asyncio.Event()
+    successor_started = asyncio.Event()
+    source = SessionSource(
+        platform=platform,
+        chat_id="generic-room",
+        chat_type="dm",
+        user_id="owner",
+    )
+    first = MessageEvent(
+        text="first", message_type=MessageType.TEXT, source=source, message_id="first",
+    )
+    second = MessageEvent(
+        text="second", message_type=MessageType.TEXT, source=source, message_id="second",
+    )
+    session_key = adapter.session_key_for_source(source)
+
+    async def handler(event):
+        if event.message_id == "first":
+            adapter._pending_messages[session_key] = second
+            return "first done"
+        successor_started.set()
+        return None
+
+    async def post_delivery():
+        callback_started.set()
+        await release_callback.wait()
+
+    adapter.set_message_handler(handler)
+    adapter.register_post_delivery_callback(session_key, post_delivery)
+    assert adapter._start_session_processing(first, session_key)
+    first_task = adapter._session_tasks[session_key]
+
+    await asyncio.wait_for(callback_started.wait(), timeout=1.0)
+    try:
+        await asyncio.wait_for(successor_started.wait(), timeout=0.25)
+    finally:
+        release_callback.set()
+        await first_task
+
+
+@pytest.mark.asyncio
 async def test_base_processing_stops_typing_before_hung_post_delivery_callback(
     monkeypatch,
 ):

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -132,6 +132,7 @@ def test_merge_pending_message_event_merges_text_and_photo_followups():
         text="first follow-up",
         message_type=MessageType.TEXT,
         source=source,
+        owner_id="opaque-owner-text",
     )
     photo_event = MessageEvent(
         text="see screenshot",
@@ -139,6 +140,7 @@ def test_merge_pending_message_event_merges_text_and_photo_followups():
         source=source,
         media_urls=["/tmp/test.png"],
         media_types=["image/png"],
+        owner_id="opaque-owner-photo",
     )
 
     merge_pending_message_event(pending, session_key, text_event, merge_text=True)
@@ -149,6 +151,8 @@ def test_merge_pending_message_event_merges_text_and_photo_followups():
     assert merged.text == "first follow-up\n\nsee screenshot"
     assert merged.media_urls == ["/tmp/test.png"]
     assert merged.media_types == ["image/png"]
+    assert text_event.metadata["relay_owner_disposition"] == "queued"
+    assert photo_event.metadata["relay_owner_disposition"] == "merged"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_split_brain_11016.py
+++ b/tests/gateway/test_session_split_brain_11016.py
@@ -142,9 +142,17 @@ class TestAdapterSessionCancellation:
 
         await adapter.handle_message(_make_event(command_text))
 
-        assert processing_cancelled.is_set(), (
-            f"{command_text} did not cancel the active processing task"
-        )
+        # Reset-like commands reply immediately; cancellation and guarded drain
+        # complete asynchronously so a wedged task cannot delay that reply.
+        await asyncio.wait_for(processing_cancelled.wait(), timeout=0.5)
+        for _ in range(50):
+            if (
+                sk not in adapter._active_sessions
+                and sk not in adapter._pending_messages
+                and sk not in adapter._session_tasks
+            ):
+                break
+            await asyncio.sleep(0.01)
         assert sk not in adapter._active_sessions
         assert sk not in adapter._pending_messages
         assert sk not in adapter._session_tasks
@@ -296,3 +304,46 @@ class TestOldTaskCannotClobberNewerGuard:
         adapter._release_session_guard(sk, guard=new_guard)
         assert sk not in adapter._active_sessions
 
+
+@pytest.mark.asyncio
+async def test_stale_command_drain_cannot_cancel_or_replace_a_fresh_successor() -> None:
+    """A detached /stop cleanup owns only the command guard it installed.
+
+    This is the /stop#1 + queued M + /stop#2 tail: once the second command
+    replaces the first command guard and starts M, the first cleanup must be a
+    no-op.  In particular it must not consume M, replace its guard, or cancel
+    the fresh task that now owns the session.
+    """
+    adapter = _make_adapter()
+    sk = _session_key()
+    stale_command_guard = asyncio.Event()
+    fresh_message_guard = asyncio.Event()
+    fresh_event = _make_event("M")
+    finish_fresh = asyncio.Event()
+    fresh_task = asyncio.create_task(finish_fresh.wait())
+    adapter._active_sessions[sk] = fresh_message_guard
+    adapter._session_tasks[sk] = fresh_task
+    adapter._pending_messages[sk] = fresh_event
+    adapter._message_handler = lambda _event: asyncio.sleep(0, result="unexpected")
+
+    try:
+        await adapter._drain_pending_after_session_command(sk, stale_command_guard)
+
+        assert adapter._active_sessions.get(sk) is fresh_message_guard
+        assert adapter._session_tasks.get(sk) is fresh_task
+        assert not fresh_task.cancelled()
+        assert adapter._pending_messages.get(sk) is fresh_event
+
+        # The fresh owner can still finish and clean up normally; the stale
+        # drain must not strand its guard after refusing to touch it.
+        adapter._pending_messages.pop(sk)
+        finish_fresh.set()
+        await fresh_task
+        adapter._cleanup_finished_session_task(sk, fresh_message_guard)
+        assert sk not in adapter._active_sessions
+        assert sk not in adapter._session_tasks
+    finally:
+        if not fresh_task.done():
+            fresh_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await fresh_task


### PR DESCRIPTION
## Summary
- bind Relay interrupts to the exact turn owner and runner generation
- route accepted interrupts through the canonical GatewayRunner hard-stop and process reaper
- correlate interrupt acknowledgements without blocking the Relay reader
- make reap/handoff barriers cancellation-safe and bounded
- consume malformed or duplicate structured prompt responses without command fallback
- negotiate Relay contract v2 and document atomic rollout requirements

## Verification
- tests/gateway/relay: 189 passed
- tests/gateway/test_pending_drain_no_recursion.py: 4 passed
- Ruff: passed
- cross-repository Mission Control candidate: 697 backend tests passed
- independent read-only final review: APPROVED

Mission Control counterpart: michtl/dashboard-v4#23.