### PR TITLE
fix(gateway): preserve scoped Telegram authorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1201,12 +1201,15 @@ invalidation. See `/skills install --now` for the canonical pattern.
 ### Compression-final persistence
 
 - A long-running turn can publish a compression child before its final durable
-  flush completes. If the atomic message batch then raises
-  `CompressionSessionClosedError`, adopt only the unique live continuation via
-  `recover_rotated_compression_session()` and retry that same batch once. Do not
-  reroute other persistence errors, guess among ambiguous children, or stamp
+  flush completes, and it can remain stale across several later compression
+  generations. If the atomic message batch then raises
+  `CompressionSessionClosedError`, walk to the live tip only when **every**
+  durable compression edge has exactly one canonical continuation; then retry
+  that same batch once. Do not reroute other persistence errors, stop at an
+  already-compressed direct child, guess among ambiguous siblings, or stamp
   `_db_persisted` before the retry succeeds. Keep the real-`SessionDB`
-  regression in `tests/run_agent/test_flush_compression_child_adoption.py`.
+  regressions in `tests/run_agent/test_flush_compression_child_adoption.py` and
+  `tests/state/test_compression_lineage_guard.py`.
 
 ### Background Process Notifications (Gateway)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1198,6 +1198,16 @@ invalidation. See `/skills install --now` for the canonical pattern.
   `LoadState=loaded`; otherwise a synthetic user-manager `TimeoutStopUSec=90s`
   can shadow the real system unit. Pin this in `test_shutdown_forensics.py`.
 
+### Compression-final persistence
+
+- A long-running turn can publish a compression child before its final durable
+  flush completes. If the atomic message batch then raises
+  `CompressionSessionClosedError`, adopt only the unique live continuation via
+  `recover_rotated_compression_session()` and retry that same batch once. Do not
+  reroute other persistence errors, guess among ambiguous children, or stamp
+  `_db_persisted` before the retry succeeds. Keep the real-`SessionDB`
+  regression in `tests/run_agent/test_flush_compression_child_adoption.py`.
+
 ### Background Process Notifications (Gateway)
 
 When `terminal(background=true, notify_on_complete=true)` is used, the gateway runs a watcher that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1184,6 +1184,20 @@ must be **cache-aware**: default to deferred invalidation (change takes
 effect next session), with an opt-in `--now` flag for immediate
 invalidation. See `/skills install --now` for the canonical pattern.
 
+### Gateway Multiplex Auth and Systemd Discovery
+
+- Adapter authorization callbacks must restore their captured profile runtime
+  scope. Delayed and reconnect-created transport tasks are not allowed to rely
+  on inherited `ContextVar` state; Telegram early intake and inline
+  approval/clarify callbacks must use the registered gateway authorization
+  callback before any process-env fallback. Keep the default and
+  secondary-profile regression cases in `test_multiplex_profile_authz.py` and
+  the end-to-end intake/callback cases in `test_telegram_auth_check.py`.
+- `systemctl show` can return success and default properties for an unknown unit.
+  Gateway timing checks must accept a manager candidate only when
+  `LoadState=loaded`; otherwise a synthetic user-manager `TimeoutStopUSec=90s`
+  can shadow the real system unit. Pin this in `test_shutdown_forensics.py`.
+
 ### Background Process Notifications (Gateway)
 
 When `terminal(background=true, notify_on_complete=true)` is used, the gateway runs a watcher that

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -64,7 +64,7 @@ import uuid
 import threading
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from agent.auxiliary_client import AuxiliaryExplicitCancellation
 from agent.context_engine import (
@@ -1204,17 +1204,16 @@ def compression_skipped_due_to_lock(agent: Any) -> bool:
     return _sig is True or isinstance(_sig, str)
 
 
-def _adopt_live_compression_child(
-    agent: Any,
+CompressionSessionRecovery = Tuple[
+    str, Dict[str, Any], List[Dict[str, Any]]
+]
+
+
+def _resolve_live_compression_child(
     session_db: Any,
     parent_session_id: str,
-) -> Optional[List[Dict[str, Any]]]:
-    """Move a stale compression contender onto the unique durable child.
-
-    Resolve and load first, then mutate the live agent. This ordering keeps the
-    stale contender fail-closed when lineage is ambiguous or the compacted
-    handoff cannot be read.
-    """
+) -> Optional[Tuple[Dict[str, Any], List[Dict[str, Any]]]]:
+    """Resolve and load a unique durable child without mutating the agent."""
     finder = getattr(type(session_db), "find_live_compression_child", None)
     loader = getattr(type(session_db), "get_messages_as_conversation", None)
     if not callable(finder) or not callable(loader):
@@ -1231,7 +1230,21 @@ def _adopt_live_compression_child(
     confirmed = finder(session_db, parent_session_id)
     if not confirmed or str(confirmed.get("id") or "") != child_session_id:
         return None
+    return cast(Dict[str, Any], child), cast(List[Dict[str, Any]], recovered)
 
+
+def _commit_live_compression_child_adoption(
+    agent: Any,
+    session_db: Any,
+    parent_session_id: str,
+    child: Dict[str, Any],
+    recovered: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Commit a previously resolved compression-child adoption in memory."""
+    child_session_id = str(child["id"])
+    lineage_parent_session_id = str(
+        child.get("parent_session_id") or parent_session_id
+    )
     agent.session_id = child_session_id
     try:
         from gateway.session_context import set_current_session_id
@@ -1261,7 +1274,9 @@ def _adopt_live_compression_child(
             on_session_start(
                 child_session_id,
                 boundary_reason="compression",
-                old_session_id=parent_session_id,
+                # The durable state carrier is the tip's immediate lineage
+                # parent, not an arbitrarily stale ancestor this process held.
+                old_session_id=lineage_parent_session_id,
                 session_db=session_db,
                 platform=getattr(agent, "platform", None) or "cli",
                 conversation_id=getattr(agent, "_gateway_session_key", None),
@@ -1289,10 +1304,30 @@ def _adopt_live_compression_child(
     return recovered
 
 
-def recover_rotated_compression_session(
+def _adopt_live_compression_child(
     agent: Any,
+    session_db: Any,
+    parent_session_id: str,
 ) -> Optional[List[Dict[str, Any]]]:
-    """Recover a stale live agent before a new turn writes to its old parent."""
+    """Move a stale compression contender onto the unique durable child.
+
+    Resolve and load first, then mutate the live agent. This ordering keeps the
+    stale contender fail-closed when lineage is ambiguous or the compacted
+    handoff cannot be read.
+    """
+    resolved = _resolve_live_compression_child(session_db, parent_session_id)
+    if resolved is None:
+        return None
+    child, recovered = resolved
+    return _commit_live_compression_child_adoption(
+        agent, session_db, parent_session_id, child, recovered
+    )
+
+
+def prepare_rotated_compression_session(
+    agent: Any,
+) -> Optional[CompressionSessionRecovery]:
+    """Resolve a stale agent's continuation without mutating live agent state."""
     session_db = getattr(agent, "_session_db", None)
     session_id = getattr(agent, "session_id", None) or ""
     if session_db is None or not session_id:
@@ -1305,9 +1340,10 @@ def recover_rotated_compression_session(
         # observing the intentional parent-ended/child-empty intermediate state.
         holder_getter = getattr(session_db, "get_compression_lock_holder", None)
         for attempt in range(21):
-            recovered = _adopt_live_compression_child(agent, session_db, session_id)
-            if recovered is not None:
-                return recovered
+            resolved = _resolve_live_compression_child(session_db, session_id)
+            if resolved is not None:
+                child, recovered = resolved
+                return session_id, child, recovered
             holder = holder_getter(session_id) if callable(holder_getter) else None
             if not holder or attempt == 20:
                 if not holder:
@@ -1336,8 +1372,52 @@ def recover_rotated_compression_session(
         return None
     except Exception as exc:
         logger.warning(
-            "compression session recovery failed for session=%s (%s: %s)",
+            "compression session recovery preparation failed for session=%s "
+            "(%s: %s)",
             session_id,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+
+def commit_rotated_compression_session(
+    agent: Any,
+    recovery: CompressionSessionRecovery,
+) -> List[Dict[str, Any]]:
+    """Commit agent adoption after the caller's guarded durable write succeeds."""
+    session_db = getattr(agent, "_session_db", None)
+    parent_session_id, child, recovered = recovery
+    current_session_id = getattr(agent, "session_id", None) or ""
+    if session_db is None or current_session_id != parent_session_id:
+        raise RuntimeError(
+            "compression recovery target changed before in-memory adoption"
+        )
+    if not child.get("id"):
+        raise RuntimeError("compression recovery child has no session id")
+    return _commit_live_compression_child_adoption(
+        agent,
+        session_db,
+        parent_session_id,
+        child,
+        recovered,
+    )
+
+
+def recover_rotated_compression_session(
+    agent: Any,
+) -> Optional[List[Dict[str, Any]]]:
+    """Recover a stale live agent before a new turn writes to its old parent."""
+    recovery = prepare_rotated_compression_session(agent)
+    if recovery is None:
+        return None
+    parent_session_id = recovery[0]
+    try:
+        return commit_rotated_compression_session(agent, recovery)
+    except Exception as exc:
+        logger.warning(
+            "compression session recovery failed for session=%s (%s: %s)",
+            parent_session_id,
             type(exc).__name__,
             exc,
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14286,9 +14286,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         store, allow-all flags — stays the single source of truth.
 
         ``profile_name`` binds the callback to the secondary adapter's own
-        multiplex profile, so its ``SessionSource`` resolves that profile's
-        secret scope instead of falling back to the active profile.
+        multiplex profile.  The callback also restores that profile's runtime
+        scope itself: adapter callbacks may run in delayed/reconnected transport
+        tasks whose inherited ContextVar state is absent, and auth must remain
+        fail-closed without falsely rejecting an allowed sender.
         """
+        profile_home: Optional[Path] = None
+        if getattr(self.config, "multiplex_profiles", False):
+            if profile_name:
+                from hermes_cli.profiles import get_profile_dir
+
+                profile_home = Path(get_profile_dir(profile_name))
+            else:
+                profile_home = Path(get_hermes_home())
+
         def check(
             user_id: str,
             chat_type: Optional[str] = None,
@@ -14303,6 +14314,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_id=user_id,
                 profile=profile_name,
             )
+            if profile_home is not None:
+                with _profile_runtime_scope(profile_home):
+                    return self._is_user_authorized(source)
             return self._is_user_authorized(source)
         return check
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3530,7 +3530,11 @@ class SessionStore:
                     child_id = str(child["id"]) if child and child.get("id") else ""
                     if child_id:
                         try:
-                            self._append_transcript_message(child_id, msg)
+                            self._append_transcript_message(
+                                child_id,
+                                msg,
+                                compression_lineage_root=session_id,
+                            )
                         except Exception as reroute_exc:
                             exc = reroute_exc
                         else:
@@ -3652,7 +3656,13 @@ class SessionStore:
                 "Failed to drain transcript spool for %s: %s", session_id, exc
             )
 
-    def _append_transcript_message(self, session_id: str, message: Dict[str, Any]) -> None:
+    def _append_transcript_message(
+        self,
+        session_id: str,
+        message: Dict[str, Any],
+        *,
+        compression_lineage_root: Optional[str] = None,
+    ) -> None:
         """Write one transcript row. Caller handles retry queuing."""
         self._db.append_message(
             session_id=session_id,
@@ -3674,6 +3684,7 @@ class SessionStore:
             # any gateway-side persistence path or the next turn's
             # replay diverges at this row.
             api_content=extract_api_content_sidecar(message),
+            compression_lineage_root=compression_lineage_root,
         )
 
     # Maximum in-memory pending messages per session before dropping the

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -362,29 +362,38 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
 
     # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
     # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # that's the common case for hermes.  ``systemctl show`` returns success
+    # plus default properties for an unknown unit, so LoadState must confirm
+    # that the candidate is real before its timeout can win.
     timeout_us: Optional[int] = None
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                [
+                    "systemctl", *flag, "show", unit_name,
+                    "--property=LoadState",
+                    "--property=TimeoutStopUSec",
+                ],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
             continue
-        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+        properties = {}
         for line in result.stdout.splitlines():
-            if line.startswith("TimeoutStopUSec="):
-                value = line.split("=", 1)[1].strip()
-                # Try numeric microseconds first
-                if value.isdigit():
-                    timeout_us = int(value)
-                else:
-                    timeout_us = _parse_systemd_duration_to_us(value)
-                if timeout_us is not None:
-                    break
+            key, separator, value = line.partition("=")
+            if separator:
+                properties[key] = value.strip()
+        if properties.get("LoadState") != "loaded":
+            continue
+        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+        value = properties.get("TimeoutStopUSec", "")
+        # Try numeric microseconds first
+        if value.isdigit():
+            timeout_us = int(value)
+        else:
+            timeout_us = _parse_systemd_duration_to_us(value)
         if timeout_us is not None:
             break
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4544,23 +4544,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         "  AND COALESCE({alias}source, '') != 'tool'\n"
     )
 
-    def find_live_compression_child(
-        self, parent_session_id: str
+    def _find_live_compression_child_on_conn(
+        self, conn, parent_session_id: str
     ) -> Optional[Dict[str, Any]]:
-        """Return the unique live direct child of a compression-ended session.
-
-        A stale agent may observe that another compression path already rotated
-        its parent. Recovery is safe only when the durable lineage identifies
-        exactly one live direct continuation. Multiple children are treated as
-        ambiguous and fail closed rather than guessing which transcript owns
-        subsequent messages.
-        """
-        if not parent_session_id:
-            return None
-        with self._lock:
-            parent = self._conn.execute(
+        """Resolve a unique continuation tip on the caller's SQLite snapshot."""
+        current = parent_session_id
+        seen = {current}
+        for _ in range(100):
+            parent = conn.execute(
                 "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
-                (parent_session_id,),
+                (current,),
             ).fetchone()
             if (
                 parent is None
@@ -4568,7 +4561,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 or parent["end_reason"] != "compression"
             ):
                 return None
-            rows = self._conn.execute(
+            rows = conn.execute(
                 """
                 SELECT s.*,
                        COALESCE(sp.prompt, s.system_prompt)
@@ -4576,16 +4569,57 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 FROM sessions s
                 LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash
                 WHERE s.parent_session_id = ?
-                  AND s.ended_at IS NULL
                 """
                 + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="s.")
                 + """
                 ORDER BY s.started_at ASC
                 LIMIT 2
                 """,
-                (parent_session_id, parent_session_id, parent_session_id),
+                (current, current, current),
             ).fetchall()
-        return self._session_row_dict(rows[0]) if len(rows) == 1 else None
+            if len(rows) != 1:
+                return None
+            child = rows[0]
+            child_session_id = str(child["id"] or "")
+            if not child_session_id or child_session_id in seen:
+                return None
+            if child["ended_at"] is None:
+                return self._session_row_dict(child)
+            if child["end_reason"] != "compression":
+                return None
+            seen.add(child_session_id)
+            current = child_session_id
+        return None
+
+    def find_live_compression_child(
+        self, parent_session_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the unique live tip of a compression continuation chain.
+
+        A stale agent may lag behind several completed compression rotations.
+        Recovery is safe only when every durable edge from the stale parent to
+        the live tip has exactly one canonical continuation. Any sibling,
+        cycle, missing handoff, or non-compression closure is ambiguous and
+        fails closed rather than guessing which transcript owns subsequent
+        messages. The complete walk uses one SQLite read snapshot so concurrent
+        writers cannot splice together observations from different lineages.
+        """
+        if not parent_session_id:
+            return None
+        with self._lock:
+            conn = self._conn
+            if conn is None:
+                return None
+            owns_transaction = not conn.in_transaction
+            if owns_transaction:
+                conn.execute("BEGIN")
+            try:
+                return self._find_live_compression_child_on_conn(
+                    conn, parent_session_id
+                )
+            finally:
+                if owns_transaction:
+                    conn.rollback()
 
     def reopen_orphaned_compression_session(self, session_id: str) -> bool:
         """Reopen a compression parent only when no continuation was published.
@@ -7563,14 +7597,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return None
 
     def _check_transcript_write_guards(
-        self, conn, session_id: str, compression_lock_holder: Optional[str]
+        self,
+        conn,
+        session_id: str,
+        compression_lock_holder: Optional[str],
+        compression_lineage_root: Optional[str] = None,
     ) -> None:
         """Transcript-append admission checks, run INSIDE the write txn.
 
         Shared by :meth:`append_message` and :meth:`append_messages_batch` so
         the two writers can never diverge on these correctness invariants
         (this guard has already needed targeted fixes — see the #74478
-        patience note below).
+        patience note below). A rerouted writer supplies its stale lineage root;
+        the expected tip is then re-resolved under this transaction's
+        ``BEGIN IMMEDIATE`` lock before any message row can land.
         """
         active_lock = conn.execute(
             "SELECT holder FROM compression_locks "
@@ -7594,6 +7634,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             and session["end_reason"] == "compression"
         ):
             raise CompressionSessionClosedError(session_id)
+        if compression_lineage_root:
+            tip = self._find_live_compression_child_on_conn(
+                conn, compression_lineage_root
+            )
+            tip_session_id = str(tip.get("id") or "") if tip else ""
+            if tip_session_id != session_id:
+                raise CompressionSessionClosedError(compression_lineage_root)
 
     @staticmethod
     def _decode_display_metadata(raw: Any) -> Optional[Dict[str, Any]]:
@@ -7663,6 +7710,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         display_kind: Optional[str] = None,
         display_metadata: Optional[Dict[str, Any]] = None,
         compression_lock_holder: Optional[str] = None,
+        compression_lineage_root: Optional[str] = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -7683,6 +7731,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (which sqlite3 cannot bind and which the conversation loop scrubs
         from every outgoing payload anyway, so the scrubbed form IS the
         wire bytes).
+
+        ``compression_lineage_root`` is set only by a reroute from a stale
+        compression parent. The expected ``session_id`` tip is revalidated
+        inside this method's write transaction before the row is inserted.
         """
         # Display metadata is presentation-only and never changes the model
         # context role/content replayed to providers.
@@ -7721,7 +7773,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         def _do(conn):
             self._check_transcript_write_guards(
-                conn, session_id, compression_lock_holder
+                conn,
+                session_id,
+                compression_lock_holder,
+                compression_lineage_root,
             )
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
@@ -7784,6 +7839,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         messages: List[Dict[str, Any]],
         compression_lock_holder: Optional[str] = None,
         chunk_rows: Optional[int] = None,
+        compression_lineage_root: Optional[str] = None,
     ) -> int:
         """Append multiple messages atomically in ONE write transaction.
 
@@ -7801,7 +7857,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Atomicity contract: all rows land or none do (the caller re-flushes
         unstamped messages on the next attempt). The same admission guards
         as :meth:`append_message` run once for the batch — same session,
-        same instant.
+        same instant. A rerouted caller passes ``compression_lineage_root``
+        so the expected tip is revalidated under the same ``BEGIN IMMEDIATE``
+        transaction that inserts the batch.
 
         ``chunk_rows`` bounds the transaction size for LARGE copies (branch
         seeds can be thousands of rows; measured: 10k rows ≈ 2.4s inside one
@@ -7822,12 +7880,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     session_id,
                     messages[start:start + chunk_rows],
                     compression_lock_holder=compression_lock_holder,
+                    compression_lineage_root=compression_lineage_root,
                 )
             return inserted_total
 
         def _do(conn):
             self._check_transcript_write_guards(
-                conn, session_id, compression_lock_holder
+                conn,
+                session_id,
+                compression_lock_holder,
+                compression_lineage_root,
             )
             inserted, tool_calls_total = self._insert_message_rows(
                 conn, session_id, messages

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -956,17 +956,38 @@ class TelegramAdapter(BasePlatformAdapter):
         if not normalized_user_id:
             return False
 
+        normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
+        if normalized_chat_type == "private":
+            normalized_chat_type = "dm"
+        elif normalized_chat_type == "supergroup":
+            normalized_chat_type = "forum" if thread_id is not None else "group"
+
+        # Approval/clarify callbacks can run in delayed PTB tasks with no
+        # inherited multiplex profile ContextVar. Prefer the gateway-supplied
+        # callback, which restores the adapter's captured profile scope, before
+        # falling back to legacy runner/env discovery.
+        try:
+            authorized = self._is_sender_authorized(
+                normalized_user_id,
+                chat_type=normalized_chat_type,
+                chat_id=str(chat_id or normalized_user_id),
+            )
+        except Exception:
+            logger.debug(
+                "[Telegram] Registered callback auth failed for user %s; "
+                "falling back to the legacy runner/env path",
+                normalized_user_id,
+                exc_info=True,
+            )
+            authorized = None
+        if authorized is not None:
+            return bool(authorized)
+
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:
                 from gateway.session import SessionSource
-
-                normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
-                if normalized_chat_type == "private":
-                    normalized_chat_type = "dm"
-                elif normalized_chat_type == "supergroup":
-                    normalized_chat_type = "forum" if thread_id is not None else "group"
 
                 source = SessionSource(
                     platform=Platform.TELEGRAM,
@@ -1154,6 +1175,26 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception:
                     pass
+
+        # The gateway registers a platform-bound callback on every live adapter.
+        # Use it before inspecting the message-handler binding: multiplex message
+        # handlers are closures (no ``__self__``), and reconnect-created PTB tasks
+        # may have no inherited profile ContextVar.  The registered callback owns
+        # restoring the correct profile scope.
+        if authorized is None:
+            try:
+                authorized = self._is_sender_authorized(
+                    user_id,
+                    chat_type=source.chat_type,
+                    chat_id=source.chat_id,
+                )
+            except Exception:
+                logger.debug(
+                    "[Telegram] Registered auth callback failed for user %s; "
+                    "falling back to the legacy runner/env path",
+                    user_id,
+                    exc_info=True,
+                )
 
         if authorized is None:
             runner = getattr(getattr(self, "_message_handler", None), "__self__", None)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2302,24 +2302,35 @@ class AIAgent:
                         raise
                     stale_session_id = self.session_id
                     from agent.conversation_compression import (
-                        recover_rotated_compression_session,
+                        commit_rotated_compression_session,
+                        prepare_rotated_compression_session,
                     )
 
-                    recovered = recover_rotated_compression_session(self)
-                    if recovered is None or self.session_id == stale_session_id:
+                    recovery = prepare_rotated_compression_session(self)
+                    if recovery is None:
                         raise
+                    recovery_parent, recovery_child, _ = recovery
+                    candidate_session_id = str(recovery_child.get("id") or "")
+                    if (
+                        recovery_parent != stale_session_id
+                        or not candidate_session_id
+                        or candidate_session_id == stale_session_id
+                    ):
+                        raise
+                    self._session_db.append_messages_batch(
+                        session_id=candidate_session_id,
+                        messages=_batch_rows,
+                        compression_lock_holder=getattr(
+                            self, "_active_compression_lock_holder", None
+                        ),
+                        compression_lineage_root=stale_session_id,
+                    )
+                    commit_rotated_compression_session(self, recovery)
                     logger.info(
                         "Final session flush adopted compression continuation "
                         "%s -> %s",
                         stale_session_id,
                         self.session_id,
-                    )
-                    self._session_db.append_messages_batch(
-                        session_id=self.session_id,
-                        messages=_batch_rows,
-                        compression_lock_holder=getattr(
-                            self, "_active_compression_lock_holder", None
-                        ),
                     )
                 self._flushed_db_message_session_id = self.session_id
                 for _written in _batch_msgs:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2282,13 +2282,46 @@ class AIAgent:
             # re-writes the whole tail (same recovery contract as before,
             # minus the partial-prefix case that could double-pay counters).
             if _batch_rows:
-                self._session_db.append_messages_batch(
-                    session_id=self.session_id,
-                    messages=_batch_rows,
-                    compression_lock_holder=getattr(
-                        self, "_active_compression_lock_holder", None
-                    ),
-                )
+                try:
+                    self._session_db.append_messages_batch(
+                        session_id=self.session_id,
+                        messages=_batch_rows,
+                        compression_lock_holder=getattr(
+                            self, "_active_compression_lock_holder", None
+                        ),
+                    )
+                except Exception as append_exc:
+                    # A long-running turn can publish its compression child and
+                    # still reach this final flush through a stale Agent path.
+                    # The batch writer rejects the ended parent before inserting
+                    # any rows. Adopt only the unique durable continuation, then
+                    # retry the same all-or-nothing batch exactly once.
+                    from hermes_state import CompressionSessionClosedError
+
+                    if not isinstance(append_exc, CompressionSessionClosedError):
+                        raise
+                    stale_session_id = self.session_id
+                    from agent.conversation_compression import (
+                        recover_rotated_compression_session,
+                    )
+
+                    recovered = recover_rotated_compression_session(self)
+                    if recovered is None or self.session_id == stale_session_id:
+                        raise
+                    logger.info(
+                        "Final session flush adopted compression continuation "
+                        "%s -> %s",
+                        stale_session_id,
+                        self.session_id,
+                    )
+                    self._session_db.append_messages_batch(
+                        session_id=self.session_id,
+                        messages=_batch_rows,
+                        compression_lock_holder=getattr(
+                            self, "_active_compression_lock_holder", None
+                        ),
+                    )
+                self._flushed_db_message_session_id = self.session_id
                 for _written in _batch_msgs:
                     _written[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the

--- a/tests/agent/test_compression_orphan_recovery.py
+++ b/tests/agent/test_compression_orphan_recovery.py
@@ -1,7 +1,9 @@
 """Recovery for legacy compression parents with no continuation child."""
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
+from agent.context_compressor import ContextCompressor
 from agent.conversation_compression import recover_rotated_compression_session
 from hermes_state import CompressionSessionClosedError, SessionDB
 
@@ -38,5 +40,58 @@ def test_recover_rotated_compression_session_keeps_parent_closed_with_child(
             pass
         else:
             raise AssertionError("compression parent with child was reopened")
+    finally:
+        db.close()
+
+
+def test_multi_generation_recovery_preserves_immediate_parent_compression_state(
+    tmp_path,
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("root", source="telegram")
+        db.append_message("root", "user", "root transcript")
+        db.end_session("root", "compression")
+        db.create_session("child", source="telegram", parent_session_id="root")
+        db.append_message("child", "user", "child handoff")
+        db.end_session("child", "compression")
+        db.create_session("tip", source="telegram", parent_session_id="child")
+        db.append_message("tip", "user", "tip handoff")
+
+        db.set_compression_fallback_streak("root", 1)
+        db.set_compression_ineffective_count("root", 1)
+        db.set_compression_fallback_streak("child", 4)
+        db.set_compression_ineffective_count("child", 2)
+        db.set_compression_fallback_streak("tip", 4)
+        db.set_compression_ineffective_count("tip", 2)
+
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=100_000,
+        ):
+            compressor = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.85,
+                protect_first_n=2,
+                protect_last_n=2,
+                quiet_mode=True,
+            )
+        compressor.bind_session_state(db, "root")
+        agent = SimpleNamespace(
+            _session_db=db,
+            session_id="root",
+            context_compressor=compressor,
+            _memory_manager=None,
+            platform="telegram",
+            _gateway_session_key="agent:main:telegram:dm:test",
+        )
+
+        recovered = recover_rotated_compression_session(agent)
+
+        assert recovered is not None
+        assert agent.session_id == "tip"
+        assert compressor._fallback_compression_streak == 4
+        assert compressor._ineffective_compression_count == 2
+        assert db.get_compression_ineffective_count("tip") == 2
     finally:
         db.close()

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -114,6 +114,50 @@ def test_adapter_auth_check_stamps_secondary_profile(monkeypatch):
     assert captured["profile"] == "coder"
 
 
+@pytest.mark.parametrize("profile_name", [None, "coder"])
+def test_adapter_auth_check_restores_profile_scope_when_invoked_unscoped(
+    monkeypatch,
+    tmp_path,
+    profile_name,
+):
+    """PTB/reconnect callbacks must not depend on inherited ContextVar state."""
+    from agent import secret_scope as ss
+    import gateway.run as gateway_run
+    from gateway.run import GatewayRunner
+    from hermes_cli import profiles as profiles_mod
+
+    profile_home = tmp_path / (profile_name or "default")
+    profile_home.mkdir()
+    (profile_home / ".env").write_text(
+        "WECOM_ALLOWED_USERS=scoped-user\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: str(profile_home))
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda _name: profile_home)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    def fake_is_user_authorized(source):
+        assert source.profile == profile_name
+        return ss.get_secret("WECOM_ALLOWED_USERS") == source.user_id
+
+    runner._is_user_authorized = fake_is_user_authorized
+
+    ss.set_multiplex_active(True)
+    scope_token = ss.set_secret_scope(None)
+    try:
+        check = runner._make_adapter_auth_check(
+            Platform.WECOM,
+            profile_name=profile_name,
+        )
+        assert check("scoped-user", "dm", "dm-chat") is True
+        assert ss.current_secret_scope() is None
+    finally:
+        ss.reset_secret_scope(scope_token)
+        ss.set_multiplex_active(False)
+
+
 def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     """Secondary profiles must pass the same open-policy startup guard."""
     from gateway.run import _own_policy_open_startup_violation

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1360,6 +1360,57 @@ class TestGatewaySessionDbRecovery:
         ]
         db.close()
 
+    def test_compression_reroute_revalidates_lineage_before_append(
+        self, tmp_path, monkeypatch
+    ):
+        import threading
+        from types import SimpleNamespace
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session("parent", source="telegram")
+            db.end_session("parent", "compression")
+            db.create_session("child", source="telegram", parent_session_id="parent")
+            db.replace_messages(
+                "child", [{"role": "user", "content": "summary"}]
+            )
+            original_find = db.find_live_compression_child
+
+            def racing_find(session_id):
+                child = original_find(session_id)
+                db.create_session(
+                    "ambiguous-sibling",
+                    source="telegram",
+                    parent_session_id="parent",
+                )
+                return child
+
+            monkeypatch.setattr(db, "find_live_compression_child", racing_find)
+            store = object.__new__(SessionStore)
+            store._db = db
+            store._lock = threading.RLock()
+            store._entries = {"route": SimpleNamespace(session_id="parent")}
+            store._loaded = True
+            store._save = lambda: None
+            store._transcript_retry_lock = threading.Lock()
+            store._dirty_transcripts = {}
+            store._transcript_append_failures = {}
+            store._fts_rebuild_attempted = False
+
+            store.append_to_transcript(
+                "parent", {"role": "assistant", "content": "must fail closed"}
+            )
+
+            assert [
+                m["content"] for m in db.get_messages_as_conversation("child")
+            ] == ["summary"]
+            assert [
+                m["content"] for m in store._dirty_transcripts["parent"]
+            ] == ["must fail closed"]
+            assert store._entries["route"].session_id == "parent"
+        finally:
+            db.close()
+
     def test_transcript_reroute_migrates_remaining_backlog_to_child(self):
         import threading
         from types import SimpleNamespace
@@ -1388,10 +1439,14 @@ class TestGatewaySessionDbRecovery:
         child_attempts = []
         failed_old_2 = False
 
-        def _append(session_id, message):
+        def _append(
+            session_id, message, *, compression_lineage_root=None
+        ):
             nonlocal failed_old_2
             if session_id == "parent":
                 raise CompressionSessionClosedError("parent")
+            if message["content"] == "old-1":
+                assert compression_lineage_root == "parent"
             child_attempts.append(message["content"])
             if message["content"] == "old-2" and not failed_old_2:
                 failed_old_2 = True

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import io
 import os
 import signal
 import sys
@@ -133,6 +134,47 @@ class TestParseSystemdDuration:
 # ---------------------------------------------------------------------------
 
 class TestCheckSystemdTimingAlignment:
+
+    def test_skips_not_found_user_unit_and_reads_loaded_system_unit(self, monkeypatch):
+        """A synthetic user-manager object must not shadow the real system unit."""
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+
+        real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/self/cgroup":
+                return io.StringIO("0::/system.slice/hermes-gateway.service\n")
+            return real_open(path, *args, **kwargs)
+
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append(command)
+            if "--user" in command:
+                stdout = (
+                    "LoadState=not-found\n"
+                    "FragmentPath=\n"
+                    "TimeoutStopUSec=1min 30s\n"
+                )
+            else:
+                stdout = (
+                    "LoadState=loaded\n"
+                    "FragmentPath=/etc/systemd/system/hermes-gateway.service\n"
+                    "TimeoutStopUSec=5min 30s\n"
+                )
+            return sf.subprocess.CompletedProcess(command, 0, stdout, "")
+
+        monkeypatch.setattr("builtins.open", fake_open)
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(300.0)
+
+        assert result is not None
+        assert result["timeout_stop_sec"] == 330.0
+        assert result["mismatch"] is False
+        assert len(calls) == 2
+        assert "--user" in calls[0]
+        assert "--user" not in calls[1]
 
     def test_returns_none_when_unit_undeterminable(self, monkeypatch):
         monkeypatch.setenv("INVOCATION_ID", "abc")

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -144,6 +144,93 @@ def test_is_user_authorized_from_message_allow_from():
     assert adapter._is_user_authorized_from_message(msg) is False
 
 
+def test_telegram_early_auth_uses_profile_scoped_gateway_callback(
+    monkeypatch,
+    tmp_path,
+):
+    """Reconnect intake must not fall back to another profile's process env."""
+    from agent import secret_scope as ss
+    from gateway.config import GatewayConfig
+    import gateway.run as gateway_run
+    from gateway.run import GatewayRunner
+
+    profile_home = tmp_path / "default"
+    profile_home.mkdir()
+    (profile_home / ".env").write_text(
+        "TELEGRAM_ALLOWED_USERS=111\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: str(profile_home))
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    def fake_is_user_authorized(source):
+        return ss.get_secret("TELEGRAM_ALLOWED_USERS") == source.user_id
+
+    runner._is_user_authorized = fake_is_user_authorized
+    adapter = _make_adapter()
+    adapter.set_authorization_check(
+        runner._make_adapter_auth_check(Platform.TELEGRAM)
+    )
+    message = _make_message(from_user_id=111, chat_id=111, chat_type="private")
+
+    ss.set_multiplex_active(True)
+    scope_token = ss.set_secret_scope(None)
+    try:
+        assert adapter._is_user_authorized_from_message(message) is True
+        assert ss.current_secret_scope() is None
+    finally:
+        ss.reset_secret_scope(scope_token)
+        ss.set_multiplex_active(False)
+
+
+def test_telegram_callback_auth_uses_profile_scoped_gateway_callback(
+    monkeypatch,
+    tmp_path,
+):
+    """Approval/clarify buttons must use the same scoped callback as intake."""
+    from agent import secret_scope as ss
+    from gateway.config import GatewayConfig
+    import gateway.run as gateway_run
+    from gateway.run import GatewayRunner
+
+    profile_home = tmp_path / "default"
+    profile_home.mkdir()
+    (profile_home / ".env").write_text(
+        "TELEGRAM_ALLOWED_USERS=111\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: str(profile_home))
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    def fake_is_user_authorized(source):
+        return ss.get_secret("TELEGRAM_ALLOWED_USERS") == source.user_id
+
+    runner._is_user_authorized = fake_is_user_authorized
+    adapter = _make_adapter()
+    adapter.set_authorization_check(
+        runner._make_adapter_auth_check(Platform.TELEGRAM)
+    )
+
+    ss.set_multiplex_active(True)
+    scope_token = ss.set_secret_scope(None)
+    try:
+        assert adapter._is_callback_user_authorized(
+            "111",
+            chat_type="private",
+            chat_id="111",
+        ) is True
+        assert ss.current_secret_scope() is None
+    finally:
+        ss.reset_secret_scope(scope_token)
+        ss.set_multiplex_active(False)
+
+
 def test_allowlist_dm_with_explicit_pair_behavior_reaches_gateway(monkeypatch):
     """Allowlist + unauthorized_dm_behavior:pair must not early-drop unknown DMs.
 

--- a/tests/run_agent/test_flush_compression_child_adoption.py
+++ b/tests/run_agent/test_flush_compression_child_adoption.py
@@ -1,0 +1,60 @@
+"""Regression for final flushes that race a compression rotation."""
+
+from types import SimpleNamespace
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _bare_agent(db: SessionDB, session_id: str) -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = session_id
+    agent._session_db = db
+    agent._session_db_created = True
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._persist_user_message_timestamp = None
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = session_id
+    agent._db_flush_scan_prefix = None
+    agent._active_compression_lock_holder = None
+    agent.context_compressor = SimpleNamespace()
+    agent._memory_manager = None
+    agent.platform = "telegram"
+    agent._gateway_session_key = "agent:main:telegram:dm:test"
+    return agent
+
+
+def test_final_flush_adopts_unique_live_compression_child(tmp_path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("parent", source="telegram")
+        db.append_message("parent", "user", "before compression")
+        db.publish_compression_child(
+            parent_session_id="parent",
+            child_session_id="child",
+            source="telegram",
+            messages=[{"role": "user", "content": "compressed handoff"}],
+            require_compression_lease=False,
+        )
+        agent = _bare_agent(db, "parent")
+        final = {"role": "assistant", "content": "finished after compression"}
+
+        result = agent._flush_messages_to_session_db_unlocked(
+            [final], conversation_history=[]
+        )
+
+        assert result is True
+        assert agent.session_id == "child"
+        assert agent._flushed_db_message_session_id == "child"
+        assert final.get("_db_persisted") is True
+        assert [row["content"] for row in db.get_messages("parent")] == [
+            "before compression"
+        ]
+        assert [row["content"] for row in db.get_messages("child")] == [
+            "compressed handoff",
+            "finished after compression",
+        ]
+    finally:
+        db.close()

--- a/tests/run_agent/test_flush_compression_child_adoption.py
+++ b/tests/run_agent/test_flush_compression_child_adoption.py
@@ -58,3 +58,104 @@ def test_final_flush_adopts_unique_live_compression_child(tmp_path) -> None:
         ]
     finally:
         db.close()
+
+
+def test_final_flush_adopts_unique_multi_generation_compression_tip(tmp_path) -> None:
+    """A stale long-running turn may lag behind several durable rotations."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("parent", source="telegram")
+        db.append_message("parent", "user", "before first compression")
+        db.publish_compression_child(
+            parent_session_id="parent",
+            child_session_id="child",
+            source="telegram",
+            messages=[{"role": "user", "content": "first compressed handoff"}],
+            require_compression_lease=False,
+        )
+        db.publish_compression_child(
+            parent_session_id="child",
+            child_session_id="grandchild",
+            source="telegram",
+            messages=[{"role": "user", "content": "second compressed handoff"}],
+            require_compression_lease=False,
+        )
+        agent = _bare_agent(db, "parent")
+        final = {"role": "assistant", "content": "finished after two rotations"}
+
+        result = agent._flush_messages_to_session_db_unlocked(
+            [final], conversation_history=[]
+        )
+
+        assert result is True
+        assert agent.session_id == "grandchild"
+        assert agent._flushed_db_message_session_id == "grandchild"
+        assert final.get("_db_persisted") is True
+        assert [row["content"] for row in db.get_messages("grandchild")] == [
+            "second compressed handoff",
+            "finished after two rotations",
+        ]
+    finally:
+        db.close()
+
+
+def test_final_flush_revalidates_tip_when_lineage_changes_before_retry(
+    tmp_path, monkeypatch
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("parent", source="telegram")
+        db.append_message("parent", "user", "before first compression")
+        db.publish_compression_child(
+            parent_session_id="parent",
+            child_session_id="child",
+            source="telegram",
+            messages=[{"role": "user", "content": "first handoff"}],
+            require_compression_lease=False,
+        )
+        db.publish_compression_child(
+            parent_session_id="child",
+            child_session_id="grandchild",
+            source="telegram",
+            messages=[{"role": "user", "content": "second handoff"}],
+            require_compression_lease=False,
+        )
+        original_append = db.append_messages_batch
+        injected = False
+
+        def racing_append(*args, **kwargs):
+            nonlocal injected
+            session_id = kwargs.get("session_id") or args[0]
+            if session_id == "grandchild" and not injected:
+                injected = True
+                db.create_session(
+                    "ambiguous-sibling",
+                    source="telegram",
+                    parent_session_id="parent",
+                )
+            return original_append(*args, **kwargs)
+
+        monkeypatch.setattr(db, "append_messages_batch", racing_append)
+        agent = _bare_agent(db, "parent")
+        final = {"role": "assistant", "content": "must fail closed"}
+
+        result = agent._flush_messages_to_session_db_unlocked(
+            [final], conversation_history=[]
+        )
+
+        assert result is False
+        assert agent.session_id == "parent"
+        assert final.get("_db_persisted") is not True
+
+        retry_result = agent._flush_messages_to_session_db_unlocked(
+            [final], conversation_history=[]
+        )
+
+        assert retry_result is False
+        assert agent.session_id == "parent"
+        assert final.get("_db_persisted") is not True
+        assert [row["content"] for row in db.get_messages("grandchild")] == [
+            "second handoff"
+        ]
+    finally:
+        db.close()

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 
 import pytest
@@ -42,6 +43,128 @@ def test_find_live_compression_child_fails_closed_when_ambiguous(db: SessionDB) 
     db.create_session("child-b", source="webui", parent_session_id="parent")
 
     assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_follows_unique_compression_chain(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("child", source="webui", parent_session_id="parent")
+    db.end_session("child", "compression")
+    db.create_session("grandchild", source="webui", parent_session_id="child")
+
+    tip = db.find_live_compression_child("parent")
+
+    assert tip is not None
+    assert tip["id"] == "grandchild"
+    assert tip["parent_session_id"] == "child"
+    assert tip["ended_at"] is None
+
+
+def test_find_live_compression_child_fails_closed_on_ambiguous_chain(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("child-a", source="webui", parent_session_id="parent")
+    db.end_session("child-a", "compression")
+    db.create_session("tip-a", source="webui", parent_session_id="child-a")
+    db.create_session("child-b", source="webui", parent_session_id="parent")
+    db.end_session("child-b", "compression")
+    db.create_session("tip-b", source="webui", parent_session_id="child-b")
+
+    assert db.find_live_compression_child("parent") is None
+
+
+def test_find_live_compression_child_uses_one_snapshot_during_walk(tmp_path) -> None:
+    path = tmp_path / "state.db"
+    reader = SessionDB(db_path=path)
+    writer = SessionDB(db_path=path)
+    try:
+        _compression_parent(reader)
+        reader.create_session("child", source="webui", parent_session_id="parent")
+        reader.end_session("child", "compression")
+        ready = threading.Event()
+        proceed = threading.Event()
+
+        class PausingConnection:
+            def __init__(self, inner):
+                self.inner = inner
+                self.paused = False
+
+            def execute(self, sql, params=()):
+                cursor = self.inner.execute(sql, params)
+                if (
+                    not self.paused
+                    and "WHERE s.parent_session_id = ?" in sql
+                    and params
+                    and params[0] == "parent"
+                ):
+                    self.paused = True
+                    ready.set()
+                    assert proceed.wait(5)
+                return cursor
+
+            def __getattr__(self, name):
+                return getattr(self.inner, name)
+
+        reader._conn = PausingConnection(reader._conn)
+
+        def mutate_lineage() -> None:
+            assert ready.wait(5)
+            writer.create_session(
+                "ambiguous-sibling", source="webui", parent_session_id="parent"
+            )
+            writer.create_session(
+                "grandchild", source="webui", parent_session_id="child"
+            )
+            proceed.set()
+
+        thread = threading.Thread(target=mutate_lineage)
+        thread.start()
+        observed = reader.find_live_compression_child("parent")
+        thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert observed is None
+        assert reader.find_live_compression_child("parent") is None
+    finally:
+        reader.close()
+        writer.close()
+
+
+def test_batch_append_revalidates_compression_tip_inside_write_transaction(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("child", source="webui", parent_session_id="parent")
+    db.create_session("sibling", source="webui", parent_session_id="parent")
+
+    with pytest.raises(RuntimeError, match="closed by compression"):
+        db.append_messages_batch(
+            "child",
+            [{"role": "assistant", "content": "must not choose a sibling"}],
+            compression_lineage_root="parent",
+        )
+
+    assert db.get_messages("child") == []
+
+
+def test_single_append_revalidates_compression_tip_inside_write_transaction(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db)
+    db.create_session("child", source="webui", parent_session_id="parent")
+    db.create_session("sibling", source="webui", parent_session_id="parent")
+
+    with pytest.raises(RuntimeError, match="closed by compression"):
+        db.append_message(
+            "child",
+            "assistant",
+            "must not choose a sibling",
+            compression_lineage_root="parent",
+        )
+
+    assert db.get_messages("child") == []
 
 
 def test_reopen_orphaned_compression_session_reopens_parent_without_child(


### PR DESCRIPTION
## Summary

- ignore synthetic `systemctl show` manager results unless `LoadState=loaded`
- capture and restore each multiplex profile runtime scope inside registered adapter authorization callbacks
- route Telegram early intake and inline approval/clarify authorization through that registered callback before legacy fallback
- document and pin the contracts in `AGENTS.md`

## Verification

- `47 passed` — focused systemd/multiplex/Telegram auth/reconnect suite
- `72 passed` — multiplex suite
- `523 passed` — broad Telegram suite; 6 aggregate order-pollution failures pass in an isolated real-PTB process
- `5224 passed, 29 skipped, 2 xfailed` — full `tests/gateway`; 8 unrelated failures classified: 3 reproduce on clean `origin/main`, 5 pass in isolated file processes
- Ruff, compileall, `git diff --check`, and static security scan passed
- bounded independent review: APPROVE; no fail-open or security regression found

## Regression contracts

- default and secondary profile callbacks work from an intentionally unscoped caller
- Telegram early intake and inline callbacks use the profile-scoped gateway callback
- a `LoadState=not-found` user-manager object cannot shadow the loaded system unit
