### PR TITLE
fix(buzz): authenticated inbound media, gated on explicit authorization (consolidates #75614)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3675,11 +3675,26 @@ class BasePlatformAdapter(ABC):
         registered via :meth:`set_authorization_check`. Returns ``None``
         when no check is registered (caller should treat as "trust unknown"
         and preserve legacy behaviour).
+
+        Only the literal booleans are propagated. A callback that returns
+        anything else is treated as "unknown" rather than coerced with
+        ``bool()``: callers that gate a credentialed side effect on an
+        explicit ``is True`` must not have a truthy non-boolean (a status
+        string, a sentinel object) silently promoted to an authorization.
         """
         if not user_id or self._authorization_check is None:
             return None
         try:
-            return bool(self._authorization_check(user_id, chat_type, chat_id))
+            result = self._authorization_check(user_id, chat_type, chat_id)
+            if result is True:
+                return True
+            if result is False:
+                return False
+            logger.warning(
+                "[%s] Authorization check returned %s for user %s; treating as unknown",
+                self.name, type(result).__name__, user_id,
+            )
+            return None
         except Exception:
             logger.warning(
                 "[%s] Authorization check raised for user %s; treating as unknown",

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -39,9 +39,11 @@ environment and is never logged.
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import re
 import shutil
+import tempfile
 import time
 from collections import OrderedDict
 from datetime import datetime
@@ -110,6 +112,95 @@ _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
 _DEFAULT_CREDENTIALS_DIR = Path("~/.config/buzz").expanduser()
+
+# Buzz-hosted Blossom media is private to the community. Inbound messages
+# carry media as markdown or bare relay URLs, so the adapter must authenticate
+# and localise those references before the gateway hands them to vision.
+_MEDIA_URL_PATTERN = (
+    r"https?://[^\s<>\[\]()]+/media/"
+    r"[0-9a-f]{64}(?:\.[a-z0-9]{1,10})?(?:\?[^\s<>\[\]()]*)?"
+)
+_MARKDOWN_MEDIA_RE = re.compile(
+    rf"!\[[^\]]*\]\(\s*(?P<url>{_MEDIA_URL_PATTERN})"
+    r"(?:\s+[\"'][^\"']*[\"'])?\s*\)",
+    re.IGNORECASE,
+)
+_BARE_MEDIA_RE = re.compile(_MEDIA_URL_PATTERN, re.IGNORECASE)
+_MEDIA_PATH_RE = re.compile(
+    r"^/media/(?P<sha>[0-9a-f]{64})(?P<ext>\.[a-z0-9]{1,10})?/?$",
+    re.IGNORECASE,
+)
+
+
+def _effective_port(parsed) -> Optional[int]:
+    try:
+        if parsed.port is not None:
+            return parsed.port
+    except ValueError:
+        return None
+    if parsed.scheme in ("https", "wss"):
+        return 443
+    if parsed.scheme in ("http", "ws"):
+        return 80
+    return None
+
+
+def _is_relay_media_url(url: str, relay_url: str) -> bool:
+    """Return whether *url* is a Buzz media object on the configured relay."""
+    candidate = urlsplit(url)
+    relay = urlsplit(relay_url)
+    if candidate.scheme not in ("http", "https"):
+        return False
+    if not candidate.hostname or not relay.hostname:
+        return False
+    if candidate.hostname.lower() != relay.hostname.lower():
+        return False
+    if _effective_port(candidate) != _effective_port(relay):
+        return False
+    return bool(_MEDIA_PATH_RE.fullmatch(candidate.path))
+
+
+def _find_relay_media_refs(
+    text: str, relay_url: str
+) -> Tuple[List[str], List[Tuple[int, int]]]:
+    """Find same-relay media URLs and the content spans that contain them."""
+    urls: List[str] = []
+    spans: List[Tuple[int, int]] = []
+    markdown_spans: List[Tuple[int, int]] = []
+
+    for match in _MARKDOWN_MEDIA_RE.finditer(text):
+        url = match.group("url")
+        if not _is_relay_media_url(url, relay_url):
+            continue
+        markdown_spans.append(match.span())
+        spans.append(match.span())
+        if url not in urls:
+            urls.append(url)
+
+    for match in _BARE_MEDIA_RE.finditer(text):
+        if any(
+            start <= match.start() and match.end() <= end
+            for start, end in markdown_spans
+        ):
+            continue
+        url = match.group(0)
+        if not _is_relay_media_url(url, relay_url):
+            continue
+        spans.append(match.span())
+        if url not in urls:
+            urls.append(url)
+
+    return urls, spans
+
+
+def _remove_media_spans(text: str, spans: List[Tuple[int, int]]) -> str:
+    chars = list(text)
+    for start, end in sorted(spans, reverse=True):
+        del chars[start:end]
+    cleaned = "".join(chars)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
 
 
 def _load_nostr_auth():
@@ -1210,6 +1301,101 @@ class BuzzAdapter(BasePlatformAdapter):
             state["seen"][event_id] = None
             self._trim_seen(state)
 
+    async def _localize_inbound_media(
+        self, text: str, message_id: str
+    ) -> Tuple[str, List[str], List[str], MessageType]:
+        """Authenticate and cache same-relay media references in *text*.
+
+        Each object is independent: one failed download is logged and skipped
+        without discarding the caption or any other successfully cached files.
+        """
+        urls, spans = _find_relay_media_refs(text, self.relay_url)
+        if not urls:
+            return text, [], [], MessageType.TEXT
+
+        cleaned_text = _remove_media_spans(text, spans)
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        media_kinds: List[str] = []
+
+        from gateway.platforms.base import (
+            cache_media_bytes,
+            validate_inbound_media_size,
+        )
+
+        for url in urls:
+            path_match = _MEDIA_PATH_RE.fullmatch(urlsplit(url).path)
+            if path_match is None:
+                continue
+            ext = (path_match.group("ext") or ".bin").lower()
+            label = f"{path_match.group('sha')[:12]}{ext}"
+            try:
+                with tempfile.TemporaryDirectory(prefix="hermes-buzz-media-") as temp_dir:
+                    download_path = Path(temp_dir) / f"buzz_{label}"
+                    code, _out, _err = await self._run_cli(
+                        ["media", "get", "-o", str(download_path), url]
+                    )
+                    if code != 0 or not download_path.is_file():
+                        logger.warning(
+                            "Buzz: failed to localize inbound media %s (exit %d)",
+                            label,
+                            code,
+                        )
+                        continue
+                    validate_inbound_media_size(
+                        download_path.stat().st_size,
+                        media_type="Buzz media",
+                    )
+                    mime_type = (
+                        mimetypes.guess_type(download_path.name)[0]
+                        or "application/octet-stream"
+                    )
+                    cached = cache_media_bytes(
+                        download_path.read_bytes(),
+                        filename=download_path.name,
+                        mime_type=mime_type,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Buzz: failed to localize inbound media %s (%s)",
+                    label,
+                    type(exc).__name__,
+                )
+                continue
+
+            if cached is None:
+                logger.warning("Buzz: rejected invalid inbound media %s", label)
+                continue
+            media_urls.append(cached.path)
+            media_types.append(cached.media_type)
+            media_kinds.append(cached.kind)
+
+        if media_urls:
+            logger.info(
+                "Buzz: localized %d inbound media attachment(s) for message %s",
+                len(media_urls),
+                message_id[:12],
+            )
+
+        if "image" in media_kinds:
+            message_type = MessageType.PHOTO
+        elif "audio" in media_kinds:
+            message_type = MessageType.AUDIO
+        elif "video" in media_kinds:
+            message_type = MessageType.VIDEO
+        elif media_kinds:
+            message_type = MessageType.DOCUMENT
+        else:
+            message_type = MessageType.TEXT
+
+        if not cleaned_text:
+            cleaned_text = (
+                "(attachment)"
+                if media_urls
+                else "(Buzz media attachment unavailable)"
+            )
+        return cleaned_text, media_urls, media_types, message_type
+
     async def _dispatch_message(
         self,
         text: str,
@@ -1224,6 +1410,10 @@ class BuzzAdapter(BasePlatformAdapter):
         if not self._message_handler:
             return
 
+        text, media_urls, media_types, message_type = await self._localize_inbound_media(
+            text, message_id
+        )
+
         source = self.build_source(
             chat_id=chat_id,
             chat_name=self._channel_names.get(chat_id, chat_id),
@@ -1234,10 +1424,12 @@ class BuzzAdapter(BasePlatformAdapter):
 
         event = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT,
+            message_type=message_type,
             source=source,
             message_id=message_id,
             timestamp=datetime.fromtimestamp(created_at) if created_at else datetime.now(),
+            media_urls=media_urls,
+            media_types=media_types,
         )
 
         await self.handle_message(event)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1301,15 +1301,36 @@ class BuzzAdapter(BasePlatformAdapter):
             self._trim_seen(state)
 
     async def _localize_inbound_media(
-        self, text: str, message_id: str
+        self,
+        text: str,
+        message_id: str,
+        *,
+        user_id: str = "",
+        chat_type: Optional[str] = None,
+        chat_id: Optional[str] = None,
     ) -> Tuple[str, List[str], List[str], MessageType]:
         """Authenticate and cache same-relay media references in *text*.
 
         Each object is independent: one failed download is logged and skipped
         without discarding the caption or any other successfully cached files.
+
+        Downloading spends this agent's Buzz credentials on a URL chosen by
+        the sender, so it runs only when the gateway's authorization callback
+        returns an explicit ``True``. The adapter's own ``allowed_users``
+        list is a pre-filter, not a substitute: a missing, failed, or
+        negative gateway decision leaves the text untouched and no
+        credentialed request is made.
         """
         urls, replacements = _find_relay_media_refs(text, self.relay_url)
         if not urls:
+            return text, [], [], MessageType.TEXT
+
+        if self._is_sender_authorized(user_id, chat_type, chat_id) is not True:
+            logger.warning(
+                "Buzz: not localizing %d media reference(s) in message %s — "
+                "sender %s… is not explicitly authorized",
+                len(urls), message_id[:12], (user_id or "?")[:8],
+            )
             return text, [], [], MessageType.TEXT
 
         cleaned_text = _replace_media_refs(text, replacements)
@@ -1410,7 +1431,11 @@ class BuzzAdapter(BasePlatformAdapter):
             return
 
         text, media_urls, media_types, message_type = await self._localize_inbound_media(
-            text, message_id
+            text,
+            message_id,
+            user_id=user_id,
+            chat_type=chat_type,
+            chat_id=chat_id,
         )
 
         source = self.build_source(

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -121,7 +121,7 @@ _MEDIA_URL_PATTERN = (
     r"[0-9a-f]{64}(?:\.[a-z0-9]{1,10})?(?:\?[^\s<>\[\]()]*)?"
 )
 _MARKDOWN_MEDIA_RE = re.compile(
-    rf"!\[[^\]]*\]\(\s*(?P<url>{_MEDIA_URL_PATTERN})"
+    rf"!\[(?P<alt>[^\]]*)\]\(\s*(?P<url>{_MEDIA_URL_PATTERN})"
     r"(?:\s+[\"'][^\"']*[\"'])?\s*\)",
     re.IGNORECASE,
 )
@@ -162,10 +162,10 @@ def _is_relay_media_url(url: str, relay_url: str) -> bool:
 
 def _find_relay_media_refs(
     text: str, relay_url: str
-) -> Tuple[List[str], List[Tuple[int, int]]]:
-    """Find same-relay media URLs and the content spans that contain them."""
+) -> Tuple[List[str], List[Tuple[int, int, str]]]:
+    """Find same-relay media URLs and their safe text replacements."""
     urls: List[str] = []
-    spans: List[Tuple[int, int]] = []
+    replacements: List[Tuple[int, int, str]] = []
     markdown_spans: List[Tuple[int, int]] = []
 
     for match in _MARKDOWN_MEDIA_RE.finditer(text):
@@ -173,7 +173,7 @@ def _find_relay_media_refs(
         if not _is_relay_media_url(url, relay_url):
             continue
         markdown_spans.append(match.span())
-        spans.append(match.span())
+        replacements.append((*match.span(), match.group("alt").strip()))
         if url not in urls:
             urls.append(url)
 
@@ -186,18 +186,17 @@ def _find_relay_media_refs(
         url = match.group(0)
         if not _is_relay_media_url(url, relay_url):
             continue
-        spans.append(match.span())
+        replacements.append((*match.span(), ""))
         if url not in urls:
             urls.append(url)
 
-    return urls, spans
+    return urls, replacements
 
 
-def _remove_media_spans(text: str, spans: List[Tuple[int, int]]) -> str:
-    chars = list(text)
-    for start, end in sorted(spans, reverse=True):
-        del chars[start:end]
-    cleaned = "".join(chars)
+def _replace_media_refs(text: str, replacements: List[Tuple[int, int, str]]) -> str:
+    cleaned = text
+    for start, end, replacement in sorted(replacements, reverse=True):
+        cleaned = f"{cleaned[:start]}{replacement}{cleaned[end:]}"
     cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
     return cleaned.strip()
@@ -1309,11 +1308,11 @@ class BuzzAdapter(BasePlatformAdapter):
         Each object is independent: one failed download is logged and skipped
         without discarding the caption or any other successfully cached files.
         """
-        urls, spans = _find_relay_media_refs(text, self.relay_url)
+        urls, replacements = _find_relay_media_refs(text, self.relay_url)
         if not urls:
             return text, [], [], MessageType.TEXT
 
-        cleaned_text = _remove_media_spans(text, spans)
+        cleaned_text = _replace_media_refs(text, replacements)
         media_urls: List[str] = []
         media_types: List[str] = []
         media_kinds: List[str] = []

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1,12 +1,14 @@
 """Tests for the Buzz platform adapter plugin."""
 
 import asyncio
+import base64
 import json
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+from gateway.platforms.base import MessageType
 
 # Load plugins/platforms/buzz/adapter.py under a unique module name
 # (plugin_adapter_buzz) so it cannot collide with other plugin adapters
@@ -422,6 +424,296 @@ class TestBuzzAdapterSend:
         assert args[args.index("--file") + 1] == str(img)
 
 
+# ── Inbound media localisation ─────────────────────────────────────────────────
+
+
+class TestInboundMediaLocalisation:
+
+    @staticmethod
+    def _capture_dispatch(adapter, *, failed_urls=None):
+        captured = []
+        cli_calls = []
+        failed_urls = set(failed_urls or [])
+
+        async def capture(event):
+            captured.append(event)
+
+        async def cli(args, *, input_text=None):
+            cli_calls.append(list(args))
+            assert args[:2] == ["media", "get"]
+            url = args[-1]
+            if url in failed_urls:
+                return 2, "", '{"error":"relay_error","message":"denied"}'
+            output_path = args[args.index("-o") + 1]
+            if url.endswith(".jpg"):
+                payload = b"\xff\xd8\xff\xe0JFIF test image"
+            elif url.endswith(".pdf"):
+                payload = b"%PDF-1.4\n% test document\n"
+            else:
+                payload = base64.b64decode(
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+                    "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+                )
+            with open(output_path, "wb") as handle:
+                handle.write(payload)
+            return 0, "", ""
+
+        adapter.handle_message = capture
+        adapter._message_handler = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+        adapter._run_cli = cli
+        return captured, cli_calls
+
+    @pytest.mark.asyncio
+    async def test_markdown_relay_image_is_localised_before_dispatch(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, cli_calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'a' * 64}.png"
+
+        await adapter._dispatch_message(
+            text=f"Please inspect this screenshot\n\n![]({media_url})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="media-event",
+            created_at=1000,
+        )
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert event.text == "Please inspect this screenshot"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+        assert event.media_urls[0].startswith(str(tmp_path / "hermes" / "cache"))
+        assert media_url not in event.text
+        assert cli_calls[0][-1] == media_url
+
+    @pytest.mark.asyncio
+    async def test_bare_relay_image_url_is_localised(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, _calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'b' * 64}.png"
+
+        await adapter._dispatch_message(
+            text=f"What is in this? {media_url}",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="bare-media-event",
+            created_at=1001,
+        )
+
+        event = captured[0]
+        assert event.text == "What is in this?"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_image_only_message_gets_attachment_placeholder(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, _calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'5' * 64}.png"
+
+        await adapter._dispatch_message(
+            text=f"![]({media_url})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="image-only-event",
+            created_at=1002,
+        )
+
+        event = captured[0]
+        assert event.text == "(attachment)"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_multiple_images_are_localised_in_content_order(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, calls = self._capture_dispatch(adapter)
+        first = f"https://test.relay/media/{'c' * 64}.png"
+        second = f"https://test.relay/media/{'d' * 64}.jpg"
+
+        await adapter._dispatch_message(
+            text=f"Compare these\n![]({first})\n{second}",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="multi-media-event",
+            created_at=1002,
+        )
+
+        event = captured[0]
+        assert event.text == "Compare these"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png", "image/jpeg"]
+        assert len(event.media_urls) == 2
+        assert [call[-1] for call in calls] == [first, second]
+
+    @pytest.mark.asyncio
+    async def test_non_image_attachment_is_cached_as_document(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, _calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'e' * 64}.pdf"
+
+        await adapter._dispatch_message(
+            text=f"Read this report\n{media_url}",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="document-media-event",
+            created_at=1003,
+        )
+
+        event = captured[0]
+        assert event.text == "Read this report"
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_types == ["application/pdf"]
+        assert len(event.media_urls) == 1
+        assert "/cache/documents/" in event.media_urls[0]
+
+    @pytest.mark.asyncio
+    async def test_download_failure_keeps_caption_and_dispatches_text(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        media_url = f"https://test.relay/media/{'f' * 64}.png"
+        captured, _calls = self._capture_dispatch(adapter, failed_urls=[media_url])
+
+        await adapter._dispatch_message(
+            text=f"The error is visible here\n![]({media_url})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="failed-media-event",
+            created_at=1004,
+        )
+
+        event = captured[0]
+        assert event.text == "The error is visible here"
+        assert event.message_type == MessageType.TEXT
+        assert event.media_urls == []
+        assert event.media_types == []
+
+    @pytest.mark.asyncio
+    async def test_one_failed_download_does_not_drop_other_media(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        failed = f"https://test.relay/media/{'2' * 64}.png"
+        succeeded = f"https://test.relay/media/{'3' * 64}.jpg"
+        captured, calls = self._capture_dispatch(adapter, failed_urls=[failed])
+
+        await adapter._dispatch_message(
+            text=f"Compare what loaded\n![]({failed})\n![]({succeeded})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="partial-media-event",
+            created_at=1005,
+        )
+
+        event = captured[0]
+        assert event.text == "Compare what loaded"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/jpeg"]
+        assert len(event.media_urls) == 1
+        assert [call[-1] for call in calls] == [failed, succeeded]
+
+    @pytest.mark.asyncio
+    async def test_real_event_handler_localises_media_before_gateway_dispatch(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {
+            "chat_type": "dm",
+            "last_ts": 0,
+            "seen": {},
+        }
+        captured = []
+        media_url = f"https://test.relay/media/{'4' * 64}.png"
+
+        async def capture(event):
+            captured.append(event)
+
+        async def cli(args, *, input_text=None):
+            if args[:2] == ["users", "get"]:
+                return 0, json.dumps([{"display_name": "Joel"}]), ""
+            assert args[:2] == ["media", "get"]
+            output_path = args[args.index("-o") + 1]
+            payload = base64.b64decode(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+                "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+            )
+            with open(output_path, "wb") as handle:
+                handle.write(payload)
+            return 0, "", ""
+
+        adapter.handle_message = capture
+        adapter._message_handler = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+        adapter._run_cli = cli
+
+        await adapter._handle_event(
+            DM_CHANNEL,
+            adapter._channel_state[DM_CHANNEL],
+            _tagged_event(
+                "handler-media-event",
+                DM_CHANNEL,
+                content=f"Can you read this? ![]({media_url})",
+                p=SELF_PUBKEY,
+            ),
+        )
+
+        assert len(captured) == 1
+        assert captured[0].text == "Can you read this?"
+        assert captured[0].message_type == MessageType.PHOTO
+        assert len(captured[0].media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_external_media_url_is_left_untouched(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, calls = self._capture_dispatch(adapter)
+        media_url = f"https://cdn.example/media/{'1' * 64}.png"
+        text = f"External reference: ![]({media_url})"
+
+        await adapter._dispatch_message(
+            text=text,
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="external-media-event",
+            created_at=1006,
+        )
+
+        event = captured[0]
+        assert event.text == text
+        assert event.message_type == MessageType.TEXT
+        assert event.media_urls == []
+        assert calls == []
+
+
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 
 
@@ -536,5 +828,3 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
-
-

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -465,7 +465,7 @@ class TestInboundMediaLocalisation:
         return captured, cli_calls
 
     @pytest.mark.asyncio
-    async def test_markdown_relay_image_is_localised_before_dispatch(
+    async def test_markdown_relay_image_preserves_alt_text_before_dispatch(
         self, monkeypatch, tmp_path
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
@@ -474,7 +474,7 @@ class TestInboundMediaLocalisation:
         media_url = f"https://test.relay/media/{'a' * 64}.png"
 
         await adapter._dispatch_message(
-            text=f"Please inspect this screenshot\n\n![]({media_url})",
+            text=f"Please inspect this screenshot\n\n![Login error dialog]({media_url})",
             chat_id=CHANNEL,
             chat_type="dm",
             user_id=OTHER_PUBKEY,
@@ -485,7 +485,7 @@ class TestInboundMediaLocalisation:
 
         assert len(captured) == 1
         event = captured[0]
-        assert event.text == "Please inspect this screenshot"
+        assert event.text == "Please inspect this screenshot\n\nLogin error dialog"
         assert event.message_type == MessageType.PHOTO
         assert event.media_types == ["image/png"]
         assert len(event.media_urls) == 1
@@ -589,7 +589,7 @@ class TestInboundMediaLocalisation:
         assert "/cache/documents/" in event.media_urls[0]
 
     @pytest.mark.asyncio
-    async def test_download_failure_keeps_caption_and_dispatches_text(
+    async def test_download_failure_preserves_caption_and_alt_text(
         self, monkeypatch, tmp_path
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
@@ -598,7 +598,7 @@ class TestInboundMediaLocalisation:
         captured, _calls = self._capture_dispatch(adapter, failed_urls=[media_url])
 
         await adapter._dispatch_message(
-            text=f"The error is visible here\n![]({media_url})",
+            text=f"The error is visible here\n![Checkout error dialog]({media_url})",
             chat_id=CHANNEL,
             chat_type="dm",
             user_id=OTHER_PUBKEY,
@@ -608,7 +608,7 @@ class TestInboundMediaLocalisation:
         )
 
         event = captured[0]
-        assert event.text == "The error is visible here"
+        assert event.text == "The error is visible here\nCheckout error dialog"
         assert event.message_type == MessageType.TEXT
         assert event.media_urls == []
         assert event.media_types == []

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -462,6 +462,11 @@ class TestInboundMediaLocalisation:
         adapter._message_handler = AsyncMock()
         adapter.send_reaction = AsyncMock(return_value=True)
         adapter._run_cli = cli
+        # Localisation spends the agent's Buzz credentials, so it is gated on
+        # an explicit gateway authorization. The gateway registers this check
+        # on every adapter it constructs; tests are authorized by default and
+        # override the callback where the gate itself is under test.
+        adapter.set_authorization_check(lambda *_args: True)
         return captured, cli_calls
 
     @pytest.mark.asyncio
@@ -672,6 +677,9 @@ class TestInboundMediaLocalisation:
         adapter._message_handler = AsyncMock()
         adapter.send_reaction = AsyncMock(return_value=True)
         adapter._run_cli = cli
+        # As the gateway does for every adapter it constructs; the gate itself
+        # is covered by TestInboundMediaAuthorizationGate.
+        adapter.set_authorization_check(lambda *_args: True)
 
         await adapter._handle_event(
             DM_CHANNEL,
@@ -712,6 +720,113 @@ class TestInboundMediaLocalisation:
         assert event.message_type == MessageType.TEXT
         assert event.media_urls == []
         assert calls == []
+
+
+class TestInboundMediaAuthorizationGate:
+    """Authenticated retrieval must never run for an unauthorized sender.
+
+    ``buzz media get`` signs the request with this agent's own key, so a
+    relay object named by an unauthorized sender must not be fetched or
+    cached. Every non-``True`` outcome — denial, no registered check, a
+    raising check, or a truthy non-boolean — must fail closed and leave the
+    message text exactly as it arrived.
+    """
+
+    @staticmethod
+    def _media_text():
+        return f"look at this ![shot](https://test.relay/media/{'a' * 64}.png)"
+
+    async def _dispatch_with_check(self, adapter, monkeypatch, tmp_path, check):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        captured, cli_calls = TestInboundMediaLocalisation._capture_dispatch(adapter)
+        adapter.set_authorization_check(check)
+        text = self._media_text()
+
+        await adapter._dispatch_message(
+            text=text,
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="gated-media-event",
+            created_at=1007,
+        )
+        return captured, cli_calls, text
+
+    @pytest.mark.asyncio
+    async def test_denied_sender_media_is_not_downloaded(self, monkeypatch, tmp_path):
+        adapter = _make_adapter()
+        captured, cli_calls, text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, lambda *_args: False
+        )
+
+        assert cli_calls == []
+        assert captured[0].text == text
+        assert captured[0].message_type == MessageType.TEXT
+        assert captured[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_missing_authorization_check_blocks_download(self, monkeypatch, tmp_path):
+        adapter = _make_adapter()
+        captured, cli_calls, text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, None
+        )
+
+        assert cli_calls == []
+        assert captured[0].text == text
+        assert captured[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_raising_authorization_check_blocks_download(self, monkeypatch, tmp_path):
+        def boom(*_args):
+            raise RuntimeError("auth backend down")
+
+        adapter = _make_adapter()
+        captured, cli_calls, text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, boom
+        )
+
+        assert cli_calls == []
+        assert captured[0].text == text
+        assert captured[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_truthy_non_boolean_is_not_an_authorization(self, monkeypatch, tmp_path):
+        """A non-boolean result must not be coerced into a credentialed fetch."""
+        adapter = _make_adapter()
+        captured, cli_calls, text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, lambda *_args: "allowed"
+        )
+
+        assert cli_calls == []
+        assert captured[0].text == text
+        assert captured[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_adapter_allowlist_does_not_override_gateway_denial(
+        self, monkeypatch, tmp_path
+    ):
+        """``allowed_users`` is a pre-filter, not a second source of truth."""
+        adapter = _make_adapter({"allowed_users": [OTHER_PUBKEY]})
+        captured, cli_calls, _text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, lambda *_args: False
+        )
+
+        assert OTHER_PUBKEY in adapter._allowed_pubkeys
+        assert cli_calls == []
+        assert captured[0].media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_authorized_sender_still_downloads(self, monkeypatch, tmp_path):
+        """The gate must not break the happy path it protects."""
+        adapter = _make_adapter()
+        captured, cli_calls, _text = await self._dispatch_with_check(
+            adapter, monkeypatch, tmp_path, lambda *_args: True
+        )
+
+        assert len(cli_calls) == 1
+        assert captured[0].message_type == MessageType.PHOTO
+        assert len(captured[0].media_urls) == 1
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -942,6 +942,72 @@ class TestShouldSendMediaAsAudio:
 # ---------------------------------------------------------------------------
 
 
+class TestIsSenderAuthorized:
+    """``_is_sender_authorized`` is a tri-state: True / False / unknown.
+
+    Callers gate credentialed side effects on an explicit ``is True``, so a
+    truthy non-boolean must resolve to unknown rather than being coerced
+    into an authorization by ``bool()``.
+    """
+
+    def _adapter(self):
+        class StubAdapter(BasePlatformAdapter):
+            async def connect(self, *, is_reconnect: bool = False):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def send(self, *a, **kw):
+                pass
+
+            async def get_chat_info(self, *a):
+                return {}
+
+        from gateway.config import Platform, PlatformConfig
+
+        return StubAdapter(config=PlatformConfig(enabled=True, token="test"),
+                           platform=Platform.TELEGRAM)
+
+    def test_no_check_registered_is_unknown(self):
+        assert self._adapter()._is_sender_authorized("user") is None
+
+    def test_empty_user_id_is_unknown(self):
+        adapter = self._adapter()
+        adapter.set_authorization_check(lambda *_a: True)
+        assert adapter._is_sender_authorized("") is None
+
+    def test_true_and_false_propagate(self):
+        adapter = self._adapter()
+        adapter.set_authorization_check(lambda *_a: True)
+        assert adapter._is_sender_authorized("user") is True
+        adapter.set_authorization_check(lambda *_a: False)
+        assert adapter._is_sender_authorized("user") is False
+
+    @pytest.mark.parametrize("result", ["allowed", 1, object(), [1]])
+    def test_truthy_non_boolean_is_unknown(self, result):
+        adapter = self._adapter()
+        adapter.set_authorization_check(lambda *_a: result)
+        assert adapter._is_sender_authorized("user") is None
+
+    def test_raising_check_is_unknown(self):
+        def boom(*_a):
+            raise RuntimeError("auth backend down")
+
+        adapter = self._adapter()
+        adapter.set_authorization_check(boom)
+        assert adapter._is_sender_authorized("user") is None
+
+    def test_check_receives_chat_context(self):
+        seen = []
+        adapter = self._adapter()
+        adapter.set_authorization_check(
+            lambda user_id, chat_type, chat_id: seen.append((user_id, chat_type, chat_id)) or True
+        )
+        adapter._is_sender_authorized("user", "group", "chan")
+        assert seen == [("user", "group", "chan")]
+
+
 class TestTruncateMessage:
     def _adapter(self):
         """Create a minimal adapter instance for testing static/instance methods."""

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -4,6 +4,8 @@ The Buzz adapter connects Hermes to a [Buzz](https://github.com/block/buzz) comm
 
 Buzz renders markdown, so agent replies keep their formatting. Images are delivered as uploads (local files) or links (URLs). Replies can thread onto an existing message via its event id.
 
+Files sent **to** the agent are fetched back off the relay with the agent's authenticated identity and cached locally, so tools receive a real file path rather than a `/media/…` URL that anonymous requests cannot read. Images, audio, video, and documents (PDFs and the like) are all handled.
+
 Inbound messages arrive over a persistent NIP-42-authenticated Nostr WebSocket subscription by default (near-instant delivery), with automatic fallback to CLI polling when the WebSocket can't be established. Outbound messages always go through the `buzz` CLI. Control it with `transport` / `BUZZ_TRANSPORT`: `auto` (default), `websocket` (require WS, fail otherwise), or `poll`. If your relay membership uses NIP-OA owner attestation, set `BUZZ_AUTH_TAG` to the four-string auth tag JSON.
 
 > Run `hermes gateway setup` and pick **Buzz** for a guided walk-through.
@@ -104,6 +106,8 @@ gateway:
 ## Access control
 
 By default the allow-list is empty, which means every community member who mentions the agent gets a response only if `BUZZ_ALLOW_ALL_USERS=true`; otherwise restrict access by listing npubs or hex pubkeys in `BUZZ_ALLOWED_USERS` (or `allowed_users` in config.yaml). Community membership itself is enforced by the relay — only members can post.
+
+The allow-list also gates **inbound attachments**: relay media is fetched with the agent's own Buzz credentials, so a download only happens for a sender the gateway explicitly authorizes. A denied, missing, or failed authorization leaves the message text untouched and makes no credentialed request.
 
 Cron jobs and notifications (`deliver=buzz`) are delivered to the **home channel** — `BUZZ_HOME_CHANNEL` if set, otherwise the first watched channel — and work even when cron runs outside the gateway process.
 


### PR DESCRIPTION
## What does this PR do?

Makes inbound Buzz attachments reach the agent. Buzz stores files as Blossom blobs at `<relay>/media/<sha256>.<ext>` and the inbound event carries only that URL; the adapter dispatched every event as text-only, so the agent received a URL that anonymous requests cannot read (`{"error":"authentication failed"}` on an auth-required relay). Images, audio, video, and documents were all unreachable — see #84112.

Same-relay media references are now downloaded with the adapter's existing authenticated `buzz media get` path, validated, cached through the gateway's media caches, and dispatched as `media_urls` / `media_types` with the matching `MessageType`. This is the Matrix behavior (`cache_image_from_bytes()` / `cache_document_from_bytes()` on inbound), which Buzz was missing.

**This is a consolidation, not a fourth parallel attempt.** The retrieval commits are @joelbrilliant's from #75614, cherry-picked with authorship intact — that PR was reviewed `keep_open salvageability=high`, the one problem raised was fixed in `dc79c5285`, and it has sat in draft since. On top of them, this adds the authorization boundary that reviewers asked for on the sibling PRs #77734 and #78051, which applies equally to the retrieval path here.

### The authorization boundary

`buzz media get` signs the request with the agent's own key against a URL chosen by the sender, so the adapter's local `allowed_users` pre-filter is not a sufficient basis for spending those credentials. Downloading now requires the gateway's authorization callback to return an explicit `True`; a denial, a missing callback, or a raising callback fails closed and leaves the message text exactly as it arrived, with no credentialed request made.

That gate needed a small base contract fix to be worth anything: `BasePlatformAdapter._is_sender_authorized()` wrapped the callback result in `bool()`, so a truthy non-boolean satisfied an `is True` check's intent while bypassing its guarantee. Only the literal booleans propagate now; anything else is "unknown", which the existing Slack and Discord callers already handle — both test `is False`, so their behavior is unchanged. The gateway registers this callback on every adapter it constructs (all three paths in `gateway/run.py`), and it delegates to `_is_user_authorized`, so the full auth chain stays the single source of truth.

## Related Issue

Fixes #84112. Supersedes #75614 (author credited by commit). Complements #77734 (authenticated, images only) and #78051 (all media kinds, public URLs only) — a document on an authentication-required relay falls between them.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/buzz/adapter.py` — localize same-relay media through authenticated `buzz media get`; per-object failure isolation; gate all retrieval on an explicit gateway authorization
- `gateway/platforms/base.py` — `_is_sender_authorized()` propagates only literal booleans; non-boolean results are logged and treated as unknown
- `tests/gateway/test_buzz_adapter.py` — `TestInboundMediaAuthorizationGate`: denial, no callback, raising callback, truthy non-boolean, allow-list-does-not-override-denial, and the authorized happy path
- `tests/gateway/test_platform_base.py` — `TestIsSenderAuthorized`: tri-state contract, including the parametrized non-boolean cases
- `website/docs/user-guide/messaging/buzz.md` — document inbound attachment handling and the authorization gate

## Validation

- `tests/gateway/test_buzz*.py tests/gateway/test_platform*.py` — 200 passed
- authorization-related regressions across `tests/gateway` (`-k "unverified or authoriz"`) — 99 passed, 1 skipped
- `ruff check` on all changed Python files — passed
- `git diff --check` — clean

Verified end-to-end against a live hosted relay before writing the patch: a PDF sent to an agent in a DM returns `{"error":"authentication failed"}` on an anonymous GET and downloads intact (313,512 bytes, valid PDF) through `buzz media get` with the adapter's configured identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
