### PR TITLE
fix(desktop): route model catalog via reconnecting gateway seam; recover textual DSML tool-call leak

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -113,6 +113,16 @@ _API_CALL_MODULES = frozenset({
     "chat_completion_helpers",
 })
 
+# DeepSeek-family endpoints can occasionally serialize their internal DSML
+# tool protocol into ordinary assistant text while also reporting a clean
+# ``finish_reason="stop"``.  Treat only the distinctive DSML envelope as a
+# dropped tool call.  Never parse or execute text as a tool call: doing so
+# would let untrusted file or web content manufacture executable actions.
+_TEXTUAL_DSML_TOOL_CALL_PATTERN = re.compile(
+    r"<\s*(?:\|\||｜｜)DSML(?:\|\||｜｜)(?:tool_calls|invoke)\b",
+    re.IGNORECASE,
+)
+
 
 def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text: str) -> None:
     """Append a provider-safe checkpoint and correction to the live turn.
@@ -6871,9 +6881,29 @@ def run_conversation(
                     truncated_response_parts = []
                     length_continue_retries = 0
                 
-                final_response = agent._strip_think_blocks(final_response).strip()
+                _textual_dsml_tool_call_leak = bool(
+                    not assistant_message.tool_calls
+                    and isinstance(final_response, str)
+                    and _TEXTUAL_DSML_TOOL_CALL_PATTERN.search(final_response)
+                )
+                if _textual_dsml_tool_call_leak:
+                    logger.warning(
+                        "Assistant content contained textual DSML tool markup "
+                        "without a structured tool call; re-prompting safely "
+                        "(model=%s provider=%s)",
+                        agent.model,
+                        agent.provider,
+                    )
+                    # Do not replay, persist, display, or speak the leaked
+                    # serialization.  A neutral assistant checkpoint preserves
+                    # provider role alternation for the bounded recovery nudge.
+                    final_response = "A tool call was emitted in an invalid text format."
+                else:
+                    final_response = agent._strip_think_blocks(final_response).strip()
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                if _textual_dsml_tool_call_leak:
+                    final_msg["content"] = final_response
 
                 # ── Dropped tool-call recovery (copilot/Claude) ────────
                 # Some providers (observed: claude-opus-4.8 / claude-sonnet-4.5
@@ -6888,14 +6918,17 @@ def run_conversation(
                 # model emit the call instead of exiting. finish_reason="stop"
                 # text finishes never enter this guard.
                 if (
-                    finish_reason == "tool_calls"
+                    (
+                        finish_reason == "tool_calls"
+                        or _textual_dsml_tool_call_leak
+                    )
                     and not assistant_message.tool_calls
                     and getattr(agent, "_dropped_toolcall_retries", 0) < 3
                 ):
                     agent._dropped_toolcall_retries = getattr(agent, "_dropped_toolcall_retries", 0) + 1
                     logger.warning(
-                        "finish_reason=tool_calls with empty tool_calls array "
-                        "(narration only) — re-prompting to emit the call "
+                        "Dropped or text-serialized tool call "
+                        "(no structured calls) — re-prompting to emit the call "
                         "(retry %d/3, model=%s provider=%s)",
                         agent._dropped_toolcall_retries, agent.model, agent.provider,
                     )

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -164,7 +164,7 @@ export function ModelPill({
           </Button>
         </DropdownMenuTrigger>
       </Tip>
-      <DropdownMenuContent align="end" className="w-64 p-0" side="top" sideOffset={8}>
+      <DropdownMenuContent align="end" className="w-80 p-0" side="top" sideOffset={8}>
         <ModelMenuCloseContext.Provider value={() => setMenuOpen(false)}>
           {model.modelMenuContent}
         </ModelMenuCloseContext.Provider>

--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -42,7 +42,7 @@ afterEach(() => {
 
 // A minimal controller — these tests are about the CATALOG's own behaviour
 // (what it lists, what it offers), not about what any host does with a pick.
-function renderMenu() {
+function renderMenu(requestGateway?: <T>(method: string, params?: Record<string, unknown>) => Promise<T>) {
   const select = vi.fn()
 
   const controller: ModelMenuController = {
@@ -59,7 +59,7 @@ function renderMenu() {
     <QueryClientProvider client={client}>
       <DropdownMenu open>
         <DropdownMenuContent>
-          <ModelCatalogMenu controller={controller} />
+          <ModelCatalogMenu controller={controller} requestGateway={requestGateway} />
         </DropdownMenuContent>
       </DropdownMenu>
     </QueryClientProvider>
@@ -73,6 +73,18 @@ function renderMenu() {
 // the kanban board would end up disagreeing about what "my models" means —
 // which is exactly the drift extracting this component was meant to prevent.
 describe('the catalog owns model curation', () => {
+  it('loads through the reconnecting gateway request path when supplied', async () => {
+    const requestGateway = vi.fn().mockResolvedValue({
+      providers: [{ models: ['claude-sonnet-4-6'], name: 'Anthropic', slug: 'anthropic' }]
+    })
+
+    renderMenu(requestGateway as never)
+
+    await screen.findByText(/Sonnet 4 6/i)
+    expect(requestGateway).toHaveBeenCalledWith('model.options', { explicit_only: true })
+    expect(getGlobalModelOptions).not.toHaveBeenCalled()
+  })
+
   it('honours the stored Edit Models shortlist', async () => {
     setVisibleModels(new Set([modelVisibilityKey('google', 'gemini-2.5-flash')]))
 
@@ -104,5 +116,25 @@ describe('the catalog owns model curation', () => {
     fireEvent.click(screen.getByText('Edit Models…'))
 
     expect($modelVisibilityOpen.get()).toBe(true)
+  })
+
+  it('marks explicitly uncensored models as NSFW with a distinct colour', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          authenticated: true,
+          models: ['venice-uncensored-1-2', 'qwen3-coder-480b-a35b-instruct-turbo'],
+          name: 'Venice',
+          slug: 'venice'
+        }
+      ]
+    })
+
+    renderMenu()
+
+    const badge = await screen.findByText('NSFW')
+    expect(badge.className).toContain('text-rose-')
+    expect(screen.getByText('KEY/OAUTH SET')).not.toBeNull()
+    expect(screen.getByText(/Qwen3 Coder/i).className).not.toContain('text-rose-')
   })
 })

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -20,8 +20,12 @@ import { usePointerQuiet } from '@/components/ui/keyboard-first'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
-import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
+import {
+  type ModelOptionsGatewayRequest,
+  modelOptionsQueryKey,
+  requestModelOptions
+} from '@/lib/model-options'
+import { displayModelName, isExplicitContentModel, modelDisplayParts } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
@@ -89,6 +93,8 @@ interface ModelCatalogMenuProps {
    *  Off for override surfaces, where a MoA preset isn't a worker model. */
   includeMoa?: boolean
   profile?: string
+  /** Reconnecting/auth-aware request seam supplied by live chat surfaces. */
+  requestGateway?: ModelOptionsGatewayRequest
   /** Session whose catalog to fetch. A live session's catalog can differ from
    *  the profile-global one, and the app invalidates the SESSION-scoped query
    *  key on model changes — a surface bound to a session must pass it or its
@@ -99,6 +105,38 @@ interface ModelCatalogMenuProps {
 interface ProviderGroup {
   families: ModelFamily[]
   provider: ModelOptionProvider
+}
+
+function providerStatus(provider: ModelOptionProvider): { className: string; label: string; title: string } {
+  if (provider.warning) {
+    return {
+      className: 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400',
+      label: 'CHECK',
+      title: provider.warning
+    }
+  }
+
+  if (provider.authenticated === false) {
+    return {
+      className: 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400',
+      label: 'SETUP',
+      title: 'No usable credential is configured for this provider.'
+    }
+  }
+
+  if (provider.authenticated === true) {
+    return {
+      className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+      label: 'KEY/OAUTH SET',
+      title: 'A credential is configured. This does not guarantee that every listed model has credits or access.'
+    }
+  }
+
+  return {
+    className: 'border-border bg-muted/40 text-(--ui-text-tertiary)',
+    label: 'CATALOG',
+    title: 'Models are listed, but this provider has not reported credential status.'
+  }
 }
 
 /**
@@ -114,6 +152,7 @@ export function ModelCatalogMenu({
   gateway,
   includeMoa = false,
   profile = 'default',
+  requestGateway,
   sessionId = null
 }: ModelCatalogMenuProps) {
   const { t } = useI18n()
@@ -133,7 +172,8 @@ export function ModelCatalogMenu({
     // Gateway-first even with no session: a connected (possibly remote)
     // gateway owns the model catalog, including virtual providers the local
     // REST fallback can't know about (#53817).
-    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway, sessionId })
+    queryFn: (): Promise<ModelOptionsResponse> =>
+      requestModelOptions({ gateway, requestGateway, sessionId })
   })
 
   const loading = modelOptions.isPending && !modelOptions.data
@@ -355,6 +395,7 @@ export function ModelCatalogMenu({
         <div className={cn('max-h-[max(150px,30dvh)] overflow-y-auto py-0.5', quietRows)} ref={listRef}>
           {groups.map(group => {
             const slug = group.provider.slug
+            const status = providerStatus(group.provider)
 
             // Collapsed when the user stored it (and not while searching, which
             // spans every model regardless of collapse state).
@@ -372,6 +413,15 @@ export function ModelCatalogMenu({
                 >
                   <span className="truncate">
                     <HighlightMatches query={search} text={group.provider.name} />
+                  </span>
+                  <span
+                    className={cn(
+                      'ml-auto shrink-0 rounded border px-1 py-px text-[0.5rem] font-semibold leading-none tracking-normal',
+                      status.className
+                    )}
+                    title={status.title}
+                  >
+                    {status.label}
                   </span>
                   <DisclosureCaret
                     className="shrink-0 text-(--ui-text-tertiary) opacity-0 transition group-hover/label:opacity-100"
@@ -414,6 +464,13 @@ export function ModelCatalogMenu({
                       .filter(Boolean)
                       .join(' ')
 
+                    const explicitContent =
+                      isExplicitContentModel(family.id) || Boolean(family.fastId && isExplicitContentModel(family.fastId))
+
+                    const { className: keyboardClassName, ...keyboardProps } = kbRowProps(
+                      `${group.provider.slug}:${family.id}`
+                    )
+
                     // Clicking the row commits the model and closes; the edit
                     // submenu (reasoning/fast) is reached by HOVER, so you can
                     // tweak those without the click dismissing everything.
@@ -428,6 +485,11 @@ export function ModelCatalogMenu({
                     return (
                       <DropdownMenuSub key={`${group.provider.slug}:${family.id}`}>
                         <DropdownMenuSubTrigger
+                          className={cn(
+                            keyboardClassName,
+                            explicitContent &&
+                              'bg-rose-500/5 text-rose-600 data-[state=open]:bg-rose-500/10 dark:text-rose-400'
+                          )}
                           hideChevron
                           onClick={activate}
                           onKeyDown={event => {
@@ -435,12 +497,17 @@ export function ModelCatalogMenu({
                               activate()
                             }
                           }}
-                          {...kbRowProps(`${group.provider.slug}:${family.id}`)}
+                          {...keyboardProps}
                         >
-                          <span className="min-w-0 flex-1 truncate">
+                          <span className={cn('min-w-0 flex-1 truncate', explicitContent && 'font-medium')}>
                             <HighlightMatches query={search} text={name} />
                             {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
                           </span>
+                          {explicitContent ? (
+                            <span className="ml-1 shrink-0 rounded border border-rose-500/30 bg-rose-500/10 px-1 py-px text-[0.5rem] font-bold leading-none tracking-wide text-rose-600 dark:text-rose-400">
+                              NSFW
+                            </span>
+                          ) : null}
                           {isCurrent ? (
                             <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" />
                           ) : null}
@@ -539,7 +606,11 @@ function groupModels(
     }
 
     const matches = (family: ModelFamily) =>
-      `${family.id} ${family.fastId ?? ''} ${provider.name} ${provider.slug} ${displayModelName(family.id)}`
+      `${family.id} ${family.fastId ?? ''} ${provider.name} ${provider.slug} ${displayModelName(family.id)} ${
+        isExplicitContentModel(family.id) || (family.fastId && isExplicitContentModel(family.fastId))
+          ? 'nsfw uncensored explicit'
+          : ''
+      }`
         .toLowerCase()
         .includes(q)
 

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -73,7 +73,8 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
   // never repaint that fallback once the catalog resolved.
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, activeSessionId),
-    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway, sessionId: activeSessionId })
+    queryFn: (): Promise<ModelOptionsResponse> =>
+      requestModelOptions({ gateway, requestGateway, sessionId: activeSessionId })
   })
 
   const { model: optionsModel, provider: optionsProvider } = currentPickerSelection(
@@ -95,7 +96,12 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
     try {
       const queryKey = modelOptionsQueryKey(profile, activeSessionId)
 
-      const next = await requestModelOptions({ gateway, refresh: true, sessionId: activeSessionId })
+      const next = await requestModelOptions({
+        gateway,
+        refresh: true,
+        requestGateway,
+        sessionId: activeSessionId
+      })
 
       queryClient.setQueryData<ModelOptionsResponse>(queryKey, next)
     } catch {
@@ -238,6 +244,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
       gateway={gateway}
       includeMoa
       profile={profile}
+      requestGateway={requestGateway}
       sessionId={activeSessionId}
     />
   )

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -42,6 +42,30 @@ describe('requestModelOptions', () => {
     })
   })
 
+  it('uses the reconnecting request path instead of a stale gateway instance', async () => {
+    const staleGateway = {
+      request: vi.fn(() => Promise.reject(new Error('Hermes gateway is not connected')))
+    }
+
+    const requestGateway = vi.fn(() => Promise.resolve(globalOptions))
+
+    await expect(
+      requestModelOptions({
+        gateway: staleGateway as never,
+        requestGateway: requestGateway as never,
+        refresh: true,
+        sessionId: 'session-1'
+      })
+    ).resolves.toBe(globalOptions)
+
+    expect(requestGateway).toHaveBeenCalledWith('model.options', {
+      explicit_only: true,
+      refresh: true,
+      session_id: 'session-1'
+    })
+    expect(staleGateway.request).not.toHaveBeenCalled()
+  })
+
   it('falls back to REST when no gateway is connected', async () => {
     await requestModelOptions({ refresh: true })
 

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -34,6 +34,8 @@ export function manualPickRemoved(
   return !models.includes(model)
 }
 
+export type ModelOptionsGatewayRequest = <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+
 interface ModelOptionsRequest {
   /** When false, include ambient/unconfigured providers (onboarding/setup
    *  surfaces). Chat pickers default to true so only explicitly configured
@@ -41,6 +43,7 @@ interface ModelOptionsRequest {
   explicitOnly?: boolean
   gateway?: HermesGateway
   refresh?: boolean
+  requestGateway?: ModelOptionsGatewayRequest
   sessionId?: null | string
 }
 
@@ -54,9 +57,10 @@ export function requestModelOptions({
   explicitOnly = true,
   gateway,
   refresh = false,
+  requestGateway,
   sessionId
 }: ModelOptionsRequest): Promise<ModelOptionsResponse> {
-  if (gateway) {
+  if (gateway || requestGateway) {
     const params: Record<string, unknown> = {}
 
     if (sessionId) {
@@ -71,7 +75,11 @@ export function requestModelOptions({
       params.explicit_only = true
     }
 
-    return gateway.request<ModelOptionsResponse>('model.options', params)
+    if (requestGateway) {
+      return requestGateway<ModelOptionsResponse>('model.options', params)
+    }
+
+    return gateway!.request<ModelOptionsResponse>('model.options', params)
   }
 
   return getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { currentPickerSelection, displayModelName, formatModelStatusLabel } from './model-status-label'
+import {
+  currentPickerSelection,
+  displayModelName,
+  formatModelStatusLabel,
+  isExplicitContentModel
+} from './model-status-label'
 import { reasoningEffortLabel } from './reasoning-effort'
 
 describe('model-status-label', () => {
@@ -9,6 +14,14 @@ describe('model-status-label', () => {
     expect(displayModelName('openai/gpt-5.5-fast')).toBe('GPT-5.5')
     expect(displayModelName('deepseek/deepseek-v4-pro-thinking')).toBe('Deepseek V4 Pro')
     expect(displayModelName('openai/gpt-5.5')).toBe('GPT-5.5')
+  })
+
+  it('only flags explicitly labelled NSFW or uncensored model ids', () => {
+    expect(isExplicitContentModel('venice-uncensored-1-2')).toBe(true)
+    expect(isExplicitContentModel('venice-uncensored-role-play')).toBe(true)
+    expect(isExplicitContentModel('my-nsfw-bypass-model')).toBe(true)
+    expect(isExplicitContentModel('qwen3-coder-480b-a35b-instruct-turbo')).toBe(false)
+    expect(isExplicitContentModel('openai/gpt-5.6-sol')).toBe(false)
   })
 
   it('strips trailing date-pin snapshots from the display name', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -95,6 +95,17 @@ export function displayModelName(model: string): string {
   return modelDisplayParts(model).name
 }
 
+/**
+ * Keep the explicit-content marker deliberately conservative: a provider can
+ * serve both general and uncensored models, so only ids that say what they are
+ * get the NSFW treatment. This avoids painting every Venice model as NSFW.
+ */
+export function isExplicitContentModel(model: string): boolean {
+  const id = model.trim().toLowerCase()
+
+  return /(^|[/_.-])(nsfw|uncensored|bypass)([/_.-]|$)/.test(id) || /uncensored[-_]?role[-_]?play/.test(id)
+}
+
 /** Status bar trigger label — model name plus the live session state (effort/fast).
  *  `defaultEffort` is the profile's configured level, used when the surface has
  *  no explicit effort so the label never advertises a default the agent won't use. */

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -53,6 +53,7 @@ class ConfigContext:
     user_providers: dict
     custom_providers: list
     excluded_providers: list = None
+    excluded_models: dict = None
 
     def with_overrides(
         self,
@@ -97,7 +98,11 @@ def load_picker_context() -> ConfigContext:
         current_provider = ""
         current_base_url = ""
     raw = cfg.get("providers")
-    excluded = cfg.get("model_catalog", {}).get("excluded_providers") or []
+    catalog_cfg = cfg.get("model_catalog", {})
+    if not isinstance(catalog_cfg, dict):
+        catalog_cfg = {}
+    excluded = catalog_cfg.get("excluded_providers") or []
+    excluded_models = catalog_cfg.get("excluded_models") or {}
     return ConfigContext(
         current_provider=current_provider,
         current_model=current_model,
@@ -105,6 +110,7 @@ def load_picker_context() -> ConfigContext:
         user_providers=raw if isinstance(raw, dict) else {},
         custom_providers=get_compatible_custom_providers(cfg),
         excluded_providers=excluded if isinstance(excluded, list) else [],
+        excluded_models=excluded_models if isinstance(excluded_models, dict) else {},
     )
 
 
@@ -199,6 +205,34 @@ def build_models_payload(
         for_picker=for_picker,
         excluded_providers=ctx.excluded_providers or [],
     )
+
+    # A provider catalog can contain retired, quota-blocked, or otherwise
+    # unusable model IDs even while the provider itself is healthy. Allow a
+    # profile to hide only those verified-bad IDs without losing the rest of
+    # the provider. Values are matched case-insensitively by provider slug;
+    # the optional "*" bucket applies to every provider.
+    excluded_models = ctx.excluded_models or {}
+    if isinstance(excluded_models, dict):
+        global_excluded = excluded_models.get("*") or []
+        for row in rows:
+            slug = str(row.get("slug") or "").strip().lower()
+            provider_excluded = excluded_models.get(slug) or []
+            blocked = {
+                str(model_id).strip().lower()
+                for model_id in [*global_excluded, *provider_excluded]
+                if str(model_id).strip()
+            }
+            if not blocked:
+                continue
+            original = row.get("models") or []
+            filtered = [
+                model_id
+                for model_id in original
+                if str(model_id).strip().lower() not in blocked
+            ]
+            if len(filtered) < len(original):
+                row["models"] = filtered
+                row["total_models"] = len(filtered)
 
     moa_row = _moa_provider_row(ctx.current_provider)
     if moa_row is not None:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -84,6 +84,48 @@ def _nous_row(model: str = "openai/gpt-5.5") -> dict:
     }
 
 
+def test_excluded_models_filters_only_matching_provider_models():
+    rows = [
+        {
+            "slug": "ollama-cloud",
+            "name": "Ollama Cloud",
+            "models": ["deepseek-v4-flash:cloud", "kimi-k2.5", "minimax-m2.5"],
+            "total_models": 3,
+            "is_current": True,
+            "is_user_defined": False,
+            "source": "built-in",
+        },
+        {
+            "slug": "openrouter",
+            "name": "OpenRouter",
+            "models": ["kimi-k2.5"],
+            "total_models": 1,
+            "is_current": False,
+            "is_user_defined": False,
+            "source": "built-in",
+        },
+    ]
+    ctx = ConfigContext(
+        current_provider="ollama-cloud",
+        current_model="deepseek-v4-flash:cloud",
+        current_base_url="https://ollama.com/v1",
+        user_providers={},
+        custom_providers=[],
+        excluded_models={"ollama-cloud": ["KIMI-K2.5", "minimax-m2.5"]},
+    )
+
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx)
+
+    by_slug = {row["slug"]: row for row in payload["providers"]}
+    ollama_row = by_slug["ollama-cloud"]
+    openrouter_row = by_slug["openrouter"]
+    assert ollama_row["models"] == ["deepseek-v4-flash:cloud"]
+    assert ollama_row["total_models"] == 1
+    assert openrouter_row["models"] == ["kimi-k2.5"]
+    assert openrouter_row["total_models"] == 1
+
+
 
 
 def test_cli_model_picker_forwards_force_refresh_to_probe_flags():
@@ -509,7 +551,5 @@ def _apply_featured_with_dates(rows, dates: dict[str, str]):
 
     with patch("agent.models_dev.get_model_info", side_effect=_fake_get_model_info):
         inventory._apply_featured(rows)
-
-
 
 

--- a/tests/run_agent/test_dropped_tool_call_recovery.py
+++ b/tests/run_agent/test_dropped_tool_call_recovery.py
@@ -66,7 +66,53 @@ def _dropped_tool_call_response(content: str):
     )
 
 
+def _textual_dsml_tool_call_response():
+    """A provider response that serializes a tool call into assistant text
+    and incorrectly finishes with ``stop`` instead of returning structured
+    ``tool_calls``."""
+    from tests.run_agent.test_run_agent import _mock_response
+
+    return _mock_response(
+        content=(
+            "<｜｜DSML｜｜tool_calls>"
+            "<｜｜DSML｜｜invoke name=\"skills_list\"/>"
+            "</｜｜DSML｜｜tool_calls>"
+        ),
+        finish_reason="stop",
+    )
+
+
 class TestDroppedToolCallRecovery:
+    def test_textual_dsml_tool_call_reprompts_without_replaying_markup(
+        self, loop_agent,
+    ):
+        """DSML tool markup emitted as plain assistant text must be treated
+        as an incomplete tool attempt, not as the final user-visible answer.
+        The leaked serialization must not be replayed to the provider."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _textual_dsml_tool_call_response(),
+            _mock_response(content="The profile contains config.yaml.", finish_reason="stop"),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("inspect the profile folder")
+
+        assert loop_agent.client.chat.completions.create.call_count == 2
+        second_call = loop_agent.client.chat.completions.create.call_args_list[1]
+        messages = second_call.kwargs.get("messages") or second_call.args[0].get("messages")
+        replayed_content = "\n".join(
+            str(message.get("content") or "") for message in messages
+        )
+        assert "DSML" not in replayed_content
+        assert "actual tool call" in replayed_content.lower()
+        assert result["final_response"] == "The profile contains config.yaml."
+
     def test_dropped_tool_call_reprompts_instead_of_exiting(self, loop_agent):
         """finish_reason=tool_calls with an empty tool_calls array must
         re-prompt the model to emit the call rather than exiting the loop
@@ -191,4 +237,3 @@ class TestDroppedToolCallRecovery:
             "_dropped_toolcall_nudge messages must be classified as "
             "ephemeral scaffolding so they are never persisted."
         )
-


### PR DESCRIPTION
## Summary
Three related fixes from the NovaMaster desktop/gateway hardening pass:

1. **Desktop model catalog now routes through the live reconnecting gateway** instead of a stale/restart-stale local gateway instance, so `Refresh Models` and catalog loads always hit the current transport. Adds provider credential/warning badges and conservative NSFW/uncensored model highlighting + search keyword.
2. **Per-provider `excluded_models` in the model catalog** — a profile can now hide only verified-bad model IDs (keyed by provider slug, optional `*` bucket) without dropping an otherwise-healthy provider; `total_models` stays consistent.
3. **Safe recovery of textual DSML tool-call leaks** — DeepSeek-family endpoints occasionally serialize their internal DSML tool protocol into ordinary assistant text with `finish_reason="stop"`. These are now detected, never replayed/persisted/displayed/spoken, and routed through the bounded dropped-tool-call retry path. Text is never parsed or executed as a tool call.

## Validation
- Python: `pytest tests/hermes_cli/test_inventory.py tests/run_agent/test_dropped_tool_call_recovery.py` → **20 passed**
- Desktop: `vitest run --project ui` on changed files → **30 passed**
- `npm run typecheck` → clean
- `eslint` (TS) and `ruff` (Python) on changed files → clean

## Commits
- `fix(desktop): route model catalog via reconnecting gateway seam`
- `feat(catalog): support per-provider excluded_models in model catalog`
- `fix(agent): safely recover textual DSML tool-call leak`