### PR TITLE
fix(telegram): resume typing after clarify callback

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6748,6 +6748,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         "Telegram clarify button resolved (id=%s, choice=%r, user=%s)",
                         clarify_id, resolved_text, user_display,
                     )
+                    if query_chat_id is not None:
+                        self.resume_typing_for_chat(str(query_chat_id))
                 else:
                     # Entry evicted (clarify_timeout) or gateway restarted
                     # between ask and tap — surface this instead of leaving a

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -153,6 +153,8 @@ class TestTelegramClarifyCallback:
         # Pre-register a clarify entry so the callback can look up the choice text
         cm.register("cidA", "sk-cb", "Pick", ["red", "green", "blue"])
         adapter._clarify_state["cidA"] = "sk-cb"
+        adapter.pause_typing_for_chat("12345")
+        assert "12345" in adapter._typing_paused
 
         query = AsyncMock()
         query.data = "cl:cidA:1"  # green
@@ -186,6 +188,7 @@ class TestTelegramClarifyCallback:
         assert entry.event.is_set()
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
+        assert "12345" not in adapter._typing_paused
 
 
     @pytest.mark.asyncio
@@ -277,4 +280,3 @@ class TestBaseAdapterClarifyFallback:
         assert "Pick a fruit" in text
         assert "1." in text and "apple" in text
         assert "2." in text and "banana" in text
-


### PR DESCRIPTION
## What does this PR do?

Fixes #84028. Telegram inline clarify buttons already resolve the waiting clarify prompt and edit the original message, but unlike the sibling exec-approval callback they left the chat typing indicator paused for the rest of the turn. This resumes typing after a successful `cl:` callback resolution so the user sees progress while the agent continues.

## Related Issue

Fixes #84028

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: call `resume_typing_for_chat()` after a successful clarify callback resolution.
- `tests/gateway/test_telegram_clarify_buttons.py`: extend the numeric-choice callback regression to start with typing paused and assert it is resumed.

## How to Test

1. Trigger a Telegram clarify prompt that pauses typing.
2. Tap an inline choice button.
3. Verify the callback resolves and the typing pause is cleared while the agent continues.

Validation run locally:

- `HERMES_PYTHON=/Users/yuanangyang/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/gateway/test_telegram_clarify_buttons.py -q`
- `HERMES_PYTHON=/Users/yuanangyang/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/gateway/test_telegram_approval_buttons.py -q`
- `/Users/yuanangyang/hermes-agent/.venv/bin/python -m ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_clarify_buttons.py`

## Checklist

### Code

- [x] I've read the Contributing Guide and repository instructions.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs by issue number and distinctive title terms.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: macOS with project venv.

### Documentation & Housekeeping

- [x] Documentation updates are N/A.
- [x] `cli-config.yaml.example` updates are N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A.
- [x] Cross-platform impact considered: callback state handling only.
- [x] Tool descriptions/schemas are N/A.

## Duplicate Check

Before coding and again before opening this PR, I searched open PRs for `#84028`, `resume typing indicator`, `Telegram clarify`, and `clarify button resolves`; no existing open PR covered this issue.