### PR TITLE
fix(cli): honor personality in oneshot mode

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -330,13 +330,19 @@ def _run_agent(
     run a single conversation.  Returns ``(final_response, run_result)``."""
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
-    from hermes_cli.config import load_config
+    from hermes_cli.config import (
+        load_config,
+        resolve_ephemeral_system_prompt_from_config,
+    )
     from hermes_cli.models import detect_provider_for_model
     from hermes_cli.runtime_provider import resolve_runtime_provider
     from hermes_cli.tools_config import _get_platform_tools
     from run_agent import AIAgent
 
     cfg = load_config()
+    ephemeral_system_prompt = os.getenv(
+        "HERMES_EPHEMERAL_SYSTEM_PROMPT", ""
+    ) or resolve_ephemeral_system_prompt_from_config(cfg)
 
     # Resolve effective model: explicit arg → env var → config.
     model_cfg = cfg.get("model") or {}
@@ -443,6 +449,7 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            ephemeral_system_prompt=ephemeral_system_prompt,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/tests/hermes_cli/test_oneshot_personality.py
+++ b/tests/hermes_cli/test_oneshot_personality.py
@@ -1,0 +1,98 @@
+"""Regression tests for personality overlays in ``hermes -z`` mode."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+from hermes_cli import oneshot
+from hermes_cli.personality import BUILTIN_PERSONALITIES
+
+
+class _FakeAgent:
+    init_kwargs: dict = {}
+
+    def __init__(self, **kwargs):
+        type(self).init_kwargs = kwargs
+
+    def run_conversation(self, prompt):
+        return {"final_response": "ok", "failed": False, "completed": True}
+
+    def shutdown_memory_provider(self, *args, **kwargs):
+        return None
+
+    def close(self):
+        return None
+
+
+def _run_oneshot(monkeypatch, config):
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(config),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("run_agent.AIAgent", _FakeAgent)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "provider": "test-provider",
+            "requested_provider": "test-provider",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+
+    response, _ = oneshot._run_agent("hello", use_config_toolsets=False)
+
+    assert response == "ok"
+    return _FakeAgent.init_kwargs
+
+
+def test_oneshot_passes_configured_personality_to_agent(monkeypatch):
+    kwargs = _run_oneshot(
+        monkeypatch,
+        {
+            "model": {"default": "test-model", "provider": "test-provider"},
+            "display": {"personality": "catgirl"},
+        },
+    )
+
+    assert kwargs["ephemeral_system_prompt"] == BUILTIN_PERSONALITIES["catgirl"]
+
+
+def test_oneshot_prefers_environment_overlay_to_personality(monkeypatch):
+    monkeypatch.setenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "environment overlay")
+
+    kwargs = _run_oneshot(
+        monkeypatch,
+        {
+            "model": {"default": "test-model", "provider": "test-provider"},
+            "display": {"personality": "catgirl"},
+        },
+    )
+
+    assert kwargs["ephemeral_system_prompt"] == "environment overlay"
+
+
+def test_oneshot_uses_manual_prompt_without_personality(monkeypatch):
+    kwargs = _run_oneshot(
+        monkeypatch,
+        {
+            "model": {"default": "test-model", "provider": "test-provider"},
+            "display": {"personality": "none"},
+            "agent": {"system_prompt": "manual overlay"},
+        },
+    )
+
+    assert kwargs["ephemeral_system_prompt"] == "manual overlay"


### PR DESCRIPTION
## Summary
- resolve the configured personality/manual system overlay in `hermes -z`
- preserve `HERMES_EPHEMERAL_SYSTEM_PROMPT` precedence from normal CLI sessions
- add regression coverage for personality, environment override, and manual prompt fallback

## Root cause
`hermes -z` bypasses `HermesCLI` and constructs `AIAgent` directly in `hermes_cli/oneshot.py`. That constructor path did not pass `ephemeral_system_prompt`, so `display.personality` and `agent.system_prompt` were silently ignored in one-shot mode.

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_resolve_ephemeral_system_prompt.py tests/hermes_cli/test_oneshot_personality.py tests/hermes_cli/test_oneshot_usage_file.py tests/hermes_cli/test_oneshot_surrogate.py -q`
- `.venv/bin/ruff check hermes_cli/oneshot.py tests/hermes_cli/test_oneshot_personality.py`
- live `hermes -z` call with a strict `HERMES_EPHEMERAL_SYSTEM_PROMPT`, verified in the response and by tracing the exact constructor argument
