### PR TITLE
fix(config): redact MCP credentials in config get output

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -645,6 +645,17 @@ def _redact_url_query_params(text: str) -> str:
     return _URL_WITH_QUERY_RE.sub(_sub, text)
 
 
+def redact_url_query_params(text: str) -> str:
+    """Redact sensitive query-string parameter values in URLs embedded in ``text``.
+
+    Public wrapper around :func:`_redact_url_query_params` for callers that need
+    the sensitive query-name policy (``apikey``, ``token``, ``key``, ...) without
+    the full-text redactor — e.g. ``hermes config get`` output, where resolved
+    MCP server URLs can embed credentials (issue #84106).
+    """
+    return _redact_url_query_params(text)
+
+
 def _redact_url_userinfo(text: str) -> str:
     """Strip `user:password@` from HTTP/WS/FTP URLs.
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4274,19 +4274,51 @@ _SECRET_CONFIG_KEYS = frozenset({
     "jwt",
 })
 
+# Case-insensitive SUFFIXES for credential-named keys (e.g. ``COINGECKO_PRO_API_KEY``).
+# Exact names are covered by ``_SECRET_CONFIG_KEYS``; these catch the common
+# ``*_API_KEY`` / ``*_TOKEN`` / ``*_SECRET`` env-map shapes used by MCP servers
+# and provider configs. Suffix-only (never substring) so benign keys like
+# ``token_count`` or ``secret_santa`` are untouched.
+_SECRET_CONFIG_KEY_SUFFIXES = (
+    "_api_key",
+    "_apikey",
+    "_token",
+    "_access_token",
+    "_refresh_token",
+    "_id_token",
+    "_secret",
+    "_client_secret",
+    "_password",
+    "_passwd",
+    "_auth",
+    "_authorization",
+    "_private_key",
+    "_bearer",
+    "_jwt",
+)
+
+
+def _is_secret_config_key(key: str) -> bool:
+    """Return whether ``key`` names a credential by exact name or secret suffix."""
+    k = key.lower()
+    return k in _SECRET_CONFIG_KEYS or k.endswith(_SECRET_CONFIG_KEY_SUFFIXES)
+
 
 def redact_config_value(value: Any, _depth: int = 0) -> Any:
     """Return a copy of ``value`` with credential-shaped keys masked for display.
 
-    Recursively walks dicts/lists and replaces the value of any key in
-    ``_SECRET_CONFIG_KEYS`` (case-insensitive) with a masked form via
-    :func:`agent.redact.mask_secret`. Non-secret keys and scalar values pass
-    through unchanged. Use this before ``print``-ing any config sub-tree that
-    might carry a custom-provider ``api_key`` — ``print`` bypasses the logging
-    redactor, and opaque tokens (e.g. Cloudflare ``cfut_...``) don't match the
-    vendor-prefix regexes either, so structural key-name masking is required.
+    Recursively walks dicts/lists and replaces the value of any key that names a
+    credential — exact match on ``_SECRET_CONFIG_KEYS`` or a secret suffix such as
+    ``*_API_KEY`` / ``*_TOKEN`` / ``*_SECRET`` (case-insensitive) — with a masked
+    form via :func:`agent.redact.mask_secret`. String leaves that embed URLs with
+    credential-named query params (e.g. ``https://...?apikey=...``) have those
+    values masked via :func:`agent.redact.redact_url_query_params`. Non-secret
+    keys and scalar values pass through unchanged. Use this before ``print``-ing
+    any config sub-tree that might carry a credential — ``print`` bypasses the
+    logging redactor, and opaque tokens (e.g. Cloudflare ``cfut_...``) don't match
+    the vendor-prefix regexes either, so structural key-name masking is required.
     """
-    from agent.redact import mask_secret
+    from agent.redact import mask_secret, redact_url_query_params
 
     # Defensive bound on recursion depth for pathological/cyclic configs.
     if _depth > 20:
@@ -4294,13 +4326,17 @@ def redact_config_value(value: Any, _depth: int = 0) -> Any:
     if isinstance(value, dict):
         out = {}
         for k, v in value.items():
-            if isinstance(k, str) and k.lower() in _SECRET_CONFIG_KEYS and isinstance(v, str) and v:
+            if isinstance(k, str) and isinstance(v, str) and v and _is_secret_config_key(k):
                 out[k] = mask_secret(v)
             else:
                 out[k] = redact_config_value(v, _depth + 1)
         return out
     if isinstance(value, list):
         return [redact_config_value(v, _depth + 1) for v in value]
+    if isinstance(value, str):
+        # Resolved strings can embed credentials in URL query params (MCP server
+        # ``url: https://...?apikey=${VAR}``), so redact those values as well.
+        return redact_url_query_params(value)
     return value
 
 
@@ -5109,17 +5145,49 @@ def set_config_value(key: str, value: str, force: bool = False):
         ))
 
 
+def _config_redaction_enabled(cfg: Dict[str, Any]) -> bool:
+    """Whether ``config get`` output should redact credentials.
+
+    Mirrors ``security.redact_secrets`` — ON by default (DEFAULT_CONFIG); an
+    explicit ``false`` opts out of display redaction for scripts that need raw
+    resolved values.
+    """
+    sec = cfg.get("security")
+    if not isinstance(sec, dict):
+        return True
+    value = sec.get("redact_secrets")
+    return True if value is None else bool(value)
+
+
 def get_config_value(key: str, *, as_json: bool = False):
-    """Print a resolved configuration value."""
+    """Print a resolved configuration value.
+
+    With ``security.redact_secrets`` enabled (the default), credential-shaped
+    values are masked before printing so resolved ``${ENV_VAR}`` references in
+    e.g. ``mcp_servers`` never leak into terminal output, transcripts, or model
+    context (issue #84106).
+    """
+    cfg = load_config()
     if _is_env_config_key(key):
         env_value = get_env_value(key.upper())
         value = _MISSING if env_value is None else env_value
     else:
-        value = _get_nested(load_config(), key)
+        value = _get_nested(cfg, key)
 
     if value is _MISSING:
         print(f"Config key not set: {key}", file=sys.stderr)
         sys.exit(1)
+
+    if value is not None and _config_redaction_enabled(cfg):
+        if isinstance(value, str) and _is_secret_config_key(key.rsplit(".", 1)[-1]):
+            # Leaf scalar under a credential-named key (e.g.
+            # ``mcp_servers.demo_env.env.COINGECKO_PRO_API_KEY``): the key context
+            # is only available here, so mask by key name.
+            from agent.redact import mask_secret
+
+            value = mask_secret(value)
+        else:
+            value = redact_config_value(value)
 
     print(_format_config_get_value(value, as_json=as_json))
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -723,3 +723,57 @@ class TestMalformedYAMLConfigPreservation:
         assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+
+
+class TestConfigGetRedaction:
+    """#84106: `config get` must redact credential-shaped values when
+    security.redact_secrets is enabled (default), so resolved ${ENV_VAR}
+    references in mcp_servers never leak into output/transcripts/model context."""
+
+    def _write_config(self, tmp_path, body):
+        (tmp_path / "config.yaml").write_text(body, encoding="utf-8")
+
+    def test_get_mcp_servers_redacts_resolved_credentials(self, _isolated_hermes_home, capsys, monkeypatch):
+        monkeypatch.setenv("COINGECKO_PRO_API_KEY", "sk-super-secret-123")
+        self._write_config(_isolated_hermes_home, (
+            "security:\n  redact_secrets: true\n"
+            "mcp_servers:\n  demo:\n    url: https://example.com\n"
+            "    env:\n      COINGECKO_PRO_API_KEY: ${COINGECKO_PRO_API_KEY}\n"
+        ))
+        from hermes_cli.config import get_config_value
+        get_config_value("mcp_servers", as_json=True)
+        out = capsys.readouterr().out
+        assert "sk-super-secret-123" not in out
+        assert "..." in out  # mask_secret format (sk-s...-123)
+
+    def test_get_leaf_env_credential_is_masked(self, _isolated_hermes_home, capsys, monkeypatch):
+        monkeypatch.setenv("MY_API_KEY", "abc-secret-xyz")
+        self._write_config(_isolated_hermes_home, (
+            "security:\n  redact_secrets: true\n"
+            "mcp_servers:\n  s:\n    env:\n      MY_API_KEY: ${MY_API_KEY}\n"
+        ))
+        from hermes_cli.config import get_config_value
+        get_config_value("mcp_servers.s.env.MY_API_KEY")
+        out = capsys.readouterr().out
+        assert "abc-secret-xyz" not in out
+
+    def test_get_leaf_url_redacts_query_credential(self, _isolated_hermes_home, capsys):
+        self._write_config(_isolated_hermes_home, (
+            "security:\n  redact_secrets: true\n"
+            "mcp_servers:\n  s:\n    url: https://x.com?apikey=leaky-value\n"
+        ))
+        from hermes_cli.config import get_config_value
+        get_config_value("mcp_servers.s.url")
+        out = capsys.readouterr().out
+        assert "leaky-value" not in out
+
+    def test_get_mcp_servers_returns_raw_when_redaction_disabled(self, _isolated_hermes_home, capsys, monkeypatch):
+        monkeypatch.setenv("COINGECKO_PRO_API_KEY", "sk-visible-456")
+        self._write_config(_isolated_hermes_home, (
+            "security:\n  redact_secrets: false\n"
+            "mcp_servers:\n  demo:\n    env:\n      COINGECKO_PRO_API_KEY: ${COINGECKO_PRO_API_KEY}\n"
+        ))
+        from hermes_cli.config import get_config_value
+        get_config_value("mcp_servers", as_json=True)
+        out = capsys.readouterr().out
+        assert "sk-visible-456" in out  # opt-out preserves raw behavior


### PR DESCRIPTION
## Summary
`hermes config get mcp_servers` resolved `${ENV_VAR}` references and printed some MCP credentials in full even when `security.redact_secrets: true`. This is especially easy to trigger from an agent session through the terminal tool, which puts the expanded credentials into model context and the session transcript.

## Change
- `agent/redact.py`: public `redact_url_query_params(text)` wrapper over the existing query-param policy (`apikey`, `token`, `key`, `code`, ...).
- `hermes_cli/config.py`:
  - `_SECRET_CONFIG_KEY_SUFFIXES` + `_is_secret_config_key()` — captures credential-shaped keys by suffix (`*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, ...) in addition to the exact-name match; suffix-only keys (`token_count`, `secret_santa`) stay intact.
  - `redact_config_value()` — uses the suffix matcher and redacts credential query params in strings.
  - `get_config_value()` — redacts the resolved value before printing when `security.redact_secrets` is active (default `true`; `false` preserves raw behavior). Leaf scalars under a credential key are masked via `mask_secret`.
- `tests/hermes_cli/test_set_config_value.py`: `TestConfigGetRedaction` — MCP servers redact resolved credentials (JSON + leaf), URL query credentials redacted, env leaf masked, opt-out returns raw.

## Verification
- `tests/hermes_cli/test_set_config_value.py`: **86 passed** (incl. 9 redaction cases).

Closes #84106