### PR TITLE
fix(usage): reconcile canonical Anthropic usage limits

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -72,6 +72,59 @@ def _parse_dt(value: Any) -> Optional[datetime]:
     return None
 
 
+def _coerce_percent_value(value: Any) -> Optional[float]:
+    """Return an already-scaled percent value when numeric and finite."""
+
+    if value is None:
+        return None
+    try:
+        percent = float(value)
+    except (TypeError, ValueError):
+        return None
+    return percent if math.isfinite(percent) else None
+
+
+def _coerce_usage_percent(value: Any) -> Optional[float]:
+    """Return a percent value for legacy Anthropic utilization fields.
+
+    Anthropic's OAuth usage endpoint has emitted both fractional utilization
+    values (``0.41``) and already-scaled percentage values (``41``). Treat
+    utilization values in ``[0, 1]`` as fractions and larger values as
+    percentages. Do not use this for fields literally named ``percent``.
+    """
+
+    percent = _coerce_percent_value(value)
+    if percent is None:
+        return None
+    return percent * 100 if 0 <= percent <= 1 else percent
+
+
+def _anthropic_scoped_limit_label(limit: dict[str, Any]) -> Optional[str]:
+    """Human label for Anthropic ``limits[]`` scoped quota entries.
+
+    Newer Claude Code/Anthropic OAuth usage responses expose model-specific
+    weekly buckets (for example the Fable weekly bucket) under ``limits`` as
+    ``kind=weekly_scoped`` instead of the legacy ``seven_day_sonnet`` /
+    ``seven_day_opus`` top-level fields. Preserve those buckets so /usage does
+    not make the old all-models weekly limit look like the only weekly signal.
+    """
+
+    if limit.get("kind") != "weekly_scoped":
+        return None
+    scope = limit.get("scope")
+    if not isinstance(scope, dict):
+        return "Scoped week"
+    model = scope.get("model")
+    if isinstance(model, dict):
+        display = str(model.get("display_name") or model.get("id") or "").strip()
+        if display:
+            return f"{display} week"
+    surface = scope.get("surface")
+    if isinstance(surface, str) and surface.strip():
+        return f"{_title_case_slug(surface)} week"
+    return "Scoped week"
+
+
 def _format_reset(dt: Optional[datetime]) -> str:
     if not dt:
         return "unknown"
@@ -777,12 +830,12 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         ("seven_day_opus", "Opus week"),
         ("seven_day_sonnet", "Sonnet week"),
     )
+    seen_labels: set[str] = set()
     for key, label in mapping:
         window = payload.get(key) or {}
-        util = window.get("utilization")
-        if util is None:
+        used = _coerce_usage_percent(window.get("utilization"))
+        if used is None:
             continue
-        used = float(util) * 100 if float(util) <= 1 else float(util)
         windows.append(
             AccountUsageWindow(
                 label=label,
@@ -790,6 +843,29 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
                 reset_at=_parse_dt(window.get("resets_at")),
             )
         )
+        seen_labels.add(label)
+
+    # Claude Code's newer /api/oauth/usage payload can carry scoped weekly
+    # buckets in a generic limits[] array while the older top-level fields (for
+    # example seven_day_sonnet) are null. This is how model-specific buckets
+    # like the Fable weekly allowance currently appear.
+    for limit in payload.get("limits") or []:
+        if not isinstance(limit, dict):
+            continue
+        label = _anthropic_scoped_limit_label(limit)
+        if not label or label in seen_labels:
+            continue
+        used = _coerce_percent_value(limit.get("percent"))
+        if used is None:
+            continue
+        windows.append(
+            AccountUsageWindow(
+                label=label,
+                used_percent=used,
+                reset_at=_parse_dt(limit.get("resets_at")),
+            )
+        )
+        seen_labels.add(label)
     details: list[str] = []
     extra = payload.get("extra_usage") or {}
     if extra.get("is_enabled"):

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -54,10 +54,16 @@ def _title_case_slug(value: Optional[str]) -> Optional[str]:
 
 
 def _parse_dt(value: Any) -> Optional[datetime]:
-    if value in {None, ""}:
+    if value is None or value == "" or isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        timestamp = float(value)
+        if not math.isfinite(timestamp):
+            return None
+        try:
+            return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        except (OSError, OverflowError, ValueError):
+            return None
     if isinstance(value, str):
         text = value.strip()
         if not text:
@@ -73,24 +79,23 @@ def _parse_dt(value: Any) -> Optional[datetime]:
 
 
 def _coerce_percent_value(value: Any) -> Optional[float]:
-    """Return an already-scaled percent value when numeric and finite."""
+    """Return a validated already-scaled percentage in ``[0, 100]``."""
 
-    if value is None:
+    if value is None or isinstance(value, bool):
         return None
     try:
         percent = float(value)
     except (TypeError, ValueError):
         return None
-    return percent if math.isfinite(percent) else None
+    return percent if math.isfinite(percent) and 0 <= percent <= 100 else None
 
 
 def _coerce_usage_percent(value: Any) -> Optional[float]:
-    """Return a percent value for legacy Anthropic utilization fields.
+    """Return a percent value for pre-``limits`` Anthropic payloads.
 
-    Anthropic's OAuth usage endpoint has emitted both fractional utilization
-    values (``0.41``) and already-scaled percentage values (``41``). Treat
-    utilization values in ``[0, 1]`` as fractions and larger values as
-    percentages. Do not use this for fields literally named ``percent``.
+    Older payloads used fractional ``utilization`` values, while newer payloads
+    pair percentage-style top-level values with canonical ``limits[].percent``
+    records. This heuristic is therefore only safe when ``limits`` is absent.
     """
 
     percent = _coerce_percent_value(value)
@@ -116,13 +121,48 @@ def _anthropic_scoped_limit_label(limit: dict[str, Any]) -> Optional[str]:
         return "Scoped week"
     model = scope.get("model")
     if isinstance(model, dict):
-        display = str(model.get("display_name") or model.get("id") or "").strip()
+        display = str(
+            model.get("display_name") or model.get("name") or model.get("id") or ""
+        ).strip()
         if display:
             return f"{display} week"
     surface = scope.get("surface")
     if isinstance(surface, str) and surface.strip():
         return f"{_title_case_slug(surface)} week"
     return "Scoped week"
+
+
+def _anthropic_scoped_limit_identity(limit: dict[str, Any]) -> tuple[str, ...]:
+    """Stable identity for first-valid-wins scoped-limit deduplication."""
+
+    scope = limit.get("scope")
+    if not isinstance(scope, dict):
+        return ("unscoped",)
+    model = scope.get("model")
+    model_id = ""
+    model_name = ""
+    if isinstance(model, dict):
+        raw_id = model.get("id")
+        if isinstance(raw_id, str):
+            model_id = raw_id.strip().casefold()
+        for key in ("display_name", "name"):
+            raw_name = model.get(key)
+            if isinstance(raw_name, str) and raw_name.strip():
+                model_name = raw_name.strip().casefold()
+                break
+    raw_surface = scope.get("surface")
+    surface = (
+        raw_surface.strip().casefold()
+        if isinstance(raw_surface, str) and raw_surface.strip()
+        else ""
+    )
+    if model_id:
+        return ("model-id", model_id, surface)
+    if model_name:
+        return ("model-name", model_name, surface)
+    if surface:
+        return ("surface", surface)
+    return ("unscoped",)
 
 
 def _format_reset(dt: Optional[datetime]) -> str:
@@ -824,16 +864,120 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         response.raise_for_status()
     payload = response.json() or {}
     windows: list[AccountUsageWindow] = []
-    mapping = (
-        ("five_hour", "Current session"),
-        ("seven_day", "Current week"),
-        ("seven_day_opus", "Opus week"),
-        ("seven_day_sonnet", "Sonnet week"),
+    raw_limits = payload.get("limits")
+    limits = (
+        [item for item in raw_limits if isinstance(item, dict)]
+        if isinstance(raw_limits, list)
+        else []
     )
-    seen_labels: set[str] = set()
-    for key, label in mapping:
-        window = payload.get(key) or {}
-        used = _coerce_usage_percent(window.get("utilization"))
+    standard_limits: dict[str, dict[str, Any]] = {}
+    for item in limits:
+        kind = item.get("kind")
+        if (
+            isinstance(kind, str)
+            and kind in {"session", "weekly_all"}
+            and _coerce_percent_value(item.get("percent")) is not None
+        ):
+            standard_limits.setdefault(kind, item)
+    top_level_keys = (
+        "five_hour",
+        "seven_day",
+        "seven_day_opus",
+        "seven_day_sonnet",
+        "seven_day_overage_included",
+    )
+    top_level_values: list[float] = []
+    for key in top_level_keys:
+        window = payload.get(key)
+        if not isinstance(window, dict):
+            continue
+        value = _coerce_percent_value(window.get("utilization"))
+        if value is not None:
+            top_level_values.append(value)
+    # A validated canonical limit identifies the percentage-style response. For
+    # a top-level-only response, one value above 1 proves that sibling values
+    # use the same percentage scale; an all-<=1 response retains the legacy
+    # fractional interpretation for backward compatibility. Empty or malformed
+    # ``limits`` arrays do not change the scale.
+    canonical_kinds = {"session", "weekly_all", "weekly_scoped"}
+    has_valid_canonical_limit = any(
+        isinstance(item.get("kind"), str)
+        and item.get("kind") in canonical_kinds
+        and _coerce_percent_value(item.get("percent")) is not None
+        for item in limits
+    )
+    uses_percent_scale = has_valid_canonical_limit or any(
+        value > 1 for value in top_level_values
+    )
+    top_level_percent = (
+        _coerce_percent_value if uses_percent_scale else _coerce_usage_percent
+    )
+
+    # Canonical limits win for standard windows. In current payloads a value of
+    # ``percent=1`` means 1%, whereas the old utilization heuristic interprets
+    # ``1`` as a complete 0-1 fraction.
+    standard_mapping = (
+        ("five_hour", "Current session", "session"),
+        ("seven_day", "Current week", "weekly_all"),
+    )
+    for key, label, canonical_kind in standard_mapping:
+        canonical = standard_limits.get(canonical_kind)
+        if canonical is not None:
+            used = _coerce_percent_value(canonical.get("percent"))
+            reset_at = canonical.get("resets_at")
+        else:
+            window = payload.get(key)
+            if not isinstance(window, dict):
+                continue
+            used = top_level_percent(window.get("utilization"))
+            reset_at = window.get("resets_at")
+        if used is None:
+            continue
+        windows.append(
+            AccountUsageWindow(
+                label=label,
+                used_percent=used,
+                reset_at=_parse_dt(reset_at),
+            )
+        )
+
+    scoped_windows: list[AccountUsageWindow] = []
+    scoped_identities: set[tuple[str, ...]] = set()
+    scoped_labels: set[str] = set()
+    for limit in limits:
+        label = _anthropic_scoped_limit_label(limit)
+        identity = _anthropic_scoped_limit_identity(limit)
+        if not label or identity in scoped_identities:
+            continue
+        used = _coerce_percent_value(limit.get("percent"))
+        if used is None:
+            continue
+        scoped_windows.append(
+            AccountUsageWindow(
+                label=label,
+                used_percent=used,
+                reset_at=_parse_dt(limit.get("resets_at")),
+            )
+        )
+        scoped_identities.add(identity)
+        scoped_labels.add(label)
+
+    # Retain older model-specific fields only when no canonical scoped window
+    # represents that model family. ``seven_day_overage_included`` is the
+    # legacy Fable allowance observed in earlier Claude Code payloads.
+    scoped_text = " ".join(scoped_labels).casefold()
+    legacy_scoped_mapping = (
+        ("seven_day_opus", "Opus week", "opus"),
+        ("seven_day_sonnet", "Sonnet week", "sonnet"),
+        ("seven_day_overage_included", "Fable week", "fable"),
+    )
+    for key, label, model_family in legacy_scoped_mapping:
+        if model_family in scoped_text:
+            continue
+        window = payload.get(key)
+        if not isinstance(window, dict):
+            continue
+        used = top_level_percent(window.get("utilization"))
         if used is None:
             continue
         windows.append(
@@ -843,31 +987,11 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
                 reset_at=_parse_dt(window.get("resets_at")),
             )
         )
-        seen_labels.add(label)
 
-    # Claude Code's newer /api/oauth/usage payload can carry scoped weekly
-    # buckets in a generic limits[] array while the older top-level fields (for
-    # example seven_day_sonnet) are null. This is how model-specific buckets
-    # like the Fable weekly allowance currently appear.
-    for limit in payload.get("limits") or []:
-        if not isinstance(limit, dict):
-            continue
-        label = _anthropic_scoped_limit_label(limit)
-        if not label or label in seen_labels:
-            continue
-        used = _coerce_percent_value(limit.get("percent"))
-        if used is None:
-            continue
-        windows.append(
-            AccountUsageWindow(
-                label=label,
-                used_percent=used,
-                reset_at=_parse_dt(limit.get("resets_at")),
-            )
-        )
-        seen_labels.add(label)
+    windows.extend(scoped_windows)
     details: list[str] = []
-    extra = payload.get("extra_usage") or {}
+    raw_extra = payload.get("extra_usage")
+    extra = raw_extra if isinstance(raw_extra, dict) else {}
     if extra.get("is_enabled"):
         used_credits = extra.get("used_credits")
         monthly_limit = extra.get("monthly_limit")

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -95,6 +95,82 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert "Credits balance: $12.50" in snapshot.details
 
 
+def test_fetch_account_usage_anthropic_includes_scoped_weekly_limits(monkeypatch):
+    reset = "2026-07-11T00:59:59.849583+00:00"
+    monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test")
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {"utilization": 30, "resets_at": "2026-07-07T10:39:59Z"},
+                "seven_day": {"utilization": 76, "resets_at": reset},
+                "seven_day_opus": None,
+                "seven_day_sonnet": None,
+                "limits": [
+                    {
+                        "kind": "session",
+                        "group": "session",
+                        "percent": 30,
+                        "resets_at": "2026-07-07T10:39:59Z",
+                    },
+                    {
+                        "kind": "weekly_all",
+                        "group": "weekly",
+                        "percent": 76,
+                        "resets_at": reset,
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "group": "weekly",
+                        "percent": 41,
+                        "resets_at": reset,
+                        "scope": {"model": {"id": None, "display_name": "Fable"}},
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "group": "weekly",
+                        "percent": 1,
+                        "resets_at": reset,
+                        "scope": {"model": {"id": None, "display_name": "Haiku"}},
+                    },
+                ],
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Current session", 30.0),
+        ("Current week", 76.0),
+        ("Fable week", 41.0),
+        ("Haiku week", 1.0),
+    ]
+    assert snapshot.windows[2].reset_at == datetime.fromisoformat(reset)
+    assert snapshot.windows[3].reset_at == datetime.fromisoformat(reset)
+
+
+def test_fetch_account_usage_anthropic_accepts_fractional_legacy_utilization(monkeypatch):
+    monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test")
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {"utilization": 0.3, "resets_at": "2026-07-07T10:39:59Z"},
+                "seven_day": {"utilization": 0.76, "resets_at": "2026-07-11T00:59:59Z"},
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [window.used_percent for window in snapshot.windows] == [30.0, 76.0]
+
+
 def test_render_account_usage_lines_includes_reset_and_provider():
     snapshot = AccountUsageSnapshot(
         provider="openai-codex",

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -152,6 +152,48 @@ def test_fetch_account_usage_anthropic_includes_scoped_weekly_limits(monkeypatch
     assert snapshot.windows[3].reset_at == datetime.fromisoformat(reset)
 
 
+def test_fetch_account_usage_anthropic_scoped_limit_fallback_labels(monkeypatch):
+    reset = "2026-07-11T00:59:59Z"
+    monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "***")
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "limits": [
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 12,
+                        "resets_at": reset,
+                        "scope": {"model": {"id": "claude-opus-4-1"}},
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 7,
+                        "resets_at": reset,
+                        "scope": {"surface": "claude_code"},
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 3,
+                        "resets_at": reset,
+                        "scope": {},
+                    },
+                ]
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("claude-opus-4-1 week", 12.0),
+        ("Claude Code week", 7.0),
+        ("Scoped week", 3.0),
+    ]
+
+
 def test_fetch_account_usage_anthropic_accepts_fractional_legacy_utilization(monkeypatch):
     monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test")
     monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -152,6 +152,245 @@ def test_fetch_account_usage_anthropic_includes_scoped_weekly_limits(monkeypatch
     assert snapshot.windows[3].reset_at == datetime.fromisoformat(reset)
 
 
+def test_fetch_account_usage_anthropic_prefers_canonical_standard_percent(
+    monkeypatch,
+):
+    reset = "2026-08-11T13:00:00Z"
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {"utilization": 0.04, "resets_at": reset},
+                "seven_day": {"utilization": 1.0, "resets_at": reset},
+                "limits": [
+                    {"kind": "session", "percent": 4, "resets_at": reset},
+                    {"kind": "weekly_all", "percent": 1, "resets_at": reset},
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 1,
+                        "resets_at": reset,
+                        "scope": {"model": {"display_name": "Fable"}},
+                    },
+                ],
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Current session", 4.0),
+        ("Current week", 1.0),
+        ("Fable week", 1.0),
+    ]
+
+
+def test_fetch_account_usage_anthropic_duplicate_standard_limits_use_first_valid(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "test-oauth-token"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "limits": [
+                    {"kind": "session", "percent": 10},
+                    {"kind": "session", "percent": 20},
+                    {"kind": "weekly_all", "percent": 30},
+                    {"kind": "weekly_all", "percent": 40},
+                ]
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Current session", 10.0),
+        ("Current week", 30.0),
+    ]
+
+
+def test_fetch_account_usage_anthropic_rejects_invalid_canonical_percent_values(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "test-oauth-token"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "limits": [
+                    {"kind": "session", "percent": 0},
+                    {"kind": "weekly_all", "percent": 100},
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": -1,
+                        "scope": {"model": {"display_name": "Negative"}},
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 101,
+                        "scope": {"model": {"display_name": "Over"}},
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": True,
+                        "scope": {"model": {"display_name": "Boolean"}},
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": float("nan"),
+                        "scope": {"model": {"display_name": "NaN"}},
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": float("inf"),
+                        "scope": {"model": {"display_name": "Infinity"}},
+                    },
+                ]
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Current session", 0.0),
+        ("Current week", 100.0),
+    ]
+
+
+def test_fetch_account_usage_anthropic_ignores_malformed_limit_fields(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "test-oauth-token"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "limits": [
+                    {"kind": ["session"], "percent": 99},
+                    {"kind": "session", "percent": 25, "resets_at": {}},
+                    {
+                        "kind": "weekly_all",
+                        "percent": 40,
+                        "resets_at": float("nan"),
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 10,
+                        "resets_at": [],
+                        "scope": {"model": {"display_name": "Fable"}},
+                    },
+                ]
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Current session", 25.0),
+        ("Current week", 40.0),
+        ("Fable week", 10.0),
+    ]
+    assert all(window.reset_at is None for window in snapshot.windows)
+
+
+def test_fetch_account_usage_anthropic_ignores_malformed_extra_usage(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "test-oauth-token"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {"utilization": 50},
+                "extra_usage": ["malformed"],
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Current session", 50.0),
+    ]
+    assert snapshot.details == ()
+
+
+def test_fetch_account_usage_anthropic_current_shape_top_level_fallback_is_percent(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "seven_day_opus": {"utilization": 1.0},
+                "limits": [
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 25,
+                        "scope": {"model": {"display_name": "Fable"}},
+                    }
+                ],
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Opus week", 1.0),
+        ("Fable week", 25.0),
+    ]
+
+
+def test_fetch_account_usage_anthropic_infers_top_level_percent_scale_across_windows(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {"utilization": 1.0},
+                "seven_day": {"utilization": 55.0},
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [window.used_percent for window in snapshot.windows] == [1.0, 55.0]
+
+
 def test_fetch_account_usage_anthropic_scoped_limit_fallback_labels(monkeypatch):
     reset = "2026-07-11T00:59:59Z"
     monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "***")
@@ -194,8 +433,86 @@ def test_fetch_account_usage_anthropic_scoped_limit_fallback_labels(monkeypatch)
     ]
 
 
+def test_fetch_account_usage_anthropic_scoped_duplicates_use_scope_identity(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "test-oauth-token"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "limits": [
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 10,
+                        "scope": {
+                            "model": {"id": "model-a", "display_name": "Shared"}
+                        },
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 20,
+                        "scope": {
+                            "model": {"id": "model-a", "display_name": "Shared"}
+                        },
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 30,
+                        "scope": {
+                            "model": {"id": "model-b", "display_name": "Shared"}
+                        },
+                    },
+                ]
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Shared week", 10.0),
+        ("Shared week", 30.0),
+    ]
+
+
+def test_fetch_account_usage_anthropic_model_name_suppresses_legacy_fable(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "test-oauth-token"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "seven_day_overage_included": {"utilization": 0.5},
+                "limits": [
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 10,
+                        "scope": {"model": {"name": "Fable 5"}},
+                    }
+                ],
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Fable 5 week", 10.0),
+    ]
+
+
 def test_fetch_account_usage_anthropic_accepts_fractional_legacy_utilization(monkeypatch):
-    monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test")
+    monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "test-oauth-token")
     monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
     monkeypatch.setattr(
         "agent.account_usage.httpx.Client",
@@ -211,6 +528,81 @@ def test_fetch_account_usage_anthropic_accepts_fractional_legacy_utilization(mon
 
     assert snapshot is not None
     assert [window.used_percent for window in snapshot.windows] == [30.0, 76.0]
+
+
+def test_fetch_account_usage_anthropic_empty_limits_keeps_fractional_legacy_scale(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "test-oauth-token"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {"utilization": 0.3},
+                "seven_day": {"utilization": 0.76},
+                "limits": [],
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [window.used_percent for window in snapshot.windows] == [30.0, 76.0]
+
+
+def test_fetch_account_usage_anthropic_malformed_limits_keep_fractional_legacy_scale(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "test-oauth-token"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {"utilization": 0.3},
+                "seven_day": {"utilization": 0.76},
+                "limits": [
+                    {"kind": ["session"], "percent": 25},
+                    {"kind": "weekly_scoped", "percent": "invalid"},
+                ],
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [window.used_percent for window in snapshot.windows] == [30.0, 76.0]
+
+
+def test_fetch_account_usage_anthropic_keeps_legacy_fable_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "seven_day": {"utilization": 0.5},
+                "seven_day_overage_included": {"utilization": 0.75},
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Current week", 50.0),
+        ("Fable week", 75.0),
+    ]
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():


### PR DESCRIPTION
## What does this PR do?

Consolidates the two open Anthropic `/usage` fixes into one credited three-commit sequence:

- preserves @CryptoKylan's scoped weekly-limit parsing from #60115, including API-provided model and surface labels;
- prefers canonical `limits[]` entries for `session` and `weekly_all` over duplicate legacy top-level fields;
- interprets canonical `percent` values literally (`1` means 1%, not 100%);
- retains legacy top-level session, weekly, Opus, Sonnet, and Fable fallbacks, with sibling-window scale inference for historical payload shapes.

Current `main` reads only the legacy top-level fields and applies a per-value `<= 1 -> x100` heuristic. That misses scoped weekly buckets present only in `limits[]` and can render an already-percent value of `1` as 100%.

This replaces #60115 and #58228. The first two commits preserve @CryptoKylan's authorship and are patch-identical to the two commits in #60115; the reconciliation is a separate third commit.

## Related Issue

Fixes #58226

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/account_usage.py`: parse canonical and scoped Anthropic limits, define precedence and percent-scale compatibility behavior, and retain legacy model fallbacks.
- `tests/test_account_usage.py`: cover canonical precedence, bounded literal percentages, scoped labels and identities, mixed top-level scale inference, malformed payload isolation, deterministic duplicate handling, fractional legacy payloads, and the legacy Fable fallback.

Parser and regression-test changes only. No configuration, tool schema, caching, credential, or message-flow surface is added.

## How to Test

1. Run `scripts/run_tests.sh tests/test_account_usage.py -q`.
2. Run `scripts/run_tests.sh tests/agent/test_account_usage.py -q`.
3. Run `scripts/run_tests.sh tests/gateway/test_usage_command.py -q`.
4. With Anthropic OAuth configured, run `/usage` and confirm standard and scoped weekly windows render without duplicate or rescaled canonical values.

## Verification Performed

- `scripts/run_tests.sh tests/test_account_usage.py -q` — 19 passed
- `scripts/run_tests.sh tests/agent/test_account_usage.py -q` — 4 passed
- `scripts/run_tests.sh tests/gateway/test_usage_command.py -q` — 5 passed
- `python3 -m ruff check .` — passed
- `python3 -m ty check agent/account_usage.py` — passed
- `python3 scripts/check-windows-footguns.py --diff upstream/main` — passed
- `git diff --check upstream/main...HEAD` — passed
- Full `scripts/run_tests.sh` on the final tree — 72 failures across 13 unrelated environment/config-sensitive files, all a strict subset of the 73 failures across 14 files reproduced on untouched current `main`; the only difference was one flaky baseline Honcho test passing on the final run. No new failure file or per-file count appeared.
- Regression-bite checks: 6 consolidated behavior tests fail on unmodified current `main`; all 8 review-driven edge-case tests fail on the pre-review commit; all 19 parser tests pass on the final tree.
- Live read-only Anthropic smoke test returned `Current session`, `Current week`, and `Fable week`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and am intentionally consolidating #60115 and #58228
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — the full suite was run, but its 72 failures are a strict subset of the 73 baseline failures reproduced on current `main`; the affected parser and gateway suites pass
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04 under WSL2

### Documentation & Housekeeping

- [x] Relevant documentation update — N/A; parser behavior is documented in code
- [x] `cli-config.yaml.example` update — N/A; no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changes
- [x] Cross-platform impact considered; Windows footgun scan passed
- [x] Tool descriptions/schemas update — N/A; no tool-schema changes
