### PR TITLE
feat(desktop): host.attachFileToComposer — SDK door to stage a file on the chat composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -6,6 +6,7 @@ import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import {
   type ComposerAttachment,
   type ComposerDraftSyncMode,
+  markMainComposerDraftScope,
   onComposerDraftSyncRequest,
   reloadPersistedDrafts,
   stashSessionDraft,
@@ -13,6 +14,7 @@ import {
 } from '@/store/composer'
 import { isBrowsingHistory } from '@/store/composer-input-history'
 
+import { markComposerMounted } from '../../hooks/composer-attach-presence'
 import {
   cloneAttachments,
   DRAFT_PERSIST_DEBOUNCE_MS,
@@ -383,10 +385,19 @@ export function useComposerDraft({
     pendingDraftPersistRef.current = null
     draftScopeRef.current = activeQueueSessionKey
 
+    // Publish the MAIN composer's stash key for out-of-page senders
+    // (host.attachFileToComposer): they stage into this session's draft.
+    // Sticky across unmount on purpose — see markMainComposerDraftScope.
+    if (target === 'main') {
+      markMainComposerDraftScope(activeQueueSessionKey)
+    }
+
+    const unmark = markComposerMounted(target)
     const { attachments, text } = takeSessionDraft(activeQueueSessionKey)
     loadIntoComposer(text, attachments)
 
     return () => {
+      unmark()
       const latestText = syncDraftFromEditor()
       const editing = queueEditStateRef.current
 
@@ -396,7 +407,7 @@ export function useComposerDraft({
         stashAt(activeQueueSessionKey, latestText)
       }
     }
-  }, [activeQueueSessionKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeQueueSessionKey, target]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // The HUD handoff's two verbs. Entering HUD mode flushes this editor's text
   // into the shared stash so the HUD's composer boots with it; leaving repaints

--- a/apps/desktop/src/app/chat/hooks/composer-attach-presence.ts
+++ b/apps/desktop/src/app/chat/hooks/composer-attach-presence.ts
@@ -1,0 +1,34 @@
+/**
+ * Mounted-composer presence — lets non-React senders (host.attachFileToComposer)
+ * choose between the live attachment atom and the per-session draft stash.
+ *
+ * Counted, not boolean: React strict-mode double-mounts and the brief overlap
+ * during route transitions mean mark/unmark pairs can interleave.
+ */
+
+const mounted = new Map<string, number>()
+
+export function markComposerMounted(target: string): () => void {
+  mounted.set(target, (mounted.get(target) ?? 0) + 1)
+
+  let released = false
+
+  return () => {
+    if (released) {
+      return
+    }
+
+    released = true
+    const next = (mounted.get(target) ?? 1) - 1
+
+    if (next <= 0) {
+      mounted.delete(target)
+    } else {
+      mounted.set(target, next)
+    }
+  }
+}
+
+export function isComposerMounted(target: string): boolean {
+  return (mounted.get(target) ?? 0) > 0
+}

--- a/apps/desktop/src/app/chat/hooks/composer-attach.test.ts
+++ b/apps/desktop/src/app/chat/hooks/composer-attach.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Contract: host.attachFileToComposer must land the attachment where the
+ * composer will actually read it — the live scope atom when a main composer
+ * is mounted, the per-session draft stash when it is not (Media Studio and
+ * every other full-page surface). The stash path is the regression under
+ * test: the original implementation wrote only to the atom, and the chat
+ * route's mount-time draft restore clobbered it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $composerAttachments,
+  clearSessionDraft,
+  markMainComposerDraftScope,
+  takeSessionDraft
+} from '@/store/composer'
+
+import { attachComposerFile } from './composer-attach'
+import { isComposerMounted, markComposerMounted } from './composer-attach-presence'
+
+const bridgeWindow = window as unknown as {
+  hermesDesktop?: { readFileDataUrl?: (path: string, maxBytes?: number) => Promise<string> }
+}
+
+describe('composer-attach-presence', () => {
+  it('counts overlapping mounts and releases idempotently', () => {
+    expect(isComposerMounted('main')).toBe(false)
+
+    const a = markComposerMounted('main')
+    const b = markComposerMounted('main')
+
+    expect(isComposerMounted('main')).toBe(true)
+    a()
+    expect(isComposerMounted('main')).toBe(true)
+    a() // double release must not steal b's claim
+    expect(isComposerMounted('main')).toBe(true)
+    b()
+    expect(isComposerMounted('main')).toBe(false)
+  })
+})
+
+describe('attachComposerFile', () => {
+  const originalBridge = bridgeWindow.hermesDesktop
+
+  beforeEach(() => {
+    $composerAttachments.set([])
+    markMainComposerDraftScope('session-a')
+    clearSessionDraft('session-a')
+    bridgeWindow.hermesDesktop = {
+      readFileDataUrl: vi.fn().mockResolvedValue('data:image/png;base64,x')
+    }
+  })
+
+  afterEach(() => {
+    bridgeWindow.hermesDesktop = originalBridge
+    $composerAttachments.set([])
+    clearSessionDraft('session-a')
+  })
+
+  it('returns false for an empty path', async () => {
+    await expect(attachComposerFile('')).resolves.toBe(false)
+  })
+
+  it('stages into the live atom while a main composer is mounted', async () => {
+    const release = markComposerMounted('main')
+
+    try {
+      await expect(attachComposerFile('/tmp/shot.png')).resolves.toBe(true)
+
+      const live = $composerAttachments.get()
+
+      expect(live).toHaveLength(1)
+      expect(live[0]).toMatchObject({ kind: 'image', path: '/tmp/shot.png', previewUrl: 'data:image/png;base64,x' })
+      // Nothing parked in the stash — the atom is authoritative while mounted.
+      expect(takeSessionDraft('session-a').attachments).toHaveLength(0)
+    } finally {
+      release()
+    }
+  })
+
+  it('stages into the session draft stash while no composer is mounted', async () => {
+    await expect(attachComposerFile('/tmp/render.mp4')).resolves.toBe(true)
+
+    expect($composerAttachments.get()).toHaveLength(0)
+
+    const stashed = takeSessionDraft('session-a')
+
+    expect(stashed.attachments).toHaveLength(1)
+    expect(stashed.attachments[0]).toMatchObject({ kind: 'file', path: '/tmp/render.mp4' })
+  })
+
+  it('resolves image previews into the stash after the fact', async () => {
+    await attachComposerFile('/tmp/late-preview.png')
+
+    const stashed = takeSessionDraft('session-a')
+
+    expect(stashed.attachments[0]?.previewUrl).toBe('data:image/png;base64,x')
+  })
+
+  it('preserves stashed draft text when staging an attachment', async () => {
+    const { stashSessionDraft } = await import('@/store/composer')
+
+    stashSessionDraft('session-a', 'half-typed thought', [])
+    await attachComposerFile('/tmp/render.mp4')
+
+    const stashed = takeSessionDraft('session-a')
+
+    expect(stashed.text).toBe('half-typed thought')
+    expect(stashed.attachments).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/app/chat/hooks/composer-attach.ts
+++ b/apps/desktop/src/app/chat/hooks/composer-attach.ts
@@ -1,0 +1,103 @@
+/**
+ * Attach a local file to the MAIN chat composer from outside React — the
+ * store-level twin of use-composer-actions' attachImagePath, callable from
+ * plugin pages and other non-hook surfaces (SDK `host.attachFileToComposer`).
+ *
+ * Two delivery paths, because the main composer is NOT globally mounted (it
+ * lives inside the chat route — a full-page surface like Media Studio has no
+ * live composer):
+ *
+ *  - composer mounted → add straight to the live scope's atom; the chip
+ *    appears immediately.
+ *  - composer unmounted → stash into the per-session draft keyed on the main
+ *    composer's LAST scope (sticky via markMainComposerDraftScope). The swap
+ *    effect restores it, chip included, when the user lands back on chat.
+ *
+ * Images attach as `kind: 'image'` (inline preview resolved best-effort);
+ * everything else attaches as a `kind: 'file'` reference. The user still
+ * reviews and sends — this only stages.
+ */
+
+import { attachmentId, pathLabel } from '@/lib/chat-runtime'
+import {
+  addComposerAttachment,
+  type ComposerAttachment,
+  getMainComposerDraftScope,
+  stashSessionDraft,
+  takeSessionDraft,
+  updateComposerAttachment,
+  upsertAttachment
+} from '@/store/composer'
+
+import { isComposerMounted } from './composer-attach-presence'
+import { attachmentPreviewDataUrl } from './use-composer-actions'
+
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'tiff'])
+
+function isImagePath(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
+
+  return IMAGE_EXTENSIONS.has(ext)
+}
+
+/** Stage into the unmounted composer's per-session draft stash. */
+function stashAttachment(attachment: ComposerAttachment): void {
+  const scope = getMainComposerDraftScope()
+  const draft = takeSessionDraft(scope)
+
+  stashSessionDraft(scope, draft.text, upsertAttachment(draft.attachments, attachment))
+}
+
+function updateStashedAttachment(attachment: ComposerAttachment): void {
+  const scope = getMainComposerDraftScope()
+  const draft = takeSessionDraft(scope)
+
+  if (draft.attachments.some(item => item.id === attachment.id)) {
+    stashSessionDraft(scope, draft.text, upsertAttachment(draft.attachments, attachment))
+  }
+}
+
+export async function attachComposerFile(filePath: string): Promise<boolean> {
+  if (!filePath) {
+    return false
+  }
+
+  const image = isImagePath(filePath)
+
+  const attachment: ComposerAttachment = {
+    id: attachmentId(image ? 'image' : 'file', filePath),
+    kind: image ? 'image' : 'file',
+    label: pathLabel(filePath),
+    detail: filePath,
+    path: filePath
+  }
+
+  const live = isComposerMounted('main')
+
+  if (live) {
+    addComposerAttachment(attachment)
+  } else {
+    stashAttachment(attachment)
+  }
+
+  if (image) {
+    try {
+      const previewUrl = await attachmentPreviewDataUrl(filePath)
+
+      if (previewUrl) {
+        const withPreview = { ...attachment, previewUrl }
+
+        // The composer may have (un)mounted while the preview resolved, which
+        // moves the attachment between the live atom and the stash (mount
+        // restores stash → atom; unmount stashes atom → stash). Update both
+        // idempotently — each is a no-op when it doesn't hold the id.
+        updateComposerAttachment(withPreview)
+        updateStashedAttachment(withPreview)
+      }
+    } catch {
+      // Preview is cosmetic — the attachment itself already landed.
+    }
+  }
+
+  return true
+}

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -108,6 +108,20 @@ export const host = {
     }
 
     return gateway.request<T>(method, params)
+  },
+
+  /** Stage a LOCAL FILE onto the main chat composer (image => inline image
+   *  attachment with preview; anything else => file attachment). The narrow
+   *  "hand my artifact to the conversation" door — the send itself stays with
+   *  the user. Returns false when no path was given. */
+  attachFileToComposer: async (filePath: string): Promise<boolean> => {
+    if (!filePath) {
+      return false
+    }
+
+    const { attachComposerFile } = await import('@/app/chat/hooks/composer-attach')
+
+    return attachComposerFile(filePath)
   }
 }
 

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -112,6 +112,24 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
  *  `$composerAttachments` reader/writer IS this scope. */
 export const mainComposerScope = createComposerAttachmentScope($composerAttachments)
 
+// ---------------------------------------------------------------------------
+// Main composer draft-scope registry — which session key the MAIN composer's
+// draft stash is (or was last) keyed on. Mirrors focus.ts's markActiveComposer
+// pattern: the mounted main composer publishes its scope from the same layout
+// effect that swaps its stash key; it deliberately does NOT clear on unmount,
+// because "hand this artifact to the chat" from another page (Media Studio,
+// a plugin pane) should target the session the user just left. Null means a
+// fresh draft (the `__new__` stash key).
+// ---------------------------------------------------------------------------
+
+let mainComposerDraftScope: string | null = null
+
+export const markMainComposerDraftScope = (scope: string | null): void => {
+  mainComposerDraftScope = scope
+}
+
+export const getMainComposerDraftScope = (): string | null => mainComposerDraftScope
+
 // Per-thread draft stash for the decoupled composer. Session lifecycle never
 // touches this — only ChatBar's scope swap reads/writes it. Text mirrors to
 // localStorage; attachments are memory-only (blobs, upload state).
@@ -218,8 +236,16 @@ export function reloadPersistedDrafts(): void {
   }
 
   // A key that vanished from storage was cleared (sent) in the other window.
+  // Only text ever reaches storage, though — an attachment-bearing local
+  // entry (chips staged while the composer is unmounted, or with no text
+  // yet) was never persisted, so its absence from storage proves nothing;
+  // deleting it here would eat the chips.
   for (const key of [...draftsBySession.keys()]) {
     if (!incoming.has(key)) {
+      if (draftsBySession.get(key)?.attachments.length) {
+        continue
+      }
+
       draftsBySession.delete(key)
       publishDraftTitle(key, '')
     }
@@ -498,7 +524,7 @@ export function clearComposerTerminalSelections() {
   $composerTerminalSelections.set({})
 }
 
-function upsertAttachment(attachments: ComposerAttachment[], attachment: ComposerAttachment) {
+export function upsertAttachment(attachments: ComposerAttachment[], attachment: ComposerAttachment) {
   const index = attachments.findIndex(item => item.id === attachment.id)
 
   if (index < 0) {


### PR DESCRIPTION
## What

Adds one SDK door: `host.attachFileToComposer(filePath)` — stage a local file onto the **main chat composer** from anywhere in the app (plugin pages included). Images become inline image attachments with a preview (via the existing preload `readFileDataUrl` bridge); everything else becomes a file reference chip. **Staging only — the send stays with the user.**

## Why

Plugins produce artifacts (generated media, exports, reports) whose natural next step is "hand it to the conversation". The SDK had no door for that. This is the one widening the Media Studio plugin needed (developed separately; it dogfoods the plugin surface and this was the single missing capability), and it's generic: any plugin or core page can use it.

## The subtle half: delivery is presence-routed

The main composer only mounts inside the chat route, so a call from a full-page surface can't just write the live attachment atom — the composer's mount-time draft restore would clobber it one frame later (this exact bug shipped in the first internal cut). Delivery routes on composer presence:

- **mounted** → live scope atom; the chip appears immediately
- **unmounted** → the per-session draft stash the composer already restores from, keyed on the main composer's last scope (published sticky from the same layout effect that swaps the stash key; `null` → the fresh-draft key)

Supporting changes, each load-bearing:

- Counted mounted-composer presence registry — strict-mode double-mounts and route-transition overlap safe.
- `reloadPersistedDrafts` no longer deletes attachment-bearing local drafts: only *text* reaches localStorage, so a key's absence from storage proves nothing about chips staged while the composer was unmounted.
- Image previews resolve into both the atom and the stash idempotently (the attachment can migrate between them while the preview loads).
- `upsertAttachment` exported for the stash path.

## Testing

- 6 contract tests (`composer-attach.test.ts`): both delivery paths, preview-after-the-fact into the stash, presence-registry overlap counting, draft-text preservation, empty-path rejection.
- `tsc` clean, eslint clean (the two `stashAt` exhaustive-deps warnings in `use-composer-draft.ts` pre-exist on main), full `--project ui` suite green on the development branch this was cut from.
- Verified live in the running app: type draft text on chat → navigate to a plugin page → attach a file → land back on chat with the chip AND the typed draft intact.

## Footprint

One new `host.*` method (lazy-imports the implementation), two small new files, minimal diffs to `composer.ts` / `use-composer-draft.ts`. No new deps, no config, no cache impact.
