### PR TITLE
feat(desktop): let users discard an in-flight dictation

### DIFF
--- a/apps/desktop/src/app/chat/composer/dictation-esc-precedence.test.tsx
+++ b/apps/desktop/src/app/chat/composer/dictation-esc-precedence.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { markActiveComposer } from './focus'
+import { useComposerEscCancel } from './hooks/use-composer-esc-cancel'
+import { useDictationEscCancel } from './hooks/use-dictation-esc-cancel'
+
+afterEach(() => {
+  cleanup()
+  document.body.innerHTML = ''
+})
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+
+// Faithful mirror of index.tsx's Escape wiring, driven through REAL DOM
+// keydown events dispatched from a focused contentEditable — not synthetic
+// window events. Esc has four claimants in the composer: the trigger popover
+// (local, role="listbox"), queue-edit exit (local), turn halt (local +
+// useComposerEscCancel on window), and dictation discard (capture-phase
+// window listener). DESIGN.md: "One cancel gesture does one thing." A
+// capture-phase preventDefault stops neither the local React handler nor the
+// bubble listener from RUNNING — both must check `defaultPrevented`, and the
+// dictation hook must yield to an open listbox. These tests pin exactly one
+// action per keypress across all live combinations.
+function Harness({
+  busy,
+  cancelDictation,
+  closeTrigger,
+  exitQueuedEdit,
+  haltRun,
+  queueEdit,
+  recording,
+  triggerOpen
+}: {
+  busy: boolean
+  cancelDictation: () => void
+  closeTrigger: () => void
+  exitQueuedEdit: () => void
+  haltRun: () => void
+  queueEdit: boolean
+  recording: boolean
+  triggerOpen: boolean
+}) {
+  // Same registration order as ChatBar: turn-cancel (bubble) first, then
+  // dictation (capture).
+  useComposerEscCancel({ awaitingInput: false, busy, onCancel: haltRun, target: 'main' })
+  useDictationEscCancel({ onCancel: cancelDictation, recording, target: 'main' })
+
+  // Mirror of handleEditorKeyDown's Escape branches in index.tsx.
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (triggerOpen && event.key === 'Escape') {
+      event.preventDefault()
+      closeTrigger()
+
+      return
+    }
+
+    if (event.key === 'Escape') {
+      if (event.defaultPrevented) {
+        return
+      }
+
+      if (queueEdit) {
+        event.preventDefault()
+        exitQueuedEdit()
+
+        return
+      }
+
+      if (busy) {
+        event.preventDefault()
+        haltRun()
+      }
+    }
+  }
+
+  return (
+    <div>
+      <div contentEditable data-testid="editor" onKeyDown={onKeyDown} suppressContentEditableWarning />
+      {triggerOpen ? <div data-testid="trigger" role="listbox" /> : null}
+    </div>
+  )
+}
+
+function renderComposer(overrides: Partial<Parameters<typeof Harness>[0]> = {}) {
+  const actions = {
+    cancelDictation: vi.fn(),
+    closeTrigger: vi.fn(),
+    exitQueuedEdit: vi.fn(),
+    haltRun: vi.fn()
+  }
+
+  markActiveComposer('main')
+  const view = render(
+    <Harness busy={false} queueEdit={false} recording={true} triggerOpen={false} {...actions} {...overrides} />
+  )
+  const editor = view.getByTestId('editor')
+  editor.focus()
+
+  return { ...actions, editor }
+}
+
+const pressEscape = (editor: HTMLElement) => fireEvent.keyDown(editor, { bubbles: true, cancelable: true, key: 'Escape' })
+
+describe('composer Escape precedence with a live dictation', () => {
+  it('recording + open completion listbox: the listbox keeps Esc, dictation survives', () => {
+    const { cancelDictation, closeTrigger, editor, haltRun } = renderComposer({ triggerOpen: true })
+
+    pressEscape(editor)
+
+    expect(closeTrigger).toHaveBeenCalledTimes(1)
+    expect(cancelDictation).not.toHaveBeenCalled()
+    expect(haltRun).not.toHaveBeenCalled()
+  })
+
+  it('recording + queue edit: dictation is discarded, the edit stays open', () => {
+    const { cancelDictation, editor, exitQueuedEdit, haltRun } = renderComposer({ queueEdit: true })
+
+    pressEscape(editor)
+
+    expect(cancelDictation).toHaveBeenCalledTimes(1)
+    expect(exitQueuedEdit).not.toHaveBeenCalled()
+    expect(haltRun).not.toHaveBeenCalled()
+  })
+
+  it('recording + busy turn: dictation is discarded, the turn keeps running', () => {
+    const { cancelDictation, editor, haltRun } = renderComposer({ busy: true })
+
+    pressEscape(editor)
+
+    expect(cancelDictation).toHaveBeenCalledTimes(1)
+    expect(haltRun).not.toHaveBeenCalled()
+  })
+
+  it('no recording: local Escape handling is untouched', () => {
+    const { cancelDictation, editor, exitQueuedEdit } = renderComposer({ queueEdit: true, recording: false })
+
+    pressEscape(editor)
+
+    expect(exitQueuedEdit).toHaveBeenCalledTimes(1)
+    expect(cancelDictation).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -66,7 +66,7 @@ export function useComposerVoice({
   const ownsWakeIndicatorRef = useRef(false)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
 
-  const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
+  const { cancelDictation, dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
     focusInput,
     maxRecordingSeconds,
     onTranscript: insertText,
@@ -284,6 +284,7 @@ export function useComposerVoice({
   })
 
   return {
+    cancelDictation,
     conversation,
     dictate,
     endConversation,

--- a/apps/desktop/src/app/chat/composer/hooks/use-dictation-esc-cancel.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-dictation-esc-cancel.test.tsx
@@ -1,0 +1,130 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { markActiveComposer } from '../focus'
+
+import { useComposerEscCancel } from './use-composer-esc-cancel'
+import { useDictationEscCancel } from './use-dictation-esc-cancel'
+
+// Esc is claimed by two composer handlers. DESIGN.md: "One cancel gesture does
+// one thing: cancel the active interaction, or close the topmost dismissable
+// surface — never both." These tests pin that contract.
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+
+function pressEscape() {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'Escape' })
+  window.dispatchEvent(event)
+
+  return event
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('useDictationEscCancel', () => {
+  it('discards the recording on Esc', () => {
+    markActiveComposer('main')
+    const onCancel = vi.fn()
+    renderHook(() => useDictationEscCancel({ onCancel, recording: true, target: 'main' }))
+
+    const event = pressEscape()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('ignores Esc when not recording', () => {
+    markActiveComposer('main')
+    const onCancel = vi.fn()
+    renderHook(() => useDictationEscCancel({ onCancel, recording: false, target: 'main' }))
+
+    pressEscape()
+
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('ignores Esc for a composer that is not the active one', () => {
+    markActiveComposer('main')
+    const onCancel = vi.fn()
+    renderHook(() => useDictationEscCancel({ onCancel, recording: true, target: 'popout' }))
+
+    pressEscape()
+
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  // The edit composer ('edit') is a real active target that has no dictation of
+  // its own — no recorder, no VoiceActivity panel — and it already claims Esc to
+  // close its trigger popover / cancel the edit. Bailing here is the correct
+  // routing decision, not a silent no-op: there is no recording to discard, and
+  // Esc must stay with the surface the user is actually in.
+  //
+  // The edit-composer root must exist in the DOM for the claim to hold: the
+  // focus bus heals a claim whose surface is gone back to the visible chat
+  // composer, so marking 'edit' without rendering it would resolve to 'main'.
+  it('leaves Esc to the edit composer when it owns focus', () => {
+    const editRoot = document.createElement('div')
+    editRoot.setAttribute('data-slot', 'aui_edit-composer-root')
+    document.body.appendChild(editRoot)
+    markActiveComposer('edit')
+
+    const onCancel = vi.fn()
+    renderHook(() => useDictationEscCancel({ onCancel, recording: true, target: 'main' }))
+
+    const event = pressEscape()
+
+    expect(onCancel).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('lets an open dialog keep Esc', () => {
+    markActiveComposer('main')
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    document.body.appendChild(dialog)
+
+    const onCancel = vi.fn()
+    renderHook(() => useDictationEscCancel({ onCancel, recording: true, target: 'main' }))
+
+    pressEscape()
+
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+})
+
+describe('Esc precedence between dictation and the running turn', () => {
+  it('cancels the dictation and NOT the agent turn when both are live', () => {
+    markActiveComposer('main')
+    const haltRun = vi.fn()
+    const cancelDictation = vi.fn()
+
+    renderHook(() =>
+      useComposerEscCancel({ awaitingInput: false, busy: true, onCancel: haltRun, target: 'main' })
+    )
+    renderHook(() => useDictationEscCancel({ onCancel: cancelDictation, recording: true, target: 'main' }))
+
+    pressEscape()
+
+    expect(cancelDictation).toHaveBeenCalledTimes(1)
+    // The capture-phase preventDefault must stop the turn from being halted too.
+    expect(haltRun).not.toHaveBeenCalled()
+  })
+
+  it('still halts the turn when no dictation is recording', () => {
+    markActiveComposer('main')
+    const haltRun = vi.fn()
+    const cancelDictation = vi.fn()
+
+    renderHook(() =>
+      useComposerEscCancel({ awaitingInput: false, busy: true, onCancel: haltRun, target: 'main' })
+    )
+    renderHook(() => useDictationEscCancel({ onCancel: cancelDictation, recording: false, target: 'main' }))
+
+    pressEscape()
+
+    expect(cancelDictation).not.toHaveBeenCalled()
+    expect(haltRun).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-dictation-esc-cancel.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-dictation-esc-cancel.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from 'react'
+
+import { triggerHaptic } from '@/lib/haptics'
+
+import { type ComposerTarget, getActiveComposer } from '../focus'
+
+interface UseDictationEscCancelOptions {
+  /** True only while audio is being captured. Transcription in flight is past
+   *  the point of recall — the audio already reached the provider. */
+  recording: boolean
+  onCancel: () => void
+  /** This composer's focus-bus key, so only the active composer reacts. */
+  target: ComposerTarget
+}
+
+/**
+ * Esc discards an in-flight dictation.
+ *
+ * Precedence matters here: `useComposerEscCancel` already claims Esc to halt a
+ * running agent turn, and DESIGN.md requires that one cancel gesture does one
+ * thing. This handler is deliberately the narrower claim — it only acts while
+ * the microphone is actually capturing, and it marks the event handled
+ * (`preventDefault`) so the turn-cancel listener bails on its own
+ * `defaultPrevented` check. In practice the two rarely overlap (dictation is a
+ * draft-time action, turn-cancel a busy-time one), but when they do, discarding
+ * the recording the user is staring at beats stopping a background turn.
+ *
+ * Unlike the turn-cancel handler this does NOT bail when focus sits in a text
+ * field: dictation is normally started from the focused composer input, so
+ * requiring focus to leave the input first would make the shortcut unreachable
+ * exactly when it is needed.
+ */
+export function useDictationEscCancel({ onCancel, recording, target }: UseDictationEscCancelOptions) {
+  const handlerRef = useRef<(event: globalThis.KeyboardEvent) => void>(() => {})
+
+  handlerRef.current = (event: globalThis.KeyboardEvent) => {
+    if (event.key !== 'Escape' || event.defaultPrevented || !recording) {
+      return
+    }
+
+    if (getActiveComposer() !== target) {
+      return
+    }
+
+    // An open dialog, popover, or completion listbox owns Esc — it must close
+    // that surface, never reach past it to the composer underneath. The trigger
+    // popover is a plain `role="listbox"`, not a radix popper, so it needs its
+    // own entry here.
+    if (
+      document.querySelector(
+        '[role="dialog"],[role="alertdialog"],[role="listbox"],[data-radix-popper-content-wrapper]'
+      )
+    ) {
+      return
+    }
+
+    event.preventDefault()
+    triggerHaptic('cancel')
+    onCancel()
+  }
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => handlerRef.current(event)
+    // Capture phase: the turn-cancel listener is registered on `window` too, and
+    // bubble-phase order would depend on hook call order. Capturing makes the
+    // precedence explicit and stable — we see Esc first, and when we consume it
+    // the turn-cancel handler bails on `defaultPrevented`.
+    window.addEventListener('keydown', onKeyDown, true)
+
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [])
+}

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder-real-seam.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder-real-seam.test.tsx
@@ -1,0 +1,150 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useVoiceRecorder } from './use-voice-recorder'
+
+// Real-seam counterpart to use-voice-recorder.test.tsx: no mock of
+// useMicRecorder. The discard claim — "the captured audio never reaches the
+// STT provider" — is a data-loss/cost boundary, so it must be proven against
+// the real recorder lifecycle (MediaRecorder wiring, chunk buffer, onstop
+// resolver), with only the browser primitives faked.
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          microphoneAccessDenied: 'denied',
+          microphoneConstraintsUnsupported: 'constraints',
+          microphoneInUse: 'in use',
+          microphonePermissionDenied: 'permission',
+          microphoneStartFailed: 'start failed',
+          microphoneUnsupported: 'unsupported',
+          noMicrophone: 'no mic',
+          noSpeechDetected: 'no speech',
+          recordingFailed: 'recording failed',
+          transcriptionFailed: 'transcription failed',
+          transcriptionUnavailable: 'transcription unavailable',
+          tryRecordingAgain: 'try again',
+          unavailable: 'unavailable'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+class FakeMediaRecorder {
+  static instances: FakeMediaRecorder[] = []
+  static isTypeSupported = () => true
+
+  mimeType = 'audio/webm'
+  ondataavailable: ((event: { data: Blob }) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onstop: (() => void) | null = null
+  state: 'inactive' | 'recording' = 'inactive'
+
+  constructor(_stream: MediaStream, options?: { mimeType?: string }) {
+    if (options?.mimeType) {
+      this.mimeType = options.mimeType
+    }
+
+    FakeMediaRecorder.instances.push(this)
+  }
+
+  start() {
+    this.state = 'recording'
+  }
+
+  stop() {
+    this.state = 'inactive'
+    // Flush a captured chunk the way a real recorder does on stop, THEN fire
+    // onstop. A cancelled recorder has these handlers detached, so the chunk
+    // must go nowhere — that detachment is exactly what this file tests.
+    this.ondataavailable?.({ data: new Blob(['captured-audio']) })
+    this.onstop?.()
+  }
+}
+
+const fakeTrack = { stop: vi.fn() }
+const fakeStream = { getTracks: () => [fakeTrack] } as unknown as MediaStream
+
+beforeEach(() => {
+  FakeMediaRecorder.instances = []
+  fakeTrack.stop.mockClear()
+
+  vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia: vi.fn(async () => fakeStream) }
+  })
+  // No AudioContext in jsdom: startMeter degrades gracefully (level stays 0),
+  // which is fine — the meter is not the seam under test.
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function renderRecorder() {
+  const onTranscribeAudio = vi.fn<(audio: Blob) => Promise<string>>(async () => 'transcribed text')
+  const onTranscript = vi.fn()
+
+  const view = renderHook(() =>
+    useVoiceRecorder({ focusInput: vi.fn(), maxRecordingSeconds: 120, onTranscribeAudio, onTranscript })
+  )
+
+  return { onTranscribeAudio, onTranscript, view }
+}
+
+describe('useVoiceRecorder against the real recorder seam', () => {
+  it('cancelDictation discards the live MediaRecorder capture without transcribing', async () => {
+    const { onTranscribeAudio, onTranscript, view } = renderRecorder()
+
+    await act(async () => {
+      view.result.current.dictate()
+      await waitFor(() => expect(FakeMediaRecorder.instances).toHaveLength(1))
+    })
+
+    await waitFor(() => expect(view.result.current.voiceStatus).toBe('recording'))
+    const recorder = FakeMediaRecorder.instances[0]
+    expect(recorder.state).toBe('recording')
+
+    act(() => {
+      view.result.current.cancelDictation()
+    })
+
+    // The real cancel path: recorder stopped, handlers detached first so the
+    // flushed chunk is dropped, tracks released, and the audio never reaches
+    // the transcription callback.
+    expect(recorder.state).toBe('inactive')
+    expect(fakeTrack.stop).toHaveBeenCalled()
+    expect(onTranscribeAudio).not.toHaveBeenCalled()
+    expect(onTranscript).not.toHaveBeenCalled()
+    expect(view.result.current.voiceStatus).toBe('idle')
+  })
+
+  it('a normal stop through the same real seam still transcribes — cancel changed nothing it should not', async () => {
+    const { onTranscribeAudio, onTranscript, view } = renderRecorder()
+
+    await act(async () => {
+      view.result.current.dictate()
+      await waitFor(() => expect(FakeMediaRecorder.instances).toHaveLength(1))
+    })
+
+    await waitFor(() => expect(view.result.current.voiceStatus).toBe('recording'))
+
+    await act(async () => {
+      view.result.current.dictate()
+    })
+
+    await waitFor(() => expect(onTranscribeAudio).toHaveBeenCalledTimes(1))
+    const audio = onTranscribeAudio.mock.calls[0][0] as Blob
+    expect(await audio.text()).toBe('captured-audio')
+    await waitFor(() => expect(onTranscript).toHaveBeenCalledWith('transcribed text'))
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
@@ -1,0 +1,127 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { MicRecording } from './use-mic-recorder'
+import { useVoiceRecorder } from './use-voice-recorder'
+
+// Cancelling dictation must DISCARD the captured audio: the mic button only
+// ever commits (stop → transcribe), so before this seam existed every started
+// recording cost an STT call the user could not back out of.
+
+const micHandle = {
+  cancel: vi.fn(),
+  start: vi.fn(async () => undefined),
+  stop: vi.fn<() => Promise<MicRecording | null>>(async () => ({
+    audio: new Blob(['audio']),
+    durationMs: 1200,
+    heardSpeech: true
+  }))
+}
+
+let recording = false
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({ handle: micHandle, level: 0, recording })
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          noSpeechDetected: 'no speech',
+          recordingFailed: 'recording failed',
+          transcriptionFailed: 'transcription failed',
+          transcriptionUnavailable: 'transcription unavailable',
+          tryRecordingAgain: 'try again',
+          unavailable: 'unavailable'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+function renderRecorder() {
+  const onTranscribeAudio = vi.fn(async () => 'transcribed text')
+  const onTranscript = vi.fn()
+  const focusInput = vi.fn()
+
+  const view = renderHook(() =>
+    useVoiceRecorder({ focusInput, maxRecordingSeconds: 120, onTranscribeAudio, onTranscript })
+  )
+
+  return { focusInput, onTranscribeAudio, onTranscript, view }
+}
+
+beforeEach(() => {
+  recording = false
+  micHandle.cancel.mockClear()
+  micHandle.start.mockClear()
+  micHandle.stop.mockClear()
+})
+
+describe('useVoiceRecorder cancelDictation', () => {
+  it('discards the recording without transcribing it', async () => {
+    const { focusInput, onTranscribeAudio, onTranscript, view } = renderRecorder()
+
+    await act(async () => {
+      await view.result.current.dictate()
+    })
+
+    recording = true
+    view.rerender()
+
+    await waitFor(() => expect(view.result.current.voiceStatus).toBe('recording'))
+
+    act(() => {
+      view.result.current.cancelDictation()
+    })
+
+    // The audio is dropped at the recorder, never committed through stop().
+    expect(micHandle.cancel).toHaveBeenCalledTimes(1)
+    expect(micHandle.stop).not.toHaveBeenCalled()
+    expect(onTranscribeAudio).not.toHaveBeenCalled()
+    expect(onTranscript).not.toHaveBeenCalled()
+
+    expect(view.result.current.voiceStatus).toBe('idle')
+    expect(view.result.current.voiceActivityState.elapsedSeconds).toBe(0)
+    expect(focusInput).toHaveBeenCalled()
+  })
+
+  it('is a no-op when no dictation is running', () => {
+    const { onTranscribeAudio, view } = renderRecorder()
+
+    act(() => {
+      view.result.current.cancelDictation()
+    })
+
+    expect(micHandle.cancel).not.toHaveBeenCalled()
+    expect(onTranscribeAudio).not.toHaveBeenCalled()
+    expect(view.result.current.voiceStatus).toBe('idle')
+  })
+
+  it('still transcribes on a normal stop — cancel does not change the commit path', async () => {
+    const { onTranscribeAudio, onTranscript, view } = renderRecorder()
+
+    await act(async () => {
+      await view.result.current.dictate()
+    })
+
+    recording = true
+    view.rerender()
+
+    await act(async () => {
+      await view.result.current.dictate()
+    })
+
+    expect(micHandle.stop).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(onTranscribeAudio).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(onTranscript).toHaveBeenCalledWith('transcribed text'))
+    expect(micHandle.cancel).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
@@ -106,11 +106,31 @@ export function useVoiceRecorder({
     }
   }
 
+  /**
+   * Discard the in-flight dictation: drop the captured audio, never transcribe.
+   * The mic button only ever *commits* a recording, so without this the user has
+   * no way out of a dictation they've changed their mind about — they'd have to
+   * pay for a transcription they don't want. Cancelling is a no-op unless we are
+   * actually recording; a transcription already in flight is past the point of
+   * recall (the audio has left for the STT provider).
+   */
+  const cancelDictation = () => {
+    if (!recording) {
+      return
+    }
+
+    clearTimers()
+    handle.cancel()
+    setElapsedSeconds(0)
+    setVoiceStatus('idle')
+    focusInput()
+  }
+
   const voiceActivityState: VoiceActivityState = {
     elapsedSeconds,
     level,
     status: voiceStatus
   }
 
-  return { dictate, voiceActivityState, voiceStatus }
+  return { cancelDictation, dictate, voiceActivityState, voiceStatus }
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -52,6 +52,7 @@ import { useComposerTrigger } from './hooks/use-composer-trigger'
 import { useComposerUndo } from './hooks/use-composer-undo'
 import { useComposerUrlDialog } from './hooks/use-composer-url-dialog'
 import { useComposerVoice } from './hooks/use-composer-voice'
+import { useDictationEscCancel } from './hooks/use-dictation-esc-cancel'
 import { useEmojiCompletions } from './hooks/use-emoji-completions'
 import { useComposerMicroActions } from './hooks/use-micro-actions'
 import { useSlashCompletions } from './hooks/use-slash-completions'
@@ -820,6 +821,13 @@ export function ChatBar({
     }
 
     if (event.key === 'Escape') {
+      // A capture-phase owner (dictation discard) already consumed this Esc.
+      // One cancel gesture does one thing — don't also exit an edit or halt
+      // the turn on the same keypress.
+      if (event.defaultPrevented) {
+        return
+      }
+
       // Editing a queued turn → Esc cancels the edit, restoring the prior draft.
       if (queueEdit) {
         event.preventDefault()
@@ -875,6 +883,7 @@ export function ChatBar({
   useComposerEscCancel({ awaitingInput, busy, onCancel: haltRun, target: scope.target })
 
   const {
+    cancelDictation,
     conversation,
     dictate,
     endConversation,
@@ -895,6 +904,15 @@ export function ChatBar({
     onSubmit,
     onTranscribeAudio,
     sessionId,
+    target: scope.target
+  })
+
+  // Esc discards an in-flight dictation. Registered after the turn-cancel hook
+  // above but listening in the capture phase, so its precedence is explicit
+  // rather than dependent on hook order.
+  useDictationEscCancel({
+    onCancel: cancelDictation,
+    recording: voiceStatus === 'recording',
     target: scope.target
   })
 
@@ -1221,7 +1239,7 @@ export function ChatBar({
                     additions beside the "+" menu and before the controls.
                     All four render nothing until something contributes. */}
                   <ContribSlot area={COMPOSER_AREAS.top} />
-                  <VoiceActivity state={voiceActivityState} />
+                  <VoiceActivity onCancel={cancelDictation} state={voiceActivityState} />
                   <VoicePlaybackActivity />
                   {queueEdit && editingQueuedPrompt && (
                     <div className="flex items-center justify-between gap-2 rounded-lg border border-[color-mix(in_srgb,var(--dt-composer-ring)_32%,transparent)] bg-accent/18 px-2 py-1">

--- a/apps/desktop/src/app/chat/composer/voice-activity.test.tsx
+++ b/apps/desktop/src/app/chat/composer/voice-activity.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import type { VoiceActivityState } from './types'
+import { VoiceActivity } from './voice-activity'
+
+// The cancel affordance lives in this panel — which only exists while a
+// dictation is in flight — rather than in the composer control row, where
+// inserting a button would shift the model pill and sibling icons sideways
+// mid-recording.
+
+function renderActivity(state: Partial<VoiceActivityState> = {}, onCancel?: () => void) {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <VoiceActivity
+        onCancel={onCancel}
+        state={{ elapsedSeconds: 3, level: 0.4, status: 'recording', ...state }}
+      />
+    </I18nProvider>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('VoiceActivity cancel', () => {
+  it('offers cancel while recording', () => {
+    const onCancel = vi.fn()
+    renderActivity({}, onCancel)
+
+    fireEvent.click(screen.getByLabelText('Cancel dictation'))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides cancel once transcription starts — the audio is already spent', () => {
+    renderActivity({ status: 'transcribing' }, vi.fn())
+
+    expect(screen.queryByLabelText('Cancel dictation')).toBeNull()
+  })
+
+  it('renders nothing at all when idle', () => {
+    const { container } = renderActivity({ status: 'idle' }, vi.fn())
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('omits cancel when no handler is wired (back-compat)', () => {
+    renderActivity()
+
+    expect(screen.queryByLabelText('Cancel dictation')).toBeNull()
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/voice-activity.tsx
+++ b/apps/desktop/src/app/chat/composer/voice-activity.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { useI18n } from '@/i18n'
-import { iconSize, Loader2, Mic, Volume2, VolumeX } from '@/lib/icons'
+import { iconSize, Loader2, Mic, Volume2, VolumeX, X } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { stopVoicePlayback } from '@/lib/voice-playback'
 import { $voicePlayback } from '@/store/voice-playback'
@@ -163,7 +163,7 @@ function PlaybackWaveform({ audioElement }: { audioElement: HTMLAudioElement | n
   return <canvas aria-hidden="true" className="block h-4 w-[88px]" ref={canvasRef} />
 }
 
-export function VoiceActivity({ state }: { state: VoiceActivityState }) {
+export function VoiceActivity({ state, onCancel }: { onCancel?: () => void; state: VoiceActivityState }) {
   const { t } = useI18n()
 
   if (state.status === 'idle') {
@@ -199,6 +199,28 @@ export function VoiceActivity({ state }: { state: VoiceActivityState }) {
       </div>
 
       <VoiceLevelBars active={recording} level={state.level} />
+
+      {/* Discard lives here, inside the panel that already appears for the
+          duration of the capture — putting it in the control row would shift
+          the model pill and every sibling icon sideways mid-dictation. Only
+          while recording: once transcription starts the audio has already
+          reached the provider, so "cancel" could no longer undo the cost.
+
+          Icon-only, matching the composer's language: every action here is a
+          glyph. Per DESIGN.md a dismiss X is self-describing, so it carries an
+          `aria-label` and no tooltip. */}
+      {recording && onCancel ? (
+        <Button
+          aria-label={t.composer.cancelDictation}
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={onCancel}
+          size="icon-xs"
+          type="button"
+          variant="ghost"
+        >
+          <X className={iconSize.xs} />
+        </Button>
+      ) : null}
     </div>
   )
 }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1689,6 +1689,7 @@ export const ar = defineLocale({
     stopShort: 'إيقاف',
     endConversation: 'إنهاء المحادثة',
     endShort: 'إنهاء',
+    cancelDictation: 'إلغاء الإملاء',
     stopDictation: 'إيقاف الإملاء',
     transcribingDictation: 'جار تفريغ الإملاء',
     voiceDictation: 'إملاء صوتي',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2037,6 +2037,7 @@ export const en: Translations = {
     stopShort: 'Stop',
     endConversation: 'End voice conversation',
     endShort: 'End',
+    cancelDictation: 'Cancel dictation',
     stopDictation: 'Stop dictation',
     transcribingDictation: 'Transcribing dictation',
     voiceDictation: 'Voice dictation',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1852,6 +1852,7 @@ export const ja = defineLocale({
     stopShort: '停止',
     endConversation: '音声会話を終了',
     endShort: '終了',
+    cancelDictation: '口述をキャンセル',
     stopDictation: '口述を停止',
     transcribingDictation: '口述を文字起こし中',
     voiceDictation: '音声口述',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1712,6 +1712,7 @@ export interface Translations {
     stopShort: string
     endConversation: string
     endShort: string
+    cancelDictation: string
     stopDictation: string
     transcribingDictation: string
     voiceDictation: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1794,6 +1794,7 @@ export const zhHant = defineLocale({
     stopShort: '停止',
     endConversation: '結束語音對話',
     endShort: '結束',
+    cancelDictation: '取消聽寫',
     stopDictation: '停止聽寫',
     transcribingDictation: '正在轉寫聽寫',
     voiceDictation: '語音聽寫',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2228,6 +2228,7 @@ export const zh: Translations = {
     stopShort: '停止',
     endConversation: '结束语音对话',
     endShort: '结束',
+    cancelDictation: '取消听写',
     stopDictation: '停止听写',
     transcribingDictation: '正在转写听写',
     voiceDictation: '语音听写',


### PR DESCRIPTION
## Summary

Starting dictation in the desktop composer committed you to a transcription. The mic button is a toggle whose only stop path is `stop()` → `onTranscribeAudio()`, so a recording started by accident — or abandoned mid-sentence — still got uploaded to the STT provider. On a metered provider that is a billable call the user did not want, with no way out: no discard control, and no keyboard escape.

This adds a discard path with two entry points invoking the same action: an icon button in the `VoiceActivity` panel, and `Esc`. Both call the recorder's existing `cancel()` seam — `useMicRecorder` already exposes it and the voice-conversation loop already uses it (`use-voice-conversation.ts:606,627`); dictation was the one consumer never wired up. `git log -p -S` shows nothing marking that omission as deliberate.

Two placement decisions worth flagging:

- **The control lives in the panel, not the control row.** A button in the composer's icon row would shift the model pill and every sibling icon sideways for the duration of the recording. `VoiceActivity` only exists while dictation runs, so the stable row stays stable. Icon-only with `aria-label` and no tooltip, per `DESIGN.md` ("the glyph is the label").
- **`Esc` precedence is explicit.** `useComposerEscCancel` claims `Esc` for halting a turn and the edit composer claims it for its own cancel. The dictation handler listens in the **capture phase** and `preventDefault()`s, so the turn-cancel listener bails on `defaultPrevented` instead of the outcome depending on hook mount order. It acts only while audio is captured, only for the active composer, and never when a dialog is open or the edit composer holds focus — that surface has no dictation of its own. (#66100 was reviewed with exactly this class of objection: a shortcut routed via `getActiveComposer()` but listened for only in ChatBar, silently no-oping on the edit composer. There is a regression test pinning the decision.)

Hidden once transcription starts — at that point the audio has already reached the provider, so "cancel" would misrepresent what it can undo.

## Changes

- `hooks/use-voice-recorder.ts` — `cancelDictation()`: clears timers, calls `handle.cancel()`, resets elapsed, restores focus. No-ops unless recording.
- `hooks/use-composer-voice.ts` — expose it from the composer's voice engine.
- `voice-activity.tsx` — optional `onCancel`; icon-only dismiss button while `status === 'recording'`.
- `hooks/use-dictation-esc-cancel.ts` — new capture-phase `Esc` handler.
- `composer/index.tsx` — wire both entry points.
- `i18n/{en,ja,zh,zh-hant,ar}.ts` + `types.ts` — `composer.cancelDictation`, all locales together.
- 3 new test files (14 tests): panel visibility per state, `Esc` bail conditions, the precedence contract, and audio-discarded-without-transcribing.

## Validation

macOS 26.2 (Apple Silicon), Hermes Desktop 0.17.0, against `main` @ `69ae247cf`. CI covers Linux; Windows untested by me. Renderer-only (React + `MediaRecorder`), no platform-specific APIs.

- [x] `npm run check` (typecheck + lint + tests + build + package) — exit 0
- [x] `npm run check:test:ui` — 3694 passed / 416 files
- [x] `npm run test:desktop:platforms` — 1035 passed, 2 skipped
- [x] `npm run check:lint` — 0 errors (93 pre-existing `no-restricted-globals` warnings; 3 from the new test files, matching every sibling test)
- [x] Sabotage check: reverting the capture-phase listener to bubble phase turns the precedence test red
- [x] `pytest` — N/A, no Python touched (`scripts/ci/classify_changes.py` → `frontend=true`, `python=false`)

Manual: start dictation → control row does not shift → ✕ (or `Esc`) discards with **no STT request** (verified in provider logs) → normal mic stop still transcribes → ✕ gone once transcribing → with a turn running *and* a recording, `Esc` discards the dictation and the turn keeps running.

## Related

Fixes #84167
