### PR TITLE
fix(agent): title ladder descends on empty completions too

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -105,6 +105,32 @@ _TITLE_RESPONSE_FORMAT = {
     },
 }
 
+# json_object is the loosest structured-output hint. DeepSeek, Moonshot/Kimi
+# and other OpenAI-compatible endpoints document only json_object (DeepSeek
+# rejects json_schema with HTTP 400 "This response_format type is unavailable
+# now"). The title prompt already embeds the expected shape and
+# _extract_title_text() has a loose-JSON scan, so a looser hint stays safe.
+_TITLE_RESPONSE_FORMAT_JSON_OBJECT = {"type": "json_object"}
+
+
+def _response_format_rejected(exc: BaseException) -> bool:
+    """True when the provider rejected the ``response_format`` parameter.
+
+    Matches the parameter name in the error text (DeepSeek: "This
+    response_format type is unavailable now"; most providers echo the
+    parameter they reject). Also catches HTTP 400s that never mention
+    ``response_format`` — vLLM gateways translate json_schema into
+    guided_grammar and fail with ``compile_grammar_error``. Auth, quota
+    and network failures are deliberately excluded: a different format
+    cannot fix those, so the ladder must not waste a retry on them.
+    """
+    text = str(exc).lower()
+    if "response_format" in text or "json_schema" in text:
+        return True
+    if "guided_grammar" in text or "xgrammar" in text or "compile_grammar" in text:
+        return True
+    return False
+
 # Control-tag wrappers that surround machine-authored content inside what is
 # nominally a "user" message. Titling from these is what produces a session
 # named after a slash command or an injected reminder rather than the user's
@@ -391,31 +417,73 @@ def generate_title(
         {"role": "user", "content": user_snippet},
     ]
 
-    try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
-            # A title is a handful of tokens. The old 500-token ceiling let a
-            # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
-        content = response.choices[0].message.content or ""
-        return _clean_title(_extract_title_text(content))
-    except Exception as e:
-        # Log at WARNING so this shows up in agent.log without debug mode.
-        # Full detail at debug level for operators who need the stack.
-        logger.warning("Title generation failed: %s", e)
+    # Walk the response-format ladder: json_schema (ideal) → json_object
+    # → unconstrained. Providers without structured-output support (e.g.
+    # DeepSeek, Console Go) 400 on json_schema; retrying looser keeps
+    # titling alive. Failures unrelated to response_format (auth, quota,
+    # network) break out immediately — a different format cannot fix those.
+    #
+    # An empty completion is treated like a rejection too: some gateways
+    # (Console Go on glm-5) accept json_schema/json_object but return a
+    # 200 with empty content, which would leave the session with the
+    # derived title even though the loosest rung works. Only return when a
+    # rung actually yields a title.
+    last_exc: Optional[BaseException] = None
+    for response_format, pin_thinking_off in (
+        (_TITLE_RESPONSE_FORMAT, False),
+        (_TITLE_RESPONSE_FORMAT_JSON_OBJECT, True),
+        (None, True),
+    ):
+        try:
+            extra_body: dict = {}
+            if response_format is not None:
+                extra_body["response_format"] = response_format
+            if pin_thinking_off:
+                # Pin thinking off so a default-on reasoning model does not
+                # burn the 64-token budget on reasoning and return empty.
+                extra_body["thinking"] = {"type": "disabled"}
+            call_kwargs = {
+                "task": "title_generation",
+                "messages": messages,
+                # A title is a handful of tokens. The old 500-token ceiling let a
+                # chatty model burn seconds generating prose we then threw away.
+                "max_tokens": 64,
+                "temperature": 0.3,
+                "timeout": timeout,
+                "main_runtime": main_runtime,
+                "extra_body": extra_body,
+            }
+            if pin_thinking_off:
+                # Profiles read reasoning_config to decide thinking, and they
+                # override extra_body, so send the disable through both
+                # channels or a reasoning profile can silently re-enable it.
+                call_kwargs["reasoning_config"] = {"enabled": False}
+            response = call_llm(**call_kwargs)
+            content = response.choices[0].message.content or ""
+            title = _clean_title(_extract_title_text(content))
+            if title:
+                return title
+            # Empty completion: try the next, looser rung instead of giving up.
+        except Exception as e:
+            last_exc = e
+            if response_format is not None and not _response_format_rejected(e):
+                break
+    # Log at WARNING so this shows up in agent.log without debug mode.
+    # Full detail at debug level for operators who need the stack.
+    if last_exc is not None:
+        logger.warning("Title generation failed: %s", last_exc)
         logger.debug("Title generation traceback", exc_info=True)
-        if failure_callback is not None:
-            try:
-                failure_callback("title generation", e)
-            except Exception:
-                logger.debug("Title generation failure_callback raised", exc_info=True)
-        return None
+    else:
+        logger.debug("Title generation returned no usable title on any rung")
+    if failure_callback is not None:
+        try:
+            failure_callback(
+                "title generation",
+                last_exc or RuntimeError("no usable title from any response-format rung"),
+            )
+        except Exception:
+            logger.debug("Title generation failure_callback raised", exc_info=True)
+    return None
 
 
 def _persist_session_title(session_db, session_id, title, *, source, dedupe=True):

--- a/contributors/emails/nformenton@Nicolass-MacBook-Air.local
+++ b/contributors/emails/nformenton@Nicolass-MacBook-Air.local
@@ -1,0 +1,2 @@
+Nicolas-Formenton
+# PR #84137 / #84021 (desktop fixes from a second machine)

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -108,6 +108,101 @@ class TestGenerateTitle:
         assert captured[0][0] == "title generation"
         assert captured[0][1] is exc
 
+    def test_falls_back_to_json_object_when_json_schema_rejected(self):
+        """Providers without structured output (DeepSeek: 400 on json_schema)
+        must get a json_object retry with thinking pinned off instead of a
+        failed title."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError(
+                    "Error code: 400 - 'This response_format type is "
+                    "unavailable now'"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Fix login button"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title("fix login button")
+
+        assert title == "Fix login button"
+        assert len(calls) == 2
+        # First attempt keeps the ideal json_schema constraint.
+        assert calls[0]["extra_body"]["response_format"]["type"] == "json_schema"
+        # Retry loosens to json_object and disables thinking so a
+        # default-on reasoning model doesn't burn the token budget.
+        assert calls[1]["extra_body"] == {
+            "response_format": {"type": "json_object"},
+            "thinking": {"type": "disabled"},
+        }
+        assert calls[1]["reasoning_config"] == {"enabled": False}
+
+    def test_falls_back_to_unconstrained_when_json_object_also_rejected(self):
+        """A provider that rejects both json_schema and json_object still
+        titles via the prompt's own JSON instruction."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) < 3:
+                raise RuntimeError(
+                    "Error code: 400 - 'This response_format type is "
+                    "unavailable now'"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Fix login button"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title("fix login button")
+
+        assert title == "Fix login button"
+        assert len(calls) == 3
+        assert calls[2]["extra_body"] == {"thinking": {"type": "disabled"}}
+
+    def test_continues_ladder_on_empty_content(self):
+        """A 200 with empty content (Console Go on glm-5 returns this for
+        json_schema AND json_object) must not stop the ladder — the
+        unconstrained rung still titles the session."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            if len(calls) < 3:
+                resp.choices[0].message.content = ""  # silent empty completion
+            else:
+                resp.choices[0].message.content = '{"title": "Improve titles"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title("improve title generation")
+
+        assert title == "Improve titles"
+        assert len(calls) == 3
+        assert calls[2]["extra_body"] == {"thinking": {"type": "disabled"}}
+
+    def test_does_not_retry_on_unrelated_errors(self):
+        """Auth/quota/network failures must not be retried — a different
+        response format cannot fix those."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError("Error code: 429 - rate limit exceeded")
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title("question")
+
+        assert title is None
+        assert len(calls) == 1
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

The title ladder descends on schema/format failures but returned unconditionally on empty 200 completions, leaving sessions untitled. It now descends to the next rung on empty completions too.

## Related Issue

Fixes #85307

Related: #83186, #83725, #82890 — this PR is a superset of the ladder family (triage comment confirms); if one of those merges first, this diff shrinks to the delta and rebases cleanly.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Title ladder descends on empty completions (`agent/title_generator.py`)
- Tests: `tests/agent/test_title_generator.py`
- `contributors/emails/nformenton@Nicolass-MacBook-Air.local` — attribution mapping

## How to Test

1. Force a title completion that returns a 200 with an empty title.
2. The ladder proceeds to the next rung instead of returning; the session ends with a title.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no native APIs

## Verification

- `pytest tests/agent/test_title_generator.py -q`: **37 passed**.
