### PR TITLE
fix(desktop): persist dropped screenshot bytes before attach

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -1,5 +1,7 @@
+import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { ComposerAttachment } from '@/store/composer'
 import { $connection } from '@/store/session'
 
 import {
@@ -7,7 +9,8 @@ import {
   type DroppedFile,
   extractDroppedFiles,
   HERMES_PATHS_MIME,
-  partitionDroppedFiles
+  partitionDroppedFiles,
+  useComposerActions
 } from './use-composer-actions'
 
 // A Finder/Explorer drop carries a native File handle; an in-app drag (project
@@ -242,5 +245,76 @@ describe('attachmentPreviewDataUrl', () => {
     $connection.set({ mode: 'remote' } as never)
 
     await expect(attachmentPreviewDataUrl('/home/gateway/shot.png')).resolves.toBe(REMOTE_PREVIEW)
+  })
+})
+
+describe('useComposerActions native image drops', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'hermesDesktop')
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('copies dropped screenshot bytes before trusting a transient macOS path', async () => {
+    const transientPath =
+      '/var/folders/x7/example/T/TemporaryItems/NSIRD_screencaptureui_4roSuW/Screen Shot 2026-08-11.png'
+
+    const durablePath = '/Users/test/Library/Application Support/Hermes/composer-images/composer_saved.png'
+    const previewUrl = 'data:image/png;base64,c2NyZWVuc2hvdA=='
+
+    const screenshot = new File([new Uint8Array([1, 2, 3])], 'Screen Shot 2026-08-11.png', {
+      type: 'image/png'
+    })
+
+    const saveImageBuffer = vi.fn(async () => durablePath)
+
+    const readFileDataUrl = vi.fn(async (path: string) => {
+      if (path === transientPath) {
+        throw new Error('temporary screenshot path disappeared')
+      }
+
+      return previewUrl
+    })
+
+    const add = vi.fn<(attachment: ComposerAttachment) => void>()
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        readFileDataUrl,
+        saveImageBuffer
+      }
+    })
+
+    const { result } = renderHook(() =>
+      useComposerActions({
+        activeSessionId: null,
+        currentCwd: '/Users/test/project',
+        requestGateway: vi.fn(),
+        scope: {
+          add,
+          remove: vi.fn(() => null),
+          target: 'test-composer'
+        }
+      })
+    )
+
+    let attached = false
+
+    await act(async () => {
+      attached = await result.current.attachDroppedItems([{ file: screenshot, path: transientPath }])
+    })
+
+    expect(attached).toBe(true)
+    expect(saveImageBuffer).toHaveBeenCalledOnce()
+    expect(readFileDataUrl).toHaveBeenCalledWith(durablePath)
+    expect(readFileDataUrl).not.toHaveBeenCalledWith(transientPath)
+    expect(add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'image',
+        path: durablePath,
+        previewUrl
+      })
+    )
   })
 })

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -595,7 +595,14 @@ export function useComposerActions({
         const isImage = file.type.startsWith('image/') || isImagePath(file.name) || (filePath && isImagePath(filePath))
 
         if (isImage) {
-          if ((filePath && (await attachImagePath(filePath))) || (await attachImageBlob(file))) {
+          // Finder may expose a dropped screenshot through a short-lived
+          // TemporaryItems/NSIRD_screencaptureui path even when the visible
+          // file has already landed on Desktop. Reading that path for the
+          // preview can succeed, then image.attach fails after macOS removes
+          // it before submit. Persist the File bytes into Desktop's durable
+          // composer-image cache first; keep the native path as a compatibility
+          // fallback for older shells that cannot save the buffer.
+          if ((await attachImageBlob(file)) || (filePath && (await attachImagePath(filePath)))) {
             attached = true
 
             continue


### PR DESCRIPTION
## What does this PR do?

Fixes macOS Finder screenshot drops that preview correctly in Desktop but fail when the prompt is submitted with `image not found`.

Finder can expose the dropped screenshot through a short-lived `TemporaryItems/NSIRD_screencaptureui...` path. Desktop previously preferred that native path over the dropped `File` bytes. The preview could read the file immediately, but `image.attach` later received the same path after macOS had removed it.

Native image drops now persist the `File` bytes into Desktop's composer-image cache first. The attachment therefore carries a durable path through prompt submission, while the native path remains a compatibility fallback if buffer persistence is unavailable.

## Related Issue

Discord support report: https://discord.com/channels/1053877538025386074/1536857447917031535

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/hooks/use-composer-actions.ts`: persist native dropped-image bytes before trusting the OS-provided path.
- `apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts`: cover a disappearing macOS screenshot path and prove the attachment uses the durable composer-image path instead.

## How to Test

1. On macOS, take a screenshot and drag the saved screenshot from Finder or Desktop into a normal Hermes Desktop conversation.
2. Wait briefly, then submit the prompt. The image should remain attached and reach the agent without an `image not found` error for the temporary screenshot path.
3. Run the focused automated checks listed below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass - not run; this is a Desktop TypeScript-only change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 with the focused Desktop UI test, Desktop typecheck, and ESLint; the macOS temporary-path behavior is covered by the regression test

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A

## Screenshots / Logs

Reported failure:

```text
image not found: /var/folders/.../T/TemporaryItems/NSIRD_screencaptureui_.../Screen
```

Validation:

```text
npm --workspace apps/desktop run test:ui -- src/app/chat/hooks/use-composer-actions.test.ts
Test Files  1 passed (1)
Tests       14 passed (14)

npm --workspace apps/desktop run typecheck
npx eslint src/app/chat/hooks/use-composer-actions.ts src/app/chat/hooks/use-composer-actions.test.ts
git diff --check
```
