### PR TITLE
test: use canonical temp path for cleanup checks

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -99,10 +99,11 @@ class TestDetectDangerousRm:
             assert "delete" in desc.lower()
 
 
-    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
-        with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self, tmp_path):
+        with mock_patch("tempfile.gettempdir", return_value=str(tmp_path)):
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                artifact = tmp_path / f"{prefix}example.py"
+                assert detect_dangerous_command(f"rm -f {artifact}") == (
                     False,
                     None,
                     None,


### PR DESCRIPTION
## Summary
- use pytest `tmp_path` for verification-artifact cleanup tests
- avoid assuming `/tmp` remains lexically unchanged after `realpath`
- preserve the existing security assertion that arbitrary symlink aliases are not exempted

## Reproduction
On macOS, `/tmp` resolves to `/private/tmp`, so the current test fails on `main` even though the implementation intentionally requires the canonical target.

## Validation
- before: targeted test fails on macOS
- after: `tests/tools/test_approval.py` passes 96/96 on macOS
- additions-only Gitleaks scan
- `git diff --check`

## Runner note
The optional locked `python-compile` recipe is currently unusable for this repository because it mounts the source read-only while `compileall` writes `__pycache__`; this is unrelated to the patch.
