### PR TITLE
fix(gateway): make post-reset sessions visible in session lists (#84109)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -52,6 +52,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _FTS_CJK_TRIGGERS,
     _FTS_TRIGGERS,
     _LISTABLE_CHILD_SQL,
+    _RESET_CHILD_SQL,
     _PREVIEW_RAW_SELECT,
     _ephemeral_child_sql,
     _shape_preview,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -97,10 +97,20 @@ _COMPRESSION_CHILD_SQL = (
     "        AND p.end_reason = 'compression')"
 )
 
+_RESET_CHILD_SQL = (
+    "EXISTS (SELECT 1 FROM sessions p"
+    "        WHERE p.id = {a}.parent_session_id"
+    "        AND p.end_reason = 'session_reset')"
+)
 
-# Rows that surface in pickers: roots + branch children (subagent runs and
-# compression continuations stay hidden).
-_LISTABLE_CHILD_SQL = f"(s.parent_session_id IS NULL OR {_BRANCH_CHILD_SQL.format(a='s')})"
+
+# Rows that surface in pickers: roots + branch children + reset children
+# (subagent runs and compression continuations stay hidden).
+_LISTABLE_CHILD_SQL = (
+    f"(s.parent_session_id IS NULL"
+    f" OR {_BRANCH_CHILD_SQL.format(a='s')}"
+    f" OR {_RESET_CHILD_SQL.format(a='s')})"
+)
 
 
 def _ephemeral_child_sql(alias: str = "s") -> str:


### PR DESCRIPTION
## Summary

Sessions created after a `/reset` are invisible in all session lists (Desktop sidebar, `/api/profiles/sessions/sidebar`, `/api/sessions`, pickers). This is a regression from d2a4d373eb which made session identity durable across restarts.

## Root Cause

After the reset-lineage change, post-reset sessions carry `parent_session_id = <previous session id>`. But `_LISTABLE_CHILD_SQL` only surfaces root sessions and branch children (`_BRANCH_CHILD_SQL`). Reset lineage (`end_reason = 'session_reset'`) matches neither pattern, so every post-reset gateway session is filtered out of all listings. Each further reset hides one more session.

## Fix

Add `_RESET_CHILD_SQL` (matching `end_reason = 'session_reset'` on the parent) and include it in `_LISTABLE_CHILD_SQL` alongside `_BRANCH_CHILD_SQL`. Subagent runs and compression continuations remain hidden via `_ephemeral_child_sql` (unchanged).

## Changes

- `hermes_state_common.py`: Add `_RESET_CHILD_SQL`, include it in `_LISTABLE_CHILD_SQL`
- `hermes_state.py`: Export `_RESET_CHILD_SQL` for back-compat

## Test Plan

- [x] `pytest tests/gateway/test_session_store_stale_prune.py tests/gateway/test_session_store_prune.py` — 17/17 pass
- [x] `python3 -c "import ast; ast.parse(...)"` — syntax OK

Fixes #84109