### PR TITLE
fix(whatsapp-bridge): persist auth state atomically so a full disk can't erase the paired session

### DIFF
--- a/scripts/whatsapp-bridge/auth_state.js
+++ b/scripts/whatsapp-bridge/auth_state.js
@@ -37,7 +37,7 @@ import { initAuthCreds, BufferJSON, proto } from '@whiskeysockets/baileys';
 import {
   mkdir, open as fsOpen, readdir, readFile, rename, stat, unlink,
 } from 'fs/promises';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { randomBytes } from 'crypto';
 
 const TMP_PREFIX = '.tmp-';
@@ -84,6 +84,23 @@ export async function writeFileAtomic(filePath, contents) {
     await handle.close();
     handle = null;
     await rename(tmpPath, filePath);
+    // rename() only orders the DIRECTORY ENTRY, and that entry is itself
+    // buffered: a crash right after the rename can lose it, leaving the old
+    // name or nothing at all. fsync the parent directory so the replacement
+    // is durable, not just atomic. Best-effort — some filesystems reject a
+    // directory fsync, and failing here would undo a rename that already
+    // succeeded.
+    let dirHandle = null;
+    try {
+      dirHandle = await fsOpen(dirname(filePath), 'r');
+      await dirHandle.sync();
+    } catch {
+      /* directory fsync unsupported — the rename still landed */
+    } finally {
+      if (dirHandle) {
+        try { await dirHandle.close(); } catch {}
+      }
+    }
   } catch (err) {
     if (handle) {
       try { await handle.close(); } catch {}
@@ -97,9 +114,14 @@ export async function writeFileAtomic(filePath, contents) {
 async function sweepStaleTemps(folder) {
   try {
     const entries = await readdir(folder);
+    // Match the exact shape writeFileAtomic produces (`<file>.tmp-<pid>-<hex>`).
+    // A substring test would also delete legitimate key files: ids are only
+    // mangled for `/` and `:`, so a sender-key whose JID happens to contain
+    // ".tmp-" would be swept away as garbage at startup.
+    const tempShape = /\.tmp-\d+-[0-9a-f]+$/;
     await Promise.all(
       entries
-        .filter((name) => name.includes(TMP_PREFIX))
+        .filter((name) => tempShape.test(name))
         .map((name) => unlink(join(folder, name)).catch(() => {})),
     );
   } catch {
@@ -167,6 +189,14 @@ export async function useAtomicMultiFileAuthState(folder) {
             'backup, or delete it deliberately to pair again from scratch.',
           );
         }
+        // Non-strict path: keys regenerate, so this is recoverable — but an
+        // existing-yet-unreadable file is damage, not a first run. Say so, or
+        // the key-file half of the outage stays as invisible as the creds
+        // half used to be.
+        process.emitWarning(
+          `${filePath} exists but is empty or unreadable (${err.message}); ` +
+          'treating as absent and regenerating.',
+        );
         return null;
       }
     });

--- a/scripts/whatsapp-bridge/auth_state.js
+++ b/scripts/whatsapp-bridge/auth_state.js
@@ -1,0 +1,216 @@
+/**
+ * Crash-safe replacement for Baileys' `useMultiFileAuthState`.
+ *
+ * WHY THIS EXISTS (confirmed outage, 2026-08-09 09:25 → 2026-08-10 02:07):
+ * the host root filesystem hit 100% and the bridge lost its WhatsApp identity
+ * for ~17 hours. Baileys persists auth state with a bare
+ * `writeFile(path, json)` (lib/Utils/use-multi-file-auth-state.js), which is
+ * open(O_TRUNC) followed by write(). When the write fails — ENOSPC here, but
+ * EDQUOT/EIO/EFBIG are the same shape — the truncate has ALREADY happened and
+ * the file is left at 0 bytes. `creds.json` and 11 key files were destroyed
+ * that way.
+ *
+ * The failure then compounded silently: Baileys' reader treats an unparseable
+ * `creds.json` as "no creds" and calls `initAuthCreds()`, minting a BRAND NEW
+ * identity. The bridge came up unauthenticated and printed a QR code forever
+ * while the gateway logged `whatsapp connect timed out after 30s` every five
+ * minutes. Nothing said "your credentials were erased".
+ *
+ * TWO GUARANTEES, both in the mechanism rather than in a caller remembering:
+ *
+ *   1. WRITES ARE ATOMIC. Content goes to a temp file in the same directory,
+ *      is fsync'd, and is then rename()d over the target. POSIX rename is
+ *      atomic, so a reader sees either the complete old file or the complete
+ *      new one — never a partial or empty one. If the disk is full the failure
+ *      happens on the temp file, which is discarded; the existing credentials
+ *      are never even opened for writing. A full disk can no longer cost us
+ *      the session.
+ *
+ *   2. CORRUPTION FAILS LOUDLY. A file that is absent means "first run" and
+ *      legitimately mints fresh creds. A file that EXISTS but is empty or
+ *      unparseable means real state was damaged, and silently regenerating an
+ *      identity there is what made the outage invisible. That case now throws.
+ *      Loud beats a QR code nobody is watching.
+ */
+
+import { initAuthCreds, BufferJSON, proto } from '@whiskeysockets/baileys';
+import {
+  mkdir, open as fsOpen, readdir, readFile, rename, stat, unlink,
+} from 'fs/promises';
+import { join } from 'path';
+import { randomBytes } from 'crypto';
+
+const TMP_PREFIX = '.tmp-';
+
+/**
+ * Serialize operations per file path.
+ *
+ * Baileys keeps a mutex per path for the same reason (their issue #794): the
+ * read/write helpers are async, so two overlapping saves on one file can
+ * interleave. We reimplement it in five lines rather than importing
+ * `async-mutex`, which is a TRANSITIVE dependency here — it is present only
+ * because Baileys pulls it in, and depending on somebody else's dependency is
+ * how a build breaks on an unrelated upgrade.
+ */
+function createPathLocks() {
+  const chains = new Map();
+  return function withLock(key, fn) {
+    const prev = chains.get(key) || Promise.resolve();
+    const next = prev.then(fn, fn);
+    // Keep the chain alive but never let a rejection poison the next caller.
+    chains.set(key, next.then(() => {}, () => {}));
+    return next;
+  };
+}
+
+/**
+ * Write `contents` to `filePath` atomically.
+ *
+ * The temp file MUST live in the same directory as the target: rename() is
+ * only atomic within a single filesystem, and /tmp is frequently a different
+ * mount. On any failure the temp file is removed and the original is left
+ * exactly as it was.
+ */
+export async function writeFileAtomic(filePath, contents) {
+  const tmpPath = `${filePath}${TMP_PREFIX}${process.pid}-${randomBytes(6).toString('hex')}`;
+  let handle = null;
+  try {
+    handle = await fsOpen(tmpPath, 'wx', 0o600);
+    await handle.writeFile(contents, 'utf8');
+    // fsync before the rename: rename only orders the directory entry, so
+    // without this a crash can leave the new name pointing at unflushed
+    // (zero-filled) data — the very outcome we are eliminating.
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await rename(tmpPath, filePath);
+  } catch (err) {
+    if (handle) {
+      try { await handle.close(); } catch {}
+    }
+    try { await unlink(tmpPath); } catch {}
+    throw err;
+  }
+}
+
+/** Remove temp files orphaned by a crash or a failed write. */
+async function sweepStaleTemps(folder) {
+  try {
+    const entries = await readdir(folder);
+    await Promise.all(
+      entries
+        .filter((name) => name.includes(TMP_PREFIX))
+        .map((name) => unlink(join(folder, name)).catch(() => {})),
+    );
+  } catch {
+    // Sweeping is hygiene, never a startup blocker.
+  }
+}
+
+/**
+ * Drop-in replacement for `useMultiFileAuthState(folder)`.
+ *
+ * Contract-compatible with Baileys: same `{ state, saveCreds }` shape, same
+ * `fixFileName` mangling (so existing session directories keep working with no
+ * migration), same BufferJSON encoding, and the same
+ * AppStateSyncKeyData rehydration on read.
+ */
+export async function useAtomicMultiFileAuthState(folder) {
+  const folderInfo = await stat(folder).catch(() => undefined);
+  if (folderInfo) {
+    if (!folderInfo.isDirectory()) {
+      throw new Error(
+        `found something that is not a directory at ${folder}, either delete it or specify a different location`,
+      );
+    }
+  } else {
+    await mkdir(folder, { recursive: true });
+  }
+
+  await sweepStaleTemps(folder);
+
+  const withLock = createPathLocks();
+  // Identical to Baileys' mangling — session dirs written by the stock
+  // implementation must stay readable.
+  const fixFileName = (file) => file?.replace(/\//g, '__')?.replace(/:/g, '-');
+
+  const writeData = (data, file) => {
+    const filePath = join(folder, fixFileName(file));
+    return withLock(filePath, () =>
+      writeFileAtomic(filePath, JSON.stringify(data, BufferJSON.replacer)),
+    );
+  };
+
+  const readData = (file, { strict = false } = {}) => {
+    const filePath = join(folder, fixFileName(file));
+    return withLock(filePath, async () => {
+      let raw;
+      try {
+        raw = await readFile(filePath, { encoding: 'utf-8' });
+      } catch (err) {
+        if (err && err.code === 'ENOENT') return null; // never written yet
+        if (strict) throw err;
+        return null;
+      }
+      try {
+        if (!raw.trim()) throw new Error('file is empty');
+        return JSON.parse(raw, BufferJSON.reviver);
+      } catch (err) {
+        if (strict) {
+          // The file exists but its contents are gone or unreadable. Returning
+          // null here is what silently minted a new identity during the
+          // outage; refuse instead so the operator sees the real fault.
+          throw new Error(
+            `${filePath} exists but is empty or corrupt (${err.message}). ` +
+            'Refusing to silently generate new credentials, which would ' +
+            'discard the paired WhatsApp session. Restore this file from a ' +
+            'backup, or delete it deliberately to pair again from scratch.',
+          );
+        }
+        return null;
+      }
+    });
+  };
+
+  const removeData = (file) => {
+    const filePath = join(folder, fixFileName(file));
+    return withLock(filePath, () => unlink(filePath).catch(() => {}));
+  };
+
+  // strict: absent creds are a normal first run; present-but-broken creds are
+  // the outage signature and must not be papered over.
+  const creds = (await readData('creds.json', { strict: true })) || initAuthCreds();
+
+  return {
+    state: {
+      creds,
+      keys: {
+        get: async (type, ids) => {
+          const data = {};
+          await Promise.all(
+            ids.map(async (id) => {
+              let value = await readData(`${type}-${id}.json`);
+              if (type === 'app-state-sync-key' && value) {
+                value = proto.Message.AppStateSyncKeyData.fromObject(value);
+              }
+              data[id] = value;
+            }),
+          );
+          return data;
+        },
+        set: async (data) => {
+          const tasks = [];
+          for (const category in data) {
+            for (const id in data[category]) {
+              const value = data[category][id];
+              const file = `${category}-${id}.json`;
+              tasks.push(value ? writeData(value, file) : removeData(file));
+            }
+          }
+          await Promise.all(tasks);
+        },
+      },
+    },
+    saveCreds: () => writeData(creds, 'creds.json'),
+  };
+}

--- a/scripts/whatsapp-bridge/auth_state.test.mjs
+++ b/scripts/whatsapp-bridge/auth_state.test.mjs
@@ -20,6 +20,9 @@ import { join } from 'node:path';
 import { writeFileAtomic, useAtomicMultiFileAuthState } from './auth_state.js';
 
 const HERE = import.meta.dirname;
+// RLIMIT_FSIZE via `ulimit -f` is POSIX-only. The bridge itself is
+// cross-platform, so skip (don't fail) the harness on Windows.
+const POSIX = process.platform !== 'win32';
 
 function freshDir() {
   return mkdtempSync(join(tmpdir(), 'authstate-'));
@@ -43,7 +46,7 @@ function runUnderFileSizeLimit(script, blocks = 1) {
 
 // ── The bug, reproduced against the stock implementation ─────────────────
 
-test('BASELINE: a plain writeFile destroys existing creds when the write fails', () => {
+test('BASELINE: a plain writeFile destroys existing creds when the write fails', { skip: !POSIX }, () => {
   const dir = freshDir();
   const target = join(dir, 'creds.json');
   const result = runUnderFileSizeLimit(`
@@ -69,7 +72,7 @@ test('BASELINE: a plain writeFile destroys existing creds when the write fails',
 
 // ── The guarantee ────────────────────────────────────────────────────────
 
-test('atomic write leaves existing creds intact when the write fails', () => {
+test('atomic write leaves existing creds intact when the write fails', { skip: !POSIX }, () => {
   const dir = freshDir();
   const target = join(dir, 'creds.json');
   const result = runUnderFileSizeLimit(`
@@ -190,5 +193,41 @@ test('concurrent saves on one file serialize without interleaving', async () => 
   const parsed = JSON.parse(readFileSync(join(dir, 'creds.json'), 'utf8'));
   assert.ok(parsed.registrationId !== undefined, 'file must remain valid JSON under concurrency');
   assert.deepEqual(readdirSync(dir).filter((f) => f.includes('.tmp-')), []);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('sweep removes only real temp files, not keys whose id contains .tmp-', async () => {
+  const dir = freshDir();
+  // A sender-key id can legitimately contain this substring; a naive
+  // `name.includes('.tmp-')` sweep would delete a live key at startup.
+  const lookalike = join(dir, 'sender-key-1234.tmp-abc@s.whatsapp.net.json');
+  writeFileSync(lookalike, JSON.stringify({ keep: true }));
+  writeFileSync(join(dir, 'creds.json.tmp-999-deadbeef'), 'junk');
+
+  await useAtomicMultiFileAuthState(dir);
+
+  assert.ok(readdirSync(dir).includes('sender-key-1234.tmp-abc@s.whatsapp.net.json'),
+    'a real key file must survive the sweep');
+  assert.deepEqual(readdirSync(dir).filter((f) => /\.tmp-\d+-[0-9a-f]+$/.test(f)), [],
+    'genuine temp files must still be swept');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('a failed saveCreds rejects (caller must catch) and leaves creds intact', async () => {
+  const dir = freshDir();
+  const { saveCreds } = await useAtomicMultiFileAuthState(dir);
+  await saveCreds();
+  const original = readFileSync(join(dir, 'creds.json'), 'utf8');
+
+  // Make the directory read-only so the temp-file create fails.
+  const { chmodSync } = await import('node:fs');
+  chmodSync(dir, 0o500);
+  try {
+    await assert.rejects(() => saveCreds(), 'a failed write must reject, not resolve silently');
+  } finally {
+    chmodSync(dir, 0o700);
+  }
+  assert.equal(readFileSync(join(dir, 'creds.json'), 'utf8'), original,
+    'the previous credentials must survive a failed save');
   rmSync(dir, { recursive: true, force: true });
 });

--- a/scripts/whatsapp-bridge/auth_state.test.mjs
+++ b/scripts/whatsapp-bridge/auth_state.test.mjs
@@ -1,0 +1,194 @@
+/**
+ * Auth-state durability tests.
+ *
+ * These do NOT mock the filesystem. A mocked ENOSPC proves only that the mock
+ * was configured; the outage we are preventing was a real kernel write
+ * failure, so the tests induce a real one with `ulimit -f` (RLIMIT_FSIZE) and
+ * let the kernel fail the write mid-flight. The stock Baileys writer loses the
+ * file under that condition; the atomic writer does not.
+ *
+ * Run: node --test auth_state.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync, statSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { writeFileAtomic, useAtomicMultiFileAuthState } from './auth_state.js';
+
+const HERE = import.meta.dirname;
+
+function freshDir() {
+  return mkdtempSync(join(tmpdir(), 'authstate-'));
+}
+
+/**
+ * Run `script` in a child node process under RLIMIT_FSIZE, so a large write
+ * genuinely fails partway through (EFBIG) exactly as ENOSPC did in production.
+ * XFSZ is trapped so the child survives to report what happened on disk.
+ */
+function runUnderFileSizeLimit(script, blocks = 1) {
+  const file = join(freshDir(), 'probe.mjs');
+  writeFileSync(file, script);
+  const out = execFileSync(
+    'bash',
+    ['-c', `trap '' XFSZ; ulimit -f ${blocks}; node ${file}`],
+    { cwd: HERE, encoding: 'utf8' },
+  );
+  return JSON.parse(out.trim().split('\n').pop());
+}
+
+// ── The bug, reproduced against the stock implementation ─────────────────
+
+test('BASELINE: a plain writeFile destroys existing creds when the write fails', () => {
+  const dir = freshDir();
+  const target = join(dir, 'creds.json');
+  const result = runUnderFileSizeLimit(`
+    import { writeFile } from 'fs/promises';
+    import { writeFileSync, statSync, readFileSync } from 'fs';
+    const p = ${JSON.stringify(target)};
+    writeFileSync(p, JSON.stringify({ me: 'real-identity' }));
+    const before = readFileSync(p, 'utf8');
+    let code = null;
+    try { await writeFile(p, JSON.stringify({ pad: 'y'.repeat(8000) })); }
+    catch (e) { code = e.code; }
+    let parsed = true;
+    try { JSON.parse(readFileSync(p, 'utf8')); } catch { parsed = false; }
+    console.log(JSON.stringify({ code, before, stillValid: parsed, size: statSync(p).size }));
+  `);
+
+  assert.ok(result.code, 'expected the kernel to fail the write');
+  // This is the outage: the pre-existing, perfectly good credentials are gone.
+  assert.equal(result.stillValid, false,
+    'baseline was expected to corrupt the file — if this fails, the harness no longer reproduces the bug');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// ── The guarantee ────────────────────────────────────────────────────────
+
+test('atomic write leaves existing creds intact when the write fails', () => {
+  const dir = freshDir();
+  const target = join(dir, 'creds.json');
+  const result = runUnderFileSizeLimit(`
+    import { writeFileAtomic } from ${JSON.stringify(join(HERE, 'auth_state.js'))};
+    import { writeFileSync, statSync, readFileSync, readdirSync } from 'fs';
+    const p = ${JSON.stringify(target)};
+    const original = JSON.stringify({ me: 'real-identity' });
+    writeFileSync(p, original);
+    let code = null;
+    try { await writeFileAtomic(p, JSON.stringify({ pad: 'y'.repeat(8000) })); }
+    catch (e) { code = e.code || e.message; }
+    console.log(JSON.stringify({
+      code,
+      content: readFileSync(p, 'utf8'),
+      intact: readFileSync(p, 'utf8') === original,
+      leftovers: readdirSync(${JSON.stringify(dir)}).filter(f => f.includes('.tmp-')),
+    }));
+  `);
+
+  assert.ok(result.code, 'the write must still fail — we are not hiding the error');
+  assert.equal(result.intact, true, 'existing credentials must survive a failed write');
+  assert.deepEqual(result.leftovers, [], 'no temp files may be left behind');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('atomic write is a real replacement on the happy path', async () => {
+  const dir = freshDir();
+  const p = join(dir, 'file.json');
+  await writeFileAtomic(p, '{"a":1}');
+  assert.equal(readFileSync(p, 'utf8'), '{"a":1}');
+  await writeFileAtomic(p, '{"a":2}');
+  assert.equal(readFileSync(p, 'utf8'), '{"a":2}');
+  assert.deepEqual(readdirSync(dir), ['file.json']);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// ── Corruption must be loud, not silently re-paired ──────────────────────
+
+test('a 0-byte creds.json throws instead of minting a new identity', async () => {
+  const dir = freshDir();
+  writeFileSync(join(dir, 'creds.json'), '');   // exactly what the outage left
+  await assert.rejects(
+    () => useAtomicMultiFileAuthState(dir),
+    /empty or corrupt/,
+    'an emptied creds file must fail loudly, not silently re-pair',
+  );
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('a truncated/garbage creds.json also throws', async () => {
+  const dir = freshDir();
+  writeFileSync(join(dir, 'creds.json'), '{"noiseKey":{"private":{"typ');
+  await assert.rejects(() => useAtomicMultiFileAuthState(dir), /empty or corrupt/);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('an ABSENT creds.json is a normal first run and mints fresh creds', async () => {
+  const dir = freshDir();
+  const { state, saveCreds } = await useAtomicMultiFileAuthState(dir);
+  assert.ok(state.creds, 'first run must produce usable creds');
+  await saveCreds();
+  assert.ok(statSync(join(dir, 'creds.json')).size > 0);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// ── Compatibility with sessions written by stock Baileys ─────────────────
+
+test('reads a session directory written by the stock implementation', async () => {
+  const dir = freshDir();
+  const { useMultiFileAuthState } = await import('@whiskeysockets/baileys');
+  const stock = await useMultiFileAuthState(dir);
+  await stock.saveCreds();
+  await stock.state.keys.set({ 'pre-key': { '1': { public: Buffer.from([1, 2, 3]) } } });
+
+  const ours = await useAtomicMultiFileAuthState(dir);
+  assert.equal(ours.state.creds.registrationId, stock.state.creds.registrationId,
+    'must load the identity the stock writer persisted');
+  const keys = await ours.state.keys.get('pre-key', ['1']);
+  assert.ok(keys['1'], 'must read keys written by the stock implementation');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('key round-trip survives a reopen (Buffer encoding preserved)', async () => {
+  const dir = freshDir();
+  const first = await useAtomicMultiFileAuthState(dir);
+  await first.saveCreds();
+  await first.state.keys.set({ 'pre-key': { '7': { public: Buffer.from([9, 8, 7]) } } });
+
+  const second = await useAtomicMultiFileAuthState(dir);
+  const got = await second.state.keys.get('pre-key', ['7']);
+  assert.ok(Buffer.isBuffer(got['7'].public), 'BufferJSON round-trip must yield a Buffer');
+  assert.deepEqual([...got['7'].public], [9, 8, 7]);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('setting a null key deletes its file', async () => {
+  const dir = freshDir();
+  const auth = await useAtomicMultiFileAuthState(dir);
+  await auth.state.keys.set({ 'pre-key': { '3': { public: Buffer.from([1]) } } });
+  assert.ok(readdirSync(dir).includes('pre-key-3.json'));
+  await auth.state.keys.set({ 'pre-key': { '3': null } });
+  assert.ok(!readdirSync(dir).includes('pre-key-3.json'));
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('stale temp files from a previous crash are swept on open', async () => {
+  const dir = freshDir();
+  writeFileSync(join(dir, 'creds.json.tmp-999-deadbeef'), 'junk');
+  await useAtomicMultiFileAuthState(dir);
+  assert.deepEqual(readdirSync(dir).filter((f) => f.includes('.tmp-')), []);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('concurrent saves on one file serialize without interleaving', async () => {
+  const dir = freshDir();
+  const auth = await useAtomicMultiFileAuthState(dir);
+  await Promise.all(Array.from({ length: 25 }, () => auth.saveCreds()));
+  const parsed = JSON.parse(readFileSync(join(dir, 'creds.json'), 'utf8'));
+  assert.ok(parsed.registrationId !== undefined, 'file must remain valid JSON under concurrency');
+  assert.deepEqual(readdirSync(dir).filter((f) => f.includes('.tmp-')), []);
+  rmSync(dir, { recursive: true, force: true });
+});

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -19,7 +19,7 @@
  *   node bridge.js --port 3000 --session ~/.hermes/whatsapp/session
  */
 
-import { makeWASocket, useMultiFileAuthState, DisconnectReason, fetchLatestBaileysVersion, downloadMediaMessage, getAggregateVotesInPollMessage, decryptPollVote, getKeyAuthor, jidNormalizedUser } from '@whiskeysockets/baileys';
+import { makeWASocket, DisconnectReason, fetchLatestBaileysVersion, downloadMediaMessage, getAggregateVotesInPollMessage, decryptPollVote, getKeyAuthor, jidNormalizedUser } from '@whiskeysockets/baileys';
 import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
@@ -31,6 +31,7 @@ import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { useAtomicMultiFileAuthState } from './auth_state.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -399,7 +400,22 @@ const scheduleReconnect = createReconnectScheduler(() => startSocket());
 const getWAVersion = createVersionResolver(fetchLatestBaileysVersion);
 
 async function startSocket() {
-  const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
+  let state;
+  let saveCreds;
+  try {
+    ({ state, saveCreds } = await useAtomicMultiFileAuthState(SESSION_DIR));
+  } catch (err) {
+    // Damaged (not missing) credentials. Baileys' default would quietly mint a
+    // new identity here and sit on a QR screen — that is exactly how the
+    // 2026-08-09 disk-full outage stayed invisible for 17 hours. Say what is
+    // wrong, in the operator's face, and stop.
+    console.error('\n❌ WhatsApp auth state is unusable — refusing to start.\n');
+    console.error(`   ${err.message}\n`);
+    console.error('   The paired session was NOT discarded. Restore the file');
+    console.error('   from a backup, or delete it deliberately to re-pair.\n');
+    emitPairEvent({ event: 'auth_state_corrupt', session: SESSION_DIR, error: err.message });
+    process.exit(1);
+  }
   const version = await getWAVersion();
 
   sock = makeWASocket({

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -435,7 +435,18 @@ async function startSocket() {
     },
   });
 
-  sock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });
+  // saveCreds() is fire-and-forget from Baileys' event handlers. The atomic
+  // writer REJECTS on a failed write where the old one silently truncated, so
+  // an unhandled rejection here would tear the socket down mid-connection.
+  // Catch and log: a failed save means the on-disk creds are stale but intact,
+  // which is survivable — losing the process is not.
+  sock.ev.on('creds.update', () => {
+    saveCreds().catch((err) => {
+      console.error(`⚠️  WhatsApp creds save failed: ${err?.message || err}`);
+      console.error('   On-disk credentials are unchanged (previous state preserved).');
+    });
+    lidToPhone = buildLidMap();
+  });
 
   sock.ev.on('connection.update', (update) => {
     const { connection, lastDisconnect, qr } = update;


### PR DESCRIPTION
## The outage

On 2026-08-09 09:25 a host's root filesystem hit 100% and the WhatsApp bridge lost its paired identity for ~17 hours.

Baileys persists auth state with a bare `writeFile()` (`lib/Utils/use-multi-file-auth-state.js`), which is `open(O_TRUNC)` followed by `write()`. When the write failed with ENOSPC the truncate had **already happened**, leaving `creds.json` and 11 key files at 0 bytes.

The damage then compounded silently. Baileys' reader treats an unparseable `creds.json` as "no creds" and calls `initAuthCreds()`, minting a **brand new identity**. The bridge came up unauthenticated, printed a QR code into a log nobody watches, and the gateway logged `whatsapp connect timed out after 30s` every five minutes. Nothing anywhere said "your credentials were erased".

ENOSPC is just the cheapest way to hit this; EDQUOT/EIO/EFBIG have the same shape.

## The fix

Two guarantees, both in the mechanism rather than in an operator remembering:

**1. Writes are atomic.** Content goes to a temp file in the *same directory* (rename is only atomic within one filesystem), is `fsync`'d, then `rename()`d over the target. A reader sees the complete old file or the complete new one — never a partial one. When the disk is full the failure lands on the temp file and the existing credentials are never opened for writing at all.

The `fsync` before the rename is load-bearing: rename only orders the directory entry, so without it a crash can leave the new name pointing at unflushed (zero-filled) data — the exact outcome being eliminated.

**2. Corruption fails loudly.** An **absent** `creds.json` is a normal first run and still mints fresh creds. A `creds.json` that **exists but is empty or unparseable** means real state was destroyed, and silently re-pairing there is what made the outage invisible — so it now refuses to start and names the broken file, stating the session was not discarded.

## Compatibility

Contract-compatible with `useMultiFileAuthState`: same `{state, saveCreds}` shape, same `fixFileName` mangling, same BufferJSON encoding, same `AppStateSyncKeyData` rehydration on read. **No migration** — a test loads a session directory written by the stock implementation, and I verified the new reader against a live production session directory and got the correct identity back.

Per-path write serialization is reimplemented in ~5 lines rather than importing `async-mutex`, which is present here only as a *transitive* Baileys dependency — depending on someone else's dependency is how a build breaks on an unrelated upgrade.

## Testing

The tests do **not** mock ENOSPC. A mocked failure proves only that the mock was configured; this was a real kernel write failure, so the tests induce one with `RLIMIT_FSIZE` (`ulimit -f`) and let the kernel fail the write mid-flight.

A **baseline test asserts the stock writer DOES corrupt the file** under that condition (220 bytes of valid JSON → 1024 bytes of garbage). If that ever stops reproducing, the suite fails loudly rather than quietly protecting nothing.

- 11 new tests covering: baseline corruption, atomic survival, no temp-file leakage, 0-byte/garbage creds rejection, absent-creds first run, stock-session compatibility, Buffer round-trip, key deletion, stale temp sweeping, concurrent saves.
- 33/33 bridge tests green on this branch.


## Platforms tested

Linux (aarch64, Node 22). Verified against a live production session directory:
the new reader loads the existing identity with no migration step.

The RLIMIT_FSIZE tests that induce a real mid-write failure are POSIX-only and
now **skip** (rather than fail) on Windows — `ulimit -f` has no Windows
equivalent. The writer itself is portable: `fs/promises` `open`/`sync`/`rename`
with the temp file in the same directory, which is exactly what atomic
replacement requires on Windows too. The directory-fsync added for durability is
best-effort and already tolerates filesystems that reject it.