### PR TITLE
fix(process): pin completion delivery to spawning session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24788,9 +24788,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return False
         try:
             metadata = {}
-            parent_session_id = str(evt.get("parent_session_id") or "").strip()
-            if parent_session_id:
-                metadata["gateway_session_id"] = parent_session_id
+            target_session_id = str(
+                evt.get("parent_session_id")
+                or evt.get("origin_ui_session_id")
+                or ""
+            ).strip()
+            if target_session_id:
+                metadata["gateway_session_id"] = target_session_id
             synth_event = MessageEvent(
                 text=synth_text,
                 message_type=MessageType.TEXT,
@@ -25560,6 +25564,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "type": "completion",
                         "session_id": session_id,
                         "session_key": session_key,
+                        "origin_ui_session_id": watcher.get(
+                            "origin_ui_session_id", ""
+                        ),
                         "platform": platform_name,
                         "chat_type": watcher.get("chat_type", ""),
                         "chat_id": chat_id,

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -334,6 +334,30 @@ async def test_inject_watch_notification_loads_session_store_off_loop(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_inject_watch_notification_pins_spawning_ui_session(
+    monkeypatch, tmp_path
+):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    evt = {
+        "session_id": "proc_watch",
+        "session_key": "agent:main:telegram:dm:123:456",
+        "origin_ui_session_id": "session-before-new",
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "123",
+        "user_id": "456",
+    }
+
+    await runner._inject_watch_notification(
+        "[SYSTEM: Background process matched]", evt
+    )
+
+    synth_event = adapter.handle_message.await_args.args[0]
+    assert synth_event.metadata["gateway_session_id"] == "session-before-new"
+
+
+@pytest.mark.asyncio
 async def test_inject_watch_notification_ignores_foreground_event_source(monkeypatch, tmp_path):
     """Negative test: watch notification must NOT route to the foreground thread."""
     from gateway.session import SessionSource

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -15,9 +15,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import GatewayConfig, Platform
 from gateway.run import GatewayRunner
-from gateway.session import SessionSource
+from gateway.session import SessionSource, SessionStore
 from tools.process_registry import ProcessRegistry, ProcessSession
 
 
@@ -83,6 +83,17 @@ def _completion_event(*, started_at, session_id="proc_reused"):
         "completion_reason": "exited",
         "output": "done\n",
     }
+
+
+class _AsyncSessionDB:
+    def __init__(self, store):
+        self._db = store._db
+
+    async def get_session(self, session_id):
+        return self._db.get_session(session_id)
+
+    async def get_compression_tip(self, session_id):
+        return self._db.get_compression_tip(session_id)
 
 
 def _stop_after_sleeps(monkeypatch, runner, count):
@@ -245,6 +256,67 @@ def test_explicit_kill_returns_output_before_consuming_notification(monkeypatch)
     }))
 
     adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_completion_after_new_is_not_routed_to_current_session(
+    monkeypatch, tmp_path, isolated_registry
+):
+    """A chat-scoped key cannot identify the pre-/new spawning session."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="678",
+    )
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    origin = store.get_or_create_session(source)
+    current = store.reset_session(origin.session_key)
+    assert current is not None
+    assert current.session_id != origin.session_id
+
+    process = ProcessSession(
+        id="proc_origin",
+        command="echo done",
+        session_key=origin.session_key,
+        origin_ui_session_id=origin.session_id,
+        started_at=1.0,
+        exited=True,
+        exit_code=0,
+        output_buffer="done\n",
+        notify_on_complete=True,
+    )
+    isolated_registry._running[process.id] = process
+    isolated_registry._move_to_finished(process)
+    event = isolated_registry.completion_queue.get_nowait()
+
+    routed = []
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner.session_store = store
+    runner._session_db = _AsyncSessionDB(store)
+
+    async def _route_like_gateway(message_event):
+        active = store.get_or_create_session(message_event.source)
+        pinned = message_event.metadata.get("gateway_session_id", "")
+        routed.append(
+            await runner._resolve_async_delegation_session(active, pinned)
+            if pinned
+            else active
+        )
+
+    adapter.handle_message.side_effect = _route_like_gateway
+    await runner._inject_watch_notification("completion", event)
+
+    assert adapter.handle_message.await_args.args[0].metadata == {
+        "gateway_session_id": origin.session_id
+    }
+    assert routed == [None]
+    assert store.get_or_create_session(source).session_id == current.session_id
+    store._db.close()
 
 
 def test_process_tool_redacts_explicit_kill_output(monkeypatch):

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -34,6 +34,7 @@ def _make_session(
     exit_code=None,
     output="",
     notify_on_complete=False,
+    origin_ui_session_id="",
 ) -> ProcessSession:
     s = ProcessSession(
         id=sid,
@@ -44,6 +45,7 @@ def _make_session(
         exit_code=exit_code,
         output_buffer=output,
         notify_on_complete=notify_on_complete,
+        origin_ui_session_id=origin_ui_session_id,
     )
     return s
 
@@ -109,6 +111,34 @@ class TestCompletionQueue:
         completion = registry.completion_queue.get_nowait()
         assert len(completion["output"]) == 2000
 
+    def test_completion_keeps_spawning_ui_session(self, registry):
+        s = _make_session(
+            notify_on_complete=True,
+            origin_ui_session_id="session-before-new",
+        )
+        s.exited = True
+        s.exit_code = 0
+        registry._running[s.id] = s
+        with patch.object(registry, "_write_checkpoint"):
+            registry._move_to_finished(s)
+
+        completion = registry.completion_queue.get_nowait()
+        assert completion["task_id"] == "t1"
+        assert completion["origin_ui_session_id"] == "session-before-new"
+
+    def test_watch_match_keeps_task_and_spawning_ui_session(self, registry):
+        s = _make_session(
+            task_id="sa-1-routing",
+            origin_ui_session_id="session-before-new",
+        )
+        s.watch_patterns = ["READY"]
+
+        registry._check_watch_patterns(s, "READY\n")
+
+        notification = registry.completion_queue.get_nowait()
+        assert notification["task_id"] == "sa-1-routing"
+        assert notification["origin_ui_session_id"] == "session-before-new"
+
     def test_multiple_completions_queued(self, registry):
         """Multiple notify processes all push to the same queue."""
         for i in range(3):
@@ -138,13 +168,17 @@ class TestCompletionQueue:
 class TestCheckpointNotify:
     def test_checkpoint_includes_notify(self, registry, tmp_path):
         with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "procs.json"):
-            s = _make_session(notify_on_complete=True)
+            s = _make_session(
+                notify_on_complete=True,
+                origin_ui_session_id="session-before-restart",
+            )
             registry._running[s.id] = s
             registry._write_checkpoint()
 
             data = json.loads((tmp_path / "procs.json").read_text())
             assert len(data) == 1
             assert data[0]["notify_on_complete"] is True
+            assert data[0]["origin_ui_session_id"] == "session-before-restart"
 
 
     def test_recover_defaults_false(self, registry, tmp_path):
@@ -161,6 +195,43 @@ class TestCheckpointNotify:
             assert recovered == 1
             s = registry.get("proc_live")
             assert s.notify_on_complete is False
+            assert s.origin_ui_session_id == ""
+
+    def test_recovery_keeps_origin_on_requeued_watcher(self, registry, tmp_path):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_owned",
+            "command": "sleep 999",
+            "pid": os.getpid(),
+            "task_id": "t1",
+            "session_key": "agent:main:telegram:dm:123:456",
+            "origin_ui_session_id": "session-before-restart",
+            "watcher_platform": "telegram",
+            "watcher_chat_id": "123",
+            "watcher_user_id": "456",
+            "watcher_interval": 5,
+            "notify_on_complete": True,
+        }]))
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            assert registry.recover_from_checkpoint() == 1
+
+        recovered = registry.get("proc_owned")
+        assert recovered.origin_ui_session_id == "session-before-restart"
+        assert registry.pending_watchers == [{
+            "session_id": "proc_owned",
+            "check_interval": 5,
+            "session_key": "agent:main:telegram:dm:123:456",
+            "origin_ui_session_id": "session-before-restart",
+            "platform": "telegram",
+            "chat_id": "123",
+            "user_id": "456",
+            "user_name": "",
+            "thread_id": "",
+            "message_id": "",
+            "notify_on_complete": True,
+            "parent_session_id": "",
+        }]
 
 
 # =========================================================================
@@ -312,6 +383,7 @@ def _silent_bg_harness(monkeypatch, tmp_path):
             watcher_thread_id="",
             watcher_message_id="",
             watcher_interval=0,
+            origin_ui_session_id=kwargs.get("origin_ui_session_id", ""),
         )
 
     monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
@@ -368,6 +440,40 @@ def test_background_with_notify_does_not_emit_hint(monkeypatch, tmp_path):
         f"Correct usage must not emit a hint, got: {result.get('hint')!r}"
     )
     assert result.get("notify_on_complete") is True
+
+
+def test_background_notify_captures_spawning_ui_session(monkeypatch, tmp_path):
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools.process_registry import process_registry
+
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    process_registry.pending_watchers = []
+    tokens = set_session_vars(
+        platform="telegram",
+        chat_id="123",
+        user_id="456",
+        session_key="agent:main:telegram:dm:123:456",
+        ui_session_id="session-before-new",
+        async_delivery=True,
+    )
+    try:
+        result = json.loads(
+            tt.terminal_tool(
+                command="pytest tests/",
+                background=True,
+                notify_on_complete=True,
+            )
+        )
+    finally:
+        clear_session_vars(tokens)
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert result["notify_on_complete"] is True
+    assert process_registry.pending_watchers[-1]["origin_ui_session_id"] == (
+        "session-before-new"
+    )
+    process_registry.pending_watchers = []
 
 
 def test_foreground_command_does_not_emit_hint(monkeypatch, tmp_path):

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -168,6 +168,7 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "cwd": "/workspace/live",
         "task_id": task_id,
         "session_key": task_id,
+        "origin_ui_session_id": "",
         "env_vars": {},
         "use_pty": False,
     }]

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -370,6 +370,7 @@ class ProcessSession:
     command: str                                 # Original command string
     task_id: str = ""                           # Task/sandbox isolation key
     session_key: str = ""                       # Gateway session key (for reset protection)
+    origin_ui_session_id: str = ""              # Spawning conversation row across /new/compression
     pid: Optional[int] = None                   # OS process ID
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
     env_ref: Any = None                         # Reference to the environment object
@@ -598,6 +599,7 @@ class ProcessRegistry:
                 self.completion_queue.put({
                     "session_id": session.id,
                     "session_key": session.session_key,
+                    "origin_ui_session_id": session.origin_ui_session_id,
                     "command": session.command,
                     "type": "watch_disabled",
                     "suppressed": session._watch_suppressed,
@@ -630,6 +632,7 @@ class ProcessRegistry:
             "session_id": session.id,
             "session_key": session.session_key,
             "task_id": session.task_id,
+            "origin_ui_session_id": session.origin_ui_session_id,
             "command": session.command,
             "type": "watch_match",
             "pattern": matched_pattern,
@@ -977,6 +980,7 @@ class ProcessRegistry:
         cwd: str = None,
         task_id: str = "",
         session_key: str = "",
+        origin_ui_session_id: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
     ) -> ProcessSession:
@@ -1004,6 +1008,7 @@ class ProcessRegistry:
             command=command,
             task_id=task_id,
             session_key=session_key,
+            origin_ui_session_id=origin_ui_session_id,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
         )
@@ -1216,6 +1221,7 @@ class ProcessRegistry:
         cwd: str = None,
         task_id: str = "",
         session_key: str = "",
+        origin_ui_session_id: str = "",
         timeout: int = 10,
     ) -> ProcessSession:
         """
@@ -1234,6 +1240,7 @@ class ProcessRegistry:
             command=command,
             task_id=task_id,
             session_key=session_key,
+            origin_ui_session_id=origin_ui_session_id,
             cwd=cwd,
             started_at=time.time(),
             env_ref=env,
@@ -1576,6 +1583,7 @@ class ProcessRegistry:
                 "session_id": session.id,
                 "session_key": session.session_key,
                 "task_id": session.task_id,
+                "origin_ui_session_id": session.origin_ui_session_id,
                 "command": session.command,
                 "exit_code": session.exit_code,
                 "completion_reason": session.completion_reason,
@@ -2565,6 +2573,7 @@ class ProcessRegistry:
                             "started_at": s.started_at,
                             "task_id": s.task_id,
                             "session_key": s.session_key,
+                            "origin_ui_session_id": s.origin_ui_session_id,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
                             "watcher_user_id": s.watcher_user_id,
@@ -2655,6 +2664,7 @@ class ProcessRegistry:
                 command=entry.get("command", "unknown"),
                 task_id=entry.get("task_id", ""),
                 session_key=entry.get("session_key", ""),
+                origin_ui_session_id=entry.get("origin_ui_session_id", ""),
                 pid=pid,
                 host_start_time=recorded_start,
                 pid_scope=pid_scope,
@@ -2684,6 +2694,7 @@ class ProcessRegistry:
                     "session_id": session.id,
                     "check_interval": session.watcher_interval,
                     "session_key": session.session_key,
+                    "origin_ui_session_id": session.origin_ui_session_id,
                     "platform": session.watcher_platform,
                     "chat_id": session.watcher_chat_id,
                     "user_id": session.watcher_user_id,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3065,8 +3065,10 @@ def terminal_tool(
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.
             # For non-local backends: runs inside the sandbox via env.execute().
+            from gateway.session_context import get_session_env as _get_session_env
             from tools.process_registry import process_registry
 
+            origin_ui_session_id = _get_session_env("HERMES_UI_SESSION_ID", "")
             effective_cwd = _resolve_command_cwd(
                 workdir=workdir,
                 default_cwd=cwd,
@@ -3080,6 +3082,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        origin_ui_session_id=origin_ui_session_id,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
                     )
@@ -3090,6 +3093,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        origin_ui_session_id=origin_ui_session_id,
                     )
 
                 result_data = {
@@ -3297,6 +3301,7 @@ def terminal_tool(
                             "session_id": proc_session.id,
                             "check_interval": 5,
                             "session_key": session_key,
+                            "origin_ui_session_id": proc_session.origin_ui_session_id,
                             "platform": proc_session.watcher_platform,
                             "chat_id": proc_session.watcher_chat_id,
                             "user_id": proc_session.watcher_user_id,


### PR DESCRIPTION
## Summary

- capture the physical UI session that owns a background terminal process at spawn time
- persist that owner through process checkpoints, recovery, watcher requeueing, and completion events
- pin synthetic gateway delivery to the captured session so a later `/new` cannot redirect the wake into the new conversation

## Root cause

Chat-backed gateway sessions retain the same `session_key` across `/new`; only the physical `session_id` rotates. Process completion events previously retained only the key, so source reconstruction selected the current session B instead of the spawning session A.

This change carries `origin_ui_session_id` through the complete process lifecycle and feeds it into the existing session-aware gateway resolver. Compression continuations can resolve to their live tip, while a terminally reset origin fails closed instead of leaking into the new session.

## Verification

Current-main reproduction before the patch used Hermes' real `SessionStore` and `ProcessRegistry`: spawn under A, reset to B, complete the process, and observe routing select B.

After the patch:

- the integrated A -> `/new` -> B regression proves the completion remains pinned to A and is not delivered to B
- checkpoint/restart coverage proves the owner survives process recovery
- watcher, match, disabled-watch, and completion event paths retain the owner
- an isolated macOS smoke test with a real harmless background process preserved A through watcher injection after the reset
- broad matrix: 726 passed, 0 failed, 3 platform skips
- final focused matrix: 46 passed, 0 failed
- Ruff, lockfile check, diff check, public-identity check, metadata scan, and gitleaks all pass

Fixes #83213
