### PR TITLE
refactor(mcp_tool): extract pagination slice R1-2 into tools/mcp_pagination.py

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/tests/tools/test_mcp_pagination_seam.py
+++ b/tests/tools/test_mcp_pagination_seam.py
@@ -1,0 +1,62 @@
+"""Compatibility and behavior seams for the extracted MCP pagination helper."""
+
+import asyncio
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from tools import mcp_pagination, mcp_tool
+
+
+@dataclass
+class _Page:
+    tools: list
+    nextCursor: object = None
+
+
+def test_pagination_names_are_identity_preserving_reexports():
+    assert mcp_tool._MCP_LIST_MAX_PAGES is mcp_pagination._MCP_LIST_MAX_PAGES
+    assert mcp_tool._paginate_full_list is mcp_pagination._paginate_full_list
+
+
+def test_pagination_reexport_remains_patchable_at_original_namespace():
+    original = mcp_tool._paginate_full_list
+    sentinel = object()
+    with patch.object(mcp_tool, "_paginate_full_list", sentinel):
+        assert mcp_tool._paginate_full_list is sentinel
+        assert mcp_pagination._paginate_full_list is original
+
+
+def test_pagination_combines_pages_and_passes_opaque_cursors():
+    calls = []
+    pages = {
+        None: _Page(["first"], "opaque-1"),
+        "opaque-1": _Page(["second"], "opaque-2"),
+        "opaque-2": _Page(["third"], None),
+    }
+
+    async def list_method(**kwargs):
+        cursor = kwargs.get("cursor")
+        calls.append(cursor)
+        return pages[cursor]
+
+    items = asyncio.run(
+        mcp_pagination._paginate_full_list(list_method, "tools", "server")
+    )
+
+    assert items == ["first", "second", "third"]
+    assert calls == [None, "opaque-1", "opaque-2"]
+
+
+def test_pagination_stops_on_non_string_cursor_and_missing_items():
+    calls = []
+
+    async def list_method(**kwargs):
+        calls.append(kwargs)
+        return _Page([], 123)
+
+    items = asyncio.run(
+        mcp_pagination._paginate_full_list(list_method, "tools", "server")
+    )
+
+    assert items == []
+    assert calls == [{}]

--- a/tools/mcp_pagination.py
+++ b/tools/mcp_pagination.py
@@ -1,0 +1,48 @@
+"""Pagination helpers for MCP list responses."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_MCP_LIST_MAX_PAGES = 50
+
+
+async def _paginate_full_list(list_method, items_attr: str, server_name: str):
+    """Drain a paginated MCP ``list_*`` call by following ``nextCursor``.
+
+    The MCP spec allows servers to paginate ``tools/list``,
+    ``resources/list``, and ``prompts/list`` responses via an opaque
+    ``nextCursor`` token. The Python SDK's ``ClientSession.list_*`` methods
+    fetch exactly one page per call, so a client that never passes the
+    cursor back silently sees only the first page — on a paginated server
+    every tool/resource/prompt past page 1 would be invisible to the agent.
+
+    Args:
+        list_method: Bound ``session.list_tools`` / ``list_resources`` /
+            ``list_prompts`` coroutine function.
+        items_attr: Result attribute holding the page's items
+            (``"tools"``, ``"resources"``, or ``"prompts"``).
+        server_name: For log messages.
+
+    Returns:
+        Combined list of items across all pages. Callers must hold the
+        server's ``_rpc_lock`` for the duration so pages come from a
+        consistent snapshot.
+    """
+    items: list = []
+    cursor = None
+    for _ in range(_MCP_LIST_MAX_PAGES):
+        result = await (list_method(cursor=cursor) if cursor else list_method())
+        items.extend(getattr(result, items_attr, None) or [])
+        cursor = getattr(result, "nextCursor", None)
+        # Per the MCP spec the cursor is an opaque string; anything else
+        # (including mock objects in tests) means "no more pages".
+        if not isinstance(cursor, str) or not cursor:
+            break
+    else:
+        logger.warning(
+            "MCP server '%s': %s pagination exceeded %d pages; "
+            "truncating at %d items",
+            server_name, items_attr, _MCP_LIST_MAX_PAGES, len(items),
+        )
+    return items

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -119,6 +119,7 @@ from urllib.parse import urlparse
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
+from tools.mcp_pagination import _MCP_LIST_MAX_PAGES, _paginate_full_list  # noqa: F401
 
 # Upper bound for the OSV malware preflight during stdio MCP startup. The
 # check makes a blocking urllib HTTPS call whose own timeout can fail to
@@ -738,48 +739,6 @@ def _prepend_path(env: dict, directory: str) -> dict:
 # Safety cap on nextCursor pagination loops so a misbehaving server that
 # returns a cursor forever cannot spin discovery indefinitely. 50 pages at
 # the common 50-100 items/page covers thousands of tools/resources/prompts.
-_MCP_LIST_MAX_PAGES = 50
-
-
-async def _paginate_full_list(list_method, items_attr: str, server_name: str):
-    """Drain a paginated MCP ``list_*`` call by following ``nextCursor``.
-
-    The MCP spec allows servers to paginate ``tools/list``,
-    ``resources/list``, and ``prompts/list`` responses via an opaque
-    ``nextCursor`` token. The Python SDK's ``ClientSession.list_*`` methods
-    fetch exactly one page per call, so a client that never passes the
-    cursor back silently sees only the first page — on a paginated server
-    every tool/resource/prompt past page 1 would be invisible to the agent.
-
-    Args:
-        list_method: Bound ``session.list_tools`` / ``list_resources`` /
-            ``list_prompts`` coroutine function.
-        items_attr: Result attribute holding the page's items
-            (``"tools"``, ``"resources"``, or ``"prompts"``).
-        server_name: For log messages.
-
-    Returns:
-        Combined list of items across all pages. Callers must hold the
-        server's ``_rpc_lock`` for the duration so pages come from a
-        consistent snapshot.
-    """
-    items: list = []
-    cursor = None
-    for _ in range(_MCP_LIST_MAX_PAGES):
-        result = await (list_method(cursor=cursor) if cursor else list_method())
-        items.extend(getattr(result, items_attr, None) or [])
-        cursor = getattr(result, "nextCursor", None)
-        # Per the MCP spec the cursor is an opaque string; anything else
-        # (including mock objects in tests) means "no more pages".
-        if not isinstance(cursor, str) or not cursor:
-            break
-    else:
-        logger.warning(
-            "MCP server '%s': %s pagination exceeded %d pages; "
-            "truncating at %d items",
-            server_name, items_attr, _MCP_LIST_MAX_PAGES, len(items),
-        )
-    return items
 
 
 def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:


### PR DESCRIPTION
## Summary

Byte-verbatim extraction of slice R1-2 from `tools/mcp_tool.py` (7,731 lines at pin `ee4bb75b532e932a1055d9a710802a7435163b6a`) into a new module, per the repo-wide god-file sharding policy — the R1 consensus's verified backup candidate (C6).

- **Moved:** `_MCP_LIST_MAX_PAGES`, `_paginate_full_list` (lines 741–782, 42 lines, nextCursor pagination cluster) → `tools/mcp_pagination.py`
- **Golden sha (window at pin):** `dc1e865a8a5db2402f387e53e347d7c2f269ec09cf2a2fe5ef3780ea58570601` — byte-verbatim, re-verified from the committed blob (module lines 7–48 == pin window, byte-identical)
- **Seam:** identity-preserving re-export in `tools/mcp_tool.py` (`from tools.mcp_pagination import _MCP_LIST_MAX_PAGES, _paginate_full_list`) — no public rename, no stale duplicate, in-file call sites resolve through the original namespace, monkeypatch authority intact. New module: minimal imports + logging/logger; no circular import; startup-latency contract preserved.
- **Seam tests:** `tests/tools/test_mcp_pagination_seam.py` — object identity both names + behavioral cases (4 passed)
- **Zero behavior change.** Diff: `tools/mcp_tool.py` 1 insertion / 42 deletions; new module 48 lines; seam test 62 lines.

## Method

5×2×3 double-blind decomposition (per the All Gods Must Die mandate): 5 blind region analysts → 5 blind adversarial witnesses → 5 consensus adjudicators → blind implementer → 2 blind re-reviewers, both **APPROVED**:

- Review 1: `C:/tmp/tg-Feature Package/mcp-tool/review/R12-review-1.md` (13,798 B) — all 7 battery gates PASS
- Review 2: `C:/tmp/tg-Feature Package/mcp-tool/review/R12-review-2.md` (11,033 B) — APPROVED, all gates

Suite evidence: pristine-pin baseline 2 failed / 486 passed / 5 skipped (both Windows-env-dependent); post-extraction identical 2-failure set + seam tests (registry 39 passed, lazy-start 17 passed). No new failures.

## Coordination table

| Item | Value |
|---|---|
| Pin | `ee4bb75b532e932a1055d9a710802a7435163b6a` (origin/main) |
| Slice | R1-2 (region 1, second slice) |
| Window | 741–782 (42 lines) |
| Module | `tools/mcp_pagination.py` |
| Golden sha | `dc1e865a8a5db2402f387e53e347d7c2f269ec09cf2a2fe5ef3780ea58570601` |
| Colliders | NONE — #83354, #83393, #83559, #83575, #83641, #83760, #83860, #83917, #84023, #84070, #84148 hunks all outside window (re-verified at extraction) |
| Dependencies | none |
| Conflicts | none |
| Merge position | standalone; no stacking |

## Dedup statement

No prior extraction of this window exists. Open-PR census for `tools/mcp_tool.py` (live-verified via GraphQL): #83354, #83393 (external) + Feature Package siblings — none touch 741–782. No duplicate work.

## Credit

- Author: Axl Ibiza, MBA (DCO-signed commit `513da9e2258`)
- Method: All Gods Must Die 5×2×3 (blind lanes, consensus contracts, blind re-review)

## 

This slice is governed by the mcp_tool : `C:/tmp/tg-Feature Package/locks/LOCK-mcp_tool.md` (posted on #78642). Former whole: 7,731 lines. Mess issues: #5467, #5468. Fixer roster: #83354, #83393.

Part of #78642
Part of #78647