### PR TITLE
fix: keep skill content hash symmetric with bundle hash ordering

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -433,6 +433,38 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_matches_installed_content_hash_when_file_and_dir_share_prefix(self, tmp_path):
+        # Regression: a file ("styles.md") whose name is a segment-prefix of a
+        # sibling directory ("styles/") sorts differently as a Path vs a
+        # string, and the two hash functions used to disagree on the same
+        # content -- install recorded one digest, `hermes skills check`
+        # compared another, so the skill reported update_available forever.
+        from tools.skills_guard import content_hash
+
+        files = {
+            "SKILL.md": "# demo\n",
+            "styles.md": "# index of styles\n",
+            "styles/a.md": "style a\n",
+            "styles/b.md": "style b\n",
+            "references.md": "# refs\n",
+            "references/x.md": "ref x\n",
+        }
+        bundle = SkillBundle(
+            name="demo-skill",
+            files=dict(files),
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        for rel, content in files.items():
+            path = skill_dir / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
 
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -697,14 +697,29 @@ def scan_skill(skill_path: Path, source: str = "community") -> ScanResult:
 
 
 def _content_digest(skill_path: Path) -> str:
-    """Canonical SHA-256 over relative paths and exact file bytes."""
+    """Canonical SHA-256 over relative paths and exact file bytes.
+
+    Files are iterated in *string* sort order of their relative paths.
+    This must stay symmetric with ``tools.skills_hub.bundle_content_hash``,
+    which sorts in-memory bundle keys (relative-path strings) the same way.
+    Sorting ``Path`` objects instead would diverge whenever a file shares a
+    segment-prefix with a directory (e.g. ``styles.md`` beside
+    ``styles/*.md``): ``PosixPath`` ordering compares path parts, so the
+    ``styles/`` children sort *before* ``styles.md``, while string ordering
+    puts ``styles.md`` first (``'.' < '/'``). Same bytes, different digest
+    -- which broke ``hermes skills check`` into reporting a permanent
+    ``update_available`` for such skills (install records the disk digest,
+    check compares the bundle digest).
+    """
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for file_path in sorted(skill_path.rglob("*")):
-            if file_path.is_file():
-                rel = file_path.relative_to(skill_path).as_posix()
-                h.update(rel.encode("utf-8") + b"\x00")
-                h.update(file_path.read_bytes())
+        for rel in sorted(
+            file_path.relative_to(skill_path).as_posix()
+            for file_path in skill_path.rglob("*")
+            if file_path.is_file()
+        ):
+            h.update(rel.encode("utf-8") + b"\x00")
+            h.update((skill_path / rel).read_bytes())
     else:
         h.update(skill_path.read_bytes())
     return h.hexdigest()


### PR DESCRIPTION
## Symptom

`hermes skills check` permanently reports `update_available` for `baoyu-article-illustrator`, even after `hermes skills update` prints "Updated 1 skill(s)". Re-running update reinstalls identical content and the status never flips to `up_to_date`.

## Root cause

Two hash functions that are documented to be symmetric disagree on ordering:

- `tools/skills_guard._content_digest` (used by `content_hash`, recorded in the hub lockfile at install time) iterated `sorted(skill_path.rglob("*"))` — **`Path` object ordering**.
- `tools/skills_hub.bundle_content_hash` (used by `check_for_skill_updates`) iterates `sorted(bundle.files)` — **relative-path string ordering**.

`PosixPath` ordering compares path *parts*, so when a file shares a segment-prefix with a directory (`references/styles.md` beside `references/styles/*.md`, which is exactly this skill's layout), the `styles/` children sort **before** `styles.md` as Paths but **after** it as strings (`'.' < '/'`). Same bytes → different digest.

So install records the disk digest in the lock while `check` compares the in-memory bundle digest. For any skill with this layout the two can never match, and the update loop spins forever (reinstall identical content, still report an update).

`content_hash`'s own docstring already mandates the symmetry: "This must stay symmetric with `tools.skills_hub.bundle_content_hash` … any change to the hash shape MUST land in both places at once."

## Fix

`_content_digest` now sorts the relative-path **strings** (same iteration order as `bundle_content_hash`). One function; the disk and bundle digests agree for identical content.

## Test

Added a regression test in `tests/tools/test_skills_hub.py` whose layout (`styles.md` + `styles/*.md`, `references.md` + `references/x.md`) previously produced divergent digests — the existing symmetry test used a layout (`references/checklist.md`) where Path and string ordering agree, which is why this slipped through.

Verified: `scripts/run_tests.sh tests/tools/test_skills_hub.py -k content_hash` passes, and end-to-end `hermes skills update` + `hermes skills check` now report `up_to_date` for the affected skill.