### PR TITLE
fix(desktop): escape spaced currency amounts from remark-math

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -2,6 +2,47 @@ import { describe, expect, it } from 'vitest'
 
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 
+describe('preprocessMarkdown currency escaping', () => {
+  it('escapes currency dollars followed by a space then a digit (US$ 5M, R$ 15.4M)', () => {
+    // Regression: "US$ 5M" used to be parsed by remark-math as `$...$` inline
+    // math, and KaTeX rendered the whole following prose run as math, mangling
+    // accents and swallowing spaces.
+    const input = '(US$ 5M), então a feature significa a mesma coisa em qualquer hora. R$ 15.4M por dia.'
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('(US\\$ 5M)')
+    expect(output).toContain('R\\$ 15.4M')
+    expect(output).not.toContain('US$ 5M')
+    expect(output).not.toContain('R$ 15.4M')
+    expect(output).toContain('então a feature significa')
+  })
+
+  it('escapes tight currency amounts ($5 and $10)', () => {
+    expect(preprocessMarkdown('$5 and $10')).toBe('\\$5 and \\$10')
+  })
+
+  it('escapes spaced currency pairs in prose ($ 1.99 and $ 2.99)', () => {
+    expect(preprocessMarkdown('$ 1.99 and $ 2.99')).toBe('\\$ 1.99 and \\$ 2.99')
+  })
+
+  it('preserves balanced numeric inline math ($4\\in A$)', () => {
+    expect(preprocessMarkdown('$4\\in A$')).toBe('$4\\in A$')
+  })
+
+  it('preserves balanced numeric inline math with a leading space ($ 4\\in A$)', () => {
+    expect(preprocessMarkdown('$ 4\\in A$')).toBe('$ 4\\in A$')
+  })
+
+  it('leaves display math and code fences untouched', () => {
+    expect(preprocessMarkdown('$$x^2$$')).toBe('$$x^2$$')
+
+    const fenced = ['```text', '$5 stays literal', '```'].join('\n')
+
+    expect(preprocessMarkdown(fenced)).toContain('$5 stays literal')
+  })
+})
+
 describe('preprocessMarkdown', () => {
   it('strips inline accidental triple-backtick starts', () => {
     const input = [

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -217,6 +217,25 @@ function isLikelyNumericInlineMath(body: string, followingCharacter: string): bo
   return true
 }
 
+/**
+ * True when `$` at `cursor` opens a currency amount: followed (after optional
+ * spaces/tabs) by a digit. Covers `$5`, `US$ 5M`, `R$ 15.4M`; a math opener is
+ * virtually never followed by whitespace then a digit.
+ */
+function isCurrencyDollarAt(text: string, cursor: number): boolean {
+  for (let i = cursor + 1; i < text.length && i <= cursor + 4; i += 1) {
+    const ch = text[i]
+
+    if (ch === ' ' || ch === '\t') {
+      continue
+    }
+
+    return /\d/u.test(ch)
+  }
+
+  return false
+}
+
 function opensCompleteInlineMath(text: string, openingIndex: number): boolean {
   const closingIndex = findClosingSingleDollar(text, openingIndex)
 
@@ -245,7 +264,7 @@ function escapeCurrencyDollarsPreservingMath(text: string): string {
   for (let cursor = 0; cursor < text.length; cursor += 1) {
     if (
       text[cursor] !== '$' ||
-      !/\d/u.test(text[cursor + 1] || '') ||
+      !isCurrencyDollarAt(text, cursor) ||
       text[cursor - 1] === '$' ||
       isEscapedAt(text, cursor)
     ) {
@@ -254,10 +273,22 @@ function escapeCurrencyDollarsPreservingMath(text: string): string {
 
     const closingIndex = findClosingSingleDollar(text, cursor)
 
+    // After the closing `$`, a digit (even after whitespace) means another
+    // price opener follows (`$ 1.99 and $ 2.99`) and the span is prose. For any
+    // other following char keep the RAW char: `$4$ and $10` must stay math
+    // because the closer is followed by a space, not a digit.
+    let afterClosing = closingIndex + 1
+
+    while (afterClosing < text.length && (text[afterClosing] === ' ' || text[afterClosing] === '\t')) {
+      afterClosing += 1
+    }
+
+    const nextEffective = /\d/u.test(text[afterClosing] || '') ? text[afterClosing] : text[closingIndex + 1] || ''
+
     if (
       closingIndex !== -1 &&
       !opensCompleteInlineMath(text, closingIndex) &&
-      isLikelyNumericInlineMath(text.slice(cursor + 1, closingIndex), text[closingIndex + 1] || '')
+      isLikelyNumericInlineMath(text.slice(cursor + 1, closingIndex), nextEffective)
     ) {
       cursor = closingIndex
 

--- a/contributors/emails/nformenton@gmail.com
+++ b/contributors/emails/nformenton@gmail.com
@@ -1,0 +1,2 @@
+Nicolas-Formenton
+# PR #84984 (desktop: drag to reorder profile groups in the All-profiles sidebar)


### PR DESCRIPTION
## What does this PR do?

remark-math parses prose currency amounts like `US$ 5M` / `R$ 15.4M` as inline math, corrupting message rendering. Escape spaced currency amounts so the parser leaves them as prose.

## Related Issue

Fixes #85306

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Escape spaced currency amounts before math parsing (`apps/desktop/src/components/assistant-ui/markdown-text.ts`)
- Tests: `apps/desktop/src/components/assistant-ui/markdown-text.test.ts`
- `contributors/emails/nformenton@gmail.com` — attribution mapping

## How to Test

1. Send a message containing `US$ 5M` and `R$ 15.4M`.
2. The amounts render as plain prose, not inline math.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no native APIs

## Verification

- `npm run test:ui -- src/components/assistant-ui/markdown-text.test.ts`: **41 passed**.
