### PR TITLE
fix(desktop): smooth-scale pet sprite frames

### DIFF
--- a/apps/desktop/src/components/pet/pet-sprite.test.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.test.tsx
@@ -222,7 +222,27 @@ describe('PetSprite RAF scheduling', () => {
     render(<PetSprite info={INFO} pauseWhenUnfocused={false} />)
 
     act(() => window.dispatchEvent(new Event('blur')))
-
     expect(raf.pending()).toBe(1)
+  })
+
+  it('draws sprite frames with bicubic smoothing for illustration art', () => {
+    const raf = installRaf()
+    const ctxMock = {
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+      imageSmoothingEnabled: false,
+      imageSmoothingQuality: 'low'
+    } as unknown as CanvasRenderingContext2D
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctxMock)
+
+    render(<PetSprite info={INFO} />)
+    act(() => raf.runNext(0))
+
+    // Petdex sheets are illustration frames, not pixel art — nearest-neighbour
+    // (the old default) makes zoomed pets look blocky. The renderer must opt
+    // into bicubic smoothing before the first draw.
+    expect(ctxMock.imageSmoothingEnabled).toBe(true)
+    expect(ctxMock.imageSmoothingQuality).toBe('high')
+    expect(ctxMock.drawImage).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/components/pet/pet-sprite.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.tsx
@@ -325,7 +325,10 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, pauseWhenUn
         const sx = frame * frameW
         const sy = row * frameH
         ctx.clearRect(0, 0, canvas.width, canvas.height)
-        ctx.imageSmoothingEnabled = false
+        // Smooth (bicubic) upscale: petdex sheets are illustration art, not
+        // pixel art — nearest-neighbour makes zoomed frames look blocky.
+        ctx.imageSmoothingEnabled = true
+        ctx.imageSmoothingQuality = 'high'
         ctx.drawImage(image, sx, sy, frameW, frameH, 0, 0, drawW, drawH)
         drawnFrame = frame
         drawnRow = row


### PR DESCRIPTION
## What does this PR do?

The desktop floating pet looks blocky/pixelated when zoomed. `PetSprite` draws each spritesheet frame with `imageSmoothingEnabled = false` (nearest-neighbour), which is the right choice for pixel art but wrong for Petdex/Codex sheets — those are 192×208 px illustration frames. Zooming such art with nearest-neighbour produces visible blocky artifacts.

This PR enables bicubic smoothing (`imageSmoothingEnabled = true` + `imageSmoothingQuality = 'high'`) for sprite draws. No behavior, animation, or config changes.

## Related Issue

No issue filed. The high-DPI backing-store half of this problem (canvas sized at CSS resolution, blurry on Retina/150% scaling) is already addressed by #83276; this PR is the complementary interpolation fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/pet/pet-sprite.tsx`: set `ctx.imageSmoothingEnabled = true` and `ctx.imageSmoothingQuality = 'high'` before `drawImage` (was `false` — nearest-neighbour).
- `apps/desktop/src/components/pet/pet-sprite.test.tsx`: new test asserting the renderer opts into bicubic smoothing before the first draw.

## How to Test

1. Start Hermes Desktop with a pet active (e.g. `/pet isekai-emotion`).
2. Alt+scroll over the pet to zoom in and out — frames should scale smoothly with no pixel blocks.
3. Previously: zoomed frames showed hard nearest-neighbour pixels.

Tested on Windows 11 (150% display scaling), pet zoomed from 0.33× to ~2×.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see #83276 note above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — *change is desktop TypeScript only; desktop unit suite (`npx vitest run apps/desktop/src/components/pet/pet-sprite.test.tsx`, 5/5) passes; Python suite runs in CI*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — canvas 2D smoothing is uniformly supported in Chromium on all platforms
