### PR TITLE
fix(agent): honor known text extensions before MIME detection

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -479,10 +479,11 @@ def _parse_file_reference_value(value: str) -> tuple[str, int | None, int | None
 
 
 def _is_binary_file(path: Path) -> bool:
+    known_text_extension = path.name.lower().endswith(
+        (".py", ".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".js", ".ts", ".astro")
+    )
     mime, _ = mimetypes.guess_type(path.name)
-    if mime and not mime.startswith("text/") and not any(
-        path.name.endswith(ext) for ext in (".py", ".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".js", ".ts")
-    ):
+    if not known_text_extension and mime and not mime.startswith("text/"):
         return True
     chunk = path.read_bytes()[:4096]
     return b"\x00" in chunk

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -121,6 +121,45 @@ def test_missing_file_becomes_warning(sample_repo: Path):
     assert "not found" in result.message.lower()
 
 
+def test_utf8_markdown_and_astro_references_are_inlined(tmp_path: Path, monkeypatch):
+    """Known text files stay readable even when MIME detection says otherwise."""
+    from agent import context_references
+    from agent.context_references import preprocess_context_references
+
+    markdown = tmp_path / "README.md"
+    astro = tmp_path / "component.astro"
+    markdown.write_text("# 日本語の見出し\n本文 café résumé\n", encoding="utf-8")
+    astro.write_text(
+        "---\nconst title = '猫';\n---\n<h1>{title}</h1>\n",
+        encoding="utf-8",
+    )
+
+    real_guess_type = context_references.mimetypes.guess_type
+
+    def generic_mime_for_text_files(name, *args, **kwargs):
+        if str(name).lower().endswith((".md", ".astro")):
+            return "application/octet-stream", None
+        return real_guess_type(name, *args, **kwargs)
+
+    monkeypatch.setattr(
+        context_references.mimetypes,
+        "guess_type",
+        generic_mime_for_text_files,
+    )
+
+    result = preprocess_context_references(
+        "Review @file:README.md and @file:component.astro",
+        cwd=tmp_path,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert not result.warnings
+    assert "# 日本語の見出し" in result.message
+    assert "<h1>{title}</h1>" in result.message
+    assert "binary file" not in result.message.lower()
+
+
 def test_binary_reference_block_maps_host_attachment_to_container_path(tmp_path: Path, monkeypatch):
     """Docker backend: a staged binary attachment's host path is rendered as the
     bind-mounted in-container path so the agent's tools can read it.

--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -601,6 +601,22 @@ class TestReadFileToolIntegration(unittest.TestCase):
         self.assertIn("1|", res["content"])  # line-number gutter
         self.assertIn("print(1)", res["content"])
 
+    def test_utf8_markdown_and_astro_read_as_text(self):
+        fixtures = {
+            "README.md": "# 日本語の見出し\n本文 café résumé\n",
+            "component.astro": "---\nconst title = '猫';\n---\n<h1>{title}</h1>\n",
+        }
+
+        for filename, content in fixtures.items():
+            p = os.path.join(self.tmp, filename)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+
+            res = json.loads(read_file_tool(p))
+
+            self.assertNotIn("error", res, res)
+            self.assertFalse(res.get("is_binary", False), res)
+            self.assertIn(content.splitlines()[0], res["content"])
 
     def test_corrupt_docx_surfaces_extraction_error(self):
         p = os.path.join(self.tmp, "bad.docx")


### PR DESCRIPTION
## What does this PR do?

Fixes false binary-file warnings when `@file:` context references expand known text files and `mimetypes.guess_type()` reports `application/octet-stream` or no useful MIME type.

The extension check now takes precedence for known text-like files, including `.astro`, while the existing NUL-byte check and binary handling remain unchanged. This is a separate code path from the UTF-8 byte-boundary issue in `tools/file_operations.py`.

## Related Issue

Related to #83863 (the adjacent `read_file` UTF-8 false-positive issue). This PR addresses the separate `@file:` context-reference MIME classification path and does not close that issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/context_references.py`
  - Treat the known text-extension allowlist as authoritative before MIME-based binary classification.
  - Add `.astro` to the known text extensions.
- `tests/agent/test_context_references.py`
  - Add a regression test using UTF-8 Markdown and Astro files while forcing generic MIME detection.
- `tests/tools/test_read_extract.py`
  - Verify UTF-8 Markdown and Astro files remain readable as text through the file tool integration.

## How to Test

The affected suites were run through the repository's canonical hermetic runner:

```text
scripts/run_tests.sh tests/agent/test_context_references.py tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_read_extract.py tests/tools/test_file_tools.py -q

5 files, 192 tests passed, 0 failed, 7 skipped
```

Additional checks:

```text
uv run --extra dev ruff check agent/context_references.py tests/agent/test_context_references.py tests/tools/test_read_extract.py
All checks passed!

git diff --check
clean
```

The complete suite was also attempted locally with `uv run --extra dev pytest -q`, but it did not finish within the 600-second local timeout. The run emitted environment-side test logging/temp-directory errors, including `OSError('disk full')`, so it is not reported as green here. The targeted canonical suites above are green, and CI should provide the authoritative full matrix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted canonical suites pass; full CI matrix is pending
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; this is a focused code/test fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

## Screenshots / Logs

Not applicable; this is a non-visual parsing fix. Test output is included above.