### PR TITLE
feat(matrix): add text-only approval controls

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1302,7 +1302,16 @@ class MatrixAdapter(BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
 
-        # Matrix reaction-based dangerous command approvals.
+        # Matrix reaction-based dangerous command approvals. Set
+        # matrix.approval_controls to "text" for command-only prompts.
+        raw_approval_controls = str(
+            config.extra.get("approval_controls", "reactions")
+        ).strip().lower()
+        self._approval_controls = (
+            raw_approval_controls
+            if raw_approval_controls in {"reactions", "text"}
+            else "reactions"
+        )
         self._approval_reaction_map = {
             "✅": "once",
             "🌀": "session",
@@ -2623,27 +2632,44 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         requester_user_id = str((metadata or {}).get("requester_user_id") or "") or None
-        scope_choices = ""
-        if smart_denied:
-            scope_choices = "Smart DENY: owner override applies to this one operation only.\n"
+        text_controls = getattr(self, "_approval_controls", "reactions") == "text"
+        if text_controls:
+            cmd_preview = self._truncate_preview(str(command or ""), self._EA_CMD_BUDGET)
+            choices = ["Reply `!approve` to run it once"]
+            if not smart_denied and allow_session:
+                choices.append("`!approve session` for this session")
+                if allow_permanent:
+                    choices.append("`!approve always` to remember it")
+            choices.append("`!deny` to cancel")
+            text = (
+                "I need your approval before running this command.\n\n"
+                f"```\n{self._ea_escape(cmd_preview)}\n```\n"
+                f"Reason: {self._ea_escape(description)}\n\n"
+                + ", or ".join(choices)
+                + "."
+            )
         else:
             scope_choices = ""
+            if smart_denied:
+                scope_choices = "Smart DENY: owner override applies to this one operation only.\n"
+            else:
+                scope_choices = ""
+                if allow_session:
+                    scope_choices += "Reply `!approve session` to approve this pattern for the session, "
+                if allow_permanent:
+                    scope_choices += "`!approve always` to approve permanently, "
+            reaction_legend_parts = ["✅ = approve once"]
             if allow_session:
-                scope_choices += "Reply `!approve session` to approve this pattern for the session, "
-            if allow_permanent:
-                scope_choices += "`!approve always` to approve permanently, "
-        reaction_legend_parts = ["✅ = approve once"]
-        if allow_session:
-            reaction_legend_parts.append("🌀 = approve for this session")
-            if allow_permanent:
-                reaction_legend_parts.append("♾️ = approve always")
-        reaction_legend_parts.append("❎ = deny")
-        text = (
-            f"{self._format_exec_approval(command, description)}\n\n"
-            f"{scope_choices}Reply `!approve` to execute once, or `!deny` to cancel.\n\n"
-            "You can also click the reaction to approve:\n"
-            + "\n".join(reaction_legend_parts)
-        )
+                reaction_legend_parts.append("🌀 = approve for this session")
+                if allow_permanent:
+                    reaction_legend_parts.append("♾️ = approve always")
+            reaction_legend_parts.append("❎ = deny")
+            text = (
+                f"{self._format_exec_approval(command, description)}\n\n"
+                f"{scope_choices}Reply `!approve` to execute once, or `!deny` to cancel.\n\n"
+                "You can also click the reaction to approve:\n"
+                + "\n".join(reaction_legend_parts)
+            )
 
         result = await self.send(chat_id, text, metadata=metadata)
         if not result.success or not result.message_id:
@@ -2662,20 +2688,21 @@ class MatrixAdapter(BasePlatformAdapter):
         self._approval_prompts_by_event[result.message_id] = prompt
         self._approval_prompt_by_session[session_key] = result.message_id
 
-        if not allow_session:
-            reactions = ("✅", "❌")
-        elif not allow_permanent:
-            reactions = ("✅", "🌀", "❌")
-        else:
-            reactions = ("✅", "🌀", "♾️", "❌")
-        for emoji in reactions:
-            try:
-                reaction_result = await self._send_reaction(chat_id, result.message_id, emoji)
-                # Save the bot's reaction event_id for later cleanup
-                if reaction_result:
-                    prompt.bot_reaction_events[emoji] = str(reaction_result)
-            except Exception as exc:
-                logger.debug("Matrix: failed to add approval reaction %s: %s", emoji, exc)
+        if not text_controls:
+            if not allow_session:
+                reactions = ("✅", "❌")
+            elif not allow_permanent:
+                reactions = ("✅", "🌀", "❌")
+            else:
+                reactions = ("✅", "🌀", "♾️", "❌")
+            for emoji in reactions:
+                try:
+                    reaction_result = await self._send_reaction(chat_id, result.message_id, emoji)
+                    # Save the bot's reaction event_id for later cleanup
+                    if reaction_result:
+                        prompt.bot_reaction_events[emoji] = str(reaction_result)
+                except Exception as exc:
+                    logger.debug("Matrix: failed to add approval reaction %s: %s", emoji, exc)
 
         return result
 
@@ -4002,6 +4029,8 @@ class MatrixAdapter(BasePlatformAdapter):
             # Check if this reaction resolves a pending approval prompt.
             prompt = self._approval_prompts_by_event.get(reacts_to)
             if prompt and not prompt.resolved:
+                if getattr(self, "_approval_controls", "reactions") == "text":
+                    return
                 if room_id != prompt.chat_id:
                     return
                 if self._matrix_prompt_expired(prompt):
@@ -5333,11 +5362,11 @@ def interactive_setup() -> None:
 
 
 def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
-    """Translate config.yaml matrix: keys into MATRIX_* env vars.
+    """Translate config.yaml Matrix keys into runtime configuration.
 
-    Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
-    matrix_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML. Returns None — everything flows through env.
+    Implements the apply_yaml_config_fn contract (#24849). Legacy environment
+    settings still flow through MATRIX_* variables; config-only settings are
+    returned for PlatformConfig.extra.
     """
     if "require_mention" in matrix_cfg and not os.getenv("MATRIX_REQUIRE_MENTION"):
         os.environ["MATRIX_REQUIRE_MENTION"] = str(matrix_cfg["require_mention"]).lower()
@@ -5371,6 +5400,8 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
         os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):
         os.environ["MATRIX_MAX_MESSAGE_LENGTH"] = str(matrix_cfg["max_message_length"])
+    if "approval_controls" in matrix_cfg:
+        return {"approval_controls": matrix_cfg["approval_controls"]}
     return None
 
 

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -3,10 +3,37 @@ import types
 import pytest
 from unittest.mock import AsyncMock, patch
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
 
 
 class TestMatrixExecApprovalReactions:
+
+    def test_text_controls_yaml_seeds_platform_extra(self):
+        from plugins.platforms.matrix.adapter import _apply_yaml_config
+
+        assert _apply_yaml_config({}, {"approval_controls": "text"}) == {
+            "approval_controls": "text"
+        }
+
+    def test_text_controls_load_through_real_gateway_config(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "matrix:\n  approval_controls: text\n",
+            encoding="utf-8",
+        )
+
+        with patch("gateway.config.get_hermes_home", return_value=tmp_path):
+            from gateway.config import load_gateway_config
+
+            config = load_gateway_config()
+
+        matrix_config = config.platforms[Platform.MATRIX]
+        assert matrix_config.extra["approval_controls"] == "text"
+
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter(matrix_config)
+        assert adapter._approval_controls == "text"
 
 
     @pytest.mark.asyncio
@@ -36,3 +63,128 @@ class TestMatrixExecApprovalReactions:
         mock_resolve.assert_called_once_with("sess-1", "once")
         assert "$target" not in adapter._approval_prompts_by_event
         assert "sess-1" not in adapter._approval_prompt_by_session
+
+    @pytest.mark.asyncio
+    async def test_text_controls_send_plain_prompt_without_reactions(self):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="tok",
+                extra={
+                    "homeserver": "https://matrix.example.org",
+                    "approval_controls": "text",
+                },
+            )
+        )
+        adapter._client = object()
+        adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="$prompt")
+        )
+        adapter._send_reaction = AsyncMock(return_value="$reaction")
+
+        result = await adapter.send_exec_approval(
+            chat_id="!room:example.org",
+            command="rm -rf /tmp/old-project",
+            session_key="sess-text",
+            description="recursive delete",
+        )
+
+        assert result.success is True
+        send_call = adapter.send.await_args
+        assert send_call is not None
+        prompt_text = send_call.args[1]
+        assert prompt_text.startswith("I need your approval before running this command")
+        assert "Reply `!approve` to run it once" in prompt_text
+        assert "`!approve session`" in prompt_text
+        assert "`!approve always`" in prompt_text
+        assert "`!deny`" in prompt_text
+        assert not any(symbol in prompt_text for symbol in ("⚠", "✅", "🌀", "♾", "❌", "❎"))
+        adapter._send_reaction.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("kwargs", "present", "absent"),
+        [
+            (
+                {"smart_denied": True},
+                ("!approve`", "!deny`"),
+                ("!approve session", "!approve always"),
+            ),
+            (
+                {"allow_session": False, "allow_permanent": False},
+                ("!approve`", "!deny`"),
+                ("!approve session", "!approve always"),
+            ),
+            (
+                {"allow_session": False, "allow_permanent": True},
+                ("!approve`", "!deny`"),
+                ("!approve session", "!approve always"),
+            ),
+        ],
+    )
+    async def test_text_controls_only_advertise_available_scopes(
+        self, kwargs, present, absent
+    ):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="tok",
+                extra={"approval_controls": "text"},
+            )
+        )
+        adapter._client = object()
+        adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="$prompt")
+        )
+        adapter._send_reaction = AsyncMock()
+
+        await adapter.send_exec_approval(
+            "!room:example.org",
+            "rm -rf /tmp/old-project",
+            "sess-scopes",
+            **kwargs,
+        )
+
+        send_call = adapter.send.await_args
+        assert send_call is not None
+        prompt_text = send_call.args[1]
+        assert all(choice in prompt_text for choice in present)
+        assert all(choice not in prompt_text for choice in absent)
+        adapter._send_reaction.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_text_controls_ignore_approval_reactions(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@liizfq:liizfq.top")
+        from plugins.platforms.matrix.adapter import MatrixAdapter, _MatrixApprovalPrompt
+
+        adapter = MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="tok",
+                extra={
+                    "homeserver": "https://matrix.example.org",
+                    "approval_controls": "text",
+                },
+            )
+        )
+        adapter._user_id = "@bot:example.org"
+        adapter._approval_prompts_by_event["$target"] = _MatrixApprovalPrompt(
+            session_key="sess-text", chat_id="!room:example.org", message_id="$target"
+        )
+
+        event = types.SimpleNamespace(
+            sender="@liizfq:liizfq.top",
+            event_id="$react-text",
+            room_id="!room:example.org",
+            content={"m.relates_to": {"event_id": "$target", "key": "✅"}},
+        )
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._on_reaction(event)
+
+        mock_resolve.assert_not_called()
+        assert "$target" in adapter._approval_prompts_by_event

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -97,6 +97,7 @@ matrix:
   session_scope: room             # auto|room|thread; room is recommended for project rooms
   auto_thread: true               # Auto-create threads for responses (default: true)
   dm_mention_threads: false       # Create thread when @mentioned in DM (default: false)
+  approval_controls: reactions    # reactions|text; text uses chat commands only
   max_message_length: 16000       # Outbound chunk size in chars (default: 16000, max: 65535)
 ```
 
@@ -118,6 +119,10 @@ MATRIX_ALLOW_ROOM_MENTIONS=false
 
 :::tip Disabling reactions
 `MATRIX_REACTIONS=false` turns off the processing-lifecycle emoji reactions (👀/✅/❌) the bot posts on inbound messages. Useful for rooms where reaction events are noisy or aren't supported by all participating clients.
+:::
+
+:::tip Text-only approvals
+Set `matrix.approval_controls: text` to replace Matrix's reaction-based dangerous-command approval card with a plain prompt. Approve or deny with `!approve`, `!approve session`, `!approve always`, or `!deny`. Text mode neither seeds approval reactions nor accepts them.
 :::
 
 :::tip Room-wide mentions


### PR DESCRIPTION
## Summary
- add `matrix.approval_controls: text` for conversational dangerous-command approval prompts
- keep `!approve`, `!approve session`, `!approve always`, and `!deny` as the complete control path
- skip approval reactions and ignore reaction events while text mode is active
- preserve the existing reaction UX as the backward-compatible default

## Verification
- `scripts/run_tests.sh tests/gateway/test_matrix.py tests/gateway/test_matrix_exec_approval.py tests/gateway/test_matrix_approval_reaction_fail_closed.py -q`
- 121 tests passed
- `uv run ruff check plugins/platforms/matrix/adapter.py tests/gateway/test_matrix_exec_approval.py`
- Docusaurus production build completed successfully

## Configuration
```yaml
matrix:
  approval_controls: text
```