### PR TITLE
fix(gateway): multiplex must not apply default-profile creds to unconfigured profiles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13710,6 +13710,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         for platform, platform_config in profile_cfg.platforms.items():
             if not platform_config.enabled:
                 continue
+            # A platform enabled in a secondary profile's config.yaml may
+            # have no credential in that profile's secret scope — the shared
+            # YAML enables it for the default profile only (#84079). Building
+            # an adapter here would treat every credential-less profile as
+            # configured for the platform and one inbound message would fan
+            # out across all of them. Mirror the primary startup loop's
+            # credential gate and skip instead; profiles with their own
+            # credential still connect below.
+            if (
+                getattr(self.config, "multiplex_profiles", False)
+                and not _platform_has_bot_credential(platform, platform_config)
+            ):
+                logger.info(
+                    "[MULTIPLEX] Profile '%s': skipping %s - no bot credential "
+                    "in this profile's secrets",
+                    profile_name,
+                    platform.value,
+                )
+                continue
             # Relay is shared process-level ingress in multiplex mode. The
             # active profile owns the one connection; connector-stamped
             # source.profile routes inbound turns to secondary profiles.
@@ -13847,6 +13866,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     with _profile_runtime_scope(profile_home):
                         profile_config = load_gateway_config().platforms.get(platform)
                         if profile_config is None or not profile_config.enabled:
+                            return
+                        # Mirrors the startup credential gate (#84079): a
+                        # credential removed from this profile's scope must
+                        # not rebuild an adapter that would fan out turns.
+                        if not _platform_has_bot_credential(platform, profile_config):
+                            logger.info(
+                                "Secondary %s reconnect skipped: no bot credential "
+                                "(profile: %s)",
+                                platform.value,
+                                profile_name,
+                            )
                             return
                         adapter = self._create_adapter(platform, profile_config)
                         if adapter is None:

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -511,3 +511,98 @@ class TestFeishuPortBindingConditional:
         assert connected == 0  # no error, just nothing connected
 
 
+class TestSecondarySkipsCredentiallessPlatforms:
+    """#84079 — multiplex must not build adapters for platforms a profile
+    has no credential for.
+
+    The shared config.yaml enables a platform once; under multiplex every
+    secondary profile reloads it inside its own secret scope, so a profile
+    whose scope lacks the platform credential resolves ``enabled=True`` with
+    an empty token. Constructing an adapter anyway treats every profile as
+    configured for the platform — one inbound message fans out across all of
+    them. These tests lock the credential gate on the secondary startup and
+    reconnect paths (the primary path got the same gate in #64674).
+    """
+
+    def _make_runner(self, monkeypatch, profile_cfg):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.adapters = {}
+        created = []
+
+        def fake_create(platform, platform_config):
+            created.append((platform, platform_config))
+            return _FakeAdapter(token=platform_config.token or None)
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
+        monkeypatch.setattr(runner, "_create_adapter", fake_create)
+        monkeypatch.setattr(runner, "_configure_profile_adapter", lambda *a, **k: None)
+        monkeypatch.setattr(
+            runner,
+            "_connect_initial_adapter_with_timeout",
+            AsyncMock(return_value=True),
+        )
+        return runner, created
+
+    @pytest.mark.asyncio
+    async def test_credentialless_platform_builds_no_adapter(self, monkeypatch, tmp_path):
+        """Enabled-in-YAML but no credential in the profile scope -> no adapter."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {
+            # Shared config.yaml enables Slack; profile-b's .env has no
+            # SLACK_BOT_TOKEN, so its scoped load resolves token="" but
+            # keeps enabled=True (#84079).
+            Platform.SLACK: PlatformConfig(enabled=True, token=""),
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="telegram-token-b"),
+        }
+        runner, created = self._make_runner(monkeypatch, profile_cfg)
+
+        connected = await runner._start_one_profile_adapters("profile-b", tmp_path, {})
+
+        # Only Telegram (which profile-b has its own credential for) gets an
+        # adapter; Slack is skipped instead of fanning out a turn per profile.
+        assert [p for p, _ in created] == [Platform.TELEGRAM]
+        assert connected == 1
+        assert Platform.TELEGRAM in runner._profile_adapters["profile-b"]
+        assert Platform.SLACK not in runner._profile_adapters["profile-b"]
+
+    @pytest.mark.asyncio
+    async def test_profile_with_own_credential_still_connects(self, monkeypatch, tmp_path):
+        """A profile that defines its own credential keeps its adapter."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {
+            Platform.SLACK: PlatformConfig(enabled=True, token="slack-token-b"),
+        }
+        runner, created = self._make_runner(monkeypatch, profile_cfg)
+
+        connected = await runner._start_one_profile_adapters("profile-b", tmp_path, {})
+
+        assert connected == 1
+        assert created == [(Platform.SLACK, profile_cfg.platforms[Platform.SLACK])]
+        assert Platform.SLACK in runner._profile_adapters["profile-b"]
+
+    @pytest.mark.asyncio
+    async def test_non_token_platform_never_skipped(self, monkeypatch, tmp_path):
+        """Platforms that do not use a bot token are never credential-gated."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {
+            # Signal authenticates via its own session path, not a token —
+            # it must still be built for every profile that enables it.
+            Platform.SIGNAL: PlatformConfig(enabled=True),
+        }
+        runner, created = self._make_runner(monkeypatch, profile_cfg)
+
+        connected = await runner._start_one_profile_adapters("profile-b", tmp_path, {})
+
+        assert connected == 1
+        assert [p for p, _ in created] == [Platform.SIGNAL]
+        assert Platform.SIGNAL in runner._profile_adapters["profile-b"]
+
+


### PR DESCRIPTION
## Summary
Under `gateway.multiplex_profiles: true`, platform credentials resolved for the default profile were applied to **every** profile. Profiles that define no credentials for a platform were still treated as configured — an adapter was constructed and a session enumerated for each one, so a single inbound message caused an N-way turn fan-out (plus Matrix construction crashes, empty Slack adapters, and duplicate-refusal noise).

## Change
- `gateway/run.py`:
  - `_start_one_profile_adapters` — skips a platform with no credential in the profile scope under multiplex, mirroring the primary-loop gate (#64674). Reuses `_platform_has_bot_credential`, which only filters the 6 token platforms (telegram/discord/slack/mattermost/matrix/weixin via `PLATFORM_TOKEN_ENV_NAMES`) — non-token platforms (Signal, WhatsApp, api_server, ...) are never skipped (legitimate fallback preserved).
  - `_run_secondary_profile_reconnect` — same gate on reconnect (mirrors the primary watcher), completing the bug class symmetrically.
- `tests/gateway/test_multiplex_adapter_registry.py`: new cases — profile without credentials builds no adapter for token platforms; profile with its own credentials builds with its own; non-token platforms unaffected; reconnect path gated.

## Verification
- `tests/gateway/test_multiplex_adapter_registry.py`: **17 passed**. Adjacent multiplex/secret-scope/config suites: **194 passed**.

Closes #84079