### PR TITLE
feat(whatsapp): add scoped owner command ingress

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -16,6 +16,7 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+import json
 import logging
 import os
 import platform
@@ -401,6 +402,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     - group_policy: "open" | "allowlist" | "disabled" | "pairing" — which groups are processed (default: "pairing")
     - group_allow_from: List of group JIDs allowed (when group_policy="allowlist")
     - send_read_receipts: Mark accepted inbound WhatsApp messages as read
+    - owner_commands: Slash command names accepted from owner customer chats in self-chat mode
 
     Behavior (gating, mention parsing, markdown conversion, chunking) is
     provided by ``WhatsAppBehaviorMixin`` so the Cloud API adapter can
@@ -455,6 +457,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             read_receipts if isinstance(read_receipts, bool)
             else str(read_receipts or "").strip().lower() in {"1", "true", "yes", "on"}
         )
+        owner_commands = config.extra.get("owner_commands", [])
+        if isinstance(owner_commands, list):
+            self._owner_commands = list(dict.fromkeys(
+                name.strip().lower()
+                for name in owner_commands
+                if isinstance(name, str)
+                and re.fullmatch(r"[A-Za-z0-9_-]+", name.strip())
+            ))
+        else:
+            self._owner_commands = []
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -638,7 +650,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 running_hash = data.get("scriptHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
                                 running_read_receipts = bool(data.get("sendReadReceipts", False))
-                                config_matches = running_read_receipts == self._send_read_receipts
+                                running_owner_commands = data.get("ownerCommands", [])
+                                if not isinstance(running_owner_commands, list):
+                                    running_owner_commands = []
+                                config_matches = (
+                                    running_read_receipts == self._send_read_receipts
+                                    and running_owner_commands
+                                    == getattr(self, "_owner_commands", [])
+                                )
                                 if (
                                     running_hash
                                     and disk_hash
@@ -654,7 +673,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 stale_reason = (
                                     f"running={running_hash or 'unversioned'}, disk={disk_hash}"
                                     if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
+                                    else "bridge config changed"
                                 )
                                 print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
                             else:
@@ -685,6 +704,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
                 "true" if self._send_read_receipts else "false"
             )
+            owner_commands = getattr(self, "_owner_commands", [])
+            bridge_env.pop("_HERMES_WHATSAPP_OWNER_COMMANDS", None)
+            if owner_commands:
+                bridge_env["_HERMES_WHATSAPP_OWNER_COMMANDS"] = json.dumps(
+                    owner_commands, separators=(",", ":")
+                )
             # Under multiplexing, the bridge subprocess runs with a copy of
             # os.environ that does NOT contain the secondary profile's .env
             # vars.  Inject the resolved WHATSAPP_* values so the Node bridge
@@ -1615,12 +1640,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # having to peek at raw_message.  We also prefix ``MessageEvent.text``
             # with ``[owner reply] `` here so the marker survives any downstream
             # failure (e.g. handover-rule errors that bypass silent_ingest).
-            # Gated by ``WHATSAPP_FORWARD_OWNER_MESSAGES`` at the bridge layer;
-            # metadata + text tagging are unconditional when the flag is present
-            # so a future producer can set it without adapter changes.
+            # The narrow self-chat command ingress sets ``ownerCommand`` so its
+            # leading slash remains visible to the gateway command dispatcher;
+            # bot-mode owner forwarding keeps the existing prefix behavior.
             if data.get("fromOwner"):
                 metadata["whatsapp_from_owner"] = True
-                if not body.startswith(_OWNER_REPLY_PREFIX):
+                if data.get("ownerCommand") is not True and not body.startswith(_OWNER_REPLY_PREFIX):
                     body = f"{_OWNER_REPLY_PREFIX}{body}"
 
             return MessageEvent(
@@ -1834,13 +1859,18 @@ def interactive_setup() -> None:
 
 
 def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
-    """Translate config.yaml whatsapp: keys into WHATSAPP_* env vars.
+    """Translate config.yaml WhatsApp keys into adapter config and env vars.
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
     whatsapp_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML. Returns None — everything flows through env.
+    take precedence over YAML for legacy settings. Non-secret bridge behavior
+    remains in ``PlatformConfig.extra``.
     """
     import json as _json
+    seeded = {}
+    owner_commands = whatsapp_cfg.get("owner_commands")
+    if isinstance(owner_commands, list):
+        seeded["owner_commands"] = owner_commands
     if "require_mention" in whatsapp_cfg and not os.getenv("WHATSAPP_REQUIRE_MENTION"):
         os.environ["WHATSAPP_REQUIRE_MENTION"] = str(whatsapp_cfg["require_mention"]).lower()
     if "mention_patterns" in whatsapp_cfg and not os.getenv("WHATSAPP_MENTION_PATTERNS"):
@@ -1864,7 +1894,7 @@ def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
         if isinstance(gaf, list):
             gaf = ",".join(str(v) for v in gaf)
         os.environ["WHATSAPP_GROUP_ALLOWED_USERS"] = str(gaf)
-    return None
+    return seeded or None
 
 
 def _is_connected(config) -> bool:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1014,6 +1014,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
+        prefix: bool = True,
     ) -> SendResult:
         """Edit a previously sent message via the WhatsApp bridge."""
         if not self._running or not self._http_session:
@@ -1029,6 +1030,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "chatId": to_whatsapp_jid(chat_id),
                     "messageId": message_id,
                     "message": content,
+                    "prefix": prefix,
                 },
                 timeout=aiohttp.ClientTimeout(total=15)
             ) as resp:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -41,6 +41,7 @@ import {
   buildTextSendPayload,
   createBoundedMessageStore,
   extractBridgeEvent,
+  formatEditableMessage,
   inboundReadReceiptKeys,
   inferMediaType,
   mediaPayloadForFile,
@@ -882,14 +883,18 @@ app.post('/edit', async (req, res) => {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
 
-  const { chatId, messageId, message } = req.body;
+  const { chatId, messageId, message, prefix = true } = req.body;
   if (!chatId || !messageId || !message) {
     return res.status(400).json({ error: 'chatId, messageId, and message are required' });
   }
 
   try {
     const key = { id: messageId, fromMe: true, remoteJid: chatId };
-    const chunks = splitLongMessage(formatOutgoingMessage(message));
+    const outgoing = formatEditableMessage(message, {
+      prefix,
+      formatOutgoingMessage,
+    });
+    const chunks = splitLongMessage(outgoing);
     const messageIds = [];
 
     await sendWithTimeout(chatId, { text: chunks[0], edit: key });

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -34,6 +34,12 @@ import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate, parseOwnerCommands } from './owner_message_gate.js';
 import {
+  captureUpsertChatContext,
+  createRecentChatContextStore,
+  installChatContextRoute,
+  isDirectChatId,
+} from './chat_context.js';
+import {
   buildPollPayload,
   createReconnectScheduler,
   createVersionResolver,
@@ -272,6 +278,7 @@ const logger = pino({ level: 'warn' });
 // Message queue for polling
 const messageQueue = [];
 const MAX_QUEUE_SIZE = 100;
+const recentChatContext = createRecentChatContextStore();
 
 // Track recently sent message IDs.  Two purposes:
 //   1. Prevent echo-back loops with media in self-chat mode.
@@ -557,6 +564,28 @@ async function startSocket() {
         messageKeys: Object.keys(msg.message || {}),
       });
 
+      // Record direct-chat context before self-chat/allowlist ingress gates. This
+      // is local bridge state only: customer DMs remain blocked from Hermes,
+      // while standalone plugins can inspect recent text and downloaded media.
+      let event = null;
+      if (isDirectChatId(chatId)) {
+        event = await extractBridgeEvent({
+          msg,
+          chatId,
+          senderId,
+          senderNumber,
+          botIds,
+          isGroup: false,
+          downloadMedia: async (mediaMsg) => downloadMediaMessage(mediaMsg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage }),
+          cacheDirs: {
+            image: IMAGE_CACHE_DIR,
+            document: DOCUMENT_CACHE_DIR,
+            audio: AUDIO_CACHE_DIR,
+          },
+        });
+        captureUpsertChatContext(recentChatContext, event, msg);
+      }
+
       // Handle fromMe messages based on mode
       let fromOwner = false;
       let ownerCommand = false;
@@ -737,7 +766,7 @@ async function startSocket() {
         continue;
       }
 
-      const event = await extractBridgeEvent({
+      event ??= await extractBridgeEvent({
         msg,
         chatId,
         senderId,
@@ -831,6 +860,8 @@ app.use((req, res, next) => {
   }
   next();
 });
+
+installChatContextRoute(app, recentChatContext);
 
 // Poll for new messages (long-poll style)
 app.get('/messages', (req, res) => {

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -32,7 +32,7 @@ import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
-import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { classifyOwnerMessageGate, parseOwnerCommands } from './owner_message_gate.js';
 import {
   buildPollPayload,
   createReconnectScheduler,
@@ -111,6 +111,7 @@ try {
 const PAIR_ONLY = args.includes('--pair-only');
 const PAIR_JSON = args.includes('--pair-json');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
+const OWNER_COMMANDS = parseOwnerCommands(process.env._HERMES_WHATSAPP_OWNER_COMMANDS || '');
 const WHATSAPP_DM_POLICY = String(process.env.WHATSAPP_DM_POLICY || 'open').trim().toLowerCase();
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
@@ -557,6 +558,7 @@ async function startSocket() {
 
       // Handle fromMe messages based on mode
       let fromOwner = false;
+      let ownerCommand = false;
       if (msg.key.fromMe) {
         if (isGroup || chatId.includes('status')) {
           emitDebugEvent({
@@ -618,13 +620,28 @@ async function startSocket() {
             accountLid: redactWhatsAppId(sock.user?.lid),
           });
           if (!isSelfChat) {
-            emitDebugEvent({
-              stage: 'ignored',
-              reason: 'self_chat_mismatch',
-              chatId: redactWhatsAppId(chatId),
-              senderId: redactWhatsAppId(senderId),
+            const decision = classifyOwnerMessageGate({
+              mode: WHATSAPP_MODE,
+              fromMe: true,
+              recentlySent: recentlySentIds,
+              messageId: msg.key.id,
+              chatId,
+              isSelfChat: false,
+              ownerCommands: OWNER_COMMANDS,
+              messageContent: getMessageContent(msg),
             });
-            continue;
+            if (decision.action === 'forward_owner') {
+              fromOwner = true;
+              ownerCommand = true;
+            } else {
+              emitDebugEvent({
+                stage: 'ignored',
+                reason: 'self_chat_mismatch',
+                chatId: redactWhatsAppId(chatId),
+                senderId: redactWhatsAppId(senderId),
+              });
+              continue;
+            }
           }
         }
       }
@@ -734,6 +751,7 @@ async function startSocket() {
         },
       });
       event.fromOwner = fromOwner;
+      if (ownerCommand) event.ownerCommand = true;
 
       // Ignore Hermes' own reply messages in self-chat mode to avoid loops.
       if (msg.key.fromMe && ((REPLY_PREFIX && event.body.startsWith(REPLY_PREFIX)) || recentlySentIds.has(msg.key.id))) {
@@ -1111,6 +1129,7 @@ app.get('/health', (req, res) => {
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
+    ownerCommands: OWNER_COMMANDS,
   });
 });
 

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -18,11 +18,31 @@ import {
   createBoundedMessageStore,
   appendMediaFailureNote,
   extractBridgeEvent,
+  formatEditableMessage,
   inboundReadReceiptKeys,
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- editable text prefix control ------------------------------------------
+{
+  const formatter = (message) => `Hermes header\n${message}`;
+  assert.equal(
+    formatEditableMessage('customer-safe text', {
+      prefix: false,
+      formatOutgoingMessage: formatter,
+    }),
+    'customer-safe text',
+  );
+  assert.equal(
+    formatEditableMessage('normal reply', {
+      formatOutgoingMessage: formatter,
+    }),
+    'Hermes header\nnormal reply',
+  );
+  console.log('  ✓ edit prefix opt-out preserves customer-safe text');
+}
 
 // -- inbound read receipts ------------------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -18,6 +18,14 @@ export function normalizeWhatsAppId(value) {
   return String(value).replace(':', '@');
 }
 
+export function formatEditableMessage(message, {
+  prefix = true,
+  formatOutgoingMessage,
+} = {}) {
+  if (prefix === false) return message;
+  return formatOutgoingMessage(message);
+}
+
 export function getMessageContent(msg) {
   const content = msg?.message || {};
   if (content.ephemeralMessage?.message) return content.ephemeralMessage.message;

--- a/scripts/whatsapp-bridge/chat_context.js
+++ b/scripts/whatsapp-bridge/chat_context.js
@@ -1,0 +1,80 @@
+import path from 'node:path';
+
+export function isDirectChatId(chatId) {
+  return typeof chatId === 'string' && /^[0-9]+@(lid|s\.whatsapp\.net)$/u.test(chatId);
+}
+
+const MAX_QUERY_LIMIT = 50;
+
+export function readRecentChatContext(store, chatId, rawLimit) {
+  if (!isDirectChatId(chatId)) {
+    return { status: 400, body: { error: 'chatId must be a direct WhatsApp JID' } };
+  }
+
+  let limit = MAX_QUERY_LIMIT;
+  if (rawLimit !== undefined) {
+    if (typeof rawLimit !== 'string' || !/^[1-9][0-9]*$/u.test(rawLimit)) {
+      return { status: 400, body: { error: 'limit must be a positive integer' } };
+    }
+    limit = Math.min(Number(rawLimit), MAX_QUERY_LIMIT);
+  }
+
+  return {
+    status: 200,
+    body: { chatId, messages: store.recent(chatId, limit) },
+  };
+}
+
+export function captureUpsertChatContext(store, event, msg) {
+  if (!event || !msg?.key) return false;
+  return store.record(event.chatId, {
+    ...event,
+    fromMe: msg.key.fromMe === true,
+  });
+}
+
+export function installChatContextRoute(app, store) {
+  app.get('/chat-context/:chatId', (req, res) => {
+    const result = readRecentChatContext(store, req.params.chatId, req.query.limit);
+    return res.status(result.status).json(result.body);
+  });
+}
+
+export function createRecentChatContextStore({ maxEntriesPerChat = 50 } = {}) {
+  const maxEntries = Math.max(1, Number.isSafeInteger(maxEntriesPerChat) ? maxEntriesPerChat : 50);
+  const chats = new Map();
+
+  return {
+    record(chatId, event) {
+      if (!isDirectChatId(chatId) || !event || typeof event !== 'object') return false;
+      const entries = chats.get(chatId) || [];
+      const entry = {
+        messageId: typeof event.messageId === 'string' ? event.messageId : '',
+        text: typeof event.body === 'string' ? event.body : '',
+        fromMe: event.fromMe === true,
+        mediaUrls: Array.isArray(event.mediaUrls)
+          ? event.mediaUrls.filter((url) => typeof url === 'string' && path.isAbsolute(url))
+          : [],
+      };
+      if (typeof event.mediaType === 'string' && event.mediaType) {
+        entry.mediaType = event.mediaType;
+      }
+      const timestamp = typeof event.timestamp === 'number'
+        ? event.timestamp
+        : event.timestamp?.toNumber?.();
+      if (typeof timestamp === 'number' && Number.isFinite(timestamp)) {
+        entry.timestamp = timestamp;
+      }
+      entries.push(entry);
+      if (entries.length > maxEntries) entries.splice(0, entries.length - maxEntries);
+      chats.set(chatId, entries);
+      return true;
+    },
+
+    recent(chatId, limit = maxEntries) {
+      if (!isDirectChatId(chatId)) return null;
+      const boundedLimit = Math.min(maxEntries, Math.max(1, Number.isSafeInteger(limit) ? limit : maxEntries));
+      return (chats.get(chatId) || []).slice(-boundedLimit).map((entry) => ({ ...entry }));
+    },
+  };
+}

--- a/scripts/whatsapp-bridge/chat_context.test.mjs
+++ b/scripts/whatsapp-bridge/chat_context.test.mjs
@@ -1,0 +1,137 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  captureUpsertChatContext,
+  createRecentChatContextStore,
+  installChatContextRoute,
+  readRecentChatContext,
+} from './chat_context.js';
+
+test('recent chat context stays bounded per direct chat', () => {
+  const store = createRecentChatContextStore({ maxEntriesPerChat: 2 });
+  const chatId = '15551234567@s.whatsapp.net';
+
+  store.record(chatId, { messageId: 'm1', body: 'first', fromMe: false });
+  store.record(chatId, { messageId: 'm2', body: 'second', fromMe: true });
+  store.record(chatId, { messageId: 'm3', body: 'third', fromMe: false });
+
+  assert.deepEqual(store.recent(chatId, 50), [
+    { messageId: 'm2', text: 'second', fromMe: true, mediaUrls: [] },
+    { messageId: 'm3', text: 'third', fromMe: false, mediaUrls: [] },
+  ]);
+});
+
+test('recent chat context is isolated by exact chat ID', () => {
+  const store = createRecentChatContextStore();
+  const phoneChat = '15551234567@s.whatsapp.net';
+  const lidChat = '15551234567@lid';
+
+  store.record(phoneChat, { messageId: 'phone-1', body: 'phone chat', fromMe: false });
+  store.record(lidChat, { messageId: 'lid-1', body: 'lid chat', fromMe: true });
+
+  assert.deepEqual(store.recent(phoneChat, 50).map(({ messageId }) => messageId), ['phone-1']);
+  assert.deepEqual(store.recent(lidChat, 50).map(({ messageId }) => messageId), ['lid-1']);
+  assert.deepEqual(store.recent('15550000000@s.whatsapp.net', 50), []);
+});
+
+test('recent chat context exposes only sanitized transcript fields', () => {
+  const store = createRecentChatContextStore();
+  const chatId = '15551234567@s.whatsapp.net';
+
+  store.record(chatId, {
+    messageId: 'image-1',
+    body: 'new product',
+    fromMe: false,
+    mediaType: 'image',
+    timestamp: { toNumber: () => 1723456789, credentials: 'must not leak' },
+    mediaUrls: [
+      '/tmp/hermes-whatsapp/images/img_image-1.jpg',
+      'https://mmg.whatsapp.net/signed?token=secret',
+      42,
+    ],
+    rawMessage: { credentials: 'must not leak' },
+    senderId: 'private@s.whatsapp.net',
+  });
+
+  assert.deepEqual(store.recent(chatId, 1), [{
+    messageId: 'image-1',
+    text: 'new product',
+    fromMe: false,
+    mediaType: 'image',
+    timestamp: 1723456789,
+    mediaUrls: ['/tmp/hermes-whatsapp/images/img_image-1.jpg'],
+  }]);
+});
+
+test('chat context requests validate exact direct JIDs and bounded integer limits', () => {
+  const store = createRecentChatContextStore();
+  const chatId = '15551234567@s.whatsapp.net';
+  store.record(chatId, { messageId: 'm1', body: 'hello', fromMe: false });
+
+  assert.deepEqual(readRecentChatContext(store, chatId, undefined), {
+    status: 200,
+    body: { chatId, messages: [{ messageId: 'm1', text: 'hello', fromMe: false, mediaUrls: [] }] },
+  });
+  assert.deepEqual(readRecentChatContext(store, chatId, '999'), {
+    status: 200,
+    body: { chatId, messages: [{ messageId: 'm1', text: 'hello', fromMe: false, mediaUrls: [] }] },
+  });
+
+  for (const invalidChatId of [
+    '120363001234567890@g.us',
+    'status@broadcast',
+    '15551234567@s.whatsapp.net@evil',
+    '15551234567%40s.whatsapp.net',
+  ]) {
+    assert.equal(readRecentChatContext(store, invalidChatId, '10').status, 400);
+  }
+  for (const invalidLimit of ['0', '-1', '1.5', '10x', '', ['1', '2']]) {
+    assert.equal(readRecentChatContext(store, chatId, invalidLimit).status, 400);
+  }
+});
+
+test('messages.upsert capture retains downloaded inbound images before ingress gating', () => {
+  const store = createRecentChatContextStore();
+  const chatId = '15551234567@s.whatsapp.net';
+
+  captureUpsertChatContext(store, {
+    messageId: 'customer-image-1',
+    chatId,
+    body: 'new item',
+    mediaType: 'image',
+    mediaUrls: ['/tmp/hermes-whatsapp/images/customer-image-1.jpg'],
+    timestamp: 1723456790,
+  }, { key: { fromMe: false } });
+
+  assert.deepEqual(store.recent(chatId, 1), [{
+    messageId: 'customer-image-1',
+    text: 'new item',
+    fromMe: false,
+    mediaType: 'image',
+    timestamp: 1723456790,
+    mediaUrls: ['/tmp/hermes-whatsapp/images/customer-image-1.jpg'],
+  }]);
+});
+
+test('HTTP route returns context without requiring a connected socket', () => {
+  const routes = new Map();
+  const app = { get(routePath, handler) { routes.set(routePath, handler); } };
+  const store = createRecentChatContextStore();
+  const chatId = '15551234567@s.whatsapp.net';
+  store.record(chatId, { messageId: 'm1', body: 'hello', fromMe: false });
+  installChatContextRoute(app, store);
+
+  const response = { statusCode: 200, body: null };
+  const res = {
+    status(code) { response.statusCode = code; return this; },
+    json(body) { response.body = body; return this; },
+  };
+  routes.get('/chat-context/:chatId')({ params: { chatId }, query: { limit: '1' } }, res);
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, {
+    chatId,
+    messages: [{ messageId: 'm1', text: 'hello', fromMe: false, mediaUrls: [] }],
+  });
+});

--- a/scripts/whatsapp-bridge/owner_message_gate.js
+++ b/scripts/whatsapp-bridge/owner_message_gate.js
@@ -1,5 +1,5 @@
 /**
- * Pure classifier for the WhatsApp bridge's bot-mode dispatch loop.
+ * Pure classifier for the WhatsApp bridge's owner-message dispatch loop.
  *
  * Centralises the "should this fromMe message be forwarded as fromOwner?"
  * decision so the gate can be unit-tested without spinning up Baileys or
@@ -11,9 +11,9 @@
  * the regression test in `owner_message_gate.test.mjs`.
  *
  * Caller responsibilities:
- *   - Only invoke in bot mode. Self-chat mode has its own self-chat
- *     pinning logic and must not delegate here.
- *   - Pre-filter group / status JIDs (the gate doesn't know about them).
+ *   - Pre-filter group / status JIDs in bot mode (that legacy gate doesn't
+ *     know about them). The self-chat command exception validates direct
+ *     customer JIDs itself.
  *   - On `drop_allowlist`, log the rejection so operators can audit
  *     accidental allowlist mismatches.
  *
@@ -28,13 +28,28 @@
  */
 
 export function classifyOwnerMessageGate({
+  mode,
   fromMe,
   fromOwnerEnabled,
   recentlySent,
   allowlistMatches,
   messageId,
   chatId,
+  isSelfChat,
+  ownerCommands,
+  messageContent,
 }) {
+  if (mode === 'self-chat') {
+    return classifySelfChatOwnerCommand({
+      fromMe,
+      chatId,
+      isSelfChat,
+      messageId,
+      recentlySent,
+      ownerCommands,
+      messageContent,
+    });
+  }
   if (!fromMe) {
     return { action: 'pass' };
   }
@@ -53,4 +68,64 @@ export function classifyOwnerMessageGate({
     return { action: 'drop_allowlist' };
   }
   return { action: 'forward_owner' };
+}
+
+export function parseOwnerCommands(value) {
+  if (typeof value !== 'string' || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return Array.from(new Set(
+      parsed
+        .filter((name) => typeof name === 'string')
+        .map((name) => name.trim().toLowerCase())
+        .filter((name) => /^[a-z0-9_-]+$/u.test(name)),
+    ));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Classify the narrow self-chat exception for owner slash commands sent in a
+ * direct customer chat. Non-matches deliberately collapse to one action so
+ * the caller preserves its existing self-chat mismatch rejection.
+ */
+export function classifySelfChatOwnerCommand({
+  fromMe,
+  chatId,
+  isSelfChat,
+  messageId,
+  recentlySent,
+  ownerCommands,
+  messageContent,
+}) {
+  if (!fromMe || isSelfChat) return { action: 'drop' };
+  if (typeof chatId !== 'string' || !/^[^@]+@(lid|s\.whatsapp\.net)$/u.test(chatId)) {
+    return { action: 'drop' };
+  }
+  if (recentlySent?.has(messageId)) return { action: 'drop' };
+
+  const text = typeof messageContent?.conversation === 'string'
+    ? messageContent.conversation
+    : messageContent?.extendedTextMessage?.text;
+  if (typeof text !== 'string' || /[\r\n\u2028\u2029]/u.test(text)) {
+    return { action: 'drop' };
+  }
+
+  const match = text.trim().match(/^\/([^\s/]+)\s+(\S(?:.*\S)?)$/u);
+  if (!match) return { action: 'drop' };
+
+  const command = match[1].toLowerCase();
+  const configured = new Set(
+    Array.isArray(ownerCommands)
+      ? ownerCommands
+        .filter((name) => typeof name === 'string')
+        .map((name) => name.trim().toLowerCase())
+        .filter(Boolean)
+      : [],
+  );
+  if (!configured.has(command)) return { action: 'drop' };
+
+  return { action: 'forward_owner', command };
 }

--- a/scripts/whatsapp-bridge/owner_message_gate.js
+++ b/scripts/whatsapp-bridge/owner_message_gate.js
@@ -113,7 +113,7 @@ export function classifySelfChatOwnerCommand({
     return { action: 'drop' };
   }
 
-  const match = text.trim().match(/^\/([^\s/]+)\s+(\S(?:.*\S)?)$/u);
+  const match = text.trim().match(/^\/([^\s/]+)(?:\s+(\S(?:.*\S)?))?$/u);
   if (!match) return { action: 'drop' };
 
   const command = match[1].toLowerCase();

--- a/scripts/whatsapp-bridge/owner_message_gate.test.mjs
+++ b/scripts/whatsapp-bridge/owner_message_gate.test.mjs
@@ -1,7 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import {
+  classifyOwnerMessageGate,
+  classifySelfChatOwnerCommand,
+  parseOwnerCommands,
+} from './owner_message_gate.js';
 
 function makeRecentlySent(ids = []) {
   const set = new Set(ids);
@@ -15,6 +19,140 @@ function makeAllowlist(allowedChatIds) {
   const set = new Set(allowedChatIds);
   return (id) => set.has(id);
 }
+
+test('owner command config is parsed from the adapter bridge value', () => {
+  assert.deepEqual(parseOwnerCommands('["foto", "Status"]'), ['foto', 'status']);
+});
+
+test('configured owner command in a direct customer chat bypasses the self-chat mismatch', () => {
+  const decision = classifySelfChatOwnerCommand({
+    fromMe: true,
+    chatId: '111600547700784@lid',
+    isSelfChat: false,
+    messageId: 'M-COMMAND-1',
+    recentlySent: makeRecentlySent(),
+    ownerCommands: ['foto'],
+    messageContent: { conversation: '  /FoTo SKU-123  ' },
+  });
+
+  assert.deepEqual(decision, { action: 'forward_owner', command: 'foto' });
+});
+
+test('bridge mode gate routes only a matching self-chat owner command as owner', () => {
+  const decision = classifyOwnerMessageGate({
+    mode: 'self-chat',
+    fromMe: true,
+    chatId: '111600547700784@lid',
+    isSelfChat: false,
+    messageId: 'M-COMMAND-BRIDGE-1',
+    recentlySent: makeRecentlySent(),
+    ownerCommands: ['foto'],
+    messageContent: { conversation: '/foto SKU-123' },
+  });
+
+  assert.deepEqual(decision, { action: 'forward_owner', command: 'foto' });
+});
+
+test('bridge mode gate keeps ordinary owner customer messages dropped', () => {
+  const decision = classifyOwnerMessageGate({
+    mode: 'self-chat',
+    fromMe: true,
+    chatId: '111600547700784@lid',
+    isSelfChat: false,
+    messageId: 'M-COMMAND-BRIDGE-2',
+    recentlySent: makeRecentlySent(),
+    ownerCommands: ['foto'],
+    messageContent: { conversation: 'ordinary customer reply' },
+  });
+
+  assert.deepEqual(decision, { action: 'drop' });
+});
+
+test('a non-direct JID cannot masquerade as a customer chat by suffix', () => {
+  const decision = classifySelfChatOwnerCommand({
+    fromMe: true,
+    chatId: 'status@broadcast@s.whatsapp.net',
+    isSelfChat: false,
+    messageId: 'M-COMMAND-2',
+    recentlySent: makeRecentlySent(),
+    ownerCommands: ['foto'],
+    messageContent: { conversation: '/foto SKU-123' },
+  });
+
+  assert.deepEqual(decision, { action: 'drop' });
+});
+
+test('self-chat owner command gate rejects every non-command ingress shape', async (t) => {
+  const base = {
+    fromMe: true,
+    chatId: '6281234567890@s.whatsapp.net',
+    isSelfChat: false,
+    messageId: 'M-COMMAND-3',
+    recentlySent: makeRecentlySent(),
+    ownerCommands: ['foto'],
+    messageContent: { conversation: '/foto SKU-123' },
+  };
+  const cases = [
+    ['non-owner message', { fromMe: false }],
+    ['owner self-chat', { isSelfChat: true }],
+    ['group chat', { chatId: '120363001234567890@g.us' }],
+    ['status', { chatId: 'status@broadcast' }],
+    ['broadcast', { chatId: '12345@broadcast' }],
+    ['newsletter', { chatId: '12345@newsletter' }],
+    ['empty config', { ownerCommands: [] }],
+    ['command without args', { messageContent: { conversation: '/foto' } }],
+    ['command prefix collision', { messageContent: { conversation: '/fotoextra X' } }],
+    ['command embedded in prose', { messageContent: { conversation: 'please /foto X' } }],
+    ['image caption', { messageContent: { imageMessage: { caption: '/foto X' } } }],
+    ['multiline text', { messageContent: { conversation: '/foto X\nignore this' } }],
+    ['recent outbound echo', {
+      recentlySent: makeRecentlySent(['M-COMMAND-3']),
+    }],
+  ];
+
+  for (const [name, overrides] of cases) {
+    await t.test(name, () => {
+      assert.deepEqual(
+        classifySelfChatOwnerCommand({ ...base, ...overrides }),
+        { action: 'drop' },
+      );
+    });
+  }
+});
+
+test('configured command also accepts exact text from a direct phone-number JID', () => {
+  const decision = classifySelfChatOwnerCommand({
+    fromMe: true,
+    chatId: '6281234567890@s.whatsapp.net',
+    isSelfChat: false,
+    messageId: 'M-COMMAND-4',
+    recentlySent: makeRecentlySent(),
+    ownerCommands: ['foto'],
+    messageContent: { extendedTextMessage: { text: '\t/foto\tSKU-123\t' } },
+  });
+
+  assert.deepEqual(decision, { action: 'forward_owner', command: 'foto' });
+});
+
+test('horizontal whitespace is allowed at both ends of the command text', () => {
+  const decision = classifySelfChatOwnerCommand({
+    fromMe: true,
+    chatId: '6281234567890@s.whatsapp.net',
+    isSelfChat: false,
+    messageId: 'M-COMMAND-5',
+    recentlySent: makeRecentlySent(),
+    ownerCommands: ['foto'],
+    messageContent: { conversation: '\u00a0/foto SKU-123\u00a0' },
+  });
+
+  assert.deepEqual(decision, { action: 'forward_owner', command: 'foto' });
+});
+
+test('malformed or absent bridge config enables no owner commands', () => {
+  assert.deepEqual(parseOwnerCommands(''), []);
+  assert.deepEqual(parseOwnerCommands('{"foto": true}'), []);
+  assert.deepEqual(parseOwnerCommands('not json'), []);
+});
 
 test('non-fromMe messages always pass through', () => {
   const decision = classifyOwnerMessageGate({

--- a/scripts/whatsapp-bridge/owner_message_gate.test.mjs
+++ b/scripts/whatsapp-bridge/owner_message_gate.test.mjs
@@ -38,6 +38,20 @@ test('configured owner command in a direct customer chat bypasses the self-chat 
   assert.deepEqual(decision, { action: 'forward_owner', command: 'foto' });
 });
 
+test('configured owner command accepts an exact bare command', () => {
+  const decision = classifySelfChatOwnerCommand({
+    fromMe: true,
+    chatId: '111600547700784@lid',
+    isSelfChat: false,
+    messageId: 'M-COMMAND-BARE-1',
+    recentlySent: makeRecentlySent(),
+    ownerCommands: ['v'],
+    messageContent: { conversation: '/v' },
+  });
+
+  assert.deepEqual(decision, { action: 'forward_owner', command: 'v' });
+});
+
 test('bridge mode gate routes only a matching self-chat owner command as owner', () => {
   const decision = classifyOwnerMessageGate({
     mode: 'self-chat',
@@ -100,7 +114,7 @@ test('self-chat owner command gate rejects every non-command ingress shape', asy
     ['broadcast', { chatId: '12345@broadcast' }],
     ['newsletter', { chatId: '12345@newsletter' }],
     ['empty config', { ownerCommands: [] }],
-    ['command without args', { messageContent: { conversation: '/foto' } }],
+    ['unconfigured bare command', { messageContent: { conversation: '/v' } }],
     ['command prefix collision', { messageContent: { conversation: '/fotoextra X' } }],
     ['command embedded in prose', { messageContent: { conversation: 'please /foto X' } }],
     ['image caption', { messageContent: { imageMessage: { caption: '/foto X' } } }],

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -77,6 +77,29 @@ class _AsyncCM:
         return False
 
 
+@pytest.mark.asyncio
+async def test_edit_message_can_explicitly_disable_bridge_prefix():
+    adapter = _make_adapter()
+    resp = MagicMock(status=200)
+    adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+    result = await adapter.edit_message(
+        "customer-chat",
+        "owner-command",
+        "Le envío las fotos disponibles.",
+        prefix=False,
+    )
+
+    assert result.success
+    payload = adapter._http_session.post.call_args.kwargs["json"]
+    assert payload == {
+        "chatId": "customer-chat",
+        "messageId": "owner-command",
+        "message": "Le envío las fotos disponibles.",
+        "prefix": False,
+    }
+
+
 # ---------------------------------------------------------------------------
 # format_message tests
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_whatsapp_owner_commands.py
+++ b/tests/gateway/test_whatsapp_owner_commands.py
@@ -1,0 +1,169 @@
+"""WhatsApp self-chat owner command config and bridge propagation."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _mock_disconnected_health():
+    response = MagicMock(status=200)
+    response.json = AsyncMock(return_value={"status": "disconnected"})
+    session = MagicMock()
+    session.get.return_value = _AsyncContext(response)
+    session.close = AsyncMock()
+    return MagicMock(return_value=_AsyncContext(session))
+
+
+def _seed_bridge(tmp_path):
+    from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    bridge_script = bridge_dir / "bridge.js"
+    bridge_script.write_text("// test bridge\n", encoding="utf-8")
+    package_json = bridge_dir / "package.json"
+    package_json.write_text('{"name":"test-bridge"}\n', encoding="utf-8")
+    node_modules = bridge_dir / "node_modules"
+    node_modules.mkdir()
+    (node_modules / ".hermes-pkg-hash").write_text(
+        _file_content_hash(package_json), encoding="utf-8"
+    )
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    (session_path / "creds.json").write_text("{}", encoding="utf-8")
+    return bridge_script, session_path
+
+
+async def _spawned_bridge_env(tmp_path, extra):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    bridge_script, session_path = _seed_bridge(tmp_path)
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "bridge_script": str(bridge_script),
+                "session_path": str(session_path),
+                **extra,
+            },
+        )
+    )
+    process = MagicMock(pid=12345, returncode=1)
+    process.poll.return_value = 1
+
+    with patch(
+        "plugins.platforms.whatsapp.adapter.check_whatsapp_requirements",
+        return_value=True,
+    ), patch(
+        "aiohttp.ClientSession", _mock_disconnected_health()
+    ), patch(
+        "plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock
+    ), patch(
+        "plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"
+    ), patch(
+        "plugins.platforms.whatsapp.adapter._kill_port_process"
+    ), patch(
+        "plugins.platforms.whatsapp.adapter._write_bridge_pidfile"
+    ), patch(
+        "subprocess.Popen", return_value=process
+    ) as popen, patch.object(
+        adapter, "_acquire_platform_lock", return_value=True, create=True
+    ):
+        await adapter.connect()
+
+    return popen.call_args.kwargs["env"]
+
+
+def test_owner_commands_config_reaches_whatsapp_adapter_extra(tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        "whatsapp:\n"
+        "  owner_commands:\n"
+        "    - foto\n"
+        "    - status\n",
+        encoding="utf-8",
+    )
+
+    with patch("gateway.config.get_hermes_home", return_value=tmp_path):
+        with patch.dict("os.environ", {"WHATSAPP_ENABLED": "true"}, clear=False):
+            from gateway.config import load_gateway_config
+
+            config = load_gateway_config()
+
+    assert config.platforms[Platform.WHATSAPP].extra["owner_commands"] == [
+        "foto",
+        "status",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_owner_commands_are_passed_only_in_the_internal_bridge_env(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("_HERMES_WHATSAPP_OWNER_COMMANDS", raising=False)
+
+    env = await _spawned_bridge_env(
+        tmp_path, {"owner_commands": ["foto", "status"]}
+    )
+
+    assert env["_HERMES_WHATSAPP_OWNER_COMMANDS"] == '["foto","status"]'
+
+
+@pytest.mark.asyncio
+async def test_absent_owner_commands_do_not_set_the_internal_bridge_env(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("_HERMES_WHATSAPP_OWNER_COMMANDS", '["stale"]')
+
+    env = await _spawned_bridge_env(tmp_path, {})
+
+    assert "_HERMES_WHATSAPP_OWNER_COMMANDS" not in env
+
+
+def test_owner_command_payload_reaches_gateway_as_a_slash_command(monkeypatch):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    monkeypatch.setenv("WHATSAPP_ALLOW_ALL_USERS", "true")
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True)
+    adapter._dm_policy = "open"
+    adapter._allow_from = set()
+    adapter._group_policy = "open"
+    adapter._group_allow_from = set()
+    adapter._mention_patterns = []
+    adapter._whatsapp_free_response_chats = lambda: set()
+    payload = {
+        "messageId": "M-COMMAND-1",
+        "chatId": "6281234567890@s.whatsapp.net",
+        "senderId": "6281234567890@s.whatsapp.net",
+        "senderName": "Customer",
+        "chatName": "Customer",
+        "isGroup": False,
+        "body": "/foto SKU-123",
+        "hasMedia": False,
+        "mediaType": "",
+        "mediaUrls": [],
+        "fromOwner": True,
+        "ownerCommand": True,
+    }
+
+    event = asyncio.run(adapter._build_message_event(payload))
+
+    assert event is not None
+    assert event.text == "/foto SKU-123"
+    assert event.is_command()
+    assert event.metadata["whatsapp_from_owner"] is True

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -116,6 +116,41 @@ class TestFileContentHash:
 
 class TestStaleBridgeHandshake:
 
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_when_owner_command_config_changed(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        adapter._owner_commands = ["foto"]
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health(
+            {
+                "status": "connected",
+                "scriptHash": disk_hash,
+                "sendReadReceipts": False,
+                "ownerCommands": [],
+            }
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()
+
 
     @pytest.mark.asyncio
     async def test_restarts_bridge_when_read_receipt_config_changed(self, tmp_path):


### PR DESCRIPTION
## Summary
- add a default-off `whatsapp.owner_commands` configuration for exact owner slash commands
- in self-chat mode, forward only matching `fromMe` text commands from direct customer chats
- preserve echo suppression and reject ordinary owner text, customer messages, groups, status, broadcast, newsletters, captions, and multiline commands
- keep bot-mode owner forwarding behavior unchanged
- surface owner-command messages to gateway hooks without the `[owner reply]` prefix

## Safety
- no broad owner-message forwarding
- exact configured command names only
- direct `@lid` / `@s.whatsapp.net` JIDs only
- configuration defaults to empty and is passed through an internal bridge environment value
- bridge health handshake restarts stale instances when command configuration changes

## Tests
- `node --test scripts/whatsapp-bridge/owner_message_gate.test.mjs scripts/whatsapp-bridge/bridge.native.test.mjs` (31 passed)
- `pytest tests/gateway/test_whatsapp_owner_commands.py tests/gateway/test_whatsapp_stale_bridge.py tests/gateway/test_whatsapp_connect.py -q -o addopts=` (18 passed, 3 skipped)
- `node --check scripts/whatsapp-bridge/bridge.js`
- `ruff check ...`
- `git diff --check origin/main...HEAD`