### PR TITLE
feat: add academic & research skills (framework-research, phd-resources, academic-writing-templates)

### DIFF
--- a/skills/research/academic-writing-templates/SKILL.md
+++ b/skills/research/academic-writing-templates/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: academic-writing-templates
+description: "LaTeX APA7 templates, AI writing tools, and article writing guides — curated from GitHub Topics: academic-writing."
+version: 1.0.0
+author: Fuad Al Fajri
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [LaTeX, APA7, Templates, Academic-Writing, Paper, Overleaf]
+    category: research
+    related_skills: [phd-resources, research-paper-writing]
+---
+
+# Academic Writing Templates & Tools
+
+Collection of LaTeX templates, AI writing tools, and paper structure guides to accelerate journal article writing.
+
+## When to Use
+
+- User asks for LaTeX templates for APA 7, journal articles, or theses
+- User asks for AI-assisted academic writing tools or prompts
+- User asks how to structure an IMRaD paper or which writing workflow to follow
+- User needs proofreading/grammar tools for academic prose
+
+Don't use for: writing an actual paper end-to-end (see `research-paper-writing` for the full pipeline). This skill curates tools and templates.
+
+## 🧠 AI Writing Tools (Priority)
+
+| Repo | ⭐ | Function |
+|------|----|--------|
+| **academic-research-skills** | 37k+ | Full Claude Code pipeline: research → write → review → finalize |
+| **opendraft** | 317 | 19-agent paper writer, verified citations via CrossRef/arXiv |
+| **Feynman** (companion-inc) | 8.3k | Standalone AI research agent + CLI |
+| **PaperOrchestra** (Google Research) | 608 | Multi-agent → submission-ready LaTeX |
+| **chatgpt-prompts-academic** | 4.8k+ | Ready-made prompts per article section |
+
+### Using with Hermes:
+
+Simply say:
+
+> "Help me write [paper section] using IMRaD template, formal academic style."
+
+Or:
+
+> "Review my paper draft for structure, argumentation, and language."
+
+## 📐 LaTeX Templates (APA 7)
+
+For journal articles and theses following APA 7:
+
+| Template | Features |
+|----------|-------|
+| **apa7-latex-template** | Zero-config Tectonic, strict APA 7 compliance |
+| **LaTeX-APA_Template** | Guided structure + sample PDF |
+| **apa-latex** | Student paper + thesis templates |
+| **LaTeX-templates** (diverse) | Collection for various needs |
+
+### How to use:
+1. Open Overleaf (overleaf.com)
+2. Pick a template or upload a .zip template
+3. Start writing
+
+## 🏗️ General Paper Templates
+
+| Template | Features |
+|----------|-------|
+| **latex-paper** | Minimalist design, arXiv-ready |
+| **latex-templates** (martinhelso) | Collection for conferences, theses, etc. |
+| **awesome-scientific-writing** | Curated toolchain: Markdown → Pandoc → LaTeX |
+
+## ✍️ Proofreading & Grammar Tools
+
+| Tool | Function | Cost |
+|------|--------|------|
+| **proselint** | Linter for academic prose | **Open source** |
+| **write-good** | Weak sentence detection | **Open source** |
+| **Rousseau** | Auto-fix common mistakes | **Open source** |
+| **Grammarly** | Full grammar & style | Freemium |
+
+## 🔄 Writing Workflow
+
+### From Zero to Submission:
+
+1. **Structure** — Decide IMRaD/other outline
+2. **Draft** — Write per section, don't be a perfectionist yet
+3. **Self-review** — Re-read, check logical flow
+4. **AI assist** — Ask Hermes to review structure & language
+5. **Proofreading** — Use proselint / Grammarly
+6. **Template** — Format per target journal template
+7. **Submit** — Prepare cover letter, metadata, files
+
+### Prompt template for Hermes:
+
+```
+I want to write a journal article about [topic].
+Target journal: [journal name, IMRaD template].
+Help me:
+1. Create a complete outline
+2. Write a draft [section]
+3. Review consistency and flow
+```
+
+## Common Pitfalls
+
+- Don't copy AI writing tools blindly — verify citations against CrossRef/arXiv (tools like opendraft do this; manual prompts don't)
+- Don't ignore journal-specific formatting — a general APA template may not match the target journal's house style
+- Don't skip proofreading tools just because an LLM drafted the text — proselint/write-good catch different issues
+
+## Verification Checklist
+
+- [ ] Recommended template matches the target output (journal article vs thesis vs conference)
+- [ ] AI tool recommendation includes citation-verification caveat
+- [ ] Writing workflow steps are complete from structure to submission
+
+## References
+
+- [GitHub Topics: academic-writing](https://github.com/topics/academic-writing) — 766 repositories
+- [academic-research-skills](https://github.com/Imbad0202/academic-research-skills) — 37k⭐
+- [PaperOrchestra](https://github.com/google-research/PaperOrchestra) — multi-agent paper writer

--- a/skills/research/framework-research/SKILL.md
+++ b/skills/research/framework-research/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: framework-research
+description: "Systematic methodology for researching external frameworks, tools, or systems — extracting architecture, concepts, use cases, and integration patterns from documentation and code."
+version: 1.0.0
+author: Fuad Al Fajri
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Research, Frameworks, Tools, Documentation, Integration]
+    category: research
+    related_skills: [grounded-citations, research-paper-writing]
+---
+
+# Framework & Tool Research
+
+Systematic methodology for researching an external framework, tool, or system from its documentation, codebase, and community resources. Produces a structured summary covering architecture, core concepts, use cases, and integration analysis.
+
+## When to Use
+
+- User asks to research, investigate, explore, or evaluate an external tool, framework, system, or library
+- User asks how to integrate or combine an external tool with their stack
+- User asks to compare tools, or explain how a library works
+
+Don't use for: one-off quick lookups ("what does this package do") — plain `web_search`/`web_extract` suffices. This skill is for producing a structured, reusable research summary.
+
+## Workflow
+
+### Phase 1: Surface Reconnaissance (5-10 min)
+
+1. **GitHub README** — navigate to the project's GitHub repo. Read the README top-to-bottom for:
+   - Elevator pitch ("what is X")
+   - Architecture diagram / overview
+   - Core concepts listed
+   - Quickstart code snippets
+   - Key features list
+
+2. **Documentation map** — find the docs index efficiently:
+   - **Mintlify-hosted docs**: hit `/llms.txt` (e.g. `https://docs.crewai.com/llms.txt`) — returns every page as a raw markdown URL
+   - **Docusaurus/GitBook**: look for a `sidebar.json`, `sidebars.js`, or `_category_.json` pattern
+   - **ReadTheDocs**: check the sitemap at `/sitemap.xml`
+   - **Raw markdown repos**: check `/docs/` directory on GitHub
+
+3. **Identify core concept pages** — from the index, pick:
+   - Architecture / Overview
+   - Core building blocks (agents, tasks, workflows, etc.)
+   - Configuration / Installation
+   - API reference (high-level)
+   - Integration guides
+
+### Phase 2: Deep Dive via Raw Markdown (fastest path)
+
+Once you have the URLs of concept pages:
+
+1. **Curl the raw markdown** — these are faster and more complete than browser navigation:
+   ```bash
+   curl -s https://docs.example.com/v1.0/en/concepts/agents.md | head -300
+   ```
+   - Mintlify pattern: `/v{version}/en/concepts/{topic}.md`
+   - GitHub raw: `https://raw.githubusercontent.com/org/repo/main/docs/{topic}.md`
+
+2. **Read sequentially by concept layer** — follow the dependency order:
+   - Foundation: What is it? Architecture overview
+   - Building blocks: Agents → Tasks → Workflows/Flows → Orchestration
+   - Execution: Configuration, processes, state management
+   - Extensions: Tools, plugins, integrations, MCP, APIs
+   - Production: Observability, checkpointing, deployment, security
+
+3. **Capture code snippets** — extract representative examples for each concept (they demonstrate API shape and usage patterns)
+
+### Phase 3: Structured Synthesis
+
+Organize findings into a report covering:
+
+| Section | Content |
+|---------|---------|
+| **What it is** | One-paragraph elevator pitch, license, stars, version |
+| **Architecture** | Tier/component diagram, data flow explanation |
+| **Core Concepts** | Each building block with parameters and relationships |
+| **Key Features** | Feature table with descriptions |
+| **Use Cases** | 3-5 concrete scenarios with agent/task breakdown |
+| **Integration Analysis** | How it maps to/complements Hermes Agent |
+
+### Phase 4: Integration Analysis with Hermes
+
+For integration analysis, evaluate:
+
+| Hermes Capability | Framework Counterpart | Relationship |
+|-------------------|----------------------|--------------|
+| `terminal` tool | Any CLI | Hermes can spawn as subprocess |
+| `web_search` | Search tools | Redundant — pick one |
+| `browser` | Web scraping tools | Redundant — pick one |
+| Skills (filesystem) | Skills/Knowledge | Complementary |
+| Memory | Memory | Complementary |
+| MCP tools | MCP support | Both support MCP |
+| `computer_use` | — | Unique to Hermes |
+| Autonomous orchestration | Flows/Workflows | Complementary layers |
+
+Define 3-4 concrete integration approaches with a recommendation.
+
+### Phase 5: Save Deliverable
+
+Write the structured report to a file and present a concise summary to the user with:
+- Architecture overview
+- Core concept map
+- Recommended integration approach
+- Key decision factors
+
+## Common Pitfalls
+
+- **Don't rely on browser for plain markdown docs** — curl the raw markdown URLs directly (faster, no truncation, no JS dependencies)
+- **Don't read pages in random order** — concepts build on each other; follow the dependency chain
+- **Don't stop at the landing page** — Mintlify SPA apps often redirect all URLs to `/`; use `llms.txt` or direct versioned `/v{...}/en/...` paths
+- **Don't over-invest in enterprise-only features** — flag them as "enterprise" but focus on open-source core
+- **Don't fabricate integration points** — if there's no natural integration point, say so honestly
+
+## Verification Checklist
+
+- [ ] Output file answers: what problem does this framework solve?
+- [ ] Output file covers: core building blocks and their relationships
+- [ ] Output file lists: concrete use cases
+- [ ] Output file states: how it can integrate with Hermes (or honestly says it can't)
+- [ ] Every claim traces to an extracted page (see `grounded-citations` for citation ledger workflow)

--- a/skills/research/phd-resources/SKILL.md
+++ b/skills/research/phd-resources/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: phd-resources
+description: "Curated tools and resources for PhD/S3 students — research lifecycle, writing, presentation, time management, and mental health."
+version: 1.0.0
+author: Fuad Al Fajri
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [PhD, Research, Writing, Presentation, Time-Management, Mental-Health]
+    category: research
+    related_skills: [academic-writing-templates, research-paper-writing, arxiv]
+---
+
+# Resources for PhD/S3 Students
+
+Curated collection of tools and resources that help during doctoral studies. Load this skill when the user asks for help with any phase of PhD work — literature search, writing, presentation, time management, or wellbeing.
+
+## When to Use
+
+- User mentions their PhD/S3 journey, dissertation, or thesis work
+- User asks for tools to find literature, manage references, or find journals
+- User asks for writing, presentation, or productivity help in an academic context
+- User asks about reproducibility, open science, or research data management
+
+## 📖 Research Paper Lifecycle
+
+### Literature Search & Discovery
+
+| Tool | Function | Cost |
+|------|--------|------|
+| **Connected Papers** | Visual graph of related papers | Free |
+| **Litmaps** | Interactive literature map | Freemium |
+| **Research Rabbit** | Citation graph discovery | **Free** |
+| **Elicit** | AI summarization + data extraction | Freemium |
+| **Semantic Scholar** | Academic search + TLDR | **Free** |
+| **Scite** | Smart citations (supporting/contrasting) | Paid |
+
+### Publication & Journals
+
+| Tool | Function |
+|------|--------|
+| **JANE** (Journal Author Name Estimator) | Find journals that fit your paper |
+| **SciRev** | Journal review speed & fairness by authors |
+| **SHERPA Romeo** | Check journal open-access policies |
+| **ORCID** | Unique lifelong author ID |
+
+## ✍️ Writing
+
+| Tool | Function |
+|------|--------|
+| **Papaja** (R package) | Write APA manuscripts from R Markdown |
+| **Preprint Templates** | Templates for arXiv, bioRxiv, etc. |
+| **QuillBot** | Paraphrasing & grammar (freemium) |
+| **Overleaf** | Online LaTeX editor + journal templates |
+
+## 📊 Presentation & Visualization
+
+| Tool | Function | Cost |
+|------|--------|------|
+| **BioRender** | Scientific illustration | Freemium |
+| **Canva** | Presentation & poster design | Freemium |
+| **Miro** | Collaborative whiteboard | Freemium |
+| **R Graph Gallery** | R chart inspiration | **Free** |
+| **Ganttrify** | Gantt chart for research timeline | **Free** |
+| **Color Oracle** | Color blindness simulation | **Free** |
+| **Figpad** | AI-assisted figure creation | Freemium |
+
+## ⏰ Time Management & Productivity
+
+| Tool | Function | Cost |
+|------|--------|------|
+| **Notion** | All-in-one workspace — notes, databases, project management | Freemium |
+| **Trello** | Kanban board — task tracking | **Free** |
+| **The Good Research Code Handbook** | Guide to reproducible research coding | **Free** (online) |
+| **Pomodoro** | 25-minute focus technique | Many free apps |
+
+## 🧠 Mental Health & Wellbeing
+
+Mental health during a PhD matters! Podcasts and communities:
+
+| Resource | Description |
+|----------|-----------|
+| **Dear Grad Student** | Podcast about graduate student ups and downs |
+| **Honest Academia** | Honest discussion about academia |
+| **Everything Hertz** | Research methodology + researcher wellbeing |
+
+**Tips:**
+- Maintain work-life balance
+- Discuss regularly with fellow PhD students
+- Don't hesitate to consult your supervisor
+- Use campus counseling facilities
+
+## 🔬 Reproducibility & Open Science
+
+| Tool | Function |
+|------|--------|
+| **OSF** (Open Science Framework) | Open research platform — store data, code, papers |
+| **Zenodo** | Publication repository for data & code |
+| **ORCID** | Unique author ID |
+| **Unpaywall** | Browser extension for free paper access |
+
+## Common Pitfalls
+
+- Don't rely on a single discovery tool — citation graphs (Connected Papers/Litmaps) and keyword search (Semantic Scholar) find different things
+- Don't wait until the end to organize references — use ORCID + a reference manager from day one
+- Don't neglect reproducibility — code and data saved at publication time beats reconstruction later
+
+## Verification Checklist
+
+- [ ] Recommendation matches the specific phase of PhD work the user is in
+- [ ] Free tools suggested before paid ones where capability is comparable
+- [ ] Mental-health and reproducibility resources included when relevant
+
+## References
+
+- [awesome-PhD](https://github.com/helenahartmann/awesome-PhD) — PhD resources


### PR DESCRIPTION
## Summary
Adds three research-category skills useful for academic users:

- **framework-research** — systematic methodology for researching external frameworks/tools from docs & code; structured report covering architecture, concepts, use cases, integration analysis with Hermes
- **phd-resources** — curated tools for PhD/S3 students: research lifecycle, writing, presentation, time management, mental health, reproducibility
- **academic-writing-templates** — LaTeX APA7 templates, AI writing tools, proofreading tools, and a zero-to-submission writing workflow

## Validation
- All three pass in-repo skill validation: frontmatter starts at byte 0, name ≤64 chars, description ≤1024 chars, total ≤100K chars
- English, no private data, no external dependencies (stdlib only)
- related_skills reference only in-repo skills

## Testing
- Validated locally with PyYAML frontmatter parser (name/description present, size limits met)
- Structure follows peer pattern: Overview → When to Use → body → Common Pitfalls → Verification Checklist