### PR TITLE
fix(security): close two lifecycle guard bypasses and one false positive

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -124,6 +124,14 @@ _DATA_SINK_EXECUTABLES = frozenset(
 # psql backslash escapes (`\! ...`). Any hit disables masking for the whole
 # segment — fail closed to the plain regex verdict.
 _UNSAFE_DATA_ARG_MARKERS = ("`", "$(", "<(", ">(", "\\!")
+# A leading dot also disables masking, because sqlite3 spells its escapes as
+# dot-commands (`.shell`, `.system`, `.import`). But `.`, `./x` and `../x`
+# are ordinary path operands, and `grep -r <pattern> .` is a far more common
+# shape than any dot-command — treating those as escapes disabled the
+# exemption for the single most ordinary way to run a recursive search,
+# blocking `grep -r 'systemctl restart hermes-gateway' .` outright. Require a
+# dot followed by a NAME character so a relative path stays a path.
+_DOT_COMMAND_ARGUMENT = re.compile(r"^\.[A-Za-z]")
 # A data sink piped into a shell/interpreter can feed matched lines straight
 # to execution (`grep 'systemctl restart hermes-gateway' f | sh`); never mask
 # such a line.
@@ -358,7 +366,7 @@ def _mask_data_sink_arguments(text: str) -> str:
             if index is not None and Path(segment[index]).name in _DATA_SINK_EXECUTABLES:
                 arguments = segment[index + 1 :]
                 if not any(
-                    argument.startswith(".")
+                    _DOT_COMMAND_ARGUMENT.match(argument)
                     or any(marker in argument for marker in _UNSAFE_DATA_ARG_MARKERS)
                     for argument in arguments
                 ):

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -195,10 +195,80 @@ def _executable_name(token: str) -> str:
     return Path(token).name or token
 
 
+# Prefixes that hand execution straight to their argument tail: the command
+# that actually runs sits further right. A guard that reads only the first
+# token sees `sudo`/`env`/`nohup` and never inspects what they run, so
+# `sudo bash ~/restart.sh` walked past the same walk that stops
+# `bash ~/restart.sh`, and `sudo launchctl submit ...` past the
+# label-independent submit block (#62891). `_PIPE_TO_INTERPRETER` above
+# already reads `sudo ` this way for the pipe case; this generalises that
+# reading to the command position.
+_TRANSPARENT_COMMAND_PREFIXES = frozenset({
+    "sudo", "doas", "env", "nohup", "setsid", "nice", "ionice", "stdbuf",
+    "timeout", "exec", "command", "builtin", "eatmydata",
+})
+
+# Options of those wrappers that consume the NEXT token as their value, so a
+# value is never mistaken for the wrapped command (`sudo -u deploy bash x.sh`).
+_TRANSPARENT_PREFIX_VALUE_OPTIONS = {
+    "sudo": {"-u", "-g", "-U", "-C", "-p", "-r", "-t", "-T",
+             "--user", "--group", "--prompt"},
+    "doas": {"-u", "-C"},
+    "env": {"-u", "--unset", "-S", "--split-string", "-C", "--chdir"},
+    "nice": {"-n", "--adjustment"},
+    "ionice": {"-c", "-n", "-p", "--class", "--classdata"},
+    "stdbuf": {"-i", "-o", "-e", "--input", "--output", "--error"},
+    "timeout": {"-s", "-k", "--signal", "--kill-after"},
+}
+
+# Wrappers whose first non-option operand is a VALUE, not the command
+# (`timeout 60 bash x.sh`).
+_TRANSPARENT_PREFIX_OPERANDS = {"timeout": 1}
+
+_ENV_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# Bound the walk: a pathological token run must not spin here.
+_MAX_PREFIX_PEELS = 8
+
+
+def _peel_transparent_prefixes(segment: list[str], index: int) -> int:
+    """Return the index of the command a wrapper chain actually executes.
+
+    Returns *index* unchanged when the token there is not a wrapper, and may
+    return ``len(segment)`` when a wrapper has no operand — callers must
+    bounds-check before indexing.
+    """
+    for _ in range(_MAX_PREFIX_PEELS):
+        if index >= len(segment):
+            return index
+        name = _executable_name(segment[index])
+        if name not in _TRANSPARENT_COMMAND_PREFIXES:
+            return index
+        value_options = _TRANSPARENT_PREFIX_VALUE_OPTIONS.get(name, frozenset())
+        index += 1
+        while index < len(segment):
+            token = segment[index]
+            if token == "--":
+                # POSIX end-of-options: the command starts at the next token.
+                index += 1
+                break
+            if token in value_options:
+                index += 2
+                continue
+            if token.startswith("-") or _ENV_ASSIGNMENT.match(token):
+                index += 1
+                continue
+            break
+        for _ in range(_TRANSPARENT_PREFIX_OPERANDS.get(name, 0)):
+            if index < len(segment) and not segment[index].startswith("-"):
+                index += 1
+    return index
+
+
 def _command_token_index(segment: list[str]) -> Optional[int]:
     """Return the executable token index after simple env assignments."""
     for index, token in enumerate(segment):
-        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", token):
+        if _ENV_ASSIGNMENT.match(token):
             continue
         return index
     return None
@@ -218,7 +288,10 @@ def contains_launchctl_submit_command(command: str) -> bool:
         index = _command_token_index(segment)
         if index is None:
             continue
-        if Path(segment[index]).name == "launchctl":
+        index = _peel_transparent_prefixes(segment, index)
+        if index >= len(segment):
+            continue
+        if _executable_name(segment[index]) == "launchctl":
             arguments = segment[index + 1 :]
             if arguments and arguments[0].lower() in {"submit", "bootstrap"}:
                 return True
@@ -359,69 +432,93 @@ def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Optiona
     return path
 
 
+def _references_at(
+    segment: list[str], index: int, cwd: Optional[str]
+) -> Iterator[Path]:
+    """Yield the scripts the token at *index* executes, if any."""
+    if index >= len(segment):
+        return
+    executable = segment[index]
+    executable_name = _executable_name(executable)
+
+    if executable_name in {".", "source"}:
+        if len(segment) > index + 1:
+            resolved = _resolve_terminal_script_path(segment[index + 1], cwd)
+            if resolved is not None:
+                yield resolved
+        return
+
+    if executable_name in _SHELL_EXECUTABLES:
+        arguments = segment[index + 1 :]
+        arg_index = 0
+        while arg_index < len(arguments):
+            argument = arguments[arg_index]
+            if argument == "--":
+                arg_index += 1
+                break
+            if argument in {"-c", "--command"}:
+                break
+            if argument in _SHELL_OPTIONS_WITH_VALUES:
+                arg_index += 2
+                continue
+            if argument.startswith("-"):
+                arg_index += 1
+                continue
+            break
+        if arg_index < len(arguments) and arguments[arg_index] not in {
+            "-c",
+            "--command",
+        }:
+            resolved = _resolve_terminal_script_path(arguments[arg_index], cwd)
+            if resolved is not None:
+                yield resolved
+        return
+
+    # A bare "/" token is pathlib's division operator in Python sources
+    # (e.g. `Path.home() / ".hermes"`), not an executable reference.
+    # Resolving it walks to the filesystem root and fails the
+    # regular-file check below, hard-blocking innocent .py scripts
+    # (#77131). Skip pure-separator tokens.
+    if executable.strip("/"):
+        if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
+            resolved = _resolve_terminal_script_path(executable, cwd)
+            if resolved is not None:
+                yield resolved
+
+
 def _iter_referenced_shell_scripts(
     command: str,
     *,
     cwd: Optional[str] = None,
 ) -> Iterator[Path]:
-    """Yield scripts executed directly or through a POSIX shell."""
+    """Yield scripts executed directly or through a POSIX shell.
+
+    Each segment is read twice: once at the token the walk has always used,
+    and again at the command a wrapper chain hands off to. Additive on
+    purpose — peeling must never REMOVE a reference the un-peeled read would
+    have found. A local script named ``./timeout`` is a script, not the
+    coreutils wrapper, and reading only the peeled index would skip it.
+    """
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
         if index is None:
             continue
-        executable = segment[index]
-        executable_name = _executable_name(executable)
-
-        if executable_name in {".", "source"}:
-            if len(segment) > index + 1:
-                resolved = _resolve_terminal_script_path(segment[index + 1], cwd)
-                if resolved is not None:
-                    yield resolved
-            continue
-
-        if executable_name in _SHELL_EXECUTABLES:
-            arguments = segment[index + 1 :]
-            arg_index = 0
-            while arg_index < len(arguments):
-                argument = arguments[arg_index]
-                if argument == "--":
-                    arg_index += 1
-                    break
-                if argument in {"-c", "--command"}:
-                    break
-                if argument in _SHELL_OPTIONS_WITH_VALUES:
-                    arg_index += 2
-                    continue
-                if argument.startswith("-"):
-                    arg_index += 1
-                    continue
-                break
-            if arg_index < len(arguments) and arguments[arg_index] not in {
-                "-c",
-                "--command",
-            }:
-                resolved = _resolve_terminal_script_path(arguments[arg_index], cwd)
-                if resolved is not None:
-                    yield resolved
-            continue
-
-        # A bare "/" token is pathlib's division operator in Python sources
-        # (e.g. `Path.home() / ".hermes"`), not an executable reference.
-        # Resolving it walks to the filesystem root and fails the
-        # regular-file check below, hard-blocking innocent .py scripts
-        # (#77131). Skip pure-separator tokens.
-        if executable.strip("/"):
-            if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
-                resolved = _resolve_terminal_script_path(executable, cwd)
-                if resolved is not None:
-                    yield resolved
+        yield from _references_at(segment, index, cwd)
+        peeled = _peel_transparent_prefixes(segment, index)
+        if peeled != index:
+            yield from _references_at(segment, peeled, cwd)
 
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:
     """Yield code passed through ``sh|bash|... -c`` for recursive scanning."""
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
-        if index is None or Path(segment[index]).name not in _SHELL_EXECUTABLES:
+        if index is None:
+            continue
+        index = _peel_transparent_prefixes(segment, index)
+        if index >= len(segment):
+            continue
+        if _executable_name(segment[index]) not in _SHELL_EXECUTABLES:
             continue
         arguments = segment[index + 1 :]
         for arg_index, argument in enumerate(arguments[:-1]):

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -179,6 +179,22 @@ def _iter_command_segments(command: str) -> Iterator[list[str]]:
             yield segment
 
 
+def _executable_name(token: str) -> str:
+    """Return the command name for a tokenized executable token.
+
+    ``Path(token).name`` is right for real paths (``/usr/bin/bash`` →
+    ``bash``), but pathlib has no name component for the pure-path tokens
+    ``.``, ``..`` and ``/``, so it returns "" for them. The POSIX
+    dot-source builtin is spelled ``.``, so keying the sourced-script
+    branch on ``Path(token).name`` alone made it unreachable: ``source
+    ./helper.sh`` was scanned but its exact synonym ``. ./helper.sh`` was
+    not, letting a referenced script carrying a lifecycle command through
+    both the cron guard and the in-gateway terminal guard. Fall back to the
+    raw token so ``.`` survives.
+    """
+    return Path(token).name or token
+
+
 def _command_token_index(segment: list[str]) -> Optional[int]:
     """Return the executable token index after simple env assignments."""
     for index, token in enumerate(segment):
@@ -354,7 +370,7 @@ def _iter_referenced_shell_scripts(
         if index is None:
             continue
         executable = segment[index]
-        executable_name = Path(executable).name
+        executable_name = _executable_name(executable)
 
         if executable_name in {".", "source"}:
             if len(segment) > index + 1:

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -214,6 +214,9 @@ def _executable_name(token: str) -> str:
 _TRANSPARENT_COMMAND_PREFIXES = frozenset({
     "sudo", "doas", "env", "nohup", "setsid", "nice", "ionice", "stdbuf",
     "timeout", "exec", "command", "builtin", "eatmydata",
+    # Privilege and namespace wrappers. Same shape — options, then the
+    # command they hand execution to.
+    "pkexec", "su", "runuser", "setpriv", "systemd-run", "nsenter", "unshare",
 })
 
 # Options of those wrappers that consume the NEXT token as their value, so a
@@ -227,6 +230,30 @@ _TRANSPARENT_PREFIX_VALUE_OPTIONS = {
     "ionice": {"-c", "-n", "-p", "--class", "--classdata"},
     "stdbuf": {"-i", "-o", "-e", "--input", "--output", "--error"},
     "timeout": {"-s", "-k", "--signal", "--kill-after"},
+    "pkexec": {"--user"},
+    "su": {"-s", "--shell", "-g", "--group", "-G", "--supp-group"},
+    "runuser": {"-u", "--user", "-s", "--shell", "-g", "--group",
+                "-G", "--supp-group"},
+    "setpriv": {"--reuid", "--regid", "--groups", "--inh-caps",
+                "--ambient-caps", "--bounding-set", "--selinux-label",
+                "--apparmor-profile"},
+    "systemd-run": {"-u", "--unit", "-p", "--property", "-E", "--setenv",
+                    "--slice", "--description", "--uid", "--gid",
+                    "--on-calendar", "--service-type"},
+    "nsenter": {"-t", "--target", "-S", "--setuid", "-G", "--setgid",
+                "-r", "--root", "-w", "--wd"},
+    "unshare": {"--map-user", "--map-group", "--setgroups", "-R", "--root",
+                "-w", "--wd"},
+}
+
+# Wrappers whose option carries a COMMAND STRING rather than an argv tail.
+# The string is shell source and must be re-scanned like `sh -c` — skipping
+# it as an opaque option value would hide whatever it runs
+# (`env -S 'bash ~/restart.sh'`).
+_STRING_COMMAND_OPTIONS = {
+    "env": ("-S", "--split-string"),
+    "su": ("-c", "--command"),
+    "runuser": ("-c", "--command"),
 }
 
 # Wrappers whose first non-option operand is a VALUE, not the command
@@ -440,6 +467,19 @@ def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Optiona
     return path
 
 
+def _iter_option_values(
+    segment: list[str], start: int, option: str
+) -> Iterator[str]:
+    """Yield values given to *option*, in both ``--opt v`` and ``--opt=v`` form."""
+    prefix = option + "="
+    for position in range(start + 1, len(segment)):
+        token = segment[position]
+        if token == option and position + 1 < len(segment):
+            yield segment[position + 1]
+        elif token.startswith(prefix):
+            yield token[len(prefix):]
+
+
 def _references_at(
     segment: list[str], index: int, cwd: Optional[str]
 ) -> Iterator[Path]:
@@ -523,6 +563,12 @@ def _iter_shell_command_payloads(command: str) -> Iterator[str]:
         index = _command_token_index(segment)
         if index is None:
             continue
+        # Command-string options are read at the ORIGINAL token: peeling past
+        # `su`/`env` would discard the very option carrying the command.
+        for option in _STRING_COMMAND_OPTIONS.get(
+            _executable_name(segment[index]), ()
+        ):
+            yield from _iter_option_values(segment, index, option)
         index = _peel_transparent_prefixes(segment, index)
         if index >= len(segment):
             continue

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1058,6 +1058,57 @@ class TestTransparentWrapperPrefixes:
         assert self._scan(f"sudo bash {clean}", cwd=str(tmp_path)) is False
 
 
+class TestRelativePathDoesNotDisableDataExemption:
+    """A leading dot disables the data-sink exemption because sqlite3 spells
+    its escapes as dot-commands (`.shell`). `.`, `./x` and `../x` are plain
+    path operands, so `grep -r <pattern> .` — the most ordinary recursive
+    search there is — was blocked outright when the pattern happened to be a
+    lifecycle string."""
+
+    def _scan(self, command):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        return contains_gateway_lifecycle_command_or_referenced_script(command)
+
+    @pytest.mark.parametrize("command", [
+        "grep -r 'systemctl restart hermes-gateway' .",
+        "grep -rn 'hermes gateway restart' ./logs",
+        "rg 'hermes gateway restart' ../archive",
+        "grep -c 'systemctl stop hermes-gateway' ./var/log/syslog",
+        "sqlite3 ./stats.db \"SELECT restart_reason FROM hermes_gateway_restarts\"",
+    ])
+    def test_relative_path_operands_keep_the_exemption(self, command):
+        assert self._scan(command) is False
+
+    @pytest.mark.parametrize("command", [
+        # Narrowing the dot test must not open an execution route: every
+        # escape hatch still fires with a relative-path operand present.
+        'sqlite3 ./db ".shell hermes gateway restart"',
+        'sqlite3 ./db ".system systemctl restart hermes-gateway"',
+        'psql ./x -c "\\! systemctl restart hermes-gateway"',
+        "grep -r 'hermes gateway restart' . | sh",
+        "grep -r 'hermes gateway restart' ./logs | bash",
+        "grep -r 'hermes gateway restart' . | sudo sh",
+        "grep -r 'x' . ; hermes gateway restart",
+        "grep -r 'x' . && systemctl restart hermes-gateway",
+        'grep -r "$(hermes gateway restart)" .',
+        "rg 'x' ./logs | xargs systemctl restart hermes-gateway",
+    ])
+    def test_relative_path_does_not_open_an_execution_route(self, command):
+        assert self._scan(command) is True
+
+    @pytest.mark.parametrize("command", [
+        # Real dot-commands must still defeat the exemption.
+        'sqlite3 db ".shell hermes gateway restart"',
+        'sqlite3 db ".system systemctl restart hermes-gateway"',
+        'psql -c "\\! systemctl restart hermes-gateway"',
+    ])
+    def test_dot_commands_still_block(self, command):
+        assert self._scan(command) is True
+
+
 class TestCreateJobBlocksLifecycleCommands:
     """The regression the CLI-layer-only guard could not catch: the agent's
     `cronjob` model tool calls cron.jobs.create_job directly, bypassing

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -976,6 +976,88 @@ class TestDotSourceIsScannedLikeSource:
         assert self._scan(f". {clean}", cwd=str(tmp_path)) is False
 
 
+class TestTransparentWrapperPrefixes:
+    """`sudo`/`env`/`nohup`/... exec their argument tail, so the command that
+    actually runs sits further right. Reading only the first token made the
+    referenced-script walk, the `sh -c` payload walk and the label-independent
+    `launchctl submit` block (#62891) all miss a wrapped invocation:
+    `sudo bash ~/restart.sh` sailed past a guard that stops
+    `bash ~/restart.sh`."""
+
+    def _scan(self, command, cwd=None):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        return contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=cwd
+        )
+
+    @pytest.fixture
+    def helper(self, tmp_path):
+        script = tmp_path / "helper.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        return script
+
+    @pytest.mark.parametrize("prefix", [
+        "sudo", "doas", "env", "nohup", "setsid", "nice", "eatmydata",
+        "exec", "command", "stdbuf -o0", "nice -n 5", "sudo -u deploy",
+        "env FOO=bar", "timeout 60", "timeout -k 5 60", "sudo --",
+    ])
+    def test_wrapped_script_reference_is_scanned(self, tmp_path, helper, prefix):
+        assert self._scan(f"{prefix} bash {helper}", cwd=str(tmp_path)) is True
+
+    @pytest.mark.parametrize("prefix", ["sudo", "env", "nohup", "timeout 60"])
+    def test_wrapped_dot_source_is_scanned(self, tmp_path, helper, prefix):
+        assert self._scan(f"{prefix} . {helper}", cwd=str(tmp_path)) is True
+
+    @pytest.mark.parametrize("prefix", ["sudo", "env", "nohup"])
+    def test_wrapped_shell_c_payload_is_scanned(self, tmp_path, helper, prefix):
+        assert self._scan(
+            f"{prefix} sh -c 'bash {helper}'", cwd=str(tmp_path)
+        ) is True
+
+    @pytest.mark.parametrize("prefix", ["sudo", "env", "nohup", "setsid"])
+    def test_wrapped_launchctl_submit_is_blocked(self, prefix):
+        from cron.lifecycle_guard import contains_launchctl_submit_command
+
+        assert contains_launchctl_submit_command(
+            f"{prefix} launchctl submit -l com.example.helper -- /usr/bin/true"
+        ) is True
+
+    @pytest.mark.parametrize("command", [
+        # Wrappers around ordinary work must stay allowed — peeling must not
+        # invent a script reference where there is none.
+        "sudo apt-get update",
+        "env FOO=bar python3 script.py",
+        "timeout 60 curl https://example.com",
+        "nohup python3 -m http.server &",
+        "sudo -u postgres psql -c 'SELECT 1'",
+        "nice -n 10 make -j4",
+        "env",
+        "sudo",
+    ])
+    def test_wrapped_benign_commands_are_allowed(self, tmp_path, command):
+        assert self._scan(command, cwd=str(tmp_path)) is False
+
+    @pytest.mark.parametrize("name", ["timeout", "env", "nice", "command"])
+    def test_local_script_named_like_a_wrapper_is_still_scanned(
+        self, tmp_path, name
+    ):
+        """`./timeout` is a script in the cwd, not the coreutils wrapper.
+        Peeling is additive precisely so it cannot swallow the reference the
+        un-peeled read finds."""
+        script = tmp_path / name
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        assert self._scan(f"./{name}", cwd=str(tmp_path)) is True
+        assert self._scan(str(script), cwd=str(tmp_path)) is True
+
+    def test_wrapped_clean_script_is_allowed(self, tmp_path):
+        clean = tmp_path / "ok.sh"
+        clean.write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
+        assert self._scan(f"sudo bash {clean}", cwd=str(tmp_path)) is False
+
+
 class TestCreateJobBlocksLifecycleCommands:
     """The regression the CLI-layer-only guard could not catch: the agent's
     `cronjob` model tool calls cron.jobs.create_job directly, bypassing

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -310,6 +310,28 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
 
+    @pytest.mark.parametrize("form", [". {path}", "source {path}"])
+    def test_blocks_lifecycle_command_in_a_dot_sourced_script(
+        self, monkeypatch, tmp_path, form
+    ):
+        """Sourcing runs the script in the CURRENT shell, so it restarts the
+        gateway just as surely as executing it. `.` and `source` are the same
+        builtin and must both be caught — `.` was not (Path(".").name == "")."""
+        import tools.terminal_tool as tt
+
+        script = tmp_path / "delayed-ops.sh"
+        script.write_text(
+            "#!/bin/bash\nsleep 45\nhermes gateway restart\n", encoding="utf-8"
+        )
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+
+        result = json.loads(
+            tt.terminal_tool(command=form.format(path=script))
+        )
+
+        assert result["exit_code"] == 1
+        assert "referenced script" in result["error"]
+
     def test_blocks_launchctl_submit_inside_gateway(self, monkeypatch, tmp_path):
         import tools.terminal_tool as tt
 
@@ -895,6 +917,64 @@ class TestLifecycleGuardModule:
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path
 # ---------------------------------------------------------------------------
+
+class TestDotSourceIsScannedLikeSource:
+    """`.` and `source` are the same POSIX builtin and must scan alike.
+
+    `Path(".").name` is "" — pathlib has no name component for a pure-path
+    token — so keying the sourced-script branch on it left the `.` spelling
+    unreachable. `source ./helper.sh` was scanned while `. ./helper.sh`
+    walked straight past both the cron guard and the in-gateway terminal
+    guard, carrying whatever the sourced script contained.
+    """
+
+    def _scan(self, command, cwd):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        return contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=cwd
+        )
+
+    @pytest.fixture
+    def helper(self, tmp_path):
+        script = tmp_path / "helper.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+        return script
+
+    @pytest.mark.parametrize("form", [". {path}", "source {path}"])
+    def test_both_spellings_block_a_referenced_script(self, tmp_path, helper, form):
+        assert self._scan(form.format(path=helper), cwd=str(tmp_path)) is True
+
+    @pytest.mark.parametrize("form", [". ./helper.sh", "source ./helper.sh"])
+    def test_both_spellings_block_a_relative_reference(self, tmp_path, helper, form):
+        assert self._scan(form, cwd=str(tmp_path)) is True
+
+    def test_env_assignment_prefix_does_not_hide_dot_source(self, tmp_path, helper):
+        assert self._scan(f"FOO=1 . {helper}", cwd=str(tmp_path)) is True
+
+    def test_dot_source_nested_in_shell_c_is_blocked(self, tmp_path, helper):
+        assert self._scan(f"sh -c '. {helper}'", cwd=str(tmp_path)) is True
+
+    @pytest.mark.parametrize("command", [
+        # `.` as a plain path argument is not a source and must stay allowed —
+        # this is the #77131 false-positive class the guard already carries
+        # scar tissue for.
+        "find . -name '*.py'",
+        "git add .",
+        "cd . && make",
+        "tar -czf out.tgz .",
+        "cp -r . /tmp/backup",
+    ])
+    def test_dot_as_an_argument_is_not_treated_as_a_source(self, tmp_path, command):
+        assert self._scan(command, cwd=str(tmp_path)) is False
+
+    def test_sourcing_a_clean_script_is_allowed(self, tmp_path):
+        clean = tmp_path / "ok.sh"
+        clean.write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
+        assert self._scan(f". {clean}", cwd=str(tmp_path)) is False
+
 
 class TestCreateJobBlocksLifecycleCommands:
     """The regression the CLI-layer-only guard could not catch: the agent's

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1025,6 +1025,48 @@ class TestTransparentWrapperPrefixes:
             f"{prefix} launchctl submit -l com.example.helper -- /usr/bin/true"
         ) is True
 
+    @pytest.mark.parametrize("prefix", [
+        # Privilege and namespace wrappers, including the option forms whose
+        # operand is a VALUE rather than the command.
+        "pkexec", "pkexec --user root",
+        "runuser -u root --", "setpriv --reuid=0 --",
+        "systemd-run --scope", "systemd-run -p X=1",
+        "nsenter --target 1 --mount", "nsenter -t 1 -m",
+        "unshare -r", "sudo pkexec",
+    ])
+    def test_privilege_and_namespace_wrappers_are_scanned(
+        self, tmp_path, helper, prefix
+    ):
+        assert self._scan(f"{prefix} bash {helper}", cwd=str(tmp_path)) is True
+
+    @pytest.mark.parametrize("command", [
+        # An option carrying a COMMAND STRING is shell source, not an opaque
+        # value: skipping it would hide whatever it runs.
+        "env -S 'bash {path}'",
+        "env --split-string='bash {path}'",
+        "su -c 'bash {path}'",
+        "su root -c 'bash {path}'",
+        "runuser -u root -c 'bash {path}'",
+    ])
+    def test_command_string_options_are_rescanned(self, tmp_path, helper, command):
+        assert self._scan(command.format(path=helper), cwd=str(tmp_path)) is True
+
+    @pytest.mark.parametrize("command", [
+        # The same wrappers around ordinary work must not start blocking.
+        "pkexec systemctl status nginx",
+        "su -c 'ls -la'",
+        "unshare -r whoami",
+        "systemd-run --scope make -j4",
+        "nsenter -t 1 -m ps aux",
+        "setpriv --reuid=0 -- id",
+        "runuser -u nobody -- whoami",
+        "env -S 'echo hi'",
+    ])
+    def test_privilege_wrappers_around_benign_work_are_allowed(
+        self, tmp_path, command
+    ):
+        assert self._scan(command, cwd=str(tmp_path)) is False
+
     @pytest.mark.parametrize("command", [
         # Wrappers around ordinary work must stay allowed — peeling must not
         # invent a script reference where there is none.


### PR DESCRIPTION
## What does this PR do?

Three independent defects in the gateway lifecycle guard, found by probing shapes that ought to be equivalent and checking whether the guard agrees. The first two are bypasses; the third is a false positive.

**1. `.` was never scanned.** `_iter_referenced_shell_scripts` keys its sourced-script branch on `Path(token).name`, and pathlib has no name component for a pure-path token — `Path(".").name` is `""`, never `"."`. The `{".", "source"}` branch was therefore unreachable for the `.` spelling, and the token fell through to the executable branch, which ignores it (no `/`, no `.sh` suffix). So:

```
source ~/.hermes/scripts/restart.sh    → blocked
.      ~/.hermes/scripts/restart.sh    → allowed
```

Same POSIX builtin, same file, same effect — sourcing runs it in the current shell. That bypasses both enforcement points: `cron.jobs.create_job`, and `tools/terminal_tool.py` when `_HERMES_GATEWAY=1`, which is the guard that stops an agent inside the gateway from triggering the SIGTERM-respawn loop (#30719).

**2. Wrapper prefixes hid the real command.** `sudo`, `env`, `nohup`, `timeout` and friends exec their argument tail, so the command that actually runs sits further right. Three guards read only the first token of a segment, saw the wrapper, and never inspected what it runs:

```
bash ~/restart.sh                          → blocked
sudo bash ~/restart.sh                     → allowed
launchctl submit -l com.x -- helper        → blocked
sudo launchctl submit -l com.x -- helper   → allowed
```

The second pair matters most: that submit block is deliberately label-independent (#62891) because wrapping a helper in a persistent launchd job is the indirect route to a restart loop — and one word of prefix defeated it.

**3. A relative path disabled the data-sink exemption.** `_mask_data_sink_arguments` exempts lifecycle text sitting in the arguments of executables that cannot run it (`grep`, `rg`, `journalctl`, `sqlite3`, …). The exemption is dropped when an argument looks like an escape back into execution — including anything starting with a dot, because sqlite3 spells its escapes as dot-commands (`.shell`, `.system`). But `.`, `./x` and `../x` are ordinary path operands, so:

```
grep -r 'systemctl restart hermes-gateway' .      → blocked
```

The most ordinary recursive search there is, blocked outright — the exact false-positive class the exemption exists to prevent. `./logs`, `../archive` and a relative sqlite3 database path fail the same way.

## Related Issue

No existing issue covers these three; I found them while reading the guard. Closest neighbours, for context:

- #30719 — the restart-loop foot-gun this guard exists to stop. Defects 1 and 2 are bypasses of it.
- #62891 — added the label-independent `launchctl submit` block that defect 2 defeats with a `sudo` prefix.
- #77131 — the earlier "`.` in a Python source is not an executable" false positive; the scar tissue from it is preserved and extended here.
- #78980 / #79020 — the *other* signal-conflation half of this guard (non-regular files reported as lifecycle commands). Deliberately untouched here; that PR owns it.

Happy to split this into three PRs if you would rather review them separately.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

All in `cron/lifecycle_guard.py`, one commit per defect:

- **`fix(security): scan dot-sourced scripts`** — new `_executable_name()` falls back to the raw token when pathlib yields no name, so `.` reaches the sourced-script branch. `..` and `/` take the same fallback and are unaffected: neither is in any command-name set, and the existing pure-separator skip still handles `/`.
- **`fix(security): see through wrapper prefixes`** — new `_peel_transparent_prefixes()` walks a bounded chain of wrappers, skipping their options, their value-taking options (`sudo -u deploy`, `stdbuf -o0`), `VAR=value` assignments, a `--` separator, and `timeout`'s duration operand. Applied to the referenced-script walk, the `sh -c` payload walk, and the `launchctl submit`/`bootstrap` block.

  In the referenced-script walk the peel is **additive** — the segment is read at the original token *and* at the peeled one — because peeling must never remove a reference the un-peeled read would have found. A local script named `./timeout` is a script, not the coreutils wrapper. That is why the per-index logic now lives in `_references_at()`, and there are tests for exactly this.

  This is not a new reading of shell syntax for the module: `_PIPE_TO_INTERPRETER` already treats `sudo ` as transparent for the pipe case. This generalises it to the command position. It is deliberately **not** applied to the data-sink masking, where peeling would widen an exemption.
- **`fix(cron): stop a relative path from disabling the data-sink exemption`** — the dot test becomes `^\.[A-Za-z]`, so a dot-command still defeats the exemption while a relative path stays a path. A dotfile operand (`.env`) still reads as a dot-command — conservative, and unchanged from today.

## How to Test

On `main`, each of these reproduces:

```bash
printf '#!/bin/sh\nhermes gateway restart\n' > /tmp/helper.sh

# 1. dot-source — `source` is caught, `.` is not
hermes cron create '0 8 * * 1' --name a --script /tmp/helper.sh --no-agent   # blocked
# but a cron script or terminal command containing `. /tmp/helper.sh` is not

# 2. wrapper prefix
#    inside a gateway session (_HERMES_GATEWAY=1):
sudo bash /tmp/helper.sh          # runs; `bash /tmp/helper.sh` is blocked

# 3. false positive
grep -r 'systemctl restart hermes-gateway' .    # blocked, and shouldn't be
```

Automated:

```bash
pytest tests/hermes_cli/test_gateway_restart_loop.py -q     # 197 passed
```

62 of those cases are new. Each commit is independently green — 139 → 179 → 197 — so the branch bisects cleanly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the neighbouring guard work (#79020) is called out above and is not touched here
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: I could not install all extras in my environment, so instead I ran the 199 test files touching `lifecycle_guard`/`terminal_tool`/`model_switch`/`runtime_provider`/`oneshot` twice, once with the patch and once with it reverted, and diffed the failure sets. **No new failures** (3933 passed / 14 failing vs baseline 3882 / 66; the gap is the new tests failing without the fixes). Also ran under `scripts/run_tests_parallel.py` for per-file isolation parity.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Python 3.11)

### Documentation & Housekeeping

- [x] N/A — internal guard logic, no user-facing surface changed
- [x] N/A — no config keys added
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure string/token logic, no OS-specific surface; `scripts/check-windows-footguns.py --all` is clean
- [x] N/A — no tool descriptions or schemas changed

## Screenshots / Logs

Beyond the unit tests, I checked for false positives at scale: every command line in this repo's own `scripts/**/*.sh`, `docker/**/*.sh` and the fenced `bash` blocks in `website/docs`, `skills`, `AGENTS.md`, `CONTRIBUTING.md` and `README.md` — 9,258 distinct lines — run through the guard on this branch and on `main`, and the verdicts diffed:

```
new false positives (this branch blocks, main allows):  0
lost detections     (this branch allows, main blocks):  0
exceptions raised:                                      0
identical set of 16 blocked lines on both sides
```

The guard's "never raises" contract also still holds against malformed input (`sudo` ×40, NUL bytes, 5,000-character operands, bare `--`, `/`, `..`): 0 exceptions.