### PR TITLE
fix(desktop): localize update dialog changelog group headers

### DIFF
--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -221,7 +221,17 @@ function IdleView({
     )
   }
 
-  const groups = buildCommitChangelog(commits)
+  const groups = buildCommitChangelog(commits, {
+    labels: {
+      new: u.changeLogNew,
+      fixed: u.changeLogFixed,
+      faster: u.changeLogFaster,
+      improved: u.changeLogImproved,
+      other: u.changeLogOther
+    },
+    fallback: { label: u.changeLogFallbackLabel, item: u.changeLogFallbackItem }
+  })
+
   const shownItems = totalItems(groups)
   const remaining = Math.max(0, behind - shownItems)
 
@@ -243,7 +253,7 @@ function IdleView({
       <div className="grid gap-3">
         {groups.map(group => (
           <div key={group.id}>
-            <p className="text-[0.625rem] font-semibold uppercase tracking-wide text-muted-foreground">{group.label}</p>
+            <p className="text-[0.625rem] font-semibold text-muted-foreground">{group.label}</p>
             <ul className="mt-1.5 grid gap-1.5 text-xs text-foreground">
               {group.items.map(item => (
                 <li className="flex items-start gap-2" key={item}>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1880,6 +1880,13 @@ export const ar = defineLocale({
     errorTitle: 'لم يكتمل التحديث',
     errorBody: 'لا داعي للقلق — لم يُفقد شيء. يمكنك إعادة المحاولة الآن.',
     notNow: 'ليس الآن',
+    changeLogNew: 'جديد',
+    changeLogFixed: 'إصلاحات',
+    changeLogFaster: 'أسرع',
+    changeLogImproved: 'تحسينات',
+    changeLogOther: 'تحسينات أخرى',
+    changeLogFallbackLabel: 'في هذا التحديث',
+    changeLogFallbackItem: 'تحسينات وإصلاحات',
     applyStatus: {
       preparing: 'جار تحديث الواجهة الخلفية...',
       pulling: 'جار تحديث الواجهة الخلفية...',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2243,6 +2243,13 @@ export const en: Translations = {
     errorTitle: 'Update didn’t finish',
     errorBody: 'No worries — nothing was lost. You can try again now.',
     notNow: 'Not now',
+    changeLogNew: "What's new",
+    changeLogFixed: 'Fixed',
+    changeLogFaster: 'Faster',
+    changeLogImproved: 'Improved',
+    changeLogOther: 'Other improvements',
+    changeLogFallbackLabel: 'In this update',
+    changeLogFallbackItem: 'Improvements and fixes',
     applyStatus: {
       preparing: 'Updating backend…',
       pulling: 'Backend updating…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2060,6 +2060,13 @@ export const ja = defineLocale({
     errorTitle: '更新が完了しませんでした',
     errorBody: 'ご安心ください。何も失われていません。今すぐ再試行できます。',
     notNow: '今は後で',
+    changeLogNew: '新機能',
+    changeLogFixed: '修正',
+    changeLogFaster: '高速化',
+    changeLogImproved: '改善',
+    changeLogOther: 'その他の改善',
+    changeLogFallbackLabel: '今回の更新',
+    changeLogFallbackItem: '改善と修正',
     applyStatus: {
       preparing: 'バックエンドを更新しています…',
       pulling: 'バックエンドを更新中…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1871,6 +1871,16 @@ export interface Translations {
     errorTitle: string
     errorBody: string
     notNow: string
+    /** Changelog group headers in the update dialog. `commit-changelog.ts`
+     *  keeps English defaults in GROUP_META/FALLBACK_GROUP; the overlay
+     *  passes these localized values through buildCommitChangelog options. */
+    changeLogNew: string
+    changeLogFixed: string
+    changeLogFaster: string
+    changeLogImproved: string
+    changeLogOther: string
+    changeLogFallbackLabel: string
+    changeLogFallbackItem: string
     applyStatus: {
       preparing: string
       pulling: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1998,6 +1998,13 @@ export const zhHant = defineLocale({
     errorTitle: '更新未完成',
     errorBody: '沒有資料遺失。您可以現在重試。',
     notNow: '暫不',
+    changeLogNew: '新增功能',
+    changeLogFixed: '修復',
+    changeLogFaster: '更快',
+    changeLogImproved: '改進',
+    changeLogOther: '其他改進',
+    changeLogFallbackLabel: '本次更新',
+    changeLogFallbackItem: '改進與修復',
     applyStatus: {
       preparing: '正在更新後端…',
       pulling: '後端更新中…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2432,6 +2432,13 @@ export const zh: Translations = {
     errorTitle: '更新未完成',
     errorBody: '没有数据丢失。你可以现在重试。',
     notNow: '暂不',
+    changeLogNew: '新增',
+    changeLogFixed: '修复',
+    changeLogFaster: '更快',
+    changeLogImproved: '改进',
+    changeLogOther: '其他改进',
+    changeLogFallbackLabel: '本次更新',
+    changeLogFallbackItem: '改进与修复',
     applyStatus: {
       preparing: '正在更新后端…',
       pulling: '后端更新中…',

--- a/apps/desktop/src/lib/commit-changelog.test.ts
+++ b/apps/desktop/src/lib/commit-changelog.test.ts
@@ -80,6 +80,41 @@ describe('buildCommitChangelog', () => {
     expect(groups).toEqual([{ id: 'other', items: ['Improvements and fixes'], label: 'In this update' }])
   })
 
+  it('resolves group labels from the provided options', () => {
+    const groups = buildCommitChangelog(
+      [
+        { summary: 'feat: a' },
+        { summary: 'fix: b' },
+        { summary: 'perf: c' }
+      ],
+      { labels: { new: 'Nouveau', fixed: 'Corrigé', faster: 'Plus rapide' } }
+    )
+
+    expect(groups.map(g => g.label)).toEqual(['Nouveau', 'Corrigé', 'Plus rapide'])
+  })
+
+  it('keeps English defaults for groups missing from a partial labels map', () => {
+    const groups = buildCommitChangelog(
+      [
+        { summary: 'feat: a' },
+        { summary: 'fix: b' },
+        { summary: 'perf: c' },
+        { summary: 'refactor: d' }
+      ],
+      { labels: { new: 'Nouveau' }, maxGroups: 4 }
+    )
+
+    expect(groups.map(g => g.label)).toEqual(['Nouveau', 'Fixed', 'Faster', 'Improved'])
+  })
+
+  it('uses the provided fallback label and item for the empty state', () => {
+    const groups = buildCommitChangelog([{ summary: 'chore: x' }], {
+      fallback: { label: 'Dans cette mise à jour', item: 'Améliorations et correctifs' }
+    })
+
+    expect(groups).toEqual([{ id: 'other', items: ['Améliorations et correctifs'], label: 'Dans cette mise à jour' }])
+  })
+
   it('dedupes identical subjects and caps the items per group', () => {
     const groups = buildCommitChangelog(
       [

--- a/apps/desktop/src/lib/commit-changelog.ts
+++ b/apps/desktop/src/lib/commit-changelog.ts
@@ -35,6 +35,11 @@ interface BuildOptions {
   maxGroups?: number
   maxPerGroup?: number
   maxTotal?: number
+  /** Per-group display labels (e.g. localized). A group without an entry
+   *  keeps its English default. */
+  labels?: Partial<Record<CommitGroupId, string>>
+  /** Label + item for the empty-state fallback group. */
+  fallback?: { label: string; item: string }
 }
 
 const GROUP_META: Record<CommitGroupId, { label: string; order: number }> = {
@@ -169,10 +174,18 @@ export function buildCommitChangelog(
     .map(([id, items]) => ({ id, items, label: GROUP_META[id].label, order: GROUP_META[id].order }))
     .sort((a, b) => a.order - b.order)
     .slice(0, maxGroups)
-    .map(({ id, items, label }): CommitGroup => ({ id, items, label }))
+    .map(({ id, items, label }): CommitGroup => ({ id, items, label: options.labels?.[id] ?? label }))
 
   if (result.length === 0) {
-    return [FALLBACK_GROUP]
+    const fallback = options.fallback
+
+    return [
+      {
+        ...FALLBACK_GROUP,
+        label: fallback?.label ?? FALLBACK_GROUP.label,
+        items: [fallback?.item ?? FALLBACK_GROUP.items[0]]
+      }
+    ]
   }
 
   return result


### PR DESCRIPTION
## Summary

The "New update available" dialog localizes its chrome through the app's i18n system, but the changelog group headers ("What's new", "Fixed", "Faster", "Improved", "Other improvements") and the empty-state copy ("In this update" / "Improvements and fixes") are hardcoded English literals in `commit-changelog.ts` (GROUP_META / FALLBACK_GROUP), rendered verbatim at `updates-overlay.tsx:246`. Any non-English locale sees English section headers inside an otherwise localized dialog.

This PR:

- Adds 7 keys to the `updates` namespace in `i18n/types.ts` and all 5 locale catalogs (en, zh, zh-hant, ja, ar). TypeScript's per-locale typing enforces every catalog adds the keys — a forgotten translation fails the build.
- Keeps `commit-changelog.ts` locale-agnostic: `buildCommitChangelog` gains optional `labels` / `fallback` overrides in `BuildOptions`, defaulting to the existing English literals so current unit tests pass unchanged.
- Routes the localized labels through in `updates-overlay.tsx` and drops the script-unsafe `uppercase tracking-wide` header styling (no-op for CJK, wrong for Arabic RTL).

## Test Plan

- `npm run typecheck` (renderer + electron + e2e tsconfigs)
- `npm run lint`
- `vitest run` (commit-changelog tests incl. new label-override cases, plus the ui project)
- Manual: update dialog renders group headers in all 5 locales

## Notes

- The changelog **bullets** remain raw commit subjects — localizing that dynamic content is tracked in #84130.
- zh / zh-hant / ja / ar translations are provisional and would benefit from a native-speaker pass before merge.

Closes #84126
