### PR TITLE
fix(webhook): validate delivery targets on subscribe

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -107,6 +107,19 @@ _BUILTIN_DELIVER_PLATFORMS = {
     "feishu", "wecom", "wecom_callback", "weixin", "bluebubbles",
     "qqbot", "yuanbao",
 }
+_SPECIAL_DELIVER_TARGETS = {"log", "github_comment"}
+
+
+def is_known_delivery_target(deliver_type: str) -> bool:
+    """Return whether a webhook delivery target can be dispatched."""
+    if deliver_type in _SPECIAL_DELIVER_TARGETS or deliver_type in _BUILTIN_DELIVER_PLATFORMS:
+        return True
+    try:
+        from gateway.platform_registry import platform_registry
+
+        return platform_registry.is_registered(deliver_type)
+    except Exception:
+        return False
 
 # Default bind host. ``None`` tells aiohttp/asyncio's ``create_server`` to bind
 # BOTH address families (IPv4 + IPv6) — the portable dual-stack default.
@@ -382,16 +395,8 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
 
-        # Cross-platform delivery — any platform with a gateway adapter.
-        # Check both built-in names and plugin-registered platforms.
-        _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
-        if not _is_known_platform:
-            try:
-                from gateway.platform_registry import platform_registry
-                _is_known_platform = platform_registry.is_registered(deliver_type)
-            except Exception:
-                pass
-        if self.gateway_runner and _is_known_platform:
+        # Cross-platform delivery — any built-in or plugin gateway adapter.
+        if self.gateway_runner and is_known_delivery_target(deliver_type):
             return await self._deliver_cross_platform(
                 deliver_type, content, delivery
             )

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -523,6 +523,17 @@ class WebhookAdapter(BasePlatformAdapter):
                         self._host,
                     )
                     continue
+                deliver = v.get("deliver", "log")
+                if not is_known_delivery_target(deliver):
+                    logger.warning(
+                        "[webhook] Dynamic route '%s' skipped: unknown delivery "
+                        "target '%s'. Update it with: hermes webhook subscribe %s "
+                        "--deliver telegram --deliver-chat-id <CHAT_ID>",
+                        k,
+                        deliver,
+                        k,
+                    )
+                    continue
                 new_dynamic[k] = v
             self._dynamic_routes = new_dynamic
             self._routes = {**self._dynamic_routes, **self._static_routes}

--- a/hermes_cli/subcommands/webhook.py
+++ b/hermes_cli/subcommands/webhook.py
@@ -38,7 +38,8 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
     wh_sub.add_argument(
         "--deliver",
         default="log",
-        help="Delivery target: log, telegram, discord, slack, etc.",
+        help="Delivery target name: log, telegram, discord, slack, etc. "
+        "Pass the target chat ID separately with --deliver-chat-id.",
     )
     wh_sub.add_argument(
         "--deliver-chat-id",

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -260,6 +260,9 @@ def _cmd_list(args):
     for name, route in subs.items():
         events = ", ".join(route.get("events", [])) or "(all)"
         deliver = route.get("deliver", "log")
+        invalid_delivery = not _is_known_delivery_target(deliver)
+        if invalid_delivery:
+            deliver = f"{deliver} (INVALID)"
         if route.get("deliver_only"):
             deliver = f"{deliver} (direct — no agent)"
         desc = route.get("description", "")
@@ -269,6 +272,11 @@ def _cmd_list(args):
         print(f"    URL:     {base_url}/webhooks/{name}")
         print(f"    Events:  {events}")
         print(f"    Deliver: {deliver}")
+        if invalid_delivery:
+            print(
+                f"    Fix:     hermes webhook subscribe {name} --deliver telegram "
+                "--deliver-chat-id <CHAT_ID>"
+            )
         if route.get("script"):
             print(f"    Script:  {route['script']}")
         print()

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -137,6 +137,21 @@ def _require_webhook_enabled() -> bool:
     return False
 
 
+def _is_known_delivery_target(delivery_target: str) -> bool:
+    from gateway.platforms.webhook import is_known_delivery_target
+
+    if is_known_delivery_target(delivery_target):
+        return True
+
+    try:
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+    except Exception:
+        return False
+    return is_known_delivery_target(delivery_target)
+
+
 def webhook_command(args):
     """Entry point for 'hermes webhook' subcommand."""
     sub = getattr(args, "webhook_action", None)
@@ -165,6 +180,15 @@ def _cmd_subscribe(args):
         print(f"Error: Invalid name '{name}'. Use lowercase alphanumeric with hyphens/underscores.")
         return
 
+    delivery_target = args.deliver or "log"
+    if not _is_known_delivery_target(delivery_target):
+        print(
+            f"Error: Unknown delivery target '{delivery_target}'. "
+            "Use a platform name such as 'telegram'; pass its chat ID "
+            "separately with --deliver-chat-id."
+        )
+        return
+
     subs = _load_subscriptions()
     is_update = name in subs
 
@@ -177,7 +201,7 @@ def _cmd_subscribe(args):
         "secret": secret,
         "prompt": args.prompt or "",
         "skills": [s.strip() for s in args.skills.split(",")] if args.skills else [],
-        "deliver": args.deliver or "log",
+        "deliver": delivery_target,
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
 

--- a/tests/gateway/test_webhook_dynamic_routes.py
+++ b/tests/gateway/test_webhook_dynamic_routes.py
@@ -41,6 +41,24 @@ class TestDynamicRouteLoading:
         assert "my-hook" in adapter._routes
         assert "static" in adapter._routes
 
+    def test_skips_route_with_unknown_delivery_target(self, tmp_path, caplog):
+        subs = {
+            "broken": {
+                "secret": "dynamic-secret",
+                "prompt": "test",
+                "deliver": "telegram/all",
+            }
+        }
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(json.dumps(subs))
+
+        adapter = _make_adapter()
+        adapter._reload_dynamic_routes()
+
+        assert "broken" not in adapter._routes
+        assert "broken" not in adapter._dynamic_routes
+        assert "unknown delivery target 'telegram/all'" in caplog.text.lower()
+        assert "--deliver telegram --deliver-chat-id" in caplog.text
+
 
 class TestDynamicRouteSecretValidation:
     """Empty/missing secrets must be rejected during hot-reload.
@@ -83,5 +101,4 @@ class TestDynamicRouteSecretValidation:
         adapter = _make_adapter()  # global secret set
         adapter._reload_dynamic_routes()
         assert "valid" in adapter._routes
-
 

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -66,6 +66,43 @@ class TestSubscribe:
         secret = _load_subscriptions()["s"]["secret"]
         assert len(secret) > 20
 
+    def test_rejects_unknown_delivery_target(self, capsys, monkeypatch):
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+        webhook_command(_make_args(
+            webhook_action="subscribe", name="bad", deliver="telegram/all"
+        ))
+
+        out = capsys.readouterr().out
+        assert "Unknown delivery target 'telegram/all'" in out
+        assert "bad" not in _load_subscriptions()
+
+    @pytest.mark.parametrize("target", ["log", "github_comment", "telegram"])
+    def test_accepts_known_delivery_target(self, target):
+        webhook_command(_make_args(
+            webhook_action="subscribe", name="valid", deliver=target
+        ))
+
+        assert _load_subscriptions()["valid"]["deliver"] == target
+
+    def test_accepts_registered_plugin_delivery_target(self, monkeypatch):
+        discovered = False
+
+        def discover_plugin():
+            nonlocal discovered
+            discovered = True
+
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", discover_plugin)
+        monkeypatch.setattr(
+            "gateway.platform_registry.platform_registry.is_registered",
+            lambda target: discovered and target == "custom_chat",
+        )
+
+        webhook_command(_make_args(
+            webhook_action="subscribe", name="plugin", deliver="custom_chat"
+        ))
+
+        assert _load_subscriptions()["plugin"]["deliver"] == "custom_chat"
+
 
 class TestList:
 
@@ -152,4 +189,3 @@ class TestWebhookEnabledGate:
         )
         import hermes_cli.webhook as wh_mod
         assert wh_mod._is_webhook_enabled() is False
-

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -116,6 +116,23 @@ class TestList:
         assert "a" in out
         assert "b" in out
 
+    def test_marks_persisted_unknown_delivery_target_invalid(self, capsys, monkeypatch):
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+        _save_subscriptions({
+            "broken": {
+                "secret": "dynamic-secret",
+                "prompt": "test",
+                "deliver": "telegram/all",
+            }
+        })
+
+        webhook_command(_make_args(webhook_action="list"))
+
+        out = capsys.readouterr().out
+        assert "Deliver: telegram/all (INVALID)" in out
+        assert "--deliver telegram --deliver-chat-id <CHAT_ID>" in out
+        assert "broken" in _load_subscriptions()
+
 
 class TestRemove:
 


### PR DESCRIPTION
## What does this PR do?

Webhook subscriptions currently persist arbitrary `--deliver` values, so a target such as `telegram/all` is accepted during setup and fails only when runtime delivery is attempted. This PR validates delivery targets before saving new subscriptions and when loading existing subscriptions, reuses the same recognition logic during runtime dispatch, and preserves support for plugin-registered platforms.

Existing invalid subscriptions remain on disk for correction, are skipped by the gateway, and are marked `INVALID` by `hermes webhook list` with an actionable update command. The supported Telegram syntax is `--deliver telegram --deliver-chat-id <CHAT_ID>`.

## Related Issue

Fixes #84171

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added shared delivery-target validation in `gateway/platforms/webhook.py` for built-in, special, and plugin-registered targets.
- Added pre-save validation and an actionable error in `hermes_cli/webhook.py`.
- Skip persisted dynamic routes with invalid delivery targets and log the exact correction command.
- Mark persisted invalid targets in `hermes webhook list` while preserving their records for correction.
- Clarified `--deliver` and `--deliver-chat-id` usage in `hermes_cli/subcommands/webhook.py`.
- Added regression coverage for new and already-persisted invalid targets.

## How to Test

1. Run `HERMES_PYTHON=/usr/bin/python3 scripts/run_tests.sh tests/hermes_cli/test_webhook_cli.py tests/hermes_cli/test_subcommands_batch.py -q` and confirm 22 tests pass.
2. Run `HERMES_PYTHON=/usr/bin/python3 scripts/run_tests.sh tests/gateway/test_webhook_dynamic_routes.py tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_integration.py -q` and confirm 44 tests pass.
3. Run `python3 -m ruff check gateway/platforms/webhook.py hermes_cli/webhook.py hermes_cli/subcommands/webhook.py tests/gateway/test_webhook_dynamic_routes.py tests/hermes_cli/test_webhook_cli.py`.
4. Run `python3 scripts/check-windows-footguns.py --all`.
5. Place a subscription with `"deliver": "telegram/all"` in `webhook_subscriptions.json`; confirm the gateway skips it with an actionable warning and `hermes webhook list` marks it `INVALID`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: updated CLI help
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test suites: 66 passed. Ruff, Windows footgun checks, `git diff --check`, and `scripts/audit_pr_attribution.py` passed.