### PR TITLE
fix(gateway): route the streaming-TTS abort through the leak-safe threadsafe bridge

### DIFF
--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -44,6 +44,7 @@ import queue
 import threading
 from typing import Any, Dict, Optional
 
+from agent.async_utils import safe_schedule_threadsafe
 from gateway.platforms.base import AudioFormat, StreamingTTSHandle
 
 logger = logging.getLogger("gateway.streaming_tts_consumer")
@@ -402,13 +403,24 @@ class StreamingTTSConsumer:
         else:
             logger.debug("streaming TTS _ABORT sentinel could not be enqueued")
         if self._handle is not None and not self._handle.aborted:
-            try:
-                self._loop.call_soon_threadsafe(
-                    asyncio.create_task,
-                    self._safe_abort(reason),
-                )
-            except Exception:
-                pass
+            # The abort has to reach the adapter: ``abort_streaming_tts`` is
+            # what restores the adapter to "not streaming" (see
+            # gateway/platforms/base.py).  A bare
+            # ``call_soon_threadsafe(asyncio.create_task, coro)`` wrapped in a
+            # swallowing ``except Exception`` drops the coroutine on the floor
+            # whenever scheduling raises — most obviously
+            # ``RuntimeError: Event loop is closed`` on the teardown path,
+            # where ``abort("cleanup")`` runs.  The coroutine is then neither
+            # awaited nor closed, so its frame leaks and Python emits
+            # ``coroutine '_safe_abort' was never awaited``.  Route it through
+            # the leak-safe bridge instead, which closes the coroutine on
+            # every failure path.
+            safe_schedule_threadsafe(
+                self._safe_abort(reason),
+                self._loop,
+                logger=logger,
+                log_message="streaming TTS abort could not be scheduled",
+            )
 
     async def wait_complete(self, timeout: float = 10.0) -> bool:
         """Wait for the drain task to finish. Returns True only on full success."""

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -42,6 +42,7 @@ import asyncio
 import logging
 import queue
 import threading
+from concurrent.futures import Future
 from typing import Any, Dict, Optional
 
 from agent.async_utils import safe_schedule_threadsafe
@@ -55,6 +56,10 @@ _DONE = object()
 
 class StreamingTTSConsumer:
     """Consumes LLM text deltas and produces streaming PCM audio for an adapter."""
+
+    # Class-level default so the attribute is readable on instances built via
+    # ``__new__`` (which never run ``__init__``) as well as normal ones.
+    _abort_future: Optional[Future] = None
 
     def __init__(
         self,
@@ -101,6 +106,7 @@ class StreamingTTSConsumer:
         self._dropped = False
         self._suppress_whole_file = False
         self._task: Optional[asyncio.Task] = None
+        self._abort_future: Optional[Future] = None
         self._lock = threading.Lock()
 
         # Pre-allocate the strip-markdown helper lazily to avoid import cycles.
@@ -415,7 +421,16 @@ class StreamingTTSConsumer:
             # ``coroutine '_safe_abort' was never awaited``.  Route it through
             # the leak-safe bridge instead, which closes the coroutine on
             # every failure path.
-            safe_schedule_threadsafe(
+            #
+            # Retain the returned future.  The loop keeps only a weak
+            # reference to a task, so an in-flight abort with no owner can be
+            # collected mid-await; the future returned by
+            # run_coroutine_threadsafe is chained to the loop-side task and
+            # keeps it alive for its whole lifetime.  This mirrors how the
+            # drain task is anchored in ``self._task`` above, and gives the
+            # caller a handle it can wait on.  It is ``None`` when scheduling
+            # failed.
+            self._abort_future = safe_schedule_threadsafe(
                 self._safe_abort(reason),
                 self._loop,
                 logger=logger,

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -443,6 +443,54 @@ class TestAbortAndCancellation:
         assert adapter.abort_count == 0
         assert consumer._aborted is True
 
+    def test_abort_future_anchors_the_task_and_reaches_the_adapter(self):
+        """A barge-in abort is owned by the consumer and reaches the adapter.
+
+        The drain task is anchored in ``self._task``; the abort scheduled by
+        ``abort()`` was the one coroutine the consumer did not own, and the
+        loop keeps only a weak reference to a task.  Retaining the future the
+        threadsafe bridge returns anchors the loop-side task and doubles as a
+        completion handle — without it there is no way for the caller to know
+        the abort landed before the adapter is torn down.
+        """
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = BlockingSecondChunkStreamer()
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("This is a sentence with a delayed tail. ")
+            await asyncio.wait_for(
+                asyncio.to_thread(streamer.first_chunk_written.wait, 2.0),
+                timeout=2.0,
+            )
+            assert consumer._handle is not None
+            assert consumer._handle.aborted is False
+
+            # Barge-in arrives on the agent worker thread, not the loop.
+            await asyncio.to_thread(consumer.abort, "barge-in")
+
+            abort_future = consumer._abort_future
+            assert abort_future is not None
+            # Nothing else owns the in-flight abort: the retained future is
+            # the only strong reference keeping the loop-side task alive.
+            gc.collect()
+
+            await asyncio.wait_for(asyncio.wrap_future(abort_future), timeout=2.0)
+
+            # abort_streaming_tts is what restores the adapter to
+            # "not streaming"; it must have run exactly once.
+            assert adapter.abort_count == 1
+            assert adapter.handle.aborted is True
+
+            # Let the blocked drain task unwind, and confirm the abort is not
+            # re-delivered on the way out.
+            streamer.allow_remaining_chunks.set()
+            await consumer.wait_complete(timeout=5.0)
+            assert adapter.abort_count == 1
+
+        _run_test(run)
+
 
 class TestFallbackSafety:
     """Pre-audio failure falls back; post-audio failure does not replay."""

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -9,9 +9,11 @@ suppression, cancellation idempotency, and concurrent-turn isolation.
 from __future__ import annotations
 
 import asyncio
+import gc
 import queue
 import threading
 import time
+import warnings
 
 import pytest
 
@@ -401,6 +403,45 @@ class TestAbortAndCancellation:
             assert adapter.abort_count <= 1
 
         _run_test(run)
+
+    def test_abort_on_a_closed_loop_closes_the_abort_coroutine(self):
+        """A closed loop must not leave the _safe_abort coroutine unawaited.
+
+        ``abort("cleanup")`` runs at turn teardown, which is exactly when the
+        gateway loop is most likely to already be closing.  Scheduling then
+        raises ``RuntimeError: Event loop is closed``; if that is swallowed
+        without closing the coroutine, its frame leaks and Python emits
+        ``coroutine '_safe_abort' was never awaited``.
+        """
+        loop = asyncio.new_event_loop()
+        adapter = FakeVoiceAdapter()
+        consumer = _make_consumer(adapter, "chat1", loop, FakeStreamer())
+        consumer._handle = StreamingTTSHandle(
+            chat_id="chat1", audio_format=consumer._audio_format
+        )
+        loop.close()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            # Must not raise: abort() is documented as callable from any
+            # thread at any point in the turn.
+            consumer.abort("cleanup")
+            gc.collect()
+
+        leaked = [
+            str(w.message)
+            for w in caught
+            if issubclass(w.category, RuntimeWarning)
+            and "never awaited" in str(w.message)
+            and "_safe_abort" in str(w.message)
+        ]
+        assert leaked == [], f"abort coroutine leaked unawaited: {leaked}"
+
+        # Scheduling failed, so there is no future to wait on and the adapter
+        # was never reached — but the consumer is still marked aborted.
+        assert consumer._abort_future is None
+        assert adapter.abort_count == 0
+        assert consumer._aborted is True
 
 
 class TestFallbackSafety:


### PR DESCRIPTION
## What does this PR do?

`StreamingTTSConsumer.abort()` delivered the adapter abort through a raw threadsafe bridge:

```python
if self._handle is not None and not self._handle.aborted:
    try:
        self._loop.call_soon_threadsafe(
            asyncio.create_task,
            self._safe_abort(reason),
        )
    except Exception:
        pass
```

Two defects, one root cause — the abort can silently never reach the adapter:

1. **The coroutine leaks when scheduling fails.** `call_soon_threadsafe` raises `RuntimeError: Event loop is closed` during a shutdown race. The bare `except Exception: pass` swallows it, and the already-constructed `self._safe_abort(reason)` coroutine is neither awaited nor closed — its frame leaks until GC and Python emits `coroutine '_safe_abort' was never awaited`.
2. **The task has no owner.** `asyncio.create_task`'s return value is discarded and the loop keeps only a weak reference to a task, so an in-flight abort that nothing references can be collected mid-await. This is the documented reason to keep a reference to a scheduled task — and this very class already does it for its drain task (`self._task = self._loop.create_task(self._run())`). The abort was the one scheduled coroutine it did not own.

**Why it is user-visible.** `abort()` is the barge-in path. `gateway/run.py` calls it at five sites: `:26018`, `:26305` and `:26407` (barge-in — the user starts talking over the bot), `:26532` (streaming-TTS finalisation timeout), and `:26890` (`_stts_finally.abort("cleanup")` at turn teardown). `abort_streaming_tts` is what "Restores adapter state to 'not streaming'" (`gateway/platforms/base.py`). If the abort is lost, `handle.aborted` stays `False`, buffered audio keeps speaking over the user, and the adapter is left believing it is still streaming for that chat — so the next turn's `begin_streaming_tts` runs against stale state. The teardown site is the worst case: it fires exactly when the loop is most likely to already be closing, i.e. straight into the leak branch.

**This is a call-site conversion, not a new mechanism.** `agent/async_utils.safe_schedule_threadsafe` exists for precisely this defect; its docstring states the invariant verbatim: *"In all failure paths the coroutine is close-d so it does not trigger 'coroutine was never awaited' warnings or leak its frame."* The repo-wide conversion of every threadsafe bridge to that helper landed in `4e89c53082b` ("fix(async): close unscheduled coroutines in all threadsafe bridges", 2026-05-15). This module was added later, in `3a4aa2f8e69` (#73862 / #60671, 2026-07-28) — `git merge-base --is-ancestor 4e89c53082b 3a4aa2f8e69` confirms the ordering — so this is a raw bridge **reintroduced after** the sweep, not one the sweep missed. `gateway/run.py` already imports and uses the helper.

Nothing in `agent/async_utils.py` or `utils.py` is touched; the helper is correct as written.

## Related Issue

No filed issue — found by auditing threadsafe bridges against the invariant `agent/async_utils.safe_schedule_threadsafe` documents. Related context: `4e89c53082b` (the repo-wide bridge sweep this call site regressed), and #73862 / #60671 (`3a4aa2f8e69`, the commit that introduced this module).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/streaming_tts_consumer.py`
  - Import `safe_schedule_threadsafe` from `agent.async_utils` and route the abort through it, replacing the raw `call_soon_threadsafe(asyncio.create_task, ...)` inside `except Exception: pass`. The helper closes the coroutine on every failure path and logs at DEBUG instead of raising, so `abort()` stays callable from any thread at any point in the turn.
  - Retain the returned `concurrent.futures.Future` on `self._abort_future`. `asyncio.run_coroutine_threadsafe` (which the helper wraps) chains the loop-side task to that future, so holding it keeps a strong reference for the task's whole lifetime, mirroring how `self._task` anchors the drain task. It also gives the caller an observable completion handle. It is `None` when scheduling failed, which is the signal the helper already returns.
  - Class-level `_abort_future` default so the attribute is readable on instances built via `__new__`, which never run `__init__`.
- `tests/gateway/test_streaming_tts_consumer.py` — two regressions added inside the existing `TestAbortAndCancellation` class:
  - `test_abort_on_a_closed_loop_closes_the_abort_coroutine`
  - `test_abort_future_anchors_the_task_and_reaches_the_adapter`

**Existing coverage could not detect either defect.** `test_abort_is_idempotent` asserts `adapter.abort_count <= 1`, which passes vacuously at `0` — a lost abort is green today. (Its behaviour is unchanged by this PR: it aborts before the drain task has run, so `_handle` is still `None` and the adapter is correctly never reached. Tightening that particular assertion would not have caught anything, so it is left alone rather than churned.)

### Sibling-site sweep

```
git grep -n -A3 "call_soon_threadsafe($" origin/main -- '*.py' | grep -v tests/ | grep "create_task\|ensure_future"
git grep -n "asyncio.run_coroutine_threadsafe" origin/main -- '*.py' | grep -v "tests/\|async_utils.py"
```

| site | disposition |
|---|---|
| `gateway/streaming_tts_consumer.py:406` | **fixed here** |
| `gateway/run.py:4480` (`_event_callback_sync`) | same root cause, but that file already has an open PR of mine in flight; kept out to avoid overlapping diffs. Will follow up separately. |
| `acp_adapter/server.py:1913` | separate subsystem, separate PR |
| `plugins/platforms/a2a/adapter.py:778` | separate subsystem, separate PR |
| `plugins/platforms/feishu/adapter.py:1854` | separate subsystem, separate PR |
| `tools/computer_use/cua_backend.py:1285` | already stores the future (`self._lifecycle_future`), so only the leak half applies; separate subsystem |

No other `create_task`/`ensure_future` exists in `gateway/streaming_tts_consumer.py`: `:215` anchors the drain task in `self._task`, and `:249`/`:346` are `await asyncio.to_thread(...)`.

## How to Test

1. Run the touched and adjacent suites:
   ```
   pytest tests/gateway/test_streaming_tts_consumer.py \
          tests/gateway/test_streaming_tts_gateway_regression.py \
          tests/agent/test_async_utils.py -q
   ```
2. Prove the regressions are real — revert only the production file and re-run:
   ```
   git checkout main -- gateway/streaming_tts_consumer.py
   pytest tests/gateway/test_streaming_tts_consumer.py -q
   ```
   Both new tests fail; the 15 pre-existing tests still pass.
3. Restore the fix and re-run — 17/17 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the touched and adjacent suites only (38 passed: `tests/gateway/test_streaming_tts_consumer.py`, `test_streaming_tts_gateway_regression.py`, `test_base_auto_tts_output_format.py`, `test_per_platform_streaming_defaults.py`, `test_post_stream_media_delivery.py`, `test_tts_media_routing.py`, `tests/agent/test_async_utils.py`), not the full suite. CI covers the rest.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), CPython 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no public API change; the rationale is in the code comment and commit bodies)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure asyncio/stdlib, no platform-specific behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

#76330 (@AlexxRussell) also touches `gateway/streaming_tts_consumer.py`, but it is a genuinely different bug and a disjoint region: it adds `_directive_holdback_index` / `_consume_directives` on the delta/chunking path (hunks at `@@ -44`, `@@ -105`, `@@ -153`, `@@ -179`) and never touches `abort()`, `_safe_abort()` or `wait_complete()`, which live at 384-423. Neither PR is a subset of the other. If both land, the only overlap is textual (an import line and one `__init__` field).

## Screenshots / Logs

Red before the production change, green after — the production file reverted to `main`, tests unchanged:

```
$ git checkout main -- gateway/streaming_tts_consumer.py
$ pytest tests/gateway/test_streaming_tts_consumer.py -q

>       assert leaked == [], f"abort coroutine leaked unawaited: {leaked}"
E       AssertionError: abort coroutine leaked unawaited:
E         ["coroutine 'StreamingTTSConsumer._safe_abort' was never awaited"]

>       abort_future = consumer._abort_future
E       AttributeError: 'StreamingTTSConsumer' object has no attribute '_abort_future'

FAILED ...::TestAbortAndCancellation::test_abort_on_a_closed_loop_closes_the_abort_coroutine
FAILED ...::TestAbortAndCancellation::test_abort_future_anchors_the_task_and_reaches_the_adapter
2 failed, 15 passed
```

```
$ git checkout HEAD -- gateway/streaming_tts_consumer.py
$ pytest tests/gateway/test_streaming_tts_consumer.py tests/gateway/test_streaming_tts_gateway_regression.py -q
18 passed
```

Each of the four commits was also checked out in turn and the suite re-run, so every commit stands alone:

```
fix(gateway): close the streaming-TTS abort coroutine when scheduling fails  -> 16 passed
fix(gateway): anchor the streaming-TTS abort future so the task survives     -> 16 passed
test(gateway): cover the closed-loop streaming-TTS abort coroutine close     -> 17 passed
test(gateway): cover the streaming-TTS abort anchor reaching the adapter     -> 18 passed
```
