### PR TITLE
fix(terminal): prevent delegated child marker snapshot leaks

### DIFF
--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -63,6 +63,12 @@ def test_export_snippet_shape():
     assert snippet.rstrip().endswith('> "$__hermes_snap_tmp"')
 
 
+def test_export_snippet_excludes_delegated_child_lineage():
+    snippet = _export_dump_excluding_session_vars('"$__hermes_snap_tmp"')
+
+    assert "HERMES_DELEGATED_CHILD_CONTEXT" in snippet
+
+
 # ---------------------------------------------------------------------------
 # Integration: real LocalEnvironment, two sessions, no cross-contamination.
 # ---------------------------------------------------------------------------
@@ -104,5 +110,28 @@ def test_shared_snapshot_no_cross_session_leak(tmp_path):
         if os.path.exists(snap):
             with open(snap) as f:
                 assert "HERMES_SESSION_ID" not in f.read()
+    finally:
+        env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_shared_snapshot_does_not_turn_later_commands_into_delegated_children(tmp_path):
+    from tools.environments.local import LocalEnvironment
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    env.init_session()
+    try:
+        delegated = env.execute(
+            "export HERMES_DELEGATED_CHILD_CONTEXT=1; "
+            "printf '%s' \"$HERMES_DELEGATED_CHILD_CONTEXT\""
+        )
+        normal = env.execute(
+            "printf '%s' \"${HERMES_DELEGATED_CHILD_CONTEXT-unset}\""
+        )
+
+        assert delegated["output"] == "1"
+        assert normal["output"] == "unset"
+        with open(env._snapshot_path) as f:
+            assert "HERMES_DELEGATED_CHILD_CONTEXT" not in f.read()
     finally:
         env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -522,7 +522,7 @@ def _cwd_marker(session_id: str) -> str:
 # as the Python-side contract for the exclusion set; the dump path unsets by
 # name/prefix instead of grepping declare lines (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|HERMES_CRON_SESSION)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|HERMES_CRON_SESSION|HERMES_DELEGATED_CHILD_CONTEXT)"
 )
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -572,7 +572,7 @@ def _export_dump_excluding_session_vars(
         # would make the FIRST command's value override a later outer
         # harness value arriving via the process env, exactly like the
         # session-var leak this dump already guards against.
-        "AI_AGENT HERMES_AGENT "
+        "AI_AGENT HERMES_AGENT HERMES_DELEGATED_CHILD_CONTEXT "
         f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
         "export -p; "
         ") || true; } "


### PR DESCRIPTION
## What changed

Persistent terminal shells could save `HERMES_DELEGATED_CHILD_CONTEXT=1` into their shared environment snapshot. After a delegated command set the marker, later top-level desktop commands inherited it and Kanban CLI mutations were falsely rejected as delegated-child activity.

This change treats the delegated-child marker as ephemeral Hermes execution identity and excludes it from both persistent snapshot dump paths.

## Regression coverage

Adds a real `LocalEnvironment` test that:

1. runs a command with the delegated-child marker;
2. runs a normal command through the same persistent shell;
3. verifies the second command sees the marker as unset;
4. verifies the snapshot file does not contain the marker.

## Verification

- `scripts/run_tests.sh tests/tools/test_snapshot_session_id_leak.py tests/tools/test_delegate_kanban_isolation.py -q` — 11 passed
- `scripts/run_tests.sh tests/tools/test_base_environment.py tests/tools/test_local_env_session_leak.py tests/tools/test_snapshot_multiline_session_env_injection.py tests/tools/test_local_shell_init.py -q` — 42 passed
- `.venv/bin/ruff check tools/environments/base.py tests/tools/test_snapshot_session_id_leak.py` — passed
- `git diff --check` — passed

🤖