### PR TITLE
fix(website): support TypeScript 6 typechecking

### DIFF
--- a/website/src/components/AutomationBlueprintsCatalog/index.tsx
+++ b/website/src/components/AutomationBlueprintsCatalog/index.tsx
@@ -25,7 +25,7 @@ interface Blueprint {
 
 const INDEX_URL = "/docs/api/automation-blueprints-index.json";
 
-function CopyButton({ text }: { text: string }): JSX.Element {
+function CopyButton({ text }: { text: string }): React.JSX.Element {
   const [copied, setCopied] = useState(false);
   return (
     <button
@@ -44,7 +44,7 @@ function CopyButton({ text }: { text: string }): JSX.Element {
   );
 }
 
-function BlueprintCard({ blueprint }: { blueprint: Blueprint }): JSX.Element {
+function BlueprintCard({ blueprint }: { blueprint: Blueprint }): React.JSX.Element {
   return (
     <div className={styles.card}>
       <div className={styles.cardHead}>
@@ -78,7 +78,7 @@ function BlueprintCard({ blueprint }: { blueprint: Blueprint }): JSX.Element {
   );
 }
 
-export default function AutomationBlueprintsCatalog(): JSX.Element {
+export default function AutomationBlueprintsCatalog(): React.JSX.Element {
   const [blueprints, setBlueprints] = useState<Blueprint[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 

--- a/website/src/components/UserStoriesCollage/index.tsx
+++ b/website/src/components/UserStoriesCollage/index.tsx
@@ -145,7 +145,7 @@ function sourceColor(source: string): string {
   }
 }
 
-export default function UserStoriesCollage(): JSX.Element {
+export default function UserStoriesCollage(): React.JSX.Element {
   const [activeCategory, setActiveCategory] = useState<string>('all');
   const [activeSource, setActiveSource] = useState<string>('all');
 

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,5 +1,13 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "resolveJsonModule": true,
+    "paths": {
+      "@site/*": ["./*"]
+    }
+  },
   "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
## Summary
- silence the intentional TypeScript 6 `baseUrl` deprecation
- restore the `@site/*` path mapping explicitly
- use `React.JSX.Element` for React 19 component return types

## Reproduction
On current `main`, `npm run typecheck` fails with TS5101 because `baseUrl` is deprecated in TypeScript 6.

## Validation
- `npm ci` (0 vulnerabilities)
- `npm run typecheck`
- `npm run build`
- additions-only Gitleaks scan
