### PR TITLE
fix(feishu): isolate lark_oapi WS globals per profile and supervise the client thread

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1322,16 +1322,98 @@ def _strip_edge_self_mentions(
             return remaining
 
 
+# ---------------------------------------------------------------------------
+# Multiplex isolation for the lark_oapi WebSocket client (#73779)
+# ---------------------------------------------------------------------------
+#
+# ``lark_oapi.ws.client`` keeps the asyncio loop used by ``Client.start()``
+# and every coroutine it spawns in a *module-level global* (``loop``), and
+# Hermes also monkey-patches ``websockets.connect`` on the shared
+# ``websockets`` module to inject per-adapter ping settings. In multiplex
+# mode every profile runs its own WS client on a dedicated thread, so the N
+# threads overwrite each other's module globals (last-write-wins): a client
+# ends up scheduling tasks on a sibling profile's loop ("Future attached to
+# a different loop" crashes) or binds to the wrong loop at construction time
+# and goes deaf from the start.
+#
+# The fix installs process-wide, thread-dispatching shims exactly once:
+#
+#   * ``ws_client_module.loop`` becomes a proxy that forwards every attribute
+#     access to the loop registered by the *current thread*. All SDK reads of
+#     the global happen on the thread that owns the loop (``start()`` blocks
+#     in ``run_until_complete`` and every ``create_task`` callback runs on
+#     the loop's own thread), so each profile transparently sees its own
+#     loop. Threads that never registered one (single-profile installs, CLI)
+#     fall back to the SDK's original module loop.
+#   * ``websockets.connect`` becomes a single dispatcher that merges the
+#     per-thread ping overrides registered by the calling profile, so
+#     profiles no longer race over the global patch or restore each other's
+#     hooks while a sibling is still connected.
+
+_WS_ISOLATION_LOCK = threading.Lock()
+_WS_ISOLATION_INSTALLED = False
+# Per-WS-thread registration: ``.loop`` (the thread's asyncio loop) and
+# ``.connect_kwargs`` (websockets.connect overrides, e.g. ping settings).
+_ws_isolation_state = threading.local()
+
+
+class _ThreadLocalLoopProxy:
+    """Forwards attribute access to the current thread's registered loop."""
+
+    def __init__(self, fallback: Any) -> None:
+        self._fallback = fallback
+
+    def _target(self) -> Any:
+        return getattr(_ws_isolation_state, "loop", None) or self._fallback
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._target(), name)
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<ThreadLocalLoopProxy target={self._target()!r}>"
+
+
+def _install_lark_ws_isolation(ws_client_module: Any) -> None:
+    """Install the thread-dispatching shims once per process (idempotent)."""
+    global _WS_ISOLATION_INSTALLED
+    with _WS_ISOLATION_LOCK:
+        if _WS_ISOLATION_INSTALLED:
+            return
+
+        ws_client_module.loop = _ThreadLocalLoopProxy(ws_client_module.loop)
+
+        real_connect = ws_client_module.websockets.connect
+
+        def _dispatch_connect(*args: Any, **kwargs: Any) -> Any:
+            overrides = getattr(_ws_isolation_state, "connect_kwargs", None) or {}
+            for key, value in overrides.items():
+                kwargs.setdefault(key, value)
+            return real_connect(*args, **kwargs)
+
+        # Keep ``inspect.signature(websockets.connect)`` honest: the SDK's
+        # ``_ws_connect_kwargs()`` probes the real signature to decide whether
+        # the installed websockets generation supports the ``proxy`` kwarg.
+        _dispatch_connect.__wrapped__ = real_connect
+        _dispatch_connect.__name__ = getattr(real_connect, "__name__", "connect")
+        ws_client_module.websockets.connect = _dispatch_connect
+        _WS_ISOLATION_INSTALLED = True
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
-    """Run the official Lark WS client in its own thread-local event loop."""
+    """Run the official Lark WS client in its own thread-local event loop.
+
+    In multiplex mode several profiles run this concurrently; the shims
+    installed by ``_install_lark_ws_isolation`` make each thread see its own
+    loop and connect overrides (see the isolation comment block above). If
+    the shims cannot be installed (unexpected SDK layout), fall back to the
+    legacy direct-assignment path so startup never breaks.
+    """
     import lark_oapi.ws.client as ws_client_module
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    ws_client_module.loop = loop
     adapter._ws_thread_loop = loop
 
-    original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)
 
     def _apply_runtime_ws_overrides() -> None:
@@ -1343,12 +1425,38 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             logger.debug("[Feishu] Failed to apply websocket runtime overrides", exc_info=True)
 
+    connect_overrides: Dict[str, Any] = {}
+    if adapter._ws_ping_interval is not None:
+        connect_overrides["ping_interval"] = adapter._ws_ping_interval
+    if adapter._ws_ping_timeout is not None:
+        connect_overrides["ping_timeout"] = adapter._ws_ping_timeout
+
+    isolated = False
+    original_connect = None
+    try:
+        _install_lark_ws_isolation(ws_client_module)
+        isolated = True
+    except Exception:
+        logger.warning(
+            "[Feishu] WS isolation install failed; falling back to legacy globals",
+            exc_info=True,
+        )
+
     def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
-        if adapter._ws_ping_interval is not None and "ping_interval" not in kwargs:
-            kwargs["ping_interval"] = adapter._ws_ping_interval
-        if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
-            kwargs["ping_timeout"] = adapter._ws_ping_timeout
+        for key, value in connect_overrides.items():
+            kwargs.setdefault(key, value)
         return original_connect(*args, **kwargs)
+
+    if isolated:
+        _ws_isolation_state.loop = loop
+        _ws_isolation_state.connect_kwargs = connect_overrides
+    else:
+        # Legacy path: assign the shared globals directly. Safe for
+        # single-profile installs; multiplex races remain possible but this
+        # preserves pre-isolation behavior when the shims cannot install.
+        ws_client_module.loop = loop
+        original_connect = ws_client_module.websockets.connect
+        ws_client_module.websockets.connect = _connect_with_overrides
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:
@@ -1357,7 +1465,6 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         _apply_runtime_ws_overrides()
         return result
 
-    ws_client_module.websockets.connect = _connect_with_overrides
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
@@ -1366,7 +1473,11 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     except Exception:
         pass
     finally:
-        ws_client_module.websockets.connect = original_connect
+        if isolated:
+            _ws_isolation_state.loop = None
+            _ws_isolation_state.connect_kwargs = None
+        else:
+            ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
             setattr(ws_client, "_configure", original_configure)
         pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
@@ -1517,6 +1628,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sdk_executor_closing = False
         self._ws_client: Optional[Any] = None
         self._ws_future: Optional[asyncio.Future] = None
+        self._ws_supervisor: Optional[asyncio.Task] = None
         self._ws_thread_loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._webhook_runner: Optional[Any] = None
@@ -1814,6 +1926,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
             self._loop = asyncio.get_running_loop()
             await self._connect_with_retry()
+            if self._connection_mode == "websocket":
+                # Supervised reconnect (#73779): the WS thread can die without
+                # any external signal; keep a watcher alive for as long as this
+                # adapter is supposed to be connected.
+                self._ws_supervisor = asyncio.ensure_future(
+                    self._supervise_websocket_thread()
+                )
             self._mark_connected()
             logger.info("[Feishu] Connected in %s mode (%s)", self._connection_mode, self._domain_name)
             return True
@@ -1827,6 +1946,9 @@ class FeishuAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Feishu/Lark."""
         self._running = False
+        if self._ws_supervisor is not None:
+            self._ws_supervisor.cancel()
+            self._ws_supervisor = None
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
         self._reset_batch_buffers()
@@ -4925,6 +5047,53 @@ class FeishuAdapter(BasePlatformAdapter):
                     exc,
                 )
                 await asyncio.sleep(wait_seconds)
+
+    async def _supervise_websocket_thread(self) -> None:
+        """Restart the WS client thread if it dies while the adapter is up.
+
+        ``lark_oapi``'s ``start()`` blocks forever on a healthy connection
+        and only returns on fatal errors. Before this watcher existed the
+        executor future was awaited solely by ``disconnect()``, so a dead
+        thread left the profile silently deaf until a gateway restart
+        (#73779). Watch the future and, on unexpected exit, rebuild the
+        client with capped exponential backoff.
+        """
+        backoff = float(getattr(self, "_ws_restart_backoff", 5.0))
+        initial_backoff = backoff
+        last_dead: Optional[asyncio.Future] = None
+        while self._running:
+            ws_future = self._ws_future
+            if ws_future is None:
+                return
+            try:
+                await asyncio.shield(ws_future)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                pass
+            # Deliberate disconnect paths nil ``_ws_client`` / ``_running``
+            # before the thread exits; only restart when the link is still
+            # expected to be up.
+            if not self._running or self._ws_client is None:
+                return
+            if ws_future is not last_dead:
+                logger.error(
+                    "[Feishu] WebSocket client thread exited unexpectedly; "
+                    "restarting in %.0fs",
+                    backoff,
+                )
+                last_dead = ws_future
+            await asyncio.sleep(backoff)
+            if not self._running:
+                return
+            try:
+                await self._connect_websocket()
+                backoff = initial_backoff
+            except Exception as exc:
+                logger.warning(
+                    "[Feishu] WebSocket restart failed (retrying): %s", exc
+                )
+                backoff = min(backoff * 2, 60.0)
 
     async def _connect_websocket(self) -> None:
         if not FEISHU_WEBSOCKET_AVAILABLE:

--- a/tests/gateway/test_feishu_ws_multiplex_isolation.py
+++ b/tests/gateway/test_feishu_ws_multiplex_isolation.py
@@ -1,0 +1,382 @@
+"""Multiplex isolation for the lark_oapi WS client (issue #73779).
+
+In multiplex mode every Feishu profile runs its own official lark_oapi WS
+client on a dedicated thread. ``lark_oapi.ws.client`` keeps the loop used by
+``Client.start()`` and all of its coroutines in a module-level global, and
+Hermes additionally monkey-patches ``websockets.connect`` on the shared
+``websockets`` module. Before this fix the N profile threads overwrote each
+other's globals (last-write-wins), which either crashed clients with
+"Future attached to a different loop" or bound a client to a sibling's loop
+at construction time so the profile never heard anything again.
+
+These tests cover:
+
+  * the thread-local loop proxy (per-thread dispatch + fallback),
+  * the per-thread ``websockets.connect`` override dispatcher,
+  * the legacy fallback path when the shims cannot install,
+  * the supervised restart of a dead WS client thread.
+"""
+
+import asyncio
+import inspect
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from plugins.platforms.feishu import adapter as feishu_adapter
+
+
+def _fake_ws_module(connect=None):
+    """A stand-in for ``lark_oapi.ws.client`` with the same global layout."""
+    if connect is None:
+        async def connect(url, **kwargs):  # pragma: no cover - not awaited
+            return MagicMock()
+
+    websockets = SimpleNamespace(connect=connect)
+    return SimpleNamespace(loop=SimpleNamespace(name="sdk-default-loop"), websockets=websockets)
+
+
+def _inject_fake_lark_module(monkeypatch, module):
+    """Make ``import lark_oapi.ws.client`` resolve to ``module``."""
+    lark = types.ModuleType("lark_oapi")
+    lark_ws = types.ModuleType("lark_oapi.ws")
+    client_mod = types.ModuleType("lark_oapi.ws.client")
+    client_mod.loop = module.loop
+    client_mod.websockets = module.websockets
+    lark.ws = lark_ws
+    lark_ws.client = client_mod
+    monkeypatch.setitem(sys.modules, "lark_oapi", lark)
+    monkeypatch.setitem(sys.modules, "lark_oapi.ws", lark_ws)
+    monkeypatch.setitem(sys.modules, "lark_oapi.ws.client", client_mod)
+    return client_mod
+
+
+def _adapter_stub(**overrides):
+    stub = SimpleNamespace(
+        _ws_thread_loop=None,
+        _ws_reconnect_nonce=None,
+        _ws_reconnect_interval=None,
+        _ws_ping_interval=None,
+        _ws_ping_timeout=None,
+    )
+    for key, value in overrides.items():
+        setattr(stub, key, value)
+    return stub
+
+
+class TestThreadLocalLoopProxy:
+    def test_dispatches_to_the_calling_threads_loop(self, monkeypatch):
+        monkeypatch.setattr(feishu_adapter, "_WS_ISOLATION_INSTALLED", False)
+        mod = _fake_ws_module()
+        feishu_adapter._install_lark_ws_isolation(mod)
+
+        results = {}
+        barrier = threading.Barrier(2)
+
+        def worker(name):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            feishu_adapter._ws_isolation_state.loop = loop
+            try:
+                # Both threads exercise the same module global concurrently;
+                # each must see its own loop.
+                barrier.wait(timeout=5)
+
+                async def probe():
+                    await asyncio.sleep(0.01)
+                    return threading.get_ident()
+
+                results[name] = mod.loop.run_until_complete(probe())
+                results[f"{name}-loop-id"] = id(loop)
+            finally:
+                feishu_adapter._ws_isolation_state.loop = None
+                loop.close()
+
+        threads = [
+            threading.Thread(target=worker, args=(f"t{i}",)) for i in range(2)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+            assert not t.is_alive()
+
+        assert results["t0"] != results["t1"]
+        assert results["t0-loop-id"] != results["t1-loop-id"]
+
+    def test_unregistered_thread_falls_back_to_sdk_loop(self, monkeypatch):
+        monkeypatch.setattr(feishu_adapter, "_WS_ISOLATION_INSTALLED", False)
+        sdk_loop = MagicMock(name="sdk-default-loop")
+        mod = _fake_ws_module()
+        mod.loop = sdk_loop
+        feishu_adapter._install_lark_ws_isolation(mod)
+
+        # No TLS registration on this thread -> forwards to the SDK default.
+        assert mod.loop.is_closed is sdk_loop.is_closed
+
+    def test_install_is_idempotent(self, monkeypatch):
+        monkeypatch.setattr(feishu_adapter, "_WS_ISOLATION_INSTALLED", False)
+        mod = _fake_ws_module()
+        feishu_adapter._install_lark_ws_isolation(mod)
+        proxy = mod.loop
+        dispatcher = mod.websockets.connect
+        feishu_adapter._install_lark_ws_isolation(mod)
+        assert mod.loop is proxy
+        assert mod.websockets.connect is dispatcher
+
+
+class TestConnectDispatcher:
+    def test_applies_only_the_calling_threads_overrides(self, monkeypatch):
+        monkeypatch.setattr(feishu_adapter, "_WS_ISOLATION_INSTALLED", False)
+        real_connect = MagicMock(name="real-connect")
+        mod = _fake_ws_module(connect=real_connect)
+        feishu_adapter._install_lark_ws_isolation(mod)
+
+        feishu_adapter._ws_isolation_state.connect_kwargs = {"ping_interval": 15}
+        mod.websockets.connect("wss://a", ping_timeout=5)
+        real_connect.assert_called_once_with(
+            "wss://a", ping_timeout=5, ping_interval=15
+        )
+
+        # A thread without registered overrides connects untouched.
+        real_connect.reset_mock()
+        seen = {}
+
+        def other_thread():
+            seen["called"] = False
+            mod.websockets.connect("wss://b")
+            seen["called"] = True
+
+        t = threading.Thread(target=other_thread)
+        t.start()
+        t.join(timeout=5)
+        assert seen["called"]
+        real_connect.assert_called_once_with("wss://b")
+
+        feishu_adapter._ws_isolation_state.connect_kwargs = None
+
+    def test_explicit_kwargs_win_over_overrides(self, monkeypatch):
+        monkeypatch.setattr(feishu_adapter, "_WS_ISOLATION_INSTALLED", False)
+        real_connect = MagicMock(name="real-connect")
+        mod = _fake_ws_module(connect=real_connect)
+        feishu_adapter._install_lark_ws_isolation(mod)
+
+        feishu_adapter._ws_isolation_state.connect_kwargs = {"ping_interval": 15}
+        mod.websockets.connect("wss://a", ping_interval=99)
+        real_connect.assert_called_once_with("wss://a", ping_interval=99)
+        feishu_adapter._ws_isolation_state.connect_kwargs = None
+
+    def test_signature_probe_still_sees_real_connect(self, monkeypatch):
+        """The SDK's ``_ws_connect_kwargs()`` inspects the connect signature
+        to detect websockets-15 ``proxy`` support; the dispatcher must not
+        hide it."""
+        monkeypatch.setattr(feishu_adapter, "_WS_ISOLATION_INSTALLED", False)
+
+        async def real_connect(url, *, proxy=None, **kwargs):
+            return None
+
+        mod = _fake_ws_module(connect=real_connect)
+        feishu_adapter._install_lark_ws_isolation(mod)
+        params = inspect.signature(mod.websockets.connect).parameters
+        assert "proxy" in params
+
+
+class TestRunOfficialClient:
+    def test_isolated_path_registers_tls_and_cleans_up(self, monkeypatch):
+        monkeypatch.setattr(feishu_adapter, "_WS_ISOLATION_INSTALLED", False)
+        mod = _fake_ws_module()
+        client_mod = _inject_fake_lark_module(monkeypatch, mod)
+
+        seen = {}
+
+        class FakeClient:
+            def start(self):
+                # SDK-style access through the module global: only works when
+                # the proxy dispatches to this thread's registered loop.
+                client_mod.loop.run_until_complete(asyncio.sleep(0))
+                seen["ran_on_loop"] = asyncio.get_event_loop()
+
+        adapter = _adapter_stub(_ws_ping_interval=30)
+        feishu_adapter._run_official_feishu_ws_client(FakeClient(), adapter)
+
+        assert "ran_on_loop" in seen
+        assert seen["ran_on_loop"].is_closed()
+        assert adapter._ws_thread_loop is None
+        # TLS entries are cleaned up so a later thread on the same pooled
+        # executor thread does not inherit a dead loop.
+        assert getattr(feishu_adapter._ws_isolation_state, "loop", None) is None
+        assert (
+            getattr(feishu_adapter._ws_isolation_state, "connect_kwargs", None)
+            is None
+        )
+
+    def test_two_concurrent_clients_each_use_their_own_loop(self, monkeypatch):
+        monkeypatch.setattr(feishu_adapter, "_WS_ISOLATION_INSTALLED", False)
+        mod = _fake_ws_module()
+        client_mod = _inject_fake_lark_module(monkeypatch, mod)
+
+        results = {}
+        barrier = threading.Barrier(2)
+
+        class FakeClient:
+            def __init__(self, name):
+                self._name = name
+
+            def start(self):
+                barrier.wait(timeout=10)
+
+                async def probe():
+                    await asyncio.sleep(0.02)
+                    return id(asyncio.get_running_loop())
+
+                results[self._name] = client_mod.loop.run_until_complete(probe())
+
+        def run(name):
+            feishu_adapter._run_official_feishu_ws_client(
+                FakeClient(name), _adapter_stub()
+            )
+
+        threads = [threading.Thread(target=run, args=(f"p{i}",)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+            assert not t.is_alive()
+
+        assert results["p0"] != results["p1"]
+
+    def test_legacy_fallback_when_install_fails(self, monkeypatch):
+        monkeypatch.setattr(feishu_adapter, "_WS_ISOLATION_INSTALLED", False)
+
+        def broken_install(module):
+            raise RuntimeError("simulated SDK layout change")
+
+        monkeypatch.setattr(
+            feishu_adapter, "_install_lark_ws_isolation", broken_install
+        )
+
+        real_connect = MagicMock(name="real-connect")
+        mod = _fake_ws_module(connect=real_connect)
+        client_mod = _inject_fake_lark_module(monkeypatch, mod)
+
+        seen = {}
+
+        class FakeClient:
+            def start(self):
+                seen["loop_global"] = client_mod.loop
+                seen["connect_during"] = client_mod.websockets.connect
+                # Legacy path: the module global is the real loop directly.
+                client_mod.loop.run_until_complete(asyncio.sleep(0))
+
+        adapter = _adapter_stub(_ws_ping_interval=30)
+        feishu_adapter._run_official_feishu_ws_client(FakeClient(), adapter)
+
+        assert isinstance(seen["loop_global"], asyncio.AbstractEventLoop)
+        # The legacy connect wrapper was active during start() ...
+        assert seen["connect_during"] is not real_connect
+        # ... and restored afterwards.
+        assert client_mod.websockets.connect is real_connect
+        assert adapter._ws_thread_loop is None
+
+
+class TestSupervisedRestart:
+    def _supervisor_stub(self):
+        stub = SimpleNamespace(
+            _running=True,
+            _ws_future=None,
+            _ws_client=object(),
+            _ws_restart_backoff=0.01,
+            connect_calls=0,
+            connect_should_fail=0,
+        )
+
+        async def _connect_websocket():
+            stub.connect_calls += 1
+            if stub.connect_should_fail > 0:
+                stub.connect_should_fail -= 1
+                raise RuntimeError("simulated restart failure")
+            loop = asyncio.get_running_loop()
+            fut = loop.create_future()
+            fut.set_result(None)  # new thread dies immediately too
+            stub._ws_future = fut
+
+        stub._connect_websocket = _connect_websocket
+        return stub
+
+    def test_restarts_a_dead_ws_thread(self):
+        async def scenario():
+            stub = self._supervisor_stub()
+            loop = asyncio.get_running_loop()
+            fut = loop.create_future()
+            fut.set_result(None)  # the WS "thread" is already dead
+            stub._ws_future = fut
+
+            task = asyncio.ensure_future(
+                feishu_adapter.FeishuAdapter._supervise_websocket_thread(stub)
+            )
+            # Give the supervisor a few backoff cycles (0.01s each).
+            for _ in range(200):
+                await asyncio.sleep(0.01)
+                if stub.connect_calls >= 2:
+                    break
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            return stub.connect_calls
+
+        calls = asyncio.run(scenario())
+        assert calls >= 2, f"supervisor should keep restarting, got {calls} restarts"
+
+    def test_stops_when_disconnect_nils_the_client(self):
+        async def scenario():
+            stub = self._supervisor_stub()
+            loop = asyncio.get_running_loop()
+            fut = loop.create_future()  # not resolved yet: thread "alive"
+            stub._ws_future = fut
+
+            task = asyncio.ensure_future(
+                feishu_adapter.FeishuAdapter._supervise_websocket_thread(stub)
+            )
+            await asyncio.sleep(0.01)  # supervisor blocks awaiting the future
+            stub._ws_client = None  # deliberate disconnect ...
+            fut.set_result(None)  # ... then the thread exits
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+            except asyncio.CancelledError:
+                pass
+            return stub, task
+
+        stub, task = asyncio.run(scenario())
+        assert task.done()
+        assert stub.connect_calls == 0
+
+    def test_restart_failure_backs_off_without_hot_loop(self):
+        async def scenario():
+            stub = self._supervisor_stub()
+            stub.connect_should_fail = 1
+            loop = asyncio.get_running_loop()
+            fut = loop.create_future()
+            fut.set_result(None)
+            stub._ws_future = fut
+
+            task = asyncio.ensure_future(
+                feishu_adapter.FeishuAdapter._supervise_websocket_thread(stub)
+            )
+            for _ in range(300):
+                await asyncio.sleep(0.01)
+                if stub.connect_calls >= 2:
+                    break
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            return stub.connect_calls
+
+        calls = asyncio.run(scenario())
+        # First restart fails, second succeeds: exactly the expected shape.
+        assert calls == 2, f"expected failed-then-successful restarts, got {calls}"


### PR DESCRIPTION
## What does this PR do?

Fixes the multiplex-mode failure where Feishu profiles either crash with `Future attached to a different loop` or go **deaf from the start** because all profiles fight over two process-wide globals, and adds a supervisor so a dead WS client thread no longer leaves a profile silently deaf until a gateway restart.

**Root cause** (verified against `lark-oapi 1.6.8`, `lark_oapi/ws/client.py`):

- The SDK keeps the asyncio loop used by `Client.start()` and every coroutine it spawns (`_ping_loop`, `_receive_message_loop`, `_handle_message`, reconnects) in a **module-level global** (`loop`, created at import time).
- Hermes' `_run_official_feishu_ws_client` therefore assigns `ws_client_module.loop = <own loop>` per profile thread and monkey-patches `ws_client_module.websockets.connect` (which patches the **shared `websockets` module**) to inject per-adapter ping settings.

In multiplex mode every profile runs its own WS client on a dedicated thread, so the N threads overwrite each other's globals (**last-write-wins**):

- a client schedules tasks on a sibling profile's loop → `Future attached to a different loop` crashes, and
- a client binds to the wrong loop at construction time → the profile receives nothing ever again ("deaf from birth"), matching the three-way reproduction in the issue (second profile deaf from start, restart does not help, separate processes work).

**The fix** installs process-wide, thread-dispatching shims exactly once:

- `ws_client_module.loop` becomes a proxy that forwards every attribute access to the loop registered by the *calling thread*. This is sound because all SDK reads of the global happen on the thread that owns the loop (`start()` blocks in `run_until_complete`; every `create_task` callback runs on the loop's own thread). Threads that never registered one (single-profile installs, CLI) fall back to the SDK's original module loop — behavior is unchanged there.
- `websockets.connect` becomes a single dispatcher merging the per-thread ping overrides registered by the calling profile, so profiles no longer race over the global patch or restore each other's hooks while a sibling is still connected. `__wrapped__` keeps `inspect.signature(websockets.connect)` honest for the SDK's `_ws_connect_kwargs()` websockets-15 `proxy` probe.
- If the shims cannot install (unexpected SDK layout), the code falls back to the legacy direct-assignment path so startup never breaks.

**Supervised reconnect**: `lark_oapi`'s `start()` blocks forever on a healthy connection and only returns on fatal errors; until now the executor future was awaited solely by `disconnect()`, so a dead thread left the profile silently deaf. The adapter now watches the future and, on unexpected exit while it is supposed to be connected, rebuilds the client with capped exponential backoff (5s → 60s).

## Related Issue

Fixes #73779

Related: #64247, #53477 (supervised-reconnect alone only covers the crash variant; this PR covers both variants plus the silent-death case).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py`:
  - new `_ThreadLocalLoopProxy` + `_install_lark_ws_isolation()` (idempotent, lock-guarded, per-thread `threading.local` registry)
  - `_run_official_feishu_ws_client()`: register per-thread loop + connect overrides instead of assigning shared globals; legacy fallback retained
  - new `_supervise_websocket_thread()`: watches `_ws_future`, restarts the client with capped backoff on unexpected thread exit; spawned by `connect()` in websocket mode, cancelled by `disconnect()`
- `tests/gateway/test_feishu_ws_multiplex_isolation.py`: 12 tests (per-thread loop dispatch under concurrency, fallback, idempotency, connect-dispatcher semantics incl. signature probe, isolated/legacy run paths with cleanup, supervised restart incl. deliberate-disconnect and failed-restart backoff)

## How to Test

1. `pytest tests/gateway/test_feishu_ws_multiplex_isolation.py -q` — 12 passed.
2. `pytest tests/gateway/ -k feishu -q` — 216 passed, 1 skipped (no regressions); `ruff check` clean.
3. Multiplex soak: run a gateway with ≥2 Feishu profiles in one process; before the fix the later profiles intermittently crash with `Future attached to a different loop` or never receive events; after the fix each thread schedules on its own loop. I will additionally run this against a real 7-profile gateway (offered in the issue thread).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

> Note: ran the full Feishu gateway suite (`tests/gateway/ -k feishu`, 216 passed) plus the new isolation tests and `ruff check`; the change is contained to the Feishu websocket path.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Failure signatures this PR eliminates (live multiplex gateway, one process, 7 profiles):

```text
ERROR agent.conversation_loop: ... RuntimeWarning: coroutine ... was never awaited / Future attached to a different loop
(gateway alive, profile connected, but no inbound events are ever delivered on the affected profile)
```
