### PR TITLE
fix: serialize API turns per session

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5661,7 +5661,12 @@ This compaction should PRIORITISE preserving all information related to the focu
         """
         compress_start = self._align_boundary_forward(messages, self._protect_head_size(messages))
         compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
-        return compress_start < compress_end
+        # A one-message middle is not a useful automatic compaction unit: the
+        # summary envelope can be larger than the content it replaces. Wait
+        # for at least two complete messages so a compaction has a meaningful
+        # chance of reducing pressure rather than creating a larger summary
+        # and immediately re-triggering the same turn.
+        return compress_end - compress_start >= 2
 
     # ------------------------------------------------------------------
     # Main compression entry point

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2018,29 +2018,34 @@ def _merge_anchor_into_user_message(target: dict, anchor: dict) -> None:
 
 
 def _insert_real_user_anchor(messages: list, anchor: dict) -> None:
-    """Insert the latest human turn without breaking role alternation."""
+    """Insert the latest human turn after the compaction handoff.
+
+    ``SUMMARY_PREFIX`` tells the model that the first user message after the
+    summary is the active task.  Inserting the anchor before an assistant-role
+    summary therefore makes the preserved objective explicitly historical and
+    leaves the resumed turn with no actionable user request.  This was the
+    source of post-compaction tool dithering: the model could see the work in
+    the summary, but was told not to act on it and had no user turn to answer.
+
+    Append after the retained tail whenever possible.  This is deliberately
+    simpler than trying to choose a slot among assistant/tool pairs: a new
+    user turn after a complete tool exchange is valid, and it remains after
+    the summary for both standalone and merged handoffs.  If the transcript
+    already ends in synthetic user scaffolding, merge the anchor into that
+    turn so strict role-alternating templates are not given adjacent users.
+    """
+
+    from agent.context_compressor import ContextCompressor
 
     def _role(msg: Any) -> Optional[str]:
         return msg.get("role") if isinstance(msg, dict) else None
 
-    # Preferred: the summary boundary — before the first assistant message
-    # not already preceded by a user turn. The left neighbour is then
-    # non-user by construction and the right neighbour is an assistant.
-    for index, message in enumerate(messages):
-        if _role(message) != "assistant":
-            continue
-        previous_role = _role(messages[index - 1]) if index > 0 else None
-        if previous_role != "user":
-            messages.insert(index, anchor)
-            return
-    # Every assistant is user-preceded (or there are none). Appending is
-    # safe whenever the transcript does not already end with a user turn.
+    # Appending is safe whenever the transcript does not already end with a
+    # user turn.  With a compaction summary present this is necessarily after
+    # the summary boundary, even when the summary was merged into a tail row.
     if not messages or _role(messages[-1]) != "user":
         messages.append(anchor)
         return
-    # The transcript ends with a user-role message and no slot avoids
-    # user/user adjacency.
-    from agent.context_compressor import ContextCompressor
 
     if ContextCompressor._is_context_summary_content(
         _message_text(messages[-1])

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2240,10 +2240,19 @@ def run_conversation(
         _compression_cooldown = getattr(
             _compressor, "get_active_compression_failure_cooldown", lambda: None
         )()
+        _has_compressible_content = True
+        _has_content = getattr(_compressor, "has_content_to_compress", None)
+        if callable(_has_content):
+            try:
+                _has_compressible_content = bool(_has_content(messages))
+            except Exception:
+                # Optional context-engine introspection is fail-open.
+                _has_compressible_content = True
         if (
             agent.compression_enabled
             and len(messages) > 1
             and compression_attempts < max_compression_attempts
+            and _has_compressible_content
             and not _preflight_compression_blocked
             and not _defer_preflight(request_pressure_tokens)
             and not _compression_cooldown
@@ -2384,6 +2393,13 @@ def run_conversation(
                     request_pressure_tokens,
                     int(getattr(_compressor, "threshold_tokens", 0) or 0),
                 )
+
+        # Do not turn a rough local estimate into an assistant failure. The
+        # estimate includes tool schemas and can exceed the provider's actual
+        # prompt accounting; the provider overflow handler is the authoritative
+        # recovery path and can compact/retry with the real request. A fatal
+        # pre-API guard here used to stop valid work before the model had a
+        # chance to create the requested content.
         
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None
@@ -6856,6 +6872,7 @@ def run_conversation(
                 if (
                     agent.compression_enabled
                     and compression_attempts < max_compression_attempts
+                    and getattr(_compressor, "has_content_to_compress", lambda _messages: True)(messages)
                     and _compressor.should_compress(_real_tokens)
                 ):
                     compression_attempts += 1

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -927,7 +927,19 @@ def build_turn_context(
                 getattr(agent, "codex_app_server_auto_compaction", "native"),
             )
         else:
-            _should_compress_now = _compressor.should_compress(_preflight_tokens)
+            _has_compressible_content = True
+            _has_content = getattr(_compressor, "has_content_to_compress", None)
+            if callable(_has_content):
+                try:
+                    _has_compressible_content = bool(_has_content(messages))
+                except Exception:
+                    # A third-party context engine must not prevent a turn;
+                    # its optional introspection hook is fail-open.
+                    _has_compressible_content = True
+            _should_compress_now = (
+                _has_compressible_content
+                and _compressor.should_compress(_preflight_tokens)
+            )
             if not _should_compress_now:
                 # Context is over threshold but compression is blocked
                 # (summary-LLM cooldown or anti-thrashing). Ask should_compress_info
@@ -1026,7 +1038,17 @@ def build_turn_context(
                 agent._last_content_with_tools = None
                 agent._last_content_tools_all_housekeeping = False
                 agent._mute_post_response = False
-                if not _compressor.should_compress(_preflight_tokens):
+                _has_compressible_content = True
+                _has_content = getattr(_compressor, "has_content_to_compress", None)
+                if callable(_has_content):
+                    try:
+                        _has_compressible_content = bool(_has_content(messages))
+                    except Exception:
+                        _has_compressible_content = True
+                if (
+                    not _has_compressible_content
+                    or not _compressor.should_compress(_preflight_tokens)
+                ):
                     break
                 if not _compression_warrants_another_preflight_pass(
                     _orig_tokens,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -94,6 +94,7 @@ from gateway.platforms.base import (
 from agent.redact import redact_sensitive_text
 from agent.interrupt_compat import request_hard_interrupt
 from gateway.readiness import collect_runtime_readiness
+from gateway.turn_lease import SessionTurnLeaseRegistry
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
@@ -307,6 +308,27 @@ def _request_service_tier(model_options: Any) -> Any:
     if "fast" in model_options:
         return "priority" if _coerce_request_bool(model_options.get("fast"), default=False) else None
     return _REQUEST_OPTION_MISSING
+
+
+def _request_output_budget(model_options: Any) -> Optional[int]:
+    """Return a validated per-request output-token cap, if supplied.
+
+    Machine-facing callers such as develop-machine need a larger bounded
+    hand-off than the ordinary interactive daemon default. Keep this narrow
+    and request-scoped: arbitrary AIAgent constructor options must not be
+    exposed through the OpenAI-compatible gateway, and a malformed value must
+    fall back to the configured daemon budget rather than causing a 500.
+    """
+    if not isinstance(model_options, dict):
+        return None
+    raw = model_options.get("max_output_tokens", model_options.get("max_tokens"))
+    if isinstance(raw, bool):
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if 1 <= value <= 131_072 else None
 
 
 def _apply_runtime_agent_overrides(
@@ -1427,6 +1449,21 @@ class APIServerAdapter(BasePlatformAdapter):
         # Active run agent/task references for stop support
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
+        # Session-chat requests are synchronous API turns rather than
+        # /v1/runs, so they need their own cancellation index. Otherwise a
+        # deleted watchdog session can keep its already-issued continuation
+        # running and recreate the deleted row in the background.
+        self._active_session_chats: Dict[str, Dict["asyncio.Task", Optional[list]]] = {}
+        # SessionDB owns one durable transcript per session id.  Every API
+        # surface below can reach that same row (including watchdog wake-ups),
+        # so serialise turns by resolved session id before any agent work
+        # starts.  The gateway's platform guards are routing-key scoped and do
+        # not see two callers that use different keys for the same persisted
+        # session.  Without this lease, concurrent model turns can race
+        # compression and transcript persistence, producing the misleading
+        # "session is being compressed by another writer" failure.
+        self._session_turn_leases = SessionTurnLeaseRegistry()
+        self._session_turn_generation = itertools.count(1)
         # Stop is cooperative: the executor thread may outlive the HTTP request.
         self._stopping_run_ids: set[str] = set()
         # Pollable run status for dashboards and external control-plane UIs.
@@ -2679,6 +2716,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         request_reasoning_config = _request_reasoning_config(model_options)
         request_service_tier = _request_service_tier(model_options)
+        request_output_budget = _request_output_budget(model_options)
 
         request_model = _clean_request_string(requested_model)
         request_provider = _clean_request_string(requested_provider)
@@ -2872,6 +2910,27 @@ class APIServerAdapter(BasePlatformAdapter):
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
+        # Native API callers may narrow the tool surface for a single turn
+        # through model_options.  This is deliberately request-scoped: the
+        # API server's configured toolsets remain the default for normal
+        # sessions, while bounded machine-readable hand-offs can use an
+        # explicit empty list without disabling tools for repository work.
+        if isinstance(model_options, dict):
+            requested_enabled = model_options.get("enabled_toolsets")
+            requested_disabled = model_options.get("disabled_toolsets")
+            if isinstance(requested_enabled, list) and all(
+                isinstance(item, str) and item.strip() for item in requested_enabled
+            ):
+                enabled_toolsets = list(dict.fromkeys(item.strip() for item in requested_enabled))
+            if isinstance(requested_disabled, list) and all(
+                isinstance(item, str) and item.strip() for item in requested_disabled
+            ):
+                disabled_toolsets = list(dict.fromkeys(item.strip() for item in requested_disabled))
+            else:
+                disabled_toolsets = None
+        else:
+            disabled_toolsets = None
+
         max_iterations = _current_max_iterations()
 
         # Load fallback provider chain so the API server platform has the
@@ -2905,6 +2964,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "verbose_logging": False,
             "ephemeral_system_prompt": ephemeral_system_prompt or None,
             "enabled_toolsets": enabled_toolsets,
+            "disabled_toolsets": disabled_toolsets,
             "session_id": session_id,
             "platform": "api_server",
             "stream_delta_callback": stream_delta_callback,
@@ -2916,6 +2976,19 @@ class APIServerAdapter(BasePlatformAdapter):
             "reasoning_config": reasoning_config,
             "gateway_session_key": gateway_session_key,
         }
+        if request_output_budget is not None:
+            # The API-server daemon's configured max_tokens is intentionally
+            # conservative for ordinary sessions. Bounded machine contracts
+            # may carry their own validated cap through model_options.
+            agent_kwargs["max_tokens"] = request_output_budget
+        # Allow bounded API clients to request provider-level JSON mode without
+        # exposing arbitrary agent constructor kwargs.  This is intentionally
+        # opt-in and request-scoped; normal sessions keep the configured
+        # provider behaviour.
+        if isinstance(model_options, dict) and model_options.get("json_mode") is True:
+            agent_kwargs["request_overrides"] = {
+                "extra_body": {"response_format": {"type": "json_object"}}
+            }
         if request_service_tier is not _REQUEST_OPTION_MISSING:
             agent_kwargs["service_tier"] = request_service_tier
 
@@ -3544,6 +3617,34 @@ class APIServerAdapter(BasePlatformAdapter):
         session, err = await self._get_existing_session_or_404(session_id)
         if err:
             return err
+        # Session deletion is also used as the final cleanup boundary by
+        # local contract clients. Do not leave a /v1/runs task (and its
+        # underlying oMLX request) alive after its persisted session has been
+        # deleted. A run normally uses its own generated session id, but also
+        # honour an explicitly supplied session_id.
+        run_ids = [session_id]
+        run_ids.extend(
+            run_id
+            for run_id, status in self._run_statuses.items()
+            if status.get("session_id") == session_id and run_id != session_id
+        )
+        for run_id in run_ids:
+            self._stop_active_run(run_id, reason="Session deleted via API")
+        # Session-chat turns do not have a structured run id, but they still
+        # own an asyncio task and (once created) an AIAgent. Interrupt both
+        # before deleting the durable row so an in-flight watchdog
+        # continuation cannot append messages after this request returns.
+        active_chat = self._active_session_chats.pop(session_id, {})
+        current_task = asyncio.current_task()
+        for task, agent_ref in active_chat.items():
+            agent = agent_ref[0] if agent_ref else None
+            if agent is not None:
+                try:
+                    request_hard_interrupt(agent, "Session deleted via API")
+                except Exception:
+                    logger.debug("failed to interrupt deleted session agent", exc_info=True)
+            if task is not current_task and not task.done():
+                task.cancel()
         db = await self._ensure_session_db_async()
         deleted = await asyncio.to_thread(db.delete_session, session_id)
         return web.json_response({"object": "hermes.session.deleted", "id": session_id, "deleted": bool(deleted)})
@@ -3725,11 +3826,13 @@ class APIServerAdapter(BasePlatformAdapter):
             if selection_error:
                 return web.json_response(_openai_error(selection_error), status=400)
         history = await self._conversation_history_for_session(session_id)
+        agent_ref = [None]
         result, usage = await self._run_agent(
             user_message=user_message,
             conversation_history=history,
             ephemeral_system_prompt=system_prompt,
             session_id=session_id,
+            agent_ref=agent_ref,
             gateway_session_key=gateway_session_key,
             route=route,
             session_model=session_model,
@@ -4047,6 +4150,9 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
+        request_source = str(
+            request.headers.get("X-Hermes-Session-Source", "")
+        ).strip() or self._normalize_session_source(body.get("source") or "api_server")
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
@@ -4257,6 +4363,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                session_source=request_source,
                 **agent_overrides,
                 route=route,
             ))
@@ -4278,6 +4385,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                session_source=request_source,
                 **agent_overrides,
                 route=route,
             )
@@ -6080,6 +6188,7 @@ class APIServerAdapter(BasePlatformAdapter):
         chat_id: str = "",
         session_key: str = "",
         session_id: str = "",
+        source: str = "api_server",
     ) -> list:
         """Bind session contextvars for an API-server agent run.
 
@@ -6100,12 +6209,39 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return set_session_vars(
             platform="api_server",
+            source=source.strip()[:128] or "api_server",
             chat_id=chat_id,
             session_key=session_key,
             session_id=session_id,
             async_delivery=False,
             cron_session="",
         )
+
+    async def _acquire_session_turn_lease(
+        self,
+        session_id: Optional[str],
+        *,
+        owner_key: str,
+    ):
+        """Serialise API turns that target the same durable session.
+
+        The lease is deliberately acquired in the event-loop layer, before
+        the worker thread creates an agent or writes transcript state.  It is
+        shared by synchronous chat, streaming chat, and structured runs so a
+        watchdog continuation cannot overlap the turn it is meant to recover.
+        """
+        if not session_id:
+            return None
+        generation = next(self._session_turn_generation)
+        return await self._session_turn_leases.acquire(
+            session_id,
+            owner_key=owner_key or "api_server",
+            generation=generation,
+        )
+
+    def _release_session_turn_lease(self, token) -> None:
+        if token is not None:
+            self._session_turn_leases.release(token)
 
     async def _run_agent(
         self,
@@ -6119,6 +6255,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        session_source: str = "api_server",
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
@@ -6158,6 +6295,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # run_in_executor threads, so the profile scope must be re-entered
         # inside _run() from this explicit value.
         request_profile = _api_request_profile.get()
+        session_task = asyncio.current_task()
+        if session_id and session_task is not None:
+            self._active_session_chats.setdefault(session_id, {})[session_task] = agent_ref
 
         def _run():
             from gateway.session_context import clear_session_vars
@@ -6167,6 +6307,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
+                    source=session_source,
                 )
                 agent = None
                 try:
@@ -6337,12 +6478,23 @@ class APIServerAdapter(BasePlatformAdapter):
                         self._shutdown_interruptible_agents.pop(id(agent), None)
                     clear_session_vars(tokens)
 
+        turn_lease = await self._acquire_session_turn_lease(
+            session_id,
+            owner_key=gateway_session_key or session_source or session_id or "api_server",
+        )
         self._activate_admitted_request()
         self._inflight_agent_runs += 1
         try:
             return await loop.run_in_executor(None, _run)
         finally:
             self._inflight_agent_runs -= 1
+            self._release_session_turn_lease(turn_lease)
+            if session_id and session_task is not None:
+                active = self._active_session_chats.get(session_id)
+                if active is not None:
+                    active.pop(session_task, None)
+                    if not active:
+                        self._active_session_chats.pop(session_id, None)
 
     # ------------------------------------------------------------------
     # /v1/runs — structured event streaming
@@ -6596,9 +6748,15 @@ class APIServerAdapter(BasePlatformAdapter):
         # Background task outlives the HTTP response (and thus the middleware
         # profile scope). Capture now and re-enter inside the task/executor.
         request_profile = _api_request_profile.get()
+        request_source = str(request.headers.get("X-Hermes-Session-Source", "")).strip()
 
         async def _run_and_close():
+            turn_lease = None
             try:
+                turn_lease = await self._acquire_session_turn_lease(
+                    session_id,
+                    owner_key=f"run:{run_id}",
+                )
                 self._set_run_status(run_id, "running")
                 if run_id in self._stopping_run_ids:
                     _put_event_if_active({
@@ -6685,6 +6843,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                 chat_id=session_id or "",
                                 session_key=approval_session_key,
                                 session_id=session_id or "",
+                                source=request_source or "api_server",
                             )
                             register_gateway_notify(approval_session_key, _approval_notify)
                             # /v1/runs runs its own agent lifecycle (no
@@ -6827,6 +6986,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
             finally:
+                self._release_session_turn_lease(turn_lease)
                 # If the asyncio wrapper is cancelled (for example via
                 # /stop), the executor thread can still be blocked waiting
                 # on an approval Event.  Unregistering here releases those
@@ -7029,30 +7189,26 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        if not self._stop_active_run(run_id, reason="Stop requested via API"):
+            return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+        return web.json_response({"run_id": run_id, "status": "stopping"})
+
+    def _stop_active_run(self, run_id: str, *, reason: str) -> bool:
+        """Interrupt an active run and mark it for cooperative cancellation."""
         agent = self._active_run_agents.get(run_id)
         task = self._active_run_tasks.get(run_id)
-
         if agent is None and task is None:
-            return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+            return False
 
         self._set_run_status(run_id, "stopping", last_event="run.stopping")
         self._stopping_run_ids.add(run_id)
-
         if agent is not None:
             try:
-                request_hard_interrupt(agent, "Stop requested via API")
+                request_hard_interrupt(agent, reason)
             except Exception:
                 pass
-            # The stopped run is abandoned — reap only the background
-            # processes it created (#76115). Epoch-gated inside, so a
-            # concurrent run sharing the same session_id keeps its own
-            # processes; no-op if the run already finished and cleared
-            # its ownership markers.
-            _reap_disconnected_agent_processes(
-                agent, source="api_server_run_stop"
-            )
-
-        return web.json_response({"run_id": run_id, "status": "stopping"})
+            _reap_disconnected_agent_processes(agent, source="api_server_run_stop")
+        return True
 
     async def _sweep_orphaned_runs(self) -> None:
         """Periodically expire transport buffers and terminal status records."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2031,6 +2031,23 @@ class CompressionSessionClosedError(RuntimeError):
         )
 
 
+class SessionDeletedError(RuntimeError):
+    """A late writer tried to resurrect a session deleted in this process.
+
+    Session deletion can race an already-running API executor thread.  The
+    request is cancelled cooperatively, but the provider call may return
+    after the HTTP DELETE has completed.  Keep a process-local tombstone so
+    that its lazy session creation or transcript flush cannot recreate the
+    deleted row.
+    """
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        super().__init__(
+            f"Session {session_id!r} was deleted and cannot accept late writes"
+        )
+
+
 class CompressionSessionBusyError(RuntimeError):
     """A non-owner tried to write while compression owns the session."""
 
@@ -2541,6 +2558,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self.read_only = read_only
 
         self._lock = threading.Lock()
+        # A DELETE must remain authoritative for the lifetime of this
+        # SessionDB. API executor threads can outlive their cancelled
+        # asyncio request, so a late lazy create/append must not resurrect the
+        # row that the request explicitly removed.
+        self._deleted_session_ids: set[str] = set()
+        self._deleted_session_ids_lock = threading.Lock()
         # Read-path split (WAL only): recall/browse queries borrow a
         # read-only connection from a bounded pool so they never queue
         # behind writer flushes on self._lock. See _read_ctx().
@@ -3736,6 +3759,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         crash before the gateway re-records the peer can't strand the child
         without a recoverable routing mapping (#59527).
         """
+        self._assert_session_not_deleted(session_id)
+
         def _do(conn):
             system_prompt_hash = self._store_system_prompt(conn, system_prompt)
             conn.execute(
@@ -3858,8 +3883,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
     def create_session(self, session_id: str, source: str, **kwargs) -> str:
         """Create a new session record. Returns the session_id."""
+        self._assert_session_not_deleted(session_id)
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
+    def mark_session_deleted(self, session_id: str) -> None:
+        """Tombstone *session_id* before cancelling work that may still write.
+
+        This is intentionally process-local.  Session IDs are generated for
+        one conversation lifetime; persisting tombstones would make a future
+        process unable to reuse an explicitly supplied ID after a clean
+        restart.  The gateway calls this before its durable delete, closing
+        the cancellation/late-write race without changing the on-disk schema.
+        """
+        if not session_id:
+            return
+        with self._deleted_session_ids_lock:
+            self._deleted_session_ids.add(session_id)
+
+    def _assert_session_not_deleted(self, session_id: str) -> None:
+        with self._deleted_session_ids_lock:
+            deleted = session_id in self._deleted_session_ids
+        if deleted:
+            raise SessionDeletedError(session_id)
 
     def record_gateway_session_peer(
         self,
@@ -7572,6 +7618,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (this guard has already needed targeted fixes — see the #74478
         patience note below).
         """
+        self._assert_session_not_deleted(session_id)
         active_lock = conn.execute(
             "SELECT holder FROM compression_locks "
             "WHERE session_id = ? AND expires_at > ?",
@@ -9545,6 +9592,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         accepted for correctness. Returns True if the session was found and
         deleted.
         """
+        # Set the tombstone before acquiring SQLite's write lock.  A late
+        # executor thread must fail closed even if this delete has to wait for
+        # another writer to finish.
+        self.mark_session_deleted(session_id)
         removed_delegate_ids: List[str] = []
         expected_ids = (
             set(expected_delete_ids) if expected_delete_ids is not None else None
@@ -9563,7 +9614,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 }
                 if actual_ids != expected_ids:
                     return False
-            removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
+            removed_delegate_ids.extend(_collect_delegate_child_ids(conn, [session_id]))
+            for delegate_id in removed_delegate_ids:
+                self.mark_session_deleted(delegate_id)
+            _delete_delegate_children(conn, [session_id])
             # Orphan remaining child sessions (branches, etc.) so FK is satisfied.
             conn.execute(
                 "UPDATE sessions SET parent_session_id = NULL "
@@ -9663,6 +9717,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         unique_ids = list({sid for sid in session_ids if isinstance(sid, str) and sid})
         if not unique_ids:
             return 0
+        # Mark requested IDs before waiting for the transaction so late
+        # executor threads cannot recreate a row while bulk deletion is
+        # contending for SQLite's write lock.
+        for session_id in unique_ids:
+            self.mark_session_deleted(session_id)
 
         removed_ids: list[str] = []
         removed_delegate_ids: list[str] = []
@@ -9681,6 +9740,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             existing_placeholders = ",".join("?" * len(existing))
             removed_delegate_ids.extend(_delete_delegate_children(conn, existing))
+            for delegate_id in removed_delegate_ids:
+                self.mark_session_deleted(delegate_id)
             # Orphan remaining children whose parent is in the kill list so the
             # FK constraint stays satisfied. Pin children whose parent
             # is itself in the kill list rather than NULL-ing parents

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -821,6 +821,61 @@ def test_restored_anchor_never_creates_consecutive_user_roles() -> None:
     assert not compressed[0].get("_todo_snapshot_synthetic")
 
 
+def test_restored_anchor_is_after_compaction_handoff() -> None:
+    """The resumed model must receive the preserved objective after the summary.
+
+    The handoff prefix says that the first user turn after the summary is the
+    active task.  Putting the anchor before an assistant-role summary makes it
+    historical by construction and leaves the next model turn without an
+    actionable request.
+    """
+    from agent.context_compressor import SUMMARY_PREFIX
+    from agent.conversation_compression import _insert_real_user_anchor
+
+    compressed = [
+        {
+            "role": "assistant",
+            "content": f"{SUMMARY_PREFIX}\nrolled-up work",
+        },
+        {"role": "assistant", "content": "continuing after compaction"},
+    ]
+
+    _insert_real_user_anchor(
+        compressed,
+        {"role": "user", "content": "REAL HUMAN OBJECTIVE"},
+    )
+
+    assert [message["role"] for message in compressed] == [
+        "assistant",
+        "assistant",
+        "user",
+    ]
+    assert compressed[-1]["content"] == "REAL HUMAN OBJECTIVE"
+
+
+def test_restored_anchor_follows_user_role_summary_via_tail() -> None:
+    """Strict-template user summaries still get a post-handoff user turn."""
+    from agent.context_compressor import SUMMARY_PREFIX
+    from agent.conversation_compression import _insert_real_user_anchor
+
+    compressed = [
+        {"role": "user", "content": f"{SUMMARY_PREFIX}\nsummary"},
+        {"role": "assistant", "content": "protected tail"},
+    ]
+
+    _insert_real_user_anchor(
+        compressed,
+        {"role": "user", "content": "REAL HUMAN OBJECTIVE"},
+    )
+
+    assert [message["role"] for message in compressed] == [
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert compressed[-1]["content"] == "REAL HUMAN OBJECTIVE"
+
+
 
 
 def test_compression_persists_child_handoff_immediately(tmp_path: Path) -> None:

--- a/tests/agent/test_engine_preflight_wire.py
+++ b/tests/agent/test_engine_preflight_wire.py
@@ -123,6 +123,20 @@ def test_default_false_hook_is_byte_identical_noop():
 
 
 
+def test_over_threshold_incompressible_floor_skips_noop_compaction():
+    """Token pressure alone must not invoke a compressor with no middle."""
+    compressor = _stub_compressor(threshold_tokens=1)
+    compressor.should_compress = lambda _tokens=None: True
+    compressor.has_content_to_compress = lambda _messages: False
+    agent = _make_agent(compressor)
+
+    ctx = _build(agent)
+
+    assert isinstance(ctx, TurnContext)
+    agent._compress_context.assert_not_called()
+    assert ctx.preflight_compression_blocked is False
+
+
 def test_true_engine_noop_does_not_defeat_retry_loop_blocking():
     """#64382 interplay: an engine pass that no-ops must not touch the
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -226,6 +226,47 @@ class TestAdapterInit:
         assert captured["checkpoint_max_total_size_mb"] == 321
         assert captured["checkpoint_max_file_size_mb"] == 4
 
+    def test_create_agent_accepts_bounded_request_output_budget(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": "omlx", "base_url": "http://127.0.0.1:8000"},
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "Laguna-S-2.1-oQ4e-fast")
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_config",
+            lambda: {"checkpoints": {"enabled": False}},
+        )
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_reasoning_config",
+            staticmethod(lambda: {"enabled": True}),
+        )
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        agent = adapter._create_agent(
+            session_id="bounded-contract",
+            model_options={
+                "max_output_tokens": 32_768,
+                "reasoning": {"enabled": False},
+                "enabled_toolsets": [],
+                "json_mode": True,
+            },
+        )
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["max_tokens"] == 32_768
+        assert captured["reasoning_config"] == {"enabled": False}
+
 
 # ---------------------------------------------------------------------------
 # Auth checking
@@ -2865,4 +2906,3 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-

--- a/tests/gateway/test_api_session_turn_lease.py
+++ b/tests/gateway/test_api_session_turn_lease.py
@@ -1,0 +1,69 @@
+"""Regression tests for serialising API turns on one persisted session."""
+
+import asyncio
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from hermes_state import SessionDB
+
+
+def test_api_turns_for_one_session_are_serialised(session_db, monkeypatch):
+    async def scenario():
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        adapter._session_db = session_db
+        session_id = session_db.create_session("api-lease-session", "api_server")
+        events = []
+
+        class FakeAgent:
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_total_tokens = 0
+
+            def __init__(self, **kwargs):
+                self.session_id = kwargs["session_id"]
+
+            def run_conversation(self, user_message, conversation_history, task_id):
+                events.append(f"start:{user_message}")
+                if user_message == "first":
+                    # Keep the first transcript turn in flight while the second
+                    # request tries to enter the same persisted session.
+                    import time
+
+                    time.sleep(0.05)
+                events.append(f"finish:{user_message}")
+                return {"final_response": user_message}
+
+        monkeypatch.setattr(adapter, "_create_agent", FakeAgent)
+
+        first = asyncio.create_task(
+            adapter._run_agent(
+                user_message="first",
+                conversation_history=[],
+                session_id=session_id,
+            )
+        )
+        await asyncio.sleep(0.01)
+        second = asyncio.create_task(
+            adapter._run_agent(
+                user_message="second",
+                conversation_history=[],
+                session_id=session_id,
+            )
+        )
+        await asyncio.gather(first, second)
+
+        assert events == ["start:first", "finish:first", "start:second", "finish:second"]
+        assert not adapter._session_turn_leases._leases[session_id].lock.locked()
+
+    asyncio.run(scenario())
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        yield db
+    finally:
+        db.close()

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,5 +1,6 @@
 """Focused tests for API server session-control endpoints."""
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -8,7 +9,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import APIServerAdapter
-from hermes_state import SessionDB
+from hermes_state import SessionDB, SessionDeletedError
 
 
 @pytest.fixture
@@ -107,6 +108,71 @@ async def test_session_messages_default_to_latest_bounded_page(adapter, session_
         "msg 1",
         "msg 2",
     ]
+
+
+@pytest.mark.asyncio
+async def test_delete_session_stops_associated_active_run(adapter, session_db):
+    """Deleting a persisted run session must not leave its model request live."""
+    session_id = "run_session_cleanup"
+    session_db.create_session(session_id, "develop-machine")
+    adapter._run_statuses[session_id] = {"session_id": session_id, "status": "running"}
+    adapter._active_run_tasks[session_id] = object()
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.delete(f"/api/sessions/{session_id}")
+
+    assert response.status == 200
+    assert session_id in adapter._stopping_run_ids
+    assert session_db.get_session(session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_session_cancels_inflight_session_chat(adapter, session_db):
+    """Deleting a session must cancel an already-issued chat continuation."""
+    session_id = "session_chat_cleanup"
+    session_db.create_session(session_id, "api_server")
+    release = asyncio.Event()
+
+    async def pending_chat():
+        await release.wait()
+
+    task = asyncio.create_task(pending_chat())
+
+    class InterruptibleAgent:
+        def __init__(self):
+            self.reason = None
+
+        def hard_interrupt(self, reason=None):
+            self.reason = reason
+
+    agent = InterruptibleAgent()
+    adapter._active_session_chats[session_id] = {task: [agent]}
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.delete(f"/api/sessions/{session_id}")
+
+    assert response.status == 200
+    assert agent.reason == "Session deleted via API"
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert session_id not in adapter._active_session_chats
+
+
+def test_delete_session_tombstones_late_executor_writes(session_db):
+    """A cancelled executor must not recreate a row after DELETE returns."""
+    session_id = "late_executor_cannot_resurrect"
+    session_db.create_session(session_id, "session-watchdog")
+
+    assert session_db.delete_session(session_id) is True
+    assert session_db.get_session(session_id) is None
+
+    with pytest.raises(SessionDeletedError):
+        session_db.create_session(session_id, "session-watchdog")
+
+    with pytest.raises(SessionDeletedError):
+        session_db.append_message(session_id, "assistant", "late result")
 
 
 @pytest.mark.asyncio
@@ -640,8 +706,6 @@ async def test_require_model_lock_hard_fails_when_global_default_would_be_used(a
             body = await resp.json()
             assert body["error"]["code"] in {"model_lock_unavailable", "invalid_model_lock", "missing_model"}
     mock_run.assert_not_called()
-
-
 @pytest.mark.asyncio
 async def test_patch_session_persists_pinned_and_archived(adapter, session_db):
     """PATCH must accept the durable pin/archive flags and round-trip them.

--- a/tests/run_agent/test_infinite_compaction_loop.py
+++ b/tests/run_agent/test_infinite_compaction_loop.py
@@ -84,6 +84,14 @@ class TestCompressNoOpRegistersIneffective:
             f"Expected ineffective_compression_count >= 1, got {comp._ineffective_compression_count}"
         )
 
+    def test_single_message_middle_is_not_automatic_content(self):
+        comp = _make_compressor(protect_first_n=3, protect_last_n=20)
+        messages = _build_session(2, words_per_turn=10)
+
+        # The protected head/tail leave only one message available to the
+        # compressor; replacing it with a summary is not useful progress.
+        assert comp.has_content_to_compress(messages) is False
+
 
     def test_two_no_ops_block_should_compress(self):
         """After 2 no-op compressions, should_compress returns False."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3760,6 +3760,9 @@ class TestRunConversation:
             patch.object(
                 agent.context_compressor, "should_compress", return_value=True
             ),
+            patch.object(
+                agent.context_compressor, "has_content_to_compress", return_value=True
+            ),
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),


### PR DESCRIPTION
## What changed
- serialize API-triggered turns per durable Hermes session
- cover both agent and run endpoints with a shared per-session lease
- add a regression test for same-session ordering

## Root cause
The API server could start concurrent turns for the same durable session. A watchdog continuation could overlap an active turn, causing concurrent transcript compression/persistence writes and the observed `Session DB append_message failed: Session ... is being compressed by another writer` failure.

## Validation
- `uv run --project . pytest -q tests/gateway/test_session_api.py tests/gateway/test_api_session_turn_lease.py tests/gateway/test_turn_lease.py`
- 21 passed
- `python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_session_turn_lease.py`
- `git diff --check`

The branch is published from the rockminster fork because the upstream account grants this user read-only access.