### PR TITLE
fix(aux): preserve named provider headers in auxiliary clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -256,7 +256,69 @@ def _openai_http_client_kwargs(
         return {}
     return {"http_client": client}
 
-def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
+def _apply_custom_provider_extra_headers(
+    kwargs: Dict[str, Any],
+    base_url: str,
+    explicit_headers: Optional[Dict[str, str]] = None,
+    named_identity_selected: bool = False,
+) -> None:
+    """Merge per-provider ``extra_headers`` onto ``kwargs['default_headers']`` last.
+
+    Thin wrapper around the shared config helper so every auxiliary OpenAI-wire
+    client-construction route mirrors the main agent (``agent/agent_init.py`` /
+    ``run_agent.py``): the most specific config level wins, applied AFTER
+    provider/SDK defaults and ``model.default_headers``. Without this the main
+    turn inherits ``custom_providers[].extra_headers`` but the auxiliary client
+    (title generation, compression, vision, web_extract) built a separate
+    OpenAI client and never received them — so a host-scoped override such as
+    ``User-Agent: curl/8.7.1`` reached the main turn but NOT the same turn's
+    title-generation call, which 502ed behind a gateway/WAF rejecting the
+    OpenAI SDK's identifying headers.
+
+    *named_identity_selected* (set by the named-custom-provider resolution
+    branch of ``resolve_provider_client``) means a provider was selected BY
+    IDENTITY, not merely by endpoint. Its own ``extra_headers`` (lifted by
+    ``_get_named_custom_provider`` and passed as *explicit_headers*, possibly
+    empty) are then authoritative — applied AFTER defaults already in *kwargs*,
+    and generic base-URL matching is SUPPRESSED. This must hold even when the
+    selected provider declares no headers: two named providers may share one
+    ``base_url`` (tenant routing / per-tenant auth) and the generic matcher
+    selects the first URL-matching entry, so a headerless ``tenant-b`` would
+    otherwise inherit ``tenant-a``'s credentials. Selecting a named provider
+    by identity is authoritative for headers, including "no headers"; generic
+    URL matching must never overwrite (or fill in) an explicitly selected
+    provider's headers.
+
+    When *named_identity_selected* is False (non-named / base-url-only routes
+    that resolved only an endpoint, not an identity), fall back to the shared
+    config helper's generic base-URL matching so behaviour is unchanged.
+
+    SECURITY: values may carry credentials — never log them.
+    """
+    if named_identity_selected:
+        if explicit_headers:
+            from hermes_cli.config import normalize_extra_headers
+            selected = normalize_extra_headers(explicit_headers)
+            if selected:
+                merged = dict(kwargs.get("default_headers") or {})
+                merged.update(selected)
+                kwargs["default_headers"] = merged
+        return
+    try:
+        from hermes_cli.config import apply_custom_provider_extra_headers_to_client_kwargs
+        apply_custom_provider_extra_headers_to_client_kwargs(kwargs, base_url)
+    except Exception:
+        logger.debug("auxiliary custom-provider extra_headers skipped", exc_info=True)
+
+
+def _create_openai_client(
+    *,
+    api_key: str,
+    base_url: str,
+    extra_headers: Optional[Dict[str, str]] = None,
+    named_identity_selected: bool = False,
+    **kwargs: Any,
+) -> Any:
     if _aux_probe_active():
         # Availability probe: credentials/base_url resolved — that is the
         # answer. Skip the openai import + httpx/SSL construction entirely.
@@ -271,6 +333,18 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
     # by default and let Hermes control the budget; explicit callers can still
     # override via kwargs.
     kwargs.setdefault("max_retries", 0)
+    # Per-provider extra HTTP headers (providers.<name>.extra_headers /
+    # custom_providers[].extra_headers) — applied LAST so the most specific
+    # config level survives, mirroring the main agent. *extra_headers*, when
+    # supplied, is the exact selected named provider's headers and takes
+    # precedence over generic base-URL matching (see helper docstring).
+    # *named_identity_selected* suppresses that generic matching even when the
+    # named provider declares no headers of its own.
+    _apply_custom_provider_extra_headers(
+        kwargs, base_url,
+        explicit_headers=extra_headers,
+        named_identity_selected=named_identity_selected,
+    )
     return OpenAI(api_key=api_key, base_url=base_url, **kwargs)
 
 
@@ -5862,7 +5936,13 @@ def _effective_provider_for_client(client: Any, fallback: str) -> str:
 # below — never look up auth env vars ad-hoc.
 
 
-def _to_async_client(sync_client, model: str, is_vision: bool = False):
+def _to_async_client(
+    sync_client,
+    model: str,
+    is_vision: bool = False,
+    extra_headers: Optional[Dict[str, str]] = None,
+    named_identity_selected: bool = False,
+):
     """Convert a sync client to its async counterpart, preserving Codex routing.
 
     When ``is_vision=True`` and the underlying base URL is Copilot, the
@@ -5939,6 +6019,18 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     # See _create_openai_client: disable SDK-internal retries so Hermes owns
     # the auxiliary retry/timeout budget (issue #54465).
     async_kwargs.setdefault("max_retries", 0)
+    # Per-provider extra HTTP headers — applied LAST (same precedence as the
+    # sync chokepoint _create_openai_client) so this distinct OpenAI-wire
+    # construction route inherits custom_providers[].extra_headers too.
+    # *extra_headers* + *named_identity_selected*, when supplied by a
+    # named-provider caller, preserve the selected provider's identity over
+    # generic base-URL matching — including suppressing it for a headerless
+    # named provider that shares another provider's base_url.
+    _apply_custom_provider_extra_headers(
+        async_kwargs, sync_base_url,
+        explicit_headers=extra_headers,
+        named_identity_selected=named_identity_selected,
+    )
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -6366,6 +6458,15 @@ def resolve_provider_client(
             # An explicit per-task api_mode override (from _resolve_task_provider_model)
             # wins; otherwise fall back to what the provider entry declared.
             entry_api_mode = (api_mode or custom_entry.get("api_mode") or "").strip()
+            # Carry the selected named provider's exact ``extra_headers``
+            # through to OpenAI client construction instead of re-deriving
+            # them from base_url. Two named providers may share one base_url
+            # while declaring distinct headers (tenant routing / per-tenant
+            # auth); generic base-URL matching would then select the first
+            # entry and route the auxiliary request to the wrong tenant / send
+            # the wrong credentials. The construction helpers apply these
+            # AFTER generic defaults and skip URL matching when they're set.
+            _named_extra_headers = custom_entry.get("extra_headers")
             if custom_base:
                 final_model = _normalize_resolved_model(
                     model
@@ -6415,8 +6516,16 @@ def resolve_provider_client(
                         _fb_headers = _apply_user_default_headers(_fb_extra.get("default_headers"))
                         if _fb_headers:
                             _fb_extra["default_headers"] = _fb_headers
-                        client = _create_openai_client(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
-                        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                        client = _create_openai_client(
+                            api_key=custom_key, base_url=_fb_clean,
+                            extra_headers=_named_extra_headers,
+                            named_identity_selected=True, **_fb_extra,
+                        )
+                        return (_to_async_client(
+                            client, final_model, is_vision=is_vision,
+                            extra_headers=_named_extra_headers,
+                            named_identity_selected=True,
+                        ) if async_mode
                                 else (client, final_model))
                     sync_anthropic = AnthropicAuxiliaryClient(
                         real_client, final_model, custom_key, custom_base, is_oauth=False,
@@ -6424,7 +6533,11 @@ def resolve_provider_client(
                     if async_mode:
                         return AsyncAnthropicAuxiliaryClient(sync_anthropic), final_model
                     return sync_anthropic, final_model
-                client = _create_openai_client(api_key=custom_key, base_url=_clean_base2, **_extra2)
+                client = _create_openai_client(
+                    api_key=custom_key, base_url=_clean_base2,
+                    extra_headers=_named_extra_headers,
+                    named_identity_selected=True, **_extra2,
+                )
                 # codex_responses or inherited auto-detect (via _wrap_if_needed).
                 # _wrap_if_needed reads the closed-over `api_mode` (the task-level
                 # override). Named-provider entry api_mode=codex_responses also
@@ -6435,7 +6548,11 @@ def resolve_provider_client(
                     client = CodexAuxiliaryClient(client, final_model)
                 else:
                     client = _wrap_if_needed(client, final_model, raw_base_for_wrap, custom_key)
-                return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                return (_to_async_client(
+                    client, final_model, is_vision=is_vision,
+                    extra_headers=_named_extra_headers,
+                    named_identity_selected=True,
+                ) if async_mode
                         else (client, final_model))
             logger.warning(
                 "resolve_provider_client: named custom provider %r has no base_url",

--- a/tests/agent/test_auxiliary_custom_provider_extra_headers.py
+++ b/tests/agent/test_auxiliary_custom_provider_extra_headers.py
@@ -1,0 +1,301 @@
+"""Tests for per-provider ``custom_providers[].extra_headers`` on the auxiliary client.
+
+Companion to ``tests/agent/test_auxiliary_user_default_headers.py`` (which
+covers the global ``model.default_headers`` override). The main agent applies
+``custom_providers[].extra_headers`` via
+``hermes_cli.config.apply_custom_provider_extra_headers_to_client_kwargs``
+(see ``run_agent.py`` / ``agent/agent_init.py``), but the auxiliary client
+(title generation, context compression, vision routing, web_extract) built a
+separate OpenAI client and never received the matching per-provider headers —
+so a host-scoped override such as ``User-Agent: curl/8.7.1`` reached the main
+turn but NOT the same turn's title-generation call, which 502ed behind a
+gateway/WAF that rejected the OpenAI SDK's identifying headers.
+
+These tests assert the auxiliary OpenAI-wire client-construction routes
+inherit the matching per-provider ``extra_headers`` and that provider-specific
+headers override pre-existing defaults (mirroring the main agent's precedence:
+SDK/profile defaults < ``model.default_headers`` < ``custom_providers[].extra_headers``).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME so load_config() reads our test config.yaml."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text("model:\n  default: test-model\n")
+
+
+def _write_config(tmp_path, config_dict):
+    import yaml
+    (tmp_path / ".hermes" / "config.yaml").write_text(yaml.dump(config_dict))
+
+
+class TestAuxClientReceivesProviderExtraHeaders:
+    """resolve_provider_client must pass the matching per-provider extra_headers
+    to the OpenAI client for a named custom provider."""
+
+    def test_named_custom_provider_extra_headers_reach_aux_client(self, tmp_path):
+        """The production reproduction: a named custom provider behind a
+        gateway/WAF declares ``extra_headers`` to override the OpenAI SDK's
+        User-Agent. The auxiliary client (title generation path) must inherit
+        them, not just the main agent."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "fastai",
+                    "base_url": "https://fastai.example.com/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("fastai", "test-model")
+
+        assert client is not None
+        assert mock_openai.called
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("User-Agent") == "curl/8.7.1"
+
+    def test_provider_headers_override_pre_existing_defaults(self, tmp_path):
+        """Provider-specific ``extra_headers`` win over pre-existing defaults
+        already in ``default_headers`` (here: a global ``model.default_headers``
+        User-Agent). The provider value is the most specific config level and
+        must survive, while unrelated defaults are preserved."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "test-model",
+                "default_headers": {"User-Agent": "sdk-default", "X-Keep": "keep-me"},
+            },
+            "custom_providers": [
+                {
+                    "name": "fastai",
+                    "base_url": "https://fastai.example.com/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("fastai", "test-model")
+
+        assert client is not None
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        # Provider-specific value overrides the pre-existing default.
+        assert headers.get("User-Agent") == "curl/8.7.1"
+        # An unrelated pre-existing default is preserved (not wiped).
+        assert headers.get("X-Keep") == "keep-me"
+
+    def test_unmatched_base_url_gets_no_provider_headers(self, tmp_path):
+        """Matching, not blanket application: an ``extra_headers`` entry whose
+        base_url does NOT match the resolved endpoint must not contribute its
+        headers (a different custom provider's credentials must never leak)."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "acme",
+                    "base_url": "https://acme.example.com/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+                {
+                    "name": "fastai",
+                    "base_url": "https://fastai.example.com/v1",
+                    "api_key": "k",
+                },
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("fastai", "test-model")
+
+        assert client is not None
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        # acme's headers must NOT leak onto a fastai client.
+        assert "User-Agent" not in headers
+
+
+class TestAuxAsyncClientReceivesProviderExtraHeaders:
+    """The async OpenAI-wire route (_to_async_client) must also inherit the
+    matching per-provider extra_headers — it builds its own AsyncOpenAI client
+    and is a distinct construction path from _create_openai_client."""
+
+    def test_to_async_client_applies_matching_provider_headers(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "fastai",
+                    "base_url": "https://fastai.example.com/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1", "X-Tag": "aux"},
+                },
+            ],
+        })
+        # A plain OpenAI-shaped sync client pointed at the custom provider's
+        # base_url — _to_async_client reads .api_key / .base_url off it.
+        sync_stub = SimpleNamespace(
+            api_key="k", base_url="https://fastai.example.com/v1"
+        )
+        with patch("openai.AsyncOpenAI") as mock_async:
+            mock_async.return_value = MagicMock()
+            from agent.auxiliary_client import _to_async_client
+            async_client, model = _to_async_client(sync_stub, "test-model")
+
+        assert mock_async.called
+        headers = mock_async.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("User-Agent") == "curl/8.7.1"
+        assert headers.get("X-Tag") == "aux"
+
+
+class TestSharedBaseUrlNamedProvidersKeepIdentity:
+    """Two named custom providers may legitimately share one ``base_url`` while
+    declaring distinct ``extra_headers`` (tenant routing / per-tenant auth).
+    Resolving a named provider must apply ONLY that provider's headers — the
+    generic base-URL matcher must never overwrite them with the first
+    URL-matching entry's headers (wrong-tenant / wrong-credential routing).
+    """
+
+    _SHARED_CONFIG = {
+        "model": {"default": "test-model"},
+        "custom_providers": [
+            {
+                "name": "tenant-a",
+                "base_url": "https://shared.example.com/v1",
+                "api_key": "k",
+                "extra_headers": {"X-Tenant": "a"},
+            },
+            {
+                "name": "tenant-b",
+                "base_url": "https://shared.example.com/v1",
+                "api_key": "k",
+                "extra_headers": {"X-Tenant": "b"},
+            },
+        ],
+    }
+
+    def test_named_provider_sends_only_its_own_headers_sync(self, tmp_path):
+        """Resolving ``tenant-b`` on the sync OpenAI-wire route must carry
+        ``X-Tenant=b`` and never ``tenant-a``'s ``X-Tenant=a``."""
+        _write_config(tmp_path, self._SHARED_CONFIG)
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("tenant-b", "test-model")
+
+        assert client is not None
+        assert mock_openai.called
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("X-Tenant") == "b"
+        # The first URL-matching entry's header must NOT leak through.
+        assert headers.get("X-Tenant") != "a"
+
+    def test_named_provider_sends_only_its_own_headers_async(self, tmp_path):
+        """The async conversion route (_to_async_client) must equally preserve
+        the selected named provider's identity when two providers share a
+        base_url. _to_async_client re-derives headers from base_url, so without
+        identity propagation it silently reverts to the first URL match."""
+        _write_config(tmp_path, self._SHARED_CONFIG)
+        # resolve_provider_client(async_mode=True) builds a sync OpenAI client
+        # then converts it via _to_async_client. Stub the sync OpenAI call so
+        # _to_async_client reads real .api_key / .base_url attributes off it.
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai, \
+                patch("openai.AsyncOpenAI") as mock_async:
+            mock_openai.return_value = SimpleNamespace(
+                api_key="k", base_url="https://shared.example.com/v1"
+            )
+            mock_async.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client(
+                "tenant-b", "test-model", async_mode=True
+            )
+
+        assert mock_async.called
+        headers = mock_async.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("X-Tenant") == "b"
+        assert headers.get("X-Tenant") != "a"
+
+
+class TestSharedBaseUrlHeaderlessNamedProviderSuppressesUrlMatch:
+    """A named provider selected by identity must suppress generic base-URL
+    matching EVEN WHEN it declares no ``extra_headers`` of its own.
+
+    tenant-a declares credential/tenant headers; tenant-b is headerless but
+    shares tenant-a's base_url (a legit setup: same gateway, different auth
+    strategy). Resolving tenant-b must NOT inherit tenant-a's headers via the
+    generic first-URL-match fallback — that would send tenant-a's credentials
+    on tenant-b's request. Selecting a named provider by identity is
+    authoritative for headers (including "no headers"); only routes with no
+    named-provider identity fall back to generic URL matching.
+    """
+
+    _SHARED_CONFIG = {
+        "model": {"default": "test-model"},
+        "custom_providers": [
+            {
+                "name": "tenant-a",
+                "base_url": "https://shared.example.com/v1",
+                "api_key": "k",
+                "extra_headers": {
+                    "X-Tenant": "a",
+                    "Authorization": "Bearer a-secret-token",
+                },
+            },
+            {
+                "name": "tenant-b",
+                "base_url": "https://shared.example.com/v1",
+                "api_key": "k",
+            },
+        ],
+    }
+
+    def test_headerless_named_provider_gets_no_other_tenants_headers_sync(self, tmp_path):
+        """Resolving headerless ``tenant-b`` (sync) must carry NEITHER
+        ``tenant-a``'s ``X-Tenant`` nor its ``Authorization``."""
+        _write_config(tmp_path, self._SHARED_CONFIG)
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("tenant-b", "test-model")
+
+        assert client is not None
+        assert mock_openai.called
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert "X-Tenant" not in headers
+        assert "Authorization" not in headers
+
+    def test_headerless_named_provider_gets_no_other_tenants_headers_async(self, tmp_path):
+        """Resolving headerless ``tenant-b`` (async conversion route) must
+        equally suppress tenant-a's headers — _to_async_client re-derives
+        headers from base_url and would otherwise revert to the first URL
+        match."""
+        _write_config(tmp_path, self._SHARED_CONFIG)
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai, \
+                patch("openai.AsyncOpenAI") as mock_async:
+            mock_openai.return_value = SimpleNamespace(
+                api_key="k", base_url="https://shared.example.com/v1"
+            )
+            mock_async.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client(
+                "tenant-b", "test-model", async_mode=True
+            )
+
+        assert mock_async.called
+        headers = mock_async.call_args.kwargs.get("default_headers", {}) or {}
+        assert "X-Tenant" not in headers
+        assert "Authorization" not in headers


### PR DESCRIPTION
## What does this PR do?

Propagates per-provider `extra_headers` from named `providers` / `custom_providers` entries to auxiliary OpenAI-wire clients.

The main agent already applies these headers, but auxiliary calls such as title generation, context compression, vision routing, and web extraction construct separate sync/async clients. A custom gateway that requires a provider-scoped header override can therefore accept the main turn while rejecting the auxiliary request from the same turn.

The selected named-provider identity is carried through client construction instead of being recovered only from `base_url`. This matters when multiple named providers share an endpoint: each provider must receive only its own routing/auth headers, and a headerless provider must not inherit another provider's headers through URL fallback.

This follows up on #40033 / #41096, which added global `model.default_headers` support. This PR covers the more specific `providers.<name>.extra_headers` / `custom_providers[].extra_headers` path.

## Related Issue

Related to #40033 and #41096.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`
  - applies matching custom-provider headers at both sync and async OpenAI client construction points;
  - preserves the exact named-provider identity when providers share a `base_url`;
  - suppresses URL fallback for a selected named provider even when its own header set is empty;
  - preserves existing default headers, with provider-specific values taking precedence.
- `tests/agent/test_auxiliary_custom_provider_extra_headers.py`
  - covers named-provider propagation, precedence, unmatched endpoints, and async conversion;
  - covers shared-endpoint providers with distinct headers;
  - covers headerless shared-endpoint providers to prevent cross-provider credential/header leakage.

## How to Test

1. Run the focused CI-parity suite:

   ```bash
   scripts/run_tests.sh \
     tests/agent/test_auxiliary_custom_provider_extra_headers.py \
     tests/agent/test_auxiliary_user_default_headers.py \
     tests/hermes_cli/test_custom_provider_extra_headers.py \
     tests/run_agent/test_custom_provider_extra_headers_client.py
   ```

2. Expected result: `27 tests passed, 0 failed`.
3. Configure a named custom OpenAI-compatible provider with a provider-scoped `extra_headers.User-Agent`, start a new Hermes process, and verify both the main response and automatic title generation complete successfully.

Manual E2E on macOS: before the change, the main turn succeeded with the provider-scoped header while title generation returned HTTP 502; after the change and a Desktop restart, the same custom provider completed the conversation and title-generation path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused canonical suite passed: 27/27
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.2, Hermes Desktop and CLI

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing key or API changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; uses the existing `extra_headers` key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python config/header propagation; no OS-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused canonical test runner:

```text
Summary: 4 files, 27 tests passed, 0 failed (100% complete)
```
