### PR TITLE
fix(honcho): make local-memory migration actually one-time

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -504,6 +504,14 @@ class HonchoMemoryProvider(MemoryProvider):
         # Honcho session by design, so uploading MEMORY.md/USER.md/SOUL.md to
         # each one would flood the backend with short-lived duplicates instead
         # of performing a one-time migration.
+        #
+        # NOTE: `not session.messages` is only a cheap fast path, not the real
+        # guard. It is true for EVERY new Honcho session, and a per-chat session
+        # key (gateway surfaces / WebUI send one per conversation) creates a new
+        # session per chat — so this check alone re-uploaded local memory on
+        # every conversation and the deriver re-derived all of it. The
+        # authoritative one-time guard is the completion marker inside
+        # migrate_memory_files().
         try:
             if not session.messages and cfg.session_strategy != "per-session":
                 from hermes_constants import get_hermes_home

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -15,6 +15,8 @@ from plugins.memory.honcho.client import get_honcho_client
 from plugins.memory.honcho.oauth import redact_tokens as _redact_tokens
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from honcho import Honcho
 
 logger = logging.getLogger(__name__)
@@ -1081,6 +1083,15 @@ class HonchoSessionManager:
         Used when Honcho activates on an instance that already has locally
         consolidated memory. Backwards compatible -- skips if files don't exist.
 
+        This is a ONE-TIME migration per (workspace, user peer): the files are
+        pre-Honcho local memory, so re-uploading them makes the deriver
+        re-derive every entry into fresh documents. The caller's
+        ``not session.messages`` check only proves *that session* is new, which
+        is true for every new session — under a per-chat session key (gateway
+        surfaces, WebUI) that fires on every conversation. The completion
+        marker below is the authoritative guard; the caller's check remains a
+        cheap fast path.
+
         Args:
             session_key: The session key to associate files with.
             memory_dir: Path to the memories directory (~/.hermes/memories/).
@@ -1094,6 +1105,15 @@ class HonchoSessionManager:
         if not memory_path.exists():
             return False
 
+        marker = self._memory_migration_marker_path()
+        if marker is not None and marker.exists():
+            logger.debug(
+                "Honcho memory file migration already completed for %s (marker: %s)",
+                self._migration_scope_label(),
+                marker,
+            )
+            return False
+
         session = self._cache.get(session_key)
         if not session:
             logger.warning("No local session cached for '%s', skipping memory migration", session_key)
@@ -1104,6 +1124,7 @@ class HonchoSessionManager:
             return False
 
         uploaded = False
+        aborted = False
         files = [
             (
                 "MEMORY.md",
@@ -1169,11 +1190,63 @@ class HonchoSessionManager:
                 uploaded = True
             except HonchoAuthError:
                 logger.error("Honcho memory migration stopped after %s: auth failed", filename)
+                aborted = True
                 break
             except Exception as e:
                 logger.error("Failed to upload %s to Honcho: %s", filename, e)
+                aborted = True
+
+        # Only stamp completion when every present file made it. A partial
+        # upload must stay retryable: marking it done would strand the missing
+        # files forever, which is worse than one duplicate upload.
+        if uploaded and not aborted:
+            self._write_memory_migration_marker()
 
         return uploaded
+
+    def _migration_scope_label(self) -> str:
+        """Human-readable (workspace, user peer) scope for log messages."""
+        workspace = getattr(self._config, "workspace_id", None) or "default"
+        peer = getattr(self._config, "peer_name", None) or "default"
+        return f"{workspace}/{peer}"
+
+    def _memory_migration_marker_path(self) -> "Path | None":
+        """Path of the one-time memory-migration completion marker.
+
+        Scoped to (workspace, user peer) so switching either one — e.g. a
+        deliberate clean-slate migration onto a fresh workspace — legitimately
+        re-runs the upload, while ordinary new sessions do not. Returns None if
+        HERMES_HOME cannot be resolved, in which case the caller falls back to
+        the previous behaviour rather than crashing.
+        """
+        from pathlib import Path
+
+        try:
+            from hermes_constants import get_hermes_home
+
+            scope = re.sub(r"[^A-Za-z0-9_.-]+", "-", self._migration_scope_label()).strip("-")
+            return Path(get_hermes_home()) / "honcho" / f"memory-migrated-{scope}"
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Could not resolve Honcho memory migration marker path: %s", e)
+            return None
+
+    def _write_memory_migration_marker(self) -> None:
+        """Record that the one-time memory-file migration has completed."""
+        marker = self._memory_migration_marker_path()
+        if marker is None:
+            return
+        try:
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.write_text(
+                f"{datetime.now().isoformat(timespec='seconds')}\n"
+                f"scope={self._migration_scope_label()}\n",
+                encoding="utf-8",
+            )
+            logger.debug("Wrote Honcho memory migration marker: %s", marker)
+        except Exception as e:
+            # Losing the marker only costs a duplicate upload next session;
+            # never let it break an otherwise successful migration.
+            logger.debug("Could not write Honcho memory migration marker: %s", e)
 
     @staticmethod
     def _normalize_card(card: Any) -> list[str]:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -389,6 +389,130 @@ class TestPerSessionMigrateGuard:
         mock_manager.migrate_memory_files.assert_not_called()
 
 
+class TestMemoryMigrationIsOneTime:
+    """migrate_memory_files must upload local memory exactly ONCE per scope.
+
+    MEMORY.md/USER.md are pre-Honcho local memory. Re-uploading them makes the
+    deriver re-derive every entry into fresh documents. The caller's
+    ``not session.messages`` check is true for every NEW Honcho session, and a
+    per-chat session key (gateway/WebUI) creates one session per conversation —
+    so before the completion marker, local memory was re-uploaded on every
+    chat. Measured on a live install: 13 duplicate documents per conversation.
+    """
+
+    def _make_manager(self, tmp_path, workspace="ws-a", peer="peer-a"):
+        from unittest.mock import MagicMock, patch
+
+        from plugins.memory.honcho.session import HonchoSessionManager
+
+        cfg = MagicMock()
+        cfg.workspace_id = workspace
+        cfg.peer_name = peer
+
+        manager = HonchoSessionManager(honcho=MagicMock(), config=cfg)
+
+        # Minimal cached session state so migrate_memory_files gets past its
+        # own precondition checks and reaches the upload loop.
+        session = MagicMock()
+        session.honcho_session_id = "sess-1"
+        session.user_peer_id = peer
+        session.assistant_peer_id = "assistant"
+        manager._cache["key-1"] = session
+        manager._sessions_cache["sess-1"] = MagicMock()
+
+        uploads: list[str] = []
+
+        def _fake_sdk_session(_sid):
+            sdk = MagicMock()
+            sdk.upload_file.side_effect = lambda file, peer, metadata: uploads.append(
+                metadata["original_file"]
+            )
+            return sdk
+
+        patches = [
+            patch.object(manager, "_sdk_session", side_effect=_fake_sdk_session),
+            patch.object(manager, "_get_or_create_peer", return_value=MagicMock()),
+            patch.object(manager, "_authed_call", side_effect=lambda _label, fn: fn()),
+            patch("hermes_constants.get_hermes_home", return_value=tmp_path),
+        ]
+        return manager, uploads, patches
+
+    @staticmethod
+    def _write_memory_files(tmp_path):
+        mem_dir = tmp_path / "memories"
+        mem_dir.mkdir(parents=True, exist_ok=True)
+        (mem_dir / "MEMORY.md").write_text("agent note", encoding="utf-8")
+        (mem_dir / "USER.md").write_text("user profile", encoding="utf-8")
+        return str(mem_dir)
+
+    def test_second_call_does_not_re_upload(self, tmp_path):
+        """The whole point: a second session must not re-upload local memory."""
+        import contextlib
+
+        manager, uploads, patches = self._make_manager(tmp_path)
+        mem_dir = self._write_memory_files(tmp_path)
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+
+            assert manager.migrate_memory_files("key-1", mem_dir) is True
+            assert uploads == ["MEMORY.md", "USER.md"]
+
+            # Simulate the next conversation: new session, same scope.
+            assert manager.migrate_memory_files("key-1", mem_dir) is False
+            assert uploads == ["MEMORY.md", "USER.md"], (
+                "local memory was re-uploaded on a second session"
+            )
+
+    def test_marker_is_scoped_so_new_workspace_still_migrates(self, tmp_path):
+        """A deliberate clean-slate move to a new workspace must re-run."""
+        import contextlib
+
+        mem_dir = self._write_memory_files(tmp_path)
+
+        manager_a, uploads_a, patches_a = self._make_manager(tmp_path, workspace="ws-a")
+        with contextlib.ExitStack() as stack:
+            for p in patches_a:
+                stack.enter_context(p)
+            assert manager_a.migrate_memory_files("key-1", mem_dir) is True
+
+        manager_b, uploads_b, patches_b = self._make_manager(tmp_path, workspace="ws-b")
+        with contextlib.ExitStack() as stack:
+            for p in patches_b:
+                stack.enter_context(p)
+            assert manager_b.migrate_memory_files("key-1", mem_dir) is True
+            assert uploads_b == ["MEMORY.md", "USER.md"]
+
+    def test_partial_upload_is_retried(self, tmp_path):
+        """A failed upload must NOT be stamped complete — fail closed."""
+        import contextlib
+        from unittest.mock import MagicMock, patch
+
+        manager, uploads, patches = self._make_manager(tmp_path)
+        mem_dir = self._write_memory_files(tmp_path)
+
+        def _failing_sdk(_sid):
+            sdk = MagicMock()
+            sdk.upload_file.side_effect = RuntimeError("network down")
+            return sdk
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            with patch.object(manager, "_sdk_session", side_effect=_failing_sdk):
+                manager.migrate_memory_files("key-1", mem_dir)
+
+            marker = manager._memory_migration_marker_path()
+            assert marker is not None and not marker.exists(), (
+                "a failed migration must stay retryable"
+            )
+
+            # Retry succeeds and uploads both files.
+            assert manager.migrate_memory_files("key-1", mem_dir) is True
+            assert uploads == ["MEMORY.md", "USER.md"]
+
+
 class TestChunkMessage:
     def test_short_message_single_chunk(self):
         result = HonchoMemoryProvider._chunk_message("hello world", 100)


### PR DESCRIPTION
## Symptom

Every new conversation on a gateway surface re-uploads the entire local memory
(`MEMORY.md` / `USER.md` / `SOUL.md`) into Honcho, and the deriver re-derives all of it into
fresh documents. The user's stored profile slowly fills with near-duplicates of itself.

## Root cause

`migrate_memory_files()` is a one-time migration for installs that had local memory before
Honcho was activated — its own wrapper text says so (`"consolidated from local conversations
BEFORE Honcho was activated"`). But its only guard lived at the call site in
`plugins/memory/honcho/__init__.py`:

```python
if not session.messages and cfg.session_strategy != "per-session":
    self._manager.migrate_memory_files(self._session_key, mem_dir)
```

`not session.messages` proves *that session* is new — which is true for **every** new Honcho
session, not once per install. And sessions are created far more often than the configured
strategy suggests, because `resolve_session_name()` ranks `gateway_session_key` **above every
strategy**:

```python
# Gateway per-chat key wins everywhere
if gateway_session_key:
    ...
    return self._enforce_session_id_limit(sanitized, gateway_session_key)
```

Hermes WebUI sends one per chat (`X-Hermes-Session-Key: webui:{session_id}`), so
`sessionStrategy: "global"` is silently inert there: one Honcho session per conversation, and
one full memory re-upload with it.

## Evidence

Live self-hosted install, workspace `hermes`, `sessionStrategy: "global"` — 4 sessions existed
instead of 1, each with 2 uploads, and documents tracked them one-for-one:

| session | msgs | uploads | documents written within 4 min |
|---|---|---|---|
| `hermes` | 14 | 2 | 13 |
| `53fbf3247f18` | 10 | 2 | 5 |
| `38219c827554` | 28 | 2 | 16 |
| `5a5290bc2004` | 2 | 2 | 13 |

The first session is literally named after the workspace (the `global` branch); the other three
are WebUI session ids — the fingerprint of the override.

21 of 56 stored documents were near-duplicates of another: the same coffee preference, the same
avatar description, the same file pointer stored twice with slightly different wording. Honcho's
`DERIVER.DEDUPLICATE` merges the closest pairs (visible as `[DUPLICATE DETECTION] Rejecting new
in favor of existing` in the deriver log), so the raw count understates the re-derivation.

## Fix

Move the authoritative guard **into** `migrate_memory_files()` — a completion marker at
`$HERMES_HOME/honcho/memory-migrated-{workspace}-{peer}` — so it holds for every call path
rather than the single call site. The caller's `not session.messages` check stays as a cheap
fast path, with a comment recording why it is insufficient alone.

Deliberate design points:

- **Scoped to (workspace, user peer).** A clean-slate migration onto a fresh workspace still
  re-runs legitimately; only ordinary new sessions are suppressed.
- **Fails closed.** The marker is written only when every present file uploaded successfully.
  A partial or auth-failed migration stays retryable — stamping it complete would strand the
  remaining files forever, which is worse than one duplicate upload.
- **Never breaks the migration.** Marker I/O failures are logged at debug; path-resolution
  failure returns `None` and falls back to the previous behaviour.

## Tests

`tests/honcho_plugin/test_session.py::TestMemoryMigrationIsOneTime` exercises the real
`HonchoSessionManager` against a temp `HERMES_HOME` (no mock of the thing under test) and covers
three behaviours: no re-upload on a second session, a new workspace still migrating, and a
failed upload remaining retryable.

**Verified the test fails before the fix:** disabling the marker check makes
`test_second_call_does_not_re_upload` fail with `assert True is False` on the second call.

```
3 passed                       # targeted
295 passed, 1 failed           # full tests/honcho_plugin/
```

The one failure is `test_pin_peer_name.py::TestPinTransition::test_cache_busting_signature_reflects_pin_peer_name`.
It **reproduces on a clean checkout of the same HEAD** in a separate worktree, so it is
pre-existing and unrelated to this change.

## Not addressed here

Whether `gateway_session_key` *should* outrank `sessionStrategy` is a separate design question —
per-chat isolation is legitimately what gateway surfaces want. This change only makes the
one-time migration honour its own contract regardless of how sessions are scoped.
