### PR TITLE
feat: add MCP server publishing & markdown reporting skills

### DIFF
--- a/skills/productivity/markdown-chart-reporting/SKILL.md
+++ b/skills/productivity/markdown-chart-reporting/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: markdown-chart-reporting
+description: "Display charts in markdown reports sent to Telegram and SiYuan — ASCII sparklines, separate PNG photos, and what NOT to do (base64 data URIs)."
+version: 1.0.0
+author: Fuad Al Fajri
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Markdown, Charts, Telegram, SiYuan, Sparkline, Reports]
+    category: productivity
+    related_skills: [siyuan-markdown-import]
+---
+
+# Charts in Markdown Reports (Telegram & SiYuan)
+
+Techniques for showing charts in `.md` reports sent to Telegram (`sendDocument`) and/or imported into SiYuan — applies to ALL reports (stocks, commodities, monitoring, research), not just one domain.
+
+## When to Use
+
+- User asks to include a chart/visual in a markdown report
+- User reports charts not rendering in Telegram or SiYuan
+- User needs to generate sparklines or PNG charts for reports
+
+## Format Decision (proven)
+
+| Method | Shows in Telegram | Shows in SiYuan | Size | Recommendation |
+|--------|:-----------------:|:---------------:|:----:|:--------------:|
+| **ASCII sparkline** (`▁▂▃▄▅▆▇█`) | ✅ text | ✅ text | ~200 B | ✅ **PRIMARY** |
+| PNG sent as **separate photo** (`sendPhoto`) | ✅ image | — | ~20 KB | ✅ for visual charts |
+| **base64 data URI** (`![x](data:image/png;base64,...)`) | ❌ not rendered | ❌ not rendered | ~29 KB | ❌ NEVER |
+
+## Critical Pitfall: base64 data URIs are NOT rendered
+
+- **SiYuan** (`createDocWithMd`): `![x](data:image/png;base64,...)` is stored as a `NodeImage` with a `NodeLinkDest` containing the string `data:...` — **not an image block**. The `.sy` file is still created (code 0) but the image is blank.
+- **Telegram document viewer**: doesn't render ANY image inside a `.md` file — base64 shows as raw text.
+- Result: base64 bloats the file to 29 KB and shows nowhere. **Remove it from markdown.**
+
+## Correct Pattern: 2 Messages per Cycle (n8n example)
+
+```
+sendDocument (.md + ASCII sparkline)  →  msg 1 (text, renders)
+GET /chart-png (bridge serves PNG binary) → prepareBinary → sendPhoto  →  msg 2 (image, renders)
+```
+- Bridge endpoint `/chart-png` sends **binary** (`send_header Content-Type: image/png` + file bytes), not base64.
+- n8n: HTTP Request node with `options.response.response: "file"` to capture binary → Code node grabs `$input.first().binary[firstKey]` → HTTP `sendPhoto` multipart-form-data, `photo` field `parameterType: formBinaryData`, `inputDataFieldName: "data"`.
+
+## ASCII Sparkline (implementation)
+
+```python
+chars = "▁▂▃▄▅▆▇█"  # U+2581..U+2588
+def sparkline(values, width=30):
+    vmin, vmax = min(values), max(values)
+    rng = (vmax - vmin) or 1
+    n = len(values)
+    step = max(1, n // width)
+    sampled = values[::step][:width]
+    return "".join(chars[int((v - vmin) / rng * 7)] for v in sampled)
+```
+Show in a markdown table: `| 🥇 Gold | \`▁▇▇▇▇█\` | Rp 2,113,294 → Rp 2,454,345 (+16%) |`
+Legend: `▁` = lowest, `█` = highest within the observation range.
+
+## PNG Charts: Dual-Axis REQUIRED for Very Different Scales
+
+- Gold (~Rp 2.4M/gram) vs Silver (~Rp 35K/gram): ~68x difference. One axis → the silver line looks flat at the bottom, misleading.
+- **Dual-axis**: gold on the left axis, silver on the right, each with its own scale.
+- Grid ticks must align: generate **exactly n+1 ticks** per axis (`nice_ticks(vmin, vmax, n=4)` with padding) so grid lines line up.
+- Generate PNG with **Pillow** (`ImageDraw.line`), WITHOUT matplotlib — PEP 668 (Debian/Ubuntu) blocks system `pip install`; use Pillow already present or a venv.
+
+## 7-Day Charts (don't rely on local logs alone)
+
+- Local logs only have data since first recording — don't claim "7 days" from 1 day of intraday data.
+- Fetch daily close data from the provider's chart API: `GET http://<proxy-host>:<port>/history?symbol=GOLD&days=7`
+- Parse: `data.chart.result[0].timestamp` + `indicators.quote[0].close` → format `YYYY-MM-DD`.
+- Convert units as needed (e.g. USD/oz → IDR/gram: `close / 31.1035 * usd_idr`).
+- Merge with the latest intraday position from local logs, label the last point "today".
+
+## Common Pitfalls
+
+1. Using base64 data URIs in markdown → renders nowhere, bloats file
+2. Single-axis chart for series with very different scales → misleading flat lines
+3. Claiming "7-day" trends from intraday-only local data
+4. Sending PNG inside the `.md` document instead of a separate `sendPhoto`
+5. matplotlib on PEP 668 systems → use Pillow or a venv
+
+## Verification Checklist
+
+- [ ] Sparkline renders as text in Telegram and SiYuan
+- [ ] PNG sent as a separate photo message (not embedded in the doc)
+- [ ] No `data:image` URIs in the final markdown
+- [ ] Dual-axis used when series scales differ greatly
+- [ ] 7-day chart based on fetched daily data, not only local intraday logs

--- a/skills/productivity/siyuan-markdown-import/SKILL.md
+++ b/skills/productivity/siyuan-markdown-import/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: siyuan-markdown-import
+description: "Import markdown documents into the SiYuan second brain with FULL content — createDocWithMd API (not the CLI import which creates empty placeholders)."
+version: 1.0.0
+author: Fuad Al Fajri
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [SiYuan, Markdown, Import, Notes, Second-Brain]
+    category: productivity
+    related_skills: [obsidian]
+---
+
+# SiYuan Markdown Import (Full Content)
+
+The correct way to import markdown files (reports, research, artifacts) into a SiYuan second brain **with full content** — not an empty placeholder.
+
+## When to Use
+
+- User wants to import a markdown file/report into SiYuan
+- User asks to archive notes, research, or artifacts into their second brain
+- A SiYuan import produced an empty doc (diagnose & fix)
+
+## ⚠️ Why not the CLI import
+
+`SiYuan-Kernel import md --file <folder>` ONLY creates an empty placeholder doc (title "import", `.sy` file 314 bytes, no markdown content). Proven repeatedly — don't use CLI for content.
+
+## Correct Method: `createDocWithMd` API
+
+```bash
+python3 - <<'EOF'
+import json, urllib.request
+conf = json.load(open('<siyuan-workspace>/conf/conf.json'))
+token = conf['api']['token']   # API token ≠ accessAuthCode (UI login)!
+md = open('/path/report.md').read()
+payload = json.dumps({
+    "notebook": "<NOTEBOOK_ID>",
+    "path": "/report-title",              # relative path, no .md
+    "markdown": md
+}).encode()
+req = urllib.request.Request("http://127.0.0.1:6806/api/filetree/createDocWithMd",
+    data=payload, method="POST",
+    headers={"Authorization": f"Token {token}", "Content-Type": "application/json"})
+print(json.loads(urllib.request.urlopen(req, timeout=30).read()))  # code: 0 = success
+EOF
+```
+
+Note: `data` in the response can be a string (not a dict) — don't call `.get()` on it; check `code` only.
+
+## Verification (REQUIRED)
+
+1. `code: 0` in the response.
+2. Check the filesystem (more reliable than `listDocsByPath` API which can return `data: null`):
+   ```bash
+   ls -lt <siyuan-workspace>/data/<NOTEBOOK_ID>/ | head -5
+   ```
+   - Correct doc: `.sy` file tens of KB (e.g. 46 KB).
+   - Empty doc: 314 bytes.
+3. Check title + keyword inside the file:
+   ```bash
+   python3 -c "
+   import json
+   d = json.load(open('<siyuan-workspace>/data/<NOTEBOOK_ID>/<DOC_ID>.sy'))
+   print(d['Properties']['title'])
+   print('keyword' in json.dumps(d))"
+   ```
+
+## Reorganize Structure: Move Docs from Subfolder → Notebook Root
+
+If the user wants docs directly visible without clicking folders (flat structure), move documents out of the import subfolder via the `moveDocs` API — NOT drag in the UI:
+
+```bash
+TOKEN=$(python3 -c "import json; print(json.load(open('<siyuan-workspace>/conf/conf.json'))['api']['token'])")
+
+# 1. Backup first (REQUIRED before move):
+cp -a <siyuan-workspace>/data <siyuan-workspace>/data.bak.$(date +%s)
+
+# 2. Get paths of all nested docs (2+ path segments, not notebook root):
+curl -s -X POST http://127.0.0.1:6806/api/query/sql -H "Authorization: Token $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"stmt":"SELECT box, path FROM blocks WHERE type='"'"'d'"'"' ORDER BY box, path"}'
+
+# 3. Move batch per notebook to root (fromPaths = array of paths, toPath = "/"):
+curl -s -X POST http://127.0.0.1:6806/api/filetree/moveDocs -H "Authorization: Token $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"fromNotebook":"<BOX>","fromPaths":["/subfolder/doc1.sy","/subfolder/doc2.sy"],"toNotebook":"<BOX>","toPath":"/"}'
+```
+
+After move:
+- **Parent folder becomes empty** (placeholder with 1 empty paragraph, `type='p'`, content `''`) → remove via `removeDocByID` `{"notebook":"<BOX>","id":"<FOLDER_ID>"}`. Verify first it's empty: SQL `SELECT COUNT(*) FROM blocks WHERE parent_id='<FOLDER_ID>' AND type!='d'` = 0.
+- **Don't touch folders that still contain documents** — remove only truly empty ones.
+- Final verification: SQL `type='d'` per box → no 3+ segment paths; `listDocsByPath` root shows docs directly.
+
+## Graph View Connectivity (Obsidian-like)
+
+Global Graph (`Alt+9`) / Graph View (`Alt+8`) only shows lines when connections exist in the `refs` table. **Key: refs are only created from real block references `((<doc-id> "title"))`** — `[[name]]` via API is NOT counted (stored as plain text, graph stays dots without lines). Tag graphs also need real tag blocks `#topic#` via `appendBlock`, not `setBlockAttrs custom-tags`.
+
+⚠️ **refs are built at kernel boot** — after adding refs/tags, RESTART the kernel (or `systemctl restart siyuan` + restart the socat tunnel if used). Verify: `SELECT COUNT(*) FROM refs` > 0.
+
+Hub pattern: 1 Index document containing `((id "title"))` links to all documents → star-shaped graph (hub-and-spoke).
+
+## Common Pitfalls
+
+- **API token** is in `conf.json` → `api.token`; `accessAuthCode` (UI password) is NOT the API token.
+- `createDocWithMd` with an existing `path` → error; use a unique path (include the date).
+- API listens on `127.0.0.1:6806` (default) — access from outside via a proxy/tunnel if needed.
+- Header auth: `Authorization: Token <token>` — not Bearer.
+- **Imported docs land in SUBFOLDER, not notebook root** (proven): Inbox → `vault-md-root/`, Archive → `arsip/` & `import/`. The notebook filetree may look EMPTY until the subfolder is expanded. Don't conclude data loss — verify first: SQL `SELECT box, COUNT(*) FROM blocks WHERE type='d' GROUP BY box`, kernel boot log (`tree/block count [55/3925]`), or `find <workspace>/data -name '*.sy' | wc -l`.
+- Endpoint `loadFiles` does NOT exist → 404 "page not found"; list docs with `listDocsByPath` (which may return `data: null` when empty).
+
+## Verification Checklist
+
+- [ ] `code: 0` returned by createDocWithMd
+- [ ] `.sy` file is tens of KB (not 314 bytes)
+- [ ] Title + expected content present in the `.sy` JSON
+- [ ] After moveDocs: no 3+ segment paths; empty placeholder folders removed
+- [ ] After adding refs/tags: kernel restarted, `refs` count > 0

--- a/skills/software-development/custom-mcp-server/SKILL.md
+++ b/skills/software-development/custom-mcp-server/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: custom-mcp-server
+description: "Build, package, and publish a custom MCP server with Python FastMCP — from writing tools to PyPI, GitHub, and the MCP Registry."
+version: 1.0.0
+author: Fuad Al Fajri
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [MCP, Python, FastMCP, PyPI, GitHub, Packaging]
+    category: software-development
+    related_skills: [mcp-server-publish, hermes-agent]
+---
+
+# Custom MCP Server Development
+
+Build a custom MCP server from scratch with FastMCP, package it for PyPI, and publish to GitHub and the MCP Registry. This skill covers the pitfalls that only show up when integrating with Hermes's MCP client.
+
+## When to Use
+
+- User wants to wrap a REST API, website, or data source as an MCP server
+- User wants to publish an MCP server to PyPI and/or the official MCP Registry
+- An MCP server fails to connect to Hermes (diagnose banner/transport issues)
+
+## 1. Build the Server with FastMCP
+
+### Prerequisites
+
+```bash
+pip install fastmcp httpx beautifulsoup4 lxml
+```
+
+### Basic structure
+
+```python
+"""MCP Server Name — short description."""
+import json
+import httpx
+from fastmcp import FastMCP
+
+mcp = FastMCP("server-name")
+BASE = "https://api.example.com"
+
+@mcp.tool()
+async def search_data(query: str) -> str:
+    """Search data by keyword."""
+    async with httpx.AsyncClient(timeout=30) as c:
+        r = await c.get(f"{BASE}/search", params={"q": query})
+    return json.dumps(r.json(), indent=2)
+
+def main():
+    mcp.run(transport="stdio")   # stdio explicit for Hermes
+
+if __name__ == "__main__":
+    main()
+```
+
+### Critical pitfall: FastMCP banner breaks the MCP handshake
+
+**Symptom:** `✗ Failed to connect: Connection closed` even though the server works when tested manually via an echo pipe.
+
+**Cause:** FastMCP 3.4 prints an ASCII banner to stdout at startup. Hermes reads stdout as JSON-RPC protocol — a banner is not JSON, so the handshake fails.
+
+**Two things REQUIRED for Hermes compatibility:**
+
+1. **Disable the banner in code:**
+```python
+from fastmcp import FastMCP, settings as fastmcp_settings
+
+fastmcp_settings.show_server_banner = False   # REQUIRED
+mcp = FastMCP("server-name")
+
+def main():
+    mcp.run(transport="stdio")   # REQUIRED — explicit stdio
+```
+
+2. **Use a shell wrapper, not direct registration:**
+```bash
+#!/bin/bash
+cd /path/to/project
+export PYTHONUNBUFFERED=1
+exec /path/to/venv/bin/python3 -m server_module_name
+```
+```bash
+chmod +x run.sh
+hermes mcp add server-name --command "$(pwd)/run.sh"   # ✅ USE THE WRAPPER
+```
+
+> ❌ `hermes mcp add --command "python3" --args "-m,server_module_name"` often fails
+> ✅ `hermes mcp add --command "/path/to/run.sh"` always works
+
+### Other FastMCP pitfalls
+
+- **`__version__` required in `server.py`** — `__init__.py` imports it. Missing → `ImportError: cannot import name '__version__'`.
+- **`mcp.run()` without explicit transport** — FastMCP 3.4 may default to `streamable-http`; Hermes MCP client only supports `stdio`. Always pass `transport="stdio"`.
+- **Interactive `hermes mcp add` needs stdin** — it asks "Enable all N tools? [Y/n/select]" and cancels if stdin is unanswered. Use `echo "Y" | hermes mcp add ...`.
+- **New MCP servers appear in the NEXT session** — the session that registers them won't see the tools in `tool_search` yet.
+
+### Pattern: MCP wrapper for a REST API with API-key auth
+
+The most effective pattern when wrapping an app that already has a REST API + auth header is a **thin proxy**: one `_request()` helper + read tools per resource + CRUD tools per entity + 2 generic tools (`api_get`/`api_post`):
+
+```python
+def _headers() -> dict:
+    return {"X-API-Key": API_KEY, "Content-Type": "application/json"}
+
+async def _request(method: str, path: str, body: dict | None = None) -> str:
+    if not API_KEY:
+        return json.dumps({"error": "API_KEY not set"}, ensure_ascii=False)
+    async with httpx.AsyncClient(timeout=60) as c:
+        r = await c.request(method, f"{BASE}{path}", headers=_headers(), json=body or {})
+    try:
+        return json.dumps(r.json(), indent=2, ensure_ascii=False)
+    except Exception:
+        return f"HTTP {r.status_code}: {r.text[:500]}"
+```
+
+**Pitfalls of this pattern:**
+1. **Don't hardcode API keys** — read from env (`YOURAPP_API_KEY`) in the `run.sh` wrapper; keep the real file chmod 600.
+2. **Generic `api_get`/`api_post` tools open every endpoint** — very useful for features without a dedicated tool, but the agent still needs per-endpoint payload knowledge (store it in the skill's `references/`).
+3. **Read the source API routes first** — payloads for create/update/delete often have hidden actions (`assign_port`, `suspend_temporary`) not visible from endpoint names.
+4. **Destructive tools** (delete, reboot) — the tool description MUST say "Cannot be undone!" so the agent confirms with the user first.
+5. **Consistent CRUD pattern**: `x_create` (required fields as required params), `x_update` (id required + optional fields, body only contains provided fields), `x_delete` (id only). Consistency helps the agent call correctly.
+
+### Verifying tools/call fails on a fast pipe
+
+**Symptom:** `echo '{initialize}' | run.sh` works — handshake OK, `tools/list` shows all tools — BUT `tools/call` produces no response.
+
+**Cause:** the fast pipe closes stdin after the last request; FastMCP hasn't processed `tools/call` yet (which needs an outbound HTTP call). Not a server bug.
+
+**Correct verification — Python subprocess with delays between requests:**
+```python
+import subprocess, json, time, select
+proc = subprocess.Popen(["/path/run.sh"],
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+def send(obj): proc.stdin.write(json.dumps(obj) + "\n"); proc.stdin.flush()
+def read(timeout=30):
+    end = time.time() + timeout
+    while time.time() < end:
+        r, _, _ = select.select([proc.stdout], [], [], 0.5)
+        if r:
+            line = proc.stdout.readline()
+            if line.strip(): return json.loads(line)
+    return None
+send({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"0.1.0","capabilities":{},"clientInfo":{"name":"t","version":"1"}}})
+read()
+send({"jsonrpc":"2.0","method":"notifications/initialized","params":{}})
+time.sleep(0.5)
+send({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"tool_name","arguments":{}}})
+print(read(40))
+```
+
+## 2. Package Structure (PyPI)
+
+```
+server-name/
+├── README.md
+├── LICENSE
+├── pyproject.toml
+├── server.json              # for MCP Registry
+├── server_name/
+│   ├── __init__.py
+│   ├── __main__.py
+│   └── server.py
+└── tests/
+    └── test_server.py
+```
+
+### `pyproject.toml`
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "server-name"
+version = "0.1.0"
+description = "Short description"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [
+    {name = "Your Name", email = "email@example.com"}
+]
+requires-python = ">=3.10"
+dependencies = [
+    "fastmcp>=3.0.0",
+    "httpx>=0.27.0",
+]
+```
+
+### `__init__.py`
+
+```python
+"""Server Name MCP Server."""
+from .server import main
+
+__version__ = "0.1.0"
+```
+
+### `__main__.py`
+
+```python
+"""Entry point for python3 -m server_name."""
+from .server import main
+
+main()
+```
+
+## 3. Build & Test
+
+```bash
+# Build wheel + source distribution
+pip install build
+cd server-name
+python3 -m build
+
+# Test import works
+python3 -c "from server_name import main; print('OK')"
+
+# Test via MCP (stdin) — ensure no banner + stdio transport
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"0.1.0","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}' | timeout 5 python3 -m server_name 2>/dev/null
+
+# Register in Hermes — shell wrapper (REQUIRED for FastMCP 3.4+)
+chmod +x run.sh
+hermes mcp add server-name --command "/path/to/run.sh"
+```
+
+## 4. Publish to PyPI
+
+```bash
+pip install twine
+cd server-name
+python3 -m twine upload dist/*
+# Needs a pypi.org account + API token
+```
+
+## 5. Publish to GitHub
+
+```bash
+cd server-name
+git init
+git add .
+git commit -m "Initial release"
+gh repo create username/server-name --push --public
+```
+
+### Security audit BEFORE pushing to a public repo (REQUIRED)
+
+Never commit private domains or internal IPs to a public repo. Scan before commit (run at repo root, skip .git/node_modules/dist/venv):
+
+```bash
+grep -rniE 'your-private\.domain|10\.0\.0\.|192\.168\.' \
+  --include='*.md' --include='*.py' --include='*.ts' --include='*.tsx' --include='*.example' --include='*.json' .
+```
+
+Replace with placeholders:
+- Private domains → `your-domain.example.com`
+- Internal IPs → `10.0.0.X` / `192.168.X.X`
+
+**Pitfalls:**
+1. **`docs/` often escapes the audit** — devplan.md, devlog.md, implementation plans carry domains & IPs. Check ALL directories, not just README/code.
+2. **Local files with credentials must be gitignored** — `run.sh` (with API key + domain) goes in `.gitignore`; commit `run.sh.example` (placeholders). Verify: `git check-ignore run.sh` and `git ls-files | grep run.sh` must be empty.
+3. **`server.py` / default configs often store real `BASE_URL`/`SSH_HOST`** — replace with placeholders; users set via env.
+4. **Verify post-push via GitHub API, NOT raw.githubusercontent.com** — the raw CDN can cache an old version for minutes after push. `git ls-remote` HEAD may be new and `git show` correct, but `curl raw.../README.md` still shows old content. Definitive check: `curl https://api.github.com/repos/<owner>/<repo>/contents/<path>` → decode `content` base64 → grep domains.
+
+## 6. Register in the MCP Registry (mcp-publisher CLI)
+
+**⚠️ Don't submit server.json via the website — use the `mcp-publisher` CLI:**
+
+```bash
+# 1. Download the release binary (don't build from source — go.mod needs a newer Go toolchain)
+curl -sL -o /tmp/mcp-publisher.tar.gz \
+  "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz"
+tar xzf /tmp/mcp-publisher.tar.gz -C /tmp
+
+# 2. Login GitHub — INTERACTIVE, device code (user authorizes at github.com/login/device)
+cd /tmp && ./mcp-publisher login github
+
+# 3. Validate (don't skip — catches 422 errors early)
+./mcp-publisher validate --file /path/server.json
+
+# 4. Publish — POSITIONAL argument (not --file!)
+./mcp-publisher publish /path/server.json
+```
+
+### `server.json` — correct format (registry schema 2025-12-11)
+
+**⚠️ The old format (id/name/publisher/package) is REJECTED by the registry (422).** Correct:
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.<username>/<server-name>",   // namespace REQUIRED: io.github.<owner>/
+  "description": "max 100 chars!",                 // >100 → 422 error
+  "version": "0.1.0",                              // top-level version REQUIRED
+  "packages": [{
+    "registryType": "pypi",                        // camelCase (pypi/npm/nuget)
+    "identifier": "server-name",
+    "version": "0.1.0",
+    "transport": { "type": "stdio" },
+    "environmentVariables": [
+      {"name": "API_KEY", "description": "...", "isRequired": true, "isSecret": true, "format": "string"}
+    ]
+  }]
+}
+```
+
+The `tools` field (array of {name, description}) is **optional** in the schema — the registry doesn't require it; if included, list only 10-15 main tools as a showcase, not all of them.
+
+### Registry pitfalls (real-world experience)
+
+1. **PyPI first, THEN registry** — the registry is metadata only; `publish` fails 400 `PyPI package not found (404)` if the package hasn't been uploaded to pypi.org. Order matters: PyPI → registry.
+2. **Description ≤100 chars** — em-dashes/unicode can count more → 422. Shorten drastically.
+3. **`registryType` camelCase** (`pypi`), top-level `version` — the old schema (id/publisher/package) → 422.
+4. **Interactive GitHub login** — run `background=true` + poll, send the device code to the user, wait ~2 min for authorization. Don't run foreground (timeout).
+5. **README must have a `mcp-name:` marker with the FULL namespace** — `> mcp-name: io.github.<user>/<server-name>` (NOT the short package name!). Registry rejects 400 `must appear as 'mcp-name: io.github.<user>/<server-name>'` if you only use the short name.
+6. **PyPI needs an API token** (`pypi-...`) from pypi.org/manage/account/token; upload: `pip install twine && python3 -m build && twine upload dist/*`. ⚠️ **Don't confuse with Recovery Codes** (16-digit, for account recovery — NOT for upload). ⚠️ **PyPI does NOT allow re-upload of the same version** — if README/description changes after 0.1.0, bump to 0.1.1 in pyproject + `__init__.py.__version__` + server.json, rebuild, re-upload.
+7. **Separate GitHub repos** for the MCP server vs the main app (different languages/ecosystems/release cycles) — READMEs link to each other.
+8. **mcp-publisher login JWT EXPIRES** — if publish fails 401 `Invalid or expired Registry JWT token` after a long pause, re-login GitHub (device code again). Don't assume an old login still works.
+9. **Badge shields.io "404 badge not found" when the value contains a slash `/`** — the path format `img.shields.io/badge/Label-value-blue` fails to parse slash-containing values. Use the query static/v1 format: `https://img.shields.io/static/v1?label=MCP%20Registry&message=io.github.%3Cuser%3E%2F<repo>&color=blue` — slash encoded `%2F` in the query param renders fine.
+10. **MCP Registry has NO per-server web page** — only an API endpoint. Point badges/links to `https://registry.modelcontextprotocol.io/v0/servers/io.github.<user>%2F<repo>/versions` (HTTP 200, JSON with versions) or the GitHub repo page.
+
+## Batch publishing multiple servers — login once, publish in sequence
+
+When publishing 3+ MCP servers at once:
+
+**The registry JWT TTL is short (±1 hour) — by design.** If you publish → pause (PyPI setup, build, checks) → publish again, the token is dead (`401 Invalid or expired Registry JWT token`). Not a bug; standard OAuth security.
+
+**Proven pattern (3 publishes in 1 login):**
+```bash
+# 1. Prepare ALL server.json files + upload to PyPI first (don't publish registry in the middle)
+for repo in a b c; do
+  # bump version, mcp-name, server.json, validate, build, twine upload
+done
+
+# 2. Login github ONCE (device code), then publish sequentially without pauses
+cd /tmp && ./mcp-publisher login github   # background + poll, user authorizes
+for repo in a b c; do
+  ./mcp-publisher publish /path/$repo/server.json
+done
+```
+
+**⚠️ `dist/` must not be committed to git** — build artifacts (wheel/sdist) clutter the repo and differ per version:
+```bash
+git rm -r --cached dist
+echo -e "\n# Build artifacts\ndist/\n*.egg-info/\n__pycache__/" >> .gitignore
+git add -A && git commit -m "chore: dist/ gitignored"
+```
+
+**Device-code-free alternative:** `login github-oidc` (GitHub Actions, automatic per-CI token) — good for routine publishing.
+
+## Common Pitfalls
+
+1. FastMCP banner not disabled → handshake fails (`Connection closed`)
+2. `mcp.run()` without `transport="stdio"` → defaults to streamable-http, unsupported by Hermes
+3. `hermes mcp add` without `echo "Y" |` → cancels on the interactive prompt
+4. Registering with direct `--args` instead of a shell wrapper → flaky connections
+5. Publishing to the registry before PyPI → 400 `PyPI package not found`
+6. Hardcoding API keys or private domains in committed files
+7. Forgetting `dist/` in `.gitignore`
+
+## Verification Checklist
+
+- [ ] Server connects via Hermes: `echo "Y" | hermes mcp add name --command "/path/run.sh"` then tools appear in a NEW session
+- [ ] `tools/call` verified with the Python subprocess method (not a fast pipe)
+- [ ] `python3 -m build` succeeds; `twine check dist/*` passes
+- [ ] `server.json` validates: `mcp-publisher validate --file server.json`
+- [ ] No private domains/IPs in any committed file (checked ALL directories incl. docs/)
+- [ ] `run.sh` is gitignored; `run.sh.example` committed
+- [ ] README has `mcp-name: io.github.<user>/<server-name>` (full namespace)
+
+## References
+
+- [FastMCP Documentation](https://fastmcp.com/)
+- [MCP Registry Guide](https://modelcontextprotocol.io/registry/about)
+- [Python Packaging Guide](https://packaging.python.org/)

--- a/skills/software-development/mcp-server-publish/SKILL.md
+++ b/skills/software-development/mcp-server-publish/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: mcp-server-publish
+description: "Publish an MCP server to PyPI and the MCP Registry — proven workflow with real-world pitfalls."
+version: 1.0.0
+author: Fuad Al Fajri
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [MCP, PyPI, Registry, Publishing, GitHub]
+    category: software-development
+    related_skills: [custom-mcp-server]
+---
+
+# Publish MCP Server to PyPI + MCP Registry
+
+Proven workflow for publishing an MCP server to the public: PyPI upload, MCP Registry registration, and GitHub. Based on hands-on experience publishing multiple FastMCP servers.
+
+## When to Use
+
+- User has a FastMCP server ready to publish publicly (PyPI/Registry/GitHub)
+- User wants to update the version of an already-published MCP server
+- User wants to add correct badges to an MCP server README
+
+## Prerequisites
+
+- Public GitHub repo (e.g. `username/*`)
+- PyPI account + API token (chmod 600 file, e.g. `~/.pypi-creds/pypi-api-token`)
+- `mcp-publisher` binary — download from GitHub releases (don't build from source):
+  ```bash
+  curl -sL -o /tmp/mcp.tar.gz "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz"
+  tar xzf /tmp/mcp.tar.gz -C /tmp
+  ```
+- venv with fastmcp + build + twine
+
+## Workflow (order matters)
+
+1. **Prepare the package first** (bump version, server.json, mcp-name) — DON'T login to the registry yet
+2. Build: `python3 -m build` → wheel + sdist
+3. Upload PyPI: `twine upload --username __token__ --password "$TOKEN" dist/*`
+4. Validate server.json: `mcp-publisher validate --file server.json` → ✅ valid
+5. Login registry ONCE: `mcp-publisher login github` (device code, needs user)
+6. Publish all servers sequentially: `mcp-publisher publish <server.json>` (JWT TTL is short!)
+7. Commit + push GitHub (dist/ gitignored)
+
+## Correct server.json format (registry schema 2025-12-11)
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.<username>/<repo>",
+  "description": "Description ≤100 chars (unicode counts!)",
+  "version": "0.1.1",
+  "packages": [{
+    "registryType": "pypi",          // camelCase, not "type"
+    "identifier": "<pypi-name>",
+    "version": "0.1.1",
+    "transport": {"type": "stdio"},
+    "environmentVariables": [{"name": "KEY", "isRequired": true, "isSecret": true, "format": "string", "description": "..."}]
+  }]
+}
+```
+
+⚠️ `mcp-publisher init` generates a correct template — use it as the base.
+
+## Pitfalls (MUST read)
+
+1. **Registry needs the package ALREADY on PyPI** — publishing to the registry before PyPI = 404 "package not found"
+2. **`mcp-name` in README must be the FULL namespace** (`io.github.<user>/<repo>`, not the short name) — otherwise: "ownership validation failed"
+3. **Registry description ≤100 chars** — unicode characters (—, emoji) count more
+4. **Registry JWT TTL is short (±1 hour)** — by design. Pattern: prepare EVERYTHING first, login once, publish sequentially. Alternative: GitHub Actions OIDC (`login github-oidc`) for automation
+5. **PyPI does not allow re-upload of the same version** — bump version (0.1.0 → 0.1.1 → 0.1.2)
+6. **`twine check dist/*`** — validate before upload
+7. **Recovery codes ≠ API token** — recovery is for account restoration (store safely), API token (`pypi-...`) is for upload
+8. **dist/ must be gitignored** — build artifacts are not for commit
+
+## README Badges (correct format)
+
+```markdown
+[![MCP Registry](https://img.shields.io/static/v1?label=MCP%20Registry&message=io.github.%3Cuser%3E%2F<repo>&color=blue)](https://registry.modelcontextprotocol.io/v0/servers/io.github.%3Cuser%3E%2F<repo>/versions)
+[![PyPI version](https://img.shields.io/pypi/v/<repo>.svg)](https://pypi.org/project/<repo>/)
+```
+
+⚠️ DON'T use `img.shields.io/badge/<label>-<value>-<color>` if the value contains `/` or spaces → **404 badge not found**. Always use `static/v1?label=...&message=...`.
+⚠️ The Registry has NO per-server web page — point the badge URL to the API endpoint `/v0/servers/io.github.<user>%2F<repo>/versions` (HTTP 200, JSON).
+
+## Security Audit BEFORE Commit (REQUIRED)
+
+Private domains & internal IPs have leaked to public repos before. Before push:
+
+```bash
+grep -rE 'your-private\.domain|10\.0\.0\.|192\.168\.' --include='*.md' --include='*.py' --include='*.ts' --include='*.tsx' --include='*.example' .
+```
+
+- Replace private domains → placeholders (`your-domain.example.com`)
+- Replace internal IPs → `10.0.0.X`, `192.168.X.X`
+- Check **docs/** too — often escapes the audit (devplan.md, devlog.md, implementation plans)
+- Local files containing credentials (run.sh, .env) MUST be gitignored
+- Verify via **GitHub API** (not raw.githubusercontent — that's a CDN cache): `GET /repos/{owner}/{repo}/contents/{file}` → base64 decode
+
+## Credentials
+
+| Item | Location |
+|---|---|
+| PyPI API token | `~/.pypi-creds/pypi-api-token` (600) |
+| PyPI recovery codes | `~/.pypi-creds/...` (600) |
+| mcp-publisher | `/tmp/mcp-publisher` |
+| GitHub token | `~/.hermes/.env` → `GITHUB_TOKEN` |
+
+## Common Pitfalls
+
+1. Publishing registry before PyPI → 404
+2. Short `mcp-name` instead of full namespace → ownership validation failed
+3. Description >100 chars with unicode → 422
+4. JWT expiry between publishes → 401, re-login
+5. Re-uploading same PyPI version → rejected
+6. Badge path format with slash values → 404 badge
+
+## Verification Checklist
+
+- [ ] `twine check dist/*` passes before upload
+- [ ] Package is on PyPI BEFORE registry publish
+- [ ] `mcp-publisher validate --file server.json` → valid
+- [ ] README has full-namespace `mcp-name:`
+- [ ] No private domains/IPs in committed files (incl. docs/)
+- [ ] Registry API endpoint returns HTTP 200 JSON with versions
+- [ ] Badges render (curl badge URL, check aria-label)
+
+## References
+
+- Related skill: `custom-mcp-server` (FastMCP package structure + Hermes wrapper)
+- Registry docs: https://modelcontextprotocol.io/registry/quickstart
+- mcp-publisher: https://github.com/modelcontextprotocol/registry


### PR DESCRIPTION
## Summary
Adds four skills for MCP server developers and markdown report authors:

- **custom-mcp-server** — build, package, and publish a custom MCP server with Python FastMCP. Covers Hermes-compatibility pitfalls that only appear in practice: FastMCP banner breaking the stdio handshake, explicit stdio transport, shell-wrapper registration, REST-API wrapper pattern, PyPI package structure, and the MCP Registry schema.
- **mcp-server-publish** — proven workflow for publishing an MCP server to PyPI + the MCP Registry: correct server.json schema (2025-12-11), publish order (PyPI before registry), JWT TTL batching, README badges that actually render, and the pre-commit security audit for private domains/IPs.
- **siyuan-markdown-import** — import markdown into SiYuan with full content via the createDocWithMd API (the CLI import only creates empty placeholders). Includes verification, moveDocs reorganization, and graph-view connectivity.
- **markdown-chart-reporting** — display charts in markdown reports sent to Telegram and SiYuan: ASCII sparklines as primary method, PNG as separate photos, and why base64 data URIs never render.

## Validation
- All four pass in-repo skill validation: frontmatter starts at byte 0, name ≤64 chars, description ≤1024 chars, total ≤100K chars
- English, no private data in bodies, stdlib-only dependencies
- related_skills reference only in-repo skills (custom-mcp-server ↔ mcp-server-publish, siyuan-markdown-import → obsidian)

## Testing
- Validated locally with PyYAML frontmatter parser (name/description present, size limits met) + private-data scan
- Structure follows peer pattern: Overview → When to Use → body → Common Pitfalls → Verification Checklist