### PR TITLE
fix(gateway): preserve transcript spool chronology

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3517,6 +3517,15 @@ class SessionStore:
             # before the DB write so other sessions are not blocked.
             msg = pending[0]
         queue_session_id = session_id
+        # Cap-spooled messages were evicted from the HEAD of this queue, so
+        # they are older than every message still in memory.  Replay them
+        # before writing the live backlog: SessionDB restores by insertion id
+        # (not timestamp), and reversing these two tiers permanently scrambles
+        # the transcript.  A failed replay must also block newer writes or an
+        # orphaned successful tool result can be dropped by alternation repair
+        # while its non-idempotent tool call remains in model history.
+        if not self._drain_spooled_drops(session_id):
+            return
         # DB write outside the retry lock — other sessions can append
         # concurrently. We re-acquire the lock only to update the queue.
         while True:
@@ -3620,22 +3629,19 @@ class SessionStore:
                         queue_empty = False
                         msg = pending[0]
                 if queue_empty:
-                    # DB write just succeeded and the in-memory backlog is
-                    # clear: replay any cap-dropped messages spooled to disk
-                    # for this session (#78182).
-                    self._drain_spooled_drops(session_id)
                     return
                 continue
 
-    def _drain_spooled_drops(self, session_id: str) -> None:
-        """Replay cap-dropped spooled transcript messages after DB recovery.
+    def _drain_spooled_drops(self, session_id: str) -> bool:
+        """Replay cap-dropped messages before the newer in-memory queue.
 
-        Best-effort: replay failures keep the spool files for the next
-        successful flush; nothing here may raise into the caller.
+        Returns whether the older tier is fully drained. Replay failures keep
+        both the spool files and the live queue for the next attempt; nothing
+        here may raise into the caller or let newer rows overtake older ones.
         """
         spooled_sessions = getattr(self, "_spooled_drop_sessions", None)
         if not spooled_sessions or session_id not in spooled_sessions:
-            return
+            return True
         try:
             from gateway.shutdown_flush import drain_transcript_spool
 
@@ -3647,10 +3653,12 @@ class SessionStore:
             )
             if not remaining:
                 spooled_sessions.discard(session_id)
+            return remaining == 0
         except Exception as exc:
             logger.warning(
                 "Failed to drain transcript spool for %s: %s", session_id, exc
             )
+            return False
 
     def _append_transcript_message(self, session_id: str, message: Dict[str, Any]) -> None:
         """Write one transcript row. Caller handles retry queuing."""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3651,7 +3651,9 @@ class SessionStore:
                     session_id, message
                 ),
             )
-            if not remaining:
+            if remaining is None:
+                return False
+            if remaining == 0:
                 spooled_sessions.discard(session_id)
             return remaining == 0
         except Exception as exc:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3543,8 +3543,7 @@ class SessionStore:
                 from hermes_state import CompressionSessionClosedError
 
                 if isinstance(exc, CompressionSessionClosedError):
-                    child = self._db.find_live_compression_child(session_id)
-                    child_id = str(child["id"]) if child and child.get("id") else ""
+                    child_id = self._find_live_compression_child_id(session_id)
                     if child_id:
                         try:
                             self._append_transcript_message(child_id, msg)
@@ -3640,6 +3639,11 @@ class SessionStore:
                     return
                 continue
 
+    def _find_live_compression_child_id(self, session_id: str) -> str:
+        """Return the unique live compression continuation, or an empty id."""
+        child = self._db.find_live_compression_child(session_id)
+        return str(child["id"]) if child and child.get("id") else ""
+
     def _drain_spooled_drops(self, session_id: str) -> bool:
         """Replay cap-dropped messages before the newer in-memory queue.
 
@@ -3652,12 +3656,20 @@ class SessionStore:
             return True
         try:
             from gateway.shutdown_flush import drain_transcript_spool
+            from hermes_state import CompressionSessionClosedError
+
+            def replay(message: Dict[str, Any]) -> None:
+                try:
+                    self._append_transcript_message(session_id, message)
+                except CompressionSessionClosedError:
+                    child_id = self._find_live_compression_child_id(session_id)
+                    if not child_id:
+                        raise
+                    self._append_transcript_message(child_id, message)
 
             _replayed, remaining = drain_transcript_spool(
                 session_id,
-                lambda message: self._append_transcript_message(
-                    session_id, message
-                ),
+                replay,
             )
             if remaining is None:
                 return False

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3525,6 +3525,15 @@ class SessionStore:
             # before the DB write so other sessions are not blocked.
             msg = pending[0]
         queue_session_id = session_id
+        # Cap-spooled messages were evicted from the HEAD of this queue, so
+        # they are older than every message still in memory.  Replay them
+        # before writing the live backlog: SessionDB restores by insertion id
+        # (not timestamp), and reversing these two tiers permanently scrambles
+        # the transcript.  A failed replay must also block newer writes or an
+        # orphaned successful tool result can be dropped by alternation repair
+        # while its non-idempotent tool call remains in model history.
+        if not self._drain_spooled_drops(session_id):
+            return
         # DB write outside the retry lock — other sessions can append
         # concurrently. We re-acquire the lock only to update the queue.
         while True:
@@ -3628,22 +3637,19 @@ class SessionStore:
                         queue_empty = False
                         msg = pending[0]
                 if queue_empty:
-                    # DB write just succeeded and the in-memory backlog is
-                    # clear: replay any cap-dropped messages spooled to disk
-                    # for this session (#78182).
-                    self._drain_spooled_drops(session_id)
                     return
                 continue
 
-    def _drain_spooled_drops(self, session_id: str) -> None:
-        """Replay cap-dropped spooled transcript messages after DB recovery.
+    def _drain_spooled_drops(self, session_id: str) -> bool:
+        """Replay cap-dropped messages before the newer in-memory queue.
 
-        Best-effort: replay failures keep the spool files for the next
-        successful flush; nothing here may raise into the caller.
+        Returns whether the older tier is fully drained. Replay failures keep
+        both the spool files and the live queue for the next attempt; nothing
+        here may raise into the caller or let newer rows overtake older ones.
         """
         spooled_sessions = getattr(self, "_spooled_drop_sessions", None)
         if not spooled_sessions or session_id not in spooled_sessions:
-            return
+            return True
         try:
             from gateway.shutdown_flush import drain_transcript_spool
 
@@ -3655,10 +3661,12 @@ class SessionStore:
             )
             if not remaining:
                 spooled_sessions.discard(session_id)
+            return remaining == 0
         except Exception as exc:
             logger.warning(
                 "Failed to drain transcript spool for %s: %s", session_id, exc
             )
+            return False
 
     def _append_transcript_message(self, session_id: str, message: Dict[str, Any]) -> None:
         """Write one transcript row. Caller handles retry queuing."""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3659,7 +3659,9 @@ class SessionStore:
                     session_id, message
                 ),
             )
-            if not remaining:
+            if remaining is None:
+                return False
+            if remaining == 0:
                 spooled_sessions.discard(session_id)
             return remaining == 0
         except Exception as exc:

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -190,7 +190,7 @@ def spool_dropped_transcript_message(
 _TRANSCRIPT_SPOOL_SEQ = itertools.count()
 
 
-def drain_transcript_spool(session_id: str, replay) -> tuple[int, int]:
+def drain_transcript_spool(session_id: str, replay) -> tuple[int, Optional[int]]:
     """Replay cap-dropped transcript messages spooled for *session_id*.
 
     ``replay(message_dict)`` is invoked for each spooled message in drop
@@ -199,14 +199,16 @@ def drain_transcript_spool(session_id: str, replay) -> tuple[int, int]:
     for the next attempt (the DB is likely still unhealthy).
 
     Returns ``(replayed, remaining)`` — messages replayed and spool files
-    left behind for a later retry.
+    left behind for a later retry. ``remaining`` is ``None`` when the spool
+    cannot be scanned, so callers cannot mistake an unknown state for an empty
+    spool.
     """
     try:
         flush_dir = _get_flush_dir()
         candidates = list(flush_dir.glob("pending-*.json"))
     except Exception as exc:
         logger.debug("Cannot scan transcript spool: %s", exc)
-        return 0, 0
+        return 0, None
 
     entries = []
     for path in candidates:

--- a/tests/gateway/test_pending_queue_spool.py
+++ b/tests/gateway/test_pending_queue_spool.py
@@ -14,6 +14,7 @@ import pytest
 
 from gateway import shutdown_flush
 from gateway.session import SessionStore
+from hermes_state import SessionDB
 
 
 def _make_store(db):
@@ -98,17 +99,103 @@ class TestSpoolOnDrop:
         )
 
         contents = [r["content"] for r in db.rows]
-        # All surviving in-memory messages plus the recovery trigger...
-        for i in range(n_extra, SessionStore._MAX_PENDING_PER_SESSION + n_extra):
-            assert f"msg{i}" in contents
-        assert "recovered" in contents
-        # ...and the previously dropped messages, replayed in drop order.
-        replayed = [c for c in contents if c in ("msg0", "msg1", "msg2")]
-        assert replayed == ["msg0", "msg1", "msg2"]
+        # The durable transcript must preserve the original chronology.  The
+        # spooled rows are older than every row still in memory, so replaying
+        # them after the live queue would permanently scramble insertion order.
+        assert contents == [
+            *(f"msg{i}" for i in range(SessionStore._MAX_PENDING_PER_SESSION + n_extra)),
+            "recovered",
+        ]
         # Spool files consumed after successful replay.
         assert _spool_files(spool_home) == []
         # Nothing pending in memory.
         assert "sess-1" not in store._dirty_transcripts
+
+    def test_tool_result_keeps_order_after_database_reopen(
+        self, spool_home, monkeypatch
+    ):
+        """A successful side-effect result must survive model replay.
+
+        ``SessionDB`` restores rows by AUTOINCREMENT id, not timestamp.  If
+        the live queue lands before its older spool, alternation repair drops
+        the now-leading tool result as an orphan and leaves its non-idempotent
+        tool call without the success receipt.
+        """
+        monkeypatch.setattr(SessionStore, "_MAX_PENDING_PER_SESSION", 2)
+        db_path = spool_home / "state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session("tool-order", "telegram")
+
+        class BrokenProxy:
+            def __init__(self, wrapped):
+                self.wrapped = wrapped
+                self.broken = True
+
+            def append_message(self, **kwargs):
+                if self.broken:
+                    raise RuntimeError("controlled database outage")
+                return self.wrapped.append_message(**kwargs)
+
+            def __getattr__(self, name):
+                return getattr(self.wrapped, name)
+
+        proxy = BrokenProxy(db)
+        store = _make_store(proxy)
+        original = [
+            {"role": "user", "content": "send the payment"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-pay-1",
+                        "type": "function",
+                        "function": {
+                            "name": "send_payment",
+                            "arguments": '{"amount": 10}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-pay-1",
+                "name": "send_payment",
+                "content": "payment sent: receipt-1",
+            },
+        ]
+        for message in original:
+            store.append_to_transcript("tool-order", message)
+
+        proxy.broken = False
+        store.append_to_transcript(
+            "tool-order", {"role": "assistant", "content": "Payment sent."}
+        )
+        db.close()
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            raw = reopened.get_messages_as_conversation(
+                "tool-order", repair_alternation=False
+            )
+            replay = reopened.get_messages_as_conversation(
+                "tool-order", repair_alternation=True
+            )
+        finally:
+            reopened.close()
+
+        assert [message["role"] for message in raw] == [
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+        ]
+        assert any(
+            message.get("role") == "tool"
+            and message.get("tool_call_id") == "call-pay-1"
+            and message.get("content") == "payment sent: receipt-1"
+            for message in replay
+        )
 
     def test_drain_only_touches_own_session(self, spool_home, monkeypatch):
         monkeypatch.setattr(SessionStore, "_MAX_PENDING_PER_SESSION", 3)
@@ -180,8 +267,10 @@ class TestSpoolOnDrop:
 
         # DB heals only for live writes; replayed (spooled) rows still fail.
         class FlakyDb(BrokenThenHealedDb):
+            reject_replays = True
+
             def append_message(self, **kwargs):
-                if kwargs["content"] in ("m0", "m1", "m2"):
+                if self.reject_replays and kwargs["content"] in ("m0", "m1", "m2"):
                     raise RuntimeError("still broken for replays")
                 self.rows.append(kwargs)
 
@@ -195,6 +284,28 @@ class TestSpoolOnDrop:
         # Spool files survive the failed replay for the next attempt.
         assert len(_spool_files(spool_home)) == 3
         assert "sess-r" in getattr(store, "_spooled_drop_sessions", set())
+        # Newer live rows must not jump ahead while an older replay is blocked.
+        assert flaky.rows == []
+        assert [m["content"] for m in store._dirty_transcripts["sess-r"]] == [
+            "m3",
+            "m4",
+            "go",
+        ]
+
+        flaky.reject_replays = False
+        store.append_to_transcript(
+            "sess-r", {"role": "user", "content": "finish"}
+        )
+        assert [row["content"] for row in flaky.rows] == [
+            "m0",
+            "m1",
+            "m2",
+            "m3",
+            "m4",
+            "go",
+            "finish",
+        ]
+        assert _spool_files(spool_home) == []
 
 
 class TestSpoolPrimitives:

--- a/tests/gateway/test_pending_queue_spool.py
+++ b/tests/gateway/test_pending_queue_spool.py
@@ -9,6 +9,7 @@ successful transcript flush — not silently discarded (#78182, #82616).
 import json
 import logging
 import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -358,6 +359,67 @@ class TestSpoolOnDrop:
             "finish",
         ]
         assert _spool_files(spool_home) == []
+
+    def test_compression_closed_parent_reroutes_spool_before_live_queue(
+        self, spool_home, monkeypatch
+    ):
+        """A closed parent must not strand its ordered recovery backlog."""
+        monkeypatch.setattr(SessionStore, "_MAX_PENDING_PER_SESSION", 2)
+        db = SessionDB(db_path=spool_home / "state.db")
+        db.create_session("parent", source="telegram")
+
+        class BrokenProxy:
+            def __init__(self, wrapped):
+                self.wrapped = wrapped
+                self.broken = True
+
+            def append_message(self, **kwargs):
+                if self.broken:
+                    raise RuntimeError("controlled database outage")
+                return self.wrapped.append_message(**kwargs)
+
+            def __getattr__(self, name):
+                return getattr(self.wrapped, name)
+
+        proxy = BrokenProxy(db)
+        store = _make_store(proxy)
+        store._lock = threading.RLock()
+        store._entries = {"route": SimpleNamespace(session_id="parent")}
+        store._loaded = True
+        store._save = lambda: None
+        store._transcript_reroutes = {}
+
+        for i in range(3):
+            store.append_to_transcript(
+                "parent", {"role": "user", "content": f"m{i}"}
+            )
+
+        assert len(_spool_files(spool_home)) == 1
+        assert [
+            message["content"]
+            for message in store._dirty_transcripts["parent"]
+        ] == ["m1", "m2"]
+
+        db.end_session("parent", "compression")
+        db.create_session("child", source="telegram", parent_session_id="parent")
+        db.replace_messages("child", [{"role": "user", "content": "summary"}])
+        assert db.find_live_compression_child("parent")["id"] == "child"
+
+        proxy.broken = False
+        store.append_to_transcript(
+            "parent", {"role": "assistant", "content": "newer"}
+        )
+
+        assert store._entries["route"].session_id == "child"
+        assert "parent" not in store._dirty_transcripts
+        assert _spool_files(spool_home) == []
+        assert [
+            message["content"]
+            for message in db.get_messages_as_conversation(
+                "child", repair_alternation=False
+            )
+        ] == ["summary", "m0", "m1", "m2", "newer"]
+        db.close()
 
 
 class TestSpoolPrimitives:

--- a/tests/gateway/test_pending_queue_spool.py
+++ b/tests/gateway/test_pending_queue_spool.py
@@ -307,6 +307,58 @@ class TestSpoolOnDrop:
         ]
         assert _spool_files(spool_home) == []
 
+    def test_spool_scan_failure_blocks_newer_live_rows(
+        self, spool_home, monkeypatch
+    ):
+        """An unknown spool state must fail closed until it can be scanned."""
+        monkeypatch.setattr(SessionStore, "_MAX_PENDING_PER_SESSION", 2)
+        db = BrokenThenHealedDb()
+        store = _make_store(db)
+
+        for i in range(3):
+            store.append_to_transcript(
+                "sess-scan", {"role": "user", "content": f"m{i}"}
+            )
+
+        assert len(_spool_files(spool_home)) == 1
+        assert "sess-scan" in store._spooled_drop_sessions
+
+        original_get_flush_dir = shutdown_flush._get_flush_dir
+
+        def _scan_boom():
+            raise OSError("controlled spool scan failure")
+
+        monkeypatch.setattr(shutdown_flush, "_get_flush_dir", _scan_boom)
+        # Avoid another cap eviction so this test isolates drain-time scanning.
+        monkeypatch.setattr(SessionStore, "_MAX_PENDING_PER_SESSION", 10)
+        db.broken = False
+        store.append_to_transcript(
+            "sess-scan", {"role": "assistant", "content": "newer"}
+        )
+
+        assert db.rows == []
+        assert [
+            message["content"]
+            for message in store._dirty_transcripts["sess-scan"]
+        ] == ["m1", "m2", "newer"]
+        assert "sess-scan" in store._spooled_drop_sessions
+
+        monkeypatch.setattr(
+            shutdown_flush, "_get_flush_dir", original_get_flush_dir
+        )
+        store.append_to_transcript(
+            "sess-scan", {"role": "assistant", "content": "finish"}
+        )
+
+        assert [row["content"] for row in db.rows] == [
+            "m0",
+            "m1",
+            "m2",
+            "newer",
+            "finish",
+        ]
+        assert _spool_files(spool_home) == []
+
 
 class TestSpoolPrimitives:
     def test_drain_skips_other_reasons(self, spool_home):


### PR DESCRIPTION
## Summary

Preserve durable transcript chronology when the gateway recovers from a database outage after the per-session pending queue has overflowed to disk.

Cap-spooled messages are older than every message still held in memory. This change replays that older durable tier before flushing the newer in-memory backlog, and fails closed when replay cannot complete or the spool cannot be scanned.

## Production impact

On current `main`, a recovered gateway can persist newer in-memory rows before older cap-spooled rows. Because `SessionDB` restores transcripts by AUTOINCREMENT insertion id rather than timestamp, that ordering becomes durable.

The deterministic tool-chain reproduction shows that a previously successful non-idempotent tool result can disappear from model replay, removing the evidence needed to prevent duplicate side-effect decisions. It does not claim that a duplicate side effect definitely occurs.

## Current-main RED reproduction

Detached RED run base: `7060ac7bedd9128223a5f226e34e734072749845` (the three affected files did not change through the rebased current main `a723351a9257e705f5d58c644f664671b2c4e96e`)

A controlled temporary `SessionDB` reproduction:

1. Limits the pending queue to two rows.
2. Holds SQLite writes behind a deterministic failure gate.
3. Queues a user request, an assistant non-idempotent tool call, and its successful tool result.
4. Restores the database and appends the final assistant response.
5. Closes and reopens the database.

Before the fix, durable roles reopen as:

```
tool, assistant, user, assistant
```

Restore-time alternation repair then produces:

```
assistant, user, assistant
```

The tool call remains, but its successful result is removed as an orphan. Applying the PR regression tests without the production fix to the detached current-main worktree produced 5 deterministic failures and 4 passes, covering chronology, tool-result replay, replay failure ordering, scan failure, and compression-child routing.

A second deterministic reproduction forces `_get_flush_dir()` to fail during spool scanning. Current main returns `(0, 0)`, treats the unknown older tier as fully drained, and persists the newer live queue. The regression asserts that no newer rows reach SQLite until scanning can prove the older tier drained.

## Root cause

Two related mechanisms violate the same ordering invariant:

1. `_append_to_transcript_serialized()` flushes the surviving in-memory queue before calling `_drain_spooled_drops()`. That reverses the durable tiers:
   - disk spool: oldest cap-evicted rows
   - memory queue: newer surviving rows
2. `drain_transcript_spool()` returns `(0, 0)` when its directory scan fails. The caller interprets that ambiguous result as proof that the spool is empty, discards its session marker, and permits newer writes.
3. The new pre-backlog drain initially replayed against a compression-closed parent. `CompressionSessionClosedError` was retained as a replay failure before the existing live-child reroute block could run, stranding the newer parent queue.

Timestamps cannot repair the first mechanism after the fact because Hermes deliberately restores messages by insertion id to avoid clock-regression errors.

## Why existing fixes/PRs do not cover this

- Merged #82718 introduced the cap-drop spool. In the current merged path, older spooled rows are drained after the live backlog.
- Open #78323 contains an earlier cap-overflow spooling approach, but it does not use or correct the current `_drain_spooled_drops` mechanism.
- Open #78552 addresses a separate, broader session fallback spool and does not touch the current cap-spool drain ordering.

A focused search for transcript spool chronology, pending queue replay order, `_drain_spooled_drops`, and older-spool/newer-live ordering found no equivalent open PR.

## Fix

- Drain cap-spooled messages before attempting the newer in-memory backlog.
- Make `_drain_spooled_drops()` report whether the older tier is fully drained.
- If replay fails, retain both the spool files and the live queue and return without writing newer rows.
- Represent an unscannable spool with `remaining=None`, keeping newer rows pending until the older tier can be proven empty.
- Reuse the existing unique live-compression-child lookup for spool replay, so older spooled rows reach the child before the existing backlog migration reroutes newer rows.
- Preserve the existing no-spool fast path and successful recovery behavior.

## Regression coverage

`tests/gateway/test_pending_queue_spool.py` now proves:

- full spool + live-queue chronology rather than message membership alone;
- real SQLite durability after close/reopen;
- a successful tool result remains correlated with its tool call in repaired model replay;
- failed replay prevents newer live rows from overtaking older spool rows;
- spool scan failure blocks newer live rows and recovers in order once scanning succeeds;
- a compression-closed parent with a unique live child replays its spool before migrating and draining the newer backlog;
- per-session isolation, spool-failure degradation, and primitive ordering remain intact.

## Validation

Run on the clean branch based directly on current upstream `main`:

```text
python -m pytest tests/gateway/test_pending_queue_spool.py -q
# 9 passed in 1.09s

python -m pytest tests/gateway/test_pending_queue_spool.py tests/gateway/test_shutdown_flush.py tests/gateway/test_7100_transient_failure_transcript.py tests/gateway/test_13121_shutdown_inflight_transcript_flush.py tests/gateway/test_load_transcript_db_only.py tests/gateway/test_session.py -q
# 83 passed in 8.64s

python -m pytest tests/gateway/test_session.py::TestGatewaySessionDbRecovery::test_compression_closed_parent_reroutes_without_retry_queue tests/gateway/test_session.py::TestGatewaySessionDbRecovery::test_transcript_reroute_migrates_remaining_backlog_to_child tests/state/test_compression_lineage_guard.py -q
# 17 passed in 8.11s

python -m pytest tests/hermes_state/test_restore_alternation_repair.py tests/hermes_state/test_append_messages_batch.py tests/test_hermes_state.py -q
# 232 passed, 2 skipped in 43.77s

python -m ruff check .
# All checks passed

python scripts/check-windows-footguns.py --all
# No Windows footguns found (956 files scanned)

git diff --check upstream/main...HEAD
# passed
```

## Compatibility / risk

The normal no-spool path still returns immediately and performs no extra filesystem work. Recovery now prioritizes correctness over availability: if an older spool entry cannot be replayed or the spool cannot be scanned, newer in-memory rows remain pending rather than being durably written out of order. Compression-closed parents reuse the existing unique-child decision; ambiguous or failed child replay remains fail-closed.

`drain_transcript_spool()` remains non-raising on scan failure. Its internal `remaining` result is now optional so an unknown state cannot be confused with zero; its only production caller handles that sentinel fail-closed.

No schemas, dependencies, configuration, lockfiles, or generated artifacts change.

## Scope intentionally excluded

- Redesigning the broader persistence fallback architecture.
- Changing startup spool recovery or spool file formats.
- Changing malformed/corrupt payload policy.
- Claiming that a duplicate side effect definitely occurs.
- Addressing unrelated SQLite/FTS outage causes.
