### PR TITLE
fix(desktop): preserve spaces in standalone MEDIA paths

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -394,6 +394,18 @@ describe('renderMediaTags', () => {
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
   })
+
+  it('does not freeze a streamed standalone MEDIA path before later space-separated chunks arrive', () => {
+    const path = '/Users/zora/Documents/ZORA/hermes/operations/B17-B Value Extraction and Retirement Receipt.md'
+    let parts = appendAssistantTextPart([], 'ready\nMEDIA:/Users/zora/Documents/ZORA/hermes/operations/B17-B')
+
+    parts = appendAssistantTextPart(parts, ' Value Ex')
+    parts = appendAssistantTextPart(parts, 'traction and Retirement Receipt.md\n')
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      `ready\n[File: B17-B Value Extraction and Retirement Receipt.md](#media:${encodeURIComponent(path)})\n`
+    )
+  })
 })
 
 describe('interleaved reasoning/text coalescing', () => {

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -380,6 +380,14 @@ describe('renderMediaTags', () => {
     expect(renderMediaTags('MEDIA:/tmp/demo.mp4')).toBe('[Video: demo.mp4](#media:%2Ftmp%2Fdemo.mp4)')
   })
 
+  it('keeps an unquoted standalone MEDIA path with spaces intact', () => {
+    const path = '/Users/zora/Documents/ZORA/hermes/operations/B17-B Value Extraction and Retirement Receipt.md'
+
+    expect(renderMediaTags(`ready\nMEDIA:${path}`)).toBe(
+      `ready\n[File: B17-B Value Extraction and Retirement Receipt.md](#media:${encodeURIComponent(path)})`
+    )
+  })
+
   it('renders streamed assistant media once the tag is complete', () => {
     const parts = appendAssistantTextPart(appendAssistantTextPart([], 'ok\nMEDIA:'), '/tmp/voice.mp3')
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -134,7 +134,8 @@ export function reasoningPart(text: string): ChatMessagePart {
   return { type: 'reasoning', text }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+const MEDIA_LINE_RE =
+  /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|[^\n]+?)[`"']?[\t ]*(\n|$)/g
 
 const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -449,8 +449,44 @@ export function appendReasoningPart(parts: ChatMessagePart[], delta: string): Ch
   return appendStreamPart(parts, 'reasoning', delta).parts
 }
 
+const TRAILING_MEDIA_LINK_RE = /\[[^\n]*\]\(#media:(?<path>[^)\n]+)\)$/
+
+function restoreTrailingMediaDirective(parts: ChatMessagePart[]): ChatMessagePart[] {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i]
+
+    if (part.type === 'text') {
+      const match = TRAILING_MEDIA_LINK_RE.exec(part.text)
+
+      if (!match?.groups?.path || match.index === undefined) {
+        return parts
+      }
+
+      try {
+        const next = [...parts]
+
+        next[i] = { ...part, text: `${part.text.slice(0, match.index)}MEDIA:${decodeURIComponent(match.groups.path)}` }
+
+        return next
+      } catch {
+        return parts
+      }
+    }
+
+    if (part.type !== 'reasoning') {
+      break
+    }
+  }
+
+  return parts
+}
+
 export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
-  const { index, parts: next } = appendStreamPart(parts, 'text', delta)
+  // A standalone MEDIA line can be rendered before the stream reveals that
+  // more filename chunks follow. Restore our trailing generated link to its
+  // directive before appending so later spaces and mid-word deltas extend the
+  // path instead of becoming prose outside a frozen link.
+  const { index, parts: next } = appendStreamPart(restoreTrailingMediaDirective(parts), 'text', delta)
   const part = next[index]
 
   if (part?.type !== 'text') {


### PR DESCRIPTION
## Summary

- preserve the complete path when Hermes Desktop renders an unquoted standalone `MEDIA:` directive containing spaces
- keep inline `MEDIA:` parsing whitespace-bounded so trailing prose is not absorbed
- recover a provisionally rendered trailing media link before later stream chunks append more filename characters
- add regressions using the exact B17-B-style Markdown filename for both complete and multi-chunk messages

## Root cause

The gateway's media extractor already supports paths containing spaces, but Desktop has a separate renderer in `renderMediaTags`. Its standalone-line regex used `\S+`, so:

```text
MEDIA:/Users/zora/Documents/.../B17-B Value Extraction and Retirement Receipt.md
```

became a link to the nonexistent truncated path ending in `B17-B`. Clicking it then surfaced the misleading gateway error “missing, unreadable, or too large.” This is the Desktop sibling of the gateway bug fixed by #2621.

The primary fix broadens only the standalone-line branch to consume the remainder of that line. The inline branch remains unchanged and continues stopping at whitespace.

Streaming exposed the same failure one layer earlier: Desktop could render the partial path ending in `B17-B` before later chunks containing the rest of the filename arrived. The streaming path now restores a trailing generated media link to its directive before appending another chunk, allowing both space-prefixed and mid-word chunks to extend the path safely.

## Verification

- both complete-message and streamed-path regressions demonstrated RED before their production changes
- focused `chat-messages.test.ts`: 55/55 PASS
- full Desktop UI suite: 3,682/3,682 PASS
- Electron suite: 1,035 PASS, 2 skipped
- Desktop typecheck: PASS
- targeted ESLint: PASS with zero warnings
- production renderer/Electron build: PASS

Full-repository Desktop ESLint reports 88 existing warnings and zero errors; this two-file change introduces none.
