### PR TITLE
fix(approval): enforce explicit timeout on smart-approval guardian call and log its outcome

### DIFF
--- a/tests/tools/test_smart_approval_policy.py
+++ b/tests/tools/test_smart_approval_policy.py
@@ -110,5 +110,47 @@ class TestSmartApprovePolicyInjection(unittest.TestCase):
         assert _smart_approve("echo hi", "flagged") == "escalate"
 
 
+    @patch("agent.auxiliary_client._get_task_timeout")
+    @patch("tools.approval._get_approval_config")
+    @patch("agent.auxiliary_client.call_llm")
+    def test_smart_approve_passes_explicit_timeout(
+        self, mock_call_llm, mock_cfg, mock_task_timeout
+    ):
+        """Regression for #82846: the guardian call must pass an explicit
+        timeout instead of relying on the default resolution inside call_llm
+        (a defeated internal timeout silently froze agent turns in
+        production). The explicit value must equal what
+        auxiliary.approval.timeout resolves to."""
+        mock_call_llm.return_value = _make_response("APPROVE")
+        mock_cfg.return_value = {"mode": "smart"}
+        mock_task_timeout.return_value = 42.0
+
+        assert _smart_approve("echo hi", "flagged") == "approve"
+        _, kwargs = mock_call_llm.call_args
+        assert kwargs.get("timeout") == 42.0
+
+
+    @patch("tools.approval._get_approval_config")
+    @patch("agent.auxiliary_client.call_llm")
+    def test_smart_approve_failure_logs_warning_and_escalates(
+        self, mock_call_llm, mock_cfg
+    ):
+        """A failed/blocked guardian call must surface as a WARNING with the
+        elapsed time (not a silent DEBUG) — #82846's hang was invisible
+        precisely because nothing logged at the failure point."""
+        from unittest.mock import patch
+
+        mock_call_llm.side_effect = TimeoutError("stalled provider")
+        mock_cfg.return_value = {"mode": "smart"}
+
+        with patch("tools.approval.logger") as mock_logger:
+            assert _smart_approve("echo hi", "flagged") == "escalate"
+
+        assert mock_logger.warning.called
+        args, _ = mock_logger.warning.call_args
+        assert "Smart approvals: LLM call failed" in args[0]
+        assert "TimeoutError" in str(args)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3070,8 +3070,22 @@ def _smart_approve(command: str, description: str) -> str:
     Inspired by OpenAI Codex's Smart Approvals guardian subagent
     (openai/codex#13860).
     """
+    _smart_t0 = time.monotonic()
     try:
-        from agent.auxiliary_client import call_llm
+        from agent.auxiliary_client import _get_task_timeout, call_llm
+
+        # Explicit timeout for the guardian call. This synchronous call gates
+        # EVERY flagged terminal command — relying on the timeout being
+        # resolved correctly inside call_llm has burned users in production:
+        # a stalled provider response silently froze the agent turn for tens
+        # of minutes with zero log output (#82846, #72500). Pass the same
+        # configured value explicitly (belt) and log the call + duration
+        # (suspenders) so a hang is visible in the logs instead of silent.
+        smart_timeout = _get_task_timeout("approval")
+        logger.debug(
+            "Smart approvals: assessing risk for command (timeout=%ss)",
+            smart_timeout,
+        )
 
         # Strip shell comments to remove the easiest injection vector.
         sanitized_command = _strip_shell_comments(command)
@@ -3128,6 +3142,11 @@ def _smart_approve(command: str, description: str) -> str:
             ],
             temperature=0,
             max_tokens=16,
+            timeout=smart_timeout,
+        )
+        logger.debug(
+            "Smart approvals: LLM call completed in %.1fs",
+            time.monotonic() - _smart_t0,
         )
 
         answer = (response.choices[0].message.content or "").strip().upper()
@@ -3140,7 +3159,15 @@ def _smart_approve(command: str, description: str) -> str:
             return "escalate"
 
     except Exception as e:
-        logger.debug("Smart approvals: LLM call failed (%s), escalating", e)
+        # WARNING (was DEBUG): a failed/blocked guardian call is a real event
+        # the operator needs to see — the whole point of #82846 is that the
+        # hang was invisible. Log the elapsed time and error class too.
+        logger.warning(
+            "Smart approvals: LLM call failed after %.1fs (%s: %s), escalating",
+            time.monotonic() - _smart_t0,
+            type(e).__name__,
+            e,
+        )
         return "escalate"
 
 


### PR DESCRIPTION
Complements #72500 (watchdog hard ceiling) — root-cause hardening + observability for the smart-approval guardian call, both gaps the watchdog fix leaves open.

## Bug Description

`_smart_approve` (tools/approval.py:3054) gates every flagged terminal command with a **synchronous auxiliary LLM call** that (a) never passes an explicit `timeout=` and (b) logs nothing on the success path and only `logger.debug` on failure. When a provider response stalls, the agent turn freezes **silently** — our production hit froze for 62 minutes with zero log output; the gateway kill-switch eventually fired and only an unrelated lifecycle-guard error surfaced afterwards (2026-08-11, Feishu gateway, approvals smart mode, DeepSeek latency spike). See #82846 for the full symptom.

## Root Cause

`call_llm` resolves its own timeout from config (`auxiliary.approval.timeout`, default 30s), but `_smart_approve` relies on that default *silently* — no explicit deadline at the call site, and nothing visible in the logs. #72500 addresses the hang with an outer watchdog thread (45s ceiling), but:
1. the call site still doesn't pass `timeout=` — the root cause (internal deadline not enforced at the call boundary) stays,
2. a normal-path failure remains logged at DEBUG, so the "invisible hang" observability hole from #82846 persists for any non-timeout failure.

## Fix

- `tools/approval.py` — resolve the same configured value the client would use (`_get_task_timeout("approval")`, honoring `auxiliary.approval.timeout`) and pass it **explicitly** to `call_llm`; log the assessment call + duration (DEBUG); promote failure logging from DEBUG to **WARNING** with elapsed time and exception class.
- Behavior unchanged on success/failure paths: timeout/failure still returns `"escalate"` (fail open to the human/pattern gate).

## How to Verify

```bash
PYTHONPATH=. python -m pytest tests/tools/test_smart_approval_policy.py -q -k "explicit_timeout or logs_warning"
```

- `test_smart_approve_passes_explicit_timeout` — asserts `call_llm` receives `timeout=42` when `auxiliary.approval.timeout` resolves to 42. **Verified as a genuine regression**: removing the `timeout=` kwarg makes the test fail.
- `test_smart_approve_failure_logs_warning_and_escalates` — asserts a `TimeoutError` from `call_llm` yields `"escalate"` and a WARNING containing the failure prefix + exception class.

## Test Plan

- `tests/tools/test_smart_approval_policy.py` — 7 passed
- `test_smart_approval_injection.py`, `test_approval_interrupt.py`, `test_execute_code_approval_cluster.py`, `test_denial_circuit_breaker.py` — 42 more passed (49 total)
- One unrelated failure in `test_approval.py::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous` is **pre-existing** (fails on clean main, unrelated to this change)

## Risk Assessment

**Low.** No new dependencies, no thread/context changes (unlike the watchdog approach — this stays on the calling thread). The timeout value is the same one `call_llm` would resolve internally; passing it explicitly only removes the reliance on internal defaulting. Logging level change (DEBUG→WARNING) affects only observability.
