### PR TITLE
feat: add iCloud MCP catalog entry

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -51,6 +52,7 @@ _MANIFEST_VERSION = 1
 
 # Substituted at install time inside `transport.command` / `transport.args`.
 _INSTALL_DIR_VAR = "${INSTALL_DIR}"
+_EXE_SUFFIX_VAR = "${EXE_SUFFIX}"
 
 
 # ─── Data classes ────────────────────────────────────────────────────────────
@@ -470,14 +472,15 @@ def _do_git_install(entry: CatalogEntry) -> Path:
     return dest
 
 
-def _expand_install_dir(value: str, install_dir: Optional[Path]) -> str:
-    if _INSTALL_DIR_VAR not in value:
-        return value
-    if install_dir is None:
-        raise CatalogError(
-            f"manifest references {_INSTALL_DIR_VAR} but no install block exists"
-        )
-    return value.replace(_INSTALL_DIR_VAR, str(install_dir))
+def _expand_install_vars(value: str, install_dir: Optional[Path]) -> str:
+    """Expand install-time path placeholders for the current platform."""
+    if _INSTALL_DIR_VAR in value:
+        if install_dir is None:
+            raise CatalogError(
+                f"manifest references {_INSTALL_DIR_VAR} but no install block exists"
+            )
+        value = value.replace(_INSTALL_DIR_VAR, str(install_dir))
+    return value.replace(_EXE_SUFFIX_VAR, ".exe" if sys.platform == "win32" else "")
 
 
 def _prompt_env_vars(specs: List[EnvVarSpec]) -> Dict[str, str]:
@@ -512,9 +515,9 @@ def _build_server_config(
     cfg: dict = {}
     t = entry.transport
     if t.type == "stdio":
-        cfg["command"] = _expand_install_dir(t.command or "", install_dir)
+        cfg["command"] = _expand_install_vars(t.command or "", install_dir)
         if t.args:
-            cfg["args"] = [_expand_install_dir(a, install_dir) for a in t.args]
+            cfg["args"] = [_expand_install_vars(a, install_dir) for a in t.args]
         if t.env:
             cfg["env"] = dict(t.env)
     elif t.type == "http":

--- a/optional-mcps/icloud/manifest.yaml
+++ b/optional-mcps/icloud/manifest.yaml
@@ -17,12 +17,12 @@ install:
   ref: 6be9cebb4f1a6dba942b458604c89dc045205ff5
   bootstrap:
     - "go version"
-    - "mkdir -p bin"
-    - "go build -trimpath -ldflags='-s -w -X main.version=v0.4.0' -o bin/icloud-mcp ./cmd/icloud-mcp"
+    # A directory target makes Go create bin/ and apply the native .exe suffix.
+    - 'go build -trimpath -ldflags="-s -w -X main.version=v0.4.0" -o bin/ ./cmd/icloud-mcp'
 
 transport:
   type: stdio
-  command: "${INSTALL_DIR}/bin/icloud-mcp"
+  command: "${INSTALL_DIR}/bin/icloud-mcp${EXE_SUFFIX}"
   version: "0.4.0"
   env:
     # Recommended first deploy: Calendar only, global read-only (7 tools).

--- a/optional-mcps/icloud/manifest.yaml
+++ b/optional-mcps/icloud/manifest.yaml
@@ -17,6 +17,7 @@ install:
   ref: 6be9cebb4f1a6dba942b458604c89dc045205ff5
   bootstrap:
     - "go version"
+    - "mkdir -p bin"
     - "go build -trimpath -ldflags='-s -w -X main.version=v0.4.0' -o bin/icloud-mcp ./cmd/icloud-mcp"
 
 transport:

--- a/optional-mcps/icloud/manifest.yaml
+++ b/optional-mcps/icloud/manifest.yaml
@@ -1,0 +1,89 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: icloud
+description: iCloud Calendar (CalDAV), optional Contacts and Mail, as a local stdio MCP.
+source: https://github.com/ThomasCrouzet/icloud-mcp
+
+# Static Go binary built from a SHA-pinned git checkout. No npm/PyPI wrapper.
+# Requires a local Go toolchain (1.25.12+) for the bootstrap build only.
+install:
+  type: git
+  url: https://github.com/ThomasCrouzet/icloud-mcp.git
+  # v0.4.0 tag object peels to this commit (2026-07-25).
+  # Catalog policy prefers pins at least ~2 weeks old; reviewers may ask to
+  # wait or repin if that cooldown is enforced at merge time.
+  ref: 6be9cebb4f1a6dba942b458604c89dc045205ff5
+  bootstrap:
+    - "go version"
+    - "go build -trimpath -ldflags='-s -w -X main.version=v0.4.0' -o bin/icloud-mcp ./cmd/icloud-mcp"
+
+transport:
+  type: stdio
+  command: "${INSTALL_DIR}/bin/icloud-mcp"
+  version: "0.4.0"
+  env:
+    # Recommended first deploy: Calendar only, global read-only (7 tools).
+    ICLOUD_MCP_READ_ONLY: "true"
+    # Credentials are prompted into ~/.hermes/.env, then interpolated here so
+    # Hermes's filtered stdio env actually passes them to the subprocess.
+    ICLOUD_EMAIL: "${ICLOUD_EMAIL}"
+    ICLOUD_PASSWORD: "${ICLOUD_PASSWORD}"
+    ICLOUD_MCP_DEFAULT_TZ: "${ICLOUD_MCP_DEFAULT_TZ}"
+
+auth:
+  type: api_key
+  env:
+    - name: ICLOUD_EMAIL
+      prompt: "iCloud email (Apple ID used for Calendar/Contacts)"
+      required: true
+      secret: false
+    - name: ICLOUD_PASSWORD
+      prompt: "Apple app-specific password (not the main Apple Account password)"
+      required: true
+      secret: true
+    - name: ICLOUD_MCP_DEFAULT_TZ
+      prompt: "IANA timezone for calendar wall-clock times (e.g. Europe/Paris)"
+      required: true
+      secret: false
+      default: "UTC"
+
+# Default to Calendar read surface + local helpers. Mutation tools remain
+# available in the install checklist when ICLOUD_MCP_READ_ONLY is later set
+# false in config; Contacts/Mail tools only appear after those domains are
+# enabled in the process environment (off by default in this entry).
+tools:
+  default_enabled:
+    - icloud_capabilities
+    - list_calendars
+    - search_events
+    - get_event
+    - find_free_slots
+    - validate_event
+    - calendar_capabilities
+
+post_install: |
+  This entry builds icloud-mcp from source at a pinned commit. You need Go
+  1.25.12+ on PATH for the bootstrap `go build`.
+
+  Default env is Calendar-only with ICLOUD_MCP_READ_ONLY=true (7 tools).
+  Create an app-specific password at https://appleid.apple.com — never use
+  the main Apple Account password.
+
+  After install, start a new Hermes session and call icloud_capabilities.
+
+  Optional domains (edit mcp_servers.icloud.env, then restart Hermes):
+    ICLOUD_MCP_ENABLE_CONTACTS=true
+    ICLOUD_MCP_ENABLE_MAIL=true
+    ICLOUD_MAIL_ADDRESS=mailbox@icloud.com
+    ICLOUD_MCP_ENABLE_MAIL_WRITE=true   # IMAP flags/move/trash; needs read-only off
+    ICLOUD_MCP_ENABLE_MAIL_SEND=true    # also needs ICLOUD_MCP_SMTP_ALLOWED_RECIPIENTS
+    ICLOUD_MCP_READ_ONLY=false          # required for any mutation or send tools
+
+  Reminders, Notes, Photos, Drive, and Messages are out of scope.
+  Release archives also ship linux/amd64, linux/arm64, and darwin/arm64;
+  Windows is CI smoke-build only (not packaged).
+
+  Re-run the tool checklist any time with:
+    hermes mcp configure icloud

--- a/optional-mcps/icloud/manifest.yaml
+++ b/optional-mcps/icloud/manifest.yaml
@@ -69,7 +69,7 @@ post_install: |
   1.25.12+ on PATH for the bootstrap `go build`.
 
   Default env is Calendar-only with ICLOUD_MCP_READ_ONLY=true (7 tools).
-  Create an app-specific password at https://appleid.apple.com — never use
+  Create an app-specific password at https://appleid.apple.com; never use
   the main Apple Account password.
 
   After install, start a new Hermes session and call icloud_capabilities.

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -556,6 +556,70 @@ class TestToolsConfigIncludeMode:
 
 
 class TestShippedCatalog:
+    @pytest.mark.parametrize(
+        ("platform_name", "expected_suffix"),
+        [("linux", ""), ("darwin", ""), ("win32", ".exe")],
+    )
+    def test_icloud_source_build_is_platform_portable(
+        self, monkeypatch, tmp_path, platform_name, expected_suffix
+    ):
+        """The iCloud bootstrap uses only cross-platform Go behavior.
+
+        The same shell commands are passed on every host. Go creates the
+        output directory and selects the native executable suffix; the
+        generated stdio command must point at that exact file.
+        """
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli import mcp_catalog
+        from hermes_cli.mcp_catalog import (
+            _build_server_config,
+            _catalog_root,
+            _parse_manifest,
+            _run_bootstrap,
+        )
+
+        manifest = _catalog_root() / "icloud" / "manifest.yaml"
+        if not manifest.exists():
+            pytest.skip("iCloud catalog manifest not present in this checkout")
+
+        entry = _parse_manifest(manifest)
+        assert entry.install is not None
+
+        commands = entry.install.bootstrap
+        build_commands = [
+            command for command in commands if command.startswith("go build ")
+        ]
+        assert len(build_commands) == 1
+        build_command = build_commands[0]
+        assert "-o bin/" in build_command
+        assert '-ldflags="' in build_command
+        assert all(
+            token not in command.lower()
+            for command in commands
+            for token in ("mkdir", "cp ", "mv ", "powershell", "bash")
+        )
+
+        calls = []
+
+        class _FakeProc:
+            returncode = 0
+
+        def fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return _FakeProc()
+
+        monkeypatch.setattr(mcp_catalog.subprocess, "run", fake_run)
+        monkeypatch.setattr(mcp_catalog.sys, "platform", platform_name)
+
+        install_dir = tmp_path / "icloud"
+        _run_bootstrap(install_dir, commands)
+        cfg = _build_server_config(entry, install_dir)
+
+        assert [command for command, _ in calls] == commands
+        assert all(call_kwargs["shell"] is True for _, call_kwargs in calls)
+        assert all(call_kwargs["cwd"] == str(install_dir) for _, call_kwargs in calls)
+        assert cfg["command"] == f"{install_dir}/bin/icloud-mcp{expected_suffix}"
+
     def test_all_shipped_manifests_parse(self, monkeypatch):
         """Every manifest in optional-mcps/ must parse cleanly.
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -162,7 +162,9 @@ root), `${workspaceFolderBasename}`, and `${pathSeparator}` / `${/}`
 
 Note this is distinct from `${INSTALL_DIR}` in catalog manifests, which is
 substituted at install-time with the path the catalog cloned the entry's
-repo into.
+repo into. Catalog manifests can also use `${EXE_SUFFIX}` in
+`transport.command` or `transport.args`; it expands to `.exe` on Windows and
+to an empty string on other platforms.
 
 ### Updating tool selection later
 


### PR DESCRIPTION
## Summary
- add a pinned optional MCP catalog entry for `icloud-mcp`
- build the Go server into the catalog bootstrap directory portably
- document Calendar-only read-only defaults and app-specific password guidance
- extend catalog tests for bootstrap output handling

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py` (24 passed)
- `npm ci` in `website` (0 vulnerabilities)
- `npm run build` in `website`
- additions-only Gitleaks scan

## Note
`npm run typecheck` currently fails unchanged on `main` because TypeScript 6 rejects the existing deprecated `baseUrl` setting. That pre-existing issue is intentionally not mixed into this PR.
