### PR TITLE
fix(agent): rotate exhausted OpenCode credentials for MoA references

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4489,6 +4489,23 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     return False
 
 
+def _pool_owns_api_key(provider: str, api_key: str) -> bool:
+    """Return whether *api_key* identifies an entry in *provider*'s pool."""
+    if not api_key:
+        return False
+    try:
+        pool = load_pool(_normalize_aux_provider(provider))
+        lookup = getattr(pool, "entry_id_for_api_key", None)
+        return bool(lookup(api_key)) if callable(lookup) else False
+    except Exception as exc:
+        logger.debug(
+            "Auxiliary client: could not match failed key to %s pool: %s",
+            provider,
+            exc,
+        )
+        return False
+
+
 def _retry_same_provider_sync(
     *,
     task: Optional[str],
@@ -9432,6 +9449,7 @@ def _call_llm_impl(
         # _select_unlocked() return the NEXT key by mistake).
         _client_api_key = str(getattr(client, "api_key", "") or "")
         if pool_provider and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err)):
+            failed_key_was_pooled = _pool_owns_api_key(pool_provider, _client_api_key)
             recovery_err = first_err
             # Skip the extra retry for clear payment/quota errors — the endpoint
             # won't accept another request with the same exhausted key.
@@ -9459,9 +9477,10 @@ def _call_llm_impl(
                         resolved_provider=resolved_provider,
                         resolved_model=resolved_model,
                         resolved_base_url=resolved_base_url,
-                        # A MoA slot may have captured the now-exhausted key in
-                        # its runtime snapshot. Rebuild from the rotated pool.
-                        resolved_api_key=None,
+                        # A MoA slot may have captured a pool key in its runtime
+                        # snapshot. Drop only that stale snapshot; a caller-pinned
+                        # key that is not in the pool must remain authoritative.
+                        resolved_api_key=None if failed_key_was_pooled else resolved_api_key,
                         resolved_api_mode=resolved_api_mode,
                         main_runtime=main_runtime,
                         final_model=final_model,
@@ -10125,6 +10144,7 @@ async def _async_call_llm_impl(
         pool_provider = _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime)
         _client_api_key = str(getattr(client, "api_key", "") or "")
         if pool_provider and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err)):
+            failed_key_was_pooled = _pool_owns_api_key(pool_provider, _client_api_key)
             recovery_err = first_err
             # Skip the extra retry for clear payment/quota errors — the endpoint
             # won't accept another request with the same exhausted key.
@@ -10152,9 +10172,9 @@ async def _async_call_llm_impl(
                         resolved_provider=resolved_provider,
                         resolved_model=resolved_model,
                         resolved_base_url=resolved_base_url,
-                        # Match sync recovery: rotation invalidates an explicit
-                        # runtime key captured before the request.
-                        resolved_api_key=None,
+                        # Match sync recovery: only a pool-sourced runtime
+                        # snapshot is invalidated by pool rotation.
+                        resolved_api_key=None if failed_key_was_pooled else resolved_api_key,
                         resolved_api_mode=resolved_api_mode,
                         final_model=final_model,
                         messages=messages,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9459,7 +9459,9 @@ def _call_llm_impl(
                         resolved_provider=resolved_provider,
                         resolved_model=resolved_model,
                         resolved_base_url=resolved_base_url,
-                        resolved_api_key=resolved_api_key,
+                        # A MoA slot may have captured the now-exhausted key in
+                        # its runtime snapshot. Rebuild from the rotated pool.
+                        resolved_api_key=None,
                         resolved_api_mode=resolved_api_mode,
                         main_runtime=main_runtime,
                         final_model=final_model,
@@ -10150,7 +10152,9 @@ async def _async_call_llm_impl(
                         resolved_provider=resolved_provider,
                         resolved_model=resolved_model,
                         resolved_base_url=resolved_base_url,
-                        resolved_api_key=resolved_api_key,
+                        # Match sync recovery: rotation invalidates an explicit
+                        # runtime key captured before the request.
+                        resolved_api_key=None,
                         resolved_api_mode=resolved_api_mode,
                         final_model=final_model,
                         messages=messages,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2670,6 +2670,9 @@ class TestAuxiliaryPoolRotationRetry:
             def has_credentials(self):
                 return True
 
+            def entry_id_for_api_key(self, api_key):
+                return "opencode-a" if api_key == "opencode-key-a" else None
+
             def mark_exhausted_and_rotate(self, **kwargs):
                 return SimpleNamespace(id="opencode-b")
 
@@ -2704,9 +2707,117 @@ class TestAuxiliaryPoolRotationRetry:
             )
 
         assert response.choices[0].message.content == "rotated-moa-reference"
+        assert mock_cached.call_args_list[1].args[0] == "opencode-go"
         assert mock_cached.call_args_list[1].kwargs["api_key"] is None
+        assert fresh_client.api_key == "opencode-key-b"
         assert fresh_client.chat.completions.create.call_count == 1
         mock_fallback.assert_not_called()
+
+    def test_call_llm_preserves_explicit_key_not_owned_by_pool(self):
+        quota_err = Exception("GoUsageLimitError: usage limit reached")
+        quota_err.status_code = 429
+
+        stale_client = MagicMock()
+        stale_client.api_key = "user-pinned-key"
+        stale_client.base_url = "https://opencode.ai/zen/go/v1"
+        stale_client.chat.completions.create.side_effect = quota_err
+
+        retry_client = MagicMock()
+        retry_client.api_key = "user-pinned-key"
+        retry_client.base_url = "https://opencode.ai/zen/go/v1"
+        retry_client.chat.completions.create.return_value = _DummyResponse("pinned-key-retry")
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def entry_id_for_api_key(self, api_key):
+                return None
+
+            def mark_exhausted_and_rotate(self, **kwargs):
+                return SimpleNamespace(id="opencode-pool-b")
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=(
+                    "opencode-go",
+                    "deepseek-v4-flash",
+                    "https://opencode.ai/zen/go/v1",
+                    "user-pinned-key",
+                    "chat_completions",
+                ),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                side_effect=[
+                    (stale_client, "deepseek-v4-flash"),
+                    (retry_client, "deepseek-v4-flash"),
+                ],
+            ) as mock_cached,
+            patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
+        ):
+            response = call_llm(
+                task="moa_reference",
+                provider="opencode-go",
+                model="deepseek-v4-flash",
+                base_url="https://opencode.ai/zen/go/v1",
+                api_key="user-pinned-key",
+                messages=[{"role": "user", "content": "advise"}],
+            )
+
+        assert response.choices[0].message.content == "pinned-key-retry"
+        assert mock_cached.call_args_list[1].kwargs["api_key"] == "user-pinned-key"
+
+    def test_call_llm_does_not_rebuild_when_pool_has_no_replacement(self):
+        quota_err = Exception("GoUsageLimitError: usage limit reached")
+        quota_err.status_code = 429
+
+        stale_client = MagicMock()
+        stale_client.api_key = "opencode-key-a"
+        stale_client.base_url = "https://opencode.ai/zen/go/v1"
+        stale_client.chat.completions.create.side_effect = quota_err
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def entry_id_for_api_key(self, api_key):
+                return "opencode-a" if api_key == "opencode-key-a" else None
+
+            def mark_exhausted_and_rotate(self, **kwargs):
+                return None
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=(
+                    "opencode-go",
+                    "deepseek-v4-flash",
+                    "https://opencode.ai/zen/go/v1",
+                    "opencode-key-a",
+                    "chat_completions",
+                ),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(stale_client, "deepseek-v4-flash"),
+            ) as mock_cached,
+            patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
+            patch("agent.auxiliary_client._try_configured_fallback_chain", return_value=(None, None, "")),
+            patch("agent.auxiliary_client._try_main_agent_model_fallback", return_value=(None, None, "")),
+        ):
+            with pytest.raises(Exception, match="GoUsageLimitError"):
+                call_llm(
+                    task="moa_reference",
+                    provider="opencode-go",
+                    model="deepseek-v4-flash",
+                    base_url="https://opencode.ai/zen/go/v1",
+                    api_key="opencode-key-a",
+                    messages=[{"role": "user", "content": "advise"}],
+                )
+
+        assert mock_cached.call_count == 1
 
     @pytest.mark.asyncio
     async def test_async_call_llm_rebuilds_without_exhausted_explicit_key(self):
@@ -2728,6 +2839,7 @@ class TestAuxiliaryPoolRotationRetry:
 
         pool = MagicMock()
         pool.has_credentials.return_value = True
+        pool.entry_id_for_api_key.return_value = "opencode-a"
         pool.mark_exhausted_and_rotate.return_value = SimpleNamespace(id="opencode-b")
 
         with (
@@ -2760,7 +2872,9 @@ class TestAuxiliaryPoolRotationRetry:
             )
 
         assert response.choices[0].message.content == "rotated-async-reference"
+        assert mock_cached.call_args_list[1].args[0] == "opencode-go"
         assert mock_cached.call_args_list[1].kwargs["api_key"] is None
+        assert fresh_client.api_key == "opencode-key-b"
         assert fresh_create.await_count == 1
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2651,6 +2651,118 @@ class TestAuxiliaryPoolRotationRetry:
         assert pool.rotate_calls[0]["status_code"] == 429
         mock_fallback.assert_not_called()
 
+    def test_call_llm_rebuilds_moa_provider_without_exhausted_explicit_key(self):
+        """A MoA slot's resolved key must not pin the post-rotation retry."""
+        quota_err = Exception("GoUsageLimitError: usage limit reached")
+        quota_err.status_code = 429
+
+        stale_client = MagicMock()
+        stale_client.api_key = "opencode-key-a"
+        stale_client.base_url = "https://opencode.ai/zen/go/v1"
+        stale_client.chat.completions.create.side_effect = [quota_err, quota_err]
+
+        fresh_client = MagicMock()
+        fresh_client.api_key = "opencode-key-b"
+        fresh_client.base_url = "https://opencode.ai/zen/go/v1"
+        fresh_client.chat.completions.create.return_value = _DummyResponse("rotated-moa-reference")
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def mark_exhausted_and_rotate(self, **kwargs):
+                return SimpleNamespace(id="opencode-b")
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=(
+                    "opencode-go",
+                    "deepseek-v4-flash",
+                    "https://opencode.ai/zen/go/v1",
+                    "opencode-key-a",
+                    "chat_completions",
+                ),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                side_effect=[
+                    (stale_client, "deepseek-v4-flash"),
+                    (fresh_client, "deepseek-v4-flash"),
+                ],
+            ) as mock_cached,
+            patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
+            patch("agent.auxiliary_client._try_payment_fallback") as mock_fallback,
+        ):
+            response = call_llm(
+                task="moa_reference",
+                provider="opencode-go",
+                model="deepseek-v4-flash",
+                base_url="https://opencode.ai/zen/go/v1",
+                api_key="opencode-key-a",
+                messages=[{"role": "user", "content": "advise"}],
+            )
+
+        assert response.choices[0].message.content == "rotated-moa-reference"
+        assert mock_cached.call_args_list[1].kwargs["api_key"] is None
+        assert fresh_client.chat.completions.create.call_count == 1
+        mock_fallback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_rebuilds_without_exhausted_explicit_key(self):
+        quota_err = Exception("GoUsageLimitError: usage limit reached")
+        quota_err.status_code = 429
+
+        stale_create = AsyncMock(side_effect=[quota_err, quota_err])
+        stale_client = SimpleNamespace(
+            api_key="opencode-key-a",
+            base_url="https://opencode.ai/zen/go/v1",
+            chat=SimpleNamespace(completions=SimpleNamespace(create=stale_create)),
+        )
+        fresh_create = AsyncMock(return_value=_DummyResponse("rotated-async-reference"))
+        fresh_client = SimpleNamespace(
+            api_key="opencode-key-b",
+            base_url="https://opencode.ai/zen/go/v1",
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fresh_create)),
+        )
+
+        pool = MagicMock()
+        pool.has_credentials.return_value = True
+        pool.mark_exhausted_and_rotate.return_value = SimpleNamespace(id="opencode-b")
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=(
+                    "opencode-go",
+                    "deepseek-v4-flash",
+                    "https://opencode.ai/zen/go/v1",
+                    "opencode-key-a",
+                    "chat_completions",
+                ),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                side_effect=[
+                    (stale_client, "deepseek-v4-flash"),
+                    (fresh_client, "deepseek-v4-flash"),
+                ],
+            ) as mock_cached,
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+        ):
+            response = await async_call_llm(
+                task="moa_reference",
+                provider="opencode-go",
+                model="deepseek-v4-flash",
+                base_url="https://opencode.ai/zen/go/v1",
+                api_key="opencode-key-a",
+                messages=[{"role": "user", "content": "advise"}],
+            )
+
+        assert response.choices[0].message.content == "rotated-async-reference"
+        assert mock_cached.call_args_list[1].kwargs["api_key"] is None
+        assert fresh_create.await_count == 1
+
 
 
 class TestAnthropicAuxiliaryReasoningTranslation:


### PR DESCRIPTION
## What does this PR do?

MoA reference models now recover when the active OpenCode Go account reaches its usage limit by rebuilding the retry client from the rotated credential pool. Without this fix, every reference slot can remain pinned to the exhausted account and fail with HTTP 429 even when another configured account is healthy.

### Symptom

A direct OpenCode Go request rotates from an exhausted credential to a healthy one, while MoA reference requests continue using the exhausted credential and return HTTP 429 / `GoUsageLimitError`.

### Impact

Users with multiple OpenCode Go credentials cannot use MoA reference models after the selected account is exhausted, despite having remaining capacity in another configured account. This can make all reference responses fail until the original account quota resets.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py` / same-provider credential-pool recovery after a MoA reference request returns a quota error.

**Causal chain:**
1. A MoA slot resolves the current pool credential and passes it as an explicit API key.
2. The auxiliary client marks that credential exhausted and rotates the provider pool, but the retry passes the previously resolved explicit key back into client construction.
3. The retry rebuilds a client with the exhausted credential and the reference request fails again instead of using the healthy account.

**Why it is wrong:** A successful pool rotation invalidates the request's explicit credential snapshot. Reusing that snapshot overrides the newly selected pool entry.

**Working sibling / contrast:** Direct provider calls that do not carry the MoA slot's explicit runtime key can rebuild from the rotated pool and succeed.

**Ruled out:** MoA fanout and model selection are not the cause. Deterministic sync and async tests reproduce the failure at the post-rotation client rebuild by showing the stale explicit key overrides the healthy pool entry.

### Fix

After successful same-provider pool rotation, both synchronous and asynchronous retry paths clear the stale explicit API key so client construction selects the newly active pool credential. Regression tests cover MoA-shaped OpenCode Go requests in both paths.

## Related Issue

Closes #84194

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - rebuild same-provider retry clients from the rotated credential pool.
- `tests/agent/test_auxiliary_client.py` - cover synchronous and asynchronous MoA reference rotation with an explicit exhausted key.

## How to Test

1. Configure two OpenCode Go credentials with the active credential exhausted and the second credential healthy.
2. Run a MoA request whose reference model uses OpenCode Go and confirm it rotates to the healthy credential instead of returning HTTP 429.
3. Run the focused automated suites:

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_client.py
scripts/run_tests.sh tests/agent/test_moa_loop.py
```

Verified locally: all 182 auxiliary-client tests and all 26 MoA loop tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the deterministic credential-pool recovery path on Windows 10

### Documentation & Housekeeping

- [x] Documentation updates are not applicable because no user-facing configuration or interface changed
- [x] `cli-config.yaml.example` updates are not applicable because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not applicable because no architecture or workflow changed
- [x] I've considered cross-platform impact; the changed recovery logic is platform-independent
- [x] Tool description and schema updates are not applicable because no tool behavior changed
