### PR TITLE
fix(gateway): unblock clarify wait on /stop or interrupt-mode messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5246,6 +5246,17 @@ class TurnRunner:
 
             timeout = _clarify_mod.get_clarify_timeout()
             response = _clarify_mod.wait_for_response(clarify_id, timeout=float(timeout))
+            # A /stop or interrupt-mode message unblocks wait_for_response
+            # via the per-thread interrupt flag (#83889). Surface that as an
+            # explicit interrupt sentinel rather than a misleading timeout
+            # message — the agent is already in the interrupted state and
+            # will wind the turn down accordingly.
+            try:
+                from tools.interrupt import is_interrupted as _clarify_is_interrupted
+            except Exception:  # pragma: no cover - optional
+                _clarify_is_interrupted = lambda: False
+            if _clarify_is_interrupted():
+                return "[interrupted by user]"
             if response is None or response == "":
                 # Timeout or session-boundary cancellation
                 return f"[user did not respond within {int(timeout / 60)}m]"

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -92,6 +92,34 @@ class TestClarifyPrimitive:
             assert result == ""
 
 
+    def test_wait_for_response_unblocks_on_interrupt(self):
+        """A /stop or interrupt-mode message must unblock the wait well
+        before the timeout. ``wait_for_response`` runs on the agent thread,
+        so signalling the per-thread interrupt flag (what the gateway's
+        interrupt path does) must make it return immediately instead of
+        blocking the full clarify timeout (#83889)."""
+        from tools import clarify_gateway as cm
+        from tools.interrupt import clear_current_thread_interrupt, set_interrupt
+
+        tid = threading.current_thread().ident
+        cm.register("id-int", "sk-int", "Pick one", ["A", "B"])
+
+        def signal_interrupt():
+            time.sleep(0.05)
+            set_interrupt(True, tid)
+
+        threading.Thread(target=signal_interrupt).start()
+        start = time.monotonic()
+        result = cm.wait_for_response("id-int", timeout=10.0)
+        elapsed = time.monotonic() - start
+        clear_current_thread_interrupt()
+
+        assert result is None
+        assert elapsed < 5.0, f"wait blocked {elapsed:.1f}s despite interrupt"
+        # The entry is cleaned up on the interrupt exit path, same as timeout.
+        assert cm.get_pending_for_session("sk-int") is None
+
+
     def test_notify_register_unregister_clears_pending(self):
         """unregister_notify cancels any pending clarify so threads unwind."""
         from tools import clarify_gateway as cm

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -128,11 +128,22 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
     except Exception:  # pragma: no cover - optional
         touch_activity_if_due = None
 
+    # Per-thread interrupt flag: /stop and interrupt-mode messages set it on
+    # the agent thread (tools.interrupt), and the wait loop below must observe
+    # it or the agent stays blocked until the full clarify timeout even though
+    # the run has been cancelled (#83889).
+    try:
+        from tools.interrupt import is_interrupted
+    except Exception:  # pragma: no cover - optional
+        is_interrupted = lambda: False
+
     # 0 / negative → unlimited: no deadline, poll forever in 1s slices.
     unlimited = timeout is None or float(timeout) <= 0.0
     deadline = None if unlimited else time.monotonic() + float(timeout)
     activity_state = {"last_touch": time.monotonic(), "start": time.monotonic()}
     while True:
+        if is_interrupted():
+            break
         if deadline is None:
             slice_s = 1.0
         else:


### PR DESCRIPTION
Fixes #83889 (root cause 1: `wait_for_response` never observes interrupts).

## Bug Description

When an agent in a gateway session calls `clarify`, the agent thread blocks in `tools/clarify_gateway.wait_for_response` on a `threading.Event` with a 1s-slice poll loop whose only side-channel is the inactivity heartbeat. The gateway's interrupt path (`_interrupt_and_clear_session` → `request_hard_interrupt` → agent `_set_interrupt(True, thread_id)`) sets the per-thread interrupt flag in `tools.interrupt`, but the blocked wait never checks it. Because the agent thread is stuck inside the tool, the run's `finally` cleanup (`clear_session` in `run_sync`) cannot execute either, so the clarify stays blocked until the full timeout (600s default) — `/stop` does nothing, and any user reply typed in the meantime is dead. Confirmed on multiplexed Feishu groups (#83889); the same mechanism applies to every platform with text-fallback clarify.

## Root Cause

`wait_for_response` (tools/clarify_gateway.py:135) polls only:
1. `entry.event.wait(timeout=slice_s)` — set by `resolve_gateway_clarify` / `clear_session`
2. `touch_activity_if_due` — inactivity heartbeat

No interrupt flag check. The per-thread interrupt mechanism (`tools.interrupt.is_interrupted()`) is exactly designed for this: the wait runs on the agent thread, and `/stop` marks that same thread. This is the same pattern `tools/environments/base.py` already uses for the heartbeat — the interrupt check is missing.

## Fix

- `tools/clarify_gateway.py` — `wait_for_response` polls `tools.interrupt.is_interrupted()` each 1s slice (same frequency as the heartbeat, try/except-guarded like the heartbeat import). On interrupt it breaks, returns `None`, and the existing post-loop cleanup removes the entry — identical exit path to a timeout.
- `gateway/run.py` — `_clarify_callback_sync` now checks the interrupt flag after `wait_for_response` returns and surfaces `"[interrupted by user]"` instead of the misleading `"[user did not respond within 10m]"` timeout message (the agent is in the interrupted state and winds the turn down).

## How to Verify

```bash
PYTHONPATH=. python -m pytest tests/tools/test_clarify_gateway.py -q -k unblocks_on_interrupt
```

The new test registers a pending clarify, signals the per-thread interrupt flag from a second thread 50ms later, and asserts `wait_for_response` returns `None` well before the 10s timeout. **Verified as a genuine regression**: reverting the fix makes the test block the full timeout and fail (11.3s, `AssertionError`); with the fix it returns in ~0.05s.

## Test Plan

- `tests/tools/test_clarify_gateway.py` — 24 passed (incl. new interrupt test)
- `tests/gateway/test_clarify_active_session_bypass.py` — 25 passed with the above (no regression)
- `tests/gateway/test_clarify_progress_leak.py`, `test_telegram_clarify_buttons.py`, `test_clarify_thread_followup_not_swallowed.py` — 9 passed

## Risk Assessment

**Low.** The interrupt check only shortens a wait that would otherwise run to its full timeout; the return path and entry cleanup are byte-for-byte the same as an existing timeout exit. `tools.interrupt` is a stdlib-only module with no new dependencies, and the import is guarded (falls back to a no-op predicate, same as the heartbeat import).
