### PR TITLE
fix(acp): honor configured max turns

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -615,6 +615,11 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
+        agent_cfg = config.get("agent")
+        if not isinstance(agent_cfg, dict):
+            agent_cfg = {}
+        max_iterations = agent_cfg.get("max_turns") or config.get("max_turns") or 500
+
         configured_mcp_servers = [
             name
             for name, cfg in (config.get("mcp_servers") or {}).items()
@@ -631,6 +636,7 @@ class SessionManager:
             "session_id": session_id,
             "session_db": self._get_db(),
             "model": model or default_model,
+            "max_iterations": max_iterations,
         }
 
         try:

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -93,7 +93,13 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.config",
-        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m", "provider": "p"}}),
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {
+                "model": {"default": "m", "provider": "p"},
+                "agent": {"max_turns": 150},
+            },
+        ),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -118,6 +124,7 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     assert captured["session_db"] is sentinel_db
     assert captured["platform"] == "acp"
     assert captured["session_id"] == "acp-session"
+    assert captured["max_iterations"] == 150
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- propagate `agent.max_turns` into ACP-created `AIAgent` instances
- retain root-level `max_turns` compatibility
- use the documented 500-turn default when no value is configured
- add regression coverage for ACP config propagation

## Root cause
The ACP session manager loaded Hermes configuration but never passed `max_iterations` into `AIAgent`. Paseo and other ACP clients therefore silently used the constructor default instead of the user-configured value.

## Verification
- `uv run --extra dev --extra acp pytest -q tests/acp_adapter` (15 passed)
- `uv run --extra dev ruff check acp_adapter/session.py tests/acp_adapter/test_acp_commands.py`
- `python3 -m compileall -q acp_adapter/session.py tests/acp_adapter/test_acp_commands.py`
- `git diff --check`