### PR TITLE
fix(kanban): show no longer uses closed DB for graph diagnostics

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1685,6 +1685,9 @@ def _cmd_show(args: argparse.Namespace) -> int:
         # ``result=``. Surfacing the latest summary here keeps ``show`` from
         # looking like a no-op when the worker actually did real work.
         latest_summary = kb.latest_summary(conn, args.task_id)
+        # Graph context must be loaded before connect_closing exits — diagnostics
+        # run after the with-block and cannot touch a closed connection.
+        graph = kb.task_graph_context(conn, task.id)
 
     if getattr(args, "json", False):
         payload = {
@@ -1763,7 +1766,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     # comments / runs.
     from hermes_cli import kanban_diagnostics as kd
     diags = kd.compute_task_diagnostics(
-        task, events, runs, graph=kb.task_graph_context(conn, task.id)
+        task, events, runs, graph=graph
     )
     if diags:
         sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -154,6 +154,26 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
+def test_kanban_show_does_not_use_closed_connection(kanban_home):
+    """Regression: text-mode show used to call task_graph_context after
+    connect_closing exited, raising sqlite3.ProgrammingError and aborting
+    diagnostics / remainder of the human-readable view.
+    """
+    import re
+
+    out1 = kc.run_slash("create 'show graph after close' --assignee worker")
+    m = re.search(r"(t_[a-f0-9]+)", out1)
+    assert m, out1
+    tid = m.group(1)
+
+    out = kc.run_slash(f"show {tid}")
+    assert "Traceback" not in out, out
+    assert "closed database" not in out, out
+    assert tid in out
+    assert "show graph after close" in out
+    assert "status:" in out.lower() or "ready" in out.lower()
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `hermes kanban show <id>` (text mode) printed the task header then crashed with `sqlite3.ProgrammingError: Cannot operate on a closed database`.
- Root cause: `_cmd_show` exited `kb.connect_closing()` before calling `kb.task_graph_context(conn, …)` for diagnostics.
- Fix: load graph context inside the connection block and pass it into `compute_task_diagnostics`.
- Regression test: `test_kanban_show_does_not_use_closed_connection`.

## Test plan
- [x] Reproduced crash on main before fix
- [x] `hermes kanban show <id>` completes without traceback after fix
- [x] `pytest tests/hermes_cli/test_kanban_cli.py::test_kanban_show_does_not_use_closed_connection` (passed)