### PR TITLE
fix(retry): ride out transient OpenAI Codex-backend failures with adaptive long backoff + recovery compact

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -81,6 +81,8 @@ from agent.prompt_caching import (
 )
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
+    codex_backend_transient_retry_ceiling,
+    is_codex_backend_transient_error,
     is_zai_coding_overload_error,
     jittered_backoff,
     zai_coding_overload_retry_ceiling,
@@ -4810,6 +4812,21 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                # OpenAI Codex-backend transient failures ("servers currently
+                # overloaded" / generic request-ID error / genuine 5xx) get the
+                # same adaptive treatment as the Z.AI overload above. The
+                # fallback chain usually points at the same Codex backend (and
+                # is skipped), so riding out the transient window on the
+                # long-backoff tier is the recovery that actually works. See
+                # codex_backend_transient_retry_ceiling() for the ceiling
+                # rationale.
+                _is_codex_backend_transient = is_codex_backend_transient_error(
+                    base_url=str(_base), error=api_error
+                )
+                if _is_codex_backend_transient:
+                    max_retries = max(
+                        max_retries, codex_backend_transient_retry_ceiling()
+                    )
                 _should_fallback = (
                     is_rate_limited
                     or (_is_transport_failure and retry_count >= 2)
@@ -5709,6 +5726,50 @@ def run_conversation(
                         agent._fallback_index = 0
                         agent._fallback_activated = False
                         continue
+
+                    # ── Transient-error recovery compact ──────────────────
+                    # The local compressor stays the recovery rail even with
+                    # native (server-side) compaction active. After exhausting
+                    # retries on a transient Codex backend error, force one
+                    # local compression pass and restart the attempt cycle
+                    # with a smaller request before trying fallback/terminal:
+                    # a materially smaller request retries later with a fresh
+                    # backoff budget and is likelier to dodge the overloaded
+                    # path. One-shot per API call block. A no-op compact (aux
+                    # LLM unreachable — often the same backend — or
+                    # compression disabled or breaker-blocked) falls through
+                    # to the existing fallback/terminal handling unchanged.
+                    if (
+                        _is_codex_backend_transient
+                        and not _retry.transient_recovery_compact_attempted
+                        and getattr(agent, "compression_enabled", True)
+                    ):
+                        _retry.transient_recovery_compact_attempted = True
+                        agent._buffer_status(
+                            "🗜️ Provider keeps failing — compacting context "
+                            "locally and retrying with a smaller request..."
+                        )
+                        _pre_recovery_len = len(messages)
+                        _pre_recovery_tokens = estimate_messages_tokens_rough(messages)
+                        messages, active_system_prompt = agent._compress_context(
+                            messages, system_message,
+                            approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                            task_id=effective_task_id,
+                        )
+                        conversation_history = conversation_history_after_compression(
+                            agent, messages, conversation_history
+                        )
+                        _post_recovery_tokens = estimate_messages_tokens_rough(messages)
+                        if len(messages) < _pre_recovery_len or (
+                            _post_recovery_tokens > 0
+                            and _post_recovery_tokens < _pre_recovery_tokens * 0.95
+                        ):
+                            time.sleep(2)
+                            _retry.restart_with_compressed_messages = True
+                            break
+                        # Compact didn't shrink the request — fall through to
+                        # fallback/terminal handling below.
+
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
@@ -5912,7 +5973,7 @@ def run_conversation(
                                 pass
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
-                if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
+                if (is_rate_limited or _is_zai_coding_overload or _is_codex_backend_transient) and not _retry_after:
                     wait_time, _backoff_policy = adaptive_rate_limit_backoff(
                         retry_count,
                         base_url=str(_base),
@@ -5920,18 +5981,27 @@ def run_conversation(
                         error=api_error,
                         default_wait=wait_time,
                     )
-                if is_rate_limited or _is_zai_coding_overload:
+                if is_rate_limited or _is_zai_coding_overload or _is_codex_backend_transient:
                     _policy_note = ""
                     if _backoff_policy == "zai_coding_overload_long":
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"
                     elif _backoff_policy == "zai_coding_overload_short":
                         _policy_note = " (Z.AI Coding overload short retry)"
-                    _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
+                    elif _backoff_policy == "codex_backend_transient_long":
+                        _policy_note = " (Codex backend transient adaptive long backoff)"
+                    elif _backoff_policy == "codex_backend_transient_short":
+                        _policy_note = " (Codex backend transient short retry)"
+                    _wait_reason = (
+                        "Provider overloaded"
+                        if (_is_zai_coding_overload or _is_codex_backend_transient)
+                        and not is_rate_limited
+                        else "Rate limited"
+                    )
                     _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
                     # Normal retries are buffered to avoid noisy transient chatter. Long
-                    # Z.AI Coding waits are different: they can last minutes, so surface
+                    # adaptive waits are different: they can last minutes, so surface
                     # progress immediately instead of making the TUI look frozen.
-                    if _backoff_policy == "zai_coding_overload_long":
+                    if _backoff_policy in ("zai_coding_overload_long", "codex_backend_transient_long"):
                         agent._emit_status(_rate_limit_status)
                     else:
                         agent._buffer_status(_rate_limit_status)

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -34,6 +34,19 @@ _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 # the two from silently desyncing if the short-retry count is ever tuned.
 _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
 
+# OpenAI's Codex subscription backend (chatgpt.com/backend-api/codex) fails
+# transiently under load with HTTP-status-less APIErrors — "Our servers are
+# currently overloaded. Please try again later." or a generic "An error
+# occurred while processing your request ... request ID ...". These clear on
+# their own within minutes, but the default 3 short retries (~2/4/8s) give up
+# long before that window closes, and the fallback chain usually points at the
+# same Codex backend (so it is skipped) — the turn then dies with a
+# user-visible provider failure. Mirror the Z.AI overload handling: keep the
+# short retries, then progressively widen the wait. Cap total added wait
+# around ~3 minutes so interactive sessions still fail visibly rather than
+# sitting silent.
+_CODEX_BACKEND_TRANSIENT_LONG_BACKOFF = (15.0, 30.0, 60.0, 90.0)
+
 
 def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     """Parse a ``Retry-After`` value into non-negative seconds.
@@ -159,6 +172,29 @@ def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, err
     )
 
 
+def is_codex_backend_transient_error(*, base_url: str | None, error: Any) -> bool:
+    """Return True for transient OpenAI Codex-backend failures worth extended retries.
+
+    The Codex subscription backend reports transient trouble either as an
+    explicit overload message or as a generic "An error occurred while
+    processing your request" with a request ID — both typically without a
+    usable HTTP status on the wrapped APIError. Genuine 5xx statuses on the
+    same backend qualify too. Auth, quota and other 4xx shapes keep their
+    normal fast-fail paths.
+    """
+    base = (base_url or "").lower()
+    if "chatgpt.com/backend-api" not in base:
+        return False
+    status = getattr(error, "status_code", None)
+    if isinstance(status, int):
+        return status >= 500
+    text = _error_text(error)
+    return (
+        "currently overloaded" in text
+        or "an error occurred while processing your request" in text
+    )
+
+
 def adaptive_rate_limit_backoff(
     attempt: int,
     *,
@@ -171,24 +207,31 @@ def adaptive_rate_limit_backoff(
     """Provider-aware rate-limit backoff.
 
     For most providers this returns ``default_wait`` unchanged. For Z.AI
-    Coding Plan GLM-5.2 overloads, keep the first ``short_attempts`` retries on
-    the normal short exponential schedule, then switch to progressively longer
-    waits (30s → 60s → 90s → 120s, capped) plus light jitter.
+    Coding Plan GLM-5.2 overloads and transient OpenAI Codex-backend failures,
+    keep the first ``short_attempts`` retries on the normal short exponential
+    schedule, then switch to progressively longer waits (per-provider long
+    table, capped) plus light jitter.
 
     ``attempt`` is 1-based, matching the retry loop's logged attempt number.
     Returns ``(wait_seconds, reason_label)`` where ``reason_label`` is suitable
     for status/log decoration when a provider-specific policy fired.
     """
-    if not is_zai_coding_overload_error(base_url=base_url, model=model, error=error):
+    if is_zai_coding_overload_error(base_url=base_url, model=model, error=error):
+        long_table = _ZAI_CODING_OVERLOAD_LONG_BACKOFF
+        label = "zai_coding_overload"
+    elif is_codex_backend_transient_error(base_url=base_url, error=error):
+        long_table = _CODEX_BACKEND_TRANSIENT_LONG_BACKOFF
+        label = "codex_backend_transient"
+    else:
         return default_wait, None
     if attempt <= short_attempts:
-        return default_wait, "zai_coding_overload_short"
+        return default_wait, f"{label}_short"
 
-    idx = min(attempt - short_attempts - 1, len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) - 1)
-    base_delay = _ZAI_CODING_OVERLOAD_LONG_BACKOFF[idx]
+    idx = min(attempt - short_attempts - 1, len(long_table) - 1)
+    base_delay = long_table[idx]
     # A smaller jitter ratio keeps long waits readable while still avoiding
     # synchronized retry storms across concurrent Hermes sessions.
-    return jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2), "zai_coding_overload_long"
+    return jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2), f"{label}_long"
 
 
 def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS) -> int:
@@ -206,3 +249,14 @@ def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD
     value for Z.AI Coding overload 429s so the 30/60/90/120s waits run.
     """
     return short_attempts + len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) + 1
+
+
+def codex_backend_transient_retry_ceiling(
+    short_attempts: int = _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS,
+) -> int:
+    """Retry-loop ceiling for the full Codex-backend transient backoff schedule.
+
+    Same shape as ``zai_coding_overload_retry_ceiling`` — see that docstring
+    for why the ceiling must sit one past the final long-backoff entry.
+    """
+    return short_attempts + len(_CODEX_BACKEND_TRANSIENT_LONG_BACKOFF) + 1

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -67,6 +67,13 @@ class TurnRetryState:
     # ── Transport / rate-limit recovery ──────────────────────────────────
     primary_recovery_attempted: bool = False
     has_retried_429: bool = False
+    # One-shot forced local compression after exhausting retries on a
+    # transient Codex-backend error (overload / 5xx-shaped APIError). The
+    # fallback chain usually points at the same backend and is skipped, so a
+    # materially smaller request retried with a fresh backoff budget is the
+    # recovery rail of last resort (local compressor stays active alongside
+    # native server-side compaction).
+    transient_recovery_compact_attempted: bool = False
 
     # ── Auth-failure provider failover ───────────────────────────────────
     # Set once we've escalated a persistent 401/403 (after the per-provider

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -30,6 +30,7 @@ EXPECTED_FIELDS = {
     "llama_cpp_grammar_retry_attempted",
     "primary_recovery_attempted",
     "has_retried_429",
+    "transient_recovery_compact_attempted",
     "auth_failover_attempted",
     "restart_with_compressed_messages",
     "restart_with_length_continuation",

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -170,6 +170,110 @@ def test_zai_overload_ceiling_makes_long_tier_reachable(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Codex-backend transient errors — detection, ceiling, adaptive long backoff
+# ---------------------------------------------------------------------------
+
+_CODEX_BASE = "https://chatgpt.com/backend-api/codex"
+
+
+def _codex_error(message, status_code=None):
+    return SimpleNamespace(status_code=status_code, message=message)
+
+
+class TestCodexBackendTransient:
+    def test_detects_overload_message(self):
+        from agent.retry_utils import is_codex_backend_transient_error
+        err = _codex_error("Our servers are currently overloaded. Please try again later.")
+        assert is_codex_backend_transient_error(base_url=_CODEX_BASE, error=err)
+
+    def test_detects_generic_request_id_error(self):
+        from agent.retry_utils import is_codex_backend_transient_error
+        err = _codex_error(
+            "An error occurred while processing your request. You can retry "
+            "your request, or contact us through our help center at "
+            "help.openai.com if the error persists. Please include the "
+            "request ID d418eb1e-b6b1-4e70-8f50-4a01d752e4f7 in your message."
+        )
+        assert is_codex_backend_transient_error(base_url=_CODEX_BASE, error=err)
+
+    def test_detects_5xx_status_regardless_of_text(self):
+        from agent.retry_utils import is_codex_backend_transient_error
+        err = _codex_error("upstream hiccup", status_code=503)
+        assert is_codex_backend_transient_error(base_url=_CODEX_BASE, error=err)
+
+    def test_rejects_other_base_url(self):
+        from agent.retry_utils import is_codex_backend_transient_error
+        err = _codex_error("Our servers are currently overloaded.")
+        assert not is_codex_backend_transient_error(
+            base_url="https://api.openai.com/v1", error=err
+        )
+
+    def test_rejects_4xx_status_even_with_matching_text(self):
+        """A 4xx on the Codex backend is auth/quota/validation territory —
+        it must keep its fast-fail path even if the body text looks
+        transient."""
+        from agent.retry_utils import is_codex_backend_transient_error
+        err = _codex_error("Our servers are currently overloaded.", status_code=429)
+        assert not is_codex_backend_transient_error(base_url=_CODEX_BASE, error=err)
+
+    def test_rejects_unrelated_statusless_error(self):
+        from agent.retry_utils import is_codex_backend_transient_error
+        err = _codex_error("Invalid prompt: your input violates our usage policy.")
+        assert not is_codex_backend_transient_error(base_url=_CODEX_BASE, error=err)
+
+    def test_ceiling_exceeds_short_attempts(self):
+        """Same invariant as the Z.AI ceiling: give-up check runs before the
+        attempt's backoff, so the ceiling must leave headroom for every
+        long-backoff entry to execute."""
+        from agent.retry_utils import (
+            codex_backend_transient_retry_ceiling,
+            _CODEX_BACKEND_TRANSIENT_LONG_BACKOFF,
+        )
+        short_attempts = 3
+        ceiling = codex_backend_transient_retry_ceiling(short_attempts)
+        assert ceiling > short_attempts
+        assert (ceiling - 1) - short_attempts >= len(_CODEX_BACKEND_TRANSIENT_LONG_BACKOFF)
+
+    def test_ceiling_makes_long_tier_reachable(self, monkeypatch):
+        """With the extended ceiling, the retry loop's attempt range walks the
+        entire long-backoff schedule."""
+        monkeypatch.setattr(retry_utils, "jittered_backoff", lambda *a, **kw: kw["base_delay"])
+        from agent.retry_utils import codex_backend_transient_retry_ceiling
+
+        err = _codex_error("Our servers are currently overloaded.")
+        ceiling = codex_backend_transient_retry_ceiling()
+
+        short_waits, long_waits = [], []
+        for attempt in range(1, ceiling):
+            _wait, policy = adaptive_rate_limit_backoff(
+                attempt,
+                base_url=_CODEX_BASE,
+                model="gpt-5.6-sol",
+                error=err,
+                default_wait=1.0,
+            )
+            if policy == "codex_backend_transient_long":
+                long_waits.append(_wait)
+            elif policy == "codex_backend_transient_short":
+                short_waits.append(_wait)
+
+        assert len(short_waits) == 3
+        assert long_waits == [15.0, 30.0, 60.0, 90.0]
+
+    def test_adaptive_backoff_untouched_for_other_providers(self):
+        err = _codex_error("Our servers are currently overloaded.")
+        wait, policy = adaptive_rate_limit_backoff(
+            5,
+            base_url="https://api.openai.com/v1",
+            model="gpt-5.6-sol",
+            error=err,
+            default_wait=7.5,
+        )
+        assert wait == 7.5
+        assert policy is None
+
+
+# ---------------------------------------------------------------------------
 # parse_retry_after_seconds — shared Retry-After parser
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

During the 2026-08-11 OpenAI incident ("Increased errors on API, Codex and Work Mode"), sessions and cron jobs on the `openai-codex` provider died with user-visible failures:

```
ERROR agent.conversation_loop: API call failed after 3 retries. An error occurred while
processing your request. ... | provider=openai-codex model=gpt-5.6-sol
```

The Codex subscription backend (`chatgpt.com/backend-api/codex`) reports transient trouble as HTTP-status-less APIErrors — "Our servers are currently overloaded. Please try again later." or a generic "An error occurred while processing your request ... request ID ...". These clear on their own within minutes, but:

1. The default 3 short retries (~2/4/8s, ~25s total) give up long before the transient window closes.
2. The fallback chain usually points at the same Codex backend, so `_try_activate_fallback` is skipped and the turn dies.
3. No recovery compaction fires — the retry-exhaustion path goes straight from transport recovery to fallback to terminal error.

## Fix

Mirrors the existing Z.AI Coding overload pattern (`is_zai_coding_overload_error` / `zai_coding_overload_retry_ceiling` / `adaptive_rate_limit_backoff`):

- **`is_codex_backend_transient_error()`**: narrow detection — Codex backend base URL AND (5xx status, or status-less error matching the two observed transient messages). 4xx keeps its fast-fail path even with matching text.
- **Extended retry ceiling (8) + adaptive long backoff (15/30/60/90s after the 3 short retries)** so the retry loop can actually ride out a multi-minute transient window. Long waits are surfaced immediately (`_emit_status`) like the Z.AI long tier.
- **One-shot recovery compact on exhaustion**: before trying fallback/terminal, force one local compression pass and restart the attempt cycle with a smaller request and a fresh backoff budget. A no-op compact (compression disabled, breaker-blocked, or aux LLM on the same failing backend) falls through to the existing handling unchanged. Guarded by a new `TurnRetryState.transient_recovery_compact_attempted` field.

## Tests

- `tests/test_retry_utils.py`: detection (both observed messages, 5xx, wrong-base-URL and 4xx negatives), ceiling-reachability invariant, full long-tier walk `[15, 30, 60, 90]`, other-provider passthrough.
- `tests/agent/test_turn_retry_state.py`: field contract updated.
- `tests/run_agent/ -k "retry or fallback or compress"`: 253 passed.

https://claude.ai/code/session_015DhWCNydj447oF3EkkFgeL
