### PR TITLE
fix(matrix): rebase #71544 onto main; only log cross-signing "verified" when the signature is valid

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1590,6 +1590,53 @@ class MatrixAdapter(BasePlatformAdapter):
                     row["session_id"],
                 )
 
+    async def _warn_if_cross_signing_signature_stale(self, client: Any) -> bool | None:
+        """Check the self-signing signature the server serves for our device.
+
+        Returns True if valid, False if the server has an invalid (stale)
+        signature, and None if the state could not be determined. A stale
+        signature cannot be replaced via /keys/signatures/upload — the
+        homeserver silently keeps the old one — so the only fix is a fresh
+        device (new access token), which is what the logged error says.
+        """
+        try:
+            from mautrix.crypto.signature import verify_signature_json
+
+            resp = await client.query_keys({client.mxid: [client.device_id]})
+            device_keys = resp.device_keys[client.mxid][client.device_id]
+            ssk_obj = resp.self_signing_keys[client.mxid]
+            ssk_pubkey = next(iter(ssk_obj.keys.values()))
+        except Exception as exc:
+            logger.warning(
+                "Matrix: could not check cross-signing signature state: %s", exc
+            )
+            return None
+        signed = (
+            device_keys.serialize()
+            if hasattr(device_keys, "serialize")
+            else device_keys
+        )
+        sigs = (signed.get("signatures") or {}).get(str(client.mxid)) or {}
+        if f"ed25519:{ssk_pubkey}" not in sigs:
+            logger.warning(
+                "Matrix: device %s has no cross-signing signature on the server",
+                client.device_id,
+            )
+            return False
+        if verify_signature_json(signed, client.mxid, ssk_pubkey, ssk_pubkey):
+            return True
+        logger.error(
+            "Matrix: the homeserver has a stale cross-signing signature for "
+            "device %s (left over from earlier device-key changes) and "
+            "silently refuses to replace it. Other clients will show this "
+            "bot as unverified and may withhold encryption keys. Fix: sign "
+            "the bot out of this session, create a new access token (fresh "
+            "device ID), update MATRIX_ACCESS_TOKEN, and restart — the "
+            "local crypto store resets automatically on device change.",
+            client.device_id,
+        )
+        return False
+
     async def _verify_device_keys_on_server(self, client: Any, olm: Any) -> bool:
         """Verify our device keys are on the homeserver after loading crypto state.
 
@@ -1956,6 +2003,14 @@ class MatrixAdapter(BasePlatformAdapter):
                         try:
                             await olm.verify_with_recovery_key(recovery_key)
                             logger.info("Matrix: cross-signing verified via recovery key")
+                            # verify_with_recovery_key signs this device with the
+                            # self-signing key and uploads the signature, but the
+                            # homeserver silently keeps a pre-existing (possibly
+                            # stale) signature and mautrix ignores per-key upload
+                            # failures. A stale signature makes other clients show
+                            # the bot as unverified and withhold room keys, so
+                            # check what the server actually serves.
+                            await self._warn_if_cross_signing_signature_stale(client)
                         except Exception as exc:
                             logger.warning("Matrix: recovery key verification failed: %s", exc)
                     else:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1605,7 +1605,6 @@ class MatrixAdapter(BasePlatformAdapter):
             resp = await client.query_keys({client.mxid: [client.device_id]})
             device_keys = resp.device_keys[client.mxid][client.device_id]
             ssk_obj = resp.self_signing_keys[client.mxid]
-            ssk_pubkey = next(iter(ssk_obj.keys.values()))
         except Exception as exc:
             logger.warning(
                 "Matrix: could not check cross-signing signature state: %s", exc
@@ -1617,22 +1616,30 @@ class MatrixAdapter(BasePlatformAdapter):
             else device_keys
         )
         sigs = (signed.get("signatures") or {}).get(str(client.mxid)) or {}
-        if f"ed25519:{ssk_pubkey}" not in sigs:
-            logger.warning(
-                "Matrix: device %s has no cross-signing signature on the server",
+        # The device should be signed by one of the server's current
+        # self-signing keys. Iterate over all of them rather than assume a
+        # single key: after key rotation the server may serve several, and
+        # the device's signature entry names the specific key id it was
+        # signed with.
+        for key_id, ssk_key in ssk_obj.keys.items():
+            if str(key_id) not in sigs:
+                continue
+            if verify_signature_json(signed, client.mxid, ssk_key, ssk_key):
+                return True
+            # The signature is present under this key id but does not verify.
+            logger.error(
+                "Matrix: the homeserver has a stale cross-signing signature for "
+                "device %s (left over from earlier device-key changes) and "
+                "silently refuses to replace it. Other clients will show this "
+                "bot as unverified and may withhold encryption keys. Fix: sign "
+                "the bot out of this session, create a new access token (fresh "
+                "device ID), update MATRIX_ACCESS_TOKEN, and restart — the "
+                "local crypto store resets automatically on device change.",
                 client.device_id,
             )
             return False
-        if verify_signature_json(signed, client.mxid, ssk_pubkey, ssk_pubkey):
-            return True
-        logger.error(
-            "Matrix: the homeserver has a stale cross-signing signature for "
-            "device %s (left over from earlier device-key changes) and "
-            "silently refuses to replace it. Other clients will show this "
-            "bot as unverified and may withhold encryption keys. Fix: sign "
-            "the bot out of this session, create a new access token (fresh "
-            "device ID), update MATRIX_ACCESS_TOKEN, and restart — the "
-            "local crypto store resets automatically on device change.",
+        logger.warning(
+            "Matrix: device %s has no cross-signing signature on the server",
             client.device_id,
         )
         return False
@@ -2013,18 +2020,31 @@ class MatrixAdapter(BasePlatformAdapter):
                             server_state = (
                                 await self._warn_if_cross_signing_signature_stale(client)
                             )
-                            # Only claim "verified" when the server check did not
-                            # prove the signature stale. On a stale signature the
-                            # helper already logged the actionable error; logging
-                            # "verified" here would contradict it and mislead
-                            # operators into thinking the device is trusted.
-                            if server_state is not False:
+                            # Only claim "verified" when the server check
+                            # confirmed the served signature is valid. When the
+                            # check could not run (None), the local recovery-key
+                            # signing did succeed but we have not confirmed the
+                            # server state, so say exactly that instead of
+                            # overclaiming "verified". When the check returned
+                            # False the helper already logged the actionable
+                            # stale-signature error.
+                            if server_state is True:
                                 logger.info(
                                     "Matrix: cross-signing verified via recovery key"
+                                )
+                            elif server_state is None:
+                                logger.info(
+                                    "Matrix: cross-signing signed via recovery key "
+                                    "(server-side signature check could not run)"
                                 )
                         except Exception as exc:
                             logger.warning("Matrix: recovery key verification failed: %s", exc)
                     else:
+                        # No recovery key configured: the bot only reads the
+                        # server's cross-signing keys here (it cannot sign the
+                        # device without the recovery key), so the stale-
+                        # signature check on the recovery-key path does not
+                        # apply to this branch.
                         try:
                             own_xsign = await olm.get_own_cross_signing_public_keys()
                         except Exception as exc:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2002,15 +2002,26 @@ class MatrixAdapter(BasePlatformAdapter):
                     if recovery_key:
                         try:
                             await olm.verify_with_recovery_key(recovery_key)
-                            logger.info("Matrix: cross-signing verified via recovery key")
                             # verify_with_recovery_key signs this device with the
                             # self-signing key and uploads the signature, but the
                             # homeserver silently keeps a pre-existing (possibly
                             # stale) signature and mautrix ignores per-key upload
                             # failures. A stale signature makes other clients show
                             # the bot as unverified and withhold room keys, so
-                            # check what the server actually serves.
-                            await self._warn_if_cross_signing_signature_stale(client)
+                            # check what the server actually serves rather than
+                            # trusting the local upload as proof of success.
+                            server_state = (
+                                await self._warn_if_cross_signing_signature_stale(client)
+                            )
+                            # Only claim "verified" when the server check did not
+                            # prove the signature stale. On a stale signature the
+                            # helper already logged the actionable error; logging
+                            # "verified" here would contradict it and mislead
+                            # operators into thinking the device is trusted.
+                            if server_state is not False:
+                                logger.info(
+                                    "Matrix: cross-signing verified via recovery key"
+                                )
                         except Exception as exc:
                             logger.warning("Matrix: recovery key verification failed: %s", exc)
                     else:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3575,3 +3575,36 @@ class TestStaleCrossSigningSignatureWarning:
         stale_check.assert_not_awaited()
 
         await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_suppresses_verified_log_when_signature_stale(
+        self, monkeypatch, caplog
+    ):
+        """A stale server signature must not be reported as 'verified'.
+
+        The old code logged ``INFO cross-signing verified via recovery key``
+        unconditionally after ``verify_with_recovery_key()``, then logged the
+        stale-signature error afterwards — a self-contradicting log sequence
+        that misled operators into thinking the device was trusted when it
+        was not. When the server-side check returns False, no 'verified'
+        INFO line may be emitted; the actionable stale-signature error is
+        already logged by the helper.
+        """
+        import logging
+
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "EsTfakerecoverykey")
+        adapter = self._encrypted_adapter()
+        mock_client, mock_olm = self._connect_mocks()
+        mock_olm.verify_with_recovery_key = AsyncMock()
+        stale_check = AsyncMock(return_value=False)
+
+        with caplog.at_level(logging.INFO):
+            assert await self._run_connect(
+                adapter, mock_client, mock_olm, stale_check
+            ) is True
+
+        mock_olm.verify_with_recovery_key.assert_awaited_once()
+        stale_check.assert_awaited_once_with(mock_client)
+        assert "cross-signing verified via recovery key" not in caplog.text
+
+        await adapter.disconnect()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3608,3 +3608,33 @@ class TestStaleCrossSigningSignatureWarning:
         assert "cross-signing verified via recovery key" not in caplog.text
 
         await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_does_not_overclaim_verified_when_check_unavailable(
+        self, monkeypatch, caplog
+    ):
+        """When the server-side check cannot run (None), do not claim 'verified'.
+
+        The local recovery-key signing succeeded, but the server state was
+        never confirmed, so logging 'verified' would overstate what we know.
+        The log must say the check could not run instead.
+        """
+        import logging
+
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "EsTfakerecoverykey")
+        adapter = self._encrypted_adapter()
+        mock_client, mock_olm = self._connect_mocks()
+        mock_olm.verify_with_recovery_key = AsyncMock()
+        stale_check = AsyncMock(return_value=None)
+
+        with caplog.at_level(logging.INFO):
+            assert await self._run_connect(
+                adapter, mock_client, mock_olm, stale_check
+            ) is True
+
+        mock_olm.verify_with_recovery_key.assert_awaited_once()
+        stale_check.assert_awaited_once_with(mock_client)
+        assert "cross-signing verified via recovery key" not in caplog.text
+        assert "signature check could not run" in caplog.text
+
+        await adapter.disconnect()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3342,3 +3342,90 @@ class TestCryptoPickleKeyMigration:
         # start still sees a legacy-key account and retries the migration.
         store.put_account.assert_not_awaited()
         assert "retried on the next start" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Stale cross-signing signature detection
+# ---------------------------------------------------------------------------
+
+def _make_xsign_client(device_sigs, ssk_pubkey="sskpubkey"):
+    """Client whose query_keys returns a device signed with the given sigs."""
+    client = MagicMock()
+    client.mxid = "@bot:example.org"
+    client.device_id = "DEVICE1"
+
+    device_keys = MagicMock()
+    device_keys.serialize.return_value = {
+        "algorithms": ["m.megolm.v1.aes-sha2"],
+        "device_id": "DEVICE1",
+        "keys": {"ed25519:DEVICE1": "devpubkey"},
+        "user_id": "@bot:example.org",
+        "signatures": {"@bot:example.org": device_sigs},
+    }
+    ssk_obj = MagicMock()
+    ssk_obj.keys = {f"ed25519:{ssk_pubkey}": ssk_pubkey}
+    client.query_keys = AsyncMock(return_value=MagicMock(
+        device_keys={"@bot:example.org": {"DEVICE1": device_keys}},
+        self_signing_keys={"@bot:example.org": ssk_obj},
+    ))
+    return client
+
+
+class TestStaleCrossSigningSignatureWarning:
+    @pytest.mark.asyncio
+    async def test_invalid_signature_logs_actionable_error(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        client = _make_xsign_client({"ed25519:sskpubkey": "bogus-signature"})
+
+        with patch(
+            "mautrix.crypto.signature.verify_signature_json", return_value=False
+        ), caplog.at_level(logging.ERROR):
+            result = await adapter._warn_if_cross_signing_signature_stale(client)
+
+        assert result is False
+        assert "stale cross-signing signature" in caplog.text
+        assert "new access token" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_valid_signature_is_quiet(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        client = _make_xsign_client({"ed25519:sskpubkey": "good-signature"})
+
+        with patch(
+            "mautrix.crypto.signature.verify_signature_json", return_value=True
+        ), caplog.at_level(logging.WARNING):
+            result = await adapter._warn_if_cross_signing_signature_stale(client)
+
+        assert result is True
+        assert caplog.text == ""
+
+    @pytest.mark.asyncio
+    async def test_missing_signature_warns(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        client = _make_xsign_client({"ed25519:DEVICE1": "self-sig-only"})
+
+        with patch(
+            "mautrix.crypto.signature.verify_signature_json", return_value=True
+        ), caplog.at_level(logging.WARNING):
+            result = await adapter._warn_if_cross_signing_signature_stale(client)
+
+        assert result is False
+        assert "no cross-signing signature" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_query_failure_returns_none(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        client = MagicMock()
+        client.mxid = "@bot:example.org"
+        client.device_id = "DEVICE1"
+        client.query_keys = AsyncMock(side_effect=RuntimeError("network down"))
+
+        with caplog.at_level(logging.WARNING):
+            result = await adapter._warn_if_cross_signing_signature_stale(client)
+
+        assert result is None
+        assert "could not check cross-signing signature state" in caplog.text

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3372,14 +3372,25 @@ def _make_xsign_client(device_sigs, ssk_pubkey="sskpubkey"):
 
 
 class TestStaleCrossSigningSignatureWarning:
+    @staticmethod
+    def _fake_signature_module(verifies: bool):
+        """Fake mautrix.crypto.signature.
+
+        The helper imports it lazily; patching the real attribute would
+        require libolm, which is not needed to exercise this logic.
+        """
+        mod = types.ModuleType("mautrix.crypto.signature")
+        mod.verify_signature_json = lambda *a, **kw: verifies
+        return {"mautrix.crypto.signature": mod}
+
     @pytest.mark.asyncio
     async def test_invalid_signature_logs_actionable_error(self, caplog):
         import logging
         adapter = _make_adapter()
         client = _make_xsign_client({"ed25519:sskpubkey": "bogus-signature"})
 
-        with patch(
-            "mautrix.crypto.signature.verify_signature_json", return_value=False
+        with patch.dict(
+            sys.modules, self._fake_signature_module(False)
         ), caplog.at_level(logging.ERROR):
             result = await adapter._warn_if_cross_signing_signature_stale(client)
 
@@ -3393,8 +3404,8 @@ class TestStaleCrossSigningSignatureWarning:
         adapter = _make_adapter()
         client = _make_xsign_client({"ed25519:sskpubkey": "good-signature"})
 
-        with patch(
-            "mautrix.crypto.signature.verify_signature_json", return_value=True
+        with patch.dict(
+            sys.modules, self._fake_signature_module(True)
         ), caplog.at_level(logging.WARNING):
             result = await adapter._warn_if_cross_signing_signature_stale(client)
 
@@ -3407,8 +3418,8 @@ class TestStaleCrossSigningSignatureWarning:
         adapter = _make_adapter()
         client = _make_xsign_client({"ed25519:DEVICE1": "self-sig-only"})
 
-        with patch(
-            "mautrix.crypto.signature.verify_signature_json", return_value=True
+        with patch.dict(
+            sys.modules, self._fake_signature_module(True)
         ), caplog.at_level(logging.WARNING):
             result = await adapter._warn_if_cross_signing_signature_stale(client)
 
@@ -3429,3 +3440,138 @@ class TestStaleCrossSigningSignatureWarning:
 
         assert result is None
         assert "could not check cross-signing signature state" in caplog.text
+
+    def _connect_mocks(self):
+        """Client/olm mocks for a successful encrypted connect()."""
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = "DEV1"
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV1")
+        )
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.query_keys = AsyncMock(return_value={"device_keys": {}})
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+
+        mock_olm = MagicMock()
+        mock_olm.load = AsyncMock()
+        mock_olm.share_keys = AsyncMock()
+        mock_olm.share_keys_min_trust = None
+        mock_olm.send_keys_min_trust = None
+        mock_olm.account = MagicMock()
+        mock_olm.account.identity_keys = {"ed25519": "fake_ed25519_key"}
+        return mock_client, mock_olm
+
+    async def _run_connect(self, adapter, mock_client, mock_olm, stale_check):
+        fake_mautrix_mods = _make_fake_mautrix()
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(
+            return_value=mock_client
+        )
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(
+            return_value=mock_olm
+        )
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        with patch.object(
+            matrix_mod, "_check_e2ee_deps", return_value=True
+        ), patch.dict("sys.modules", fake_mautrix_mods), patch.object(
+            adapter, "_refresh_dm_cache", AsyncMock()
+        ), patch.object(
+            adapter, "_sync_loop", AsyncMock(return_value=None)
+        ), patch.object(
+            adapter, "_verify_device_keys_on_server", AsyncMock(return_value=True)
+        ), patch.object(
+            adapter, "_warn_if_cross_signing_signature_stale", stale_check
+        ):
+            return await adapter.connect()
+
+    def _encrypted_adapter(self):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        return MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="syt_test_access_token",
+                extra={
+                    "homeserver": "https://matrix.example.org",
+                    "user_id": "@bot:example.org",
+                    "encryption": True,
+                    "device_id": "DEV1",
+                },
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_connect_checks_signature_after_recovery_key_verify(
+        self, monkeypatch
+    ):
+        """The server-side check must run at the call site, not just in tests.
+
+        A green helper proves nothing if connect() never awaits it.
+        """
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "EsTfakerecoverykey")
+        adapter = self._encrypted_adapter()
+        mock_client, mock_olm = self._connect_mocks()
+        mock_olm.verify_with_recovery_key = AsyncMock()
+        stale_check = AsyncMock(return_value=True)
+
+        assert await self._run_connect(
+            adapter, mock_client, mock_olm, stale_check
+        ) is True
+
+        mock_olm.verify_with_recovery_key.assert_awaited_once()
+        stale_check.assert_awaited_once_with(mock_client)
+
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_skips_signature_check_when_verify_fails(
+        self, monkeypatch
+    ):
+        """If recovery-key verification itself failed there is no new
+        signature to inspect, so the check must not run."""
+        monkeypatch.setenv("MATRIX_RECOVERY_KEY", "EsTfakerecoverykey")
+        adapter = self._encrypted_adapter()
+        mock_client, mock_olm = self._connect_mocks()
+        mock_olm.verify_with_recovery_key = AsyncMock(
+            side_effect=RuntimeError("bad recovery key")
+        )
+        stale_check = AsyncMock(return_value=True)
+
+        assert await self._run_connect(
+            adapter, mock_client, mock_olm, stale_check
+        ) is True
+
+        stale_check.assert_not_awaited()
+
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_skips_signature_check_without_recovery_key(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("MATRIX_RECOVERY_KEY", raising=False)
+        adapter = self._encrypted_adapter()
+        mock_client, mock_olm = self._connect_mocks()
+        mock_olm.verify_with_recovery_key = AsyncMock()
+        mock_olm.get_own_cross_signing_public_keys = AsyncMock(
+            return_value=MagicMock()
+        )
+        stale_check = AsyncMock(return_value=True)
+
+        assert await self._run_connect(
+            adapter, mock_client, mock_olm, stale_check
+        ) is True
+
+        mock_olm.verify_with_recovery_key.assert_not_awaited()
+        stale_check.assert_not_awaited()
+
+        await adapter.disconnect()

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -455,6 +455,18 @@ MATRIX_RECOVERY_KEY=EsT... your recovery key here
 
 On each startup, if `MATRIX_RECOVERY_KEY` is set, Hermes imports cross-signing keys from the homeserver's secure secret storage and signs the current device. This is idempotent and safe to leave enabled permanently.
 
+:::warning[Stale cross-signing signatures]
+Signing the device on startup succeeds locally but is **not** always enough. If the homeserver already holds a cross-signing signature for this device — typically left over from an earlier device-key change — it silently keeps the old one, and `/keys/signatures/upload` reports no error. The bot then keeps starting cleanly while other clients show it as unverified and withhold room keys.
+
+Hermes now checks what the server actually serves after signing and logs an error when the served signature does not verify:
+
+```
+Matrix: the homeserver has a stale cross-signing signature for device ABCD1234 ...
+```
+
+A stale signature cannot be replaced in place. To recover, sign the bot out of that session, create a **new access token** (which yields a fresh device ID), update `MATRIX_ACCESS_TOKEN`, and restart. The local crypto store resets automatically on device change. Re-running startup signing with the same device will not clear it.
+:::
+
 If Hermes bootstraps a new Matrix recovery key, it never logs the raw key. Set
 `MATRIX_RECOVERY_KEY_OUTPUT_FILE=/secure/path/matrix-recovery-key.txt` before
 startup to write a generated key once with file mode `0600`; the file is not


### PR DESCRIPTION
Carries #71544 (by @ckaznocha) forward onto current `main`, plus a
refinement. Authorship of the original two commits is preserved.

## Why a fresh PR

#71544 is `dirty` against current `main` and unmodified since Aug 3. This
branch is the same work rebased to a clean, conflict-free head, with a
refinement on top. Fold it back into #71544 if preferred.

## Changes

**Rebase** — both commits apply after resolving additive conflicts in
`adapter.py` and `test_matrix.py`. Nothing dropped.

**Refinement** — the recovery-key path logged `INFO cross-signing verified
via recovery key` before running the stale-signature check, producing a
contradiction in the exact failure the check exists to catch:

```
INFO  cross-signing verified via recovery key
ERROR the homeserver has a stale cross-signing signature for device ...
```

This sequence appeared in production while every message showed
"encrypted by a device not verified by its owner." The check now runs
first, and "verified" is only logged when the signature is not stale.
Healthy behavior is unchanged.

## Tests

- `test_connect_suppresses_verified_log_when_signature_stale` — no
  "verified" line when the server check returns `False`.
- Matrix suite: 126 passed. `ruff` clean.

## Platforms

Linux.
