### PR TITLE
fix(delegation): use prompt occupancy for summary budgets

### DIFF
--- a/tests/tools/test_delegate_summary_budget.py
+++ b/tests/tools/test_delegate_summary_budget.py
@@ -16,15 +16,18 @@ import tools.delegate_tool as dt
 
 
 class _FakeCompressor:
-    def __init__(self, context_length, max_tokens):
+    def __init__(self, context_length, max_tokens, last_real_prompt_tokens):
         self.context_length = context_length
         self.max_tokens = max_tokens
+        self.last_real_prompt_tokens = last_real_prompt_tokens
 
 
 class _FakeParent:
-    def __init__(self, context_length, used_tokens, max_tokens):
-        self.context_compressor = _FakeCompressor(context_length, max_tokens)
-        self.session_prompt_tokens = used_tokens
+    def __init__(self, context_length, used_tokens, max_tokens, session_prompt_tokens=None):
+        self.context_compressor = _FakeCompressor(context_length, max_tokens, used_tokens)
+        self.session_prompt_tokens = (
+            used_tokens if session_prompt_tokens is None else session_prompt_tokens
+        )
 
 
 def test_small_summaries_pass_through_untouched():
@@ -76,3 +79,23 @@ def test_empty_results_is_noop():
         [{"task_index": 0, "status": "failed", "summary": None}],
         _FakeParent(131_000, 1_000, 8_000),
     )
+
+
+def test_cumulative_session_tokens_do_not_trigger_floor(monkeypatch):
+    monkeypatch.setattr(dt, "_load_config", lambda: {"max_summary_chars": 0})
+    parent = _FakeParent(
+        context_length=1_000_000,
+        used_tokens=143_000,
+        max_tokens=8_000,
+        session_prompt_tokens=11_090_000,
+    )
+    results = [
+        {"task_index": 0, "summary": "A" * 5_900, "status": "completed"},
+        {"task_index": 1, "summary": "B" * 3_900, "status": "completed"},
+    ]
+
+    dt._apply_summary_budget(results, parent)
+
+    assert dt._parent_summary_char_budget(parent, len(results)) > 5_900
+    assert results[0]["summary"] == "A" * 5_900
+    assert results[1]["summary"] == "B" * 3_900

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1998,7 +1998,10 @@ def _parent_summary_char_budget(parent_agent, n_summaries: int) -> Optional[int]
         if not isinstance(context_length, int) or context_length <= 0:
             return None
 
-        used_tokens = getattr(parent_agent, "session_prompt_tokens", 0)
+        # session_prompt_tokens is a cumulative billing counter, including
+        # cache hits. The compressor tracks the provider-reported occupancy of
+        # the current prompt separately.
+        used_tokens = getattr(compressor, "last_real_prompt_tokens", 0)
         if not isinstance(used_tokens, (int, float)) or used_tokens < 0:
             used_tokens = 0
 


### PR DESCRIPTION
## What does this PR do?

Fixes delegate-task summary sizing in long cached sessions. The budget now reads `context_compressor.last_real_prompt_tokens`, the provider-reported occupancy of the current prompt, instead of the cumulative `session_prompt_tokens` billing counter. This prevents healthy 1M-context sessions from collapsing every subagent summary to the 2,000-character floor after cache-hit usage accumulates.

## Related Issue

Fixes #84020

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py`: calculate dynamic summary headroom from the compressor's latest real prompt-token measurement.
- `tests/tools/test_delegate_summary_budget.py`: model current occupancy separately from cumulative usage and cover the long cached-session regression.

## How to Test

1. Run `source "$VIRTUAL_ENV/bin/activate" && /opt/homebrew/bin/timeout -k 30 480 pytest tests/tools/test_delegate_summary_budget.py -q --timeout=60`.
2. Run `source "$VIRTUAL_ENV/bin/activate" && /opt/homebrew/bin/timeout -k 30 480 pytest tests/tools/test_delegate*.py tests/tools/test_async_delegation.py tests/tools/test_delegation_live_log.py -q -x --timeout=60` (164 passed locally).
3. Run `source "$VIRTUAL_ENV/bin/activate" && /opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`; local collection stops at the unrelated `tests/gateway/test_teams.py` optional-dependency assertion before delegation tests execute.
4. Run `python scripts/check-windows-footguns.py` and `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

Not applicable.

## Screenshots / Logs

`164 passed in 39.79s` for the delegate integration coverage.

The full suite was attempted with the configured bounded command but stopped at `tests/gateway/test_teams.py` during collection because the local Teams optional dependency check returned false.

<!-- autocontrib:worker-id=issue-new-f6153fa1 kind=pr-open -->