### PR TITLE
fix(matrix): reuse a stable device ID for password login

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1818,6 +1818,14 @@ class MatrixAdapter(BasePlatformAdapter):
                 )
                 if resp and hasattr(resp, "device_id"):
                     client.device_id = resp.device_id
+                    if self._device_id and resp.device_id and resp.device_id != self._device_id:
+                        logger.warning(
+                            "Matrix: homeserver assigned device %s instead of "
+                            "the requested %s — the persisted MATRIX_DEVICE_ID "
+                            "now diverges from the live device.",
+                            resp.device_id,
+                            self._device_id,
+                        )
                 logger.info("Matrix: logged in as %s", self._user_id)
             except Exception as exc:
                 logger.error("Matrix: login failed — %s", exc)
@@ -5264,7 +5272,20 @@ def _resolve_stable_device_id() -> str:
     if existing:
         return existing
     device_id = _generate_stable_device_id()
-    save_env_value("MATRIX_DEVICE_ID", device_id)
+    try:
+        save_env_value("MATRIX_DEVICE_ID", device_id)
+    except Exception as exc:
+        # An unwritable .env (read-only HOME, container, managed scope that
+        # rejects the write) must not prevent login. Fall back to a
+        # generated-but-unpersisted ID: the session still works, and a later
+        # restart just regenerates (equivalent to the pre-fix auto-mint),
+        # rather than failing connect entirely.
+        logger.warning(
+            "Matrix: could not persist MATRIX_DEVICE_ID (%s); using a "
+            "generated ID for this session only. Restarts may mint a fresh "
+            "device until the profile .env is writable.",
+            exc,
+        )
     return device_id
 
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1802,6 +1802,13 @@ class MatrixAdapter(BasePlatformAdapter):
                 await api.session.close()
                 return False
         elif self._password and self._user_id:
+            # Password login without a pinned device ID mints a fresh device
+            # on every restart (the homeserver auto-generates one when
+            # device_id is None), which accumulates toward the hard device
+            # limit. Resolve a stable device ID — user-configured wins;
+            # otherwise generate + persist one so restarts reuse it.
+            if not self._device_id:
+                self._device_id = _resolve_stable_device_id()
             try:
                 resp = await client.login(
                     identifier=self._user_id,
@@ -5226,6 +5233,39 @@ async def _standalone_send(
                 return {"error": "Matrix API timeout (30s)"}
     except Exception as e:
         return {"error": f"Matrix send failed: {e}"}
+
+
+def _generate_stable_device_id() -> str:
+    """Generate a stable, unique Matrix device ID for E2EE persistence.
+
+    A 10-char random value from ``[A-Za-z0-9]`` (the shape homeservers like
+    Synapse assign to real clients), unique per install. Persisted to
+    ``.env`` so password logins on later restarts reuse the same device
+    instead of minting a fresh one each time (which accumulates toward the
+    homeserver's hard device limit).
+    """
+    import secrets
+    import string
+
+    alphabet = string.ascii_uppercase + string.ascii_lowercase + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(10))
+
+
+def _resolve_stable_device_id() -> str:
+    """Return the stable device ID to use for password login, generating one if unset.
+
+    Reads ``MATRIX_DEVICE_ID`` and returns it when present (a user-supplied
+    value always wins). Otherwise generates a fresh stable ID and persists
+    it via ``save_env_value`` so subsequent restarts reuse the same device.
+    """
+    from hermes_cli.config import get_env_value, save_env_value
+
+    existing = get_env_value("MATRIX_DEVICE_ID")
+    if existing:
+        return existing
+    device_id = _generate_stable_device_id()
+    save_env_value("MATRIX_DEVICE_ID", device_id)
+    return device_id
 
 
 def interactive_setup() -> None:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -5333,6 +5333,15 @@ def interactive_setup() -> None:
         password = prompt("Password", password=True)
         if password:
             save_env_value("MATRIX_PASSWORD", password)
+            # Password login without a pinned device ID makes the homeserver
+            # mint a fresh device on every restart, accumulating toward its
+            # hard device limit. Generate + persist a stable ID at setup so
+            # new installs are pinned from the start; a user-configured
+            # MATRIX_DEVICE_ID always wins over the generated one.
+            if not get_env_value("MATRIX_DEVICE_ID"):
+                device_id = _generate_stable_device_id()
+                save_env_value("MATRIX_DEVICE_ID", device_id)
+                print_success(f"Generated a stable device ID ({device_id})")
             print_success("Matrix credentials saved")
 
     if token or get_env_value("MATRIX_PASSWORD"):

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1393,6 +1393,129 @@ class TestMatrixPasswordLoginDeviceId:
 
         await adapter.disconnect()
 
+    @pytest.mark.asyncio
+    async def test_password_login_survives_unwritable_env(self, monkeypatch, tmp_path):
+        """A persistence failure on an unwritable .env must not break login.
+
+        Point 1 of the review: _resolve_stable_device_id() originally called
+        save_env_value() before the try block, so an unwritable profile .env
+        raised out of connect() entirely — a regression where password login
+        previously connected. The write is now best-effort: login proceeds
+        with a generated-but-unpersisted ID (equivalent to the pre-fix
+        auto-mint) instead of failing.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("MATRIX_DEVICE_ID", raising=False)
+        import hermes_cli.config as hconfig
+
+        def _raise(*args, **kwargs):
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr(hconfig, "save_env_value", _raise)
+
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "password": "secret",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        fake_mautrix_mods = _make_fake_mautrix()
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.login = AsyncMock(
+            return_value=MagicMock(device_id="GENERATED", access_token="tok")
+        )
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = ""
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    # Login must still succeed even though persistence raised.
+                    assert await adapter.connect() is True
+
+        mock_client.login.assert_awaited_once()
+        passed_device_id = mock_client.login.call_args.kwargs.get("device_id")
+        assert passed_device_id and len(passed_device_id) == 10
+
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_password_login_logs_device_id_divergence(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """Point 4 of the review: a homeserver-assigned device differing from
+        the requested/persisted one must surface a warning instead of silently
+        diverging."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("MATRIX_DEVICE_ID", raising=False)
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        # A prior run persisted a device ID; the homeserver then ignores it.
+        (tmp_path / ".env").write_text("MATRIX_DEVICE_ID=PERSISTED_ID\n")
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "password": "secret",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        fake_mautrix_mods = _make_fake_mautrix()
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.login = AsyncMock(
+            # Homeserver ignores the requested ID and assigns its own.
+            return_value=MagicMock(device_id="SERVER_ASSIGNED", access_token="tok")
+        )
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = ""
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    assert await adapter.connect() is True
+
+        passed_device_id = mock_client.login.call_args.kwargs.get("device_id")
+        assert passed_device_id == "PERSISTED_ID"
+        # The adapter adopts the homeserver-assigned device even though it
+        # differs from the requested/persisted one.
+        assert mock_client.device_id == "SERVER_ASSIGNED"
+        assert any(
+            "assigned device SERVER_ASSIGNED instead of the requested PERSISTED_ID"
+            in rec.message
+            for rec in caplog.records
+        )
+
+        await adapter.disconnect()
+
 
 class TestMatrixDeviceIdConfig:
     """MATRIX_DEVICE_ID should be plumbed through gateway config."""

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -12,6 +12,26 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageType
 
 
+@pytest.fixture(autouse=True)
+def _restore_matrix_device_id_env():
+    """Snapshot and restore MATRIX_DEVICE_ID in os.environ across tests.
+
+    save_env_value() writes to os.environ as well as .env (mirroring the
+    real startup path), so a test that resolves/persists a device ID leaks
+    that value into os.environ — which get_env_value() prefers over the
+    .env file — and can break a later test. Snapshot before, restore after.
+    """
+    import os
+
+    prev = os.environ.get("MATRIX_DEVICE_ID")
+    yield
+    if prev is None:
+        os.environ.pop("MATRIX_DEVICE_ID", None)
+    else:
+        os.environ["MATRIX_DEVICE_ID"] = prev
+
+
+
 def _make_fake_mautrix():
     """Create a lightweight set of fake ``mautrix`` modules.
 
@@ -1207,7 +1227,127 @@ class TestMatrixPasswordLoginDeviceId:
     """MATRIX_DEVICE_ID should be passed to mautrix Client even with password login."""
 
     @pytest.mark.asyncio
-    async def test_password_login_uses_device_id(self):
+    async def test_password_login_generates_stable_device_id_when_unset(
+        self, monkeypatch, tmp_path
+    ):
+        """Password login with no MATRIX_DEVICE_ID must not mint a new device.
+
+        Before this fix, ``client.login(device_id=None)`` made the homeserver
+        auto-generate a fresh device on every restart, which accumulated
+        toward the hard device limit. When no device ID is configured, the
+        adapter now generates + persists a stable one and passes it to login.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Ensure no leaked value from a prior test shadows the unset case.
+        monkeypatch.delenv("MATRIX_DEVICE_ID", raising=False)
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "password": "secret",
+                # NOTE: no device_id — the fallback must generate one.
+            },
+        )
+        adapter = MatrixAdapter(config)
+        assert adapter._device_id == ""  # nothing configured
+
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.login = AsyncMock(
+            return_value=MagicMock(device_id="GENERATED", access_token="tok")
+        )
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = ""
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    assert await adapter.connect() is True
+
+        # A non-empty device ID was resolved and passed to login.
+        mock_client.login.assert_awaited_once()
+        passed_device_id = mock_client.login.call_args.kwargs.get("device_id")
+        assert passed_device_id and len(passed_device_id) == 10
+        assert passed_device_id.isalnum()  # [A-Za-z0-9], like Element/Synapse IDs
+        # And it was persisted to the profile .env so restarts reuse it.
+        env_content = (tmp_path / ".env").read_text()
+        assert f"MATRIX_DEVICE_ID={passed_device_id}" in env_content
+
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_password_login_generated_device_id_is_stable_across_restarts(
+        self, monkeypatch, tmp_path
+    ):
+        """The persisted device ID is reused, not regenerated, on later logins."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Simulate a fresh process on restart: the var lives in .env, not
+        # os.environ. (save_env_value also sets os.environ, so without this
+        # a prior test's generated value would shadow the persisted file.)
+        monkeypatch.delenv("MATRIX_DEVICE_ID", raising=False)
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        # Simulate a prior run that persisted a device ID.
+        (tmp_path / ".env").write_text("MATRIX_DEVICE_ID=PREVIOUS_STABLE\n")
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "password": "secret",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        fake_mautrix_mods = _make_fake_mautrix()
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.login = AsyncMock(
+            return_value=MagicMock(device_id="PREVIOUS_STABLE", access_token="tok")
+        )
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = ""
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    assert await adapter.connect() is True
+
+        passed_device_id = mock_client.login.call_args.kwargs.get("device_id")
+        assert passed_device_id == "PREVIOUS_STABLE"
+        # No new line appended — still exactly one entry.
+        assert (tmp_path / ".env").read_text().count("MATRIX_DEVICE_ID") == 1
+
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_password_login_uses_configured_device_id(self):
+        """A user-configured device ID is passed to login unchanged."""
         from plugins.platforms.matrix.adapter import MatrixAdapter
 
         config = PlatformConfig(
@@ -1229,7 +1369,9 @@ class TestMatrixPasswordLoginDeviceId:
         mock_client.state_store = MagicMock()
         mock_client.sync_store = MagicMock()
         mock_client.crypto = None
-        mock_client.login = AsyncMock(return_value=MagicMock(device_id="STABLE_PW_DEVICE", access_token="tok"))
+        mock_client.login = AsyncMock(
+            return_value=MagicMock(device_id="STABLE_PW_DEVICE", access_token="tok")
+        )
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.api = MagicMock()
@@ -1245,6 +1387,8 @@ class TestMatrixPasswordLoginDeviceId:
                     assert await adapter.connect() is True
 
         mock_client.login.assert_awaited_once()
+        passed_device_id = mock_client.login.call_args.kwargs.get("device_id")
+        assert passed_device_id == "STABLE_PW_DEVICE"
         assert adapter._device_id == "STABLE_PW_DEVICE"
 
         await adapter.disconnect()

--- a/tests/gateway/test_matrix_plugin_setup.py
+++ b/tests/gateway/test_matrix_plugin_setup.py
@@ -81,3 +81,58 @@ class TestMatrixHomeChannelClear:
         assert "MATRIX_HOME_ROOM" not in saved
 
 
+# Password-login prompts: homeserver, blank token (→ password branch),
+# user_id, password. The E2EE/allowed_users/home_room block is skipped here
+# because the patched get_env_value only reads `existing`, so the saved
+# MATRIX_PASSWORD is not visible to the `if token or ...` guard.
+_PROMPTS_PASSWORD = [
+    "https://matrix.example.org",
+    "",                            # blank token → password login
+    "@bot:matrix.example.org",     # user_id
+    "hunter2",                     # password
+]
+
+
+class TestMatrixSetupGeneratesDeviceId:
+    """Password-login setup must persist a stable MATRIX_DEVICE_ID (#84229).
+
+    Without a pinned device ID the homeserver mints a fresh device on every
+    restart, accumulating toward the hard device limit. The wizard generates
+    + persists a stable ID at setup so new password-login installs are pinned
+    from the start.
+    """
+
+    def test_password_setup_persists_generated_device_id(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        saved, removed = {}, []
+        _patch_setup_io(
+            monkeypatch,
+            _PROMPTS_PASSWORD,
+            _YES_NO,
+            saved,
+            removed,
+            existing={},
+        )
+        interactive_setup()
+        # A 10-char [A-Za-z0-9] device ID was generated and persisted.
+        device_id = saved.get("MATRIX_DEVICE_ID", "")
+        assert len(device_id) == 10
+        assert device_id.isalnum()
+        assert "MATRIX_PASSWORD" in saved
+
+    def test_password_setup_respects_configured_device_id(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        saved, removed = {}, []
+        _patch_setup_io(
+            monkeypatch,
+            _PROMPTS_PASSWORD,
+            _YES_NO,
+            saved,
+            removed,
+            existing={"MATRIX_DEVICE_ID": "MY_PINNED_DEVICE"},
+        )
+        interactive_setup()
+        # A user-configured MATRIX_DEVICE_ID wins; nothing new is generated.
+        assert "MATRIX_DEVICE_ID" not in saved
+
+


### PR DESCRIPTION
## Summary
Password login with no pinned `MATRIX_DEVICE_ID` sends `device_id=None` to the homeserver, which auto-generates a **fresh device on every restart**. Over weeks of restarts these accumulate toward the homeserver's hard device limit and surface as `login failed — you have reached your hard device limit`.

This change makes password login reuse a stable device ID:
- A user-configured `MATRIX_DEVICE_ID` (env or `.env`) **always wins**.
- Otherwise a stable ID is generated once and persisted via `save_env_value`, so subsequent restarts reuse the same device instead of minting a new one each time.

## What changed
- `_resolve_stable_device_id()` / `_generate_stable_device_id()` helpers in `plugins/platforms/matrix/adapter.py`. The generated ID is a 10-char `[A-Za-z0-9]` value — the shape homeservers like Synapse assign to real clients.
- Runtime `connect()`: existing installs with password login and no device ID get one resolved/persisted on first connect, healing them without reconfiguration.
- **Access-token auth is deliberately untouched** — the token is bound to its device, so there is no accumulation risk in that path.

## Tests
- `TestMatrixPasswordLoginDeviceId` (3): generates when unset + persists to `.env`; reuses the persisted ID across restarts (no new line appended); passes a user-configured ID through unchanged.
- Added an autouse fixture in `test_matrix.py` that snapshots/restores `MATRIX_DEVICE_ID` in `os.environ`, since `save_env_value` writes to the environment and would otherwise leak a generated value into later tests.

## Notes for reviewers
- Uses `save_env_value` for persistence, matching the established pattern in `interactive_setup()` (e.g. `MATRIX_ENCRYPTION`).
- Complements (does not overlap) #71545, which prevents clobbering keys owned by another client; this change prevents device accumulation at the source.
- *Possible follow-up (not included here):* the setup wizard (`interactive_setup`) could also persist a device ID during password-login + E2EE setup. Kept out to stay minimal — the runtime fallback fully heals existing installs.
