### PR TITLE
fix(update): verify Windows gateway cold-start survives before reporting success

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3416,6 +3416,13 @@ def _cold_start_windows_gateway_after_update() -> None:
     Best-effort and idempotent: re-checks that nothing is running first so a
     concurrent start (e.g. the autostart entry firing) can't produce a
     duplicate gateway.
+
+    A successful ``Popen`` only proves the process was created, not that it
+    survived (e.g. a Windows job object denying breakaway kills it before it
+    logs anything — #84185). So the success line is gated on the same
+    post-spawn liveness poll every other ``_spawn_detached`` caller uses
+    (``gateway_windows._report_gateway_start``), instead of being printed
+    unconditionally from the returned PID.
     """
     if not _m()._is_windows():
         return
@@ -3444,7 +3451,7 @@ def _cold_start_windows_gateway_after_update() -> None:
 
     if pid:
         print()
-        print(f"  ✓ Starting Windows gateway after update (PID {pid})")
+        gateway_windows._report_gateway_start(f"cold-start after update (PID {pid})")
 
 def _for_each_systemd_gateway_unit(
     list_units_stdout: str,

--- a/tests/hermes_cli/test_update_cold_start_gateway_liveness.py
+++ b/tests/hermes_cli/test_update_cold_start_gateway_liveness.py
@@ -1,0 +1,50 @@
+"""#84185: a Windows gateway cold-started after update that dies immediately
+(e.g. a job object denying breakaway) must not be reported as started.
+
+``_cold_start_windows_gateway_after_update`` used to print the success line
+straight off a successful ``Popen`` return, which only proves the process was
+created, not that it survived. This asserts the observable output: the
+success line is gated on the process actually being found alive afterwards,
+same as every other ``_spawn_detached`` caller.
+"""
+
+from __future__ import annotations
+
+from hermes_cli import gateway as hermes_gateway
+from hermes_cli import gateway_windows
+from hermes_cli import main as cli_main
+from hermes_cli import update_cmd
+
+
+def _run_cold_start(monkeypatch, capsys, *, surviving_pids):
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+
+    # The pre-spawn re-check (``all_profiles=True``) must find nothing
+    # running so the cold-start path proceeds and actually spawns.
+    monkeypatch.setattr(
+        hermes_gateway,
+        "find_gateway_pids",
+        lambda all_profiles=False: [] if all_profiles else surviving_pids,
+    )
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", lambda: 4242)
+    # Avoid the real 6s/0.4s poll loop in _report_gateway_start.
+    monkeypatch.setattr(
+        gateway_windows, "_wait_for_gateway_ready", lambda *a, **k: surviving_pids
+    )
+
+    update_cmd._cold_start_windows_gateway_after_update()
+
+    return capsys.readouterr().out
+
+
+def test_cold_start_reports_failure_when_process_does_not_survive(monkeypatch, capsys):
+    out = _run_cold_start(monkeypatch, capsys, surviving_pids=[])
+
+    assert "✓ Starting Windows gateway after update" not in out
+    assert "no process detected" in out
+
+
+def test_cold_start_reports_success_when_process_survives(monkeypatch, capsys):
+    out = _run_cold_start(monkeypatch, capsys, surviving_pids=[4242])
+
+    assert "✓ Gateway started via cold-start after update" in out


### PR DESCRIPTION
## Bug Description

Fixes #84185.

On Windows, `hermes update` cold-starts a fresh gateway when an autostart entry is installed but nothing was running. `_cold_start_windows_gateway_after_update()` printed `✓ Starting Windows gateway after update (PID <n>)` as soon as `gateway_windows._spawn_detached()` returned a PID — but a successful `Popen` only proves `CreateProcess` succeeded, not that the child survived.

The reporter's and Halldrix's investigation (see issue thread) traced the actual death to `_spawn_detached()`'s job-object handling: `CREATE_BREAKAWAY_FROM_JOB` can fail with `OSError` when the parent's job denies breakaway (as during the updater hand-off), and the fallback spawn without breakaway leaves the child inside the parent's job — where it gets hard-killed when the updater process exits, before it ever initializes logging or writes `gateway.pid`. The `✓` line is printed regardless, so the failure is invisible.

## Fix

Route the cold-start success report through `gateway_windows._report_gateway_start()` — the same post-spawn liveness poll (`_wait_for_gateway_ready`, up to 6s) that every other `_spawn_detached()` caller in `gateway_windows.py` already uses (`install()`, `_install_startup_fallback()`). If the process is actually found alive afterward, it prints success with the PID(s); if not, it prints a failure line with a hint to check `gateway.log` / `gateway-stdio.log` instead of a false `✓`.

This directly matches the issue's stated expected behavior: "A gateway cold-started after an update should actually survive, or the updater should report a failure instead of printing ✓."

Out of scope for this minimal fix: actually escaping the job object (e.g. via `schtasks /run` per Halldrix's fix-direction comment) and the related #76129 (opposite failure — an unwanted gateway surviving when `hermes serve` is the runtime). Those are separate, larger changes; this PR only fixes the silent/false success report.

## Test Plan

Added `tests/hermes_cli/test_update_cold_start_gateway_liveness.py`, asserting the observable printed output (not just that a helper was called):

- `test_cold_start_reports_failure_when_process_does_not_survive` — spawn returns a PID but the post-spawn poll finds nothing alive → asserts the `✓ Starting Windows gateway after update` line is absent and a "no process detected" message is printed.
- `test_cold_start_reports_success_when_process_survives` — spawn returns a PID and the post-spawn poll finds it alive → asserts a success line is printed.

Verified the test fails without the fix:

```
$ git checkout HEAD~1 -- hermes_cli/update_cmd.py   # (or hand-revert the print block)
$ python3 -m pytest tests/hermes_cli/test_update_cold_start_gateway_liveness.py -v
FAILED test_cold_start_reports_failure_when_process_does_not_survive - AssertionError: assert '✓ Starting Windows gateway after update' not in '...'
FAILED test_cold_start_reports_success_when_process_survives - AssertionError: assert '✓ Gateway started via cold-start after update' in '...'
2 failed in 0.40s

$ git checkout HEAD -- hermes_cli/update_cmd.py     # fix restored
$ python3 -m pytest tests/hermes_cli/test_update_cold_start_gateway_liveness.py -v
test_cold_start_reports_failure_when_process_does_not_survive PASSED
test_cold_start_reports_success_when_process_survives PASSED
2 passed in 0.38s
```

Also ran the neighboring suites to check for regressions:

```
$ python3 -m pytest tests/hermes_cli/test_gateway_windows.py tests/hermes_cli/test_update_orphan_backend_reap.py tests/hermes_cli/test_update_cold_start_gateway_liveness.py -v
23 passed, 2 skipped
```

`ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_update_cold_start_gateway_liveness.py` — clean.

A broader `pytest tests/hermes_cli/ -k "gateway or update"` run shows 7 pre-existing failures unrelated to this change (missing `pytest-asyncio` plugin, `managed_uv`/`web_server_profile_unification` tests that depend on the hermetic `scripts/run_tests.sh` environment this sandbox doesn't fully replicate) — none touch `update_cmd.py`, `gateway_windows.py`, or the cold-start path.

## AI assistance disclosure

This PR was written with AI assistance (Claude Code).
