### PR TITLE
fix(secrets): avoid eager Bitwarden crypto imports

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -47,10 +47,6 @@ import zipfile
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-
 from agent.secret_sources._cache import (
     CachedFetch as _CachedFetch,
     DiskCache,
@@ -375,6 +371,9 @@ def _b64d(text: str) -> bytes:
 
 def _derive_encrypted_cache_key(access_token: str, salt: bytes) -> bytes:
     """Derive the local cache encryption key from the bootstrap BWS token."""
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
     return HKDF(
         algorithm=hashes.SHA256(),
         length=32,
@@ -397,6 +396,8 @@ def _write_encrypted_disk_cache(
     """
     path = _encrypted_disk_cache_path(home_path)
     try:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
         cache_dir = path.parent
         cache_dir.mkdir(parents=True, exist_ok=True)
         try:
@@ -459,6 +460,8 @@ def _read_encrypted_disk_cache(
         return None
     path = _encrypted_disk_cache_path(home_path)
     try:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
         payload = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(payload, dict):
             return None

--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -41,11 +41,8 @@ import sys
 from pathlib import Path
 from typing import Dict, Optional
 
-# Reuse the exact result shape the bitwarden source returns so
-# hermes_cli.env_loader can consume both providers identically.
-from agent.secret_sources.base import ErrorKind, SecretSource
+from agent.secret_sources.base import ErrorKind, FetchResult, SecretSource
 from agent.secret_sources.base import get_source_environment
-from agent.secret_sources.bitwarden import FetchResult
 
 __all__ = [
     "FetchResult",

--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -41,8 +41,11 @@ import sys
 from pathlib import Path
 from typing import Dict, Optional
 
-from agent.secret_sources.base import ErrorKind, FetchResult, SecretSource
+# Reuse the exact result shape the bitwarden source returns so
+# hermes_cli.env_loader can consume both providers identically.
+from agent.secret_sources.base import ErrorKind, SecretSource
 from agent.secret_sources.base import get_source_environment
+from agent.secret_sources.bitwarden import FetchResult
 
 __all__ = [
     "FetchResult",

--- a/tests/secret_sources/test_lazy_imports.py
+++ b/tests/secret_sources/test_lazy_imports.py
@@ -43,12 +43,13 @@ def test_bitwarden_import_does_not_require_cryptography(monkeypatch):
     assert module.BitwardenSource().name == "bitwarden"
 
 
-def test_command_source_registers_when_bitwarden_import_fails(monkeypatch):
-    """The command source is independent of the Bitwarden implementation."""
+def test_builtin_sources_register_when_cryptography_import_fails(monkeypatch):
+    """Broken cryptography must not poison bundled source registration."""
     _drop_modules(
         monkeypatch,
         "agent.secret_sources.bitwarden",
         "agent.secret_sources.command",
+        "cryptography",
     )
 
     from agent.secret_sources import registry
@@ -57,10 +58,10 @@ def test_command_source_registers_when_bitwarden_import_fails(monkeypatch):
     monkeypatch.setattr(
         sys,
         "meta_path",
-        [_BlockingFinder("agent.secret_sources.bitwarden"), *sys.meta_path],
+        [_BlockingFinder("cryptography"), *sys.meta_path],
     )
 
     names = {source.name for source in registry.list_sources()}
 
     assert "command" in names
-    assert "bitwarden" not in names
+    assert "bitwarden" in names

--- a/tests/secret_sources/test_lazy_imports.py
+++ b/tests/secret_sources/test_lazy_imports.py
@@ -1,0 +1,66 @@
+"""Regression tests for optional secret-source import boundaries."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.abc
+import sys
+
+
+class _BlockingFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, blocked_prefix: str):
+        self.blocked_prefix = blocked_prefix
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == self.blocked_prefix or fullname.startswith(
+            f"{self.blocked_prefix}."
+        ):
+            raise ImportError(f"blocked import: {fullname}")
+        return None
+
+
+def _drop_modules(monkeypatch, *prefixes: str) -> None:
+    for name in list(sys.modules):
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def test_bitwarden_import_does_not_require_cryptography(monkeypatch):
+    """A broken optional cryptography wheel must not break source registration."""
+    _drop_modules(monkeypatch, "agent.secret_sources.bitwarden", "cryptography")
+
+    import agent.secret_sources as package
+
+    monkeypatch.delattr(package, "bitwarden", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "meta_path",
+        [_BlockingFinder("cryptography"), *sys.meta_path],
+    )
+
+    module = importlib.import_module("agent.secret_sources.bitwarden")
+
+    assert module.BitwardenSource().name == "bitwarden"
+
+
+def test_command_source_registers_when_bitwarden_import_fails(monkeypatch):
+    """The command source is independent of the Bitwarden implementation."""
+    _drop_modules(
+        monkeypatch,
+        "agent.secret_sources.bitwarden",
+        "agent.secret_sources.command",
+    )
+
+    from agent.secret_sources import registry
+
+    registry._reset_registry_for_tests()
+    monkeypatch.setattr(
+        sys,
+        "meta_path",
+        [_BlockingFinder("agent.secret_sources.bitwarden"), *sys.meta_path],
+    )
+
+    names = {source.name for source in registry.list_sources()}
+
+    assert "command" in names
+    assert "bitwarden" not in names


### PR DESCRIPTION
## Summary

Fixes #83680.

- defer Bitwarden encrypted-cache `cryptography` imports until encrypted cache read/write is actually used
- keep the bundled Bitwarden source importable/registerable when an optional `cryptography` wheel cannot load
- add regression coverage for broken optional crypto imports during secret-source registration

## Duplicate check

A triage note compared this with #74703. I verified #74703 and narrowed this PR away from its `command.py` scope. #74703 lazy-imports the Bitwarden module from `secrets_cli` and decouples `CommandSource`; this PR now covers the separate direct `agent.secret_sources.bitwarden` import path needed for #83680.

## Validation

- `scripts/run_tests.sh tests/secret_sources/test_lazy_imports.py -q`
- `scripts/run_tests.sh tests/test_command_secret_source.py tests/test_bitwarden_secrets.py tests/secret_sources/test_secret_source_registry.py -q`
- `.venv/bin/ruff check agent/secret_sources/bitwarden.py tests/secret_sources/test_lazy_imports.py`
