### PR TITLE
feat(tts): add native Kokoro provider, document self-hosted OpenAI-compatible TTS

### DIFF
--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -56,6 +56,7 @@ _BUILTIN_NAMES = frozenset({
     "neutts",
     "kittentts",
     "piper",
+    "kokoro",
     "deepinfra",
 })
 

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -322,6 +322,8 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   ],
   'tts.kittentts.voice': ['Jasper'],
   'tts.piper.voice': ['en_US-libritts-high', 'en_US-lessac-medium', 'en_US-amy-medium', 'en_US-ryan-high', 'en_GB-alan-medium'],
+  'tts.kokoro.voice': ['af_heart', 'af_bella', 'af_nicole', 'af_sarah', 'am_adam', 'am_michael', 'bf_emma', 'bm_george'],
+  'tts.kokoro.lang_code': ['a', 'b', 'e', 'f', 'h', 'i', 'j', 'p', 'z'],
   'tts.neutts.model': ['neuphonic/neutts-air-q4-gguf', 'neuphonic/neutts-air-q8-gguf', 'neuphonic/neutts-air'],
   // Text-to-speech backends — kept in sync with the built-in source of truth
   // (agent/tts_registry.py::_BUILTIN_NAMES / tools/tts_tool.py::
@@ -336,7 +338,8 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
     'gemini',
     'neutts',
     'kittentts',
-    'piper'
+    'piper',
+    'kokoro'
   ],
   'stt.openai.model': ['whisper-1', 'gpt-4o-mini-transcribe', 'gpt-4o-transcribe', 'gpt-transcribe'],
   'stt.mistral.model': ['voxtral-mini-latest', 'voxtral-mini-2602'],
@@ -368,6 +371,8 @@ export const FREE_INPUT_KEYS = new Set([
   'tts.kittentts.model',
   'tts.kittentts.voice',
   'tts.piper.voice',
+  'tts.kokoro.voice',
+  'tts.kokoro.lang_code',
   'tts.deepinfra.model',
   'tts.deepinfra.voice'
 ])
@@ -506,6 +511,10 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     piper: {
       voice: 'Piper Voice'
     },
+    kokoro: {
+      voice: 'Kokoro Voice',
+      langCode: 'Kokoro Language'
+    },
     deepinfra: {
       model: 'DeepInfra TTS Model',
       voice: 'DeepInfra Voice'
@@ -606,6 +615,10 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     },
     neutts: {
       device: 'Local inference device for NeuTTS.'
+    },
+    kokoro: {
+      voice: 'Kokoro voice. af_* = US English female, am_* = US English male, bf_*/bm_* = British.',
+      langCode: 'Kokoro language code — must match the voice prefix.'
     }
   },
   stt: {

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -321,7 +321,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
     'KittenML/kitten-tts-mini-0.8-int8'
   ],
   'tts.kittentts.voice': ['Jasper'],
-  'tts.piper.voice': ['en_US-lessac-medium', 'en_US-amy-medium', 'en_US-ryan-high', 'en_GB-alan-medium'],
+  'tts.piper.voice': ['en_US-libritts-high', 'en_US-lessac-medium', 'en_US-amy-medium', 'en_US-ryan-high', 'en_GB-alan-medium'],
   'tts.neutts.model': ['neuphonic/neutts-air-q4-gguf', 'neuphonic/neutts-air-q8-gguf', 'neuphonic/neutts-air'],
   // Text-to-speech backends — kept in sync with the built-in source of truth
   // (agent/tts_registry.py::_BUILTIN_NAMES / tools/tts_tool.py::

--- a/apps/desktop/src/app/settings/voice-provider-fields.test.ts
+++ b/apps/desktop/src/app/settings/voice-provider-fields.test.ts
@@ -25,6 +25,7 @@ describe('voiceProviderKeys', () => {
       'gemini',
       'kittentts',
       'piper',
+      'kokoro',
       'deepinfra',
       'minimax'
     ]) {

--- a/cli.py
+++ b/cli.py
@@ -18565,6 +18565,21 @@ def main(
         )
         cli._preload_skills_thread.start()
 
+    # Warm the local Piper TTS voice in the background (when configured).
+    # The model load otherwise sits on the critical path of the first TTS
+    # request; preloading at boot makes every request — including the first —
+    # serve from the in-process voice cache. Fire-and-forget: skips itself
+    # unless tts.provider is piper, preload is enabled, and the voice is
+    # already downloaded.
+    try:
+        from tools.tts_tool import preload_piper_voice
+
+        threading.Thread(
+            target=preload_piper_voice, name="tts-piper-preload", daemon=True
+        ).start()
+    except Exception:
+        logger.debug("piper TTS preload not available", exc_info=True)
+
     # Join the background worktree creation (started above) before anything
     # consumes TERMINAL_CWD / wt_info — the HermesCLI construction it
     # overlapped with is done. Setup failure keeps the old abort semantics.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27887,6 +27887,23 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception as e:
         logger.debug("MCP tool discovery failed: %s", e)
 
+    # Warm the local Piper TTS voice in the background (when configured).
+    # The ONNX model load is seconds of CPU on the critical path of the
+    # first TTS request; preloading at boot makes every request — including
+    # the first — serve from the in-process voice cache. Runs on a daemon
+    # thread (never blocks the event loop) and skips itself unless
+    # tts.provider is piper, preload is enabled, and the voice is already
+    # downloaded.
+    try:
+        import threading as _threading
+        from tools.tts_tool import preload_piper_voice
+
+        _threading.Thread(
+            target=preload_piper_voice, name="tts-piper-preload", daemon=True
+        ).start()
+    except Exception:
+        logger.debug("piper TTS preload not available", exc_info=True)
+
     # Start the gateway
     try:
         success = await runner.start()

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1484,7 +1484,7 @@ DEFAULT_CONFIG = {
     # Gemini 32000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
         # Set explicitly to pin a backend:
-        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local) | "kokoro" (local)
         "provider": "edge",
         "edge": {
             "voice": "en-US-AriaNeural",
@@ -1557,6 +1557,15 @@ DEFAULT_CONFIG = {
             # "noise_w_scale": 0.8,
             # "volume": 1.0,
             # "normalize_audio": True,
+        },
+        "kokoro": {
+            # Kokoro-82M: Apache-2.0 open-weight neural TTS, runs fully
+            # local. Install: pip install kokoro (+ espeak-ng system binary
+            # for English OOD fallback).
+            "voice": "af_heart",   # af_* = US English female, am_* = US English male, bf_*/bm_* = British, etc.
+            "lang_code": "a",      # 'a' = American English, 'b' = British, 'e' = Spanish, 'f' = French, 'h' = Hindi, 'i' = Italian, 'j' = Japanese, 'p' = Brazilian Portuguese, 'z' = Mandarin
+            "speed": 1.0,          # 0.5-2.0 playback speed
+            # "device": "",        # "" = auto (CUDA when available, else CPU); "cpu" or "cuda" to pin
         },
         "deepinfra": {
             "model": "",  # empty = first tts-tagged model from the live catalog

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1542,10 +1542,14 @@ DEFAULT_CONFIG = {
             "device": "cpu",  # cpu, cuda, or mps
         },
         "piper": {
-            # Voice name (e.g. "en_US-lessac-medium") downloaded on first
+            # Voice name (e.g. "en_US-libritts-high") downloaded on first
             # use, OR an absolute path to a pre-downloaded .onnx file.
             # Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md
-            "voice": "en_US-lessac-medium",
+            "voice": "en_US-libritts-high",
+            # Preload the voice into memory at startup (gateway/CLI boot) so
+            # the first TTS request doesn't pay the model-load latency. The
+            # load is skipped until the voice is downloaded locally.
+            "preload": True,
             # "voices_dir": "",        # Override voice cache dir; default = ~/.hermes/cache/piper-voices/
             # "use_cuda": False,       # Requires onnxruntime-gpu
             # "length_scale": 1.0,     # 2.0 = twice as slow

--- a/hermes_cli/doctor_live.py
+++ b/hermes_cli/doctor_live.py
@@ -40,7 +40,7 @@ GROQ_MODELS_URL = "https://api.groq.com/openai/v1/models"
 ELEVENLABS_VOICES_URL = "https://api.elevenlabs.io/v1/voices"
 
 # TTS/STT providers that never touch the network (nothing to probe).
-_LOCAL_AUDIO_PROVIDERS = {"", "local", "edge", "neutts", "kittentts", "piper"}
+_LOCAL_AUDIO_PROVIDERS = {"", "local", "edge", "neutts", "kittentts", "piper", "kokoro"}
 
 
 @dataclass

--- a/hermes_cli/subcommands/tools.py
+++ b/hermes_cli/subcommands/tools.py
@@ -81,10 +81,10 @@ def build_tools_parser(subparsers, *, cmd_tools: Callable) -> None:
             "Run the install/bootstrap hook a tool backend declares — the\n"
             "same step `hermes tools` runs after you pick a provider that\n"
             "needs extra dependencies (browser Chromium, Camofox, cua-driver,\n"
-            "KittenTTS/Piper, ddgs, Spotify, Langfuse, xAI). Stable,\n"
+            "KittenTTS/Piper/Kokoro, ddgs, Spotify, Langfuse, xAI). Stable,\n"
             "non-interactive target the dashboard spawns to drive backend\n"
             "setup. Keys: agent_browser, camofox, cua_driver, kittentts,\n"
-            "piper, ddgs, spotify, langfuse, xai_grok."
+            "piper, kokoro, ddgs, spotify, langfuse, xai_grok."
         ),
     )
     tools_postsetup_p.add_argument(

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -398,10 +398,18 @@ TOOL_CATEGORIES = {
             {
                 "name": "Piper",
                 "badge": "local · free",
-                "tag": "Local neural TTS, 44 languages (voices ~20-90MB)",
+                "tag": "Local neural TTS, 44 languages (voices ~20-120MB)",
                 "env_vars": [],
                 "tts_provider": "piper",
                 "post_setup": "piper",
+            },
+            {
+                "name": "Kokoro",
+                "badge": "local · free",
+                "tag": "Local 82M open-weight neural TTS, 9 languages (Apache-2.0)",
+                "env_vars": [],
+                "tts_provider": "kokoro",
+                "post_setup": "kokoro",
             },
             {
                 "name": "DeepInfra TTS",
@@ -1883,6 +1891,29 @@ def _run_post_setup(post_setup_key: str):
         _print_info("    Default voice: en_US-libritts-high (downloaded on first TTS call)")
         _print_info("    Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md")
         _print_info("    Switch voices by setting tts.piper.voice in ~/.hermes/config.yaml")
+
+    elif post_setup_key == "kokoro":
+        try:
+            __import__("kokoro")
+            _print_success("    kokoro is already installed")
+        except ImportError:
+            _print_info("    Installing kokoro (torch + 82M model, downloads on first use)...")
+            try:
+                result = _pip_install(["-U", "kokoro", "--quiet"], timeout=600)
+                if result.returncode == 0:
+                    _print_success("    kokoro installed")
+                else:
+                    _print_warning("    kokoro install failed:")
+                    _print_info(f"      {(result.stderr or '').strip()[:300]}")
+                    _print_info("    Run manually: uv pip install -U kokoro")
+                    return
+            except subprocess.TimeoutExpired:
+                _print_warning("    kokoro install timed out (>10min)")
+                _print_info("    Run manually: uv pip install -U kokoro")
+                return
+        _print_info("    Default voice: af_heart (American English). espeak-ng is required for English OOD fallback:")
+        _print_info("      sudo apt-get install espeak-ng  (Debian/Ubuntu)")
+        _print_info("    Switch voices by setting tts.kokoro.voice in ~/.hermes/config.yaml")
 
     elif post_setup_key == "ddgs":
         try:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1880,7 +1880,7 @@ def _run_post_setup(post_setup_key: str):
                 _print_warning("    piper-tts install timed out (>5min)")
                 _print_info("    Run manually: uv pip install -U piper-tts")
                 return
-        _print_info("    Default voice: en_US-lessac-medium (downloaded on first TTS call)")
+        _print_info("    Default voice: en_US-libritts-high (downloaded on first TTS call)")
         _print_info("    Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md")
         _print_info("    Switch voices by setting tts.piper.voice in ~/.hermes/config.yaml")
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -926,7 +926,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"],
+        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper", "kokoro"],
     },
     "stt.provider": {
         "type": "select",

--- a/tests/tools/test_tts_kokoro.py
+++ b/tests/tools/test_tts_kokoro.py
@@ -1,0 +1,224 @@
+"""
+Tests for the native Kokoro TTS provider.
+
+These tests pin the resolution / caching / dispatch paths for Kokoro
+without requiring the ``kokoro`` package (or torch) to actually be
+installed — the pipeline is monkey-patched to avoid the torch/model load.
+"""
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools import tts_tool
+from tools.tts_tool import (
+    BUILTIN_TTS_PROVIDERS,
+    DEFAULT_KOKORO_LANG_CODE,
+    DEFAULT_KOKORO_VOICE,
+    PROVIDER_MAX_TEXT_LENGTH,
+    _check_kokoro_available,
+    check_tts_requirements,
+    text_to_speech_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry / constants
+# ---------------------------------------------------------------------------
+
+class TestKokoroRegistration:
+    def test_kokoro_is_a_builtin_provider(self):
+        assert "kokoro" in BUILTIN_TTS_PROVIDERS
+
+    def test_kokoro_has_a_text_length_cap(self):
+        assert PROVIDER_MAX_TEXT_LENGTH.get("kokoro", 0) > 0
+
+
+# ---------------------------------------------------------------------------
+# _check_kokoro_available
+# ---------------------------------------------------------------------------
+
+class TestCheckKokoroAvailable:
+    def test_returns_bool_without_raising(self):
+        # We don't care about the current environment's answer — just that
+        # the probe never raises on a machine without kokoro installed.
+        assert isinstance(_check_kokoro_available(), bool)
+
+
+# ---------------------------------------------------------------------------
+# _generate_kokoro_tts — stubbed so we don't need kokoro/torch installed
+# ---------------------------------------------------------------------------
+
+class _StubResult:
+    """Stand-in for KPipeline.Result: holds an audio array (plain list)."""
+
+    def __init__(self, audio):
+        self.audio = audio
+
+
+class _StubKPipeline:
+    """Stand-in for kokoro.KPipeline used by the synthesis tests."""
+
+    instances: list[tuple] = []
+    calls: list[tuple] = []
+
+    def __init__(self, lang_code, device=None):
+        _StubKPipeline.instances.append((lang_code, device))
+
+    def __call__(self, text, voice=None, speed=1, **kwargs):
+        _StubKPipeline.calls.append((text, voice, speed))
+        audio = [0.0] * 2400  # 0.1s at 24kHz
+        return iter([_StubResult(audio)])
+
+
+@pytest.fixture(autouse=True)
+def _reset_kokoro_cache():
+    """Clear the module-level pipeline cache between tests."""
+    tts_tool._kokoro_pipeline_cache.clear()
+    _StubKPipeline.instances = []
+    _StubKPipeline.calls = []
+    yield
+    tts_tool._kokoro_pipeline_cache.clear()
+
+
+@pytest.fixture
+def _stub_soundfile():
+    """Stub soundfile — the real package isn't installed in the CI venv, and
+    _generate_kokoro_tts does `import soundfile as sf` at runtime."""
+    fake_sf = MagicMock()
+
+    def _fake_write(path, audio, samplerate):
+        # Emulate writing a real file so downstream path checks succeed.
+        Path(path).write_bytes(b"RIFF\x00\x00\x00\x00WAVEfmt fake")
+
+    fake_sf.write = _fake_write
+    with patch.dict("sys.modules", {"soundfile": fake_sf}):
+        yield fake_sf
+
+
+class TestGenerateKokoroTts:
+    def test_synthesizes_wav_with_configured_voice(self, tmp_path, monkeypatch, _stub_soundfile):
+        monkeypatch.setattr(tts_tool, "_import_kokoro", lambda: _StubKPipeline)
+
+        out_path = str(tmp_path / "out.wav")
+        config = {"kokoro": {"voice": "am_adam", "lang_code": "a"}}
+
+        result = tts_tool._generate_kokoro_tts("hello", out_path, config)
+
+        assert result == out_path
+        assert Path(out_path).exists()
+        assert Path(out_path).stat().st_size > 0
+        assert _StubKPipeline.instances == [("a", None)]
+        assert _StubKPipeline.calls == [("hello", "am_adam", 1.0)]
+
+    def test_uses_defaults_when_unconfigured(self, tmp_path, monkeypatch, _stub_soundfile):
+        monkeypatch.setattr(tts_tool, "_import_kokoro", lambda: _StubKPipeline)
+
+        result = tts_tool._generate_kokoro_tts("hi", str(tmp_path / "out.wav"), {})
+
+        assert _StubKPipeline.instances == [(DEFAULT_KOKORO_LANG_CODE, None)]
+        assert _StubKPipeline.calls == [("hi", DEFAULT_KOKORO_VOICE, 1.0)]
+
+    def test_pipeline_cached_across_calls(self, tmp_path, monkeypatch, _stub_soundfile):
+        monkeypatch.setattr(tts_tool, "_import_kokoro", lambda: _StubKPipeline)
+
+        config = {"kokoro": {"voice": "af_heart", "lang_code": "a"}}
+        tts_tool._generate_kokoro_tts("one", str(tmp_path / "a.wav"), config)
+        tts_tool._generate_kokoro_tts("two", str(tmp_path / "b.wav"), config)
+
+        # One pipeline construction (model load) for both calls.
+        assert _StubKPipeline.instances == [("a", None)]
+        assert [c[0] for c in _StubKPipeline.calls] == ["one", "two"]
+
+    def test_lang_change_loads_separate_pipeline(self, tmp_path, monkeypatch, _stub_soundfile):
+        monkeypatch.setattr(tts_tool, "_import_kokoro", lambda: _StubKPipeline)
+
+        tts_tool._generate_kokoro_tts("hello", str(tmp_path / "a.wav"), {"kokoro": {"lang_code": "a"}})
+        tts_tool._generate_kokoro_tts("hola", str(tmp_path / "b.wav"), {"kokoro": {"lang_code": "e"}})
+
+        assert _StubKPipeline.instances == [("a", None), ("e", None)]
+
+    def test_device_knob_forwarded(self, tmp_path, monkeypatch, _stub_soundfile):
+        monkeypatch.setattr(tts_tool, "_import_kokoro", lambda: _StubKPipeline)
+
+        config = {"kokoro": {"device": "cpu"}}
+        tts_tool._generate_kokoro_tts("hi", str(tmp_path / "out.wav"), config)
+
+        assert _StubKPipeline.instances == [("a", "cpu")]
+
+    def test_empty_audio_raises(self, tmp_path, monkeypatch, _stub_soundfile):
+        class _EmptyPipeline(_StubKPipeline):
+            def __call__(self, text, voice=None, speed=1, **kwargs):
+                return iter([])
+
+        monkeypatch.setattr(tts_tool, "_import_kokoro", lambda: _EmptyPipeline)
+
+        with pytest.raises(RuntimeError, match="no audio"):
+            tts_tool._generate_kokoro_tts("hi", str(tmp_path / "out.wav"), {"kokoro": {}})
+
+
+# ---------------------------------------------------------------------------
+# text_to_speech_tool end-to-end (provider == "kokoro")
+# ---------------------------------------------------------------------------
+
+class TestTextToSpeechToolWithKokoro:
+    def test_dispatches_to_kokoro(self, tmp_path, monkeypatch, _stub_soundfile):
+        monkeypatch.setattr(tts_tool, "_import_kokoro", lambda: _StubKPipeline)
+
+        cfg = {"provider": "kokoro", "kokoro": {"voice": "af_heart"}}
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+
+        result = text_to_speech_tool(text="hi", output_path=str(tmp_path / "clip.wav"))
+        data = json.loads(result)
+
+        assert data["success"] is True, data
+        assert data["provider"] == "kokoro"
+        assert Path(data["file_path"]).exists()
+
+    def test_missing_package_surfaces_error(self, tmp_path, monkeypatch):
+        def raise_import():
+            raise ImportError("No module named 'kokoro'")
+
+        monkeypatch.setattr(tts_tool, "_import_kokoro", raise_import)
+
+        cfg = {"provider": "kokoro"}
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+
+        result = text_to_speech_tool(text="hi", output_path=str(tmp_path / "clip.wav"))
+        data = json.loads(result)
+
+        assert data["success"] is False
+        assert "kokoro" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# check_tts_requirements
+# ---------------------------------------------------------------------------
+
+class TestCheckTtsRequirementsKokoro:
+    def test_kokoro_install_satisfies_requirements(self, monkeypatch):
+        # Drop every other provider so we can isolate the kokoro signal.
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "kokoro"})
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: (_ for _ in ()).throw(ImportError()))
+        monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: (_ for _ in ()).throw(ImportError()))
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: (_ for _ in ()).throw(ImportError()))
+        monkeypatch.setattr(tts_tool, "_import_mistral_client", lambda: (_ for _ in ()).throw(ImportError()))
+        monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: False)
+        monkeypatch.setattr(tts_tool, "_check_kittentts_available", lambda: False)
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: False)
+        monkeypatch.setattr(tts_tool, "_has_any_command_tts_provider", lambda: False)
+        monkeypatch.setattr(tts_tool, "_has_openai_audio_backend", lambda: False)
+        for env in ("MINIMAX_API_KEY", "XAI_API_KEY", "GEMINI_API_KEY",
+                    "GOOGLE_API_KEY", "MISTRAL_API_KEY", "ELEVENLABS_API_KEY"):
+            monkeypatch.delenv(env, raising=False)
+
+        # Now toggle the kokoro check on and off.
+        monkeypatch.setattr(tts_tool, "_check_kokoro_available", lambda: False)
+        assert check_tts_requirements() is False
+
+        monkeypatch.setattr(tts_tool, "_check_kokoro_available", lambda: True)
+        assert check_tts_requirements() is True

--- a/tests/tools/test_tts_piper.py
+++ b/tests/tools/test_tts_piper.py
@@ -8,6 +8,7 @@ without requiring the ``piper-tts`` package to actually be installed
 
 import json
 import sys
+import time
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -22,6 +23,7 @@ from tools.tts_tool import (
     _check_piper_available,
     _resolve_piper_voice_path,
     check_tts_requirements,
+    preload_piper_voice,
     text_to_speech_tool,
 )
 
@@ -177,6 +179,106 @@ class TestGeneratePiperTts:
             tts_tool._generate_piper_tts("hi", str(tmp_path / f"out-{speaker}.wav"), config)
 
         # Only one PiperVoice.load() call across four calls with different speakers.
+        assert _StubPiperVoice.loaded == [str(model)]
+
+
+# ---------------------------------------------------------------------------
+# preload_piper_voice
+# ---------------------------------------------------------------------------
+
+class TestPreloadPiperVoice:
+    def _wait_for_load(self, timeout=5.0):
+        """Wait for the background preload thread to finish loading."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if _StubPiperVoice.loaded:
+                return True
+            time.sleep(0.02)
+        return bool(_StubPiperVoice.loaded)
+
+    def test_skips_when_provider_not_piper(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+        cfg = {"provider": "edge", "piper": {"voice": "en_US-libritts-high"}}
+
+        assert preload_piper_voice(cfg) is False
+        assert _StubPiperVoice.loaded == []
+
+    def test_skips_when_preload_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+        cfg = {"provider": "piper", "piper": {"voice": "en_US-libritts-high", "preload": False}}
+
+        assert preload_piper_voice(cfg) is False
+        assert _StubPiperVoice.loaded == []
+
+    def test_skips_when_voice_not_downloaded(self, tmp_path, monkeypatch):
+        # Empty voices dir — the model was never downloaded. Preload must
+        # NOT trigger a download; the first TTS call handles that.
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+        cfg = {
+            "provider": "piper",
+            "piper": {"voice": "en_US-libritts-high", "voices_dir": str(tmp_path)},
+        }
+
+        assert preload_piper_voice(cfg) is False
+        assert _StubPiperVoice.loaded == []
+
+    def test_skips_when_piper_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: False)
+        cfg = {"provider": "piper", "piper": {"voice": "en_US-libritts-high"}}
+
+        assert preload_piper_voice(cfg) is False
+        assert _StubPiperVoice.loaded == []
+
+    def test_loads_configured_voice_in_background(self, tmp_path, monkeypatch):
+        model = tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx"
+        model.write_bytes(b"model")
+        (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx.json").write_text("{}")
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+
+        cfg = {
+            "provider": "piper",
+            "piper": {"voice": DEFAULT_PIPER_VOICE, "voices_dir": str(tmp_path)},
+        }
+
+        assert preload_piper_voice(cfg) is True
+        assert self._wait_for_load()
+        assert _StubPiperVoice.loaded == [str(model)]
+        # Voice is resident in the process cache — a later TTS call reuses it.
+        assert len(tts_tool._piper_voice_cache) == 1
+
+    def test_noop_when_already_cached(self, tmp_path, monkeypatch):
+        model = tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx"
+        model.write_bytes(b"model")
+        (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx.json").write_text("{}")
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+
+        cfg = {
+            "provider": "piper",
+            "piper": {"voice": DEFAULT_PIPER_VOICE, "voices_dir": str(tmp_path)},
+        }
+
+        assert preload_piper_voice(cfg) is True
+        assert self._wait_for_load()
+        loaded_count = len(_StubPiperVoice.loaded)
+
+        # Second preload (e.g. another startup hook) must not reload.
+        assert preload_piper_voice(cfg) is True
+        time.sleep(0.1)
+        assert _StubPiperVoice.loaded == _StubPiperVoice.loaded[:loaded_count]
+
+    def test_uses_default_voice_when_unconfigured(self, tmp_path, monkeypatch):
+        model = tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx"
+        model.write_bytes(b"model")
+        (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx.json").write_text("{}")
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: True)
+
+        cfg = {"provider": "piper", "piper": {"voices_dir": str(tmp_path)}}
+
+        assert preload_piper_voice(cfg) is True
+        assert self._wait_for_load()
         assert _StubPiperVoice.loaded == [str(model)]
 
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -219,7 +219,7 @@ DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
-DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
+DEFAULT_PIPER_VOICE = "en_US-libritts-high"  # high-quality tier; ~120MB model
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-02-hd"
@@ -2913,7 +2913,7 @@ def _resolve_piper_voice_path(voice: str, download_dir: Path) -> str:
 
     Accepts any of:
       - Absolute / expanded path to an .onnx file the user already has
-      - A voice *name* like ``en_US-lessac-medium`` (downloads to
+      - A voice *name* like ``en_US-libritts-high`` (downloads to
         ``download_dir`` on first use via ``python -m piper.download_voices``)
 
     Raises RuntimeError if the model can't be located or downloaded.
@@ -3059,6 +3059,102 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
             os.rename(wav_path, output_path)
 
     return output_path
+
+
+# ===========================================================================
+# Provider: Piper — startup preload
+# ===========================================================================
+#
+# The voice model is cached per-process (see _piper_voice_cache above), so a
+# long-lived gateway/CLI process only pays the model load once. That load is
+# still on the critical path of the FIRST TTS request (~1-3s for a CPU
+# high-quality voice, and Piper's libritts-high default is one of the bigger
+# models). ``preload_piper_voice`` warms the cache at startup in a background
+# thread so the first request is served from memory.
+
+# Guards the preload path only — the cache itself stays lock-free for the
+# normal tool-call path (a duplicate load on a rare tool-call race is cheap;
+# a duplicate load at every startup is not).
+_piper_preload_lock = threading.Lock()
+
+
+def preload_piper_voice(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+    """Warm the configured Piper voice so the first TTS request is instant.
+
+    Reads the live TTS config: preload only fires when ``tts.provider`` is
+    ``piper`` and ``tts.piper.preload`` is enabled (default ``True``). The
+    load runs in a background daemon thread so startup is never blocked.
+
+    Startup never triggers a voice *download* — if the configured voice
+    isn't already cached locally, preload is skipped and the first TTS call
+    downloads it as before. Returns True when the voice is already resident
+    or a warm-up load was started; False when preload is not applicable
+    (wrong provider, preload disabled, voice not downloaded, piper missing).
+    """
+    try:
+        if tts_config is None:
+            tts_config = _load_tts_config()
+        if not isinstance(tts_config, dict):
+            return False
+        if (tts_config.get("provider") or "edge") != "piper":
+            return False
+        if not _check_piper_available():
+            return False
+        piper_config = tts_config.get("piper") or {}
+        if not isinstance(piper_config, dict):
+            piper_config = {}
+        if not bool(piper_config.get("preload", True)):
+            return False
+
+        voice_name = piper_config.get("voice") or DEFAULT_PIPER_VOICE
+        download_dir = Path(
+            piper_config.get("voices_dir") or _get_piper_voices_dir()
+        ).expanduser()
+        use_cuda = bool(piper_config.get("use_cuda", False))
+
+        # Resolve WITHOUT downloading (unlike _resolve_piper_voice_path):
+        # a missing model must defer to the normal first-call download path.
+        candidate = Path(voice_name).expanduser()
+        if candidate.suffix.lower() == ".onnx" and candidate.exists():
+            model_path = str(candidate)
+        else:
+            cached = download_dir / f"{voice_name}.onnx"
+            if not (cached.exists() and (download_dir / f"{voice_name}.onnx.json").exists()):
+                logger.info(
+                    "[Piper] Voice '%s' not downloaded yet — skipping preload "
+                    "(first TTS call will download it)", voice_name,
+                )
+                return False
+            model_path = str(cached)
+
+        cache_key = f"{model_path}::cuda={use_cuda}"
+        if cache_key in _piper_voice_cache:
+            return True
+
+        def _warm() -> None:
+            with _piper_preload_lock:
+                if cache_key in _piper_voice_cache:
+                    return
+                logger.info("[Piper] Preloading voice: %s", model_path)
+                try:
+                    _tts_cache_get_or_load(
+                        _piper_voice_cache,
+                        cache_key,
+                        lambda: _import_piper().load(model_path, use_cuda=use_cuda),
+                    )
+                    logger.info("[Piper] Voice preloaded")
+                except Exception:
+                    # Never take startup down with the TTS engine — the
+                    # first TTS call will retry the load and surface errors.
+                    logger.exception(
+                        "[Piper] Voice preload failed — first TTS call will load it"
+                    )
+
+        threading.Thread(target=_warm, name="piper-voice-preload", daemon=True).start()
+        return True
+    except Exception:
+        logger.debug("[Piper] Preload skipped", exc_info=True)
+        return False
 
 
 # ===========================================================================

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -13,6 +13,7 @@ Built-in TTS providers:
 - NeuTTS (local, free, no API key): On-device TTS via neutts
 - KittenTTS (local, free, no API key): On-device 25MB model
 - Piper (local, free, no API key): OHF-Voice/piper1-gpl neural VITS, 44 languages
+- Kokoro (local, free, no API key): 82M open-weight neural TTS, 9 languages
 
 Custom command providers:
 - Users can declare any number of named providers with ``type: command``
@@ -203,6 +204,19 @@ def _import_piper():
     return PiperVoice
 
 
+def _import_kokoro():
+    """Lazy import Kokoro. Returns the KPipeline class or raises ImportError.
+
+    Kokoro is an optional, fully-local 82M-parameter neural TTS engine
+    (Apache-2.0 weights). ``pip install kokoro`` provides the package; the
+    ``espeak-ng`` system binary is required for English out-of-dictionary
+    fallback and several non-English languages. Models download from
+    HuggingFace on first use.
+    """
+    from kokoro import KPipeline
+    return KPipeline
+
+
 # ===========================================================================
 # Defaults
 # ===========================================================================
@@ -220,6 +234,8 @@ MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-libritts-high"  # high-quality tier; ~120MB model
+DEFAULT_KOKORO_VOICE = "af_heart"  # American English, female; see docs for the full voice list
+DEFAULT_KOKORO_LANG_CODE = "a"  # 'a' = American English; 'b' = British; 'e' = Spanish; 'f' = French; 'h' = Hindi; 'i' = Italian; 'j' = Japanese; 'p' = Brazilian Portuguese; 'z' = Mandarin
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-02-hd"
@@ -283,6 +299,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "kokoro": 2000,       # local 82M model, quality falls off on long text
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -779,6 +796,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "neutts",
     "kittentts",
     "piper",
+    "kokoro",
     "deepinfra",
 })
 
@@ -2896,6 +2914,15 @@ def _check_piper_available() -> bool:
         return False
 
 
+def _check_kokoro_available() -> bool:
+    """Check whether the kokoro package is importable."""
+    try:
+        import importlib.util
+        return importlib.util.find_spec("kokoro") is not None
+    except Exception:
+        return False
+
+
 def _get_piper_voices_dir() -> Path:
     """Return the directory where Hermes caches Piper voice models.
 
@@ -3221,6 +3248,100 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 
 
 # ===========================================================================
+# Provider: Kokoro (local, 82M neural TTS)
+# ===========================================================================
+
+# Module-level cache for Kokoro KPipeline instances. A pipeline holds the
+# loaded 82M model plus its voice packs — constructing one costs seconds of
+# torch/model load, so it is keyed on (lang_code, device) and reused across
+# requests (LRU-bounded like the other model caches).
+_kokoro_pipeline_cache: Dict[str, Any] = {}
+
+
+def _generate_kokoro_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using the local Kokoro TTS engine.
+
+    Kokoro is an 82M-parameter open-weight (Apache-2.0) neural TTS model
+    that runs fully locally on CPU or GPU. Requires ``pip install kokoro``
+    (torch-based) plus the ``espeak-ng`` system binary for English
+    out-of-dictionary fallback and some non-English languages. The model
+    downloads from HuggingFace on first use.
+
+    Args:
+        text: Text to convert to speech.
+        output_path: Where to save the audio file.
+        tts_config: TTS config dict (``tts.kokoro`` sub-block).
+
+    Returns:
+        Path to the saved audio file.
+    """
+    KPipeline = _import_kokoro()
+    kk_config = tts_config.get("kokoro") or {} if isinstance(tts_config, dict) else {}
+    if not isinstance(kk_config, dict):
+        kk_config = {}
+    lang_code = kk_config.get("lang_code") or DEFAULT_KOKORO_LANG_CODE
+    voice = kk_config.get("voice") or DEFAULT_KOKORO_VOICE
+    speed = float(kk_config.get("speed", 1.0))
+    # Empty string = auto (Kokoro picks CUDA when available, else CPU);
+    # "cpu"/"cuda" pin explicitly, mirroring tts.neutts.device.
+    device = (kk_config.get("device") or "").strip() or None
+
+    cache_key = f"{lang_code}::device={device}"
+
+    def _load_pipeline():
+        logger.info("[Kokoro] Loading pipeline (lang=%s, device=%s)", lang_code, device)
+        pipeline = KPipeline(lang_code=lang_code, device=device)
+        logger.info("[Kokoro] Pipeline loaded")
+        return pipeline
+
+    pipeline = _tts_cache_get_or_load(_kokoro_pipeline_cache, cache_key, _load_pipeline)
+
+    logger.info("[Kokoro] Synthesizing (voice=%s, lang=%s)", voice, lang_code)
+    chunks = []
+    for result in pipeline(text, voice=voice, speed=speed):
+        audio = result.audio
+        if audio is None:
+            continue
+        # KPipeline yields torch tensors; detach+move to numpy so we can
+        # concatenate without importing torch here (torch is a kokoro dep,
+        # numpy is universal).
+        if hasattr(audio, "detach"):
+            audio = audio.detach().cpu().numpy()
+        chunks.append(audio)
+    if not chunks:
+        raise RuntimeError("Kokoro produced no audio output")
+    if len(chunks) == 1:
+        audio = chunks[0]
+    else:
+        import numpy as np
+        audio = np.concatenate(chunks)
+
+    # Kokoro outputs 24kHz mono float32. Caller handles downstream
+    # MP3/Opus conversion via ffmpeg (same contract as Piper/KittenTTS).
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    import soundfile as sf
+    sf.write(wav_path, audio, 24000)
+
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
+        else:
+            # No ffmpeg — keep WAV and return that path
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
 # Main tool function
 # ===========================================================================
 def _text_to_speech_single(
@@ -3461,6 +3582,20 @@ def _text_to_speech_single(
             logger.info("Generating speech with Piper (local)...")
             _generate_piper_tts(text, file_str, tts_config)
 
+        elif provider == "kokoro":
+            try:
+                _import_kokoro()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "Kokoro provider selected but 'kokoro' package not installed. "
+                             "Run 'hermes tools' and select Kokoro under TTS, or install "
+                             "manually: pip install kokoro (requires the espeak-ng system "
+                             "binary for English OOD fallback)",
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Kokoro (local)...")
+            _generate_kokoro_tts(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -3534,7 +3669,7 @@ def _text_to_speech_single(
                 voice_compatible = file_str.endswith(".ogg")
         elif (
             want_opus
-            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
+            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper", "kokoro"}
             and not file_str.endswith(".ogg")
         ):
             opus_path = _convert_to_opus(file_str)
@@ -3861,6 +3996,8 @@ def check_tts_requirements() -> bool:
         return _check_kittentts_available()
     if provider == "piper":
         return _check_piper_available()
+    if provider == "kokoro":
+        return _check_kokoro_available()
 
     try:
         from agent.tts_registry import get_provider
@@ -4573,7 +4710,7 @@ TTS_SCHEMA = {
                 "description": (
                     "Optional TTS provider override. Accepts built-in names "
                     "(edge, openai, elevenlabs, minimax, xai, mistral, gemini, "
-                    "neutts, kittentts, piper), user-declared command provider "
+                    "neutts, kittentts, piper, kokoro), user-declared command provider "
                     "names from tts.providers.<name>, or plugin-registered names. "
                     "When omitted, the configured tts.provider from config.yaml is used."
                 )

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -239,10 +239,13 @@ Piper is a fast, local neural TTS engine from the Open Home Foundation (the Home
 tts:
   provider: piper
   piper:
-    voice: en_US-lessac-medium
+    voice: en_US-libritts-high
+    preload: true   # load the voice at startup so the first request is instant
 ```
 
-On the first TTS call for a voice that isn't cached locally, Hermes runs `python -m piper.download_voices <name>` and downloads the model (~20-90MB depending on quality tier) into `~/.hermes/cache/piper-voices/`. Subsequent calls reuse the cached model.
+The default voice is `en_US-libritts-high` — Piper's highest-quality English tier. On the first TTS call for a voice that isn't cached locally, Hermes runs `python -m piper.download_voices <name>` and downloads the model (~20-120MB depending on quality tier) into `~/.hermes/cache/piper-voices/`. Subsequent calls reuse the cached model.
+
+**Kept loaded for serving.** Once a voice has been downloaded, Hermes preloads it into memory in the background at startup (CLI or gateway boot) when `tts.piper.preload` is `true` (the default). The first TTS request is then served from the in-memory model instead of paying the multi-second ONNX load, so voice replies are consistently fast. Set `preload: false` to disable (e.g. to keep the process footprint small when Piper is rarely used).
 
 **Picking a voice.** The [full voice catalog](https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md) covers English, Spanish, French, German, Italian, Dutch, Portuguese, Russian, Polish, Turkish, Chinese, Arabic, Hindi, and more — each with `x_low` / `low` / `medium` / `high` quality tiers. Sample voices at [rhasspy.github.io/piper-samples](https://rhasspy.github.io/piper-samples/).
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,7 +14,7 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with eleven providers:
+Convert text to speech with twelve providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
@@ -29,6 +29,7 @@ Convert text to speech with eleven providers:
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
 | **Piper** | Good | Free (local) | None needed |
+| **Kokoro** | Excellent | Free (local) | None needed |
 
 ### Platform Delivery
 
@@ -44,7 +45,7 @@ Convert text to speech with eleven providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "deepinfra" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "deepinfra" | "neutts" | "kittentts" | "piper" | "kokoro"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -258,6 +259,57 @@ tts:
 ```
 
 **Advanced knobs** (`tts.piper.length_scale` / `noise_scale` / `noise_w_scale` / `volume` / `normalize_audio`, `use_cuda`) correspond 1:1 to Piper's `SynthesisConfig`. They're ignored on older `piper-tts` versions.
+
+### Kokoro (local, 82M, 9 languages)
+
+Kokoro is an open-weight (Apache-2.0) neural TTS model with 82M parameters. It runs fully locally on CPU or GPU, needs no API key, and punches well above its size — often compared to far larger commercial models.
+
+**Install:** `pip install kokoro` plus the `espeak-ng` system binary (needed for English out-of-dictionary fallback and some non-English languages):
+
+```bash
+pip install kokoro
+# Debian/Ubuntu:
+sudo apt-get install espeak-ng
+```
+
+The model (~300MB) downloads from HuggingFace on first use.
+
+**Switch to Kokoro:**
+
+```yaml
+tts:
+  provider: kokoro
+  kokoro:
+    voice: af_heart        # af_* = US English female, am_* = US English male, bf_*/bm_* = British, …
+    lang_code: a           # must match the voice prefix; 'a' = US English (default)
+    speed: 1.0             # 0.5–2.0
+    # device: ""           # "" = auto (CUDA when available, else CPU); "cpu" or "cuda" to pin
+```
+
+The `lang_code` must match the voice prefix: `a` (American English: `af_*`/`am_*`), `b` (British: `bf_*`/`bm_*`), `e` (Spanish), `f` (French), `h` (Hindi), `i` (Italian), `j` (Japanese), `p` (Brazilian Portuguese), `z` (Mandarin). Popular voices include `af_heart`, `af_bella`, `af_nicole`, `am_adam`, `am_michael`, `bf_emma`, `bm_george`. The pipeline (model + voices) is cached per process, so repeated calls don't reload it.
+
+### Self-hosted OpenAI-compatible TTS endpoints
+
+The `openai` provider is not limited to OpenAI's API — point `tts.openai.base_url` at any self-hosted or third-party server that implements the OpenAI `/v1/audio/speech` contract, and it just works:
+
+```yaml
+tts:
+  provider: openai
+  openai:
+    base_url: "http://localhost:8880/v1"   # e.g. a local kokoro-fastapi server
+    api_key: "not-needed"                  # most self-hosted servers ignore it
+    model: "kokoro"                        # whatever model id the server exposes
+    voice: "af_heart"
+    # language: "a"                        # sent as lang_code for servers that support it (Kokoro)
+```
+
+Popular self-hosted options:
+
+- **[kokoro-fastapi](https://github.com/remsky/Kokoro-FastAPI)** — serves Kokoro-82M over an OpenAI-compatible API with one command: `docker run -p 8880:8880 remsky/kokoro-fastapi`
+- **Kokoro-TTS-Local** — a local Kokoro server with an OpenAI-compatible `/v1/audio/speech` route (CPU-first Docker setup available)
+- **Anything else that implements `/v1/audio/speech`** — LocalAI, XTTS-compatible servers, etc. — anything that accepts `{model, voice, input}` and returns audio bytes
+
+The managed-Nous-gateway resolution is skipped entirely when `base_url` is set, so a self-hosted endpoint never requires an OpenAI key.
 
 ### Custom command providers
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -434,7 +434,7 @@ stt:
 
 # Text-to-Speech
 tts:
-  provider: "edge"                 # "edge" (free) | "elevenlabs" | "openai" | "neutts" | "minimax" | "mistral" | "gemini" | "xai" | "kittentts" | "piper"
+  provider: "edge"                 # "edge" (free) | "elevenlabs" | "openai" | "neutts" | "minimax" | "mistral" | "gemini" | "xai" | "kittentts" | "piper" | "kokoro"
   edge:
     voice: "en-US-AriaNeural"      # 322 voices, 74 languages
   elevenlabs:


### PR DESCRIPTION
## What

Two additions for local/self-hosted TTS:

1. **Native `kokoro` TTS provider** — fully-local 82M-parameter open-weight (Apache-2.0) neural TTS. Adds a built-in provider alongside Piper/KittenTTS/NeuTTS:
   - `_generate_kokoro_tts()`: `KPipeline(lang_code, device)` → 24kHz audio → WAV → standard ffmpeg/Opus pipeline
   - Pipeline (model + voices) LRU-cached per `(lang_code, device)` so repeated calls skip the multi-second torch/model load
   - Config: `tts.kokoro.{voice, lang_code, speed, device}` — default `af_heart` / `a` (US English); `device` empty = auto (CUDA when available)
   - Wired into `BUILTIN_TTS_PROVIDERS`, `agent/tts_registry._BUILTIN_NAMES`, dispatch, `check_tts_requirements`, provider caps, `hermes tools` installer (`pip install kokoro` + espeak-ng hint), web server options, doctor live probes, desktop settings UI
   - Docs: Kokoro section with install steps, lang/voice table, and notes

2. **Self-hosted OpenAI-compatible TTS docs** — `tts.openai.base_url` already supported endpoints like kokoro-fastapi; now documented with a worked example (base_url + api_key + model/voice) and popular options. Note: Piper's HTTP server is intentionally NOT listed — its `/synthesize` API is not OpenAI-compatible.

## Files

- `tools/tts_tool.py` — provider implementation, dispatch, requirements
- `agent/tts_registry.py`, `hermes_cli/{config_defaults,tools_config,web_server,doctor_live,subcommands/tools}.py`
- `apps/desktop/src/app/settings/constants.ts` + `voice-provider-fields.test.ts`
- `website/docs/user-guide/features/tts.md`, `voice-mode.md`
- `tests/tools/test_tts_kokoro.py` — 12 tests (stubbed pipeline, no torch needed)

## Test

`pytest tests/tools/test_tts_kokoro.py tests/tools/test_tts_piper.py tests/agent/test_tts_registry.py tests/hermes_cli/test_config.py` — 194 passed.