### PR TITLE
fix(langfuse): preserve Responses tool input items

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -489,6 +489,28 @@ def _serialize_messages(messages: Any) -> list[dict[str, Any]]:
     for message in messages[-12:]:
         if not isinstance(message, dict):
             continue
+        item_type = message.get("type")
+        if item_type == "function_call":
+            serialized.append({
+                "type": item_type,
+                "call_id": message.get("call_id"),
+                "name": _safe_value(message.get("name")),
+                "arguments": _safe_value(
+                    message.get("arguments"),
+                    parse_json_strings=True,
+                ),
+            })
+            continue
+        if item_type == "function_call_output":
+            serialized.append({
+                "type": item_type,
+                "call_id": message.get("call_id"),
+                "output": _safe_value(
+                    message.get("output"),
+                    parse_json_strings=True,
+                ),
+            })
+            continue
         role = message.get("role")
         item = {
             "role": role,

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -531,6 +531,38 @@ class TestRequestMessageCoercion:
 
 
 class TestToolCallOutputBackfill:
+    def test_serialize_messages_preserves_responses_tool_items(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        messages = [
+            {
+                "type": "function_call",
+                "call_id": "call-1",
+                "name": "web_extract",
+                "arguments": '{"urls": ["https://example.com"]}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call-1",
+                "output": '{"ok": true}',
+            },
+        ]
+
+        assert mod._serialize_messages(messages) == [
+            {
+                "type": "function_call",
+                "call_id": "call-1",
+                "name": "web_extract",
+                "arguments": {"urls": ["https://example.com"]},
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call-1",
+                "output": {"ok": True},
+            },
+        ]
+
     def test_post_tool_call_backfills_matching_turn_tool_call_output(self, monkeypatch):
         sys.modules.pop("plugins.observability.langfuse", None)
         mod = importlib.import_module("plugins.observability.langfuse")


### PR DESCRIPTION
## Summary
- preserve OpenAI Responses `function_call` fields in Langfuse generation inputs
- preserve matching `function_call_output` payloads instead of rendering them as `role: null, content: null`
- continue applying the existing `_safe_value` truncation, JSON parsing, depth, and data-URI redaction rules

## Root cause
`pre_api_request` passes the actual Responses API `input` array to the Langfuse plugin, but `_serialize_messages()` treated every item as a chat message and retained only `role` and `content`. Responses tool items use `type`, `call_id`, `name`, `arguments`, and `output`, so those fields were dropped from the generation observation.

## Test plan
- [x] Added regression coverage for `function_call` and `function_call_output` serialization
- [x] `HERMES_PYTHON=$(PYENV_VERSION=3.12.12 pyenv which python) scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py -q` (25 passed)
- [x] `PYENV_VERSION=3.12.12 python -m ruff check plugins/observability/langfuse/__init__.py tests/plugins/test_langfuse_plugin.py`
- [x] Independent review: no security concerns or logic errors