### PR TITLE
feat(whatsapp): send native media albums

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1217,6 +1217,76 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         except Exception:
             return await super().send_image(chat_id, image_url, caption, reply_to, metadata)
 
+    async def send_multiple_images(
+        self,
+        chat_id: str,
+        images: list[tuple[str, str]],
+        metadata: Optional[Dict[str, Any]] = None,
+        human_delay: float = 0.0,
+    ) -> None:
+        """Send two or more images as one native WhatsApp album."""
+        if len(images) < 2 or not self._running or not self._http_session:
+            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+            return
+
+        from urllib.parse import unquote, urlparse
+        import aiohttp
+
+        items = []
+        try:
+            for image_url, caption in images:
+                if self._is_animation_url(image_url):
+                    await super().send_multiple_images(chat_id, images, metadata, human_delay)
+                    return
+                if image_url.startswith("file://"):
+                    file_path = unquote(urlparse(image_url).path)
+                else:
+                    file_path = await cache_image_from_url(image_url)
+                if not os.path.exists(file_path):
+                    raise FileNotFoundError(file_path)
+                item: Dict[str, Any] = {
+                    "filePath": file_path,
+                    "mediaType": "image",
+                }
+                if caption:
+                    item["caption"] = caption
+                items.append(item)
+        except Exception as exc:
+            logger.warning("[%s] Could not prepare native WhatsApp album; using per-image fallback: %s", self.name, exc)
+            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+            return
+
+        payload: Dict[str, Any] = {
+            "chatId": to_whatsapp_jid(chat_id),
+            "items": items,
+        }
+        should_fallback = False
+        try:
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/send-album",
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=120),
+            ) as resp:
+                data = await resp.json()
+                if not data.get("attempted", True):
+                    should_fallback = True
+                elif resp.status not in (200, 207) or not data.get("success", False):
+                    logger.error(
+                        "[%s] Native WhatsApp album send failed (%s): %s",
+                        self.name,
+                        resp.status,
+                        data,
+                    )
+        except Exception as exc:
+            # The bridge may already have sent the parent and some children.
+            # Do not fall back here or successful children would be duplicated.
+            logger.error("[%s] Native WhatsApp album request failed: %s", self.name, exc, exc_info=True)
+            return
+
+        if should_fallback:
+            logger.warning("[%s] Native WhatsApp album was rejected before send; using per-image fallback", self.name)
+            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+
     async def send_image_file(
         self,
         chat_id: str,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1229,7 +1229,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
             return
 
-        from urllib.parse import unquote, urlparse
+        from urllib.parse import unquote
         import aiohttp
 
         items = []
@@ -1239,7 +1239,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     await super().send_multiple_images(chat_id, images, metadata, human_delay)
                     return
                 if image_url.startswith("file://"):
-                    file_path = unquote(urlparse(image_url).path)
+                    # Match BasePlatformAdapter's file URI contract. In
+                    # particular, file://C%3A%5C... must retain the drive.
+                    file_path = unquote(image_url[7:])
                 else:
                     file_path = await cache_image_from_url(image_url)
                 if not os.path.exists(file_path):
@@ -1267,16 +1269,20 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=120),
             ) as resp:
-                data = await resp.json()
-                if not data.get("attempted", True):
+                if resp.status in (404, 405):
+                    # An older bridge has no album route, so no send occurred.
                     should_fallback = True
-                elif resp.status not in (200, 207) or not data.get("success", False):
-                    logger.error(
-                        "[%s] Native WhatsApp album send failed (%s): %s",
-                        self.name,
-                        resp.status,
-                        data,
-                    )
+                else:
+                    data = await resp.json()
+                    if not data.get("attempted", True):
+                        should_fallback = True
+                    elif resp.status not in (200, 207) or not data.get("success", False):
+                        logger.error(
+                            "[%s] Native WhatsApp album send failed (%s): %s",
+                            self.name,
+                            resp.status,
+                            data,
+                        )
         except Exception as exc:
             # The bridge may already have sent the parent and some children.
             # Do not fall back here or successful children would be duplicated.

--- a/scripts/whatsapp-bridge/album_route.js
+++ b/scripts/whatsapp-bridge/album_route.js
@@ -1,11 +1,43 @@
 import { prepareAlbumItems, sendAlbumSequence } from './bridge_helpers.js';
 
+export async function sendAlbumMessageWithWatchdog({
+  socket,
+  chatId,
+  payload,
+  mediaUploadTimeoutMs,
+  watchdogTimeoutMs,
+  onFatalTimeout,
+}) {
+  let timer;
+  const sendPromise = Promise.resolve().then(() => socket.sendMessage(
+    chatId,
+    payload,
+    { mediaUploadTimeoutMs },
+  ));
+  const timeoutPromise = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      const error = new Error(`album send timed out after ${watchdogTimeoutMs}ms`);
+      try {
+        onFatalTimeout(error);
+      } finally {
+        // Production's fatal callback terminates the bridge synchronously, so
+        // an unresolved Baileys send can never escape this queue slot. Tests
+        // use a non-fatal callback and observe the rejection instead.
+        reject(error);
+      }
+    }, watchdogTimeoutMs);
+  });
+  return Promise.race([sendPromise, timeoutPromise]).finally(() => clearTimeout(timer));
+}
+
 export function registerAlbumRoute(app, {
   getSocket,
   getConnectionState,
   enqueueSend,
   trackSentMessageId,
   messageStore,
+  sendTimeoutMs = 60000,
+  onFatalTimeout = () => {},
 }) {
   app.post('/send-album', async (req, res) => {
     const socket = getSocket();
@@ -44,10 +76,18 @@ export function registerAlbumRoute(app, {
       chatId,
       items: preparedItems,
       // Do not race album socket writes against a timer. A losing sendMessage
-      // promise cannot be cancelled; releasing the global queue would allow it
-      // to overlap later sends and recreate cross-chat contamination.
+      // promise cannot be cancelled safely. Baileys gets a real upload timeout
+      // that destroys the HTTP request; a slightly longer watchdog terminates
+      // the bridge if sendMessage itself still fails to settle.
       send: async (targetChatId, payload) => {
-        const sent = await socket.sendMessage(targetChatId, payload);
+        const sent = await sendAlbumMessageWithWatchdog({
+          socket,
+          chatId: targetChatId,
+          payload,
+          mediaUploadTimeoutMs: Math.max(1000, sendTimeoutMs - 5000),
+          watchdogTimeoutMs: sendTimeoutMs,
+          onFatalTimeout,
+        });
         trackSentMessageId(sent);
         messageStore.remember(sent);
         return sent;

--- a/scripts/whatsapp-bridge/album_route.js
+++ b/scripts/whatsapp-bridge/album_route.js
@@ -1,0 +1,60 @@
+import { prepareAlbumItems, sendAlbumSequence } from './bridge_helpers.js';
+
+export function registerAlbumRoute(app, {
+  getSocket,
+  getConnectionState,
+  enqueueSend,
+  trackSentMessageId,
+  messageStore,
+}) {
+  app.post('/send-album', async (req, res) => {
+    const socket = getSocket();
+    if (!socket || getConnectionState() !== 'connected') {
+      return res.status(503).json({
+        success: false,
+        attempted: false,
+        status: 'not_connected',
+        error: 'Not connected to WhatsApp',
+      });
+    }
+
+    const { chatId, items } = req.body;
+    if (!chatId || !Array.isArray(items)) {
+      return res.status(400).json({
+        success: false,
+        attempted: false,
+        status: 'validation_error',
+        error: 'chatId and items are required',
+      });
+    }
+
+    let preparedItems;
+    try {
+      preparedItems = prepareAlbumItems(items);
+    } catch (error) {
+      return res.status(400).json({
+        success: false,
+        attempted: false,
+        status: 'validation_error',
+        error: error.message,
+      });
+    }
+
+    const result = await enqueueSend(() => sendAlbumSequence({
+      chatId,
+      items: preparedItems,
+      // Do not race album socket writes against a timer. A losing sendMessage
+      // promise cannot be cancelled; releasing the global queue would allow it
+      // to overlap later sends and recreate cross-chat contamination.
+      send: async (targetChatId, payload) => {
+        const sent = await socket.sendMessage(targetChatId, payload);
+        trackSentMessageId(sent);
+        messageStore.remember(sent);
+        return sent;
+      },
+    }));
+
+    const statusCode = result.success ? 200 : (result.status === 'partial_failure' ? 207 : 502);
+    return res.status(statusCode).json(result);
+  });
+}

--- a/scripts/whatsapp-bridge/album_route.test.mjs
+++ b/scripts/whatsapp-bridge/album_route.test.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import express from 'express';
 
-import { registerAlbumRoute } from './album_route.js';
+import { registerAlbumRoute, sendAlbumMessageWithWatchdog } from './album_route.js';
 
 function createQueue() {
   let tail = Promise.resolve();
@@ -34,6 +34,32 @@ async function withServer(socket, fn) {
   } finally {
     await new Promise(resolve => server.close(resolve));
   }
+}
+
+{
+  let fatalCalls = 0;
+  let sendOptions;
+  const socket = {
+    sendMessage: async (_chatId, _payload, options) => {
+      sendOptions = options;
+      return new Promise(() => {});
+    },
+  };
+
+  await assert.rejects(
+    () => sendAlbumMessageWithWatchdog({
+      socket,
+      chatId: '15551234567@s.whatsapp.net',
+      payload: { image: Buffer.from('stuck') },
+      mediaUploadTimeoutMs: 10,
+      watchdogTimeoutMs: 20,
+      onFatalTimeout: async () => { fatalCalls += 1; },
+    }),
+    /timed out after 20ms/,
+  );
+  assert.equal(fatalCalls, 1);
+  assert.deepEqual(sendOptions, { mediaUploadTimeoutMs: 10 });
+  console.log('  ✓ hung album sends trigger the fatal watchdog within a bounded time');
 }
 
 {

--- a/scripts/whatsapp-bridge/album_route.test.mjs
+++ b/scripts/whatsapp-bridge/album_route.test.mjs
@@ -1,0 +1,113 @@
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import express from 'express';
+
+import { registerAlbumRoute } from './album_route.js';
+
+function createQueue() {
+  let tail = Promise.resolve();
+  return fn => {
+    const task = tail.then(fn, fn);
+    tail = task.catch(() => {});
+    return task;
+  };
+}
+
+async function withServer(socket, fn) {
+  const app = express();
+  app.use(express.json());
+  registerAlbumRoute(app, {
+    getSocket: () => socket,
+    getConnectionState: () => 'connected',
+    enqueueSend: createQueue(),
+    trackSentMessageId: () => {},
+    messageStore: { remember: () => {} },
+  });
+  const server = await new Promise(resolve => {
+    const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
+  });
+  try {
+    const address = server.address();
+    await fn(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+{
+  const dir = mkdtempSync(path.join(tmpdir(), 'hermes-wa-album-route-'));
+  const first = path.join(dir, 'first.jpg');
+  const second = path.join(dir, 'second.jpg');
+  writeFileSync(first, Buffer.from('first'));
+  writeFileSync(second, Buffer.from('second'));
+  const calls = [];
+  const parentKey = {
+    id: 'parent',
+    remoteJid: '15551234567@s.whatsapp.net',
+  };
+  const socket = {
+    sendMessage: async (chatId, payload) => {
+      calls.push({ chatId, payload });
+      return { key: calls.length === 1 ? parentKey : { id: `child-${calls.length - 1}`, remoteJid: chatId } };
+    },
+  };
+
+  await withServer(socket, async baseUrl => {
+    const response = await fetch(`${baseUrl}/send-album`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        chatId: '15551234567@s.whatsapp.net',
+        items: [
+          { filePath: first, mediaType: 'image' },
+          { filePath: second, mediaType: 'image' },
+        ],
+      }),
+    });
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(body.status, 'success');
+    assert.equal(body.parentMessageId, 'parent');
+    assert.deepEqual(body.childMessageIds, ['child-1', 'child-2']);
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls[0].payload.album, {
+      expectedImageCount: 2,
+      expectedVideoCount: 0,
+    });
+    assert.deepEqual(calls[1].payload.albumParentKey, parentKey);
+  });
+  console.log('  ✓ /send-album sends a native parent and associated children over HTTP');
+}
+
+{
+  let sends = 0;
+  const socket = {
+    sendMessage: async () => {
+      sends += 1;
+      return { key: { id: 'unexpected' } };
+    },
+  };
+  await withServer(socket, async baseUrl => {
+    const response = await fetch(`${baseUrl}/send-album`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        chatId: '15551234567@s.whatsapp.net',
+        items: [
+          { filePath: '/definitely/missing/one.jpg', mediaType: 'image' },
+          { filePath: '/definitely/missing/two.jpg', mediaType: 'image' },
+        ],
+      }),
+    });
+    const body = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(body.attempted, false);
+    assert.equal(body.status, 'validation_error');
+    assert.equal(sends, 0);
+  });
+  console.log('  ✓ missing files fail preflight before the album parent is attempted');
+}
+
+console.log('\n✅ All WhatsApp album route integration tests passed.');

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -31,6 +31,7 @@ import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
+import { registerAlbumRoute } from './album_route.js';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
@@ -47,8 +48,6 @@ import {
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
-  prepareAlbumItems,
-  sendAlbumSequence,
 } from './bridge_helpers.js';
 
 // Parse CLI args
@@ -996,50 +995,12 @@ app.post('/send-media', async (req, res) => {
   }
 });
 
-// Send multiple images/videos as one native WhatsApp album. The whole parent
-// + children sequence occupies one queue slot so unrelated sends cannot
-// interleave with the album on the shared Baileys socket.
-app.post('/send-album', async (req, res) => {
-  if (!sock || connectionState !== 'connected') {
-    return res.status(503).json({ error: 'Not connected to WhatsApp' });
-  }
-
-  const { chatId, items, delayMs } = req.body;
-  if (!chatId || !Array.isArray(items)) {
-    return res.status(400).json({ error: 'chatId and items are required' });
-  }
-
-  try {
-    // Preflight every file before the parent is sent. Known local failures
-    // must not leave an empty or permanently incomplete album envelope.
-    const preparedItems = prepareAlbumItems(items);
-    const parsedDelayMs = Number(delayMs || 0);
-    if (!Number.isFinite(parsedDelayMs) || parsedDelayMs < 0) {
-      return res.status(400).json({ error: 'delayMs must be a non-negative number' });
-    }
-
-    const result = await enqueueSend(() => sendAlbumSequence({
-      chatId,
-      items: preparedItems,
-      delayMs: Math.min(parsedDelayMs, 60000),
-      send: async (targetChatId, payload) => {
-        const sent = await sendSocketWithTimeout(targetChatId, payload);
-        trackSentMessageId(sent);
-        messageStore.remember(sent);
-        return sent;
-      },
-    }));
-
-    const statusCode = result.success ? 200 : (result.status === 'partial_failure' ? 207 : 502);
-    return res.status(statusCode).json(result);
-  } catch (err) {
-    return res.status(400).json({
-      success: false,
-      attempted: false,
-      status: 'validation_error',
-      error: err.message,
-    });
-  }
+registerAlbumRoute(app, {
+  getSocket: () => sock,
+  getConnectionState: () => connectionState,
+  enqueueSend,
+  trackSentMessageId,
+  messageStore,
 });
 
 // Send poll primitive. Approval UX is intentionally not wired here; gateway

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -10,6 +10,7 @@
  *   POST /send           - Send a message { chatId, message, replyTo? }
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
+ *   POST /send-album     - Send a native media album { chatId, items[], delayMs? }
  *   POST /send-location  - Send location pin { chatId, latitude, longitude, name?, address? }
  *   POST /typing         - Send typing indicator { chatId }
  *   GET  /chat/:id       - Get chat info
@@ -46,6 +47,8 @@ import {
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
+  prepareAlbumItems,
+  sendAlbumSequence,
 } from './bridge_helpers.js';
 
 // Parse CLI args
@@ -142,7 +145,7 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function sendWithTimeout(chatId, payload, options = {}, timeoutMs = SEND_TIMEOUT_MS) {
+function sendSocketWithTimeout(chatId, payload, options = {}, timeoutMs = SEND_TIMEOUT_MS) {
   let timer;
   const timeoutPromise = new Promise((_, reject) => {
     timer = setTimeout(
@@ -150,10 +153,12 @@ function sendWithTimeout(chatId, payload, options = {}, timeoutMs = SEND_TIMEOUT
       timeoutMs,
     );
   });
-  return enqueueSend(() =>
-    Promise.race([sock.sendMessage(chatId, payload, options), timeoutPromise])
-      .finally(() => clearTimeout(timer))
-  );
+  return Promise.race([sock.sendMessage(chatId, payload, options), timeoutPromise])
+    .finally(() => clearTimeout(timer));
+}
+
+function sendWithTimeout(chatId, payload, options = {}, timeoutMs = SEND_TIMEOUT_MS) {
+  return enqueueSend(() => sendSocketWithTimeout(chatId, payload, options, timeoutMs));
 }
 
 function formatOutgoingMessage(message) {
@@ -988,6 +993,52 @@ app.post('/send-media', async (req, res) => {
     res.json({ success: true, messageId: sent?.key?.id });
   } catch (err) {
     res.status(500).json({ error: err.message });
+  }
+});
+
+// Send multiple images/videos as one native WhatsApp album. The whole parent
+// + children sequence occupies one queue slot so unrelated sends cannot
+// interleave with the album on the shared Baileys socket.
+app.post('/send-album', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { chatId, items, delayMs } = req.body;
+  if (!chatId || !Array.isArray(items)) {
+    return res.status(400).json({ error: 'chatId and items are required' });
+  }
+
+  try {
+    // Preflight every file before the parent is sent. Known local failures
+    // must not leave an empty or permanently incomplete album envelope.
+    const preparedItems = prepareAlbumItems(items);
+    const parsedDelayMs = Number(delayMs || 0);
+    if (!Number.isFinite(parsedDelayMs) || parsedDelayMs < 0) {
+      return res.status(400).json({ error: 'delayMs must be a non-negative number' });
+    }
+
+    const result = await enqueueSend(() => sendAlbumSequence({
+      chatId,
+      items: preparedItems,
+      delayMs: Math.min(parsedDelayMs, 60000),
+      send: async (targetChatId, payload) => {
+        const sent = await sendSocketWithTimeout(targetChatId, payload);
+        trackSentMessageId(sent);
+        messageStore.remember(sent);
+        return sent;
+      },
+    }));
+
+    const statusCode = result.success ? 200 : (result.status === 'partial_failure' ? 207 : 502);
+    return res.status(statusCode).json(result);
+  } catch (err) {
+    return res.status(400).json({
+      success: false,
+      attempted: false,
+      status: 'validation_error',
+      error: err.message,
+    });
   }
 });
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -10,7 +10,7 @@
  *   POST /send           - Send a message { chatId, message, replyTo? }
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
- *   POST /send-album     - Send a native media album { chatId, items[], delayMs? }
+ *   POST /send-album     - Send a native media album { chatId, items[] }
  *   POST /send-location  - Send location pin { chatId, latitude, longitude, name?, address? }
  *   POST /typing         - Send typing indicator { chatId }
  *   GET  /chat/:id       - Get chat info
@@ -1001,6 +1001,11 @@ registerAlbumRoute(app, {
   enqueueSend,
   trackSentMessageId,
   messageStore,
+  sendTimeoutMs: SEND_TIMEOUT_MS,
+  onFatalTimeout: error => {
+    console.error(`[bridge] fatal album send timeout: ${error.message}; restarting bridge`);
+    process.exit(1);
+  },
 });
 
 // Send poll primitive. Approval UX is intentionally not wired here; gateway

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -300,9 +300,9 @@ import {
   assert.equal(prepared.length, 2);
   assert.equal(prepared[0].type, 'image');
   assert.equal(prepared[0].filePath, first);
-  assert.equal(prepared[0].payload.mimetype, 'image/jpeg');
+  assert.equal(prepared[0].createPayload().mimetype, 'image/jpeg');
   assert.equal(prepared[1].type, 'video');
-  assert.equal(prepared[1].payload.caption, 'clip');
+  assert.equal(prepared[1].createPayload().caption, 'clip');
   console.log('  ✓ album files are fully validated and prepared before parent send');
 }
 

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -7,12 +7,13 @@
 
 import { strict as assert } from 'node:assert';
 import { createHash } from 'node:crypto';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { getAggregateVotesInPollMessage } from '@whiskeysockets/baileys';
 
 import {
+  buildAlbumPlan,
   buildPollPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
@@ -22,6 +23,8 @@ import {
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
+  prepareAlbumItems,
+  sendAlbumSequence,
 } from './bridge_helpers.js';
 
 // -- inbound read receipts ------------------------------------------------
@@ -239,6 +242,124 @@ import {
 }
 
 // -- outbound media/poll helpers -----------------------------------------
+{
+  const calls = [];
+  const parentKey = {
+    id: 'album-parent',
+    remoteJid: '15551234567@s.whatsapp.net',
+    fromMe: true,
+  };
+  const send = async (chatId, payload) => {
+    calls.push({ chatId, payload });
+    if (calls.length === 1) {
+      return { key: parentKey };
+    }
+    return { key: { id: `album-child-${calls.length - 1}`, remoteJid: chatId, fromMe: true } };
+  };
+  const items = [
+    { type: 'image', filePath: '/tmp/one.jpg', payload: { image: Buffer.from('one'), mimetype: 'image/jpeg' } },
+    { type: 'image', filePath: '/tmp/two.jpg', payload: { image: Buffer.from('two'), mimetype: 'image/jpeg' } },
+    { type: 'video', filePath: '/tmp/three.mp4', payload: { video: Buffer.from('three'), mimetype: 'video/mp4' } },
+  ];
+
+  const plan = buildAlbumPlan(items);
+  assert.deepEqual(plan.parentPayload, {
+    album: { expectedImageCount: 2, expectedVideoCount: 1 },
+  });
+
+  const result = await sendAlbumSequence({
+    chatId: '15551234567@s.whatsapp.net',
+    items,
+    send,
+  });
+
+  assert.equal(calls.length, 4);
+  assert.deepEqual(calls[0].payload, plan.parentPayload);
+  for (const childCall of calls.slice(1)) {
+    assert.deepEqual(childCall.payload.albumParentKey, parentKey);
+  }
+  assert.equal(result.success, true);
+  assert.equal(result.parentMessageId, 'album-parent');
+  assert.deepEqual(result.childMessageIds, ['album-child-1', 'album-child-2', 'album-child-3']);
+  assert.equal(result.items[0].filePath, '/tmp/one.jpg');
+  console.log('  ✓ album sequence sends one parent then associated media children');
+}
+
+{
+  const albumDir = mkdtempSync(path.join(tmpdir(), 'hermes-wa-album-'));
+  const first = path.join(albumDir, 'first.jpg');
+  const second = path.join(albumDir, 'second.mp4');
+  writeFileSync(first, Buffer.from('first'));
+  writeFileSync(second, Buffer.from('second'));
+
+  const prepared = prepareAlbumItems([
+    { filePath: first, mediaType: 'image' },
+    { filePath: second, mediaType: 'video', caption: 'clip' },
+  ]);
+
+  assert.equal(prepared.length, 2);
+  assert.equal(prepared[0].type, 'image');
+  assert.equal(prepared[0].filePath, first);
+  assert.equal(prepared[0].payload.mimetype, 'image/jpeg');
+  assert.equal(prepared[1].type, 'video');
+  assert.equal(prepared[1].payload.caption, 'clip');
+  console.log('  ✓ album files are fully validated and prepared before parent send');
+}
+
+{
+  const calls = [];
+  const send = async (chatId, payload) => {
+    calls.push({ chatId, payload });
+    if (calls.length === 1) return { key: { id: 'parent', remoteJid: chatId } };
+    if (calls.length === 3) throw new Error('child upload failed');
+    return { key: { id: `child-${calls.length - 1}`, remoteJid: chatId } };
+  };
+
+  const result = await sendAlbumSequence({
+    chatId: '15551234567@s.whatsapp.net',
+    items: [
+      { type: 'image', filePath: '/tmp/one.jpg', payload: { image: Buffer.from('one') } },
+      { type: 'image', filePath: '/tmp/two.jpg', payload: { image: Buffer.from('two') } },
+      { type: 'image', filePath: '/tmp/three.jpg', payload: { image: Buffer.from('three') } },
+    ],
+    send,
+  });
+
+  assert.equal(calls.length, 4, 'later children still send after one child fails');
+  assert.equal(result.success, false);
+  assert.equal(result.status, 'partial_failure');
+  assert.deepEqual(result.childMessageIds, ['child-1', 'child-3']);
+  assert.deepEqual(result.items[1], {
+    index: 1,
+    filePath: '/tmp/two.jpg',
+    success: false,
+    error: 'child upload failed',
+  });
+  console.log('  ✓ partial album failures are explicit and do not duplicate successful children');
+}
+
+{
+  const result = await sendAlbumSequence({
+    chatId: '15551234567@s.whatsapp.net',
+    items: [
+      { type: 'image', payload: { image: Buffer.from('one') } },
+      { type: 'image', payload: { image: Buffer.from('two') } },
+    ],
+    send: async () => { throw new Error('parent send timed out'); },
+  });
+
+  assert.deepEqual(result, {
+    success: false,
+    attempted: true,
+    status: 'parent_failure',
+    parentMessageId: null,
+    childMessageIds: [],
+    items: [],
+    error: 'parent send timed out',
+  });
+  console.log('  ✓ parent failures are distinguished from preflight validation failures');
+}
+
 {
   const payload = mediaPayloadForFile({
     buffer: Buffer.from('gif89a'),

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { randomBytes } from 'crypto';
 
 export const MIME_MAP = {
@@ -544,12 +544,17 @@ export function buildAlbumPlan(items) {
     if (!['image', 'video'].includes(type)) {
       throw new Error(`album item ${index} must be an image or video`);
     }
-    if (!item?.payload || typeof item.payload !== 'object') {
-      throw new Error(`album item ${index} payload is required`);
+    if ((!item?.payload || typeof item.payload !== 'object') && typeof item?.createPayload !== 'function') {
+      throw new Error(`album item ${index} payload or createPayload is required`);
     }
     if (type === 'image') expectedImageCount += 1;
     if (type === 'video') expectedVideoCount += 1;
-    return { type, filePath: item.filePath, payload: item.payload };
+    return {
+      type,
+      filePath: item.filePath,
+      payload: item.payload,
+      createPayload: item.createPayload,
+    };
   });
 
   return {
@@ -569,6 +574,7 @@ export function prepareAlbumItems(items) {
     const filePath = String(item?.filePath || '').trim();
     if (!filePath) throw new Error(`album item ${index} filePath is required`);
     if (!existsSync(filePath)) throw new Error(`album item ${index} file not found: ${filePath}`);
+    accessSync(filePath, constants.R_OK);
 
     const ext = filePath.toLowerCase().split('.').pop();
     const inferredType = inferMediaType(ext);
@@ -577,19 +583,25 @@ export function prepareAlbumItems(items) {
       throw new Error(`album item ${index} must be an image or video matching its file type`);
     }
 
-    const payload = mediaPayloadForFile({
-      buffer: readFileSync(filePath),
+    return {
+      type,
       filePath,
-      mediaType: type,
-      caption: item?.caption,
-      fileName: item?.fileName,
-    });
-    if (!payload) throw new Error(`album item ${index} could not be prepared`);
-    return { type, filePath, payload };
+      createPayload: () => {
+        const payload = mediaPayloadForFile({
+          buffer: readFileSync(filePath),
+          filePath,
+          mediaType: type,
+          caption: item?.caption,
+          fileName: item?.fileName,
+        });
+        if (!payload) throw new Error(`album item ${index} could not be prepared`);
+        return payload;
+      },
+    };
   });
 }
 
-export async function sendAlbumSequence({ chatId, items, send, delayMs = 0 }) {
+export async function sendAlbumSequence({ chatId, items, send }) {
   if (typeof send !== 'function') throw new Error('album send function is required');
   const plan = buildAlbumPlan(items);
   let parent;
@@ -612,8 +624,9 @@ export async function sendAlbumSequence({ chatId, items, send, delayMs = 0 }) {
   for (let index = 0; index < plan.children.length; index += 1) {
     const child = plan.children[index];
     try {
+      const payload = child.payload || child.createPayload();
       const sent = await send(chatId, {
-        ...child.payload,
+        ...payload,
         albumParentKey: parent.key,
       });
       if (!sent?.key?.id) throw new Error('album child send returned no message id');
@@ -625,9 +638,6 @@ export async function sendAlbumSequence({ chatId, items, send, delayMs = 0 }) {
         success: false,
         error: error?.message || String(error),
       });
-    }
-    if (delayMs > 0 && index < plan.children.length - 1) {
-      await new Promise(resolve => setTimeout(resolve, delayMs));
     }
   }
 

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { mkdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { randomBytes } from 'crypto';
 
 export const MIME_MAP = {
@@ -530,6 +530,119 @@ export function mediaPayloadForFile({ buffer, filePath, mediaType, caption, file
     default:
       return null;
   }
+}
+
+export function buildAlbumPlan(items) {
+  if (!Array.isArray(items) || items.length < 2) {
+    throw new Error('at least two album items are required');
+  }
+
+  let expectedImageCount = 0;
+  let expectedVideoCount = 0;
+  const children = items.map((item, index) => {
+    const type = String(item?.type || '').trim().toLowerCase();
+    if (!['image', 'video'].includes(type)) {
+      throw new Error(`album item ${index} must be an image or video`);
+    }
+    if (!item?.payload || typeof item.payload !== 'object') {
+      throw new Error(`album item ${index} payload is required`);
+    }
+    if (type === 'image') expectedImageCount += 1;
+    if (type === 'video') expectedVideoCount += 1;
+    return { type, filePath: item.filePath, payload: item.payload };
+  });
+
+  return {
+    parentPayload: {
+      album: { expectedImageCount, expectedVideoCount },
+    },
+    children,
+  };
+}
+
+export function prepareAlbumItems(items) {
+  if (!Array.isArray(items) || items.length < 2) {
+    throw new Error('at least two album items are required');
+  }
+
+  return items.map((item, index) => {
+    const filePath = String(item?.filePath || '').trim();
+    if (!filePath) throw new Error(`album item ${index} filePath is required`);
+    if (!existsSync(filePath)) throw new Error(`album item ${index} file not found: ${filePath}`);
+
+    const ext = filePath.toLowerCase().split('.').pop();
+    const inferredType = inferMediaType(ext);
+    const type = String(item?.mediaType || inferredType).trim().toLowerCase();
+    if (!['image', 'video'].includes(type) || type !== inferredType) {
+      throw new Error(`album item ${index} must be an image or video matching its file type`);
+    }
+
+    const payload = mediaPayloadForFile({
+      buffer: readFileSync(filePath),
+      filePath,
+      mediaType: type,
+      caption: item?.caption,
+      fileName: item?.fileName,
+    });
+    if (!payload) throw new Error(`album item ${index} could not be prepared`);
+    return { type, filePath, payload };
+  });
+}
+
+export async function sendAlbumSequence({ chatId, items, send, delayMs = 0 }) {
+  if (typeof send !== 'function') throw new Error('album send function is required');
+  const plan = buildAlbumPlan(items);
+  let parent;
+  try {
+    parent = await send(chatId, plan.parentPayload);
+    if (!parent?.key?.id) throw new Error('album parent send returned no message id');
+  } catch (error) {
+    return {
+      success: false,
+      attempted: true,
+      status: 'parent_failure',
+      parentMessageId: null,
+      childMessageIds: [],
+      items: [],
+      error: error?.message || String(error),
+    };
+  }
+
+  const itemResults = [];
+  for (let index = 0; index < plan.children.length; index += 1) {
+    const child = plan.children[index];
+    try {
+      const sent = await send(chatId, {
+        ...child.payload,
+        albumParentKey: parent.key,
+      });
+      if (!sent?.key?.id) throw new Error('album child send returned no message id');
+      itemResults.push({ index, filePath: child.filePath, success: true, messageId: sent.key.id });
+    } catch (error) {
+      itemResults.push({
+        index,
+        filePath: child.filePath,
+        success: false,
+        error: error?.message || String(error),
+      });
+    }
+    if (delayMs > 0 && index < plan.children.length - 1) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+
+  const childMessageIds = itemResults
+    .filter(item => item.success)
+    .map(item => item.messageId);
+  const success = itemResults.every(item => item.success);
+  return {
+    success,
+    attempted: true,
+    status: success ? 'success' : 'partial_failure',
+    parentMessageId: parent.key.id,
+    childMessageIds,
+    items: itemResults,
+  };
 }
 
 export function buildPollPayload({ question, options, selectableCount = 1 }) {

--- a/tests/gateway/test_whatsapp_native_delivery.py
+++ b/tests/gateway/test_whatsapp_native_delivery.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -136,5 +136,61 @@ async def test_native_album_does_not_hold_global_queue_for_human_delay(tmp_path)
 
     payload = session.post.call_args.kwargs["json"]
     assert "delayMs" not in payload
+
+
+@pytest.mark.asyncio
+async def test_native_album_falls_back_when_old_bridge_returns_non_json_404(tmp_path):
+    adapter = _make_adapter()
+    session = adapter._http_session
+    assert session is not None
+    first = tmp_path / "first.jpg"
+    second = tmp_path / "second.jpg"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    missing_route = MagicMock(status=404)
+    missing_route.json = AsyncMock(side_effect=ValueError("not json"))
+    media_resp = MagicMock(status=200)
+    media_resp.json = AsyncMock(return_value={"success": True})
+    session.post = MagicMock(side_effect=[
+        _AsyncCM(missing_route),
+        _AsyncCM(media_resp),
+        _AsyncCM(media_resp),
+    ])
+
+    await adapter.send_multiple_images(
+        "15551234567",
+        [(first.as_uri(), ""), (second.as_uri(), "")],
+    )
+
+    assert [call.args[0] for call in session.post.call_args_list] == [
+        "http://127.0.0.1:3000/send-album",
+        "http://127.0.0.1:3000/send-media",
+        "http://127.0.0.1:3000/send-media",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_native_album_preserves_windows_file_uri_paths():
+    adapter = _make_adapter()
+    session = adapter._http_session
+    assert session is not None
+    resp = MagicMock(status=200)
+    resp.json = AsyncMock(return_value={"success": True})
+    session.post = MagicMock(return_value=_AsyncCM(resp))
+
+    with patch("plugins.platforms.whatsapp.adapter.os.path.exists", return_value=True):
+        await adapter.send_multiple_images(
+            "15551234567",
+            [
+                ("file://C%3A%5Cphotos%5Cone.jpg", ""),
+                ("file://C%3A%5Cphotos%5Ctwo.jpg", ""),
+            ],
+        )
+
+    items = session.post.call_args.kwargs["json"]["items"]
+    assert [item["filePath"] for item in items] == [
+        "C:\\photos\\one.jpg",
+        "C:\\photos\\two.jpg",
+    ]
 
 

--- a/tests/gateway/test_whatsapp_native_delivery.py
+++ b/tests/gateway/test_whatsapp_native_delivery.py
@@ -43,3 +43,98 @@ async def test_send_location_posts_to_bridge_location_endpoint():
     }
 
 
+@pytest.mark.asyncio
+async def test_send_multiple_images_posts_one_native_album_request(tmp_path):
+    adapter = _make_adapter()
+    session = adapter._http_session
+    assert session is not None
+    first = tmp_path / "first.jpg"
+    second = tmp_path / "second.jpg"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    resp = MagicMock(status=200)
+    resp.json = AsyncMock(return_value={
+        "success": True,
+        "parentMessageId": "album-parent",
+        "childMessageIds": ["child-1", "child-2"],
+    })
+    session.post = MagicMock(return_value=_AsyncCM(resp))
+
+    await adapter.send_multiple_images(
+        "15551234567",
+        [(first.as_uri(), ""), (second.as_uri(), "second caption")],
+    )
+
+    session.post.assert_called_once()
+    call = session.post.call_args
+    assert call.args[0] == "http://127.0.0.1:3000/send-album"
+    assert call.kwargs["json"] == {
+        "chatId": "15551234567@s.whatsapp.net",
+        "items": [
+            {"filePath": str(first), "mediaType": "image"},
+            {"filePath": str(second), "mediaType": "image", "caption": "second caption"},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_multiple_images_falls_back_when_album_preflight_was_not_attempted(tmp_path):
+    adapter = _make_adapter()
+    session = adapter._http_session
+    assert session is not None
+    first = tmp_path / "first.jpg"
+    second = tmp_path / "second.jpg"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+
+    validation_resp = MagicMock(status=400)
+    validation_resp.json = AsyncMock(return_value={
+        "success": False,
+        "attempted": False,
+        "status": "validation_error",
+        "error": "invalid album",
+    })
+    media_resp = MagicMock(status=200)
+    media_resp.json = AsyncMock(return_value={"success": True, "messageId": "child"})
+    session.post = MagicMock(side_effect=[
+        _AsyncCM(validation_resp),
+        _AsyncCM(media_resp),
+        _AsyncCM(media_resp),
+    ])
+
+    await adapter.send_multiple_images(
+        "15551234567",
+        [(first.as_uri(), ""), (second.as_uri(), "")],
+    )
+
+    urls = [call.args[0] for call in session.post.call_args_list]
+    assert urls == [
+        "http://127.0.0.1:3000/send-album",
+        "http://127.0.0.1:3000/send-media",
+        "http://127.0.0.1:3000/send-media",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_native_album_does_not_hold_global_queue_for_human_delay(tmp_path):
+    adapter = _make_adapter()
+    session = adapter._http_session
+    assert session is not None
+    first = tmp_path / "first.jpg"
+    second = tmp_path / "second.jpg"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    resp = MagicMock(status=200)
+    resp.json = AsyncMock(return_value={"success": True})
+    session.post = MagicMock(return_value=_AsyncCM(resp))
+
+    await adapter.send_multiple_images(
+        "15551234567",
+        [(first.as_uri(), ""), (second.as_uri(), "")],
+        human_delay=2.5,
+    )
+
+    payload = session.post.call_args.kwargs["json"]
+    assert "delayMs" not in payload
+
+

--- a/tests/gateway/test_whatsapp_native_delivery.py
+++ b/tests/gateway/test_whatsapp_native_delivery.py
@@ -194,3 +194,34 @@ async def test_native_album_preserves_windows_file_uri_paths():
     ]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "body"),
+    [
+        (207, {"success": False, "attempted": True, "status": "partial_failure"}),
+        (502, {"success": False, "attempted": True, "status": "parent_failure"}),
+    ],
+)
+async def test_attempted_album_failures_never_fall_back_to_individual_media(
+    tmp_path, status, body,
+):
+    adapter = _make_adapter()
+    session = adapter._http_session
+    assert session is not None
+    first = tmp_path / "first.jpg"
+    second = tmp_path / "second.jpg"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    resp = MagicMock(status=status)
+    resp.json = AsyncMock(return_value=body)
+    session.post = MagicMock(return_value=_AsyncCM(resp))
+
+    await adapter.send_multiple_images(
+        "15551234567",
+        [(first.as_uri(), ""), (second.as_uri(), "")],
+    )
+
+    session.post.assert_called_once()
+    assert session.post.call_args.args[0] == "http://127.0.0.1:3000/send-album"
+
+


### PR DESCRIPTION
## Summary
- add a native `/send-album` bridge route using Baileys album parent + `albumParentKey` children
- keep the complete parent/children sequence in one global send-queue task
- preflight every file before the parent and return explicit success, partial, parent-failure, and per-item results
- use native albums for 2+ static images in the WhatsApp adapter, with safe per-image fallback only when no album send was attempted
- retain single-image and animated-media behavior

## Safety and reliability
- album socket writes are awaited directly rather than raced against an uncancellable timeout, preserving queue serialization
- no whole-album retry after an ambiguous or partial send
- media buffers are created lazily per child instead of retaining the full album in memory
- old bridges returning 404/405 fall back safely to `/send-media`

## Tests
- all `scripts/whatsapp-bridge/*.test.mjs` passed, including real HTTP route coverage
- `pytest tests/gateway -k whatsapp -o addopts= -q`: 178 passed, 4 skipped
- Ruff, Node syntax checks, and `git diff --check` passed
- manual self-chat test against a connected Baileys session: parent + 2 image children succeeded with distinct message IDs