### PR TITLE
Fix WhatsApp bridge port ownership cleanup

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -20,6 +20,7 @@ import logging
 import os
 import platform
 import signal
+import socket
 import subprocess
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -59,6 +60,24 @@ logger = logging.getLogger(__name__)
 # Inbound owner-typed WhatsApp text is prefixed at MessageEvent construction so
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
+
+
+def _log_bridge_port_conflict(platform_name: str, port: int) -> None:
+    """Log operator action when another listener blocks bridge startup."""
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+            pass
+    except (OSError, TypeError, ValueError, OverflowError):
+        return
+
+    logger.error(
+        "[%s] WhatsApp bridge could not start: port %d is already in use. "
+        "Hermes will not terminate the process using that port. Stop the "
+        "listener manually or configure a different WhatsApp bridge_port, "
+        "then retry.",
+        platform_name,
+        port,
+    )
 
 
 def _bridge_pid_is_ours(pid: int, session_path: Path, expected_start) -> bool:
@@ -672,6 +691,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 if self._bridge_process.poll() is not None:
                     print(f"[{self.name}] Bridge process died (exit code {self._bridge_process.returncode})")
                     print(f"[{self.name}] Check log: {self._bridge_log}")
+                    _log_bridge_port_conflict(self.name, self._bridge_port)
                     self._close_bridge_log()
                     return False
                 try:
@@ -692,6 +712,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if not http_ready:
                 print(f"[{self.name}] Bridge HTTP server did not start in 15s")
                 print(f"[{self.name}] Check log: {self._bridge_log}")
+                if self._bridge_process.poll() is not None:
+                    _log_bridge_port_conflict(self.name, self._bridge_port)
                 self._close_bridge_log()
                 return False
             
@@ -704,6 +726,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     if self._bridge_process.poll() is not None:
                         print(f"[{self.name}] Bridge process died during connection")
                         print(f"[{self.name}] Check log: {self._bridge_log}")
+                        _log_bridge_port_conflict(self.name, self._bridge_port)
                         self._close_bridge_log()
                         return False
                     try:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -19,7 +19,6 @@ import asyncio
 import logging
 import os
 import platform
-import re
 import signal
 import subprocess
 
@@ -60,82 +59,6 @@ logger = logging.getLogger(__name__)
 # Inbound owner-typed WhatsApp text is prefixed at MessageEvent construction so
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
-
-
-def _listener_pids_on_port(port: int) -> list:
-    """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
-
-    This must match only LISTEN sockets. A bare ``lsof -i :PORT`` (or
-    ``fuser PORT/tcp``) also returns *clients* whose connection merely involves
-    that port number — e.g. a browser with a tab open on a local dev server
-    sharing the port. SIGTERMing those closed the user's browser at irregular
-    intervals. Restricting to LISTEN state frees the port for a new bridge
-    without ever touching an unrelated client.
-    """
-    pids: list = []
-    try:
-        result = subprocess.run(
-            ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
-            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
-        )
-        for line in result.stdout.strip().splitlines():
-            try:
-                pids.append(int(line))
-            except ValueError:
-                pass
-        if pids:
-            return pids
-    except FileNotFoundError:
-        pass  # lsof not installed — fall through to ss
-    # Fallback: ss (iproute2, present on virtually every modern Linux).
-    try:
-        result = subprocess.run(
-            ["ss", "-ltnHp", f"sport = :{port}"],
-            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
-        )
-        for m in re.finditer(r"pid=(\d+)", result.stdout):
-            pids.append(int(m.group(1)))
-    except FileNotFoundError:
-        pass
-    return pids
-
-
-def _kill_port_process(port: int) -> None:
-    """Kill any process *listening* on the given TCP port (a stale bridge)."""
-    try:
-        if _IS_WINDOWS:
-            from hermes_cli._subprocess_compat import windows_hide_flags
-
-            # Use netstat to find the PID bound to this port, then taskkill
-            result = subprocess.run(
-                ["netstat", "-ano", "-p", "TCP"],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
-                creationflags=windows_hide_flags(),
-            )
-            for line in result.stdout.splitlines():
-                parts = line.split()
-                if len(parts) >= 5 and parts[3] == "LISTENING":
-                    local_addr = parts[1]
-                    if local_addr.endswith(f":{port}"):
-                        try:
-                            subprocess.run(
-                                ["taskkill", "/PID", parts[4], "/F"],
-                                capture_output=True, timeout=5,
-                                creationflags=windows_hide_flags(),
-                            )
-                        except subprocess.SubprocessError:
-                            pass
-        else:
-            # POSIX: only ever signal a process LISTENING on the port. A client
-            # whose connection happens to involve this port number (a browser
-            # tab on a local dev server, etc.) must never be killed.
-            for pid in _listener_pids_on_port(port):
-                try:
-                    os.kill(pid, signal.SIGTERM)
-                except (ProcessLookupError, PermissionError, OSError):
-                    pass
-    except Exception:
-        pass
 
 
 def _bridge_pid_is_ours(pid: int, session_path: Path, expected_start) -> bool:
@@ -662,9 +585,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             except Exception:
                 pass  # Bridge not running, start a new one
             
-            # Kill any orphaned bridge from a previous gateway run
+            # Stop only the orphaned bridge identified by this session's
+            # pidfile. A process merely listening on the configured port is
+            # not proof of ownership and must never be terminated.
             _kill_stale_bridge_by_pidfile(self._session_path)
-            _kill_port_process(self._bridge_port)
             await asyncio.sleep(1)
             
             # Start the bridge process in its own process group.

--- a/tests/gateway/test_whatsapp_bridge_pidfile.py
+++ b/tests/gateway/test_whatsapp_bridge_pidfile.py
@@ -17,19 +17,12 @@ import subprocess
 import sys
 import time
 
-import pytest
-
-import os
-import socket
-
 from plugins.platforms.whatsapp.adapter import (
     _bridge_pid_is_ours,
-    _kill_port_process,
     _kill_stale_bridge_by_pidfile,
-    _listener_pids_on_port,
     _write_bridge_pidfile,
 )
-from gateway.status import get_process_start_time, _pid_exists
+from gateway.status import get_process_start_time
 
 
 def _spawn_sleeper(*extra_argv) -> subprocess.Popen:
@@ -89,40 +82,3 @@ class TestIdentityGuard:
             if proc.poll() is None:
                 proc.kill()
                 proc.wait()
-
-
-class TestKillPortProcess:
-    """Freeing the bridge port must target only LISTENers, never clients.
-
-    Root cause of the live Firefox kills: ``lsof -ti :PORT`` (and ``fuser
-    PORT/tcp``) also returned *client* sockets whose connection merely involved
-    the port number. The WhatsApp bridge uses port 3000 by default — a common
-    local dev-server port — so a browser tab on ``localhost:3000`` was matched
-    and SIGTERMed every time the (crash-looping) bridge restarted.
-    """
-
-    def test_listener_lookup_excludes_client_process(self):
-        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        srv.bind(("127.0.0.1", 0))
-        port = srv.getsockname()[1]
-        srv.listen(5)
-        # A separate process holding a *client* connection to that port.
-        client = subprocess.Popen([
-            sys.executable, "-c",
-            "import socket,time; c=socket.create_connection(('127.0.0.1',%d)); time.sleep(0.2)" % port,
-        ])
-        try:
-            conn, _ = srv.accept()  # establish the client connection
-            pids = _listener_pids_on_port(port)
-            if os.getpid() not in pids:
-                pytest.skip("neither lsof nor ss detected the listener here")
-            # The listener (this process) is found; the client process is NOT —
-            # the LISTEN filter is what spares unrelated clients like a browser.
-            assert client.pid not in pids
-            conn.close()
-        finally:
-            client.kill()
-            client.wait()
-            srv.close()
-

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -13,7 +13,6 @@ Regression tests for two bugs in WhatsAppAdapter.connect():
 """
 
 import asyncio
-import signal
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -303,75 +302,6 @@ class TestBridgeRuntimeFailure:
         assert result is False
         mock_fh.close.assert_called_once()
         assert adapter._bridge_log_fh is None
-
-
-# ---------------------------------------------------------------------------
-# _kill_port_process() cross-platform tests
-# ---------------------------------------------------------------------------
-
-class TestKillPortProcess:
-    """Verify _kill_port_process uses platform-appropriate commands."""
-
-    @pytest.mark.windows_only
-    def test_uses_netstat_and_taskkill_on_windows(self):
-        """``windows_only``: netstat/taskkill are Windows binaries. The old
-        ``_IS_WINDOWS`` patch selected this branch on Linux, where neither
-        exists, so the mocked argv was the only thing under test."""
-        from plugins.platforms.whatsapp.adapter import _kill_port_process
-
-        netstat_output = (
-            "  Proto  Local Address          Foreign Address        State           PID\n"
-            "  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       12345\n"
-            "  TCP    0.0.0.0:3001           0.0.0.0:0              LISTENING       99999\n"
-        )
-        mock_netstat = MagicMock(stdout=netstat_output)
-        mock_taskkill = MagicMock()
-
-        def run_side_effect(cmd, **kwargs):
-            if cmd[0] == "netstat":
-                return mock_netstat
-            if cmd[0] == "taskkill":
-                return mock_taskkill
-            return MagicMock()
-
-        with patch("plugins.platforms.whatsapp.adapter.subprocess.run", side_effect=run_side_effect) as mock_run:
-            _kill_port_process(3000)
-
-        # netstat called
-        assert any(
-            call.args[0][0] == "netstat" for call in mock_run.call_args_list
-        )
-        # taskkill called with correct PID
-        assert any(
-            call.args[0] == ["taskkill", "/PID", "12345", "/F"]
-            for call in mock_run.call_args_list
-        )
-
-
-    @pytest.mark.linux_only
-    def test_kills_only_listeners_on_linux(self):
-        """POSIX path SIGTERMs only LISTENer PIDs (never clients) — the #43846 fix.
-
-        Replaces the old fuser-based test: ``fuser``/bare ``lsof -i`` also
-        matched client sockets sharing the port number, which closed unrelated
-        processes (a browser tab on the same port). The implementation now
-        resolves listeners via ``_listener_pids_on_port`` and signals only those.
-
-        ``linux_only``: asserts the POSIX ``os.kill``/SIGTERM path, which is
-        genuinely selected here without patching ``_IS_WINDOWS``.
-        """
-        from plugins.platforms.whatsapp import adapter as wa
-
-        kills = []
-        with patch("plugins.platforms.whatsapp.adapter._listener_pids_on_port",
-                   return_value=[55555]) as mock_listeners, \
-             patch("plugins.platforms.whatsapp.adapter.os.kill",
-                   side_effect=lambda pid, sig: kills.append((pid, sig))):
-            wa._kill_port_process(3000)
-
-        mock_listeners.assert_called_once_with(3000)
-        assert kills == [(55555, signal.SIGTERM)]
-
 
 # ---------------------------------------------------------------------------
 # Persistent HTTP session lifecycle

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -154,8 +154,10 @@ class TestStaleBridgeHandshake:
 
     @pytest.mark.asyncio
     @pytest.mark.linux_only
-    async def test_foreign_listener_on_bridge_port_survives_connect(self, tmp_path):
-        """Bridge bootstrap must never terminate an unrelated port owner."""
+    async def test_foreign_listener_on_bridge_port_survives_connect(
+        self, tmp_path, caplog
+    ):
+        """An unrelated port owner survives and produces manual recovery help."""
         bridge_dir = _setup_bridge_dir(tmp_path)
         _fresh_node_modules(bridge_dir)
         adapter = _make_adapter(
@@ -197,10 +199,6 @@ class TestStaleBridgeHandshake:
             ), patch(
                 "plugins.platforms.whatsapp.adapter.subprocess.Popen",
                 return_value=failed_bridge,
-            ), patch(
-                "plugins.platforms.whatsapp.adapter._listener_pids_on_port",
-                return_value=[listener.pid],
-                create=True,
             ), patch.object(
                 adapter,
                 "_acquire_platform_lock",
@@ -211,6 +209,9 @@ class TestStaleBridgeHandshake:
 
             assert result is False
             assert listener.poll() is None
+            assert f"port {adapter._bridge_port} is already in use" in caplog.text
+            assert "Hermes will not terminate the process" in caplog.text
+            assert "Stop the listener manually" in caplog.text
         finally:
             listener.terminate()
             try:

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -17,6 +17,8 @@ package.json changes, not only when node_modules is missing.
 """
 
 import asyncio
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -144,12 +146,78 @@ class TestStaleBridgeHandshake:
              patch("aiohttp.ClientSession", mock_client), \
              patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
              patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
-             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
              patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
              patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
             await adapter.connect()
 
         mock_popen.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.linux_only
+    async def test_foreign_listener_on_bridge_port_survives_connect(self, tmp_path):
+        """Bridge bootstrap must never terminate an unrelated port owner."""
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+
+        listener = subprocess.Popen(
+            [
+                sys.executable,
+                "-u",
+                "-c",
+                (
+                    "from http.server import ThreadingHTTPServer,"
+                    "SimpleHTTPRequestHandler;"
+                    "server=ThreadingHTTPServer(('127.0.0.1',0),"
+                    "SimpleHTTPRequestHandler);"
+                    "print(server.server_port,flush=True);"
+                    "server.serve_forever()"
+                ),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        try:
+            assert listener.stdout is not None
+            adapter._bridge_port = int(listener.stdout.readline().strip())
+
+            failed_bridge = MagicMock()
+            failed_bridge.poll.return_value = 1
+            failed_bridge.returncode = 1
+            with patch(
+                "plugins.platforms.whatsapp.adapter.check_whatsapp_requirements",
+                return_value=True,
+            ), patch(
+                "plugins.platforms.whatsapp.adapter.asyncio.sleep",
+                new_callable=AsyncMock,
+            ), patch(
+                "plugins.platforms.whatsapp.adapter.subprocess.Popen",
+                return_value=failed_bridge,
+            ), patch(
+                "plugins.platforms.whatsapp.adapter._listener_pids_on_port",
+                return_value=[listener.pid],
+                create=True,
+            ), patch.object(
+                adapter,
+                "_acquire_platform_lock",
+                return_value=True,
+                create=True,
+            ):
+                result = await adapter.connect()
+
+            assert result is False
+            assert listener.poll() is None
+        finally:
+            listener.terminate()
+            try:
+                listener.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                listener.kill()
+                listener.wait(timeout=5)
 
 
 class TestDepRefreshStamp:
@@ -169,7 +237,6 @@ class TestDepRefreshStamp:
              patch("aiohttp.ClientSession", _mock_health({"status": "disconnected"})), \
              patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
              patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
-             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
              patch("subprocess.run") as mock_run, \
              patch("subprocess.Popen", return_value=mock_proc), \
              patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
@@ -196,7 +263,6 @@ class TestCacheDirEnvPassthrough:
              patch("aiohttp.ClientSession", _mock_health({"status": "disconnected"})), \
              patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
              patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
-             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
              patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
              patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
             await adapter.connect()


### PR DESCRIPTION
## Summary

- remove every code path that terminates a process merely because it owns the configured WhatsApp bridge port
- retain cleanup only for a bridge recorded by the session PID file and revalidated by process start time (or strict legacy command-line identity)
- add a real-process regression proving an unrelated HTTP listener survives bridge startup

## Why

A configured port collision caused the WhatsApp reconnect loop to kill an unrelated Next.js service every five minutes. A port number is not proof that Hermes owns the listener.

## Validation

- rebased onto current upstream `ed5e17f4b86da0c4f09c0694757b6074ae6b9d16`
- all 17 WhatsApp gateway test files: 115 passed, 1 expected Windows-only skip
- focused Ruff check and `git diff --check`
- merge-tree against the current base is clean
- live old-base fix was separately canaried through three real 301-second collision cycles; the foreign website PID survived and its public routes stayed healthy

No platform API or message behavior changes.