### PR TITLE
feat(state): DB storage layer for the cross-process turn lease (#67442)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5756,6 +5756,165 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return None
         return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
 
+    # ------------------------------------------------------------------
+    # Cross-process turn lease (#67442)
+    #
+    # gateway/turn_lease.py serializes [load history -> run -> flush] within a
+    # single process. It cannot see a CLI process and a gateway process
+    # sharing one session_id through CLI-continuity, which is the route that
+    # produced the #64934 transcript interleaving. These methods are the
+    # cross-process coordination point for that pair, shaped deliberately like
+    # the compression-lock protocol above: the PK row IS the mutex, expiry
+    # reclaims a crashed holder, and every failure path degrades rather than
+    # wedging a turn.
+    # ------------------------------------------------------------------
+
+    def try_acquire_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        *,
+        surface: str = "",
+        run_generation: int = 0,
+        ttl_seconds: float = 120.0,
+    ) -> bool:
+        """Atomically acquire the cross-process turn lease. True iff we own it.
+
+        Expired leases are reclaimed transparently, so a crashed holder wedges
+        the session for at most ``ttl_seconds`` rather than forever. A
+        same-holder re-acquire refreshes the row and returns True, keeping
+        retry paths idempotent.
+
+        Mirrors :meth:`try_acquire_compression_lock`'s
+        DELETE-stale-or-own + INSERT-OR-IGNORE + confirm-SELECT shape. SQLite
+        serializes writers, so the sequence is atomic against other processes:
+        exactly one racing caller sees its own holder in the confirming
+        SELECT.
+
+        Returns False — never raises — when the lease subsystem is unusable.
+        Callers treat that as "exclusivity not proven" and decide their own
+        posture: turn serialization proceeds unserialized (no worse than
+        today), while an ownership fence must refuse.
+        """
+        if not session_id or not holder:
+            return False
+        now = time.time()
+        expires_at = now + float(ttl_seconds)
+
+        def _do(conn):
+            conn.execute(
+                "DELETE FROM turn_leases "
+                "WHERE session_id = ? AND (expires_at < ? OR holder = ?)",
+                (session_id, now, holder),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO turn_leases "
+                "(session_id, holder, surface, run_generation, acquired_at, "
+                " heartbeat_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    session_id,
+                    holder,
+                    str(surface or ""),
+                    int(run_generation),
+                    now,
+                    now,
+                    expires_at,
+                ),
+            )
+            row = conn.execute(
+                "SELECT holder FROM turn_leases WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            return row is not None and (
+                row["holder"] if isinstance(row, sqlite3.Row) else row[0]
+            ) == holder
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning("try_acquire_turn_lease(%s) failed: %s", session_id, exc)
+            return False
+
+    def refresh_turn_lease(
+        self, session_id: str, holder: str, *, ttl_seconds: float = 120.0
+    ) -> bool:
+        """Extend a held lease's expiry. False when we no longer own it.
+
+        A turn outliving ``ttl_seconds`` would otherwise have its row reclaimed
+        by the next acquirer and interleave with it. False is the signal that
+        this already happened — the caller has lost ownership and must not
+        assume exclusivity for the remainder of the turn.
+        """
+        if not session_id or not holder:
+            return False
+        now = time.time()
+        expires_at = now + float(ttl_seconds)
+
+        def _do(conn):
+            cur = conn.execute(
+                "UPDATE turn_leases SET heartbeat_at = ?, expires_at = ? "
+                "WHERE session_id = ? AND holder = ? AND expires_at >= ?",
+                (now, expires_at, session_id, holder, now),
+            )
+            return cur.rowcount > 0
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning("refresh_turn_lease(%s) failed: %s", session_id, exc)
+            return False
+
+    def release_turn_lease(
+        self, session_id: str, holder: str, *, run_generation: Optional[int] = None
+    ) -> None:
+        """Release the lease iff we still own it. Idempotent.
+
+        The ``holder`` check stops a late-returning turn from deleting a fresh
+        lease someone else acquired after ours expired. Pass ``run_generation``
+        to additionally scope the release to one acquisition — needed when a
+        single holder id can hold the lease more than once (a retried run) and
+        the stale attempt must not release the live one.
+        """
+        if not session_id or not holder:
+            return
+
+        def _do(conn):
+            if run_generation is None:
+                conn.execute(
+                    "DELETE FROM turn_leases WHERE session_id = ? AND holder = ?",
+                    (session_id, holder),
+                )
+            else:
+                conn.execute(
+                    "DELETE FROM turn_leases "
+                    "WHERE session_id = ? AND holder = ? AND run_generation = ?",
+                    (session_id, holder, int(run_generation)),
+                )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning("release_turn_lease(%s) failed: %s", session_id, exc)
+
+    def get_turn_lease_holder(self, session_id: str) -> Optional[str]:
+        """Return the current (non-expired) lease holder, or None.
+
+        Diagnostic helper — not part of the locking protocol. Do NOT gate a
+        write on this: it is a point-in-time read, and the lease can be
+        reclaimed between the read and the write. Use the acquire result, or
+        compare ``run_generation``, when correctness depends on ownership.
+        """
+        if not session_id:
+            return None
+        row = self._conn.execute(
+            "SELECT holder FROM turn_leases "
+            "WHERE session_id = ? AND expires_at >= ?",
+            (session_id, time.time()),
+        ).fetchone()
+        if row is None:
+            return None
+        return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
+
     def touch_session_activity(
         self,
         session_id: str,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -383,6 +383,27 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+-- Cross-process turn lease (#67442). The in-process registry in
+-- gateway/turn_lease.py serializes [load history -> run -> flush] within one
+-- process; it cannot see a CLI process and a gateway process sharing one
+-- session_id via CLI-continuity. This row is the cross-process coordination
+-- point for that pair. Deliberately shaped like compression_locks above:
+-- session_id is the PK, so the row IS the mutex.
+--
+-- run_generation is a fencing token: it identifies WHICH acquisition owns the
+-- lease, so a consumer that needs to reject a stale holder's late write can
+-- compare generations rather than trusting a liveness check that was true at
+-- acquire time and stale by write time.
+CREATE TABLE IF NOT EXISTS turn_leases (
+    session_id TEXT PRIMARY KEY,
+    holder TEXT NOT NULL,
+    surface TEXT NOT NULL DEFAULT '',
+    run_generation INTEGER NOT NULL DEFAULT 0,
+    acquired_at REAL NOT NULL,
+    heartbeat_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -419,6 +440,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
     ON messages(session_id)
     WHERE role = 'assistant' AND tool_calls IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_turn_leases_expires ON turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery

--- a/tests/hermes_state/test_turn_lease_store.py
+++ b/tests/hermes_state/test_turn_lease_store.py
@@ -71,26 +71,71 @@ def test_blank_session_or_holder_never_acquires(state):
     assert state.try_acquire_turn_lease("s1", "") is False
 
 
-def test_concurrent_acquire_grants_exactly_one_winner(state):
-    """The invariant the whole feature rests on, under real thread contention."""
+def test_concurrent_acquire_grants_exactly_one_winner(tmp_path):
+    """The invariant the whole feature rests on, raced at the SQLite layer.
+
+    Each thread opens its OWN ``SessionDB`` on the same file. That detail is
+    the test: ``_execute_write`` wraps its whole BEGIN IMMEDIATE transaction in
+    ``self._lock``, a *per-instance* ``threading.Lock`` (hermes_state.py:2543,
+    3311). Racing 8 threads through one shared instance would prove only that
+    that mutex works — the writers would be ordered in Python and never
+    contend in SQLite at all. Separate instances mean separate locks and
+    separate connections, which is the shape of the case this table exists
+    for: two OS processes sharing one state.db.
+    """
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path).close()  # create the schema once, up front
+
     winners = []
-    lock = threading.Lock()
+    guard = threading.Lock()
     start = threading.Barrier(8)
 
     def contend(i):
-        start.wait()
-        if state.try_acquire_turn_lease("shared", f"holder:{i}", ttl_seconds=60):
-            with lock:
-                winners.append(f"holder:{i}")
+        db = SessionDB(db_path)
+        try:
+            start.wait()
+            if db.try_acquire_turn_lease("shared", f"holder:{i}", ttl_seconds=60):
+                with guard:
+                    winners.append(f"holder:{i}")
+        finally:
+            db.close()
 
     threads = [threading.Thread(target=contend, args=(i,)) for i in range(8)]
     for t in threads:
         t.start()
     for t in threads:
-        t.join(timeout=30)
+        t.join(timeout=60)
 
     assert len(winners) == 1, f"expected exactly one winner, got {winners}"
-    assert state.get_turn_lease_holder("shared") == winners[0]
+
+    verify = SessionDB(db_path)
+    try:
+        assert verify.get_turn_lease_holder("shared") == winners[0]
+    finally:
+        verify.close()
+
+
+def test_second_process_sees_the_first_holders_lease(tmp_path):
+    """A lease taken on one connection is visible/blocking on another.
+
+    The cross-process contract in one assertion: without shared visibility
+    through the DB row, the CLI-continuity pair behind #64934 would each
+    believe they hold the session.
+    """
+    db_path = tmp_path / "state.db"
+    cli = SessionDB(db_path)
+    gateway = SessionDB(db_path)
+    try:
+        assert cli.try_acquire_turn_lease("s1", "cli:1", ttl_seconds=60) is True
+        # Different instance, different connection, different lock:
+        assert gateway.try_acquire_turn_lease("s1", "gw:2", ttl_seconds=60) is False
+        assert gateway.get_turn_lease_holder("s1") == "cli:1"
+
+        cli.release_turn_lease("s1", "cli:1")
+        assert gateway.try_acquire_turn_lease("s1", "gw:2", ttl_seconds=60) is True
+    finally:
+        cli.close()
+        gateway.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_state/test_turn_lease_store.py
+++ b/tests/hermes_state/test_turn_lease_store.py
@@ -18,8 +18,11 @@ a mocked connection would prove nothing about it.
 """
 
 import sqlite3
+import subprocess
+import sys
 import threading
 import time
+from pathlib import Path
 
 import pytest
 
@@ -111,6 +114,62 @@ def test_concurrent_acquire_grants_exactly_one_winner(tmp_path):
     verify = SessionDB(db_path)
     try:
         assert verify.get_turn_lease_holder("shared") == winners[0]
+    finally:
+        verify.close()
+
+
+_CHILD_ACQUIRE = """
+import sys, time
+from pathlib import Path
+sys.path.insert(0, sys.argv[1])
+from hermes_state import SessionDB
+
+db_path, start_at, holder = Path(sys.argv[2]), float(sys.argv[3]), sys.argv[4]
+db = SessionDB(db_path)
+try:
+    while time.time() < start_at:   # converge the racers on a wall-clock start
+        time.sleep(0.001)
+    print("WON" if db.try_acquire_turn_lease(
+        "shared", holder, ttl_seconds=60) else "LOST")
+finally:
+    db.close()
+"""
+
+
+def test_separate_os_processes_grant_exactly_one_winner(tmp_path):
+    """The literal claim: real OS processes, one state.db, one winner.
+
+    The sibling thread test races separate ``SessionDB`` instances, which is
+    enough to reach SQLite — but it still shares one interpreter. This spawns
+    actual subprocesses, so nothing is shared: separate interpreters, separate
+    connections, no GIL in common. That is the configuration #67442 is about
+    (a CLI process and a gateway process on one session), so it is worth
+    proving directly rather than by extrapolation.
+    """
+    repo_root = str(Path(__file__).resolve().parents[2])
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path).close()  # create the schema before the race
+
+    start_at = time.time() + 2.0  # leave room for interpreter startup
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", _CHILD_ACQUIRE, repo_root,
+             str(db_path), str(start_at), f"proc:{i}"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        for i in range(3)
+    ]
+    results = []
+    for p in procs:
+        out, err = p.communicate(timeout=120)
+        assert p.returncode == 0, f"child failed: {err}"
+        results.append(out.strip())
+
+    assert results.count("WON") == 1, f"expected exactly one winner, got {results}"
+
+    verify = SessionDB(db_path)
+    try:
+        assert verify.get_turn_lease_holder("shared") is not None
     finally:
         verify.close()
 

--- a/tests/hermes_state/test_turn_lease_store.py
+++ b/tests/hermes_state/test_turn_lease_store.py
@@ -1,0 +1,215 @@
+"""Storage-layer conformance for the cross-process turn lease (#67442).
+
+``gateway/turn_lease.py``'s in-process registry cannot see a CLI process and a
+gateway process sharing one session_id through CLI-continuity — the route that
+produced the #64934 transcript interleaving. These tests pin the DB-level
+contract the cross-process lease depends on:
+
+* acquire is atomic — exactly one of N racing callers wins,
+* a crashed holder is reclaimed by expiry rather than wedging the session
+  forever,
+* release is holder-scoped, so a late-returning turn cannot delete a lease
+  somebody else now holds,
+* refresh reports lost ownership instead of silently succeeding.
+
+Contention is exercised with real threads against one SQLite file rather than
+mocks: the whole point of this layer is what happens when two writers race, and
+a mocked connection would prove nothing about it.
+"""
+
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def state(tmp_path):
+    st = SessionDB(tmp_path / "state.db")
+    yield st
+    try:
+        st.close()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Acquire
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_grants_the_lease(state):
+    assert state.try_acquire_turn_lease("s1", "cli:1", surface="cli") is True
+    assert state.get_turn_lease_holder("s1") == "cli:1"
+
+
+def test_second_holder_is_refused_while_lease_is_live(state):
+    assert state.try_acquire_turn_lease("s1", "cli:1", ttl_seconds=60) is True
+    assert state.try_acquire_turn_lease("s1", "gateway:2", ttl_seconds=60) is False
+    assert state.get_turn_lease_holder("s1") == "cli:1"
+
+
+def test_same_holder_reacquire_is_idempotent(state):
+    """Retry paths must not deadlock against their own row."""
+    assert state.try_acquire_turn_lease("s1", "cli:1", ttl_seconds=60) is True
+    assert state.try_acquire_turn_lease("s1", "cli:1", ttl_seconds=60) is True
+    assert state.get_turn_lease_holder("s1") == "cli:1"
+
+
+def test_leases_are_per_session(state):
+    assert state.try_acquire_turn_lease("s1", "cli:1") is True
+    assert state.try_acquire_turn_lease("s2", "cli:1") is True
+    assert state.get_turn_lease_holder("s1") == "cli:1"
+    assert state.get_turn_lease_holder("s2") == "cli:1"
+
+
+def test_blank_session_or_holder_never_acquires(state):
+    assert state.try_acquire_turn_lease("", "cli:1") is False
+    assert state.try_acquire_turn_lease("s1", "") is False
+
+
+def test_concurrent_acquire_grants_exactly_one_winner(state):
+    """The invariant the whole feature rests on, under real thread contention."""
+    winners = []
+    lock = threading.Lock()
+    start = threading.Barrier(8)
+
+    def contend(i):
+        start.wait()
+        if state.try_acquire_turn_lease("shared", f"holder:{i}", ttl_seconds=60):
+            with lock:
+                winners.append(f"holder:{i}")
+
+    threads = [threading.Thread(target=contend, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert len(winners) == 1, f"expected exactly one winner, got {winners}"
+    assert state.get_turn_lease_holder("shared") == winners[0]
+
+
+# ---------------------------------------------------------------------------
+# Expiry reclamation — a crashed holder must not wedge the session
+# ---------------------------------------------------------------------------
+
+
+def test_expired_lease_is_reclaimed_by_the_next_acquirer(state):
+    assert state.try_acquire_turn_lease("s1", "crashed", ttl_seconds=0.05) is True
+    time.sleep(0.1)
+    assert state.try_acquire_turn_lease("s1", "next", ttl_seconds=60) is True
+    assert state.get_turn_lease_holder("s1") == "next"
+
+
+def test_expired_lease_reports_no_holder(state):
+    state.try_acquire_turn_lease("s1", "crashed", ttl_seconds=0.05)
+    time.sleep(0.1)
+    assert state.get_turn_lease_holder("s1") is None
+
+
+def test_holder_is_none_for_unknown_session(state):
+    assert state.get_turn_lease_holder("never-seen") is None
+
+
+# ---------------------------------------------------------------------------
+# Refresh
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_extends_a_held_lease(state):
+    assert state.try_acquire_turn_lease("s1", "cli:1", ttl_seconds=0.2) is True
+    assert state.refresh_turn_lease("s1", "cli:1", ttl_seconds=60) is True
+    time.sleep(0.25)
+    # Would have expired on the original TTL; the refresh moved it out.
+    assert state.get_turn_lease_holder("s1") == "cli:1"
+    assert state.try_acquire_turn_lease("s1", "other", ttl_seconds=60) is False
+
+
+def test_refresh_fails_for_a_non_holder(state):
+    state.try_acquire_turn_lease("s1", "cli:1", ttl_seconds=60)
+    assert state.refresh_turn_lease("s1", "impostor", ttl_seconds=60) is False
+
+
+def test_refresh_fails_after_the_lease_was_reclaimed(state):
+    """The signal a long turn needs: ownership was lost mid-flight."""
+    state.try_acquire_turn_lease("s1", "slow", ttl_seconds=0.05)
+    time.sleep(0.1)
+    state.try_acquire_turn_lease("s1", "next", ttl_seconds=60)
+    assert state.refresh_turn_lease("s1", "slow", ttl_seconds=60) is False
+
+
+def test_refresh_of_unknown_session_is_false(state):
+    assert state.refresh_turn_lease("nope", "cli:1") is False
+
+
+# ---------------------------------------------------------------------------
+# Release
+# ---------------------------------------------------------------------------
+
+
+def test_release_frees_the_lease(state):
+    state.try_acquire_turn_lease("s1", "cli:1", ttl_seconds=60)
+    state.release_turn_lease("s1", "cli:1")
+    assert state.get_turn_lease_holder("s1") is None
+    assert state.try_acquire_turn_lease("s1", "other", ttl_seconds=60) is True
+
+
+def test_release_by_a_non_holder_is_a_no_op(state):
+    """A late-returning turn must not free a lease someone else now holds."""
+    state.try_acquire_turn_lease("s1", "current", ttl_seconds=60)
+    state.release_turn_lease("s1", "stale-loser")
+    assert state.get_turn_lease_holder("s1") == "current"
+
+
+def test_release_is_idempotent(state):
+    state.try_acquire_turn_lease("s1", "cli:1", ttl_seconds=60)
+    state.release_turn_lease("s1", "cli:1")
+    state.release_turn_lease("s1", "cli:1")  # must not raise
+    assert state.get_turn_lease_holder("s1") is None
+
+
+def test_generation_scoped_release_ignores_a_stale_attempt(state):
+    """One holder id, two acquisitions: the retried run must not release the live one."""
+    state.try_acquire_turn_lease("s1", "cli:1", run_generation=1, ttl_seconds=0.05)
+    time.sleep(0.1)
+    state.try_acquire_turn_lease("s1", "cli:1", run_generation=2, ttl_seconds=60)
+
+    state.release_turn_lease("s1", "cli:1", run_generation=1)  # stale
+    assert state.get_turn_lease_holder("s1") == "cli:1"
+
+    state.release_turn_lease("s1", "cli:1", run_generation=2)  # live
+    assert state.get_turn_lease_holder("s1") is None
+
+
+# ---------------------------------------------------------------------------
+# Degradation — the lease subsystem must never wedge a turn
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_returns_false_when_the_store_errors(state, monkeypatch):
+    """Unusable lease store => exclusivity not proven, never an exception."""
+
+    def _boom(*_a, **_kw):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(state, "_execute_write", _boom)
+    assert state.try_acquire_turn_lease("s1", "cli:1") is False
+    assert state.refresh_turn_lease("s1", "cli:1") is False
+    state.release_turn_lease("s1", "cli:1")  # must not raise
+
+
+def test_surface_and_generation_round_trip(state):
+    """Recorded for diagnostics and fencing; assert they actually persist."""
+    state.try_acquire_turn_lease(
+        "s1", "cli:1", surface="cli", run_generation=7, ttl_seconds=60
+    )
+    row = state._conn.execute(
+        "SELECT surface, run_generation FROM turn_leases WHERE session_id = ?",
+        ("s1",),
+    ).fetchone()
+    assert row["surface"] == "cli"
+    assert row["run_generation"] == 7


### PR DESCRIPTION
## What

Adds the DB-level storage contract for the cross-process turn lease (#67442): a `turn_leases` table plus `try_acquire_turn_lease` / `refresh_turn_lease` / `release_turn_lease` / `get_turn_lease_holder` on `SessionDB`.

Storage only. No consumer is wired in this PR, and it deliberately takes **no position** on lease policy — see "Why this is separable" below.

## Why

`gateway/turn_lease.py`'s `SessionTurnLeaseRegistry` (from #67401) serializes `[load history → run → flush]` within one process. It is per-process state, so it cannot see a CLI process and a gateway process sharing one `session_id` through CLI-continuity — the many-to-one route behind #64934. A DB row is the only thing both processes can observe.

Opened at @webtecnica's request on #67442, who descoped a parallel storage attempt in favour of this one. Not speculative infrastructure per `AGENTS.md:97` — two concrete consumers are on record, and that policy explicitly allows the consumer to ship separately:

- #67454's `TurnLease` async context manager (@webtecnica) calls exactly this API and will stack on top;
- @TheAngryPit's Codex App Server thread-continuity work needs the same substrate for ownership fencing.

## Design

Shaped deliberately like the existing `compression_locks` protocol rather than inventing a new one: `session_id` is the PK, so **the row is the mutex**. Acquire is `DELETE stale-or-own` → `INSERT OR IGNORE` → confirming `SELECT`; SQLite serializes writers, so exactly one of N racing processes sees its own holder in the confirmation.

Two points beyond a plain mutex, both from the #67442 discussion:

**`run_generation` is a fencing token.** An ownership check at acquire time is TOCTOU for any consumer that must reject a stale holder's *late write* — the original owner can write between the check and the write. Storing the generation makes that rejectable after the fact. `release_turn_lease` accepts an optional `run_generation` so a retried run cannot release the live acquisition. Consumers need not use it today; the column has to exist now, because retrofitting a fencing token once external consumers depend on the table is the painful version.

**Every failure path returns `False` / no-ops instead of raising.** `False` means *exclusivity was not proven*, which leaves the posture choice to each consumer: turn serialization can proceed unserialized (no worse than main today), while an ownership fence must refuse. The storage layer does not choose.

`get_turn_lease_holder` is diagnostics only and documents that it must not gate a write — it is a point-in-time read.

## Why this is separable

The maintainer decision still open on #67442 is about lease *semantics* (fail-open vs fail-closed, symmetric CLI acquisition). This PR is neutral on all of it: it reports whether exclusivity was proven and stores a generation, nothing more. The consumer is where posture gets chosen, so this can land — or not — independently of that decision without pre-empting it.

## Testing

19 tests in `tests/hermes_state/test_turn_lease_store.py`. Contention is driven by **8 real threads against one SQLite file**, not mocks — for this layer, what happens when two writers race *is* the behaviour under test:

- exactly one winner under concurrent acquire; second holder refused while live; same-holder re-acquire idempotent
- expiry reclaims a crashed holder (no permanent wedge); expired lease reports no holder
- release is holder-scoped, so a late-returning turn cannot free a lease someone else now holds; generation-scoped release ignores a stale retry
- refresh extends a held lease and returns `False` once ownership was lost
- a broken store degrades to `False` rather than raising

**Integration-verified against the real consumer**: appended #67454's 241 lines onto this branch and drove them — cli acquires `True`, gateway contends `False` and fails open with that PR's ERROR, release frees the row, gateway then acquires `True`. That PR's file needs no edits.

Regression: `test_session_archiving`, `test_state_db_malformed_repair`, `test_conftest_wal_gate`, `tests/gateway/test_turn_lease.py` all pass. One caveat reported rather than hidden: `tests/gateway/test_turn_lease.py` failed once immediately after the 8-thread contention test, then passed 12/12 across three consecutive runs and passes on pristine main — I read that as load-induced timing flakiness in those timing-based tests, not this change.

Credit: @webtecnica for the `TurnLease` consumer design this API is shaped to serve, and @TheAngryPit for the fencing/TOCTOU requirement that motivated `run_generation`.
