### PR TITLE
fix(state): stable tiebreaker for Telegram DM topic binding order

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10549,6 +10549,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     ) -> List[Dict[str, Any]]:
         """All Telegram DM topic bindings for one chat, newest first.
 
+        ``updated_at`` alone is not a total order: it is a ``time.time()``
+        float written by :meth:`bind_telegram_topic`, so two topics bound in
+        the same tick tie and SQLite may return them in either order.  The
+        sole caller (``_recover_telegram_topic_thread_id``) takes the *first*
+        row for a user as "most-recent topic", so a tie there routes a lobby
+        reply into an arbitrary lane.  ``rowid`` breaks it deterministically:
+        the table is upserted via ``ON CONFLICT(chat_id, thread_id) DO
+        UPDATE``, so rowids are stable and ascend with insertion order.
+
         Read-only; returns [] if the bindings table doesn't exist yet
         (does not trigger the topic-mode migration).
         """
@@ -10556,7 +10565,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             try:
                 rows = self._conn.execute(
                     "SELECT * FROM telegram_dm_topic_bindings "
-                    "WHERE chat_id = ? ORDER BY updated_at DESC",
+                    "WHERE chat_id = ? ORDER BY updated_at DESC, rowid DESC",
                     (str(chat_id),),
                 ).fetchall()
             except sqlite3.OperationalError:

--- a/hermes_state_telegram.py
+++ b/hermes_state_telegram.py
@@ -226,11 +226,22 @@ class SessionTelegramTopicsMixin:
     def list_telegram_topic_bindings_for_chat(
         self, *, chat_id: str, profile_name: str = "default"
     ) -> List[Dict[str, Any]]:
-        """All bindings for one chat, newest first ([] when the table is absent)."""
+        """All bindings for one chat, newest first ([] when the table is absent).
+
+        "Newest first" has to be a *total* order. ``updated_at`` is a ``time.time()``
+        float written by :meth:`bind_telegram_topic`, so two topics bound in the same
+        tick tie and SQLite is then free to return them in either order. The sole
+        caller (``GatewayRunner._recover_telegram_topic_thread_id``) takes the *first*
+        row for a user as their most-recent topic, so a tie there routes a lobby-shaped
+        DM reply into an arbitrary lane. ``rowid`` breaks the tie deterministically:
+        the table is upserted via ``ON CONFLICT(profile_name, chat_id, thread_id) DO
+        UPDATE``, so a row's rowid is stable and ascends with insertion order.
+        """
         profile_name = _normalize_telegram_topic_profile_name(profile_name)
         try:
             rows = self._read_all(
-                "SELECT * FROM telegram_dm_topic_bindings WHERE profile_name = ? AND chat_id = ? ORDER BY updated_at DESC",
+                "SELECT * FROM telegram_dm_topic_bindings WHERE profile_name = ? AND chat_id = ? "
+                "ORDER BY updated_at DESC, rowid DESC",
                 (profile_name, str(chat_id)),
             )
         except sqlite3.OperationalError:

--- a/tests/hermes_state/test_telegram_topic_binding_order.py
+++ b/tests/hermes_state/test_telegram_topic_binding_order.py
@@ -8,8 +8,11 @@ topic.  ``ORDER BY updated_at DESC`` alone does not give a total order --
 tick tie and SQLite may return them in either order.  A tie there sends a
 lobby-shaped reply into an arbitrary lane.
 
-These tests bind topics back-to-back (no sleep) so the tie is the normal
-case, not a rare one.
+These tests force every binding to share one ``updated_at`` rather than
+relying on back-to-back writes landing in the same tick: that depends on
+the platform's clock resolution, and on a high-resolution clock the
+tiebreaker would never be reached. Each test asserts the tie exists
+before asserting the order.
 """
 from __future__ import annotations
 
@@ -29,27 +32,62 @@ def _bind(db: SessionDB, *, chat_id: str, thread_id: str, user_id: str, session_
     )
 
 
-def test_same_tick_bindings_return_newest_first(tmp_path):
-    """Two topics bound in the same tick: the later one must come first."""
+def _force_tie(db: SessionDB, chat_id: str, ts: float = 1_760_000_000.0) -> None:
+    """Give every binding in *chat_id* the same ``updated_at``.
+
+    Binding back-to-back usually ties on its own, but that depends on the
+    platform's ``time.time()`` resolution -- on a high-resolution clock the
+    writes get distinct timestamps and the ``rowid`` tiebreaker is never
+    reached, so the test would pass without exercising what it names.
+    Forcing the tie makes these tests deterministic on every platform.
+    """
+    with db._lock:
+        db._conn.execute(
+            "UPDATE telegram_dm_topic_bindings SET updated_at = ? WHERE chat_id = ?",
+            (ts, chat_id),
+        )
+        db._conn.commit()
+
+
+def _assert_tied(db: SessionDB, chat_id: str) -> None:
+    """Guard: the rows really do tie, so the tiebreaker is under test."""
+    with db._lock:
+        distinct = db._conn.execute(
+            "SELECT COUNT(DISTINCT updated_at) FROM telegram_dm_topic_bindings "
+            "WHERE chat_id = ?",
+            (chat_id,),
+        ).fetchone()[0]
+    assert distinct == 1, (
+        f"expected all bindings to share one updated_at, saw {distinct} distinct "
+        "values — the rowid tiebreaker would not be exercised"
+    )
+
+
+def test_tied_bindings_return_newest_first(tmp_path):
+    """Two topics sharing an updated_at: the later-inserted one must lead."""
     db = SessionDB(db_path=tmp_path / "state.db")
     for i, thread in enumerate(("111", "222")):
         _bind(db, chat_id="chat-1", thread_id=thread, user_id="u1", session_id=f"s{i}")
+    _force_tie(db, "chat-1")
+    _assert_tied(db, "chat-1")
 
     rows = db.list_telegram_topic_bindings_for_chat(chat_id="chat-1")
     assert [r["thread_id"] for r in rows] == ["222", "111"], (
-        "bindings written in the same tick came back in insertion order or "
-        "arbitrary order; the newest must lead"
+        "tied bindings came back in insertion order or arbitrary order; "
+        "the newest must lead"
     )
 
 
 def test_ordering_is_stable_across_repeated_reads(tmp_path):
-    """The same rows must come back in the same order every time."""
+    """The same tied rows must come back in the same order every time."""
     db = SessionDB(db_path=tmp_path / "state.db")
     for i in range(8):
         _bind(
             db, chat_id="chat-1", thread_id=str(100 + i),
             user_id="u1", session_id=f"s{i}",
         )
+    _force_tie(db, "chat-1")
+    _assert_tied(db, "chat-1")
 
     orders = {
         tuple(r["thread_id"] for r in db.list_telegram_topic_bindings_for_chat(chat_id="chat-1"))

--- a/tests/hermes_state/test_telegram_topic_binding_order.py
+++ b/tests/hermes_state/test_telegram_topic_binding_order.py
@@ -1,0 +1,81 @@
+"""Telegram DM topic bindings must come back in a *total* order.
+
+``list_telegram_topic_bindings_for_chat`` documents "newest first", and
+``GatewayRunner._recover_telegram_topic_thread_id`` relies on that: it walks
+the rows and takes the first one belonging to the user as their most-recent
+topic.  ``ORDER BY updated_at DESC`` alone does not give a total order --
+``updated_at`` is a ``time.time()`` float, so two topics bound in the same
+tick tie and SQLite may return them in either order.  A tie there sends a
+lobby-shaped reply into an arbitrary lane.
+
+These tests bind topics back-to-back (no sleep) so the tie is the normal
+case, not a rare one.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _bind(db: SessionDB, *, chat_id: str, thread_id: str, user_id: str, session_id: str):
+    db.create_session(session_id, "telegram", user_id=user_id)
+    db.bind_telegram_topic(
+        chat_id=chat_id,
+        thread_id=thread_id,
+        user_id=user_id,
+        session_key=f"agent:main:telegram:dm:{chat_id}:{thread_id}",
+        session_id=session_id,
+    )
+
+
+def test_same_tick_bindings_return_newest_first(tmp_path):
+    """Two topics bound in the same tick: the later one must come first."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    for i, thread in enumerate(("111", "222")):
+        _bind(db, chat_id="chat-1", thread_id=thread, user_id="u1", session_id=f"s{i}")
+
+    rows = db.list_telegram_topic_bindings_for_chat(chat_id="chat-1")
+    assert [r["thread_id"] for r in rows] == ["222", "111"], (
+        "bindings written in the same tick came back in insertion order or "
+        "arbitrary order; the newest must lead"
+    )
+
+
+def test_ordering_is_stable_across_repeated_reads(tmp_path):
+    """The same rows must come back in the same order every time."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    for i in range(8):
+        _bind(
+            db, chat_id="chat-1", thread_id=str(100 + i),
+            user_id="u1", session_id=f"s{i}",
+        )
+
+    orders = {
+        tuple(r["thread_id"] for r in db.list_telegram_topic_bindings_for_chat(chat_id="chat-1"))
+        for _ in range(25)
+    }
+    assert len(orders) == 1, f"ordering varied across reads: {orders}"
+    # Newest binding first.
+    assert next(iter(orders))[0] == "107"
+
+
+def test_explicit_updated_at_still_wins_over_the_tiebreaker(tmp_path):
+    """rowid only breaks ties -- a genuinely newer updated_at still leads."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _bind(db, chat_id="chat-1", thread_id="111", user_id="u1", session_id="s0")
+    _bind(db, chat_id="chat-1", thread_id="222", user_id="u1", session_id="s1")
+
+    # Make the *older* rowid unambiguously the most recently updated.
+    with db._lock:
+        db._conn.execute(
+            "UPDATE telegram_dm_topic_bindings SET updated_at = ? "
+            "WHERE chat_id = ? AND thread_id = ?",
+            (9_999_999_999.0, "chat-1", "111"),
+        )
+        db._conn.commit()
+
+    rows = db.list_telegram_topic_bindings_for_chat(chat_id="chat-1")
+    assert [r["thread_id"] for r in rows] == ["111", "222"], (
+        "rowid must be a tiebreaker only, never override updated_at"
+    )


### PR DESCRIPTION
## Problem

`SessionDB.list_telegram_topic_bindings_for_chat()` documents "newest first", and its only caller depends on that. `GatewayRunner._recover_telegram_topic_thread_id()` walks the rows and takes the first one belonging to the user as their most-recent topic:

```python
for b in bindings:  # newest-first
    if str(b.get("user_id") or "") == user_id:
```

But the query orders on one column:

```sql
SELECT * FROM telegram_dm_topic_bindings WHERE chat_id = ? ORDER BY updated_at DESC
```

`updated_at` is a `time.time()` float written by `bind_telegram_topic()`, so two topics bound in the same tick tie — and SQLite may return a tie in either order. When that happens, a lobby-shaped DM reply (omitted `message_thread_id`, or General `"1"`) is recovered into an **arbitrary** lane instead of the user's newest topic. That is a user-visible routing bug, not only a test artifact.

## Fix

```sql
ORDER BY updated_at DESC, rowid DESC
```

`rowid` is the right tiebreaker here: the table is upserted via `ON CONFLICT(chat_id, thread_id) DO UPDATE`, so rowids are stable across rebinds and ascend with insertion order. It only breaks ties — a genuinely newer `updated_at` still wins, which the third test pins explicitly.

This is the same class of bug as #53811 (stable tiebreaker for the default `list_sessions_rich` ordering) in a different table, and it matches the convention already used by the `order_by_last_active` branch of `list_sessions_rich`: `... s.started_at DESC, s.id DESC`.

## How it surfaced

`tests/gateway/test_telegram_prune_stale_topic_binding_31501.py::TestRecoveryAfterPrune::test_recovery_no_longer_returns_pruned_topic` binds `"111"` then `"222"` back-to-back and asserts recovery picks `"222"`. On Windows it failed **4 of 8** runs in isolation:

```
AssertionError: assert '111' == '222'
```

After this change: **12 of 12** passing.

## Tests

Three new cases in `tests/hermes_state/test_telegram_topic_binding_order.py`:

- same-tick bindings return newest first
- ordering is stable across 25 repeated reads of the same 8 rows
- an explicitly newer `updated_at` still outranks a higher `rowid`

The repeated-read case is the reliable detector — it fails on the pre-fix query (a different row leads across reads of identical data). The other two are tie-shaped and can pass by luck, which is noted in the test module docstring.

`tests/hermes_state/` passes (91). Verified this change does not affect the `list_sessions_rich` flakes seen nearby: `test_numeric_resume_fallback_uses_exact_lane_candidates` is ~50% flaky both with and without this patch (11/20 vs 8/20), for the separate reason #53811 addresses.
