### PR TITLE
feat(cron): support opt-in multi-message Slack delivery for sectioned output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1602,6 +1602,174 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+_MAX_SECTION_MESSAGES = 8
+_SECTION_HEADING_RE = re.compile(
+    r"(?:\*[^*\n]+\*|_[^_\n]+_|#{1,3}\s+\S.*)\s*$"
+)
+
+
+def _split_section_messages(content: str) -> list[str]:
+    """Split conservative top-level report sections without touching code fences.
+
+    This parser deliberately accepts only heading-only Slack emphasis lines and
+    Markdown H1--H3 lines.  Anything without at least two usable sections, or
+    a report that would create an accidental message burst, remains one payload.
+    """
+    if not isinstance(content, str) or not content.strip():
+        return [content]
+
+    lines = content.splitlines(keepends=True)
+    headings: list[int] = []
+    fence: Optional[tuple[str, int]] = None
+    for index, line in enumerate(lines):
+        fence_match = re.match(r"\s*(([`~])\2{2,})", line)
+        if fence_match:
+            marker = fence_match.group(1)
+            marker_char = fence_match.group(2)
+            if fence is None:
+                fence = (marker_char, len(marker))
+            elif marker_char == fence[0] and len(marker) >= fence[1]:
+                fence = None
+            continue
+        if fence is None and _SECTION_HEADING_RE.fullmatch(line.rstrip("\r\n")):
+            headings.append(index)
+
+    if len(headings) < 2 or len(headings) > _MAX_SECTION_MESSAGES:
+        return [content]
+
+    sections: list[str] = []
+    preamble = "".join(lines[:headings[0]])
+    for position, start in enumerate(headings):
+        end = headings[position + 1] if position + 1 < len(headings) else len(lines)
+        segment = (preamble if position == 0 else "") + "".join(lines[start:end])
+        segment = segment.strip()
+        if segment:
+            sections.append(segment)
+
+    return sections if 2 <= len(sections) <= _MAX_SECTION_MESSAGES else [content]
+
+
+def _deliver_sectioned_slack_payloads(
+    *,
+    job: dict,
+    platform,
+    platform_name: str,
+    pconfig,
+    config,
+    adapters,
+    runtime_adapter,
+    loop,
+    chat_id: str,
+    thread_id: Optional[str],
+    payloads: list[str],
+    transport,
+) -> Optional[str]:
+    """Deliver Slack sections in order without retrying an aggregate payload.
+
+    A section whose live send never dispatched may use the existing standalone
+    transport.  An in-flight confirmation timeout is intentionally terminal:
+    re-sending could duplicate that section after earlier sections succeeded.
+    """
+    from tools.send_message_tool import _send_to_platform
+
+    confirmed = 0
+    live_ready = runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)()
+    router = route_target = route_metadata = None
+    if live_ready:
+        from gateway.delivery import DeliveryRouter, DeliveryTarget
+        router = DeliveryRouter(config, adapters)
+        route_target = DeliveryTarget(
+            platform=platform, chat_id=str(chat_id),
+            thread_id=str(thread_id) if thread_id is not None else None, is_explicit=True,
+        )
+        route_metadata = {"job_id": job["id"]}
+        if thread_id:
+            route_metadata["thread_id"] = str(thread_id)
+
+    def incomplete(reason: str) -> str:
+        return (
+            f"section delivery incomplete: {confirmed}/{len(payloads)} confirmed for "
+            f"{platform_name}:{chat_id}; {reason}"
+        )
+
+    for section_number, payload in enumerate(payloads, start=1):
+        fallback_needed = not live_ready
+        if live_ready:
+            assert router is not None and route_target is not None and route_metadata is not None
+            from agent.async_utils import safe_schedule_threadsafe
+            future = safe_schedule_threadsafe(
+                router._deliver_to_platform(route_target, payload, route_metadata), loop,
+            )
+            if future is None:
+                fallback_needed = True
+            else:
+                try:
+                    send_result = future.result(timeout=60)
+                except TimeoutError:
+                    if not future.cancel():
+                        return incomplete(
+                            f"section {section_number} was dispatched but confirmation is uncertain; not retried"
+                        )
+                    fallback_needed = True
+                except Exception as exc:
+                    logger.warning(
+                        "Job '%s': live section %s send to %s:%s failed: %s",
+                        job["id"], section_number, platform_name, chat_id, exc,
+                    )
+                    fallback_needed = True
+                else:
+                    if isinstance(send_result, dict):
+                        send_success = bool(send_result.get("success", False))
+                    else:
+                        send_success = _confirm_adapter_delivery(send_result)
+                    if send_success:
+                        confirmed += 1
+                        continue
+                    fallback_needed = True
+
+        if fallback_needed:
+            if transport is not None and transport.is_relay:
+                return incomplete(
+                    f"section {section_number} could not be confirmed through relay transport"
+                )
+            if _interpreter_shutting_down():
+                return incomplete(f"section {section_number} skipped — interpreter is shutting down")
+            coro = _send_to_platform(
+                platform, pconfig, chat_id, payload, thread_id=thread_id, media_files=[]
+            )
+            try:
+                result = asyncio.run(coro)
+            except RuntimeError as run_err:
+                # Match the aggregate path: an already-running event loop means
+                # this coroutine was never started, so close it and retry only
+                # this section in a fresh thread.
+                coro.close()
+                if _interpreter_shutting_down(run_err):
+                    return incomplete(f"section {section_number} skipped — interpreter is shutting down")
+                try:
+                    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                    try:
+                        future = pool.submit(
+                            asyncio.run,
+                            _send_to_platform(
+                                platform, pconfig, chat_id, payload,
+                                thread_id=thread_id, media_files=[],
+                            ),
+                        )
+                        result = future.result(timeout=30)
+                    finally:
+                        pool.shutdown(wait=False)
+                except Exception as exc:
+                    return incomplete(f"section {section_number} fallback failed: {exc}")
+            except Exception as exc:
+                return incomplete(f"section {section_number} fallback failed: {exc}")
+            if result and result.get("error"):
+                return incomplete(f"section {section_number} fallback failed: {result['error']}")
+            confirmed += 1
+
+    return None
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -1873,6 +2041,68 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # and (worse) suppresses the DM-fallback mirror via thread_seeded.
                 thread_id = new_thread_id
                 opened_thread_id = new_thread_id
+
+        # Opt-in Slack-only section delivery.  Build the payloads after target
+        # and continuation routing are resolved so every send uses the same
+        # logical platform, channel, and thread.  MEDIA delivery stays on the
+        # existing aggregate path to preserve one attachment transaction.
+        split_payloads = [cleaned_delivery_content.strip()]
+        split_requested = (
+            user_cfg is not None
+            and isinstance(user_cfg.get("cron", {}), dict)
+            and user_cfg.get("cron", {}).get("split_section_messages") is True
+            and not wrap_response
+            and platform == Platform.SLACK
+            and not media_files
+        )
+        if split_requested:
+            split_payloads = _split_section_messages(cleaned_delivery_content.strip())
+        if len(split_payloads) > 1:
+            section_error = _deliver_sectioned_slack_payloads(
+                job=job,
+                platform=platform,
+                platform_name=platform_name,
+                pconfig=pconfig,
+                config=config,
+                adapters=adapters,
+                runtime_adapter=runtime_adapter,
+                loop=loop,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                payloads=split_payloads,
+                transport=transport,
+            )
+            if section_error:
+                logger.warning("Job '%s': %s", job["id"], section_error)
+                delivery_errors.append(section_error)
+                continue
+
+            logger.info(
+                "Job '%s': delivered %s sections to %s:%s",
+                job["id"], len(split_payloads), platform_name, chat_id,
+            )
+            # The combined clean result is the continuation record.  Section
+            # sends are transport detail, not separate conversation turns.
+            if opened_thread_id and not thread_seeded:
+                _seed_cron_thread_session(
+                    job, runtime_adapter, platform_name, chat_id,
+                    opened_thread_id, mirror_text,
+                    chat_name=origin.get("chat_name"),
+                )
+                thread_seeded = True
+            if in_channel_surface and mirror_this_target and not thread_seeded:
+                inchannel_seeded = _seed_cron_channel_session(
+                    job, runtime_adapter, platform_name, chat_id,
+                    mirror_text, is_dm=is_dm_target,
+                    user_id=origin_user_id,
+                    chat_name=origin.get("chat_name"),
+                )
+            _maybe_mirror_cron_delivery(
+                job, platform_name, chat_id, mirror_text,
+                thread_id=thread_id, user_id=origin_user_id,
+                enabled=mirror_this_target and not thread_seeded and not inchannel_seeded,
+            )
+            continue
 
         if live_adapter_ready:
             # Telegram topic routing (#22773, regression fixed #52060): a

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2287,6 +2287,9 @@ DEFAULT_CONFIG = {
         # Wrap delivered cron responses with a header (task name) and footer
         # ("The agent cannot see this message").  Set to false for clean output.
         "wrap_response": True,
+        # Deliver recognized top-level sections as sequential Slack messages.
+        # Default off preserves the historic one-result/one-message contract.
+        "split_section_messages": False,
         # Make cron deliveries CONTINUABLE: a user can reply to a cron brief
         # and the agent has it in context (no "what is Task #2?" amnesia).
         # Default False preserves the historical isolation guarantee (cron

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, _split_section_messages, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -284,6 +284,145 @@ class TestDeliverResultWrapping:
         assert "-------------" in sent_content
         assert "Here is today's summary." in sent_content
         assert "To stop or manage this job" in sent_content
+
+
+class TestCronSlackSectionDelivery:
+    def _safe_media_path(self, tmp_path, monkeypatch, name, data=b"media"):
+        root = tmp_path / "media-cache"
+        media_file = root / name
+        media_file.parent.mkdir(parents=True, exist_ok=True)
+        media_file.write_bytes(data)
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (root,),
+        )
+        return media_file.resolve()
+
+    def _slack_config(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        config = MagicMock()
+        config.platforms = {Platform.SLACK: pconfig}
+        return config
+
+    def test_parser_preserves_preamble_and_ignores_code_fences(self):
+        content = (
+            "Preamble\n"
+            "*Report*\nhealthy\n"
+            "```\n*not a heading*\n```\n"
+            "~~~\n*also not a heading*\n~~~\n"
+            "````\n```\n*still not a heading*\n````\n"
+            "## Actions\nreview approval\n"
+        )
+        assert _split_section_messages(content) == [
+            "Preamble\n*Report*\nhealthy\n```\n*not a heading*\n```\n~~~\n*also not a heading*\n~~~\n````\n```\n*still not a heading*\n````",
+            "## Actions\nreview approval",
+        ]
+
+    def test_parser_falls_back_for_no_or_excessive_sections(self):
+        plain = "ordinary report\nwith no boundary"
+        assert _split_section_messages(plain) == [plain]
+        excessive = "\n".join(f"*S{n}*\nbody" for n in range(9))
+        assert _split_section_messages(excessive) == [excessive]
+
+    def test_enabled_slack_sends_ordered_sections_to_same_thread(self):
+        from gateway.config import Platform
+
+        sent = AsyncMock(return_value={"success": True})
+        job = {"id": "sections", "deliver": "slack:C01234567:1700000000.000100"}
+        content = "Preamble\n*Report*\nhealthy\n*Actions*\nreview approval"
+        with (
+            patch("gateway.config.load_gateway_config", return_value=self._slack_config()),
+            patch("cron.scheduler.load_config", return_value={"cron": {
+                "wrap_response": False, "split_section_messages": True,
+            }}),
+            patch("tools.send_message_tool._send_to_platform", new=sent),
+        ):
+            assert _deliver_result(job, content) is None
+
+        assert sent.await_count == 2
+        assert [call.args[3] for call in sent.await_args_list] == [
+            "Preamble\n*Report*\nhealthy", "*Actions*\nreview approval",
+        ]
+        assert all(call.args[0] == Platform.SLACK for call in sent.await_args_list)
+        assert all(call.args[2] == "C01234567" for call in sent.await_args_list)
+        assert all(call.kwargs["thread_id"] == "1700000000.000100" for call in sent.await_args_list)
+
+    def test_default_off_and_non_slack_stay_single_message(self):
+        from gateway.config import Platform
+
+        for deliver, config in [
+            ("slack:C123", {"cron": {"wrap_response": False}}),
+            ("telegram:123", {"cron": {"wrap_response": False, "split_section_messages": True}}),
+        ]:
+            pconfig = MagicMock()
+            pconfig.enabled = True
+            gateway_config = MagicMock()
+            gateway_config.platforms = {Platform(deliver.split(":", 1)[0]): pconfig}
+            sent = AsyncMock(return_value={"success": True})
+            with (
+                patch("gateway.config.load_gateway_config", return_value=gateway_config),
+                patch("cron.scheduler.load_config", return_value=config),
+                patch("tools.send_message_tool._send_to_platform", new=sent),
+            ):
+                assert _deliver_result({"id": deliver, "deliver": deliver}, "*One*\na\n*Two*\nb") is None
+            sent.assert_awaited_once()
+
+    def test_media_delivery_stays_aggregate(self, tmp_path, monkeypatch):
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "report.mp3")
+        sent = AsyncMock(return_value={"success": True})
+        content = f"*One*\na\nMEDIA:{media_path}\n*Two*\nb"
+        with (
+            patch("gateway.config.load_gateway_config", return_value=self._slack_config()),
+            patch("cron.scheduler.load_config", return_value={"cron": {
+                "wrap_response": False, "split_section_messages": True,
+            }}),
+            patch("tools.send_message_tool._send_to_platform", new=sent),
+        ):
+            assert _deliver_result({"id": "media", "deliver": "slack:C01234567"}, content) is None
+
+        sent.assert_awaited_once()
+        assert sent.await_args is not None
+        assert sent.await_args.kwargs["media_files"]
+
+    def test_live_timeout_after_second_section_reports_partial_without_resend(self):
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        first = Future()
+        first.set_result(MagicMock(success=True))
+        second = Future()
+        second.result = MagicMock(side_effect=TimeoutError("timed out"))
+        second.cancel = MagicMock(return_value=False)
+        futures = iter([first, second])
+
+        def fake_schedule(coro, _loop):
+            coro.close()
+            return next(futures)
+
+        standalone = AsyncMock(return_value={"success": True})
+        with (
+            patch("gateway.config.load_gateway_config", return_value=self._slack_config()),
+            patch("cron.scheduler.load_config", return_value={"cron": {
+                "wrap_response": False, "split_section_messages": True,
+            }}),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=fake_schedule),
+            patch("tools.send_message_tool._send_to_platform", new=standalone),
+        ):
+            result = _deliver_result(
+                {"id": "partial", "deliver": "slack:C123"}, "*One*\na\n*Two*\nb",
+                adapters={Platform.SLACK: adapter}, loop=loop,
+            )
+
+        assert result is not None
+        assert "section delivery incomplete: 1/2 confirmed" in result
+        assert "not retried" in result
+        standalone.assert_not_awaited()
 
 
     def test_relay_fronted_home_uses_relay_config_and_live_adapter(self, monkeypatch, tmp_path):

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -267,6 +267,22 @@ By default (`cron.wrap_response: true`), cron deliveries are wrapped with:
 
 The `[SILENT]` prefix in a cron response suppresses delivery entirely — useful for jobs that only need to write to files or perform side effects.
 
+### Opt-in Slack section delivery
+
+Set `cron.split_section_messages: true` together with `cron.wrap_response: false`
+to deliver a Slack cron result with two or more recognized top-level sections as
+ordered messages in the same resolved channel and thread. Recognized boundaries
+are Slack emphasis-only heading lines (`*Heading*` or `_Heading_`) and Markdown
+H1--H3 lines. Code fences are ignored. This is delivery-time segmentation of one
+cron execution and one model result; it does not create another gateway, job, or
+model call.
+
+The option is default-off, applies only to Slack text-only deliveries, and falls
+back to one message for malformed/no/excessive sections. Media and non-Slack
+deliveries retain their aggregate delivery behavior. If a later section cannot
+be confirmed, the scheduler reports partial delivery and does not resend the
+combined result.
+
 ### Session Isolation
 
 Cron deliveries are NOT mirrored into gateway session conversation history. They exist only in the cron job's own session. This prevents message alternation violations in the target chat's conversation.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -372,6 +372,25 @@ cron:
   wrap_response: false
 ```
 
+### Sectioned Slack delivery
+
+For reports that need separate Slack messages per top-level section, opt in with
+both settings below:
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  wrap_response: false
+  split_section_messages: true
+```
+
+One cron execution and one model response are still used. Hermes sends valid
+top-level Slack (`*Heading*`, `_Heading_`) or Markdown (`#` through `###`) report
+sections sequentially to the same Slack channel/thread. It ignores heading-like
+lines in fenced code blocks and safely falls back to one message for no, malformed,
+or excessive sections. This setting is default-off, is Slack-only, and does not
+split `MEDIA:` deliveries.
+
 ### Continuable jobs (reply to a cron delivery)
 
 By default a cron delivery is fire-and-forget: the message is sent, but it does


### PR DESCRIPTION
## Summary

- Adds documented, default-off `cron.split_section_messages`.
- When enabled for text-only Slack deliveries with `cron.wrap_response: false`, recognized top-level sections are sent sequentially to the resolved channel and thread.
- Keeps non-Slack, media-bearing, default, relay, and fallback behavior on the existing single-message path.
- Makes partial section delivery explicit and avoids re-sending an aggregate after a possibly-dispatched section; combined mirror/continuation seeding occurs once after complete delivery.

## Tests

- `uv run ruff check cron/scheduler.py hermes_cli/config_defaults.py tests/cron/test_scheduler.py`
- `uv run python -m pytest tests/cron/test_scheduler.py -o 'addopts=' -q` — 74 passed
- `pre_final_gate.py --mode code` — PASS

## Limitation

The repository-wide suite could not run in this environment: the default dev environment lacks `acp`/`aiohttp`, while `uv sync --all-extras` is blocked building `python-olm`. Targeted cron coverage passed.