### PR TITLE
feat(tts): default Piper to en_US-libritts-high and preload it at startup

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -321,7 +321,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
     'KittenML/kitten-tts-mini-0.8-int8'
   ],
   'tts.kittentts.voice': ['Jasper'],
-  'tts.piper.voice': ['en_US-lessac-medium', 'en_US-amy-medium', 'en_US-ryan-high', 'en_GB-alan-medium'],
+  'tts.piper.voice': ['en_US-libritts-high', 'en_US-lessac-medium', 'en_US-amy-medium', 'en_US-ryan-high', 'en_GB-alan-medium'],
   'tts.neutts.model': ['neuphonic/neutts-air-q4-gguf', 'neuphonic/neutts-air-q8-gguf', 'neuphonic/neutts-air'],
   // Text-to-speech backends — kept in sync with the built-in source of truth
   // (agent/tts_registry.py::_BUILTIN_NAMES / tools/tts_tool.py::

--- a/cli.py
+++ b/cli.py
@@ -18565,6 +18565,21 @@ def main(
         )
         cli._preload_skills_thread.start()
 
+    # Warm the local Piper TTS voice in the background (when configured).
+    # The model load otherwise sits on the critical path of the first TTS
+    # request; preloading at boot makes every request — including the first —
+    # serve from the in-process voice cache. Fire-and-forget: skips itself
+    # unless tts.provider is piper, preload is enabled, and the voice is
+    # already downloaded.
+    try:
+        from tools.tts_tool import preload_piper_voice
+
+        threading.Thread(
+            target=preload_piper_voice, name="tts-piper-preload", daemon=True
+        ).start()
+    except Exception:
+        logger.debug("piper TTS preload not available", exc_info=True)
+
     # Join the background worktree creation (started above) before anything
     # consumes TERMINAL_CWD / wt_info — the HermesCLI construction it
     # overlapped with is done. Setup failure keeps the old abort semantics.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27887,6 +27887,23 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception as e:
         logger.debug("MCP tool discovery failed: %s", e)
 
+    # Warm the local Piper TTS voice in the background (when configured).
+    # The ONNX model load is seconds of CPU on the critical path of the
+    # first TTS request; preloading at boot makes every request — including
+    # the first — serve from the in-process voice cache. Runs on a daemon
+    # thread (never blocks the event loop) and skips itself unless
+    # tts.provider is piper, preload is enabled, and the voice is already
+    # downloaded.
+    try:
+        import threading as _threading
+        from tools.tts_tool import preload_piper_voice
+
+        _threading.Thread(
+            target=preload_piper_voice, name="tts-piper-preload", daemon=True
+        ).start()
+    except Exception:
+        logger.debug("piper TTS preload not available", exc_info=True)
+
     # Start the gateway
     try:
         success = await runner.start()

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1542,10 +1542,14 @@ DEFAULT_CONFIG = {
             "device": "cpu",  # cpu, cuda, or mps
         },
         "piper": {
-            # Voice name (e.g. "en_US-lessac-medium") downloaded on first
+            # Voice name (e.g. "en_US-libritts-high") downloaded on first
             # use, OR an absolute path to a pre-downloaded .onnx file.
             # Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md
-            "voice": "en_US-lessac-medium",
+            "voice": "en_US-libritts-high",
+            # Preload the voice into memory at startup (gateway/CLI boot) so
+            # the first TTS request doesn't pay the model-load latency. The
+            # load is skipped until the voice is downloaded locally.
+            "preload": True,
             # "voices_dir": "",        # Override voice cache dir; default = ~/.hermes/cache/piper-voices/
             # "use_cuda": False,       # Requires onnxruntime-gpu
             # "length_scale": 1.0,     # 2.0 = twice as slow

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1880,7 +1880,7 @@ def _run_post_setup(post_setup_key: str):
                 _print_warning("    piper-tts install timed out (>5min)")
                 _print_info("    Run manually: uv pip install -U piper-tts")
                 return
-        _print_info("    Default voice: en_US-lessac-medium (downloaded on first TTS call)")
+        _print_info("    Default voice: en_US-libritts-high (downloaded on first TTS call)")
         _print_info("    Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md")
         _print_info("    Switch voices by setting tts.piper.voice in ~/.hermes/config.yaml")
 

--- a/tests/tools/test_tts_piper.py
+++ b/tests/tools/test_tts_piper.py
@@ -8,6 +8,7 @@ without requiring the ``piper-tts`` package to actually be installed
 
 import json
 import sys
+import time
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -22,6 +23,7 @@ from tools.tts_tool import (
     _check_piper_available,
     _resolve_piper_voice_path,
     check_tts_requirements,
+    preload_piper_voice,
     text_to_speech_tool,
 )
 
@@ -177,6 +179,106 @@ class TestGeneratePiperTts:
             tts_tool._generate_piper_tts("hi", str(tmp_path / f"out-{speaker}.wav"), config)
 
         # Only one PiperVoice.load() call across four calls with different speakers.
+        assert _StubPiperVoice.loaded == [str(model)]
+
+
+# ---------------------------------------------------------------------------
+# preload_piper_voice
+# ---------------------------------------------------------------------------
+
+class TestPreloadPiperVoice:
+    def _wait_for_load(self, timeout=5.0):
+        """Wait for the background preload thread to finish loading."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if _StubPiperVoice.loaded:
+                return True
+            time.sleep(0.02)
+        return bool(_StubPiperVoice.loaded)
+
+    def test_skips_when_provider_not_piper(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+        cfg = {"provider": "edge", "piper": {"voice": "en_US-libritts-high"}}
+
+        assert preload_piper_voice(cfg) is False
+        assert _StubPiperVoice.loaded == []
+
+    def test_skips_when_preload_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+        cfg = {"provider": "piper", "piper": {"voice": "en_US-libritts-high", "preload": False}}
+
+        assert preload_piper_voice(cfg) is False
+        assert _StubPiperVoice.loaded == []
+
+    def test_skips_when_voice_not_downloaded(self, tmp_path, monkeypatch):
+        # Empty voices dir — the model was never downloaded. Preload must
+        # NOT trigger a download; the first TTS call handles that.
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+        cfg = {
+            "provider": "piper",
+            "piper": {"voice": "en_US-libritts-high", "voices_dir": str(tmp_path)},
+        }
+
+        assert preload_piper_voice(cfg) is False
+        assert _StubPiperVoice.loaded == []
+
+    def test_skips_when_piper_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: False)
+        cfg = {"provider": "piper", "piper": {"voice": "en_US-libritts-high"}}
+
+        assert preload_piper_voice(cfg) is False
+        assert _StubPiperVoice.loaded == []
+
+    def test_loads_configured_voice_in_background(self, tmp_path, monkeypatch):
+        model = tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx"
+        model.write_bytes(b"model")
+        (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx.json").write_text("{}")
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+
+        cfg = {
+            "provider": "piper",
+            "piper": {"voice": DEFAULT_PIPER_VOICE, "voices_dir": str(tmp_path)},
+        }
+
+        assert preload_piper_voice(cfg) is True
+        assert self._wait_for_load()
+        assert _StubPiperVoice.loaded == [str(model)]
+        # Voice is resident in the process cache — a later TTS call reuses it.
+        assert len(tts_tool._piper_voice_cache) == 1
+
+    def test_noop_when_already_cached(self, tmp_path, monkeypatch):
+        model = tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx"
+        model.write_bytes(b"model")
+        (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx.json").write_text("{}")
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+
+        cfg = {
+            "provider": "piper",
+            "piper": {"voice": DEFAULT_PIPER_VOICE, "voices_dir": str(tmp_path)},
+        }
+
+        assert preload_piper_voice(cfg) is True
+        assert self._wait_for_load()
+        loaded_count = len(_StubPiperVoice.loaded)
+
+        # Second preload (e.g. another startup hook) must not reload.
+        assert preload_piper_voice(cfg) is True
+        time.sleep(0.1)
+        assert _StubPiperVoice.loaded == _StubPiperVoice.loaded[:loaded_count]
+
+    def test_uses_default_voice_when_unconfigured(self, tmp_path, monkeypatch):
+        model = tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx"
+        model.write_bytes(b"model")
+        (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx.json").write_text("{}")
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+
+        cfg = {"provider": "piper", "piper": {"voices_dir": str(tmp_path)}}
+
+        assert preload_piper_voice(cfg) is True
+        assert self._wait_for_load()
         assert _StubPiperVoice.loaded == [str(model)]
 
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -219,7 +219,7 @@ DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
-DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
+DEFAULT_PIPER_VOICE = "en_US-libritts-high"  # high-quality tier; ~120MB model
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-02-hd"
@@ -2913,7 +2913,7 @@ def _resolve_piper_voice_path(voice: str, download_dir: Path) -> str:
 
     Accepts any of:
       - Absolute / expanded path to an .onnx file the user already has
-      - A voice *name* like ``en_US-lessac-medium`` (downloads to
+      - A voice *name* like ``en_US-libritts-high`` (downloads to
         ``download_dir`` on first use via ``python -m piper.download_voices``)
 
     Raises RuntimeError if the model can't be located or downloaded.
@@ -3059,6 +3059,102 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
             os.rename(wav_path, output_path)
 
     return output_path
+
+
+# ===========================================================================
+# Provider: Piper — startup preload
+# ===========================================================================
+#
+# The voice model is cached per-process (see _piper_voice_cache above), so a
+# long-lived gateway/CLI process only pays the model load once. That load is
+# still on the critical path of the FIRST TTS request (~1-3s for a CPU
+# high-quality voice, and Piper's libritts-high default is one of the bigger
+# models). ``preload_piper_voice`` warms the cache at startup in a background
+# thread so the first request is served from memory.
+
+# Guards the preload path only — the cache itself stays lock-free for the
+# normal tool-call path (a duplicate load on a rare tool-call race is cheap;
+# a duplicate load at every startup is not).
+_piper_preload_lock = threading.Lock()
+
+
+def preload_piper_voice(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+    """Warm the configured Piper voice so the first TTS request is instant.
+
+    Reads the live TTS config: preload only fires when ``tts.provider`` is
+    ``piper`` and ``tts.piper.preload`` is enabled (default ``True``). The
+    load runs in a background daemon thread so startup is never blocked.
+
+    Startup never triggers a voice *download* — if the configured voice
+    isn't already cached locally, preload is skipped and the first TTS call
+    downloads it as before. Returns True when the voice is already resident
+    or a warm-up load was started; False when preload is not applicable
+    (wrong provider, preload disabled, voice not downloaded, piper missing).
+    """
+    try:
+        if tts_config is None:
+            tts_config = _load_tts_config()
+        if not isinstance(tts_config, dict):
+            return False
+        if (tts_config.get("provider") or "edge") != "piper":
+            return False
+        if not _check_piper_available():
+            return False
+        piper_config = tts_config.get("piper") or {}
+        if not isinstance(piper_config, dict):
+            piper_config = {}
+        if not bool(piper_config.get("preload", True)):
+            return False
+
+        voice_name = piper_config.get("voice") or DEFAULT_PIPER_VOICE
+        download_dir = Path(
+            piper_config.get("voices_dir") or _get_piper_voices_dir()
+        ).expanduser()
+        use_cuda = bool(piper_config.get("use_cuda", False))
+
+        # Resolve WITHOUT downloading (unlike _resolve_piper_voice_path):
+        # a missing model must defer to the normal first-call download path.
+        candidate = Path(voice_name).expanduser()
+        if candidate.suffix.lower() == ".onnx" and candidate.exists():
+            model_path = str(candidate)
+        else:
+            cached = download_dir / f"{voice_name}.onnx"
+            if not (cached.exists() and (download_dir / f"{voice_name}.onnx.json").exists()):
+                logger.info(
+                    "[Piper] Voice '%s' not downloaded yet — skipping preload "
+                    "(first TTS call will download it)", voice_name,
+                )
+                return False
+            model_path = str(cached)
+
+        cache_key = f"{model_path}::cuda={use_cuda}"
+        if cache_key in _piper_voice_cache:
+            return True
+
+        def _warm() -> None:
+            with _piper_preload_lock:
+                if cache_key in _piper_voice_cache:
+                    return
+                logger.info("[Piper] Preloading voice: %s", model_path)
+                try:
+                    _tts_cache_get_or_load(
+                        _piper_voice_cache,
+                        cache_key,
+                        lambda: _import_piper().load(model_path, use_cuda=use_cuda),
+                    )
+                    logger.info("[Piper] Voice preloaded")
+                except Exception:
+                    # Never take startup down with the TTS engine — the
+                    # first TTS call will retry the load and surface errors.
+                    logger.exception(
+                        "[Piper] Voice preload failed — first TTS call will load it"
+                    )
+
+        threading.Thread(target=_warm, name="piper-voice-preload", daemon=True).start()
+        return True
+    except Exception:
+        logger.debug("[Piper] Preload skipped", exc_info=True)
+        return False
 
 
 # ===========================================================================

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -239,10 +239,13 @@ Piper is a fast, local neural TTS engine from the Open Home Foundation (the Home
 tts:
   provider: piper
   piper:
-    voice: en_US-lessac-medium
+    voice: en_US-libritts-high
+    preload: true   # load the voice at startup so the first request is instant
 ```
 
-On the first TTS call for a voice that isn't cached locally, Hermes runs `python -m piper.download_voices <name>` and downloads the model (~20-90MB depending on quality tier) into `~/.hermes/cache/piper-voices/`. Subsequent calls reuse the cached model.
+The default voice is `en_US-libritts-high` — Piper's highest-quality English tier. On the first TTS call for a voice that isn't cached locally, Hermes runs `python -m piper.download_voices <name>` and downloads the model (~20-120MB depending on quality tier) into `~/.hermes/cache/piper-voices/`. Subsequent calls reuse the cached model.
+
+**Kept loaded for serving.** Once a voice has been downloaded, Hermes preloads it into memory in the background at startup (CLI or gateway boot) when `tts.piper.preload` is `true` (the default). The first TTS request is then served from the in-memory model instead of paying the multi-second ONNX load, so voice replies are consistently fast. Set `preload: false` to disable (e.g. to keep the process footprint small when Piper is rarely used).
 
 **Picking a voice.** The [full voice catalog](https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md) covers English, Spanish, French, German, Italian, Dutch, Portuguese, Russian, Polish, Turkish, Chinese, Arabic, Hindi, and more — each with `x_low` / `low` / `medium` / `high` quality tiers. Sample voices at [rhasspy.github.io/piper-samples](https://rhasspy.github.io/piper-samples/).
 


### PR DESCRIPTION
## What

Two changes for Piper (local TTS):

1. **Default voice → `en_US-libritts-high`** — Piper's highest-quality English tier, replacing `en_US-lessac-medium` as the built-in default (`DEFAULT_PIPER_VOICE`, `tts.piper.voice` config default, docs, desktop suggestions, `hermes tools` hint).

2. **Preload the voice at startup so it's always warm for serving** — new `preload_piper_voice()` in `tools/tts_tool.py` loads the configured Piper voice into the in-process model cache in a background daemon thread at CLI boot (`cli.py main()`) and gateway boot (`gateway/run.py start_gateway()`). The first TTS request is served from memory instead of paying the multi-second ONNX load, which was the reported 'responses feel slow with piper' symptom.

## How it behaves

- Fires only when `tts.provider: piper` and `tts.piper.preload` is enabled (default `true`).
- **Never downloads at startup** — if the voice isn't already cached locally, preload skips and the first TTS call downloads it as before.
- Load runs on a daemon thread — never blocks CLI/gateway startup; failures are logged and deferred to the first TTS call.
- Already-cached voices are a no-op; the preload path is lock-guarded so a startup hook + first tool call can't double-load.

## Files

- `tools/tts_tool.py` — default voice, `preload_piper_voice()`
- `cli.py`, `gateway/run.py` — startup hooks
- `hermes_cli/config_defaults.py` — `voice` default + `preload` knob
- `hermes_cli/tools_config.py` — installer hint text
- `website/docs/user-guide/features/tts.md` — docs
- `apps/desktop/src/app/settings/constants.ts` — voice suggestions
- `tests/tools/test_tts_piper.py` — 7 new preload tests

## Test

`pytest tests/tools/test_tts_piper.py tests/agent/test_tts_registry.py` — 19 + 79 passed.