### PR TITLE
fix(plugins): serialize concurrent dynamic module loads

### DIFF
--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -22,10 +22,17 @@ import importlib
 import importlib.util
 import logging
 import sys
+import threading
 from pathlib import Path
 from typing import List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+# A module published in ``sys.modules`` is not ready for reuse until
+# exec_module() and engine extraction finish. Serialize that transaction so
+# concurrent agent construction never observes a partial context-engine module.
+# RLock preserves same-thread import re-entry.
+_ENGINE_LOAD_LOCK = threading.RLock()
 
 _CONTEXT_ENGINE_PLUGINS_DIR = Path(__file__).parent
 
@@ -98,6 +105,12 @@ def load_context_engine(name: str) -> Optional["ContextEngine"]:
 
 
 def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
+    """Thread-safe wrapper around the dynamic engine import transaction."""
+    with _ENGINE_LOAD_LOCK:
+        return _load_engine_from_dir_unlocked(engine_dir)
+
+
+def _load_engine_from_dir_unlocked(engine_dir: Path) -> Optional["ContextEngine"]:
     """Import an engine module and extract the ContextEngine instance.
 
     The module must have either:

--- a/plugins/cron_providers/__init__.py
+++ b/plugins/cron_providers/__init__.py
@@ -32,6 +32,7 @@ import importlib.machinery
 import importlib.util
 import logging
 import sys
+import threading
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -42,6 +43,11 @@ _CRON_PLUGINS_DIR = Path(__file__).parent
 # Synthetic parent package for user-installed providers, so they don't
 # collide with bundled providers in sys.modules.
 _USER_NAMESPACE = "_hermes_user_cron"
+
+# Match the memory-provider loader invariant: a module published in
+# ``sys.modules`` is not ready for reuse until exec_module() and provider
+# extraction finish. RLock preserves same-thread import re-entry.
+_PROVIDER_LOAD_LOCK = threading.RLock()
 
 
 def _register_synthetic_package(name: str, search_locations: List[str]) -> None:
@@ -213,6 +219,12 @@ def load_cron_scheduler(name: str) -> Optional["CronScheduler"]:  # noqa: F821
 
 
 def _load_provider_from_dir(provider_dir: Path) -> Optional["CronScheduler"]:  # noqa: F821
+    """Thread-safe wrapper around the dynamic provider import transaction."""
+    with _PROVIDER_LOAD_LOCK:
+        return _load_provider_from_dir_unlocked(provider_dir)
+
+
+def _load_provider_from_dir_unlocked(provider_dir: Path) -> Optional["CronScheduler"]:  # noqa: F821
     """Import a provider module and extract the CronScheduler instance.
 
     The module must have either:

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -37,6 +37,7 @@ import importlib.metadata
 import importlib.util
 import logging
 import sys
+import threading
 from pathlib import Path
 from typing import List, Optional, Tuple, TYPE_CHECKING
 from hermes_cli.config import cfg_get
@@ -53,6 +54,13 @@ _REGISTERED_MEMORY_PROVIDER_SKILLS: dict[str, Path] = {}
 # Synthetic parent package for user-installed providers, so they don't
 # collide with bundled providers in sys.modules.
 _USER_NAMESPACE = "_hermes_user_memory"
+
+# ``module_from_spec`` sets ``__file__`` before the module body executes, so a
+# concurrent caller cannot use the cached module's ``__file__`` as a readiness
+# signal. Keep publication, execution, and provider extraction in one critical
+# section so every caller observes a fully initialized module. RLock preserves
+# same-thread import re-entry.
+_PROVIDER_LOAD_LOCK = threading.RLock()
 
 
 def _register_synthetic_package(name: str, search_locations: List[str]) -> None:
@@ -417,6 +425,19 @@ def _load_provider_from_entry_point(
 
 
 def _load_provider_from_dir(
+    provider_dir: Path,
+    *,
+    register_skills: bool = True,
+) -> Optional["MemoryProvider"]:
+    """Thread-safe wrapper around the dynamic provider import transaction."""
+    with _PROVIDER_LOAD_LOCK:
+        return _load_provider_from_dir_unlocked(
+            provider_dir,
+            register_skills=register_skills,
+        )
+
+
+def _load_provider_from_dir_unlocked(
     provider_dir: Path,
     *,
     register_skills: bool = True,

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -429,7 +429,15 @@ def _load_provider_from_dir(
     *,
     register_skills: bool = True,
 ) -> Optional["MemoryProvider"]:
-    """Thread-safe wrapper around the dynamic provider import transaction."""
+    """Serialize module readiness and its one-time registration transaction.
+
+    ``register()`` remains inside the boundary deliberately: it returns the
+    provider and may register provider-owned skills/hooks/tools. Returning to a
+    sibling caller before those registrations finish would expose another
+    partially initialized provider state. Skill registration only validates a
+    path and updates in-memory plugin-manager mappings; it does not read the
+    skill body or perform network I/O.
+    """
     with _PROVIDER_LOAD_LOCK:
         return _load_provider_from_dir_unlocked(
             provider_dir,

--- a/tests/agent/test_context_engine_host_contract.py
+++ b/tests/agent/test_context_engine_host_contract.py
@@ -33,6 +33,47 @@ from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
+def test_concurrent_context_engine_load_waits_for_module_execution(
+    tmp_path, monkeypatch
+):
+    """Concurrent callers must not reuse a partially executed engine module."""
+    import concurrent.futures
+    import sys
+    import plugins.context_engine as context_plugins
+
+    engine_dir = tmp_path / "slowcontext"
+    engine_dir.mkdir()
+    (engine_dir / "__init__.py").write_text(
+        "import time\n"
+        "time.sleep(0.15)\n"
+        "from agent.context_engine import ContextEngine\n"
+        "class SlowContext(ContextEngine):\n"
+        "    @property\n"
+        "    def name(self): return 'slowcontext'\n"
+        "    def should_compress(self, prompt_tokens=None): return False\n"
+        "    def compress(self, messages, **kwargs): return messages\n"
+        "    def update_from_response(self, usage): pass\n"
+        "def register(ctx): ctx.register_context_engine(SlowContext())\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(context_plugins, "_CONTEXT_ENGINE_PLUGINS_DIR", tmp_path)
+    sys.modules.pop("plugins.context_engine.slowcontext", None)
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+            engines = list(
+                pool.map(
+                    lambda _: context_plugins.load_context_engine("slowcontext"),
+                    range(32),
+                )
+            )
+    finally:
+        sys.modules.pop("plugins.context_engine.slowcontext", None)
+
+    assert all(engine is not None for engine in engines)
+    assert {engine.name for engine in engines} == {"slowcontext"}
+
+
 def _bare_agent() -> AIAgent:
     agent = object.__new__(AIAgent)
     agent.session_id = "test-session"

--- a/tests/agent/test_context_engine_host_contract.py
+++ b/tests/agent/test_context_engine_host_contract.py
@@ -69,6 +69,8 @@ def test_concurrent_context_engine_load_waits_for_module_execution(
             )
     finally:
         sys.modules.pop("plugins.context_engine.slowcontext", None)
+        if hasattr(context_plugins, "slowcontext"):
+            delattr(context_plugins, "slowcontext")
 
     assert all(engine is not None for engine in engines)
     assert {engine.name for engine in engines} == {"slowcontext"}

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -335,6 +335,48 @@ class TestPluginMemoryDiscovery:
         from plugins.memory import load_memory_provider
         assert load_memory_provider("nonexistent_provider") is None
 
+    def test_concurrent_provider_load_waits_for_module_execution(
+        self, tmp_path, monkeypatch
+    ):
+        """Concurrent callers must not reuse a partially executed module."""
+        import concurrent.futures
+        import sys
+        import plugins.memory as memory_plugins
+
+        provider_dir = tmp_path / "slowmemory"
+        provider_dir.mkdir()
+        (provider_dir / "__init__.py").write_text(
+            "import time\n"
+            "time.sleep(0.15)\n"
+            "from agent.memory_provider import MemoryProvider\n"
+            "class SlowMemory(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self): return 'slowmemory'\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+            "def register(ctx): ctx.register_memory_provider(SlowMemory())\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", tmp_path)
+        sys.modules.pop("plugins.memory.slowmemory", None)
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+                providers = list(
+                    pool.map(
+                        lambda _: memory_plugins.load_memory_provider("slowmemory"),
+                        range(32),
+                    )
+                )
+        finally:
+            sys.modules.pop("plugins.memory.slowmemory", None)
+
+        assert all(provider is not None for provider in providers)
+        assert {provider.name for provider in providers} == {"slowmemory"}
+
 
 class TestUserInstalledProviderDiscovery:
     """Memory providers installed to $HERMES_HOME/plugins/ should be found.

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -373,9 +373,56 @@ class TestPluginMemoryDiscovery:
                 )
         finally:
             sys.modules.pop("plugins.memory.slowmemory", None)
+            if hasattr(memory_plugins, "slowmemory"):
+                delattr(memory_plugins, "slowmemory")
 
         assert all(provider is not None for provider in providers)
         assert {provider.name for provider in providers} == {"slowmemory"}
+
+    def test_register_skills_finishes_before_locked_load_returns(
+        self, tmp_path, monkeypatch
+    ):
+        """Skill registration stays inside the one-time readiness boundary."""
+        import sys
+        import plugins.memory as memory_plugins
+
+        provider_dir = tmp_path / "skillmemory"
+        provider_dir.mkdir()
+        (provider_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "class SkillMemory(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self): return 'skillmemory'\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(SkillMemory())\n"
+            "    ctx.register_skill('ready-skill', 'SKILL.md')\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", tmp_path)
+        sys.modules.pop("plugins.memory.skillmemory", None)
+        registered = []
+        monkeypatch.setattr(
+            memory_plugins._ProviderCollector,
+            "register_skill",
+            lambda self, *args, **kwargs: registered.append(args[0]),
+        )
+
+        try:
+            provider = memory_plugins.load_memory_provider(
+                "skillmemory", register_skills=True
+            )
+        finally:
+            sys.modules.pop("plugins.memory.skillmemory", None)
+            if hasattr(memory_plugins, "skillmemory"):
+                delattr(memory_plugins, "skillmemory")
+
+        assert provider is not None
+        assert registered == ["ready-skill"]
 
 
 class TestUserInstalledProviderDiscovery:

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -185,6 +185,44 @@ def test_load_unknown_cron_scheduler_returns_none():
     assert load_cron_scheduler("does-not-exist-xyz") is None
 
 
+def test_concurrent_cron_provider_load_waits_for_module_execution(
+    tmp_path, monkeypatch
+):
+    """Concurrent callers must not reuse a partially executed cron module."""
+    import concurrent.futures
+    import sys
+    import plugins.cron_providers as cron_plugins
+
+    provider_dir = tmp_path / "slowcron"
+    provider_dir.mkdir()
+    (provider_dir / "__init__.py").write_text(
+        "import time\n"
+        "time.sleep(0.15)\n"
+        "from cron.scheduler_provider import CronScheduler\n"
+        "class SlowCron(CronScheduler):\n"
+        "    @property\n"
+        "    def name(self): return 'slowcron'\n"
+        "    def start(self, stop_event, **kwargs): pass\n"
+        "def register(ctx): ctx.register_cron_scheduler(SlowCron())\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cron_plugins, "_CRON_PLUGINS_DIR", tmp_path)
+    sys.modules.pop("plugins.cron_providers.slowcron", None)
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+            providers = list(
+                pool.map(lambda _: cron_plugins.load_cron_scheduler("slowcron"), range(32))
+            )
+    finally:
+        sys.modules.pop("plugins.cron_providers.slowcron", None)
+        if hasattr(cron_plugins, "slowcron"):
+            delattr(cron_plugins, "slowcron")
+
+    assert all(provider is not None for provider in providers)
+    assert {provider.name for provider in providers} == {"slowcron"}
+
+
 def test_cron_provider_package_does_not_shadow_core_cron_package(monkeypatch):
     """Putting plugins/ first on sys.path must not hide the core cron package."""
     from importlib.machinery import PathFinder


### PR DESCRIPTION
## What does this PR do?

Fixes #47954 by serializing the complete dynamic module-load transaction for memory providers, cron providers, and context engines.

All three loaders publish a module in `sys.modules` before `exec_module()` finishes. A concurrent caller can therefore reuse the cached module while its body is still executing, find neither `register()` nor the expected subclass, and return `None`. A losing `AIAgent` can then run for its lifetime without the configured memory provider or context engine.

The fix wraps publication, module execution, and instance extraction in a module-level `threading.RLock` for each loader family. A re-entrant lock preserves legitimate same-thread import re-entry while ensuring concurrent callers only observe fully initialized modules.

@teknium1 this implements the synchronization and deterministic concurrent-load regression requested in the review on #47958. It replaces the closed fixed-delay approaches from #47958/#47960 rather than retrying an incomplete module after an arbitrary timeout.

Thanks to @stepanov1975 for identifying and reproducing the sibling context-engine loader race. Their reported 31/32 failure shape is now covered by the same invariant and a deterministic regression.

## Verification

On unmodified current `main`, the three new concurrency tests fail:

- memory provider loader: repeated `loaded but no provider instance found`
- cron provider loader: repeated `loaded but no provider instance found`
- context-engine loader: repeated `loaded but no engine instance found`

With this fix:

- All three concurrency regressions pass.
- Full affected and neighboring test set: **117 passed**.
  - `tests/agent/test_memory_provider.py`
  - `tests/cron/test_scheduler_provider.py`
  - `tests/agent/test_context_engine_host_contract.py`
  - `tests/run_agent/test_memory_provider_init.py`
  - `tests/run_agent/test_plugin_context_engine_init.py`
  - `tests/plugins/test_chronos_cron.py`
  - `tests/plugins/test_chronos_verify.py`
- `ruff check`, `py_compile`, and `git diff --check` pass.

## Scope

No provider/engine behavior, lifecycle caching, configuration, or public API changes. This only makes the existing dynamic import transactions safe under concurrent initialization.
