### PR TITLE
fix(kanban): tolerate corrupt event payloads

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4233,7 +4233,7 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
     ).fetchone()
     try:
         payload = json.loads(row["payload"]) if row and row["payload"] else {}
-    except (json.JSONDecodeError, TypeError):
+    except (TypeError, ValueError, RecursionError):
         payload = {}
     if not isinstance(payload, dict):
         payload = {}
@@ -4591,7 +4591,7 @@ def _retry_status_for_run(
     ).fetchone()
     try:
         payload = json.loads(event["payload"]) if event and event["payload"] else {}
-    except (json.JSONDecodeError, TypeError):
+    except (TypeError, ValueError, RecursionError):
         payload = {}
     if not isinstance(payload, dict):
         payload = {}
@@ -6205,7 +6205,7 @@ def request_review(
                     if changes_event and changes_event["payload"]
                     else {}
                 )
-            except (json.JSONDecodeError, TypeError):
+            except (TypeError, ValueError, RecursionError):
                 changes_payload = {}
             prior_reviewer = (
                 changes_payload.get("reviewer")
@@ -6329,7 +6329,7 @@ def request_changes(
                 if claimed_event and claimed_event["payload"]
                 else {}
             )
-        except (json.JSONDecodeError, TypeError):
+        except (TypeError, ValueError, RecursionError):
             claimed_payload = {}
         if not isinstance(claimed_payload, dict):
             claimed_payload = {}
@@ -6350,7 +6350,7 @@ def request_changes(
                 if requested_event["payload"]
                 else {}
             )
-        except (json.JSONDecodeError, TypeError):
+        except (TypeError, ValueError, RecursionError):
             requested_payload = {}
         if not isinstance(requested_payload, dict):
             requested_payload = {}
@@ -6617,7 +6617,7 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
                 if review_event and review_event["payload"]
                 else {}
             )
-        except (json.JSONDecodeError, TypeError):
+        except (TypeError, ValueError, RecursionError):
             handoff = {}
         implementer = handoff.get("implementer")
         if not isinstance(implementer, str) or not implementer.strip():

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -632,6 +632,31 @@ def test_reopen_review_task_returns_to_ready(kanban_home: Path) -> None:
         assert kb.reopen_review_task(conn, tid) is False
 
 
+def test_reopen_review_tolerates_invalid_utf8_handoff(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="corrupt handoff", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert kb.request_review(
+            conn,
+            tid,
+            summary="v1",
+            reviewer="reviewer",
+            expected_run_id=claimed.current_run_id,
+        )
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_events SET payload = ? "
+                "WHERE task_id = ? AND kind = 'review_requested'",
+                (b"\x80", tid),
+            )
+
+        assert kb.reopen_review_task(conn, tid)
+        reopened = kb.get_task(conn, tid)
+        assert reopened is not None
+        assert reopened.status == "ready"
+
+
 def test_review_cycle_end_to_end(kanban_home: Path) -> None:
     """Full loop: run -> review -> follow-up reopen -> re-run -> review ->
     approve -> done. Never blocks, never triages, and stays wake-subscribed

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -149,10 +149,10 @@ def test_same_card_review_supports_changes_and_approval_without_block_loop(conn)
     assert completed.block_recurrences == 0
 
 
-@pytest.mark.parametrize("bad_payload", [None, "{not-json", "{}"])
+@pytest.mark.parametrize("bad_payload", [None, "{not-json", "{}", b"\x80"])
 def test_rereview_requires_explicit_reviewer_when_provenance_is_invalid(
     conn,
-    bad_payload: str | None,
+    bad_payload: str | bytes | None,
 ) -> None:
     task_id, review = _claimed_review(conn, "Malformed reviewer provenance")
     assert kb.request_changes(
@@ -271,10 +271,10 @@ def test_parent_reopen_blocks_request_review_until_parent_is_done(conn) -> None:
     )
 
 
-@pytest.mark.parametrize("bad_payload", ["{not-json", "[]"])
+@pytest.mark.parametrize("bad_payload", ["{not-json", "[]", b"\x80"])
 def test_request_changes_fails_closed_on_malformed_review_provenance(
     conn,
-    bad_payload: str,
+    bad_payload: str | bytes,
 ):
     task_id = kb.create_task(conn, title="Malformed handoff", assignee="builder")
     implementation = kb.claim_task(conn, task_id, claimer="builder:1")
@@ -310,14 +310,18 @@ def test_request_changes_fails_closed_on_malformed_review_provenance(
     assert task.current_run_id == review.current_run_id
 
 
-def test_reclaim_fails_safe_on_non_object_claim_provenance(conn) -> None:
+@pytest.mark.parametrize("bad_payload", ["[]", b"\x80"])
+def test_reclaim_fails_safe_on_non_object_claim_provenance(
+    conn,
+    bad_payload: str | bytes,
+) -> None:
     task_id, _review = _claimed_review(conn, "Non-object claimed payload")
     with kb.write_txn(conn):
         conn.execute(
-            "UPDATE task_events SET payload = '[]' "
+            "UPDATE task_events SET payload = ? "
             "WHERE task_id = ? AND kind = 'claimed' "
             "AND run_id = (SELECT current_run_id FROM tasks WHERE id = ?)",
-            (task_id, task_id),
+            (bad_payload, task_id, task_id),
         )
     assert kb.reclaim_task(conn, task_id, signal_fn=lambda *_args: None)
     task = kb.get_task(conn, task_id)
@@ -414,6 +418,47 @@ def test_review_escalation_unblocks_back_to_review(conn) -> None:
     resumed = kb.get_task(conn, task_id)
     assert resumed is not None
     assert resumed.status == "review"
+
+
+def test_invalid_utf8_block_payload_unblocks_to_legacy_ready(conn) -> None:
+    task_id, review = _claimed_review(conn, "Corrupt blocked payload")
+    assert kb.block_task(
+        conn,
+        task_id,
+        reason="needs_input: maintainer decision required",
+        kind="needs_input",
+        expected_run_id=review.current_run_id,
+    )
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE task_events SET payload = ? "
+            "WHERE task_id = ? AND kind = 'blocked'",
+            (b"\x80", task_id),
+        )
+
+    assert kb.unblock_task(conn, task_id)
+    resumed = kb.get_task(conn, task_id)
+    assert resumed is not None
+    assert resumed.status == "ready"
+
+
+def test_request_changes_fails_closed_on_invalid_utf8_claim_provenance(conn) -> None:
+    task_id, review = _claimed_review(conn, "Corrupt claimed payload")
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE task_events SET payload = ? "
+            "WHERE task_id = ? AND kind = 'claimed' AND run_id = ?",
+            (b"\x80", task_id, review.current_run_id),
+        )
+
+    ok, detail = kb.request_changes(
+        conn,
+        task_id,
+        reason="Needs changes.",
+        expected_run_id=review.current_run_id,
+    )
+    assert ok is False
+    assert detail == "active run was not claimed from review"
 
 
 def test_review_dependency_wait_reenters_review_after_parent_finishes(conn) -> None:


### PR DESCRIPTION
## What does this PR do?

Kanban lifecycle operations now treat undecodable or pathologically malformed historical `task_events.payload` values the same way they already treat invalid JSON: they preserve each operation's existing safe fallback instead of raising from `json.loads()`.

### Symptom

SQLite permits a `TEXT`-declared column to contain a BLOB. If a historical event payload contains invalid UTF-8 bytes such as `b"\x80"`, Python's `json.loads()` raises `UnicodeDecodeError`. The six durable Kanban event readers caught only `JSONDecodeError` and `TypeError`, so unblock, reclaim/retry, re-review, request-changes, and review-reopen operations could crash instead of following their documented malformed-provenance behavior.

### Root cause

`UnicodeDecodeError` is a `ValueError`, not a `JSONDecodeError`. The event readers' exception boundaries therefore covered invalid JSON syntax but not invalid byte encoding. Deeply nested JSON can also raise `RecursionError` before a safe fallback is selected.

### Fix

- Change the six durable event-payload decoder boundaries in `hermes_cli/kanban_db.py` to catch `TypeError`, `ValueError`, and `RecursionError`.
- Preserve every reader's existing fallback semantics:
  - unblock/retry phase falls back to legacy `ready`;
  - malformed review provenance fails closed;
  - review reopen proceeds without trusting a malformed implementer handoff.
- Add public production-path regressions using a real temporary SQLite database with raw invalid UTF-8 BLOB payloads.

This is deliberately independent of blocker-cause fingerprinting and block-loop auto-decompose policy; it does not add schema, configuration, or routing behavior.

## Related work

- Related malformed-history edge discovered while reviewing #83645.
- Does not replace or compete with #83645 or #81353.

## Verification

The new invalid-UTF-8 cases were run against unmodified current `main` first and failed at all six intended readers with `UnicodeDecodeError` (**6 failed, 6 passed**). After the fix:

```text
12 focused malformed-payload cases passed
49 affected Kanban lifecycle tests passed
Ruff passed
git diff --check passed
```

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Searched open, closed, and merged issues/PRs for this error class
- [x] Reproduced on current `main`
- [x] Fixed all six sibling durable event readers in `kanban_db.py`
- [x] Added real SQLite/public-path regression coverage
- [x] No schema, dependency, configuration, or documentation changes